### PR TITLE
Fixed printing the tasks in job output in DAG execution order

### DIFF
--- a/bundle/run/output/job.go
+++ b/bundle/run/output/job.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TaskOutput struct {
-	Name    string
+	TaskKey string
 	Output  RunOutput
 	EndTime int64
 }
@@ -46,7 +46,7 @@ func (out *JobOutput) String() (string, error) {
 			return "", nil
 		}
 		result.WriteString("=======\n")
-		result.WriteString(fmt.Sprintf("Task %s:\n", v.Name))
+		result.WriteString(fmt.Sprintf("Task %s:\n", v.TaskKey))
 		result.WriteString(fmt.Sprintf("%s\n", taskString))
 	}
 	return result.String(), nil
@@ -69,7 +69,7 @@ func GetJobOutput(ctx context.Context, w *databricks.WorkspaceClient, runId int6
 		if err != nil {
 			return nil, err
 		}
-		task := TaskOutput{Name: task.TaskKey, Output: toRunOutput(jobRunOutput), EndTime: task.EndTime}
+		task := TaskOutput{TaskKey: task.TaskKey, Output: toRunOutput(jobRunOutput), EndTime: task.EndTime}
 		result.TaskOutputs = append(result.TaskOutputs, task)
 	}
 	return result, nil

--- a/bundle/run/output/job_test.go
+++ b/bundle/run/output/job_test.go
@@ -15,7 +15,7 @@ func TestSingleTaskJobOutputToString(t *testing.T) {
 	}
 	myJob := JobOutput{
 		TaskOutputs: []TaskOutput{
-			{Name: "my_notebook_task", Output: &taskNotebook, EndTime: 0},
+			{TaskKey: "my_notebook_task", Output: &taskNotebook, EndTime: 0},
 		},
 	}
 
@@ -36,8 +36,8 @@ func TestMultiTaskJobOutputToString(t *testing.T) {
 	}
 	myJob := JobOutput{
 		TaskOutputs: []TaskOutput{
-			{Name: "my_bar_task", Output: &taskBar, EndTime: 0},
-			{Name: "my_foo_task", Output: &taskFoo, EndTime: 0},
+			{TaskKey: "my_bar_task", Output: &taskBar, EndTime: 0},
+			{TaskKey: "my_foo_task", Output: &taskFoo, EndTime: 0},
 		},
 	}
 
@@ -69,9 +69,9 @@ func TestTaskJobOutputOrderToString(t *testing.T) {
 	}
 	myJob := JobOutput{
 		TaskOutputs: []TaskOutput{
-			{Name: "my_baz_task", Output: &taskBaz, EndTime: 1683553233331},
-			{Name: "my_bar_task", Output: &taskBar, EndTime: 1683553223508},
-			{Name: "my_foo_task", Output: &taskFoo, EndTime: 1683553217598},
+			{TaskKey: "my_baz_task", Output: &taskBaz, EndTime: 1683553233331},
+			{TaskKey: "my_bar_task", Output: &taskBar, EndTime: 1683553223508},
+			{TaskKey: "my_foo_task", Output: &taskFoo, EndTime: 1683553217598},
 		},
 	}
 


### PR DESCRIPTION
Fixes #259

## Changes
Sort task output in an execution order based on task end time

## Tests
Added `TestTaskJobOutputOrderToString` unit test.

Bundle configuration used for manual testing

```
bundle:
  name: multiple-tasks

workspace:
  host: ***

environments:
  development: {
    default: true
  }

  production: {}

resources:
  jobs:
    my_job_with_file_task:
      name: "[${bundle.environment}] Job with multiple tasks"

      tasks:
        - task_key: Task1
          existing_cluster_id: ***
          spark_python_task:
            python_file: ./test.py

        - task_key: Task2
          depends_on:
            - task_key: Task1
          existing_cluster_id: ***
          spark_python_task:
            python_file: ./test.py

        - task_key: Task3
          depends_on:
            - task_key: Task2
          existing_cluster_id: ***
          spark_python_task:
            python_file: ./test.py

        - task_key: Task4
          depends_on:
            - task_key: Task1
          existing_cluster_id: ***
          spark_python_task:
            python_file: ./test.py
```


Output

```
> bricks bundle run my_job_with_file_task

Run URL: ***

2023-05-08 16:08:00 "[development] Job with multiple tasks" RUNNING 
2023-05-08 16:08:23 "[development] Job with multiple tasks" TERMINATED SUCCESS 
Output:
=======
Task Task1:
Hello

=======
Task Task4:
Hello

=======
Task Task2:
Hello

=======
Task Task3:
Hello

```
