### PR TITLE
Remove dependency on global state for the root command

### DIFF
--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -47,7 +47,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 		if output != nil {
-			switch root.OutputType() {
+			switch root.OutputType(cmd) {
 			case flags.OutputText:
 				resultString, err := output.String()
 				if err != nil {
@@ -61,7 +61,7 @@ var runCmd = &cobra.Command{
 				}
 				cmd.OutOrStdout().Write(b)
 			default:
-				return fmt.Errorf("unknown output type %s", root.OutputType())
+				return fmt.Errorf("unknown output type %s", root.OutputType(cmd))
 			}
 		}
 		return nil

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -21,9 +21,9 @@ var workspaceClient int
 var accountClient int
 var currentUser int
 
-func init() {
-	RootCmd.PersistentFlags().StringP("profile", "p", "", "~/.databrickscfg profile")
-	RootCmd.RegisterFlagCompletionFunc("profile", databrickscfg.ProfileCompletion)
+func initProfileFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringP("profile", "p", "", "~/.databrickscfg profile")
+	cmd.RegisterFlagCompletionFunc("profile", databrickscfg.ProfileCompletion)
 }
 
 func MustAccountClient(cmd *cobra.Command, args []string) error {

--- a/cmd/root/bundle.go
+++ b/cmd/root/bundle.go
@@ -118,8 +118,8 @@ func environmentCompletion(cmd *cobra.Command, args []string, toComplete string)
 	return maps.Keys(b.Config.Environments), cobra.ShellCompDirectiveDefault
 }
 
-func init() {
+func initEnvironmentFlag(cmd *cobra.Command) {
 	// To operate in the context of a bundle, all commands must take an "environment" parameter.
-	RootCmd.PersistentFlags().StringP("environment", "e", "", "bundle environment to use (if applicable)")
-	RootCmd.RegisterFlagCompletionFunc("environment", environmentCompletion)
+	cmd.PersistentFlags().StringP("environment", "e", "", "bundle environment to use (if applicable)")
+	cmd.RegisterFlagCompletionFunc("environment", environmentCompletion)
 }

--- a/cmd/root/io.go
+++ b/cmd/root/io.go
@@ -10,32 +10,43 @@ import (
 
 const envOutputFormat = "DATABRICKS_OUTPUT_FORMAT"
 
-var outputType flags.Output = flags.OutputText
+type outputFlag struct {
+	output flags.Output
+}
 
-func init() {
+func initOutputFlag(cmd *cobra.Command) *outputFlag {
+	f := outputFlag{
+		output: flags.OutputText,
+	}
+
 	// Configure defaults from environment, if applicable.
 	// If the provided value is invalid it is ignored.
 	if v, ok := os.LookupEnv(envOutputFormat); ok {
-		outputType.Set(v)
+		f.output.Set(v)
 	}
 
-	RootCmd.PersistentFlags().VarP(&outputType, "output", "o", "output type: text or json")
+	cmd.PersistentFlags().VarP(&f.output, "output", "o", "output type: text or json")
+	return &f
 }
 
-func OutputType() flags.Output {
-	return outputType
+func OutputType(cmd *cobra.Command) flags.Output {
+	f, ok := cmd.Flag("output").Value.(*flags.Output)
+	if !ok {
+		panic("output flag not defined")
+	}
+
+	return *f
 }
 
-func initializeIO(cmd *cobra.Command) error {
+func (f *outputFlag) initializeIO(cmd *cobra.Command) error {
 	var template string
 	if cmd.Annotations != nil {
 		// rely on zeroval being an empty string
 		template = cmd.Annotations["template"]
 	}
 
-	cmdIO := cmdio.NewIO(outputType, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), template)
+	cmdIO := cmdio.NewIO(f.output, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), template)
 	ctx := cmdio.InContext(cmd.Context(), cmdIO)
 	cmd.SetContext(ctx)
-
 	return nil
 }

--- a/cmd/root/progress_logger.go
+++ b/cmd/root/progress_logger.go
@@ -7,42 +7,55 @@ import (
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
+	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
 const envProgressFormat = "DATABRICKS_CLI_PROGRESS_FORMAT"
 
-func resolveModeDefault(format flags.ProgressLogFormat) flags.ProgressLogFormat {
-	if (logLevel.String() == "disabled" || logFile.String() != "stderr") &&
+type progressLoggerFlag struct {
+	flags.ProgressLogFormat
+
+	log *logFlags
+}
+
+func (f *progressLoggerFlag) resolveModeDefault(format flags.ProgressLogFormat) flags.ProgressLogFormat {
+	if (f.log.level.String() == "disabled" || f.log.file.String() != "stderr") &&
 		term.IsTerminal(int(os.Stderr.Fd())) {
 		return flags.ModeInplace
 	}
 	return flags.ModeAppend
 }
 
-func initializeProgressLogger(ctx context.Context) (context.Context, error) {
-	if logLevel.String() != "disabled" && logFile.String() == "stderr" &&
-		progressFormat == flags.ModeInplace {
+func (f *progressLoggerFlag) initializeContext(ctx context.Context) (context.Context, error) {
+	if f.log.level.String() != "disabled" && f.log.file.String() == "stderr" &&
+		f.ProgressLogFormat == flags.ModeInplace {
 		return nil, fmt.Errorf("inplace progress logging cannot be used when log-file is stderr")
 	}
 
-	format := progressFormat
+	format := f.ProgressLogFormat
 	if format == flags.ModeDefault {
-		format = resolveModeDefault(format)
+		format = f.resolveModeDefault(format)
 	}
 
 	progressLogger := cmdio.NewLogger(format)
 	return cmdio.NewContext(ctx, progressLogger), nil
 }
 
-var progressFormat = flags.NewProgressLogFormat()
+func initProgressLoggerFlag(cmd *cobra.Command, logFlags *logFlags) *progressLoggerFlag {
+	f := progressLoggerFlag{
+		ProgressLogFormat: flags.NewProgressLogFormat(),
 
-func init() {
+		log: logFlags,
+	}
+
 	// Configure defaults from environment, if applicable.
 	// If the provided value is invalid it is ignored.
 	if v, ok := os.LookupEnv(envProgressFormat); ok {
-		progressFormat.Set(v)
+		f.Set(v)
 	}
-	RootCmd.PersistentFlags().Var(&progressFormat, "progress-format", "format for progress logs (append, inplace, json)")
-	RootCmd.RegisterFlagCompletionFunc("progress-format", progressFormat.Complete)
+
+	cmd.PersistentFlags().Var(&f.ProgressLogFormat, "progress-format", "format for progress logs (append, inplace, json)")
+	cmd.RegisterFlagCompletionFunc("progress-format", f.ProgressLogFormat.Complete)
+	return &f
 }

--- a/cmd/root/progress_logger_test.go
+++ b/cmd/root/progress_logger_test.go
@@ -60,7 +60,7 @@ func TestNoErrorOnNonStderrLogFile(t *testing.T) {
 
 func TestDefaultLoggerModeResolution(t *testing.T) {
 	plt, _, _, progressFormat := initializeProgressLoggerTest(t)
-	require.Equal(t, progressFormat, flags.ModeDefault)
+	require.Equal(t, *progressFormat, flags.ModeDefault)
 	ctx, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	require.NoError(t, err)
 	logger, ok := cmdio.FromContext(ctx)

--- a/cmd/root/progress_logger_test.go
+++ b/cmd/root/progress_logger_test.go
@@ -6,38 +6,62 @@ import (
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+type progressLoggerTest struct {
+	*cobra.Command
+	*logFlags
+	*progressLoggerFlag
+}
+
+func initializeProgressLoggerTest(t *testing.T) (
+	*progressLoggerTest,
+	*flags.LogLevelFlag,
+	*flags.LogFileFlag,
+	*flags.ProgressLogFormat,
+) {
+	plt := &progressLoggerTest{
+		Command: &cobra.Command{},
+	}
+	plt.logFlags = initLogFlags(plt.Command)
+	plt.progressLoggerFlag = initProgressLoggerFlag(plt.Command, plt.logFlags)
+	return plt, &plt.logFlags.level, &plt.logFlags.file, &plt.progressLoggerFlag.ProgressLogFormat
+}
+
 func TestInitializeErrorOnIncompatibleConfig(t *testing.T) {
+	plt, logLevel, logFile, progressFormat := initializeProgressLoggerTest(t)
 	logLevel.Set("info")
 	logFile.Set("stderr")
 	progressFormat.Set("inplace")
-	_, err := initializeProgressLogger(context.Background())
+	_, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	assert.ErrorContains(t, err, "inplace progress logging cannot be used when log-file is stderr")
 }
 
 func TestNoErrorOnDisabledLogLevel(t *testing.T) {
+	plt, logLevel, logFile, progressFormat := initializeProgressLoggerTest(t)
 	logLevel.Set("disabled")
 	logFile.Set("stderr")
 	progressFormat.Set("inplace")
-	_, err := initializeProgressLogger(context.Background())
+	_, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestNoErrorOnNonStderrLogFile(t *testing.T) {
+	plt, logLevel, logFile, progressFormat := initializeProgressLoggerTest(t)
 	logLevel.Set("info")
 	logFile.Set("stdout")
 	progressFormat.Set("inplace")
-	_, err := initializeProgressLogger(context.Background())
+	_, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestDefaultLoggerModeResolution(t *testing.T) {
-	progressFormat = flags.NewProgressLogFormat()
+	plt, _, _, progressFormat := initializeProgressLoggerTest(t)
 	require.Equal(t, progressFormat, flags.ModeDefault)
-	ctx, err := initializeProgressLogger(context.Background())
+	ctx, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	require.NoError(t, err)
 	logger, ok := cmdio.FromContext(ctx)
 	assert.True(t, ok)

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -13,26 +13,34 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-// RootCmd represents the base command when called without any subcommands
-var RootCmd = &cobra.Command{
-	Use:     "databricks",
-	Short:   "Databricks CLI",
-	Version: build.GetInfo().Version,
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "databricks",
+		Short:   "Databricks CLI",
+		Version: build.GetInfo().Version,
 
-	// Cobra prints the usage string to stderr if a command returns an error.
-	// This usage string should only be displayed if an invalid combination of flags
-	// is specified and not when runtime errors occur (e.g. resource not found).
-	// The usage string is include in [flagErrorFunc] for flag errors only.
-	SilenceUsage: true,
+		// Cobra prints the usage string to stderr if a command returns an error.
+		// This usage string should only be displayed if an invalid combination of flags
+		// is specified and not when runtime errors occur (e.g. resource not found).
+		// The usage string is include in [flagErrorFunc] for flag errors only.
+		SilenceUsage: true,
 
-	// Silence error printing by cobra. Errors are printed through cmdio.
-	SilenceErrors: true,
+		// Silence error printing by cobra. Errors are printed through cmdio.
+		SilenceErrors: true,
+	}
 
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	// Initialize flags
+	logFlags := initLogFlags(cmd)
+	progressLoggerFlag := initProgressLoggerFlag(cmd, logFlags)
+	outputFlag := initOutputFlag(cmd)
+	initProfileFlag(cmd)
+	initEnvironmentFlag(cmd)
+
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
 		// Configure default logger.
-		ctx, err := initializeLogger(ctx)
+		ctx, err := logFlags.initializeContext(ctx)
 		if err != nil {
 			return err
 		}
@@ -43,7 +51,7 @@ var RootCmd = &cobra.Command{
 			slog.String("args", strings.Join(os.Args, ", ")))
 
 		// Configure progress logger
-		ctx, err = initializeProgressLogger(ctx)
+		ctx, err = progressLoggerFlag.initializeContext(ctx)
 		if err != nil {
 			return err
 		}
@@ -51,7 +59,7 @@ var RootCmd = &cobra.Command{
 		cmd.SetContext(ctx)
 
 		// Configure command IO
-		err = initializeIO(cmd)
+		err = outputFlag.initializeIO(cmd)
 		if err != nil {
 			return err
 		}
@@ -63,7 +71,11 @@ var RootCmd = &cobra.Command{
 		ctx = withUpstreamInUserAgent(ctx)
 		cmd.SetContext(ctx)
 		return nil
-	},
+	}
+
+	cmd.SetFlagErrorFunc(flagErrorFunc)
+	cmd.SetVersionTemplate("Databricks CLI v{{.Version}}\n")
+	return cmd
 }
 
 // Wrap flag errors to include the usage string.
@@ -104,7 +116,5 @@ func Execute(cmd *cobra.Command) {
 	}
 }
 
-func init() {
-	RootCmd.SetFlagErrorFunc(flagErrorFunc)
-	RootCmd.SetVersionTemplate("Databricks CLI v{{.Version}}\n")
-}
+// Keep a global copy until all commands can be initialized.
+var RootCmd = New()


### PR DESCRIPTION
## Changes

This change is another step towards a CLI without globals. Also see #595.

The flags for the root command are now encapsulated in struct types.

## Tests

Unit tests pass.
