### PR TITLE
Build snapshot release for demo branches

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -3,7 +3,8 @@ name: release-snapshot
 on:
   push:
     branches:
-      - main
+      - "main"
+      - "demo-*"
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Changes

Idea: we use `demo-*` branches for demo-able builds that are not yet ready to be merged.

## Tests

n/a
