### PR TITLE
Fixed error reporting when included invalid files in include section

### DIFF
--- a/bundle/config/mutator/process_root_includes.go
+++ b/bundle/config/mutator/process_root_includes.go
@@ -52,7 +52,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) error
 
 		// If the entry is not a glob pattern and no matches found,
 		// return an error because the file defined is not found
-		if len(matches) == 0 && !strings.Contains(entry, "*") {
+		if len(matches) == 0 && !strings.ContainsAny(entry, "*?[") {
 			return fmt.Errorf("%s defined in 'include' section does not match any files", entry)
 		}
 

--- a/bundle/config/mutator/process_root_includes.go
+++ b/bundle/config/mutator/process_root_includes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
@@ -49,7 +50,9 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) error
 			return err
 		}
 
-		if len(matches) == 0 {
+		// If the entry is not a glob pattern and no matches found,
+		// return an error because the file defined is not found
+		if len(matches) == 0 && !strings.Contains(entry, "*") {
 			return fmt.Errorf("%s defined in 'include' section does not match any files", entry)
 		}
 

--- a/bundle/config/mutator/process_root_includes.go
+++ b/bundle/config/mutator/process_root_includes.go
@@ -49,6 +49,10 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) error
 			return err
 		}
 
+		if len(matches) == 0 {
+			return fmt.Errorf("%s defined in 'include' section does not match any files", entry)
+		}
+
 		// Filter matches to ones we haven't seen yet.
 		var includes []string
 		for _, match := range matches {

--- a/bundle/config/mutator/process_root_includes_test.go
+++ b/bundle/config/mutator/process_root_includes_test.go
@@ -108,3 +108,17 @@ func TestProcessRootIncludesRemoveDups(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a.yml"}, bundle.Config.Include)
 }
+
+func TestProcessRootIncludesNotExists(t *testing.T) {
+	bundle := &bundle.Bundle{
+		Config: config.Root{
+			Path: t.TempDir(),
+			Include: []string{
+				"notexist.yml",
+			},
+		},
+	}
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notexist.yml defined in 'include' section does not match any files")
+}

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -118,7 +118,7 @@ func (r *Root) Load(path string) error {
 	}
 	err = yaml.Unmarshal(raw, r)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load %s: %w", path, err)
 	}
 
 	r.Path = filepath.Dir(path)

--- a/bundle/tests/include_invalid/bundle.yml
+++ b/bundle/tests/include_invalid/bundle.yml
@@ -1,0 +1,5 @@
+bundle:
+  name: include_invalid
+
+include:
+  - notexists.yml

--- a/bundle/tests/include_test.go
+++ b/bundle/tests/include_test.go
@@ -24,7 +24,6 @@ func TestIncludeInvalid(t *testing.T) {
 func TestIncludeWithGlob(t *testing.T) {
 	b := load(t, "./include_with_glob")
 
-	// Test that both jobs were loaded.
 	keys := maps.Keys(b.Config.Resources.Jobs)
 	sort.Strings(keys)
 	assert.Equal(t, []string{"my_job"}, keys)

--- a/bundle/tests/include_test.go
+++ b/bundle/tests/include_test.go
@@ -1,0 +1,35 @@
+package config_tests
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestIncludeInvalid(t *testing.T) {
+	b, err := bundle.Load("./include_invalid")
+	require.NoError(t, err)
+	err = bundle.Apply(context.Background(), b, bundle.Seq(mutator.DefaultMutators()...))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notexists.yml defined in 'include' section does not match any files")
+}
+
+func TestIncludeWithGlob(t *testing.T) {
+	b := load(t, "./include_with_glob")
+
+	// Test that both jobs were loaded.
+	keys := maps.Keys(b.Config.Resources.Jobs)
+	sort.Strings(keys)
+	assert.Equal(t, []string{"my_job"}, keys)
+
+	job := b.Config.Resources.Jobs["my_job"]
+	assert.Equal(t, "1", job.ID)
+	assert.Equal(t, "include_with_glob/job.yml", filepath.ToSlash(job.ConfigFilePath))
+}

--- a/bundle/tests/include_with_glob/bundle.yml
+++ b/bundle/tests/include_with_glob/bundle.yml
@@ -1,0 +1,7 @@
+bundle:
+  name: include_with_glob
+
+include:
+  - "*.yml"
+  - "?.yml"
+  - "[a-z].yml"

--- a/bundle/tests/include_with_glob/job.yml
+++ b/bundle/tests/include_with_glob/job.yml
@@ -1,0 +1,4 @@
+resources:
+  jobs:
+    my_job:
+      id: 1


### PR DESCRIPTION
## Changes
Fixed error reporting when included invalid files in include section

Case 1. When the file to include is invalid, throw an error
Case 2. When the file is loaded but the schema is wrong, indicate which file is failed to load

## Tests

With non-existent notexists.yml

```
databricks bundle deploy
Error: notexists.yml defined in 'include' section does not match any files

```

With malformed notexists.yml
```
databricks bundle deploy
Error: failed to load /Users/andrew.nester/dabs/wheel/notexists.yml: error unmarshaling JSON: json: cannot unmarshal string into Go value of type config.Root
```

