### PR TITLE
Prompt once for a client profile

### DIFF
--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -59,8 +59,7 @@ func accountClientOrPrompt(ctx context.Context, cfg *config.Config, allowPrompt 
 	if err != nil {
 		return nil, err
 	}
-	cfg = &config.Config{Profile: profile}
-	a, err = databricks.NewAccountClient((*databricks.Config)(cfg))
+	a, err = databricks.NewAccountClient(&databricks.Config{Profile: profile})
 	if err == nil {
 		err = a.Config.Authenticate(emptyHttpRequest(ctx))
 		if err != nil {
@@ -128,8 +127,7 @@ func workspaceClientOrPrompt(ctx context.Context, cfg *config.Config, allowPromp
 	if err != nil {
 		return nil, err
 	}
-	cfg = &config.Config{Profile: profile}
-	w, err = databricks.NewWorkspaceClient((*databricks.Config)(cfg))
+	w, err = databricks.NewWorkspaceClient(&databricks.Config{Profile: profile})
 	if err == nil {
 		err = w.Config.Authenticate(emptyHttpRequest(ctx))
 		if err != nil {

--- a/cmd/root/auth_test.go
+++ b/cmd/root/auth_test.go
@@ -2,13 +2,177 @@ package root
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmptyHttpRequest(t *testing.T) {
 	ctx, _ := context.WithCancel(context.Background())
 	req := emptyHttpRequest(ctx)
 	assert.Equal(t, req.Context(), ctx)
+}
+
+type promptFn func(ctx context.Context, cfg *config.Config, retry bool) (any, error)
+
+var accountPromptFn = func(ctx context.Context, cfg *config.Config, retry bool) (any, error) {
+	return accountClientOrPrompt(ctx, cfg, retry)
+}
+
+var workspacePromptFn = func(ctx context.Context, cfg *config.Config, retry bool) (any, error) {
+	return workspaceClientOrPrompt(ctx, cfg, retry)
+}
+
+func expectPrompts(t *testing.T, fn promptFn, config *config.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// Channel to pass errors from the prompting function back to the test.
+	errch := make(chan error, 1)
+
+	ctx, io := cmdio.SetupTest(ctx)
+	go func() {
+		defer close(errch)
+		defer cancel()
+		_, err := fn(ctx, config, true)
+		errch <- err
+	}()
+
+	// Expect a prompt
+	line, _, err := io.Stderr.ReadLine()
+	if assert.NoError(t, err, "Expected to read a line from stderr") {
+		assert.Contains(t, string(line), "Search:")
+	} else {
+		// If there was an error reading from stderr, the prompting function must have terminated early.
+		assert.NoError(t, <-errch)
+	}
+}
+
+func expectReturns(t *testing.T, fn promptFn, config *config.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	ctx, _ = cmdio.SetupTest(ctx)
+	client, err := fn(ctx, config, true)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestAccountClientOrPrompt(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, ".databrickscfg")
+	err := os.WriteFile(
+		configFile,
+		[]byte(`
+			[account-1111]
+			host = https://accounts.azuredatabricks.net/
+			account_id = 1111
+			token = foobar
+
+			[account-1112]
+			host = https://accounts.azuredatabricks.net/
+			account_id = 1112
+			token = foobar
+			`),
+		0755)
+	require.NoError(t, err)
+	t.Setenv("DATABRICKS_CONFIG_FILE", configFile)
+	t.Setenv("PATH", "/nothing")
+
+	t.Run("Prompt if nothing is specified", func(t *testing.T) {
+		expectPrompts(t, accountPromptFn, &config.Config{})
+	})
+
+	t.Run("Prompt if a workspace host is specified", func(t *testing.T) {
+		expectPrompts(t, accountPromptFn, &config.Config{
+			Host:      "https://adb-1234567.89.azuredatabricks.net/",
+			AccountID: "1234",
+			Token:     "foobar",
+		})
+	})
+
+	t.Run("Prompt if account ID is not specified", func(t *testing.T) {
+		expectPrompts(t, accountPromptFn, &config.Config{
+			Host:  "https://accounts.azuredatabricks.net/",
+			Token: "foobar",
+		})
+	})
+
+	t.Run("Prompt if no credential provider can be configured", func(t *testing.T) {
+		expectPrompts(t, accountPromptFn, &config.Config{
+			Host:      "https://accounts.azuredatabricks.net/",
+			AccountID: "1234",
+		})
+	})
+
+	t.Run("Returns if configuration is valid", func(t *testing.T) {
+		expectReturns(t, accountPromptFn, &config.Config{
+			Host:      "https://accounts.azuredatabricks.net/",
+			AccountID: "1234",
+			Token:     "foobar",
+		})
+	})
+
+	t.Run("Returns if a valid profile is specified", func(t *testing.T) {
+		expectReturns(t, accountPromptFn, &config.Config{
+			Profile: "account-1111",
+		})
+	})
+}
+
+func TestWorkspaceClientOrPrompt(t *testing.T) {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, ".databrickscfg")
+	err := os.WriteFile(
+		configFile,
+		[]byte(`
+			[workspace-1111]
+			host = https://adb-1111.11.azuredatabricks.net/
+			token = foobar
+
+			[workspace-1112]
+			host = https://adb-1112.12.azuredatabricks.net/
+			token = foobar
+			`),
+		0755)
+	require.NoError(t, err)
+	t.Setenv("DATABRICKS_CONFIG_FILE", configFile)
+	t.Setenv("PATH", "/nothing")
+
+	t.Run("Prompt if nothing is specified", func(t *testing.T) {
+		expectPrompts(t, workspacePromptFn, &config.Config{})
+	})
+
+	t.Run("Prompt if an account host is specified", func(t *testing.T) {
+		expectPrompts(t, workspacePromptFn, &config.Config{
+			Host:      "https://accounts.azuredatabricks.net/",
+			AccountID: "1234",
+			Token:     "foobar",
+		})
+	})
+
+	t.Run("Prompt if no credential provider can be configured", func(t *testing.T) {
+		expectPrompts(t, workspacePromptFn, &config.Config{
+			Host: "https://adb-1111.11.azuredatabricks.net/",
+		})
+	})
+
+	t.Run("Returns if configuration is valid", func(t *testing.T) {
+		expectReturns(t, workspacePromptFn, &config.Config{
+			Host:  "https://adb-1111.11.azuredatabricks.net/",
+			Token: "foobar",
+		})
+	})
+
+	t.Run("Returns if a valid profile is specified", func(t *testing.T) {
+		expectReturns(t, workspacePromptFn, &config.Config{
+			Profile: "workspace-1111",
+		})
+	})
 }

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -205,6 +205,13 @@ func Prompt(ctx context.Context) *promptui.Prompt {
 	}
 }
 
+func RunSelect(ctx context.Context, prompt *promptui.Select) (int, string, error) {
+	c := fromContext(ctx)
+	prompt.Stdin = io.NopCloser(c.in)
+	prompt.Stdout = nopWriteCloser{c.err}
+	return prompt.Run()
+}
+
 func (c *cmdIO) simplePrompt(label string) *promptui.Prompt {
 	return &promptui.Prompt{
 		Label:  label,

--- a/libs/cmdio/testing.go
+++ b/libs/cmdio/testing.go
@@ -1,0 +1,46 @@
+package cmdio
+
+import (
+	"bufio"
+	"context"
+	"io"
+)
+
+type Test struct {
+	Done context.CancelFunc
+
+	Stdin  *bufio.Writer
+	Stdout *bufio.Reader
+	Stderr *bufio.Reader
+}
+
+func SetupTest(ctx context.Context) (context.Context, *Test) {
+	rin, win := io.Pipe()
+	rout, wout := io.Pipe()
+	rerr, werr := io.Pipe()
+
+	cmdio := &cmdIO{
+		interactive: true,
+		in:          rin,
+		out:         wout,
+		err:         werr,
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	ctx = InContext(ctx, cmdio)
+
+	// Wait for context to be done, so we can drain stdin and close the pipes.
+	go func() {
+		<-ctx.Done()
+		rin.Close()
+		wout.Close()
+		werr.Close()
+	}()
+
+	return ctx, &Test{
+		Done:   cancel,
+		Stdin:  bufio.NewWriter(win),
+		Stdout: bufio.NewReader(rout),
+		Stderr: bufio.NewReader(rerr),
+	}
+}


### PR DESCRIPTION
## Changes

The previous implementation ran the risk of infinite looping for the account client due to a mismatch in determining what constitutes an account client between the CLI and SDK (see [here](https://github.com/databricks/cli/blob/83443bae8d8ad4df3758f4192c6bbe613faae9c4/libs/databrickscfg/profiles.go#L61) and [here](https://github.com/databricks/databricks-sdk-go/blob/0fdc5165e57a4e7af6ec97b47595c6dddf37b10b/config/config.go#L160)).

Ultimately, this code must never infinite loop. If a user is prompted and selects a profile that cannot be used, they should receive that feedback immediately and try again, instead of being prompted again.

Related to #726.

## Tests
<!-- How is this tested? -->

