### PR TITLE
Build 32 bit Windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,12 @@ builds:
   goarch:
     - amd64
     - arm64
+    - '386'
+  ignore:
+    - goos: darwin
+      goarch: '386'
+    - goos: linux
+      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Win32 is needed by VSCode as a fallback.