### PR TITLE
Do not fail snapshot destroy if snapshot does not exist

### DIFF
--- a/libs/sync/snapshot.go
+++ b/libs/sync/snapshot.go
@@ -128,7 +128,7 @@ func (s *Snapshot) Save(ctx context.Context) error {
 
 func (s *Snapshot) Destroy(ctx context.Context) error {
 	err := os.Remove(s.SnapshotPath)
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to destroy sync snapshot file: %s", err)
 	}
 	return nil


### PR DESCRIPTION
## Changes
`bricks bundle destroy` would fail if the sync snapshot did not exist

## Tests
Manually

After:
```
shreyas.goenka@THW32HFW6T bundle-destroy % bricks bundle destroy --auto-approve
No resources to destroy!

Remote directory /Users/shreyas.goenka@databricks.com/.bundle/destroy/default will be deleted
Successfully deleted files!
```

Before:
```
shreyas.goenka@THW32HFW6T bundle-destroy % bricks bundle destroy --auto-approve
No resources to destroy!

Remote directory /Users/shreyas.goenka@databricks.com/.bundle/destroy/default will be deleted
Error: failed to destroy sync snapshot file: remove /Users/shreyas.goenka/projects/bundle-destroy/.databricks/bundle/default/sync-snapshots/a5bd1966cb8980a9.json: no such file or directory
```
