### PR TITLE
Fix host based auth conflicting with DEFAULT profile

### DIFF
--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -88,9 +88,12 @@ func (w *Workspace) Client() (*databricks.WorkspaceClient, error) {
 		AzureLoginAppID:  w.AzureLoginAppID,
 	}
 
+	// HACKY fix to not used host based auth when the profile is already set
+	profile := os.Getenv("DATABRICKS_CONFIG_PROFILE")
+
 	// If only the host is configured, we try and unambiguously match it to
 	// a profile in the user's databrickscfg file. Override the default loaders.
-	if w.Host != "" {
+	if w.Host != "" && w.Profile == "" && profile == "" {
 		cfg.Loaders = []config.Loader{
 			// Load auth creds from env vars
 			config.ConfigAttributes,


### PR DESCRIPTION
## Changes
Consider the following host based configuration:
```
bundle:
  name: job_with_file_task

workspace:
  host: https://e2-dogfood.staging.cloud.databricks.com/
```

If you have a DEFAULT profile, then this host is ignored. The solution proposed here is to remove the profile config loader if host is explicitly specified in the bundle config.

This does come with a cost, namely that if a `DATABRICKS_CONFIG_PROFILE` env var will be ignored, which maybe goes against unified auth spec

The ideal solution here is probably to make a change to go-SDK to not select DEFAULT profile if host is not empty

## Tests
<!-- How is this tested? -->

