### PR TITLE
[DECO-68] Modify acceptance test to work with deco testing infra and represent vscode usecase

### DIFF
--- a/internal/sync_test.go
+++ b/internal/sync_test.go
@@ -79,7 +79,7 @@ func TestAccFullSync(t *testing.T) {
 	cmd.Stderr = &cmdErr
 	cmd.Dir = bricksRepo
 	// bricks sync command will inherit the env vars from process
-	os.Setenv("BRICKS_ROOT", projectDir)
+	t.Setenv("BRICKS_ROOT", projectDir)
 	err = cmd.Start()
 	assert.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
Contains changes to make this integration test work on our GitHub actions testing env

1. use go run main.go to run bricks sync to run the latest bricks from master
2. Log the output from the bricks sync process to allow for debugging
3. removed databricks.yml and instead rely on BRICKS_ROOT and other env vars for auth and bricks sync
4. Added --persist-snapshot set to false to test full sync (same as is used in the vscode extension

<img width="898" alt="Screenshot 2022-09-27 at 4 26 18 PM" src="https://user-images.githubusercontent.com/88374338/192553769-7af08ca0-b73a-4cf6-a214-8c58edc4c3e5.png">

The additional logs in the picture above are from a wip PR in deco cli that I made some changes to in order to make deco cli work with bricks : https://github.com/databricks/eng-dev-ecosystem/pull/97