### PR TITLE
Release v0.100.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,29 @@
 # Version changelog
 
+## 0.100.0
+
+This release bumps the minor version to 100 to disambiguate between Databricks CLI "v1" (the Python version)
+and this version, Databricks CLI "v2". This release is a major rewrite of the CLI, and is not backwards compatible.
+
+CLI:
+* Rename bricks -> databricks ([#389](https://github.com/databricks/cli/pull/389)).
+
+Bundles:
+* Added ability for deferred mutator execution ([#380](https://github.com/databricks/cli/pull/380)).
+* Do not truncate local state file when pulling remote changes ([#382](https://github.com/databricks/cli/pull/382)).
+
 ## 0.0.32
- * Add support for variables in bundle config. Introduces 4 ways of setting variable values, which in decreasing order of priority are: ([#383](https://github.com/databricks/cli/pull/383))([#359](https://github.com/databricks/cli/pull/359)).
-	1. Command line flag. For example: `--var="foo=bar"`
-	2. Environment variable. eg: BUNDLE_VAR_foo=bar
-	3. Default value as defined in the applicable environments block
-	4. Default value defined in variable definition
- * Make the git details bundle config block optional ([#372](https://github.com/databricks/cli/pull/372)).
- * Fix api post integration tests ([#371](https://github.com/databricks/cli/pull/371)).
- * Fix table of content by removing not required top-level item ([#366](https://github.com/databricks/cli/pull/366)).
- * Fix printing the tasks in job output in DAG execution order ([#377](https://github.com/databricks/cli/pull/377)).
- * Improved error message when 'bricks bundle run' is executed before 'bricks bundle deploy' ([#378](https://github.com/databricks/cli/pull/378)).
+
+* Add support for variables in bundle config. Introduces 4 ways of setting variable values, which in decreasing order of priority are: ([#383](https://github.com/databricks/cli/pull/383))([#359](https://github.com/databricks/cli/pull/359)).
+  1. Command line flag. For example: `--var="foo=bar"`
+  2. Environment variable. eg: BUNDLE_VAR_foo=bar
+  3. Default value as defined in the applicable environments block
+  4. Default value defined in variable definition
+* Make the git details bundle config block optional ([#372](https://github.com/databricks/cli/pull/372)).
+* Fix api post integration tests ([#371](https://github.com/databricks/cli/pull/371)).
+* Fix table of content by removing not required top-level item ([#366](https://github.com/databricks/cli/pull/366)).
+* Fix printing the tasks in job output in DAG execution order ([#377](https://github.com/databricks/cli/pull/377)).
+* Improved error message when 'bricks bundle run' is executed before 'bricks bundle deploy' ([#378](https://github.com/databricks/cli/pull/378)).
 
 ## 0.0.31
 


### PR DESCRIPTION
## Changes

This release bumps the minor version to 100 to disambiguate between Databricks CLI "v1" (the Python version)
and this version, Databricks CLI "v2". This release is a major rewrite of the CLI, and is not backwards compatible.

CLI:
* Rename bricks -> databricks ([#389](https://github.com/databricks/cli/pull/389)).

Bundles:
* Added ability for deferred mutator execution ([#380](https://github.com/databricks/cli/pull/380)).
* Do not truncate local state file when pulling remote changes ([#382](https://github.com/databricks/cli/pull/382)).