### PR TITLE
Fix: bundle destroy fails when bundle.tf.json file is deleted

### DIFF
--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -14,9 +14,9 @@ func Destroy() bundle.Mutator {
 		lock.Acquire(),
 		bundle.Defer(
 			bundle.Seq(
-				terraform.StatePull(),
 				terraform.Interpolate(),
 				terraform.Write(),
+				terraform.StatePull(),
 				terraform.Plan(terraform.PlanGoal("destroy")),
 				terraform.Destroy(),
 				terraform.StatePush(),

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -15,6 +15,8 @@ func Destroy() bundle.Mutator {
 		bundle.Defer(
 			bundle.Seq(
 				terraform.StatePull(),
+				terraform.Interpolate(),
+				terraform.Write(),
 				terraform.Plan(terraform.PlanGoal("destroy")),
 				terraform.Destroy(),
 				terraform.StatePush(),


### PR DESCRIPTION
## Changes
Adds the following steps to the destroy phase:
1. interpolate
2. write

Resolves #518 

## Tests
Tested manually due there not being an examples for tests to use.
