### PR TITLE
Allow sync to workspace path

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -63,7 +63,10 @@ func ensureRemotePathIsUsable(ctx context.Context, wsc *databricks.WorkspaceClie
 			if err != nil {
 				return fmt.Errorf("unable to create directory at %s: %w", path, err)
 			}
-			return ensureRemotePathIsUsable(ctx, wsc, me, path)
+			info, err = wsc.Workspace.GetStatusByPath(ctx, path)
+			if err != nil {
+				return err
+			}
 		default:
 			return err
 		}


### PR DESCRIPTION
With this change:
* Paths under `/Workspace/<me>` and `/Repos/<me>` are allowed
* The sync destination is checked to be either a directory or a repository
* If it is under `/Repos` and doesn't exist, the command returns an error