### PR TITLE
Add implementation of filer.Filer for local filesystem

### DIFF
--- a/internal/filer_test.go
+++ b/internal/filer_test.go
@@ -31,6 +31,8 @@ func (f filerTest) assertContents(ctx context.Context, name string, contents str
 		return
 	}
 
+	defer reader.Close()
+
 	var body bytes.Buffer
 	_, err = io.Copy(&body, reader)
 	if !assert.NoError(f, err) {

--- a/libs/filer/filer.go
+++ b/libs/filer/filer.go
@@ -111,7 +111,7 @@ type Filer interface {
 	Write(ctx context.Context, path string, reader io.Reader, mode ...WriteMode) error
 
 	// Read file at `path`.
-	Read(ctx context.Context, path string) (io.Reader, error)
+	Read(ctx context.Context, path string) (io.ReadCloser, error)
 
 	// Delete file or directory at `path`.
 	Delete(ctx context.Context, path string, mode ...DeleteMode) error

--- a/libs/filer/fs_test.go
+++ b/libs/filer/fs_test.go
@@ -70,13 +70,13 @@ func (f *fakeFiler) Write(ctx context.Context, p string, reader io.Reader, mode 
 	return fmt.Errorf("not implemented")
 }
 
-func (f *fakeFiler) Read(ctx context.Context, p string) (io.Reader, error) {
+func (f *fakeFiler) Read(ctx context.Context, p string) (io.ReadCloser, error) {
 	_, ok := f.entries[p]
 	if !ok {
 		return nil, fs.ErrNotExist
 	}
 
-	return strings.NewReader("foo"), nil
+	return io.NopCloser(strings.NewReader("foo")), nil
 }
 
 func (f *fakeFiler) Delete(ctx context.Context, p string, mode ...DeleteMode) error {

--- a/libs/filer/local_client.go
+++ b/libs/filer/local_client.go
@@ -68,7 +68,7 @@ func (w *LocalClient) Write(ctx context.Context, name string, reader io.Reader, 
 
 }
 
-func (w *LocalClient) Read(ctx context.Context, name string) (io.Reader, error) {
+func (w *LocalClient) Read(ctx context.Context, name string) (io.ReadCloser, error) {
 	absPath, err := w.root.Join(name)
 	if err != nil {
 		return nil, err

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -152,7 +152,7 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 	return err
 }
 
-func (w *WorkspaceFilesClient) Read(ctx context.Context, name string) (io.Reader, error) {
+func (w *WorkspaceFilesClient) Read(ctx context.Context, name string) (io.ReadCloser, error) {
 	absPath, err := w.root.Join(name)
 	if err != nil {
 		return nil, err
@@ -184,7 +184,7 @@ func (w *WorkspaceFilesClient) Read(ctx context.Context, name string) (io.Reader
 	if err != nil {
 		return nil, err
 	}
-	return bytes.NewReader(b), nil
+	return io.NopCloser(bytes.NewReader(b)), nil
 }
 
 func (w *WorkspaceFilesClient) Delete(ctx context.Context, name string, mode ...DeleteMode) error {


### PR DESCRIPTION
## Changes

Local file reads on Windows require the file handle to be closed after using it. This commit includes an interface change to return an `io.ReadCloser` from `Read` to accommodate this.

## Tests

The existing integration tests for the filer interface all pass.