### PR TITLE
Include $PATH in set of environment variables to pass along.

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -78,6 +78,14 @@ func inheritEnvVars(env map[string]string) error {
 		env["HOME"] = home
 	}
 
+	// Include $PATH in set of environment variables to pass along.
+	// This is necessary to ensure that our Terraform provider can use the
+	// same auxiliary programs (e.g. `az`, or `gcloud`) as the CLI.
+	path, ok := os.LookupEnv("PATH")
+	if ok {
+		env["PATH"] = path
+	}
+
 	// Include $TF_CLI_CONFIG_FILE to override terraform provider in development.
 	configFile, ok := os.LookupEnv("TF_CLI_CONFIG_FILE")
 	if ok {

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -277,6 +277,7 @@ func TestInheritEnvVars(t *testing.T) {
 	env := map[string]string{}
 
 	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("PATH", "/foo:/bar")
 	t.Setenv("TF_CLI_CONFIG_FILE", "/tmp/config.tfrc")
 
 	err := inheritEnvVars(env)
@@ -285,6 +286,7 @@ func TestInheritEnvVars(t *testing.T) {
 
 	require.Equal(t, map[string]string{
 		"HOME":               "/home/testuser",
+		"PATH":               "/foo:/bar",
 		"TF_CLI_CONFIG_FILE": "/tmp/config.tfrc",
 	}, env)
 }


### PR DESCRIPTION
## Changes

This is necessary to ensure that our Terraform provider can use the same auxiliary programs (e.g. `az`, or `gcloud`) as the CLI.

## Tests

Unit test and manual verification.
