### PR TITLE
Release v0.100.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Version changelog
 
+## 0.100.1
+
+CLI:
+* Sync: Gracefully handle broken notebook files ([#398](https://github.com/databricks/cli/pull/398)).
+* Add version flag to print version and exit ([#394](https://github.com/databricks/cli/pull/394)).
+* Pass temporary directory environment variables to subprocesses ([#395](https://github.com/databricks/cli/pull/395)).
+* Rename environment variables `BRICKS_` -> `DATABRICKS_` ([#393](https://github.com/databricks/cli/pull/393)).
+* Update to Go SDK v0.9.0 ([#396](https://github.com/databricks/cli/pull/396)).
+
 ## 0.100.0
 
 This release bumps the minor version to 100 to disambiguate between Databricks CLI "v1" (the Python version)


### PR DESCRIPTION
## Changes

CLI:
* Sync: Gracefully handle broken notebook files ([#398](https://github.com/databricks/cli/pull/398)).
* Add version flag to print version and exit ([#394](https://github.com/databricks/cli/pull/394)).
* Pass temporary directory environment variables to subprocesses ([#395](https://github.com/databricks/cli/pull/395)).
* Rename environment variables `BRICKS_` -> `DATABRICKS_` ([#393](https://github.com/databricks/cli/pull/393)).
* Update to Go SDK v0.9.0 ([#396](https://github.com/databricks/cli/pull/396)).
