### PR TITLE
Fixes to SAML auth process and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,27 @@
 default: build
 
-fmt:
+fmt: $(GOPATH)/bin/goimports
 	@echo "✓ Formatting source code with goimports ..."
 	@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 	@echo "✓ Formatting source code with gofmt ..."
 	@gofmt -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-lint: vendor
+$(GOPATH)/bin/goimports:
+	go install golang.org/x/tools/cmd/goimports@latest
+
+lint: vendor $(GOPATH)/bin/staticcheck
 	@echo "✓ Linting source code with https://staticcheck.io/ ..."
 	@staticcheck ./...
 
-test: lint
+$(GOPATH)/bin/staticcheck:
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+
+test: lint $(GOPATH)/bin/gotestsum
 	@echo "✓ Running tests ..."
 	@gotestsum --format pkgname-and-test-fails --no-summary=skipped --raw-command go test -v -json -short -coverprofile=coverage.txt ./...
+
+$(GOPATH)/bin/gotestsum:
+	go install gotest.tools/gotestsum@latest
 
 coverage: test
 	@echo "✓ Opening coverage for unit tests ..."
@@ -22,9 +31,12 @@ build: vendor
 	@echo "✓ Building source code with go build ..."
 	@go build -mod vendor
 
-snapshot:
+snapshot: $(GOPATH)/bin/goreleaser
 	@echo "✓ Building dev snapshot"
 	@goreleaser build --snapshot --clean --single-target
+
+$(GOPATH)/bin/goreleaser:
+	go install github.com/goreleaser/goreleaser@latest
 
 vendor:
 	@echo "✓ Filling vendor folder with library code ..."

--- a/bundle/tests/autoload_git_test.go
+++ b/bundle/tests/autoload_git_test.go
@@ -1,6 +1,7 @@
 package config_tests
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,19 @@ import (
 func TestGitConfig(t *testing.T) {
 	b := load(t, "./autoload_git")
 	assert.Equal(t, "foo", b.Config.Bundle.Git.Branch)
-	sshUrl := "git@github.com:databricks/cli.git"
-	httpsUrl := "https://github.com/databricks/cli"
-	assert.Contains(t, []string{sshUrl, httpsUrl}, b.Config.Bundle.Git.OriginURL)
+
+	// We need to ensure that we allow people to fork the repo, so we test against a regex.
+	// Otherwise, their OriginURL will be different to ours.
+	sshUrlRegex := `git@github.com:\w+\/cli.git`
+	httpsUrlRegex := `https:\/\/github\.com\/\w+\/cli(?:.git)?`
+	regexList := []*regexp.Regexp{regexp.MustCompile(sshUrlRegex), regexp.MustCompile(httpsUrlRegex)}
+
+	match := false
+	for _, regex := range regexList {
+		if regex.MatchString(b.Config.Bundle.Git.OriginURL) {
+			match = true
+			break
+		}
+	}
+	assert.True(t, match)
 }

--- a/libs/auth/cache/cache.go
+++ b/libs/auth/cache/cache.go
@@ -74,6 +74,11 @@ func (c *TokenCache) Lookup(key string) (*oauth2.Token, error) {
 }
 
 func (c *TokenCache) location() (string, error) {
+	// Allow users to override the location of the token cache file
+	tokenCacheDirName, exists := os.LookupEnv("DATABRICKS_TOKEN_CACHE_DIR")
+	if exists {
+		return filepath.Join(tokenCacheDirName, tokenCacheFile), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("home: %w", err)

--- a/libs/auth/cache/cache_test.go
+++ b/libs/auth/cache/cache_test.go
@@ -103,3 +103,13 @@ func TestStoreOnDev(t *testing.T) {
 	// macOS: read-only file system
 	assert.Error(t, err)
 }
+
+func TestOverrideTokenCacheLocationUsingEnvVar(t *testing.T) {
+	t.Setenv("DATABRICKS_TOKEN_CACHE_DIR", os.TempDir())
+	c := &TokenCache{}
+	err := c.Store("x", &oauth2.Token{
+		AccessToken: "abc",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, c.fileLocation, os.TempDir())
+}


### PR DESCRIPTION
Hi!

We are starting to use the new CLI tooling locally, and are finding a few problems.  I have not raised issues for these currently, let me know if that is a requirement?

## Changes
This PR does the following:
1. Split appRedirectAddr so that we can bind to the port, allowing bindinng on all interfaces.  Without this, binding to `localhost` on a multi-interface system can problematically end up binding incorrectly.  This is particularly obvious trying to run this under Docker, as it prevents binding and port forwarding correctly to the host.
2. Allow setting the token cache directory without modifying HOME env var.  Whilst modifying the `HOME` env allows redirecting the token cache, this is a bit painful.  Use case is multiple repositories with different auth, currently they would clash, with this approach you can override per call/environment.
3. Fixes to Makefile to ensure tools are available.  Otherwise on first call for each target they will fail if not previously installed.
4. Fixes a test that expects an origin to be the DataBricks GitHub project, and fails if not.

## Tests
1. appRedirectAddr changes manually tested with auth locally.
2. Unit tests added for token cache directory changes.  Also tested manually.
3. Fixes tested via local build.
4. Tests fixed and tested locally.

Regards,

Ben
