### PR TITLE
Add merge_group trigger for build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   tests:


### PR DESCRIPTION
## Changes

Also see [GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

## Tests

n/a
