### PR TITLE
Fix lint error regarding struct with unexported fields

### DIFF
--- a/cmd/sync/github.go
+++ b/cmd/sync/github.go
@@ -85,8 +85,8 @@ func githubGetPAT(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to acquire access token: %w", err)
 	}
 	raw, err = json.Marshal(struct {
-		note   string
-		scopes []string
+		Note   string   `json:"note"`
+		Scopes []string `json:"scopes"`
 	}{"test token", []string{}})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Unexported fields are skipped during marshalling, so this would be a nop.

The code in `./cmd/sync/github*.go` is currently unused.

Confirmed that staticcheck passes when run with:

```
staticcheck -checks SA9005 ./...
```