### PR TITLE
Confirm that override with a zero value doesn't work

### DIFF
--- a/bundle/tests/environment_overrides/resources/databricks.yml
+++ b/bundle/tests/environment_overrides/resources/databricks.yml
@@ -9,6 +9,13 @@ resources:
     job1:
       name: "base job"
 
+  pipelines:
+    boolean1:
+      photon: true
+
+    boolean2:
+      photon: false
+
 environments:
   development:
     default: true
@@ -18,3 +25,12 @@ environments:
       jobs:
         job1:
           name: "staging job"
+
+      pipelines:
+        boolean1:
+          # Note: setting a property to a zero value (in Go) does not have effect.
+          # See the corresponding test for details.
+          photon: false
+
+        boolean2:
+          photon: true

--- a/bundle/tests/environment_overrides_test.go
+++ b/bundle/tests/environment_overrides_test.go
@@ -19,9 +19,20 @@ func TestEnvironmentOverridesWorkspaceStaging(t *testing.T) {
 func TestEnvironmentOverridesResourcesDev(t *testing.T) {
 	b := loadEnvironment(t, "./environment_overrides/resources", "development")
 	assert.Equal(t, "base job", b.Config.Resources.Jobs["job1"].Name)
+
+	// Base values are preserved in the development environment.
+	assert.Equal(t, true, b.Config.Resources.Pipelines["boolean1"].Photon)
+	assert.Equal(t, false, b.Config.Resources.Pipelines["boolean2"].Photon)
 }
 
 func TestEnvironmentOverridesResourcesStaging(t *testing.T) {
 	b := loadEnvironment(t, "./environment_overrides/resources", "staging")
 	assert.Equal(t, "staging job", b.Config.Resources.Jobs["job1"].Name)
+
+	// Overrides are only applied if they are not zero-valued.
+	// This means that in its current form, we cannot override a true value with a false value.
+	// Note: this is not desirable and will be addressed by representing our configuration
+	// in a different structure (e.g. with cty), instead of Go structs.
+	assert.Equal(t, true, b.Config.Resources.Pipelines["boolean1"].Photon)
+	assert.Equal(t, true, b.Config.Resources.Pipelines["boolean2"].Photon)
 }


### PR DESCRIPTION
## Changes

This is not desirable and will be addressed by representing our configuration in a different structure (e.g. with cty, or with 
plain `any`), instead of Go structs.

## Tests

Pass.