### PR TITLE
Include commit hash in snapshot version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,7 +30,7 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 snapshot:
-  name_template: '{{ incpatch .Version }}-devel'
+  name_template: '{{ incpatch .Version }}-dev+{{ .ShortCommit }}'
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
After this change the version for snapshot builds looks like `0.0.21-dev+65020f3`.

This is valid semver per the regexp on https://semver.org/.