### PR TITLE
Correct name for force acquire deploy flag

### DIFF
--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -17,7 +17,7 @@ func newDeployCommand() *cobra.Command {
 	var forceLock bool
 	var computeID string
 	cmd.Flags().BoolVar(&force, "force", false, "Force-override Git branch validation.")
-	cmd.Flags().BoolVar(&forceLock, "force-deploy", false, "Force acquisition of deployment lock.")
+	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
 	cmd.Flags().StringVarP(&computeID, "compute-id", "c", "", "Override compute in the deployment with the given compute ID.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/locker_test.go
+++ b/internal/locker_test.go
@@ -90,7 +90,7 @@ func TestAccLock(t *testing.T) {
 				indexOfAnInactiveLocker = i
 			}
 			assert.ErrorContains(t, lockerErrs[i], "lock acquired by")
-			assert.ErrorContains(t, lockerErrs[i], "Use --force to override")
+			assert.ErrorContains(t, lockerErrs[i], "Use --force-lock to override")
 		}
 	}
 	assert.Equal(t, 1, countActive, "Exactly one locker should successfull acquire the lock")

--- a/libs/locker/locker.go
+++ b/libs/locker/locker.go
@@ -105,10 +105,10 @@ func (locker *Locker) assertLockHeld(ctx context.Context) error {
 		return err
 	}
 	if activeLockState.ID != locker.State.ID && !activeLockState.IsForced {
-		return fmt.Errorf("deploy lock acquired by %s at %v. Use --force to override", activeLockState.User, activeLockState.AcquisitionTime)
+		return fmt.Errorf("deploy lock acquired by %s at %v. Use --force-lock to override", activeLockState.User, activeLockState.AcquisitionTime)
 	}
 	if activeLockState.ID != locker.State.ID && activeLockState.IsForced {
-		return fmt.Errorf("deploy lock force acquired by %s at %v. Use --force to override", activeLockState.User, activeLockState.AcquisitionTime)
+		return fmt.Errorf("deploy lock force acquired by %s at %v. Use --force-lock to override", activeLockState.User, activeLockState.AcquisitionTime)
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes
As discussed here, the name for this flag should be `force-lock`: https://github.com/databricks/cli/pull/578#discussion_r1276233445

## Tests
Manually and existing tests
