### PR TITLE
goreleaser deprecated --rm-dist in favor of --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build: vendor
 
 snapshot:
 	@echo "✓ Building dev snapshot"
-	@goreleaser build --snapshot --rm-dist --single-target
+	@goreleaser build --snapshot --clean --single-target
 
 vendor:
 	@echo "✓ Filling vendor folder with library code ..."


### PR DESCRIPTION
See https://goreleaser.com/deprecations#-rm-dist.

Observed in goreleaser step in https://github.com/databricks/bricks/actions/runs/4752794591/jobs/8443579583.