### PR TITLE
Upgrade to actions/setup-go@v4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,10 +26,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.0
-          cache: true
 
       - name: Set go env
         run: |
@@ -54,9 +53,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.21.0
 
           # No need to download cached dependencies when running gofmt.
           cache: false

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -19,26 +19,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        id: go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.0
-
-      - name: Locate cache paths
-        id: cache
-        run: |
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-
-      # Note: use custom caching because below performs a cross platform build
-      # through goreleaser and don't want to share a cache with the test builds.
-      - name: Setup caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ steps.cache.outputs.GOMODCACHE }}
-            ${{ steps.cache.outputs.GOCACHE }}
-          key: release-${{ runner.os }}-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', '.goreleaser.yaml') }}
 
       - name: Hide snapshot tag to outsmart GoReleaser
         run: git tag -d snapshot || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,26 +18,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        id: go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.0
-
-      - name: Locate cache paths
-        id: cache
-        run: |
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-
-      # Note: use custom caching because below performs a cross platform build
-      # through goreleaser and don't want to share a cache with the test builds.
-      - name: Setup caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ steps.cache.outputs.GOMODCACHE }}
-            ${{ steps.cache.outputs.GOCACHE }}
-          key: release-${{ runner.os }}-go-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.sum', '.goreleaser.yaml') }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
## Changes

Version 4 enables caching by default so we no longer need to explicitly enable it: https://github.com/actions/setup-go#v4.

The build cache only reuses a cache from a repo's default branch, which for this repository is `main`. After enabling the merge queue, we no longer run builds on the `main` branch after push, but on merge queue branches. With no more builds on the `main` branch there is no longer a cache to reuse.

This change fixes that by making the `release(-snapshot)?` workflows use the same caching mechanism. These run off of the `main` branch, so the cache they save can be reused by builds triggered on PRs or from the merge queue.

## Tests

We have to merge this to see if it works.

