### PR TITLE
Release v0.100.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Version changelog
 
+## 0.100.3
+
+CLI:
+ * Add directory tracking to sync ([#425](https://github.com/databricks/cli/pull/425)).
+ * Add fs cat command for dbfs files ([#430](https://github.com/databricks/cli/pull/430)).
+ * Add fs ls command for dbfs ([#429](https://github.com/databricks/cli/pull/429)).
+ * Add fs mkdirs command for dbfs ([#432](https://github.com/databricks/cli/pull/432)).
+ * Add fs rm command for dbfs ([#433](https://github.com/databricks/cli/pull/433)).
+ * Add installation instructions ([#458](https://github.com/databricks/cli/pull/458)).
+ * Add new line to cmdio JSON rendering ([#443](https://github.com/databricks/cli/pull/443)).
+ * Add profile on `databricks auth login` ([#423](https://github.com/databricks/cli/pull/423)).
+ * Add readable console logger ([#370](https://github.com/databricks/cli/pull/370)).
+ * Add workspace export-dir command ([#449](https://github.com/databricks/cli/pull/449)).
+ * Added secrets input prompt for secrets put-secret command ([#413](https://github.com/databricks/cli/pull/413)).
+ * Added spinner when loading command prompts ([#420](https://github.com/databricks/cli/pull/420)).
+ * Better error message if can not load prompts ([#437](https://github.com/databricks/cli/pull/437)).
+ * Changed service template to correctly handle required positional arguments ([#405](https://github.com/databricks/cli/pull/405)).
+ * Do not generate prompts for certain commands ([#438](https://github.com/databricks/cli/pull/438)).
+ * Do not prompt for List methods ([#411](https://github.com/databricks/cli/pull/411)).
+ * Do not use FgWhite and FgBlack for terminal output ([#435](https://github.com/databricks/cli/pull/435)).
+ * Skip path translation of job task for jobs with a Git source ([#404](https://github.com/databricks/cli/pull/404)).
+ * Tweak profile prompt ([#454](https://github.com/databricks/cli/pull/454)).
+ * Update with the latest Go SDK ([#457](https://github.com/databricks/cli/pull/457)).
+ * Use cmdio in version command for `--output` flag ([#419](https://github.com/databricks/cli/pull/419)).
+
+Bundles:
+ * Check for nil environment before accessing it ([#453](https://github.com/databricks/cli/pull/453)).
+
+Dependencies:
+ * Bump github.com/hashicorp/terraform-json from 0.16.0 to 0.17.0 ([#459](https://github.com/databricks/cli/pull/459)).
+ * Bump github.com/mattn/go-isatty from 0.0.18 to 0.0.19 ([#412](https://github.com/databricks/cli/pull/412)).
+
+Internal:
+ * Add Mkdir and ReadDir functions to filer.Filer interface ([#414](https://github.com/databricks/cli/pull/414)).
+ * Add Stat function to filer.Filer interface ([#421](https://github.com/databricks/cli/pull/421)).
+ * Add check for path is a directory in filer.ReadDir ([#426](https://github.com/databricks/cli/pull/426)).
+ * Add fs.FS adapter for the filer interface ([#422](https://github.com/databricks/cli/pull/422)).
+ * Add implementation of filer.Filer for local filesystem ([#460](https://github.com/databricks/cli/pull/460)).
+ * Allow equivalence checking of filer errors to fs errors ([#416](https://github.com/databricks/cli/pull/416)).
+ * Fix locker integration test ([#417](https://github.com/databricks/cli/pull/417)).
+ * Implement DBFS filer ([#139](https://github.com/databricks/cli/pull/139)).
+ * Include recursive deletion in filer interface ([#442](https://github.com/databricks/cli/pull/442)).
+ * Make filer.Filer return fs.DirEntry from ReadDir ([#415](https://github.com/databricks/cli/pull/415)).
+ * Speed up sync integration tests ([#428](https://github.com/databricks/cli/pull/428)).
+
 ## 0.100.2
 
 CLI:


### PR DESCRIPTION
## Changes

CLI:
 * Add directory tracking to sync ([#425](https://github.com/databricks/cli/pull/425)).
 * Add fs cat command for dbfs files ([#430](https://github.com/databricks/cli/pull/430)).
 * Add fs ls command for dbfs ([#429](https://github.com/databricks/cli/pull/429)).
 * Add fs mkdirs command for dbfs ([#432](https://github.com/databricks/cli/pull/432)).
 * Add fs rm command for dbfs ([#433](https://github.com/databricks/cli/pull/433)).
 * Add installation instructions ([#458](https://github.com/databricks/cli/pull/458)).
 * Add new line to cmdio JSON rendering ([#443](https://github.com/databricks/cli/pull/443)).
 * Add profile on `databricks auth login` ([#423](https://github.com/databricks/cli/pull/423)).
 * Add readable console logger ([#370](https://github.com/databricks/cli/pull/370)).
 * Add workspace export-dir command ([#449](https://github.com/databricks/cli/pull/449)).
 * Added secrets input prompt for secrets put-secret command ([#413](https://github.com/databricks/cli/pull/413)).
 * Added spinner when loading command prompts ([#420](https://github.com/databricks/cli/pull/420)).
 * Better error message if can not load prompts ([#437](https://github.com/databricks/cli/pull/437)).
 * Changed service template to correctly handle required positional arguments ([#405](https://github.com/databricks/cli/pull/405)).
 * Do not generate prompts for certain commands ([#438](https://github.com/databricks/cli/pull/438)).
 * Do not prompt for List methods ([#411](https://github.com/databricks/cli/pull/411)).
 * Do not use FgWhite and FgBlack for terminal output ([#435](https://github.com/databricks/cli/pull/435)).
 * Skip path translation of job task for jobs with a Git source ([#404](https://github.com/databricks/cli/pull/404)).
 * Tweak profile prompt ([#454](https://github.com/databricks/cli/pull/454)).
 * Update with the latest Go SDK ([#457](https://github.com/databricks/cli/pull/457)).
 * Use cmdio in version command for `--output` flag ([#419](https://github.com/databricks/cli/pull/419)).

Bundles:
 * Check for nil environment before accessing it ([#453](https://github.com/databricks/cli/pull/453)).

Dependencies:
 * Bump github.com/hashicorp/terraform-json from 0.16.0 to 0.17.0 ([#459](https://github.com/databricks/cli/pull/459)).
 * Bump github.com/mattn/go-isatty from 0.0.18 to 0.0.19 ([#412](https://github.com/databricks/cli/pull/412)).

Internal:
 * Add Mkdir and ReadDir functions to filer.Filer interface ([#414](https://github.com/databricks/cli/pull/414)).
 * Add Stat function to filer.Filer interface ([#421](https://github.com/databricks/cli/pull/421)).
 * Add check for path is a directory in filer.ReadDir ([#426](https://github.com/databricks/cli/pull/426)).
 * Add fs.FS adapter for the filer interface ([#422](https://github.com/databricks/cli/pull/422)).
 * Add implementation of filer.Filer for local filesystem ([#460](https://github.com/databricks/cli/pull/460)).
 * Allow equivalence checking of filer errors to fs errors ([#416](https://github.com/databricks/cli/pull/416)).
 * Fix locker integration test ([#417](https://github.com/databricks/cli/pull/417)).
 * Implement DBFS filer ([#139](https://github.com/databricks/cli/pull/139)).
 * Include recursive deletion in filer interface ([#442](https://github.com/databricks/cli/pull/442)).
 * Make filer.Filer return fs.DirEntry from ReadDir ([#415](https://github.com/databricks/cli/pull/415)).
 * Speed up sync integration tests ([#428](https://github.com/databricks/cli/pull/428)).
