### PR TITLE
Remove base path checks during sync

### DIFF
--- a/libs/sync/path_test.go
+++ b/libs/sync/path_test.go
@@ -7,37 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPathNestedUnderBasePaths(t *testing.T) {
-	me := iam.User{
-		UserName: "jane@doe.com",
-	}
-
-	// Not nested under allowed base paths.
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.com"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.com/."))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.com/.."))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos/john@doe.com"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.comsuffix/foo"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos/"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Repos"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.com"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.com/."))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.com/.."))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users/john@doe.com"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.comsuffix/foo"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users/"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/Users"))
-	assert.Error(t, checkPathNestedUnderBasePaths(&me, "/"))
-
-	// Nested under allowed base paths.
-	assert.NoError(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.com/foo"))
-	assert.NoError(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.com/./foo"))
-	assert.NoError(t, checkPathNestedUnderBasePaths(&me, "/Repos/jane@doe.com/foo/bar/qux"))
-	assert.NoError(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.com/foo"))
-	assert.NoError(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.com/./foo"))
-	assert.NoError(t, checkPathNestedUnderBasePaths(&me, "/Users/jane@doe.com/foo/bar/qux"))
-}
-
 func TestPathToRepoPath(t *testing.T) {
 	me := iam.User{
 		UserName: "jane@doe.com",


### PR DESCRIPTION
## Changes
Earlier we removed recursive deletion from sync. This makes it safe enough for us to not restrict sync to just the namespace of the user.

This PR removes that base path validation. 

Note: If the sync destination is under `/Repos` we still only create missing directories required if the path is under my namespace ie matches `/Repos/@me/`

## Tests
Manually

Before:
```
shreyas.goenka@THW32HFW6T hello-bundle % cli bundle deploy
Starting upload of bundle files
Error: path must be nested under /Users/shreyas.goenka@databricks.com or /Repos/shreyas.goenka@databricks.com
```

After:
```
shreyas.goenka@THW32HFW6T hello-bundle % cli bundle deploy
Starting upload of bundle files
Uploaded bundle files at /Shared/common-test/hello-bundle/files!

Starting resource deployment
Resource deployment completed!
```