### PR TITLE
Fixed processing jobs libraries with remote path

### DIFF
--- a/bundle/libraries/libraries.go
+++ b/bundle/libraries/libraries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
@@ -111,5 +112,20 @@ func libPath(library *compute.Library) string {
 }
 
 func isLocalLibrary(library *compute.Library) bool {
-	return libPath(library) != ""
+	path := libPath(library)
+	if path == "" {
+		return false
+	}
+
+	return !isDbfsPath(path) && !isWorkspacePath(path)
+}
+
+func isDbfsPath(path string) bool {
+	return strings.HasPrefix(path, "dbfs:/")
+}
+
+func isWorkspacePath(path string) bool {
+	return strings.HasPrefix(path, "/Workspace/") ||
+		strings.HasPrefix(path, "/Users/") ||
+		strings.HasPrefix(path, "/Shared/")
 }

--- a/bundle/tests/bundle/python_wheel/bundle.yml
+++ b/bundle/tests/bundle/python_wheel/bundle.yml
@@ -17,3 +17,5 @@ resources:
           python_wheel_task:
             package_name: "my_test_code"
             entry_point: "run"
+          libraries:
+          - whl: ./my_test_code/dist/*.whl

--- a/bundle/tests/bundle/python_wheel_dbfs_lib/bundle.yml
+++ b/bundle/tests/bundle/python_wheel_dbfs_lib/bundle.yml
@@ -7,9 +7,9 @@ resources:
       name: "[${bundle.environment}] My Wheel Job"
       tasks:
         - task_key: TestTask
-          existing_cluster_id: "0717-aaaaa-bbbbbb"
+          existing_cluster_id: "0717-132531-5opeqon1"
           python_wheel_task:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./dist/*.whl
+          - whl: dbfs://path/to/dist/mywheel.whl

--- a/bundle/tests/bundle/wheel_test.go
+++ b/bundle/tests/bundle/wheel_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/libraries"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +22,10 @@ func TestBundlePythonWheelBuild(t *testing.T) {
 	matches, err := filepath.Glob("python_wheel/my_test_code/dist/my_test_code-*.whl")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
+
+	match := libraries.MatchWithArtifacts()
+	err = match.Apply(context.Background(), b)
+	require.NoError(t, err)
 }
 
 func TestBundlePythonWheelBuildAutoDetect(t *testing.T) {
@@ -34,4 +39,21 @@ func TestBundlePythonWheelBuildAutoDetect(t *testing.T) {
 	matches, err := filepath.Glob("python_wheel/my_test_code/dist/my_test_code-*.whl")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(matches))
+
+	match := libraries.MatchWithArtifacts()
+	err = match.Apply(context.Background(), b)
+	require.NoError(t, err)
+}
+
+func TestBundlePythonWheelWithDBFSLib(t *testing.T) {
+	b, err := bundle.Load("./python_wheel_dbfs_lib")
+	require.NoError(t, err)
+
+	m := phases.Build()
+	err = m.Apply(context.Background(), b)
+	require.NoError(t, err)
+
+	match := libraries.MatchWithArtifacts()
+	err = match.Apply(context.Background(), b)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Changes
Some library paths such as for Spark jobs, can reference a lib on remote path, for example DBFS.
This PR fixes how CLI handles such libraries and do not report them as missing locally.

## Tests
Added unit tests + ran `databricks bundle deploy` manually
