### PR TITLE
Revert snapshot name template to previous value

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 snapshot:
-  name_template: '{{ .ProjectName }}'
+  name_template: '{{ incpatch .Version }}-devel'
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
This was changed in #159 but not necessary to have a stable binary name.