### PR TITLE
Throw error when job run is skipped due to max_concurrent_runs

### DIFF
--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -190,6 +190,10 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) error {
 	if err != nil {
 		return err
 	}
+	if run.State.LifeCycleState == jobs.RunLifeCycleStateSkipped {
+		log.Infof(ctx, "Run was skipped!")
+		return fmt.Errorf("run skipped: %s", run.State.StateMessage)
+	}
 
 	switch run.State.ResultState {
 	// The run was canceled at user request.


### PR DESCRIPTION
Tested manually:

Before we did not have get any errors/logs and silently failed in this case

```
shreyas.goenka@THW32HFW6T job-output % bricks bundle run foo
Error: run skipped: Skipping this run because the limit of 1 maximum concurrent runs has been reached.
```