### PR TITLE
Return better error messages for invalid JSON schema types in templates

### DIFF
--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -1,5 +1,11 @@
 package jsonschema
 
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
 // defines schema for a json object
 type Schema struct {
 	// Type of the object
@@ -47,3 +53,34 @@ const (
 	ArrayType   Type = "array"
 	IntegerType Type = "integer"
 )
+
+func validate(schema *Schema) error {
+	for _, v := range schema.Properties {
+		switch v.Type {
+		case NumberType, BooleanType, StringType, IntegerType:
+			continue
+		case "int", "int32", "int64":
+			return fmt.Errorf("type %s is not a recognized json schema type. Please use \"integer\" instead", v.Type)
+		case "float", "float32", "float64":
+			return fmt.Errorf("type %s is not a recognized json schema type. Please use \"number\" instead", v.Type)
+		case "bool":
+			return fmt.Errorf("type %s is not a recognized json schema type. Please use \"boolean\" instead", v.Type)
+		default:
+			return fmt.Errorf("type %s is not a recognized json schema type", v.Type)
+		}
+	}
+	return nil
+}
+
+func Load(path string) (*Schema, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	schema := &Schema{}
+	err = json.Unmarshal(b, schema)
+	if err != nil {
+		return nil, err
+	}
+	return schema, validate(schema)
+}

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -54,7 +54,7 @@ const (
 	IntegerType Type = "integer"
 )
 
-func validate(schema *Schema) error {
+func (schema *Schema) validate() error {
 	for _, v := range schema.Properties {
 		switch v.Type {
 		case NumberType, BooleanType, StringType, IntegerType:
@@ -82,5 +82,5 @@ func Load(path string) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return schema, validate(schema)
+	return schema, schema.validate()
 }

--- a/libs/jsonschema/schema_test.go
+++ b/libs/jsonschema/schema_test.go
@@ -18,27 +18,27 @@ func TestJsonSchemaValidate(t *testing.T) {
 		}
 	}
 
-	err = validate(toSchema("string"))
+	err = toSchema("string").validate()
 	assert.NoError(t, err)
 
-	err = validate(toSchema("boolean"))
+	err = toSchema("boolean").validate()
 	assert.NoError(t, err)
 
-	err = validate(toSchema("number"))
+	err = toSchema("number").validate()
 	assert.NoError(t, err)
 
-	err = validate(toSchema("integer"))
+	err = toSchema("integer").validate()
 	assert.NoError(t, err)
 
-	err = validate(toSchema("int"))
+	err = toSchema("int").validate()
 	assert.EqualError(t, err, "type int is not a recognized json schema type. Please use \"integer\" instead")
 
-	err = validate(toSchema("float"))
+	err = toSchema("float").validate()
 	assert.EqualError(t, err, "type float is not a recognized json schema type. Please use \"number\" instead")
 
-	err = validate(toSchema("bool"))
+	err = toSchema("bool").validate()
 	assert.EqualError(t, err, "type bool is not a recognized json schema type. Please use \"boolean\" instead")
 
-	err = validate(toSchema("foobar"))
+	err = toSchema("foobar").validate()
 	assert.EqualError(t, err, "type foobar is not a recognized json schema type")
 }

--- a/libs/jsonschema/schema_test.go
+++ b/libs/jsonschema/schema_test.go
@@ -1,0 +1,44 @@
+package jsonschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonSchemaValidate(t *testing.T) {
+	var err error
+	toSchema := func(s string) *Schema {
+		return &Schema{
+			Properties: map[string]*Schema{
+				"foo": {
+					Type: Type(s),
+				},
+			},
+		}
+	}
+
+	err = validate(toSchema("string"))
+	assert.NoError(t, err)
+
+	err = validate(toSchema("boolean"))
+	assert.NoError(t, err)
+
+	err = validate(toSchema("number"))
+	assert.NoError(t, err)
+
+	err = validate(toSchema("integer"))
+	assert.NoError(t, err)
+
+	err = validate(toSchema("int"))
+	assert.EqualError(t, err, "type int is not a recognized json schema type. Please use \"integer\" instead")
+
+	err = validate(toSchema("float"))
+	assert.EqualError(t, err, "type float is not a recognized json schema type. Please use \"number\" instead")
+
+	err = validate(toSchema("bool"))
+	assert.EqualError(t, err, "type bool is not a recognized json schema type. Please use \"boolean\" instead")
+
+	err = validate(toSchema("foobar"))
+	assert.EqualError(t, err, "type foobar is not a recognized json schema type")
+}

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -18,12 +18,7 @@ type config struct {
 
 func newConfig(ctx context.Context, schemaPath string) (*config, error) {
 	// Read config schema
-	schemaBytes, err := os.ReadFile(schemaPath)
-	if err != nil {
-		return nil, err
-	}
-	schema := &jsonschema.Schema{}
-	err = json.Unmarshal(schemaBytes, schema)
+	schema, err := jsonschema.Load(schemaPath)
 	if err != nil {
 		return nil, err
 	}
@@ -41,15 +36,8 @@ func newConfig(ctx context.Context, schemaPath string) (*config, error) {
 
 func validateSchema(schema *jsonschema.Schema) error {
 	for _, v := range schema.Properties {
-		switch v.Type {
-		case jsonschema.NumberType, jsonschema.BooleanType, jsonschema.StringType, jsonschema.IntegerType:
-			continue
-		case jsonschema.ArrayType, jsonschema.ObjectType:
+		if v.Type == jsonschema.ArrayType || v.Type == jsonschema.ObjectType {
 			return fmt.Errorf("property type %s is not supported by bundle templates", v.Type)
-		case "int", "int32", "int64":
-			return fmt.Errorf("type %s is not a recognized json schema type. Please use \"integer\" instead", v.Type)
-		default:
-			return fmt.Errorf("type %s is not a recognized json schema type", v.Type)
 		}
 	}
 	return nil

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -191,10 +191,4 @@ func TestTemplateValidateSchema(t *testing.T) {
 
 	err = validateSchema(toSchema("array"))
 	assert.EqualError(t, err, "property type array is not supported by bundle templates")
-
-	err = validateSchema(toSchema("int"))
-	assert.EqualError(t, err, "type int is not a recognized json schema type. Please use \"integer\" instead")
-
-	err = validateSchema(toSchema("foobar"))
-	assert.EqualError(t, err, "type foobar is not a recognized json schema type")
 }

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -161,3 +161,40 @@ func TestTemplateConfigValidateTypeForInvalidType(t *testing.T) {
 	err = c.validate()
 	assert.EqualError(t, err, `incorrect type for int_val. expected type integer, but value is "this-should-be-an-int"`)
 }
+
+func TestTemplateValidateSchema(t *testing.T) {
+	var err error
+	toSchema := func(s string) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Properties: map[string]*jsonschema.Schema{
+				"foo": {
+					Type: jsonschema.Type(s),
+				},
+			},
+		}
+	}
+
+	err = validateSchema(toSchema("string"))
+	assert.NoError(t, err)
+
+	err = validateSchema(toSchema("boolean"))
+	assert.NoError(t, err)
+
+	err = validateSchema(toSchema("number"))
+	assert.NoError(t, err)
+
+	err = validateSchema(toSchema("integer"))
+	assert.NoError(t, err)
+
+	err = validateSchema(toSchema("object"))
+	assert.EqualError(t, err, "property type object is not supported by bundle templates")
+
+	err = validateSchema(toSchema("array"))
+	assert.EqualError(t, err, "property type array is not supported by bundle templates")
+
+	err = validateSchema(toSchema("int"))
+	assert.EqualError(t, err, "type int is not a recognized json schema type. Please use \"integer\" instead")
+
+	err = validateSchema(toSchema("foobar"))
+	assert.EqualError(t, err, "type foobar is not a recognized json schema type")
+}

--- a/libs/template/utils.go
+++ b/libs/template/utils.go
@@ -69,9 +69,6 @@ func toString(v any, T jsonschema.Type) (string, error) {
 	case jsonschema.ArrayType, jsonschema.ObjectType:
 		return "", fmt.Errorf("cannot format object of type %s as a string. Value of object: %#v", T, v)
 	default:
-		if T == "int" {
-			return "", fmt.Errorf(`unknown json schema type %q. Please use "integer" instead`, T)
-		}
 		return "", fmt.Errorf("unknown json schema type: %q", T)
 	}
 }
@@ -95,9 +92,6 @@ func fromString(s string, T jsonschema.Type) (any, error) {
 	case jsonschema.ArrayType, jsonschema.ObjectType:
 		return "", fmt.Errorf("cannot parse string as object of type %s. Value of string: %q", T, s)
 	default:
-		if T == "int" {
-			return "", fmt.Errorf(`unknown json schema type %q. Please use "integer" instead`, T)
-		}
 		return "", fmt.Errorf("unknown json schema type: %q", T)
 	}
 

--- a/libs/template/utils.go
+++ b/libs/template/utils.go
@@ -66,8 +66,13 @@ func toString(v any, T jsonschema.Type) (string, error) {
 			return "", err
 		}
 		return strconv.FormatInt(intVal, 10), nil
-	default:
+	case jsonschema.ArrayType, jsonschema.ObjectType:
 		return "", fmt.Errorf("cannot format object of type %s as a string. Value of object: %#v", T, v)
+	default:
+		if T == "int" {
+			return "", fmt.Errorf(`unknown json schema type %q. Please use "integer" instead`, T)
+		}
+		return "", fmt.Errorf("unknown json schema type: %q", T)
 	}
 }
 
@@ -87,8 +92,13 @@ func fromString(s string, T jsonschema.Type) (any, error) {
 		v, err = strconv.ParseFloat(s, 32)
 	case jsonschema.IntegerType:
 		v, err = strconv.ParseInt(s, 10, 64)
-	default:
+	case jsonschema.ArrayType, jsonschema.ObjectType:
 		return "", fmt.Errorf("cannot parse string as object of type %s. Value of string: %q", T, s)
+	default:
+		if T == "int" {
+			return "", fmt.Errorf(`unknown json schema type %q. Please use "integer" instead`, T)
+		}
+		return "", fmt.Errorf("unknown json schema type: %q", T)
 	}
 
 	// Return more readable error incase of a syntax error

--- a/libs/template/utils_test.go
+++ b/libs/template/utils_test.go
@@ -83,9 +83,6 @@ func TestTemplateToString(t *testing.T) {
 
 	_, err = toString("abc", "foobar")
 	assert.EqualError(t, err, "unknown json schema type: \"foobar\"")
-
-	_, err = toString("abc", "int")
-	assert.EqualError(t, err, "unknown json schema type \"int\". Please use \"integer\" instead")
 }
 
 func TestTemplateFromString(t *testing.T) {
@@ -121,7 +118,4 @@ func TestTemplateFromString(t *testing.T) {
 
 	_, err = fromString("1.0", "foobar")
 	assert.EqualError(t, err, "unknown json schema type: \"foobar\"")
-
-	_, err = fromString("1.0", "int")
-	assert.EqualError(t, err, "unknown json schema type \"int\". Please use \"integer\" instead")
 }

--- a/libs/template/utils_test.go
+++ b/libs/template/utils_test.go
@@ -80,6 +80,12 @@ func TestTemplateToString(t *testing.T) {
 
 	_, err = toString("abc", jsonschema.IntegerType)
 	assert.EqualError(t, err, "cannot convert \"abc\" to an integer")
+
+	_, err = toString("abc", "foobar")
+	assert.EqualError(t, err, "unknown json schema type: \"foobar\"")
+
+	_, err = toString("abc", "int")
+	assert.EqualError(t, err, "unknown json schema type \"int\". Please use \"integer\" instead")
 }
 
 func TestTemplateFromString(t *testing.T) {
@@ -112,4 +118,10 @@ func TestTemplateFromString(t *testing.T) {
 
 	_, err = fromString("1.0", jsonschema.IntegerType)
 	assert.EqualError(t, err, "could not parse \"1.0\" as a integer: strconv.ParseInt: parsing \"1.0\": invalid syntax")
+
+	_, err = fromString("1.0", "foobar")
+	assert.EqualError(t, err, "unknown json schema type: \"foobar\"")
+
+	_, err = fromString("1.0", "int")
+	assert.EqualError(t, err, "unknown json schema type \"int\". Please use \"integer\" instead")
 }


### PR DESCRIPTION
## Changes
Adds a function to validate json schema types added by the author. The default json unmarshaller does not validate that the parsed type matches the enum defined in `jsonschema.Type`

Includes some other improvements to provide better error messages.

This PR was prompted by usability difficulties reported by @mingyu89 during mlops stack migration.

## Tests
Unit tests
