### PR TITLE
Ignore databricks_permissions resource when loading Terraform state

### DIFF
--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -193,6 +193,8 @@ func TerraformToBundle(state *tfjson.State, config *config.Root) error {
 			cur := config.Resources.Experiments[resource.Name]
 			conv(tmp, &cur)
 			config.Resources.Experiments[resource.Name] = cur
+		case "databricks_permissions":
+			// Ignore; no need to pull these back into the configuration.
 		default:
 			return fmt.Errorf("missing mapping for %s", resource.Type)
 		}


### PR DESCRIPTION
## Changes

The databricks_permissions resource may be generated if a bundle resource includes a `permissions` block. There's no need to incorporate details from the materialization into the bundle configuration struct.

## Tests

Confirmed that this fixes `bricks bundle run` when dealing with a bundle with permission configuration.