### PR TITLE
Fix lint errors for using deprecated functionality

### DIFF
--- a/cmd/sync/github.go
+++ b/cmd/sync/github.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -28,7 +28,7 @@ func githubGetPAT(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	raw, err := ioutil.ReadAll(response.Body)
+	raw, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}
@@ -58,7 +58,7 @@ func githubGetPAT(ctx context.Context) (string, error) {
 		if err != nil {
 			return retries.Halt(err)
 		}
-		raw, err := ioutil.ReadAll(response.Body)
+		raw, err := io.ReadAll(response.Body)
 		if err != nil {
 			return retries.Continuef("failed to read body: %w", err)
 		}
@@ -100,7 +100,7 @@ func githubGetPAT(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	raw, _ = ioutil.ReadAll(response.Body)
+	raw, _ = io.ReadAll(response.Body)
 	log.Printf("[INFO] %s", raw)
 	// TODO: convert to PAT
 	return bearer, nil

--- a/git/fileset.go
+++ b/git/fileset.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -45,7 +44,7 @@ func MustGetFileSet() FileSet {
 
 func New(root string) FileSet {
 	lines := []string{".git"}
-	rawIgnore, err := ioutil.ReadFile(fmt.Sprintf("%s/.gitignore", root))
+	rawIgnore, err := os.ReadFile(fmt.Sprintf("%s/.gitignore", root))
 	if err == nil {
 		// add entries from .gitignore if the file exists (did read correctly)
 		for _, line := range strings.Split(string(rawIgnore), "\n") {

--- a/project/config.go
+++ b/project/config.go
@@ -2,7 +2,7 @@ package project
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 
@@ -83,7 +83,7 @@ func loadProjectConf() (prj Project, err error) {
 	if err != nil {
 		return
 	}
-	raw, err := ioutil.ReadAll(config)
+	raw, err := io.ReadAll(config)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Functionality from `io/ioutil` has moved to the `io` and `os` packages in go1.16 ([reference](https://pkg.go.dev/io/ioutil)).

Confirmed that staticcheck passes when run with:

```
staticcheck -checks SA1019 ./...
```