### PR TITLE
[DONTMERGE] Show 'databricks bundle init' template in CLI prompt

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/git"
 	"github.com/databricks/cli/libs/template"
 	"github.com/spf13/cobra"
@@ -57,9 +58,6 @@ func newInitCommand() *cobra.Command {
 		if len(args) > 0 {
 			templatePath = args[0]
 		} else {
-			return errors.New("please specify a template")
-
-			/* TODO: propose to use default-python (once #708 is merged)
 			var err error
 			if !cmdio.IsOutTTY(ctx) || !cmdio.IsInTTY(ctx) {
 				return errors.New("please specify a template")
@@ -68,7 +66,6 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			*/
 		}
 
 		if !isRepoUrl(templatePath) {


### PR DESCRIPTION
This restores the template from https://github.com/databricks/cli/pull/686 in CLI prompts for once #686 and #708 are merged.