### PR TITLE
Execute paths without the .tmpl extension as templates

### DIFF
--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -124,15 +124,15 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	perm := info.Mode().Perm()
 
+	// Execute relative path template to get destination path for the file
+	relPath, err := r.executeTemplate(relPathTemplate)
+	if err != nil {
+		return nil, err
+	}
+
 	// If file name does not specify the `.tmpl` extension, then it is copied
 	// over as is, without treating it as a template
 	if !strings.HasSuffix(relPathTemplate, templateExtension) {
-		// Execute relative path template to get destination path for the file
-		relPath, err := r.executeTemplate(relPathTemplate)
-		if err != nil {
-			return nil, err
-		}
-
 		return &copyFile{
 			dstPath: &destinationPath{
 				root:    r.instanceRoot,
@@ -143,6 +143,10 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 			srcPath:  relPathTemplate,
 			srcFiler: r.templateFiler,
 		}, nil
+	} else {
+		// Trim the .tmpl suffix from file name, if specified in the template
+		// path
+		relPath = strings.TrimSuffix(relPath, templateExtension)
 	}
 
 	// read template file's content
@@ -164,14 +168,6 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute file content for %s. %w", relPathTemplate, err)
-	}
-
-	// Execute relative path template after stripping the .tmpl extension to
-	// get destination path for the file
-	relPathTemplate = strings.TrimSuffix(relPathTemplate, templateExtension)
-	relPath, err := r.executeTemplate(relPathTemplate)
-	if err != nil {
-		return nil, err
 	}
 
 	return &inMemoryFile{

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -124,16 +124,15 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	perm := info.Mode().Perm()
 
-	// Execute relative path template to get materialized path for the file
-	relPathTemplate = strings.TrimSuffix(relPathTemplate, templateExtension)
-	relPath, err := r.executeTemplate(relPathTemplate)
-	if err != nil {
-		return nil, err
-	}
-
 	// If file name does not specify the `.tmpl` extension, then it is copied
 	// over as is, without treating it as a template
 	if !strings.HasSuffix(relPathTemplate, templateExtension) {
+		// Execute relative path template to get destination path for the file
+		relPath, err := r.executeTemplate(relPathTemplate)
+		if err != nil {
+			return nil, err
+		}
+
 		return &copyFile{
 			dstPath: &destinationPath{
 				root:    r.instanceRoot,
@@ -152,6 +151,13 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 		return nil, err
 	}
 	defer templateReader.Close()
+
+	// Execute relative path template after stripping the .tmpl extension to
+	// get destination path for the file
+	relPath, err := r.executeTemplate(strings.TrimSuffix(relPathTemplate, templateExtension))
+	if err != nil {
+		return nil, err
+	}
 
 	// execute the contents of the file as a template
 	contentTemplate, err := io.ReadAll(templateReader)

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -124,13 +124,20 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	perm := info.Mode().Perm()
 
+	// Execute relative path template to get materialized path for the file
+	relPathTemplate = strings.TrimSuffix(relPathTemplate, templateExtension)
+	relPath, err := r.executeTemplate(relPathTemplate)
+	if err != nil {
+		return nil, err
+	}
+
 	// If file name does not specify the `.tmpl` extension, then it is copied
 	// over as is, without treating it as a template
 	if !strings.HasSuffix(relPathTemplate, templateExtension) {
 		return &copyFile{
 			dstPath: &destinationPath{
 				root:    r.instanceRoot,
-				relPath: relPathTemplate,
+				relPath: relPath,
 			},
 			perm:     perm,
 			ctx:      r.ctx,
@@ -158,13 +165,6 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute file content for %s. %w", relPathTemplate, err)
-	}
-
-	// Execute relative path template to get materialized path for the file
-	relPathTemplate = strings.TrimSuffix(relPathTemplate, templateExtension)
-	relPath, err := r.executeTemplate(relPathTemplate)
-	if err != nil {
-		return nil, err
 	}
 
 	return &inMemoryFile{

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -152,13 +152,6 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	defer templateReader.Close()
 
-	// Execute relative path template after stripping the .tmpl extension to
-	// get destination path for the file
-	relPath, err := r.executeTemplate(strings.TrimSuffix(relPathTemplate, templateExtension))
-	if err != nil {
-		return nil, err
-	}
-
 	// execute the contents of the file as a template
 	contentTemplate, err := io.ReadAll(templateReader)
 	if err != nil {
@@ -171,6 +164,14 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute file content for %s. %w", relPathTemplate, err)
+	}
+
+	// Execute relative path template after stripping the .tmpl extension to
+	// get destination path for the file
+	relPathTemplate = strings.TrimSuffix(relPathTemplate, templateExtension)
+	relPath, err := r.executeTemplate(relPathTemplate)
+	if err != nil {
+		return nil, err
 	}
 
 	return &inMemoryFile{

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -470,6 +470,6 @@ func TestRendererSubTemplateInPath(t *testing.T) {
 	err = r.walk()
 	require.NoError(t, err)
 
-	assert.Equal(t, filepath.Join(tmpDir, "my_directory/my_file"), r.files[0].DstPath().absPath())
+	assert.Equal(t, filepath.Join(tmpDir, "my_directory", "my_file"), r.files[0].DstPath().absPath())
 	assert.Equal(t, "my_directory/my_file", r.files[0].DstPath().relPath)
 }

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -459,3 +459,17 @@ func TestRendererFileTreeRendering(t *testing.T) {
 	assert.DirExists(t, filepath.Join(tmpDir, "my_directory"))
 	assert.FileExists(t, filepath.Join(tmpDir, "my_directory", "my_file"))
 }
+
+func TestRendererSubTemplateInPath(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	r, err := newRenderer(ctx, nil, "./testdata/template-in-path/template", "./testdata/template-in-path/library", tmpDir)
+	require.NoError(t, err)
+
+	err = r.walk()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join(tmpDir, "my_directory/my_file"), r.files[0].DstPath().absPath())
+	assert.Equal(t, "my_directory/my_file", r.files[0].DstPath().relPath)
+}

--- a/libs/template/testdata/template-in-path/library/my_funcs.tmpl
+++ b/libs/template/testdata/template-in-path/library/my_funcs.tmpl
@@ -1,0 +1,7 @@
+{{define "dir_name" -}}
+my_directory
+{{- end}}
+
+{{define "file_name" -}}
+my_file
+{{- end}}


### PR DESCRIPTION
## Changes
The `.tmpl` extension is only meant as a qualifier for whether the file content is executed as a template. All file paths in the `template` directory should be treated as valid go text templates. 

Before only paths with the `.tmpl` extensions would be resolved as templates, after this change, all file paths are interpreted as templates.

## Tests
Unit test. The newly added unit tests also asserts that the file path is correct, even when the `.tmpl` extension is missing.