### PR TITLE
Pass through $HOME when invoking Terraform

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -96,6 +96,12 @@ func (m *initialize) Apply(ctx context.Context, b *bundle.Bundle) ([]bundle.Muta
 		return nil, err
 	}
 
+	// Include $HOME in set of environment variables to pass along.
+	home, ok := os.LookupEnv("HOME")
+	if ok {
+		env["HOME"] = home
+	}
+
 	// Configure environment variables for auth for Terraform to use.
 	log.Debugf(ctx, "Environment variables for Terraform: %s", strings.Join(maps.Keys(env), ", "))
 	err = tf.SetEnv(env)

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -1,0 +1,39 @@
+package terraform
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/databricks/bricks/bundle"
+	"github.com/databricks/bricks/bundle/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitEnvironmentVariables(t *testing.T) {
+	_, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skipf("cannot find terraform binary: %s", err)
+	}
+
+	bundle := &bundle.Bundle{
+		Config: config.Root{
+			Path: t.TempDir(),
+			Bundle: config.Bundle{
+				Environment: "whatever",
+				Terraform: &config.Terraform{
+					ExecPath: "terraform",
+				},
+			},
+		},
+	}
+
+	// Trigger initialization of workspace client.
+	// TODO(pietern): create test fixture that initializes a mocked client.
+	t.Setenv("DATABRICKS_HOST", "https://x")
+	t.Setenv("DATABRICKS_TOKEN", "foobar")
+	bundle.WorkspaceClient()
+
+	_, err = Initialize().Apply(context.Background(), bundle)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Changes

This is useful when developing the Databricks Terraform provider where you keep a local-only build of the provider and refer to it using $HOME from `~/.terraformrc`, for example like this:

```
plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"
```

## Tests

That $HOME is passed through cannot be tested as is because the `tfexec.Terraform` struct doesn't expose it through public fields or methods. What can be tested is a successful run of the initialize mutator and this is included in this commit.