### PR TITLE
Fix formatting in renderer.go

### DIFF
--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -184,7 +184,6 @@ func (r *renderer) computeFile(relPathTemplate string) (*inMemoryFile, error) {
 	}, nil
 }
 
-
 // This function walks the template file tree to generate an in memory representation
 // of a project.
 //


### PR DESCRIPTION
## Changes
Due to a bug in Github UI, https://github.com/databricks/cli/pull/589 got merged without passing the go/fmt formatting checks

This PR fixes the formatting which breaks the PR checks
