### PR TITLE
Better error message if can not load prompts

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -101,7 +101,7 @@ var {{.CamelName}}Cmd = &cobra.Command{
 					names, err := {{if .Service.IsAccounts}}a{{else}}w{{end}}.{{(.Service.TrimPrefix "account").PascalName}}.{{.Service.List.NamedIdMap.PascalName}}(ctx{{if .Service.List.Request}}, {{.Service.Package.Name}}.{{.Service.List.Request.PascalName}}{}{{end}})
 					close(promptSpinner)
 					if err != nil {
-						return fmt.Errorf("failed to load names for {{.Service.TitleName}} drop-down. Please manually specify required arguments")
+						return fmt.Errorf("failed to load names for {{.Service.TitleName}} drop-down. Please manually specify required arguments. Original error: %w", err)
 					}
 					id, err := cmdio.Select(ctx, names, "{{range .Request.RequiredFields}}{{.Summary | trimSuffix "."}}{{end}}")
 					if err != nil {

--- a/cmd/account/budgets/budgets.go
+++ b/cmd/account/budgets/budgets.go
@@ -99,7 +99,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Budgets.BudgetWithStatusNameToBudgetIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Budgets drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Budgets drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Budget ID")
 				if err != nil {
@@ -158,7 +158,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Budgets.BudgetWithStatusNameToBudgetIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Budgets drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Budgets drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Budget ID")
 				if err != nil {

--- a/cmd/account/credentials/credentials.go
+++ b/cmd/account/credentials/credentials.go
@@ -118,7 +118,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Credentials.CredentialCredentialsNameToCredentialsIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Credentials drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API credential configuration ID")
 				if err != nil {
@@ -177,7 +177,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Credentials.CredentialCredentialsNameToCredentialsIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Credentials drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API credential configuration ID")
 				if err != nil {

--- a/cmd/account/groups/groups.go
+++ b/cmd/account/groups/groups.go
@@ -116,7 +116,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Groups.GroupDisplayNameToIdMap(ctx, iam.ListAccountGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a group in the Databricks account")
 				if err != nil {
@@ -174,7 +174,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Groups.GroupDisplayNameToIdMap(ctx, iam.ListAccountGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a group in the Databricks account")
 				if err != nil {
@@ -289,7 +289,7 @@ var patchCmd = &cobra.Command{
 				names, err := a.Groups.GroupDisplayNameToIdMap(ctx, iam.ListAccountGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a group in the Databricks account")
 				if err != nil {
@@ -355,7 +355,7 @@ var updateCmd = &cobra.Command{
 				names, err := a.Groups.GroupDisplayNameToIdMap(ctx, iam.ListAccountGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks group ID")
 				if err != nil {

--- a/cmd/account/ip-access-lists/ip-access-lists.go
+++ b/cmd/account/ip-access-lists/ip-access-lists.go
@@ -137,7 +137,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding IP access list")
 				if err != nil {
@@ -195,7 +195,7 @@ var getCmd = &cobra.Command{
 				names, err := a.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding IP access list")
 				if err != nil {

--- a/cmd/account/log-delivery/log-delivery.go
+++ b/cmd/account/log-delivery/log-delivery.go
@@ -188,7 +188,7 @@ var getCmd = &cobra.Command{
 				names, err := a.LogDelivery.LogDeliveryConfigurationConfigNameToConfigIdMap(ctx, billing.ListLogDeliveryRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Log Delivery drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Log Delivery drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks log delivery configuration ID")
 				if err != nil {

--- a/cmd/account/networks/networks.go
+++ b/cmd/account/networks/networks.go
@@ -63,7 +63,7 @@ var createCmd = &cobra.Command{
 				names, err := a.Networks.NetworkNetworkNameToNetworkIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Networks drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Networks drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The human-readable name of the network configuration")
 				if err != nil {
@@ -126,7 +126,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Networks.NetworkNetworkNameToNetworkIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Networks drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Networks drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API network configuration ID")
 				if err != nil {
@@ -185,7 +185,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Networks.NetworkNetworkNameToNetworkIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Networks drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Networks drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API network configuration ID")
 				if err != nil {

--- a/cmd/account/private-access/private-access.go
+++ b/cmd/account/private-access/private-access.go
@@ -128,7 +128,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.PrivateAccess.PrivateAccessSettingsPrivateAccessSettingsNameToPrivateAccessSettingsIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Private Access drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Private Access drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API private access settings ID")
 				if err != nil {
@@ -193,7 +193,7 @@ var getCmd = &cobra.Command{
 				names, err := a.PrivateAccess.PrivateAccessSettingsPrivateAccessSettingsNameToPrivateAccessSettingsIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Private Access drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Private Access drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API private access settings ID")
 				if err != nil {

--- a/cmd/account/service-principals/service-principals.go
+++ b/cmd/account/service-principals/service-principals.go
@@ -115,7 +115,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListAccountServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a service principal in the Databricks account")
 				if err != nil {
@@ -174,7 +174,7 @@ var getCmd = &cobra.Command{
 				names, err := a.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListAccountServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a service principal in the Databricks account")
 				if err != nil {
@@ -290,7 +290,7 @@ var patchCmd = &cobra.Command{
 				names, err := a.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListAccountServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a service principal in the Databricks account")
 				if err != nil {
@@ -359,7 +359,7 @@ var updateCmd = &cobra.Command{
 				names, err := a.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListAccountServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks service principal ID")
 				if err != nil {

--- a/cmd/account/storage/storage.go
+++ b/cmd/account/storage/storage.go
@@ -114,7 +114,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Storage.StorageConfigurationStorageConfigurationNameToStorageConfigurationIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Storage drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Storage drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API storage configuration ID")
 				if err != nil {
@@ -172,7 +172,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Storage.StorageConfigurationStorageConfigurationNameToStorageConfigurationIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Storage drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Storage drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks Account API storage configuration ID")
 				if err != nil {

--- a/cmd/account/users/users.go
+++ b/cmd/account/users/users.go
@@ -124,7 +124,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Users.UserUserNameToIdMap(ctx, iam.ListAccountUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a user in the Databricks account")
 				if err != nil {
@@ -182,7 +182,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Users.UserUserNameToIdMap(ctx, iam.ListAccountUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a user in the Databricks account")
 				if err != nil {
@@ -298,7 +298,7 @@ var patchCmd = &cobra.Command{
 				names, err := a.Users.UserUserNameToIdMap(ctx, iam.ListAccountUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a user in the Databricks account")
 				if err != nil {
@@ -367,7 +367,7 @@ var updateCmd = &cobra.Command{
 				names, err := a.Users.UserUserNameToIdMap(ctx, iam.ListAccountUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Account Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks user ID")
 				if err != nil {

--- a/cmd/account/vpc-endpoints/vpc-endpoints.go
+++ b/cmd/account/vpc-endpoints/vpc-endpoints.go
@@ -70,7 +70,7 @@ var createCmd = &cobra.Command{
 				names, err := a.VpcEndpoints.VpcEndpointVpcEndpointNameToVpcEndpointIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Vpc Endpoints drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Vpc Endpoints drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The human-readable name of the storage configuration")
 				if err != nil {
@@ -136,7 +136,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.VpcEndpoints.VpcEndpointVpcEndpointNameToVpcEndpointIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Vpc Endpoints drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Vpc Endpoints drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks VPC endpoint ID")
 				if err != nil {
@@ -198,7 +198,7 @@ var getCmd = &cobra.Command{
 				names, err := a.VpcEndpoints.VpcEndpointVpcEndpointNameToVpcEndpointIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Vpc Endpoints drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Vpc Endpoints drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks VPC endpoint ID")
 				if err != nil {

--- a/cmd/account/workspaces/workspaces.go
+++ b/cmd/account/workspaces/workspaces.go
@@ -89,7 +89,7 @@ var createCmd = &cobra.Command{
 				names, err := a.Workspaces.WorkspaceWorkspaceNameToWorkspaceIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The workspace's human-readable name")
 				if err != nil {
@@ -171,7 +171,7 @@ var deleteCmd = &cobra.Command{
 				names, err := a.Workspaces.WorkspaceWorkspaceNameToWorkspaceIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Workspace ID")
 				if err != nil {
@@ -245,7 +245,7 @@ var getCmd = &cobra.Command{
 				names, err := a.Workspaces.WorkspaceWorkspaceNameToWorkspaceIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Workspace ID")
 				if err != nil {
@@ -459,7 +459,7 @@ var updateCmd = &cobra.Command{
 				names, err := a.Workspaces.WorkspaceWorkspaceNameToWorkspaceIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspaces drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Workspace ID")
 				if err != nil {

--- a/cmd/workspace/alerts/alerts.go
+++ b/cmd/workspace/alerts/alerts.go
@@ -111,7 +111,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Alerts.AlertNameToIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Alerts drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Alerts drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -169,7 +169,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Alerts.AlertNameToIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Alerts drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Alerts drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {

--- a/cmd/workspace/cluster-policies/cluster-policies.go
+++ b/cmd/workspace/cluster-policies/cluster-policies.go
@@ -83,7 +83,7 @@ var createCmd = &cobra.Command{
 				names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Cluster Policy name requested by the user")
 				if err != nil {
@@ -142,7 +142,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the policy to delete")
 				if err != nil {
@@ -256,7 +256,7 @@ var getCmd = &cobra.Command{
 				names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Canonical unique identifier for the cluster policy")
 				if err != nil {

--- a/cmd/workspace/clusters/clusters.go
+++ b/cmd/workspace/clusters/clusters.go
@@ -174,7 +174,7 @@ var createCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The Spark version of the cluster, e.g")
 				if err != nil {
@@ -257,7 +257,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The cluster to be terminated")
 				if err != nil {
@@ -448,7 +448,7 @@ var eventsCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the cluster to retrieve events about")
 				if err != nil {
@@ -512,7 +512,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The cluster about which to retrieve information")
 				if err != nil {
@@ -688,7 +688,7 @@ var permanentDeleteCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The cluster to be deleted")
 				if err != nil {
@@ -748,7 +748,7 @@ var pinCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "<needs content added>")
 				if err != nil {
@@ -815,7 +815,7 @@ var resizeCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The cluster to be resized")
 				if err != nil {
@@ -898,7 +898,7 @@ var restartCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The cluster to be started")
 				if err != nil {
@@ -1013,7 +1013,7 @@ var startCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The cluster to be started")
 				if err != nil {
@@ -1090,7 +1090,7 @@ var unpinCmd = &cobra.Command{
 				names, err := w.Clusters.ClusterInfoClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "<needs content added>")
 				if err != nil {

--- a/cmd/workspace/dashboards/dashboards.go
+++ b/cmd/workspace/dashboards/dashboards.go
@@ -110,7 +110,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Dashboards.DashboardNameToIdMap(ctx, sql.ListDashboardsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Dashboards drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Dashboards drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -169,7 +169,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Dashboards.DashboardNameToIdMap(ctx, sql.ListDashboardsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Dashboards drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Dashboards drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -279,7 +279,7 @@ var restoreCmd = &cobra.Command{
 				names, err := w.Dashboards.DashboardNameToIdMap(ctx, sql.ListDashboardsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Dashboards drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Dashboards drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {

--- a/cmd/workspace/git-credentials/git-credentials.go
+++ b/cmd/workspace/git-credentials/git-credentials.go
@@ -65,7 +65,7 @@ var createCmd = &cobra.Command{
 				names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Git provider")
 				if err != nil {
@@ -123,7 +123,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding credential to access")
 				if err != nil {
@@ -184,7 +184,7 @@ var getCmd = &cobra.Command{
 				names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding credential to access")
 				if err != nil {
@@ -277,7 +277,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding credential to access")
 				if err != nil {

--- a/cmd/workspace/global-init-scripts/global-init-scripts.go
+++ b/cmd/workspace/global-init-scripts/global-init-scripts.go
@@ -114,7 +114,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.GlobalInitScripts.GlobalInitScriptDetailsNameToScriptIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Global Init Scripts drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Global Init Scripts drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the global init script")
 				if err != nil {
@@ -172,7 +172,7 @@ var getCmd = &cobra.Command{
 				names, err := w.GlobalInitScripts.GlobalInitScriptDetailsNameToScriptIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Global Init Scripts drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Global Init Scripts drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the global init script")
 				if err != nil {

--- a/cmd/workspace/groups/groups.go
+++ b/cmd/workspace/groups/groups.go
@@ -116,7 +116,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Groups.GroupDisplayNameToIdMap(ctx, iam.ListGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a group in the Databricks workspace")
 				if err != nil {
@@ -174,7 +174,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Groups.GroupDisplayNameToIdMap(ctx, iam.ListGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a group in the Databricks workspace")
 				if err != nil {
@@ -289,7 +289,7 @@ var patchCmd = &cobra.Command{
 				names, err := w.Groups.GroupDisplayNameToIdMap(ctx, iam.ListGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a group in the Databricks workspace")
 				if err != nil {
@@ -355,7 +355,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Groups.GroupDisplayNameToIdMap(ctx, iam.ListGroupsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Groups drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks group ID")
 				if err != nil {

--- a/cmd/workspace/instance-pools/instance-pools.go
+++ b/cmd/workspace/instance-pools/instance-pools.go
@@ -133,7 +133,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The instance pool to be terminated")
 				if err != nil {
@@ -253,7 +253,7 @@ var getCmd = &cobra.Command{
 				names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical unique identifier for the instance pool")
 				if err != nil {

--- a/cmd/workspace/ip-access-lists/ip-access-lists.go
+++ b/cmd/workspace/ip-access-lists/ip-access-lists.go
@@ -138,7 +138,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding IP access list to modify")
 				if err != nil {
@@ -196,7 +196,7 @@ var getCmd = &cobra.Command{
 				names, err := w.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding IP access list to modify")
 				if err != nil {

--- a/cmd/workspace/jobs/jobs.go
+++ b/cmd/workspace/jobs/jobs.go
@@ -74,7 +74,7 @@ var cancelAllRunsCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier of the job to cancel all runs of")
 				if err != nil {
@@ -141,7 +141,7 @@ var cancelRunCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "This field is required")
 				if err != nil {
@@ -290,7 +290,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier of the job to delete")
 				if err != nil {
@@ -351,7 +351,7 @@ var deleteRunCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier of the run for which to retrieve the metadata")
 				if err != nil {
@@ -414,7 +414,7 @@ var exportRunCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier for the run")
 				if err != nil {
@@ -475,7 +475,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier of the job to retrieve information about")
 				if err != nil {
@@ -543,7 +543,7 @@ var getRunCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier of the run for which to retrieve the metadata")
 				if err != nil {
@@ -613,7 +613,7 @@ var getRunOutputCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier for the run")
 				if err != nil {
@@ -802,7 +802,7 @@ var repairRunCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The job run ID of the run to repair")
 				if err != nil {
@@ -951,7 +951,7 @@ var runNowCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the job to be executed")
 				if err != nil {
@@ -1128,7 +1128,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The canonical identifier of the job to update")
 				if err != nil {

--- a/cmd/workspace/metastores/metastores.go
+++ b/cmd/workspace/metastores/metastores.go
@@ -201,7 +201,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Metastores.MetastoreInfoNameToMetastoreIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID of the metastore")
 				if err != nil {
@@ -260,7 +260,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Metastores.MetastoreInfoNameToMetastoreIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID of the metastore")
 				if err != nil {
@@ -488,7 +488,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Metastores.MetastoreInfoNameToMetastoreIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID of the metastore")
 				if err != nil {
@@ -552,7 +552,7 @@ var updateAssignmentCmd = &cobra.Command{
 				names, err := w.Metastores.MetastoreInfoNameToMetastoreIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Metastores drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "A workspace ID")
 				if err != nil {

--- a/cmd/workspace/pipelines/pipelines.go
+++ b/cmd/workspace/pipelines/pipelines.go
@@ -136,7 +136,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -197,7 +197,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -309,7 +309,7 @@ var listPipelineEventsCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -423,7 +423,7 @@ var listUpdatesCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The pipeline to return updates for")
 				if err != nil {
@@ -486,7 +486,7 @@ var resetCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -566,7 +566,7 @@ var startUpdateCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -629,7 +629,7 @@ var stopCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -724,7 +724,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique identifier for this pipeline")
 				if err != nil {

--- a/cmd/workspace/providers/providers.go
+++ b/cmd/workspace/providers/providers.go
@@ -111,7 +111,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of the provider")
 				if err != nil {
@@ -171,7 +171,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of the provider")
 				if err != nil {
@@ -283,7 +283,7 @@ var listSharesCmd = &cobra.Command{
 				names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of the provider in which to list shares")
 				if err != nil {
@@ -349,7 +349,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The name of the Provider")
 				if err != nil {

--- a/cmd/workspace/queries/queries.go
+++ b/cmd/workspace/queries/queries.go
@@ -121,7 +121,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Queries.QueryNameToIdMap(ctx, sql.ListQueriesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -180,7 +180,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Queries.QueryNameToIdMap(ctx, sql.ListQueriesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -292,7 +292,7 @@ var restoreCmd = &cobra.Command{
 				names, err := w.Queries.QueryNameToIdMap(ctx, sql.ListQueriesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {
@@ -358,7 +358,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Queries.QueryNameToIdMap(ctx, sql.ListQueriesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "")
 				if err != nil {

--- a/cmd/workspace/recipients/recipients.go
+++ b/cmd/workspace/recipients/recipients.go
@@ -116,7 +116,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Recipients.RecipientInfoNameToMetastoreIdMap(ctx, sharing.ListRecipientsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of the recipient")
 				if err != nil {
@@ -176,7 +176,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Recipients.RecipientInfoNameToMetastoreIdMap(ctx, sharing.ListRecipientsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of the recipient")
 				if err != nil {
@@ -340,7 +340,7 @@ var sharePermissionsCmd = &cobra.Command{
 				names, err := w.Recipients.RecipientInfoNameToMetastoreIdMap(ctx, sharing.ListRecipientsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The name of the Recipient")
 				if err != nil {
@@ -406,7 +406,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Recipients.RecipientInfoNameToMetastoreIdMap(ctx, sharing.ListRecipientsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Recipients drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of Recipient")
 				if err != nil {

--- a/cmd/workspace/repos/repos.go
+++ b/cmd/workspace/repos/repos.go
@@ -117,7 +117,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding repo to access")
 				if err != nil {
@@ -178,7 +178,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding repo to access")
 				if err != nil {
@@ -295,7 +295,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID for the corresponding repo to access")
 				if err != nil {

--- a/cmd/workspace/schemas/schemas.go
+++ b/cmd/workspace/schemas/schemas.go
@@ -114,7 +114,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Schemas.SchemaInfoNameToFullNameMap(ctx, catalog.ListSchemasRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Schemas drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Schemas drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Full name of the schema")
 				if err != nil {
@@ -174,7 +174,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Schemas.SchemaInfoNameToFullNameMap(ctx, catalog.ListSchemasRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Schemas drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Schemas drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Full name of the schema")
 				if err != nil {
@@ -293,7 +293,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Schemas.SchemaInfoNameToFullNameMap(ctx, catalog.ListSchemasRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Schemas drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Schemas drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Full name of the schema")
 				if err != nil {

--- a/cmd/workspace/service-principals/service-principals.go
+++ b/cmd/workspace/service-principals/service-principals.go
@@ -115,7 +115,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a service principal in the Databricks workspace")
 				if err != nil {
@@ -174,7 +174,7 @@ var getCmd = &cobra.Command{
 				names, err := w.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a service principal in the Databricks workspace")
 				if err != nil {
@@ -290,7 +290,7 @@ var patchCmd = &cobra.Command{
 				names, err := w.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a service principal in the Databricks workspace")
 				if err != nil {
@@ -359,7 +359,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.ServicePrincipals.ServicePrincipalDisplayNameToIdMap(ctx, iam.ListServicePrincipalsRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Service Principals drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks service principal ID")
 				if err != nil {

--- a/cmd/workspace/tables/tables.go
+++ b/cmd/workspace/tables/tables.go
@@ -66,7 +66,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Tables.TableInfoNameToTableIdMap(ctx, catalog.ListTablesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Tables drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Tables drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Full name of the table")
 				if err != nil {
@@ -130,7 +130,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Tables.TableInfoNameToTableIdMap(ctx, catalog.ListTablesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Tables drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Tables drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Full name of the table")
 				if err != nil {
@@ -261,7 +261,7 @@ var listSummariesCmd = &cobra.Command{
 				names, err := w.Tables.TableInfoNameToTableIdMap(ctx, catalog.ListTablesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Tables drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Tables drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Name of parent catalog for tables of interest")
 				if err != nil {

--- a/cmd/workspace/token-management/token-management.go
+++ b/cmd/workspace/token-management/token-management.go
@@ -110,7 +110,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.TokenManagement.TokenInfoCommentToTokenIdMap(ctx, settings.ListTokenManagementRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the token to get")
 				if err != nil {
@@ -168,7 +168,7 @@ var getCmd = &cobra.Command{
 				names, err := w.TokenManagement.TokenInfoCommentToTokenIdMap(ctx, settings.ListTokenManagementRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the token to get")
 				if err != nil {

--- a/cmd/workspace/tokens/tokens.go
+++ b/cmd/workspace/tokens/tokens.go
@@ -111,7 +111,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Tokens.TokenInfoCommentToTokenIdMap(ctx)
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Tokens drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Tokens drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The ID of the token to be revoked")
 				if err != nil {

--- a/cmd/workspace/users/users.go
+++ b/cmd/workspace/users/users.go
@@ -124,7 +124,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Users.UserUserNameToIdMap(ctx, iam.ListUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a user in the Databricks workspace")
 				if err != nil {
@@ -182,7 +182,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Users.UserUserNameToIdMap(ctx, iam.ListUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a user in the Databricks workspace")
 				if err != nil {
@@ -298,7 +298,7 @@ var patchCmd = &cobra.Command{
 				names, err := w.Users.UserUserNameToIdMap(ctx, iam.ListUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Unique ID for a user in the Databricks workspace")
 				if err != nil {
@@ -367,7 +367,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Users.UserUserNameToIdMap(ctx, iam.ListUsersRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Users drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Databricks user ID")
 				if err != nil {

--- a/cmd/workspace/volumes/volumes.go
+++ b/cmd/workspace/volumes/volumes.go
@@ -139,7 +139,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Volumes.VolumeInfoNameToVolumeIdMap(ctx, catalog.ListVolumesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The three-level (fully qualified) name of the volume")
 				if err != nil {
@@ -261,7 +261,7 @@ var readCmd = &cobra.Command{
 				names, err := w.Volumes.VolumeInfoNameToVolumeIdMap(ctx, catalog.ListVolumesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The three-level (fully qualified) name of the volume")
 				if err != nil {
@@ -330,7 +330,7 @@ var updateCmd = &cobra.Command{
 				names, err := w.Volumes.VolumeInfoNameToVolumeIdMap(ctx, catalog.ListVolumesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The three-level (fully qualified) name of the volume")
 				if err != nil {

--- a/cmd/workspace/warehouses/warehouses.go
+++ b/cmd/workspace/warehouses/warehouses.go
@@ -153,7 +153,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Required")
 				if err != nil {
@@ -254,7 +254,7 @@ var editCmd = &cobra.Command{
 				names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Required")
 				if err != nil {
@@ -341,7 +341,7 @@ var getCmd = &cobra.Command{
 				names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Required")
 				if err != nil {
@@ -539,7 +539,7 @@ var startCmd = &cobra.Command{
 				names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Required")
 				if err != nil {
@@ -626,7 +626,7 @@ var stopCmd = &cobra.Command{
 				names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "Required")
 				if err != nil {

--- a/cmd/workspace/workspace/workspace.go
+++ b/cmd/workspace/workspace/workspace.go
@@ -67,7 +67,7 @@ var deleteCmd = &cobra.Command{
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The absolute path of the notebook or directory")
 				if err != nil {
@@ -135,7 +135,7 @@ var exportCmd = &cobra.Command{
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The absolute path of the object or directory")
 				if err != nil {
@@ -194,7 +194,7 @@ var getStatusCmd = &cobra.Command{
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The absolute path of the notebook or directory")
 				if err != nil {
@@ -260,7 +260,7 @@ var importCmd = &cobra.Command{
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The absolute path of the object or directory")
 				if err != nil {
@@ -375,7 +375,7 @@ var mkdirsCmd = &cobra.Command{
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
 				close(promptSpinner)
 				if err != nil {
-					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments")
+					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
 				id, err := cmdio.Select(ctx, names, "The absolute path of the directory")
 				if err != nil {


### PR DESCRIPTION
## Changes
Better error message if can not load prompts

## Tests
Setup 2 jobs with the same name and ran `cli job get`

```
andrew.nester@HFW9Y94129 multiples-tasks % ../../cli/cli jobs get
Error: failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: duplicate .Settings.Name: duplicatejob
```

