### PR TITLE
Fix locker integration test

### DIFF
--- a/internal/locker_test.go
+++ b/internal/locker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"math/rand"
 	"sync"
 	"testing"
@@ -142,7 +143,7 @@ func TestAccLock(t *testing.T) {
 	err = lockers[indexOfActiveLocker].Unlock(ctx)
 	assert.NoError(t, err)
 	remoteLocker, err = locker.GetActiveLockState(ctx)
-	assert.ErrorContains(t, err, "File not found.", "remote lock file not deleted on unlock")
+	assert.ErrorIs(t, err, fs.ErrNotExist, "remote lock file not deleted on unlock")
 	assert.Nil(t, remoteLocker)
 	assert.False(t, lockers[indexOfActiveLocker].Active)
 


### PR DESCRIPTION
## Changes

The failure was caused by swapping out the error types returned by the filer in #139.

## Tests

Integration tests pass again.
