### PR TITLE
Replace API call to test configuration with dummy authenticate call

### DIFF
--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -94,14 +94,7 @@ TRY_AUTH: // or try picking a config profile dynamically
 		return err
 	}
 
-	// Verify that the client is configured correctly by authenticating a dummy request.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/doesntmatter", nil)
-	if err != nil {
-		// This can only fail if the context is nil, which would be a bug.
-		panic(err)
-	}
-
-	err = w.Config.Authenticate(req)
+	err = w.Config.Authenticate(emptyHttpRequest(ctx))
 	if cmdio.IsInteractive(ctx) && errors.Is(err, config.ErrCannotConfigureAuth) {
 		profile, err := askForWorkspaceProfile()
 		if err != nil {
@@ -213,4 +206,15 @@ func AccountClient(ctx context.Context) *databricks.AccountClient {
 		panic("cannot get *databricks.AccountClient. Please report it as a bug")
 	}
 	return a
+}
+
+// To verify that a client is configured correctly, we pass an empty HTTP request
+// to a client's `config.Authenticate` function. Note: this functionality
+// should be supported by the SDK itself.
+func emptyHttpRequest(ctx context.Context) *http.Request {
+	req, err := http.NewRequestWithContext(ctx, "", "", nil)
+	if err != nil {
+		panic(err)
+	}
+	return req
 }

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -93,7 +93,6 @@ TRY_AUTH: // or try picking a config profile dynamically
 	if err != nil {
 		return err
 	}
-
 	err = w.Config.Authenticate(emptyHttpRequest(ctx))
 	if cmdio.IsInteractive(ctx) && errors.Is(err, config.ErrCannotConfigureAuth) {
 		profile, err := askForWorkspaceProfile()
@@ -192,6 +191,17 @@ func askForAccountProfile() (string, error) {
 	return profiles[i].Name, nil
 }
 
+// To verify that a client is configured correctly, we pass an empty HTTP request
+// to a client's `config.Authenticate` function. Note: this functionality
+// should be supported by the SDK itself.
+func emptyHttpRequest(ctx context.Context) *http.Request {
+	req, err := http.NewRequestWithContext(ctx, "", "", nil)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
 func WorkspaceClient(ctx context.Context) *databricks.WorkspaceClient {
 	w, ok := ctx.Value(&workspaceClient).(*databricks.WorkspaceClient)
 	if !ok {
@@ -206,15 +216,4 @@ func AccountClient(ctx context.Context) *databricks.AccountClient {
 		panic("cannot get *databricks.AccountClient. Please report it as a bug")
 	}
 	return a
-}
-
-// To verify that a client is configured correctly, we pass an empty HTTP request
-// to a client's `config.Authenticate` function. Note: this functionality
-// should be supported by the SDK itself.
-func emptyHttpRequest(ctx context.Context) *http.Request {
-	req, err := http.NewRequestWithContext(ctx, "", "", nil)
-	if err != nil {
-		panic(err)
-	}
-	return req
 }

--- a/cmd/root/auth_test.go
+++ b/cmd/root/auth_test.go
@@ -1,0 +1,14 @@
+package root
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyHttpRequest(t *testing.T) {
+	ctx, _ := context.WithCancel(context.Background())
+	req := emptyHttpRequest(ctx)
+	assert.Equal(t, req.Context(), ctx)
+}


### PR DESCRIPTION
## Changes

This reduces the latency of every workspace command by the duration of a single API call to retrieve the current user (which can take up to a full second).

Note: the better place to verify that a request can be authenticated is the SDK itself.

## Tests

* Unit test to confirm an the empty `*http.Request` can be constructed
* Manually confirmed that the additional API call no longer happens
