### PR TITLE
Fixed error on multiple profiles and failure to create a new profile with configured cluster

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -57,6 +57,12 @@ var loginCmd = &cobra.Command{
 		}
 
 		if configureCluster {
+			// We need to save profile before it's used to initialise new workspace client.
+			// Otherwise it will complain about non existing profile
+			err = databrickscfg.SaveToProfile(ctx, &cfg)
+			if err != nil {
+				return err
+			}
 			w, err := databricks.NewWorkspaceClient((*databricks.Config)(&cfg))
 			if err != nil {
 				return err

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -49,20 +49,15 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 
+		// We need the config without the profile before it's used to initialise new workspace client below.
+		// Otherwise it will complain about non existing profile because it was not yet saved.
 		cfg := config.Config{
 			Host:      perisistentAuth.Host,
 			AccountID: perisistentAuth.AccountID,
 			AuthType:  "databricks-cli",
-			Profile:   profileName,
 		}
 
 		if configureCluster {
-			// We need to save profile before it's used to initialise new workspace client.
-			// Otherwise it will complain about non existing profile
-			err = databrickscfg.SaveToProfile(ctx, &cfg)
-			if err != nil {
-				return err
-			}
 			w, err := databricks.NewWorkspaceClient((*databricks.Config)(&cfg))
 			if err != nil {
 				return err
@@ -83,6 +78,7 @@ var loginCmd = &cobra.Command{
 			cfg.ClusterID = clusterId
 		}
 
+		cfg.Profile = profileName
 		err = databrickscfg.SaveToProfile(ctx, &cfg)
 		if err != nil {
 			return err

--- a/libs/databrickscfg/loader.go
+++ b/libs/databrickscfg/loader.go
@@ -76,6 +76,9 @@ func (l profileFromHostLoader) Configure(cfg *config.Config) error {
 	// Normalized version of the configured host.
 	host := normalizeHost(cfg.Host)
 	match, err := findMatchingProfile(configFile, func(s *ini.Section) bool {
+		if cfg.Profile != "" {
+			return cfg.Profile == s.Name()
+		}
 		key, err := s.GetKey("host")
 		if err != nil {
 			log.Tracef(ctx, "section %s: %s", s.Name(), err)

--- a/libs/databrickscfg/ops.go
+++ b/libs/databrickscfg/ops.go
@@ -89,8 +89,6 @@ func SaveToProfile(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	// zeroval profile name before adding it to a section
-	cfg.Profile = ""
 	cfg.ConfigFile = ""
 
 	// clear old keys in case we're overriding the section
@@ -99,7 +97,7 @@ func SaveToProfile(ctx context.Context, cfg *config.Config) error {
 	}
 
 	for _, attr := range config.ConfigAttributes {
-		if attr.IsZero(cfg) {
+		if attr.IsZero(cfg) || attr.Name == "profile" {
 			continue
 		}
 		key := section.Key(attr.Name)


### PR DESCRIPTION
## Changes
#### Issue 1

When running `./cli auth login <host> --configure-cluster` and providing a new name, CLI failed with
```
Error: resolve: /Users/andrew.nester/.databrickscfg has no d123 profile configured. Config: host=<host>, profile=d123, databricks_cli_path=./cli. Env: DATABRICKS_CLI_PATH
```

In order to resolve this, we need to save profile information before we use it to configure a new client.

#### Issue 2

When configuring multiple profiles for the same host, CLI was failing with

```
Error: multiple profiles matched: my-demo-profile, aaaa, xxxx, bbbbb, asdasd, xxxxx
```

## Tests
Running `./cli auth login <host> --configure-cluster` multiple times for the same host and different profile names succeeds

