### PR TITLE
Added transformation mutator for Python wheel task for them to work on DBR <13.1

### DIFF
--- a/bundle/artifacts/artifacts.go
+++ b/bundle/artifacts/artifacts.go
@@ -165,3 +165,36 @@ func getUploadBasePath(b *bundle.Bundle) (string, error) {
 
 	return path.Join(artifactPath, ".internal"), nil
 }
+
+func UploadNotebook(ctx context.Context, notebook string, b *bundle.Bundle) (string, error) {
+	raw, err := os.ReadFile(notebook)
+	if err != nil {
+		return "", fmt.Errorf("unable to read %s: %w", notebook, errors.Unwrap(err))
+	}
+
+	uploadPath, err := getUploadBasePath(b)
+	if err != nil {
+		return "", err
+	}
+
+	remotePath := path.Join(uploadPath, path.Base(notebook))
+	// Make sure target directory exists.
+	err = b.WorkspaceClient().Workspace.MkdirsByPath(ctx, path.Dir(remotePath))
+	if err != nil {
+		return "", fmt.Errorf("unable to create directory for %s: %w", remotePath, err)
+	}
+
+	// Import to workspace.
+	err = b.WorkspaceClient().Workspace.Import(ctx, workspace.Import{
+		Path:      remotePath,
+		Overwrite: true,
+		Format:    workspace.ImportFormatSource,
+		Content:   base64.StdEncoding.EncodeToString(raw),
+		Language:  workspace.LanguagePython,
+	})
+	if err != nil {
+		return "", fmt.Errorf("unable to import %s: %w", remotePath, err)
+	}
+
+	return remotePath, nil
+}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/lock"
 	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/libraries"
+	"github.com/databricks/cli/bundle/python"
 )
 
 // The deploy phase deploys artifacts and resources.
@@ -21,6 +22,7 @@ func Deploy() bundle.Mutator {
 				libraries.MatchWithArtifacts(),
 				artifacts.CleanUp(),
 				artifacts.UploadAll(),
+				python.TransformWheelTask(),
 				terraform.Interpolate(),
 				terraform.Write(),
 				terraform.StatePull(),

--- a/bundle/python/transform.go
+++ b/bundle/python/transform.go
@@ -1,0 +1,106 @@
+package python
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/artifacts"
+	"github.com/databricks/cli/bundle/libraries"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+)
+
+// This mutator takes the wheel task and trasnforms it into notebook
+// which installs uploaded wheels using %pip and then calling corresponding
+// entry point.
+func TransformWheelTask() bundle.Mutator {
+	return &transform{}
+}
+
+type transform struct {
+}
+
+func (m *transform) Name() string {
+	return "python.TransformWheelTask"
+}
+
+const INSTALL_WHEEL_CODE = `%%pip install --force-reinstall %s`
+
+const NOTEBOOK_CODE = `
+%%python
+%s
+
+from contextlib import redirect_stdout
+import io
+import sys
+sys.argv = [%s]
+
+import pkg_resources
+_func = pkg_resources.load_entry_point("%s", "console_scripts", "%s")
+
+f = io.StringIO()
+with redirect_stdout(f):
+	_func()
+s = f.getvalue()
+dbutils.notebook.exit(s)
+`
+
+func (m *transform) Apply(ctx context.Context, b *bundle.Bundle) error {
+	// TODO: do the transformaton only for DBR < 13.1 and (maybe?) existing clusters
+	wheelTasks := libraries.FindAllWheelTasks(b)
+	for _, wheelTask := range wheelTasks {
+		taskDefinition := wheelTask.PythonWheelTask
+		libraries := wheelTask.Libraries
+
+		wheelTask.PythonWheelTask = nil
+		wheelTask.Libraries = nil
+
+		path, err := generateNotebookWrapper(taskDefinition, libraries)
+		if err != nil {
+			return err
+		}
+
+		remotePath, err := artifacts.UploadNotebook(context.Background(), path, b)
+		if err != nil {
+			return err
+		}
+
+		os.Remove(path)
+
+		wheelTask.NotebookTask = &jobs.NotebookTask{
+			NotebookPath: remotePath,
+		}
+	}
+	return nil
+}
+
+func generateNotebookWrapper(task *jobs.PythonWheelTask, libraries []compute.Library) (string, error) {
+	pipInstall := ""
+	for _, lib := range libraries {
+		pipInstall = pipInstall + "\n" + fmt.Sprintf(INSTALL_WHEEL_CODE, lib.Whl)
+	}
+	content := fmt.Sprintf(NOTEBOOK_CODE, pipInstall, generateParameters(task), task.PackageName, task.EntryPoint)
+
+	tmpDir := os.TempDir()
+	filename := fmt.Sprintf("notebook_%s_%s.ipynb", task.PackageName, task.EntryPoint)
+	path := filepath.Join(tmpDir, filename)
+
+	err := os.WriteFile(path, bytes.NewBufferString(content).Bytes(), 0644)
+	return path, err
+}
+
+func generateParameters(task *jobs.PythonWheelTask) string {
+	params := append([]string{"python"}, task.Parameters...)
+	for k, v := range task.NamedParameters {
+		params = append(params, fmt.Sprintf("%s=%s", k, v))
+	}
+	for i := range params {
+		params[i] = `"` + params[i] + `"`
+	}
+	return strings.Join(params, ", ")
+}


### PR DESCRIPTION
## Changes
Added transformation mutator for Python wheel task for them to work on DBR <13.1

Using wheels upload to Workspace file system as cluster libraries is not supported in DBR < 13.1

In order to make Python wheel work correctly on DBR < 13.1 we do the following:
1. Build and upload python wheel as usual
2. Transform python wheel task into special notebook task which does the following
a. Installs all necessary wheels with %pip magic
b. Executes defined entry point with all provided parameters
3. Upload this notebook file to workspace file system
4. Deploy transformed job task

This is also beneficial for executing on existing clusters because this notebook always reinstall wheels so if there are any changes to the wheel package, they are correctly picked up

## Tests
bundle.yml

```yaml
bundle:
  name: wheel-task

workspace:
  host: ****

resources:
  jobs:
    test_job:
      name: "[${bundle.environment}] My Wheel Job"
      tasks:
        - task_key: TestTask
          existing_cluster_id: "***"
          python_wheel_task:
            package_name: "my_test_code"
            entry_point: "run"
            parameters: ["first argument","first value","second argument","second value"]
          libraries:
          - whl: ./dist/*.whl
```

Output
```
andrew.nester@HFW9Y94129 wheel % databricks bundle run test_job
Run URL: ***

2023-08-03 15:58:04 "[default] My Wheel Job" TERMINATED SUCCESS 
Output:
=======
Task TestTask:
Hello from my func
Got arguments v1:
['python', 'first argument', 'first value', 'second argument', 'second value']

```

