### PR TITLE
Remove redundant terraform initialize mutator

### DIFF
--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -21,7 +21,6 @@ var runCmd = &cobra.Command{
 		b := bundle.Get(cmd.Context())
 		err := bundle.Apply(cmd.Context(), b, []bundle.Mutator{
 			phases.Initialize(),
-			terraform.Initialize(),
 			terraform.Load(),
 		})
 		if err != nil {


### PR DESCRIPTION
Tested manually that bricks bundle run runs a pipeline.

phases.Initialize already has terraform.Initialize mutator