### PR TITLE
Make `bricks auth` use `all-apis` scope

### DIFF
--- a/libs/auth/oauth.go
+++ b/libs/auth/oauth.go
@@ -201,18 +201,7 @@ func (a *PersistentAuth) oauth2Config() (*oauth2.Config, error) {
 	// taxonomy of all scopes ready and implemented.
 	scopes := []string{
 		"offline_access",
-		"unity-catalog",
-		"accounts",
-		"clusters",
-		"mlflow",
-		"scim",
-		"sql",
-	}
-	if a.AccountID != "" {
-		scopes = []string{
-			"offline_access",
-			"accounts",
-		}
+		"all-apis",
 	}
 	endpoints, err := a.oidcEndpoints()
 	if err != nil {


### PR DESCRIPTION
## Changes
Use `all-apis` scope, so that we can use the issued token for SCIM APIs. The production environment has to be tuned in order to enable `all-apis` scope for a specific account.

## Tests
Manual

