### PR TITLE
Add internal tag for bundle fields to be skipped from schema

### DIFF
--- a/bundle/config/environment.go
+++ b/bundle/config/environment.go
@@ -12,7 +12,8 @@ type Environment struct {
 	// Determines the mode of the environment.
 	// For example, 'mode: development' can be used for deployments for
 	// development purposes.
-	Mode Mode `json:"mode,omitempty"`
+	// TODO: remove the todo tag once this field is operational
+	Mode Mode `json:"mode,omitempty" bundle:"preview"`
 
 	// Overrides the compute used for jobs and other supported assets.
 	ComputeID string `json:"compute_id,omitempty"`

--- a/bundle/config/environment.go
+++ b/bundle/config/environment.go
@@ -12,7 +12,7 @@ type Environment struct {
 	// Determines the mode of the environment.
 	// For example, 'mode: development' can be used for deployments for
 	// development purposes.
-	// TODO: remove the todo tag once this field is operational
+	// TODO: remove the "preview" tag once this field is operational
 	Mode Mode `json:"mode,omitempty" bundle:"preview"`
 
 	// Overrides the compute used for jobs and other supported assets.

--- a/bundle/config/environment.go
+++ b/bundle/config/environment.go
@@ -12,8 +12,7 @@ type Environment struct {
 	// Determines the mode of the environment.
 	// For example, 'mode: development' can be used for deployments for
 	// development purposes.
-	// TODO: remove the "preview" tag once this field is operational
-	Mode Mode `json:"mode,omitempty" bundle:"preview"`
+	Mode Mode `json:"mode,omitempty"`
 
 	// Overrides the compute used for jobs and other supported assets.
 	ComputeID string `json:"compute_id,omitempty"`

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -24,7 +24,7 @@ type Workspace struct {
 	Host               string `json:"host,omitempty"`
 	Profile            string `json:"profile,omitempty"`
 	AuthType           string `json:"auth_type,omitempty"`
-	MetadataServiceURL string `json:"metadata_service_url,omitempty"`
+	MetadataServiceURL string `json:"metadata_service_url,omitempty" bundle:"internal"`
 
 	// OAuth specific attributes.
 	ClientID string `json:"client_id,omitempty"`

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -23,7 +23,7 @@ type Workspace struct {
 	// Generic attributes.
 	Host               string `json:"host,omitempty"`
 	Profile            string `json:"profile,omitempty"`
-	AuthType           string `json:"auth_type,omitempty"`
+	AuthType           string `json:"auth_type,omitempty" bundle:"preview"`
 	MetadataServiceURL string `json:"metadata_service_url,omitempty"`
 
 	// OAuth specific attributes.

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -23,7 +23,7 @@ type Workspace struct {
 	// Generic attributes.
 	Host               string `json:"host,omitempty"`
 	Profile            string `json:"profile,omitempty"`
-	AuthType           string `json:"auth_type,omitempty" bundle:"preview"`
+	AuthType           string `json:"auth_type,omitempty"`
 	MetadataServiceURL string `json:"metadata_service_url,omitempty"`
 
 	// OAuth specific attributes.

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -9,6 +9,15 @@ import (
 	"github.com/databricks/cli/libs/jsonschema"
 )
 
+// Fields tagged "readonly" should not be emitted in the schema as they are
+// computed at runtime, and should not be assigned a value by the bundle author.
+const readonlyTag = "readonly"
+
+// Fields tagged "preview" are still under active development and should not
+// be shown to users in the schema. This tag is meant to be  temporary and
+// should be removed once the field is ready to be used widely by customers.
+const previewTag = "preview"
+
 // This function translates golang types into json schema. Here is the mapping
 // between json schema types and golang types
 //
@@ -197,7 +206,7 @@ func toSchema(golangType reflect.Type, docs *Docs, tracker *tracker) (*jsonschem
 		required := []string{}
 		for _, child := range children {
 			bundleTag := child.Tag.Get("bundle")
-			if bundleTag == "readonly" {
+			if bundleTag == readonlyTag || bundleTag == previewTag {
 				continue
 			}
 

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -13,10 +13,9 @@ import (
 // computed at runtime, and should not be assigned a value by the bundle author.
 const readonlyTag = "readonly"
 
-// Fields tagged "preview" are still under active development and should not
-// be shown to users in the schema. This tag is meant to be  temporary and
-// should be removed once the field is ready to be used widely by customers.
-const previewTag = "preview"
+// Annotation for internal bundle fields that should not be exposed to customers.
+// Fields can be tagged as "internal" to remove them from the generated schema.
+const internalTag = "internal"
 
 // This function translates golang types into json schema. Here is the mapping
 // between json schema types and golang types
@@ -206,7 +205,7 @@ func toSchema(golangType reflect.Type, docs *Docs, tracker *tracker) (*jsonschem
 		required := []string{}
 		for _, child := range children {
 			bundleTag := child.Tag.Get("bundle")
-			if bundleTag == readonlyTag || bundleTag == previewTag {
+			if bundleTag == readonlyTag || bundleTag == internalTag {
 				continue
 			}
 

--- a/bundle/schema/schema_test.go
+++ b/bundle/schema/schema_test.go
@@ -1463,16 +1463,16 @@ func TestBundleReadOnlytag(t *testing.T) {
 	assert.Equal(t, expected, string(jsonSchema))
 }
 
-func TestBundlePreviewTag(t *testing.T) {
+func TestBundleInternalTag(t *testing.T) {
 	type Pokemon struct {
-		Pikachu string `json:"pikachu" bundle:"preview"`
+		Pikachu string `json:"pikachu" bundle:"internal"`
 		Raichu  string `json:"raichu"`
 	}
 
 	type Foo struct {
 		Pokemon *Pokemon `json:"pokemon"`
 		Apple   int      `json:"apple"`
-		Mango   string   `json:"mango" bundle:"preview"`
+		Mango   string   `json:"mango" bundle:"internal"`
 	}
 
 	elem := Foo{}

--- a/bundle/schema/schema_test.go
+++ b/bundle/schema/schema_test.go
@@ -1462,3 +1462,55 @@ func TestBundleReadOnlytag(t *testing.T) {
 	t.Log("[DEBUG] expected: ", expected)
 	assert.Equal(t, expected, string(jsonSchema))
 }
+
+func TestBundlePreviewTag(t *testing.T) {
+	type Pokemon struct {
+		Pikachu string `json:"pikachu" bundle:"preview"`
+		Raichu  string `json:"raichu"`
+	}
+
+	type Foo struct {
+		Pokemon *Pokemon `json:"pokemon"`
+		Apple   int      `json:"apple"`
+		Mango   string   `json:"mango" bundle:"preview"`
+	}
+
+	elem := Foo{}
+
+	schema, err := New(reflect.TypeOf(elem), nil)
+	assert.NoError(t, err)
+
+	jsonSchema, err := json.MarshalIndent(schema, "		", "	")
+	assert.NoError(t, err)
+
+	expected :=
+		`{
+			"type": "object",
+			"properties": {
+				"apple": {
+					"type": "number"
+				},
+				"pokemon": {
+					"type": "object",
+					"properties": {
+						"raichu": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"raichu"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"pokemon",
+				"apple"
+			]
+		}`
+
+	t.Log("[DEBUG] actual: ", string(jsonSchema))
+	t.Log("[DEBUG] expected: ", expected)
+	assert.Equal(t, expected, string(jsonSchema))
+}


### PR DESCRIPTION
## Changes
This PR:
1. Introduces the "internal" tag to bundle configs that should not be visible to customers.
2. Annotates "metadata_service_url" as an internal field.

## Tests
Unit tests.
