### PR TITLE
Use direct download for workspace filer read

### DIFF
--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -3,7 +3,6 @@ package filer
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -187,18 +186,7 @@ func (w *WorkspaceFilesClient) Read(ctx context.Context, name string) (io.ReadCl
 
 	// Export file contents. Note the /workspace/export API has a limit of 10MBs
 	// for the file size
-	// TODO: use direct download once it's fixed. see: https://github.com/databricks/cli/issues/452
-	res, err := w.workspaceClient.Workspace.Export(ctx, workspace.ExportRequest{
-		Path: absPath,
-	})
-	if err != nil {
-		return nil, err
-	}
-	b, err := base64.StdEncoding.DecodeString(res.Content)
-	if err != nil {
-		return nil, err
-	}
-	return io.NopCloser(bytes.NewReader(b)), nil
+	return w.workspaceClient.Workspace.Download(ctx, absPath)
 }
 
 func (w *WorkspaceFilesClient) Delete(ctx context.Context, name string, mode ...DeleteMode) error {


### PR DESCRIPTION
## Changes
Use the download method from the SDK in the read method for the WSFS implementation of the filer interface.

Closes #452.

## Tests
Tested by existing integration tests
