### PR TITLE
Fix output panic

### DIFF
--- a/bundle/run/job_output.go
+++ b/bundle/run/job_output.go
@@ -36,6 +36,9 @@ func (out *JobOutput) String() (string, error) {
 	taskKeys := maps.Keys(out.TaskOutputs)
 	sort.Strings(taskKeys)
 	for _, k := range taskKeys {
+		if out.TaskOutputs[k] == nil {
+			continue
+		}
 		taskString, err := out.TaskOutputs[k].String()
 		if err != nil {
 			return "", nil


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Output now:
```
{
  "run_page_url": "https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#job/6199333392110/run/1088443776202122",
  "task_outputs": {
    "input": null,
    "process": {
      "logs": "[Row(max(id)=9)]\n",
      "logs_truncated": false
    }
  }
}
```

## Tests
<!-- How is this tested? -->

