### PR TITLE
Remove version suffix from snapshot binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ builds:
       goarch: '386'
     - goos: linux
       goarch: '386'
-  binary: '{{ .ProjectName }}_v{{ .Version }}'
+  binary: '{{ .ProjectName }}'
 archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
@@ -30,7 +30,7 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 snapshot:
-  name_template: '{{ incpatch .Version }}-devel'
+  name_template: '{{ .ProjectName }}'
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
After this change it's possible to have a stable symlink for development:

<img width="172" alt="image" src="https://user-images.githubusercontent.com/259697/209996850-68bcb6da-b8f9-4b5a-9ac3-ff3ef35cd751.png">
