### PR TITLE
[DECO-531] Increase timeout for file import api calls

### DIFF
--- a/libs/sync/repofiles/repofiles.go
+++ b/libs/sync/repofiles/repofiles.go
@@ -51,7 +51,9 @@ func (r *RepoFiles) readLocal(relativePath string) ([]byte, error) {
 }
 
 func (r *RepoFiles) writeRemote(ctx context.Context, relativePath string, content []byte) error {
-	apiClient, err := client.New(r.workspaceClient.Config)
+	apiClientConfig := r.workspaceClient.Config
+	apiClientConfig.HTTPTimeoutSeconds = 600
+	apiClient, err := client.New(apiClientConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR increases the client side timeout for upload API calls to 10 minutes to give sync enough time to import larger files