### PR TITLE
Goreleaser docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,17 @@ jobs:
         with:
           go-version: 1.21.x
 
+      # If this is not added here, you cannot run this from a forked repository
+      - name: Add Lowercase Repository Name to Environment
+        run: |
+          echo REPOSITORY_NAME_LOWERCASE=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+
+      - uses: "docker/login-action@v2"
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Run GoReleaser
         id: releaser
         uses: goreleaser/goreleaser-action@v4
@@ -32,6 +43,7 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_IMAGE_NAME: ${{ env.REPOSITORY_NAME_LOWERCASE }}
 
   create-setup-cli-release-pr:
     needs: goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,3 +56,35 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+
+dockers:
+  -
+    id: amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:{{ replace .Version "+" "-" }}-amd64
+      - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:latest-amd64
+    build_flag_templates:
+        - "--build-arg=BASE_IMAGE_ARCH=base"
+        - "--platform=linux/amd64"
+  -
+    id: arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:{{ replace .Version "+" "-" }}-arm64
+      - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:latest-arm64
+    build_flag_templates:
+        - "--build-arg=BASE_IMAGE_ARCH=base:latest-arm64"
+        - "--platform=linux/arm64"
+
+docker_manifests:
+- name_template: ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:{{ replace .Version "+" "-" }}
+  image_templates:
+  - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:{{ replace .Version "+" "-" }}-amd64
+  - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:{{ replace .Version "+" "-" }}-arm64
+- name_template: ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:latest
+  image_templates:
+  - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:latest-amd64
+  - ghcr.io/{{ envOrDefault "DOCKER_IMAGE_NAME" "databricks/cli" }}:latest-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+ARG BASE_IMAGE_ARCH=base
+FROM gcr.io/distroless/$BASE_IMAGE_ARCH
+COPY databricks /
+ENTRYPOINT ["/databricks"]

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,27 @@
 default: build
 
-fmt:
+fmt: $(GOPATH)/bin/goimports
 	@echo "✓ Formatting source code with goimports ..."
 	@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 	@echo "✓ Formatting source code with gofmt ..."
 	@gofmt -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-lint: vendor
+$(GOPATH)/bin/goimports:
+	go install golang.org/x/tools/cmd/goimports@latest
+
+lint: vendor $(GOPATH)/bin/staticcheck
 	@echo "✓ Linting source code with https://staticcheck.io/ ..."
 	@staticcheck ./...
 
-test: lint
+$(GOPATH)/bin/staticcheck:
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+
+test: lint $(GOPATH)/bin/gotestsum
 	@echo "✓ Running tests ..."
 	@gotestsum --format pkgname-and-test-fails --no-summary=skipped --raw-command go test -v -json -short -coverprofile=coverage.txt ./...
+
+$(GOPATH)/bin/gotestsum:
+	go install gotest.tools/gotestsum@latest
 
 coverage: test
 	@echo "✓ Opening coverage for unit tests ..."
@@ -22,13 +31,19 @@ build: vendor
 	@echo "✓ Building source code with go build ..."
 	@go build -mod vendor
 
-snapshot:
+snapshot: $(GOPATH)/bin/goreleaser
 	@echo "✓ Building dev snapshot"
 	@go build -o .databricks/databricks
+
+$(GOPATH)/bin/goreleaser:
+	go install github.com/goreleaser/goreleaser@latest
 
 vendor:
 	@echo "✓ Filling vendor folder with library code ..."
 	@go mod vendor
 
-.PHONY: build vendor coverage test lint fmt
+release-local: $(GOPATH)/bin/goreleaser
+	@echo "✓ Running goreleaser locally"
+	@goreleaser release --snapshot --clean
 
+.PHONY: build vendor coverage test lint fmt


### PR DESCRIPTION
## Changes
Adds a Dockerfile and creates amd64 and arm64 Docker images as part of goreleaser build.  Adds a Makefile target that allows release testing locally to ensure that the Docker images build correctly.  Also adds Makefile dependencies to allow most steps to work correctly without prior installs, and fixes a test that fails on forks.

## Tests
Resultant images have been tested for functionality locally.
GitHub release actions have not been tested.
