### PR TITLE
Remove dependency on project package in libs/sync

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -120,14 +120,26 @@ var syncCmd = &cobra.Command{
 			return err
 		}
 
-		s := sync.Sync{
-			LocalPath:       prj.Root(),
-			RemotePath:      *remotePath,
-			PersistSnapshot: *persistSnapshot,
-			PollInterval:    *interval,
+		cacheDir, err := prj.CacheDir()
+		if err != nil {
+			return err
 		}
 
-		return s.RunWatchdog(ctx, wsc)
+		opts := sync.SyncOptions{
+			LocalPath:        prj.Root(),
+			RemotePath:       *remotePath,
+			PersistSnapshot:  *persistSnapshot,
+			SnapshotBasePath: cacheDir,
+			PollInterval:     *interval,
+			WorkspaceClient:  wsc,
+		}
+
+		s, err := sync.New(opts)
+		if err != nil {
+			return err
+		}
+
+		return s.RunWatchdog(ctx)
 	},
 }
 

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -2,25 +2,60 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/databricks/bricks/git"
 	"github.com/databricks/bricks/libs/sync/repofiles"
 	"github.com/databricks/databricks-sdk-go"
 )
 
-type Sync struct {
+type SyncOptions struct {
 	LocalPath  string
 	RemotePath string
 
 	PersistSnapshot bool
 
+	SnapshotBasePath string
+
 	PollInterval time.Duration
+
+	WorkspaceClient *databricks.WorkspaceClient
+
+	Host string
+}
+
+type Sync struct {
+	*SyncOptions
+
+	fileSet *git.FileSet
+}
+
+// New initializes and returns a new [Sync] instance.
+func New(opts SyncOptions) (*Sync, error) {
+	fileSet := git.NewFileSet(opts.LocalPath)
+	err := fileSet.EnsureValidGitIgnoreExists()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: The host may be late-initialized in certain Azure setups where we
+	// specify the workspace by its resource ID. tracked in: https://databricks.atlassian.net/browse/DECO-194
+	opts.Host = opts.WorkspaceClient.Config.Host
+	if opts.Host == "" {
+		return nil, fmt.Errorf("failed to resolve host for snapshot")
+	}
+
+	return &Sync{
+		SyncOptions: &opts,
+		fileSet:     fileSet,
+	}, nil
 }
 
 // RunWatchdog kicks off a polling loop to monitor local changes and synchronize
 // them to the remote workspace path.
-func (s *Sync) RunWatchdog(ctx context.Context, wsc *databricks.WorkspaceClient) error {
-	repoFiles := repofiles.Create(s.RemotePath, s.LocalPath, wsc)
+func (s *Sync) RunWatchdog(ctx context.Context) error {
+	repoFiles := repofiles.Create(s.RemotePath, s.LocalPath, s.WorkspaceClient)
 	syncCallback := syncCallback(ctx, repoFiles)
-	return spawnWatchdog(ctx, s.PollInterval, syncCallback, s.RemotePath, s.PersistSnapshot)
+	return spawnWatchdog(ctx, syncCallback, s)
 }


### PR DESCRIPTION
The code depended on the project package for:
* git.FileSet in the watchdog
* project.CacheDir to determine snapshot path

These dependencies are now denormalized in the SyncOptions struct.

Follow up for #173.