### PR TITLE
Rewrite notebook path relative to Git repository root

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -7,11 +7,14 @@
 package bundle
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/databricks/bricks/bundle/config"
+	"github.com/databricks/bricks/folders"
+	"github.com/databricks/bricks/libs/git"
 	"github.com/databricks/bricks/libs/locker"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -114,4 +117,13 @@ func (b *Bundle) CacheDir(paths ...string) (string, error) {
 	}
 
 	return dir, nil
+}
+
+func (b *Bundle) GitRepository() (*git.Repository, error) {
+	rootPath, err := folders.FindDirWithLeaf(b.Config.Path, ".git")
+	if err != nil {
+		return nil, fmt.Errorf("unable to locate repository root: %w", err)
+	}
+
+	return git.NewRepository(rootPath)
 }

--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -32,6 +32,11 @@ type Repository struct {
 	ignore map[string][]ignoreRules
 }
 
+// Root returns the repository root.
+func (r *Repository) Root() string {
+	return r.rootPath
+}
+
 // loadConfig loads and combines user specific and repository specific configuration files.
 func (r *Repository) loadConfig() (*config, error) {
 	config, err := globalGitConfig()

--- a/libs/git/repository_test.go
+++ b/libs/git/repository_test.go
@@ -26,6 +26,9 @@ func TestRepository(t *testing.T) {
 	tr := testRepository{t, repo}
 	require.NoError(t, err)
 
+	// Check that the root path is real.
+	assert.True(t, filepath.IsAbs(repo.Root()))
+
 	// Check that top level ignores work.
 	assert.True(t, tr.Ignore(".DS_Store"))
 	assert.True(t, tr.Ignore("foo.pyc"))


### PR DESCRIPTION
## Changes

If a job's `git_source` field is set we assume an intent to source all notebooks in notebook tasks from that Git source.

To accommodate this without requiring the user to rewrite all paths to be relative to the Git repository root, we perform this transformation automatically.

## Tests

Existing and newly added tests pass.
