### PR TITLE
Work on GitHub actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,13 +18,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
 
-
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
-        with:
-          token:  ${{ secrets.DECO_GITHUB_TOKEN }}
-          submodules: recursive
+        uses: actions/checkout@v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
@@ -32,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.18.8
           cache: true
 
       - name: Set go env
@@ -53,12 +49,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.18.8
 
           # No need to download cached dependencies when running gofmt.
           cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
-        with:
-          token:  ${{ secrets.DECO_GITHUB_TOKEN }}
-          submodules: recursive
+        uses: actions/checkout@v3
+
       - name: Unshallow
         run: git fetch --prune --unshallow
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.18.8
           cache: true
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.1.0
         with:


### PR DESCRIPTION
This does:
* Use actions/checkout@v3 (fixes node.js v12 deprecation warning)
* Pin Go version to 1.18.8 to make caching work better
* Remove checkout of submodules (we don't have any anymore)