### PR TITLE
Add dbfs scheme prefix to paths in cp command output

### DIFF
--- a/cmd/fs/cp.go
+++ b/cmd/fs/cp.go
@@ -15,9 +15,11 @@ import (
 )
 
 type copy struct {
-	ctx         context.Context
-	sourceFiler filer.Filer
-	targetFiler filer.Filer
+	ctx          context.Context
+	sourceFiler  filer.Filer
+	targetFiler  filer.Filer
+	sourceScheme string
+	targetScheme string
 }
 
 func (c *copy) cpWriteCallback(sourceDir, targetDir string) fs.WalkDirFunc {
@@ -78,29 +80,47 @@ func (c *copy) cpFileToFile(sourcePath, targetPath string) error {
 		err = c.targetFiler.Write(c.ctx, targetPath, r)
 		// skip if file already exists
 		if err != nil && errors.Is(err, fs.ErrExist) {
-			return emitCpFileSkippedEvent(c.ctx, sourcePath, targetPath)
+			return c.emitCpFileSkippedEvent(sourcePath, targetPath)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	return emitCpFileCopiedEvent(c.ctx, sourcePath, targetPath)
+	return c.emitCpFileCopiedEvent(sourcePath, targetPath)
 }
 
 // TODO: emit these events on stderr
 // TODO: add integration tests for these events
-func emitCpFileSkippedEvent(ctx context.Context, sourcePath, targetPath string) error {
-	event := newFileSkippedEvent(sourcePath, targetPath)
+func (c *copy) emitCpFileSkippedEvent(sourcePath, targetPath string) error {
+	fullSourcePath := sourcePath
+	if c.sourceScheme != "" {
+		fullSourcePath = path.Join(c.sourceScheme+":", sourcePath)
+	}
+	fullTargetPath := targetPath
+	if c.targetScheme != "" {
+		fullTargetPath = path.Join(c.targetScheme+":", targetPath)
+	}
+
+	event := newFileSkippedEvent(fullSourcePath, fullTargetPath)
 	template := "{{.SourcePath}} -> {{.TargetPath}} (skipped; already exists)\n"
 
-	return cmdio.RenderWithTemplate(ctx, event, template)
+	return cmdio.RenderWithTemplate(c.ctx, event, template)
 }
 
-func emitCpFileCopiedEvent(ctx context.Context, sourcePath, targetPath string) error {
-	event := newFileCopiedEvent(sourcePath, targetPath)
+func (c *copy) emitCpFileCopiedEvent(sourcePath, targetPath string) error {
+	fullSourcePath := sourcePath
+	if c.sourceScheme != "" {
+		fullSourcePath = path.Join(c.sourceScheme+":", sourcePath)
+	}
+	fullTargetPath := targetPath
+	if c.targetScheme != "" {
+		fullTargetPath = path.Join(c.targetScheme+":", targetPath)
+	}
+
+	event := newFileCopiedEvent(fullSourcePath, fullTargetPath)
 	template := "{{.SourcePath}} -> {{.TargetPath}}\n"
 
-	return cmdio.RenderWithTemplate(ctx, event, template)
+	return cmdio.RenderWithTemplate(c.ctx, event, template)
 }
 
 var cpOverwrite bool
@@ -144,10 +164,21 @@ var cpCmd = &cobra.Command{
 			return err
 		}
 
+		sourceScheme := ""
+		if isDbfsPath(fullSourcePath) {
+			sourceScheme = "dbfs"
+		}
+		targetScheme := ""
+		if isDbfsPath(fullTargetPath) {
+			targetScheme = "dbfs"
+		}
+
 		c := copy{
-			ctx:         ctx,
-			sourceFiler: sourceFiler,
-			targetFiler: targetFiler,
+			ctx:          ctx,
+			sourceFiler:  sourceFiler,
+			targetFiler:  targetFiler,
+			sourceScheme: sourceScheme,
+			targetScheme: targetScheme,
 		}
 
 		// Get information about file at source path

--- a/cmd/fs/helpers.go
+++ b/cmd/fs/helpers.go
@@ -54,3 +54,7 @@ func filerForPath(ctx context.Context, fullPath string) (filer.Filer, string, er
 		return nil, "", fmt.Errorf(`unsupported scheme %s specified for path %s. Please specify scheme "dbfs" or "file". Example: file:/foo/bar or file:/c:/foo/bar`, scheme, fullPath)
 	}
 }
+
+func isDbfsPath(path string) bool {
+	return strings.HasPrefix(path, "dbfs:/")
+}


### PR DESCRIPTION
## Changes
Adds the dbfs:/ prefix to paths output by the cp command so they can be used with the CLI

## Tests
Manually

Currently there are no integration tests for command output, I'll add them in separately