### PR TITLE
[DECO-553] Escape file path strings in URL

### DIFF
--- a/libs/sync/repofiles/repofiles.go
+++ b/libs/sync/repofiles/repofiles.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -61,9 +62,8 @@ func (r *RepoFiles) writeRemote(ctx context.Context, relativePath string, conten
 	if err != nil {
 		return err
 	}
-	apiPath := fmt.Sprintf(
-		"/api/2.0/workspace-files/import-file/%s?overwrite=true",
-		strings.TrimLeft(remotePath, "/"))
+	escapedPath := url.QueryEscape(strings.TrimLeft(remotePath, "/"))
+	apiPath := fmt.Sprintf("/api/2.0/workspace-files/import-file/%s?overwrite=true", escapedPath)
 
 	err = apiClient.Do(ctx, http.MethodPost, apiPath, content, nil)
 


### PR DESCRIPTION
Tested manually

Before:
```
shreyas.goenka@THW32HFW6T test-dbx % bricks sync --full . /Repos/shreyas.goenka@databricks.com/test-dbx
2023/02/27 19:51:17 [INFO] Remote file sync location: /Repos/shreyas.goenka@databricks.com/test-dbx
2023/02/27 19:51:17 [INFO] Action: PUT: #foo.py, .gitignore
2023/02/27 19:51:19 [INFO] Uploaded .gitignore
Error: Creating file failed. An item with path /Repos/shreyas.goenka@databricks.com/test-dbx already exists
```

After:
```
shreyas.goenka@THW32HFW6T test-dbx % bricks sync --full . /Repos/shreyas.goenka@databricks.com/test-dbx
2023/02/27 19:51:46 [INFO] Remote file sync location: /Repos/shreyas.goenka@databricks.com/test-dbx
2023/02/27 19:51:46 [INFO] Action: PUT: #foo.py, .gitignore
2023/02/27 19:51:47 [INFO] Uploaded .gitignore
2023/02/27 19:51:47 [INFO] Uploaded #foo.py
```