### PR TITLE
Use cmdio in version command for `--output` flag

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,34 +1,25 @@
 package version
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/internal/build"
+	"github.com/databricks/cli/libs/cmdio"
 	"github.com/spf13/cobra"
 )
-
-var detail = false
 
 var versionCmd = &cobra.Command{
 	Use:  "version",
 	Args: cobra.NoArgs,
 
-	RunE: func(cmd *cobra.Command, args []string) error {
-		info := build.GetInfo()
-		if detail {
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-			return enc.Encode(info)
-		}
+	Annotations: map[string]string{
+		"template": "Databricks CLI v{{.Version}}\n",
+	},
 
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "Databricks CLI v%s\n", info.Version)
-		return err
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmdio.Render(cmd.Context(), build.GetInfo())
 	},
 }
 
 func init() {
-	versionCmd.Flags().BoolVar(&detail, "detail", false, "output detailed version information as JSON")
 	root.RootCmd.AddCommand(versionCmd)
 }

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -26,4 +27,16 @@ func TestVersionCommand(t *testing.T) {
 	stdout, stderr := RequireSuccessfulRun(t, "version")
 	assert.Equal(t, expectedVersion, stdout.String())
 	assert.Equal(t, "", stderr.String())
+}
+
+func TestVersionCommandWithJSONOutput(t *testing.T) {
+	stdout, stderr := RequireSuccessfulRun(t, "version", "--output", "json")
+	assert.NotEmpty(t, stdout.String())
+	assert.Equal(t, "", stderr.String())
+
+	// Deserialize stdout and confirm we see the right fields.
+	var output map[string]any
+	err := json.Unmarshal(stdout.Bytes(), &output)
+	assert.NoError(t, err)
+	assert.Equal(t, build.GetInfo().Version, output["Version"])
 }


### PR DESCRIPTION
## Changes

Use cmdio in the version command such that it accepts the `--output` flag.

This removes the existing `--detail` flag which previously made the command print JSON output.

## Tests

New integration test passes.

