### PR TITLE
Set BRICKS_CLI_PATH only if it cannot be derived from $PATH

### DIFF
--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/databricks/bricks/libs/databrickscfg"
 	"github.com/databricks/databricks-sdk-go"
@@ -103,5 +104,11 @@ func (w *Workspace) Client() (*databricks.WorkspaceClient, error) {
 }
 
 func init() {
-	os.Setenv("BRICKS_CLI_PATH", os.Args[0])
+	arg0 := os.Args[0]
+
+	// Configure BRICKS_CLI_PATH only if our caller intends to use this specific version of this binary.
+	// Otherwise, if it is equal to its basename, processes can find it in $PATH.
+	if arg0 != filepath.Base(arg0) {
+		os.Setenv("BRICKS_CLI_PATH", arg0)
+	}
 }


### PR DESCRIPTION
## Changes

Related to #237.

Output of `bricks auth env` now doesn't include `BRICKS_CLI_PATH` if it can be found in $PATH.

## Tests

Verified manually.
