### PR TITLE
Function to limit interpolation to specific path

### DIFF
--- a/bundle/config/interpolation/lookup_test.go
+++ b/bundle/config/interpolation/lookup_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExcludePath(t *testing.T) {
-	tmp := struct {
-		A map[string]string `json:"a"`
-		B map[string]string `json:"b"`
-		C map[string]string `json:"c"`
-	}{
+type interpolationFixture struct {
+	A map[string]string `json:"a"`
+	B map[string]string `json:"b"`
+	C map[string]string `json:"c"`
+}
+
+func fixture() interpolationFixture {
+	return interpolationFixture{
 		A: map[string]string{
 			"x": "1",
 		},
@@ -24,7 +26,10 @@ func TestExcludePath(t *testing.T) {
 			"bx": "${b.x}",
 		},
 	}
+}
 
+func TestExcludePath(t *testing.T) {
+	tmp := fixture()
 	m := interpolate{
 		fn: ExcludeLookupsInPath("a"),
 	}
@@ -36,4 +41,19 @@ func TestExcludePath(t *testing.T) {
 	assert.Equal(t, "2", tmp.B["x"])
 	assert.Equal(t, "${a.x}", tmp.C["ax"])
 	assert.Equal(t, "2", tmp.C["bx"])
+}
+
+func TestIncludePath(t *testing.T) {
+	tmp := fixture()
+	m := interpolate{
+		fn: IncludeLookupsInPath("a"),
+	}
+
+	err := m.expand(&tmp)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1", tmp.A["x"])
+	assert.Equal(t, "2", tmp.B["x"])
+	assert.Equal(t, "1", tmp.C["ax"])
+	assert.Equal(t, "${b.x}", tmp.C["bx"])
 }


### PR DESCRIPTION
New function `IncludeLookupsInPath` is counterpart to `ExcludeLookupsInPath`.