### PR TITLE
Remove unused function git.RepoExists

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -9,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/databricks/bricks/folders"
-	"github.com/databricks/databricks-sdk-go"
-	"github.com/databricks/databricks-sdk-go/service/repos"
 	giturls "github.com/whilp/git-urls"
 	"gopkg.in/ini.v1"
 )
@@ -80,19 +77,4 @@ func RepositoryName() (string, error) {
 	}
 	base := path.Base(origin.Path)
 	return strings.TrimSuffix(base, ".git"), nil
-}
-
-func RepoExists(remotePath string, ctx context.Context, w *databricks.WorkspaceClient) (bool, error) {
-	repos, err := w.Repos.ListAll(ctx, repos.List{})
-	if err != nil {
-		return false, fmt.Errorf("could not get repos: %s", err)
-	}
-	foundRepo := false
-	for _, repo := range repos {
-		if repo.Path == remotePath {
-			foundRepo = true
-			break
-		}
-	}
-	return foundRepo, nil
 }


### PR DESCRIPTION
This function is no longer in use.

The SDK has native functionality for this through `GetByName`.

Closes #57.