### PR TITLE
Decode contents by default in workspace export command

### DIFF
--- a/cmd/workspace/workspace/overrides.go
+++ b/cmd/workspace/workspace/overrides.go
@@ -8,4 +8,7 @@ func init() {
 	{{header "ID"}}	{{header "Type"}}	{{header "Language"}}	{{header "Path"}}
 	{{range .}}{{green "%d" .ObjectId}}	{{blue "%s" .ObjectType}}	{{cyan "%s" .Language}}	{{.Path|cyan}}
 	{{end}}`)
+
+	// The export command prints the contents of the file to stdout by default.
+	exportCmd.Annotations["template"] = `{{.Content | b64_decode}}`
 }

--- a/libs/cmdio/render.go
+++ b/libs/cmdio/render.go
@@ -1,6 +1,8 @@
 package cmdio
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"strings"
@@ -92,6 +94,27 @@ func renderTemplate(w io.Writer, tmpl string, v any) error {
 		},
 		"pretty_date": func(t time.Time) string {
 			return t.Format("2006-01-02T15:04:05Z")
+		},
+		"b64_encode": func(in string) (string, error) {
+			var out bytes.Buffer
+			enc := base64.NewEncoder(base64.StdEncoding, &out)
+			_, err := enc.Write([]byte(in))
+			if err != nil {
+				return "", err
+			}
+			err = enc.Close()
+			if err != nil {
+				return "", err
+			}
+			return out.String(), nil
+		},
+		"b64_decode": func(in string) (string, error) {
+			dec := base64.NewDecoder(base64.StdEncoding, strings.NewReader(in))
+			out, err := io.ReadAll(dec)
+			if err != nil {
+				return "", err
+			}
+			return string(out), nil
 		},
 	}).Parse(tmpl)
 	if err != nil {


### PR DESCRIPTION
## Changes

Also see #525.

The direct download flag has been removed in newer versions because of the content type issue.

Instead, we can make the command decode the base64 output when the output mode is text.

```
$ databricks workspace export /some/path/script.sh
#!/bin/bash
echo "this is a script"
```

## Tests

New integration test.

