### PR TITLE
Do not try auto detect Python package if no Python wheel tasks defined

### DIFF
--- a/bundle/artifacts/whl/autodetect.go
+++ b/bundle/artifacts/whl/autodetect.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/libraries"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/log"
 )
 
 type detectPkg struct {
@@ -25,6 +27,11 @@ func (m *detectPkg) Name() string {
 }
 
 func (m *detectPkg) Apply(ctx context.Context, b *bundle.Bundle) error {
+	wheelTasks := libraries.FindAllWheelTasks(b)
+	if len(wheelTasks) == 0 {
+		log.Infof(ctx, "No wheel tasks in databricks.yml config, skipping auto detect")
+		return nil
+	}
 	cmdio.LogString(ctx, "artifacts.whl.AutoDetect: Detecting Python wheel project...")
 
 	// checking if there is setup.py in the bundle root

--- a/bundle/libraries/libraries.go
+++ b/bundle/libraries/libraries.go
@@ -25,24 +25,46 @@ func (a *match) Name() string {
 }
 
 func (a *match) Apply(ctx context.Context, b *bundle.Bundle) error {
-	r := b.Config.Resources
-	for k := range b.Config.Resources.Jobs {
-		tasks := r.Jobs[k].JobSettings.Tasks
-		for i := range tasks {
-			task := &tasks[i]
-			if isMissingRequiredLibraries(task) {
-				return fmt.Errorf("task '%s' is missing required libraries. Please include your package code in task libraries block", task.TaskKey)
-			}
-			for j := range task.Libraries {
-				lib := &task.Libraries[j]
-				err := findArtifactsAndMarkForUpload(ctx, lib, b)
-				if err != nil {
-					return err
-				}
+	tasks := findAllTasks(b)
+	for _, task := range tasks {
+		if isMissingRequiredLibraries(task) {
+			return fmt.Errorf("task '%s' is missing required libraries. Please include your package code in task libraries block", task.TaskKey)
+		}
+		for j := range task.Libraries {
+			lib := &task.Libraries[j]
+			err := findArtifactsAndMarkForUpload(ctx, lib, b)
+			if err != nil {
+				return err
 			}
 		}
 	}
 	return nil
+}
+
+func findAllTasks(b *bundle.Bundle) []*jobs.Task {
+	r := b.Config.Resources
+	result := make([]*jobs.Task, 0)
+	for k := range b.Config.Resources.Jobs {
+		tasks := r.Jobs[k].JobSettings.Tasks
+		for i := range tasks {
+			task := &tasks[i]
+			result = append(result, task)
+		}
+	}
+
+	return result
+}
+
+func FindAllWheelTasks(b *bundle.Bundle) []*jobs.Task {
+	tasks := findAllTasks(b)
+	wheelTasks := make([]*jobs.Task, 0)
+	for _, task := range tasks {
+		if task.PythonWheelTask != nil {
+			wheelTasks = append(wheelTasks, task)
+		}
+	}
+
+	return wheelTasks
 }
 
 func isMissingRequiredLibraries(task *jobs.Task) bool {


### PR DESCRIPTION
## Changes
Fixes #673 

It also includes a change for `libraries` from #635 to get the list of wheel tasks
