### PR TITLE
Allow logger defaults to be configured through environment variables

### DIFF
--- a/cmd/root/logger.go
+++ b/cmd/root/logger.go
@@ -3,11 +3,18 @@ package root
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/databricks/bricks/libs/flags"
 	"github.com/databricks/bricks/libs/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slog"
+)
+
+const (
+	envBricksLogFile   = "BRICKS_LOG_FILE"
+	envBricksLogLevel  = "BRICKS_LOG_LEVEL"
+	envBricksLogFormat = "BRICKS_LOG_FORMAT"
 )
 
 func initializeLogger(ctx context.Context, cmd *cobra.Command) (context.Context, error) {
@@ -41,6 +48,18 @@ var logLevel = flags.NewLogLevelFlag()
 var logOutput = flags.OutputText
 
 func init() {
+	// Configure defaults from environment, if applicable.
+	// If the provided value is invalid it is ignored.
+	if v, ok := os.LookupEnv(envBricksLogFile); ok {
+		logFile.Set(v)
+	}
+	if v, ok := os.LookupEnv(envBricksLogLevel); ok {
+		logLevel.Set(v)
+	}
+	if v, ok := os.LookupEnv(envBricksLogFormat); ok {
+		logOutput.Set(v)
+	}
+
 	RootCmd.PersistentFlags().Var(&logFile, "log-file", "file to write logs to")
 	RootCmd.PersistentFlags().Var(&logLevel, "log-level", "log level")
 	RootCmd.PersistentFlags().Var(&logOutput, "log-format", "log output format (text or json)")


### PR DESCRIPTION
These environment variables configure defaults for the logger related flags:
* `BRICKS_LOG_FILE`
* `BRICKS_LOG_LEVEL`
* `BRICKS_LOG_FORMAT`