### PR TITLE
Support tab completion for profiles

### DIFF
--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -23,6 +23,7 @@ var currentUser int
 
 func init() {
 	RootCmd.PersistentFlags().StringP("profile", "p", "", "~/.databrickscfg profile")
+	RootCmd.RegisterFlagCompletionFunc("profile", databrickscfg.ProfileCompletion)
 }
 
 func MustAccountClient(cmd *cobra.Command, args []string) error {

--- a/libs/databrickscfg/profiles.go
+++ b/libs/databrickscfg/profiles.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/spf13/cobra"
 )
 
 // Profile holds a subset of the keys in a databrickscfg profile.
@@ -98,4 +99,12 @@ func LoadProfiles(path string, fn ProfileMatchFunction) (file string, profiles P
 	}
 
 	return
+}
+
+func ProfileCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_, profiles, err := LoadProfiles(DefaultPath, func(p Profile) bool { return true })
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	return profiles.Names(), cobra.ShellCompDirectiveNoFileComp
 }

--- a/libs/databrickscfg/profiles.go
+++ b/libs/databrickscfg/profiles.go
@@ -60,6 +60,10 @@ func MatchAccountProfiles(p Profile) bool {
 	return p.Host != "" && p.AccountID != ""
 }
 
+func MatchAllProfiles(p Profile) bool {
+	return true
+}
+
 const DefaultPath = "~/.databrickscfg"
 
 func LoadProfiles(path string, fn ProfileMatchFunction) (file string, profiles Profiles, err error) {
@@ -102,7 +106,7 @@ func LoadProfiles(path string, fn ProfileMatchFunction) (file string, profiles P
 }
 
 func ProfileCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	_, profiles, err := LoadProfiles(DefaultPath, func(p Profile) bool { return true })
+	_, profiles, err := LoadProfiles(DefaultPath, MatchAllProfiles)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}


### PR DESCRIPTION
## Changes
Currently, `databricks --profile <TAB>` autocompletes with the shell default behavior, listing files in the local directory. This is not a great experience. Especially given that the suggested profile names for accounts are so long, it can be cumbersome to type them out by hand. This PR configures autocompletion for `--profile` to inspect the profiles of ~/.databrickscfg.

One potential improvement is to filter the response based on whether the command is known to be account-level or workspace-level.

## Tests
Manual test.
<img width="579" alt="Screenshot_11_07_2023__18_31" src="https://github.com/databricks/cli/assets/1850319/d7a3acd0-2511-45ac-bd82-95567775c10a">
