### PR TITLE
Make top level workspace optional in JSON schema

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -36,7 +36,7 @@ type Root struct {
 
 	// Workspace contains details about the workspace to connect to
 	// and paths in the workspace tree to use for this bundle.
-	Workspace Workspace `json:"workspace"`
+	Workspace Workspace `json:"workspace,omitempty"`
 
 	// Artifacts contains a description of all code artifacts in this bundle.
 	Artifacts map[string]*Artifact `json:"artifacts,omitempty"`


### PR DESCRIPTION
## Tests
Tested manually. `"workspace"` is no longer a required field in the generated JSON schema
