### PR TITLE
Use pointers to resources in bundle configuration

### DIFF
--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -1,9 +1,11 @@
 package config
 
-import "github.com/databricks/bricks/bundle/config/resources"
+import (
+	"github.com/databricks/bricks/bundle/config/resources"
+)
 
 // Resources defines Databricks resources associated with the bundle.
 type Resources struct {
-	Jobs      map[string]resources.Job      `json:"jobs,omitempty"`
-	Pipelines map[string]resources.Pipeline `json:"pipelines,omitempty"`
+	Jobs      map[string]*resources.Job      `json:"jobs,omitempty"`
+	Pipelines map[string]*resources.Pipeline `json:"pipelines,omitempty"`
 }

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -33,8 +33,8 @@ func TestConvertJob(t *testing.T) {
 
 	var config = config.Root{
 		Resources: config.Resources{
-			Jobs: map[string]resources.Job{
-				"my_job": src,
+			Jobs: map[string]*resources.Job{
+				"my_job": &src,
 			},
 		},
 	}
@@ -67,8 +67,8 @@ func TestConvertJobTaskLibraries(t *testing.T) {
 
 	var config = config.Root{
 		Resources: config.Resources{
-			Jobs: map[string]resources.Job{
-				"my_job": src,
+			Jobs: map[string]*resources.Job{
+				"my_job": &src,
 			},
 		},
 	}


### PR DESCRIPTION
Avoid copy-by-value when iterating over these maps.