### PR TITLE
Fix notebook showing up in template when not selected

### DIFF
--- a/libs/template/templates/default-python/template/__preamble.tmpl
+++ b/libs/template/templates/default-python/template/__preamble.tmpl
@@ -28,7 +28,7 @@ This file only template directives; it is skipped for the actual output.
 {{end}}
 
 {{if $notNotebook}}
-  {{skip "{{.project_name}}/src/notebook.iypnb"}}
+  {{skip "{{.project_name}}/src/notebook.ipynb"}}
 {{end}}
 
 {{if (and $notDLT $notNotebook $notPython)}}


### PR DESCRIPTION
## Changes
This fixes a typo that caused the notebook.ipynb file to show up even if the user answered "no" to the question about including a notebook.

## Tests
We have matrix validation tests for all the yes/no combinations and whether the build + validate. There is no current test for the absence of files.
