### PR TITLE
Added build and upload steps for Python wheel artifacts

### DIFF
--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -42,5 +42,5 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return bundle.Apply(ctx, b, wheel.Build(m.name))
 	}
 
-	return nil, nil
+	return nil
 }

--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/artifacts/notebook"
+	"github.com/databricks/cli/bundle/artifacts/wheel"
 )
 
 func BuildAll() bundle.Mutator {
@@ -37,5 +38,9 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return bundle.Apply(ctx, b, notebook.Build(m.name))
 	}
 
-	return nil
+	if artifact.PythonPackage != nil {
+		return bundle.Apply(ctx, b, wheel.Build(m.name))
+	}
+
+	return nil, nil
 }

--- a/bundle/artifacts/upload.go
+++ b/bundle/artifacts/upload.go
@@ -42,5 +42,5 @@ func (m *upload) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return bundle.Apply(ctx, b, wheel.Upload(m.name))
 	}
 
-	return nil, nil
+	return nil
 }

--- a/bundle/artifacts/upload.go
+++ b/bundle/artifacts/upload.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/artifacts/notebook"
+	"github.com/databricks/cli/bundle/artifacts/wheel"
 )
 
 func UploadAll() bundle.Mutator {
@@ -37,5 +38,9 @@ func (m *upload) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return bundle.Apply(ctx, b, notebook.Upload(m.name))
 	}
 
-	return nil
+	if artifact.PythonPackage != nil {
+		return bundle.Apply(ctx, b, wheel.Upload(m.name))
+	}
+
+	return nil, nil
 }

--- a/bundle/artifacts/wheel/build.go
+++ b/bundle/artifacts/wheel/build.go
@@ -25,10 +25,10 @@ func (m *build) Name() string {
 	return fmt.Sprintf("wheel.Build(%s)", m.name)
 }
 
-func (m *build) Apply(ctx context.Context, b *bundle.Bundle) ([]bundle.Mutator, error) {
+func (m *build) Apply(ctx context.Context, b *bundle.Bundle) error {
 	a, ok := b.Config.Artifacts[m.name]
 	if !ok {
-		return nil, fmt.Errorf("artifact doesn't exist: %s", m.name)
+		return fmt.Errorf("artifact doesn't exist: %s", m.name)
 	}
 	cmdio.LogString(ctx, fmt.Sprintf("Starting build of Python wheel artifact: %s", m.name))
 
@@ -38,21 +38,21 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) ([]bundle.Mutator, 
 		artifact.Path = d
 	}
 	if _, err := os.Stat(artifact.Path); os.IsNotExist(err) {
-		return nil, fmt.Errorf("artifact path does't exists: %s", artifact.Path)
+		return fmt.Errorf("artifact path does't exists: %s", artifact.Path)
 	}
 	wheelPath, err := python.BuildWheel(ctx, artifact.Path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	artifact.LocalPath = wheelPath
 
 	remotePath := b.Config.Workspace.ArtifactsPath
 	if remotePath == "" {
-		return nil, fmt.Errorf("remote artifact path not configured")
+		return fmt.Errorf("remote artifact path not configured")
 	}
 	artifact.RemotePath = path.Join(remotePath, path.Base(wheelPath))
 	cmdio.LogString(ctx, fmt.Sprintf("Built Python wheel artifact: %s", m.name))
 
-	return nil, nil
+	return nil
 }

--- a/bundle/artifacts/wheel/build.go
+++ b/bundle/artifacts/wheel/build.go
@@ -1,0 +1,58 @@
+package wheel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/python"
+)
+
+type build struct {
+	name string
+}
+
+func Build(name string) bundle.Mutator {
+	return &build{
+		name: name,
+	}
+}
+
+func (m *build) Name() string {
+	return fmt.Sprintf("wheel.Build(%s)", m.name)
+}
+
+func (m *build) Apply(ctx context.Context, b *bundle.Bundle) ([]bundle.Mutator, error) {
+	a, ok := b.Config.Artifacts[m.name]
+	if !ok {
+		return nil, fmt.Errorf("artifact doesn't exist: %s", m.name)
+	}
+	cmdio.LogString(ctx, fmt.Sprintf("Starting build of Python wheel artifact: %s", m.name))
+
+	artifact := a.PythonPackage
+	if artifact.Path == "" {
+		d, _ := os.Getwd()
+		artifact.Path = d
+	}
+	if _, err := os.Stat(artifact.Path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("artifact path does't exists: %s", artifact.Path)
+	}
+	wheelPath, err := python.BuildWheel(ctx, artifact.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	artifact.LocalPath = wheelPath
+
+	remotePath := b.Config.Workspace.ArtifactsPath
+	if remotePath == "" {
+		return nil, fmt.Errorf("remote artifact path not configured")
+	}
+	artifact.RemotePath = path.Join(remotePath, path.Base(wheelPath))
+	cmdio.LogString(ctx, fmt.Sprintf("Built Python wheel artifact: %s", m.name))
+
+	return nil, nil
+}

--- a/bundle/artifacts/wheel/upload.go
+++ b/bundle/artifacts/wheel/upload.go
@@ -1,0 +1,68 @@
+package wheel
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+type upload struct {
+	name string
+}
+
+func Upload(name string) bundle.Mutator {
+	return &upload{
+		name: name,
+	}
+}
+
+func (m *upload) Name() string {
+	return fmt.Sprintf("wheel.Upload(%s)", m.name)
+}
+
+func (m *upload) Apply(ctx context.Context, b *bundle.Bundle) ([]bundle.Mutator, error) {
+	a, ok := b.Config.Artifacts[m.name]
+	if !ok {
+		return nil, fmt.Errorf("artifact doesn't exist: %s", m.name)
+	}
+
+	cmdio.LogString(ctx, fmt.Sprintf("Starting upload of Python wheel artifact: %s", m.name))
+
+	artifact := a.PythonPackage
+	raw, err := os.ReadFile(artifact.LocalPath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read %s: %w", m.name, errors.Unwrap(err))
+	}
+
+	// Make sure target directory exists.
+	err = b.WorkspaceClient().Workspace.MkdirsByPath(ctx, path.Dir(artifact.RemotePath))
+	if err != nil {
+		var apiErr *apierr.APIError
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode != "RESOURCE_ALREADY_EXISTS" {
+			return nil, fmt.Errorf("unable to create directory for %s: %w", path.Dir(artifact.RemotePath), err)
+		}
+	}
+
+	// Import to workspace.
+	err = b.WorkspaceClient().Workspace.Import(ctx, workspace.Import{
+		Path:      artifact.RemotePath,
+		Overwrite: true,
+		Format:    workspace.ExportFormatSource,
+		Language:  workspace.LanguagePython,
+		Content:   base64.StdEncoding.EncodeToString(raw),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to import %s: %w", m.name, err)
+	}
+
+	cmdio.LogString(ctx, fmt.Sprintf("Uploaded Python wheel artifact: %s. Artifact path: %s", m.name, artifact.RemotePath))
+	return nil, nil
+}

--- a/bundle/config/artifact.go
+++ b/bundle/config/artifact.go
@@ -5,7 +5,8 @@ import "github.com/databricks/databricks-sdk-go/service/workspace"
 // Artifact defines a single local code artifact that can be
 // built/uploaded/referenced in the context of this bundle.
 type Artifact struct {
-	Notebook *NotebookArtifact `json:"notebook,omitempty"`
+	Notebook      *NotebookArtifact      `json:"notebook,omitempty"`
+	PythonPackage *PythonPackageArtifact `json:"python_package,omitempty"`
 }
 
 type NotebookArtifact struct {
@@ -13,6 +14,14 @@ type NotebookArtifact struct {
 
 	// Language is detected during build step.
 	Language workspace.Language `json:"language,omitempty" bundle:"readonly"`
+
+	// Paths are synthesized during build step.
+	LocalPath  string `json:"local_path,omitempty" bundle:"readonly"`
+	RemotePath string `json:"remote_path,omitempty" bundle:"readonly"`
+}
+
+type PythonPackageArtifact struct {
+	Path string `json:"path"`
 
 	// Paths are synthesized during build step.
 	LocalPath  string `json:"local_path,omitempty" bundle:"readonly"`


### PR DESCRIPTION
## Changes
Added build and upload steps for Python wheel artifacts

#### TODO (next PRs)
- Way to configure a job to execute Python wheel package built and deployed via bundle
- Auto detect location of Python package

## Tests
### Example of DAB bundle config

```
bundle:
  name: wheel-task

artifacts:
  my_test_package:
    python_package: {}

workspace:
  host: ***

resources:
  jobs:
    test_job:
      name: "[${bundle.environment}] My Wheel Job"

      tasks:
        - task_key: TestTask
          existing_cluster_id: ***
...

```

Building and deploying bundle
```
andrew.nester@HFW9Y94129 wheel % cli bundle deploy
Starting build of Python wheel artifact: my_test_package
Built Python wheel artifact: my_test_package
Starting upload of bundle files
Uploaded bundle files at /Users/andrew.nester@databricks.com/.bundle/wheel-task/development/files!

Starting upload of Python wheel artifact: my_test_package
Uploaded Python wheel artifact: my_test_package. Artifact path: /Users/andrew.nester@databricks.com/.bundle/wheel-task/development/artifacts/my_test_package-0.0.1-py3-none-any.whl
Starting resource deployment

```

### Example with a wrong path

```
bundle:
  name: wheel-task

artifacts:
  my_test_package:
    python_package: {
      path: "./non-existing-package"
    }
...
```

Building and deploying bundle
```
andrew.nester@HFW9Y94129 wheel % cli bundle deploy
Starting build of Python wheel artifact: my_test_package
Error: artifact path does't exists: ./non-existing-package
```

