### PR TITLE
Fix failing fs mkdir test on azure

### DIFF
--- a/internal/fs_mkdir_test.go
+++ b/internal/fs_mkdir_test.go
@@ -112,6 +112,6 @@ func TestAccFsMkdirWhenFileExistsAtPath(t *testing.T) {
 	// assert run fails
 	_, _, err = RequireErrorRun(t, "fs", "mkdir", "dbfs:"+path.Join(tmpDir, "hello"))
 	// Different cloud providers return different errors.
-	regex := regexp.MustCompile(`^Path is a file: .*$|^Cannot create directory .* because .* is an existing file$|^mkdirs\(hadoopPath: .*, permission: rwxrwxrwx\): failed$`)
+	regex := regexp.MustCompile(`^Path is a file: .*$|^Cannot create directory .* because .* is an existing file.$|^mkdirs\(hadoopPath: .*, permission: rwxrwxrwx\): failed$`)
 	assert.Regexp(t, regex, err.Error())
 }

--- a/internal/fs_mkdir_test.go
+++ b/internal/fs_mkdir_test.go
@@ -112,6 +112,6 @@ func TestAccFsMkdirWhenFileExistsAtPath(t *testing.T) {
 	// assert run fails
 	_, _, err = RequireErrorRun(t, "fs", "mkdir", "dbfs:"+path.Join(tmpDir, "hello"))
 	// Different cloud providers return different errors.
-	regex := regexp.MustCompile(`^Path is a file: .*$|^Cannot create directory .* because .* is an existing file.$|^mkdirs\(hadoopPath: .*, permission: rwxrwxrwx\): failed$`)
+	regex := regexp.MustCompile(`^Path is a file: .*$|^Cannot create directory .* because .* is an existing file\.$|^mkdirs\(hadoopPath: .*, permission: rwxrwxrwx\): failed$`)
 	assert.Regexp(t, regex, err.Error())
 }


### PR DESCRIPTION
Regex check was missing a "." character and adding it in fixes the test. The test now passes on all three cloud providers
