### PR TITLE
Error when file does not exist

### DIFF
--- a/bundle/config/mutator/translate_notebook_paths.go
+++ b/bundle/config/mutator/translate_notebook_paths.go
@@ -3,7 +3,6 @@ package mutator
 import (
 	"context"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -35,10 +34,6 @@ func (m *translateNotebookPaths) rewritePath(b *bundle.Bundle, p *string) error 
 	absPath := filepath.Join(b.Config.Path, relPath)
 	nb, _, err := notebook.Detect(absPath)
 	if err != nil {
-		// Ignore if this file doesn't exist. Maybe it's an absolute workspace path?
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return fmt.Errorf("unable to determine if %s is a notebook: %w", relPath, err)
 	}
 

--- a/libs/notebook/detect.go
+++ b/libs/notebook/detect.go
@@ -3,6 +3,8 @@ package notebook
 import (
 	"bufio"
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -38,6 +40,10 @@ func readHeader(path string) ([]byte, error) {
 // If it is, it returns the notebook language.
 func Detect(path string) (notebook bool, language workspace.Language, err error) {
 	header := ""
+
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return false, "", fmt.Errorf("file %s does not exist", path)
+	}
 
 	// Determine which header to expect based on filename extension.
 	ext := strings.ToLower(filepath.Ext(path))


### PR DESCRIPTION
We should error out when the file does not exist. I had a workspace path set as the notebook path and I got an error that it's not a notebook which is very confusing. 

If we want to refer to an existing workspace notebook we should use a separate "fixture" field

Before (./my_notebook_task does not exist):
```
shreyas.goenka@THW32HFW6T job-output % bricks bundle deploy
Error: file at my_notebook_task is not a notebook
```

After:
```
shreyas.goenka@THW32HFW6T job-output % bricks bundle deploy
Error: unable to determine if my_notebook_task is a notebook: file /Users/shreyas.goenka/projects/job-output/my_notebook_task does not exist
```