### PR TITLE
Added end-to-end test for deploying and running Python wheel task

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
@@ -59,6 +60,7 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 		Product:    product.Terraform,
 		Version:    version.Must(version.NewVersion("1.5.5")),
 		InstallDir: binDir,
+		Timeout:    1 * time.Minute,
 	}
 	execPath, err = installer.Install(ctx)
 	if err != nil {

--- a/internal/bundle/bundles/python_wheel_task/databricks_template_schema.json
+++ b/internal/bundle/bundles/python_wheel_task/databricks_template_schema.json
@@ -1,0 +1,17 @@
+{
+    "properties": {
+        "project_name": {
+            "type": "string",
+            "default": "my_test_code",
+            "description": "Unique name for this project"
+        },
+        "spark_version": {
+            "type": "string",
+            "description": "Spark version used for job cluster"
+        },
+        "node_type_id": {
+            "type": "string",
+            "description": "Node type id for job cluster"
+        }
+    }
+}

--- a/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
@@ -4,7 +4,7 @@ bundle:
 resources:
   jobs:
     some_other_job:
-      name: "[${bundle.environment}] Test Wheel Job"
+      name: "[${bundle.target}] Test Wheel Job"
       tasks:
         - task_key: TestTask
           new_cluster:

--- a/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
@@ -1,0 +1,21 @@
+bundle:
+  name: wheel-task
+
+resources:
+  jobs:
+    some_other_job:
+      name: "[${bundle.environment}] Test Wheel Job"
+      tasks:
+        - task_key: TestTask
+          new_cluster:
+            num_workers: 1
+            spark_version: "{{.spark_version}}"
+            node_type_id: "{{.node_type_id}}"
+          python_wheel_task:
+            package_name: my_test_code
+            entry_point: run
+            parameters:
+              - "one"
+              - "two"
+          libraries:
+          - whl: ./dist/*.whl

--- a/internal/bundle/bundles/python_wheel_task/template/setup.py.tmpl
+++ b/internal/bundle/bundles/python_wheel_task/template/setup.py.tmpl
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+import {{.project_name}}
+
+setup(
+    name="{{.project_name}}",
+    version={{.project_name}}.__version__,
+    author={{.project_name}}.__author__,
+    url="https://databricks.com",
+    author_email="john.doe@databricks.com",
+    description="my example wheel",
+    packages=find_packages(include=["{{.project_name}}"]),
+    entry_points={"group1": "run={{.project_name}}.__main__:main"},
+    install_requires=["setuptools"],
+)

--- a/internal/bundle/bundles/python_wheel_task/template/{{.project_name}}/__init__.py
+++ b/internal/bundle/bundles/python_wheel_task/template/{{.project_name}}/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "0.0.1"
+__author__ = "Databricks"

--- a/internal/bundle/bundles/python_wheel_task/template/{{.project_name}}/__main__.py
+++ b/internal/bundle/bundles/python_wheel_task/template/{{.project_name}}/__main__.py
@@ -1,0 +1,16 @@
+"""
+The entry point of the Python Wheel
+"""
+
+import sys
+
+
+def main():
+    # This method will print the provided arguments
+    print("Hello from my func")
+    print("Got arguments:")
+    print(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/bundle/helpers.go
+++ b/internal/bundle/helpers.go
@@ -1,38 +1,30 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
-	"embed"
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/bundle/config/mutator"
-	"github.com/databricks/cli/bundle/deploy/terraform"
-	"github.com/databricks/cli/bundle/phases"
-	"github.com/databricks/cli/bundle/run"
+	"github.com/databricks/cli/cmd"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/template"
 )
 
-//go:embed all:bundles
-var builtinBundles embed.FS
-
 func copyBuiltInTemplate(templateName string, dst string) (string, error) {
-	_, err := fs.Stat(builtinBundles, path.Join("bundles", templateName))
+	filename := filepath.Join("bundles", templateName)
+	_, err := os.Stat(filename)
 	if err != nil {
 		return "", err
 	}
 
-	err = fs.WalkDir(builtinBundles, "bundles", func(path string, entry fs.DirEntry, err error) error {
+	err = filepath.WalkDir("bundles", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -41,7 +33,7 @@ func copyBuiltInTemplate(templateName string, dst string) (string, error) {
 		if entry.IsDir() {
 			return os.Mkdir(targetPath, 0755)
 		} else {
-			content, err := fs.ReadFile(builtinBundles, path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
@@ -62,7 +54,7 @@ func initTestTemplate(t *testing.T, templateName string, config map[string]any) 
 		return "", err
 	}
 
-	bundelRoot := t.TempDir()
+	bundleRoot := t.TempDir()
 	configFilePath, err := writeConfigFile(t, config)
 	if err != nil {
 		return "", err
@@ -72,8 +64,8 @@ func initTestTemplate(t *testing.T, templateName string, config map[string]any) 
 	cmd := cmdio.NewIO(flags.OutputJSON, strings.NewReader(""), os.Stdout, os.Stderr, "bundles")
 	ctx = cmdio.InContext(ctx, cmd)
 
-	err = template.Materialize(ctx, configFilePath, templateRoot, bundelRoot)
-	return bundelRoot, err
+	err = template.Materialize(ctx, configFilePath, templateRoot, bundleRoot)
+	return bundleRoot, err
 }
 
 func writeConfigFile(t *testing.T, config map[string]any) (string, error) {
@@ -84,88 +76,40 @@ func writeConfigFile(t *testing.T, config map[string]any) (string, error) {
 
 	dir := t.TempDir()
 	filepath := filepath.Join(dir, "config.json")
-	fmt.Println(string(bytes))
+	t.Log("Configuration for template: ", string(bytes))
+
 	err = os.WriteFile(filepath, bytes, 0644)
 	return filepath, err
 }
 
-func loadBundle(ctx context.Context, path string) (*bundle.Bundle, error) {
-	b, err := bundle.Load(ctx, path)
-	if err != nil {
-		return nil, err
-	}
-
-	err = bundle.Apply(ctx, b, bundle.Seq(mutator.DefaultMutators()...))
-	if err != nil {
-		return nil, err
-	}
-
-	err = bundle.Apply(ctx, b, mutator.SelectDefaultTarget())
-	if err != nil {
-		return nil, err
-	}
-
-	return b, err
-}
-
-func deployBundle(path string) (*bundle.Bundle, error) {
+func deployBundle(t *testing.T, path string) error {
 	ctx := context.Background()
-	b, err := loadBundle(ctx, path)
-	if err != nil {
-		return nil, err
-	}
+	t.Setenv("BUNDLE_ROOT", path)
 
-	err = bundle.Apply(ctx, b, phases.Initialize())
-	if err != nil {
-		return nil, err
-	}
+	deploy := cmd.New()
+	deploy.SetArgs([]string{"bundle", "deploy", "--force-lock"})
 
-	err = bundle.Apply(ctx, b, phases.Build())
-	if err != nil {
-		return nil, err
-	}
-
-	b.AutoApprove = true
-	b.Config.Bundle.Lock.Force = true
-
-	err = bundle.Apply(ctx, b, phases.Deploy())
-	return b, err
+	return deploy.ExecuteContext(ctx)
 }
 
-func runResource(path string, key string) (string, error) {
+func runResource(t *testing.T, path string, key string) (string, error) {
 	ctx := context.Background()
 	ctx = cmdio.NewContext(ctx, cmdio.Default())
-	b, err := loadBundle(ctx, path)
-	if err != nil {
-		return "", err
-	}
 
-	err = bundle.Apply(ctx, b, bundle.Seq(
-		phases.Initialize(),
-		terraform.Interpolate(),
-		terraform.Write(),
-		terraform.StatePull(),
-		terraform.Load(),
-	))
+	run := cmd.New()
+	run.SetArgs([]string{"bundle", "run", key})
+	buffer := new(bytes.Buffer)
+	run.SetOut(buffer)
 
-	if err != nil {
-		return "", err
-	}
-
-	runner, err := run.Find(b, "some_other_job")
-	if err != nil {
-		return "", err
-	}
-
-	output, err := runner.Run(ctx, &run.Options{})
-	if err != nil {
-		return "", err
-	}
-
-	return output.String()
+	return buffer.String(), run.ExecuteContext(ctx)
 }
 
-func destroyBundle(b *bundle.Bundle) error {
+func destroyBundle(t *testing.T, path string) error {
 	ctx := context.Background()
-	return bundle.Apply(ctx, b, phases.Destroy())
+	t.Setenv("BUNDLE_ROOT", path)
+
+	deploy := cmd.New()
+	deploy.SetArgs([]string{"bundle", "destroy", "--auto-approve"})
+
+	return deploy.ExecuteContext(ctx)
 }

--- a/internal/bundle/helpers.go
+++ b/internal/bundle/helpers.go
@@ -1,0 +1,171 @@
+package bundle
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/deploy/terraform"
+	"github.com/databricks/cli/bundle/phases"
+	"github.com/databricks/cli/bundle/run"
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/template"
+)
+
+//go:embed all:bundles
+var builtinBundles embed.FS
+
+func copyBuiltInTemplate(templateName string, dst string) (string, error) {
+	_, err := fs.Stat(builtinBundles, path.Join("bundles", templateName))
+	if err != nil {
+		return "", err
+	}
+
+	err = fs.WalkDir(builtinBundles, "bundles", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		targetPath := filepath.Join(dst, path)
+		if entry.IsDir() {
+			return os.Mkdir(targetPath, 0755)
+		} else {
+			content, err := fs.ReadFile(builtinBundles, path)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(targetPath, content, 0644)
+		}
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dst, "bundles", templateName), nil
+}
+
+func initTestTemplate(t *testing.T, templateName string, config map[string]any) (string, error) {
+	templateRoot, err := copyBuiltInTemplate(templateName, t.TempDir())
+	if err != nil {
+		return "", err
+	}
+
+	bundelRoot := t.TempDir()
+	configFilePath, err := writeConfigFile(t, config)
+	if err != nil {
+		return "", err
+	}
+
+	ctx := root.SetWorkspaceClient(context.Background(), nil)
+	cmd := cmdio.NewIO(flags.OutputJSON, strings.NewReader(""), os.Stdout, os.Stderr, "bundles")
+	ctx = cmdio.InContext(ctx, cmd)
+
+	err = template.Materialize(ctx, configFilePath, templateRoot, bundelRoot)
+	return bundelRoot, err
+}
+
+func writeConfigFile(t *testing.T, config map[string]any) (string, error) {
+	bytes, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+
+	dir := t.TempDir()
+	filepath := filepath.Join(dir, "config.json")
+	fmt.Println(string(bytes))
+	err = os.WriteFile(filepath, bytes, 0644)
+	return filepath, err
+}
+
+func loadBundle(ctx context.Context, path string) (*bundle.Bundle, error) {
+	b, err := bundle.Load(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bundle.Apply(ctx, b, bundle.Seq(mutator.DefaultMutators()...))
+	if err != nil {
+		return nil, err
+	}
+
+	err = bundle.Apply(ctx, b, mutator.SelectDefaultTarget())
+	if err != nil {
+		return nil, err
+	}
+
+	return b, err
+}
+
+func deployBundle(path string) (*bundle.Bundle, error) {
+	ctx := context.Background()
+	b, err := loadBundle(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bundle.Apply(ctx, b, phases.Initialize())
+	if err != nil {
+		return nil, err
+	}
+
+	err = bundle.Apply(ctx, b, phases.Build())
+	if err != nil {
+		return nil, err
+	}
+
+	b.AutoApprove = true
+	b.Config.Bundle.Lock.Force = true
+
+	err = bundle.Apply(ctx, b, phases.Deploy())
+	return b, err
+}
+
+func runResource(path string, key string) (string, error) {
+	ctx := context.Background()
+	ctx = cmdio.NewContext(ctx, cmdio.Default())
+	b, err := loadBundle(ctx, path)
+	if err != nil {
+		return "", err
+	}
+
+	err = bundle.Apply(ctx, b, bundle.Seq(
+		phases.Initialize(),
+		terraform.Interpolate(),
+		terraform.Write(),
+		terraform.StatePull(),
+		terraform.Load(),
+	))
+
+	if err != nil {
+		return "", err
+	}
+
+	runner, err := run.Find(b, "some_other_job")
+	if err != nil {
+		return "", err
+	}
+
+	output, err := runner.Run(ctx, &run.Options{})
+	if err != nil {
+		return "", err
+	}
+
+	return output.String()
+}
+
+func destroyBundle(b *bundle.Bundle) error {
+	ctx := context.Background()
+	return bundle.Apply(ctx, b, phases.Destroy())
+}

--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -1,0 +1,41 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccPythonWheelTaskDeployAndRun(t *testing.T) {
+	env := internal.GetEnvOrSkipTest(t, "CLOUD_ENV")
+	t.Log(env)
+
+	var nodeTypeId string
+	if env == "gcp" {
+		nodeTypeId = "n1-standard-4"
+	} else if env == "aws" {
+		nodeTypeId = "i3.xlarge"
+	} else {
+		nodeTypeId = "Standard_DS4_v2"
+	}
+
+	bundleRoot, err := initTestTemplate(t, "python_wheel_task", map[string]any{
+		"node_type_id":  nodeTypeId,
+		"spark_version": "13.2.x-snapshot-scala2.12",
+	})
+	require.NoError(t, err)
+
+	b, err := deployBundle(bundleRoot)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		destroyBundle(b)
+	})
+
+	out, err := runResource(bundleRoot, "some_other_job")
+	require.NoError(t, err)
+	require.Contains(t, out, "Hello from my func")
+	require.Contains(t, out, "Got arguments:")
+	require.Contains(t, out, "['python', 'one', 'two']")
+}

--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -26,14 +26,14 @@ func TestAccPythonWheelTaskDeployAndRun(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	b, err := deployBundle(bundleRoot)
+	err = deployBundle(t, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(b)
+		destroyBundle(t, bundleRoot)
 	})
 
-	out, err := runResource(bundleRoot, "some_other_job")
+	out, err := runResource(t, bundleRoot, "some_other_job")
 	require.NoError(t, err)
 	require.Contains(t, out, "Hello from my func")
 	require.Contains(t, out, "Got arguments:")

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -58,6 +58,8 @@ type cobraTestRunner struct {
 	stdout bytes.Buffer
 	stderr bytes.Buffer
 
+	ctx context.Context
+
 	// Line-by-line output.
 	// Background goroutines populate these channels by reading from stdout/stderr pipes.
 	stdoutLines <-chan string
@@ -128,7 +130,7 @@ func (t *cobraTestRunner) RunBackground() {
 	t.registerFlagCleanup(root)
 
 	errch := make(chan error)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.ctx)
 
 	// Tee stdout/stderr to buffers.
 	stdoutR = io.TeeReader(stdoutR, &t.stdout)
@@ -234,6 +236,15 @@ func (c *cobraTestRunner) Eventually(condition func() bool, waitFor time.Duratio
 func NewCobraTestRunner(t *testing.T, args ...string) *cobraTestRunner {
 	return &cobraTestRunner{
 		T:    t,
+		ctx:  context.Background(),
+		args: args,
+	}
+}
+
+func NewCobraTestRunnerWithContext(t *testing.T, ctx context.Context, args ...string) *cobraTestRunner {
+	return &cobraTestRunner{
+		T:    t,
+		ctx:  ctx,
 		args: args,
 	}
 }


### PR DESCRIPTION
## Changes
Added end-to-end test for deploying and running Python wheel task

## Tests
Test successfully passed on all environments, takes about 9-10 minutes to pass.

```
Deleted snapshot file at /var/folders/nt/xjv68qzs45319w4k36dhpylc0000gp/T/TestAccPythonWheelTaskDeployAndRun1845899209/002/.databricks/bundle/default/sync-snapshots/1f7cc766ffe038d6.json
Successfully deleted files!
2023/09/06 17:50:50 INFO Releasing deployment lock mutator=destroy mutator=seq mutator=seq mutator=deferred mutator=lock:release
--- PASS: TestAccPythonWheelTaskDeployAndRun (508.16s)
PASS
coverage: 77.9% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       508.810s        coverage: 77.9% of statements in ./...
```
