### PR TITLE
Remove push to main trigger for build workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,8 +3,6 @@ name: build
 on:
   pull_request:
     types: [opened, synchronize]
-  push:
-    branches: [main]
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
## Changes

Commits going through the merge queue are tested there using their final SHA as if they were already in main. The push-to-main trigger therefore duplicates the builds that were already triggered from the merge queue.

## Tests

![Screenshot 2023-07-27 at 15 37 17](https://github.com/databricks/cli/assets/9845/ff7af5dd-0d2c-48c2-89b2-7ecf3d121071)
