### PR TITLE
Add tests for fileSet adding `databricks` to .gitignore

### DIFF
--- a/libs/git/fileset_test.go
+++ b/libs/git/fileset_test.go
@@ -1,7 +1,9 @@
 package git
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,4 +33,33 @@ func TestFileSetNonCleanRoot(t *testing.T) {
 	files, err := fileSet.All()
 	require.NoError(t, err)
 	assert.Len(t, files, 6)
+}
+
+func TestFilesetAddsCacheDirToGitIgnore(t *testing.T) {
+	projectDir := t.TempDir()
+	fileSet, err := NewFileSet(projectDir)
+	require.NoError(t, err)
+	fileSet.EnsureValidGitIgnoreExists()
+
+	gitIgnorePath := filepath.Join(projectDir, ".gitignore")
+	assert.FileExists(t, gitIgnorePath)
+	fileBytes, err := os.ReadFile(gitIgnorePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(fileBytes), ".databricks")
+}
+
+func TestFilesetDoesNotCacheDirToGitIgnoreIfAlreadyPresent(t *testing.T) {
+	projectDir := t.TempDir()
+	gitIgnorePath := filepath.Join(projectDir, ".gitignore")
+
+	fileSet, err := NewFileSet(projectDir)
+	require.NoError(t, err)
+	err = os.WriteFile(gitIgnorePath, []byte(".databricks"), 0o644)
+	require.NoError(t, err)
+
+	fileSet.EnsureValidGitIgnoreExists()
+
+	b, err := os.ReadFile(gitIgnorePath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(string(b), ".databricks"))
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

These are flows that were earlier only being tested in package `project`. Since package `project` has been deleted in https://github.com/databricks/bricks/pull/321, we needed to add coverage as done here

## Tests
<!-- How is this tested? -->

