### PR TITLE
Add omitempty tag to bundle git details

### DIFF
--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -27,5 +27,5 @@ type Bundle struct {
 
 	// Contains Git information like current commit, current branch and
 	// origin url. Automatically loaded by reading .git directory if not specified
-	Git Git `json:"git"`
+	Git Git `json:"git,omitempty"`
 }


### PR DESCRIPTION
## Changes
Add omit empty tag to git details. Otherwise this field becomes a required field in the config json schema

## Tests
Tested by regenerating the json schema and checking that the git field is now optional 
