### PR TITLE
Fix wrap around issues with inplace logging

### DIFF
--- a/libs/cmdio/logger.go
+++ b/libs/cmdio/logger.go
@@ -46,9 +46,16 @@ func (l *Logger) Log(event Event) {
 	switch l.Mode {
 	case flags.ModeInplace:
 		if l.isFirstEvent {
-			l.Writer.Write([]byte("\n"))
+			// save cursor location
+			l.Writer.Write([]byte("\033[s"))
 		}
-		l.Writer.Write([]byte("\033[1F"))
+
+		// move cursor to saved location
+		l.Writer.Write([]byte("\033[u"))
+
+		// clear from cursor to end of screen
+		l.Writer.Write([]byte("\033[0J"))
+
 		l.Writer.Write([]byte(event.String()))
 		l.Writer.Write([]byte("\n"))
 


### PR DESCRIPTION
## Changes
We deal with wraparounds for long lines of text in a bad way. This PR fixes that by saving the cursor position

## Tests
Manually
