### PR TITLE
Add `persist-snapshot` to bricks sync

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -59,11 +59,11 @@ var interval *time.Duration
 
 var remotePath *string
 
-var disableSnapshot *bool
+var persistSnapshot *bool
 
 func init() {
 	root.RootCmd.AddCommand(syncCmd)
 	interval = syncCmd.Flags().Duration("interval", 1*time.Second, "project files polling interval")
 	remotePath = syncCmd.Flags().String("remote-path", "", "remote path to store repo in. eg: /Repos/me@example.com/test-repo")
-	disableSnapshot = syncCmd.Flags().Bool("disable-snapshot", false, "Disable local snapshots of sync state")
+	persistSnapshot = syncCmd.Flags().Bool("persist-snapshot", true, "whether to store local snapshots of sync state")
 }

--- a/cmd/sync/watchdog.go
+++ b/cmd/sync/watchdog.go
@@ -94,7 +94,7 @@ func (w *watchdog) main(ctx context.Context, applyDiff func(diff) error) {
 	// load from json or sync it every time there's an action
 	state := snapshot{}
 	root := w.files.Root()
-	if !(*disableSnapshot) {
+	if *persistSnapshot {
 		err := state.loadSnapshot(root)
 		if err != nil {
 			log.Printf("[ERROR] cannot load snapshot: %s", err)
@@ -123,7 +123,7 @@ func (w *watchdog) main(ctx context.Context, applyDiff func(diff) error) {
 				w.failure = err
 				return
 			}
-			if !(*disableSnapshot) {
+			if *persistSnapshot {
 				err = state.storeSnapshot(root)
 				if err != nil {
 					log.Printf("[ERROR] cannot store snapshot: %s", err)


### PR DESCRIPTION
Tested manually

We are adding this flag because the default bricks sync is not robust against changing the profile and other project config changes. This will be used in the initial version of the vscode extention