### PR TITLE
Rename init project-dir flag to output-dir

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -42,10 +42,9 @@ func newInitCommand() *cobra.Command {
 	}
 
 	var configFile string
-	var projectDir string
+	var outputDir string
 	cmd.Flags().StringVar(&configFile, "config-file", "", "File containing input parameters for template initialization.")
-	cmd.Flags().StringVar(&projectDir, "project-dir", "", "The project will be initialized in this directory.")
-	cmd.MarkFlagRequired("project-dir")
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "The project will be initialized in this directory.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		templatePath := args[0]
@@ -54,7 +53,7 @@ func newInitCommand() *cobra.Command {
 		if !isRepoUrl(templatePath) {
 			// skip downloading the repo because input arg is not a URL. We assume
 			// it's a path on the local file system in that case
-			return template.Materialize(ctx, configFile, templatePath, projectDir)
+			return template.Materialize(ctx, configFile, templatePath, outputDir)
 		}
 
 		// Download the template in a temporary directory
@@ -72,7 +71,7 @@ func newInitCommand() *cobra.Command {
 		}
 		defer os.RemoveAll(templateDir)
 
-		return template.Materialize(ctx, configFile, templateDir, projectDir)
+		return template.Materialize(ctx, configFile, templateDir, outputDir)
 	}
 
 	return cmd

--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -44,7 +44,7 @@ func newInitCommand() *cobra.Command {
 	var configFile string
 	var outputDir string
 	cmd.Flags().StringVar(&configFile, "config-file", "", "File containing input parameters for template initialization.")
-	cmd.Flags().StringVar(&outputDir, "output-dir", "", "The project will be initialized in this directory.")
+	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory to write the initialized template to.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		templatePath := args[0]

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -16,8 +16,8 @@ const schemaFileName = "databricks_template_schema.json"
 //	ctx: 			context containing a cmdio object. This is used to prompt the user
 //	configFilePath: file path containing user defined config values
 //	templateRoot: 	root of the template definition
-//	projectDir: 	root of directory where to initialize the project
-func Materialize(ctx context.Context, configFilePath, templateRoot, projectDir string) error {
+//	outputDir: 	root of directory where to initialize the template
+func Materialize(ctx context.Context, configFilePath, templateRoot, outputDir string) error {
 	templatePath := filepath.Join(templateRoot, templateDirName)
 	libraryPath := filepath.Join(templateRoot, libraryDirName)
 	schemaPath := filepath.Join(templateRoot, schemaFileName)
@@ -48,7 +48,7 @@ func Materialize(ctx context.Context, configFilePath, templateRoot, projectDir s
 	}
 
 	// Walk and render the template, since input configuration is complete
-	r, err := newRenderer(ctx, config.values, templatePath, libraryPath, projectDir)
+	r, err := newRenderer(ctx, config.values, templatePath, libraryPath, outputDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Changes
This PR:
1. Renames the project-dir flag to output-dir
2. Makes the project dir flag optional. When unspecified we default to the current working directory.

## Tests
Manually
