### PR TITLE
Drain sync event channel before returning

### DIFF
--- a/cmd/sync/output.go
+++ b/cmd/sync/output.go
@@ -1,10 +1,10 @@
 package sync
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"io"
-	"log"
 
 	"github.com/databricks/bricks/libs/sync"
 )
@@ -30,8 +30,10 @@ func jsonOutput(ctx context.Context, ch <-chan sync.Event, w io.Writer) {
 	}
 }
 
-// Read synchronization events and log them at the INFO level.
-func logOutput(ctx context.Context, ch <-chan sync.Event) {
+// Read synchronization events and write them as text to the specified writer (typically stdout).
+func textOutput(ctx context.Context, ch <-chan sync.Event, w io.Writer) {
+	bw := bufio.NewWriter(w)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -43,7 +45,9 @@ func logOutput(ctx context.Context, ch <-chan sync.Event) {
 			// Log only if something actually happened.
 			// Sync events produce an empty string if nothing happened.
 			if str := e.String(); str != "" {
-				log.Printf("[INFO] %s", e.String())
+				bw.WriteString(str)
+				bw.WriteString("\r\n")
+				bw.Flush()
 			}
 		}
 	}

--- a/libs/sync/event.go
+++ b/libs/sync/event.go
@@ -142,6 +142,7 @@ func newEventComplete(seq int, put []string, delete []string) Event {
 
 type EventNotifier interface {
 	Notify(ctx context.Context, event Event)
+	Close()
 }
 
 // ChannelNotifier implements [EventNotifier] and sends events to its channel.
@@ -156,9 +157,17 @@ func (n *ChannelNotifier) Notify(ctx context.Context, e Event) {
 	}
 }
 
+func (n *ChannelNotifier) Close() {
+	close(n.ch)
+}
+
 // NopNotifier implements [EventNotifier] and does nothing.
 type NopNotifier struct{}
 
 func (n *NopNotifier) Notify(ctx context.Context, e Event) {
 	// Discard
+}
+
+func (n *NopNotifier) Close() {
+	// Nothing to do
 }

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -96,6 +96,14 @@ func (s *Sync) Events() <-chan Event {
 	return ch
 }
 
+func (s *Sync) Close() {
+	if s.notifier == nil {
+		return
+	}
+	s.notifier.Close()
+	s.notifier = nil
+}
+
 func (s *Sync) notifyStart(ctx context.Context, d diff) {
 	// If this is not the initial iteration we can ignore no-ops.
 	if s.seq > 0 && d.IsEmpty() {


### PR DESCRIPTION
Not waiting means the last few events may or may not be printed.
This is relevant in the mode where sync runs once and then terminates.