### PR TITLE
Configure log level to info by default

### DIFF
--- a/libs/flags/log_level_flag.go
+++ b/libs/flags/log_level_flag.go
@@ -25,7 +25,9 @@ type LogLevelFlag struct {
 
 func NewLogLevelFlag() LogLevelFlag {
 	return LogLevelFlag{
-		l: log.LevelDisabled,
+		// Note: we log at INFO level by default until
+		// we implement progress reporting to stdout/stderr.
+		l: log.LevelInfo,
 	}
 }
 


### PR DESCRIPTION
Note: we log at INFO level by default until
we implement progress reporting to stdout/stderr.