### PR TITLE
Fix conversion of job parameters

### DIFF
--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -90,6 +90,12 @@ func BundleToTerraform(config *config.Root) (*schema.Root, bool) {
 					Tag:      git.GitTag,
 				}
 			}
+
+			for _, v := range src.Parameters {
+				var t schema.ResourceJobParameter
+				conv(v, &t)
+				dst.Parameter = append(dst.Parameter, t)
+			}
 		}
 
 		tfroot.Resource.Job[k] = &dst

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -29,6 +29,16 @@ func TestConvertJob(t *testing.T) {
 				GitProvider: jobs.GitProviderGitHub,
 				GitUrl:      "https://github.com/foo/bar",
 			},
+			Parameters: []jobs.JobParameterDefinition{
+				{
+					Name:    "param1",
+					Default: "default1",
+				},
+				{
+					Name:    "param2",
+					Default: "default2",
+				},
+			},
 		},
 	}
 
@@ -44,6 +54,9 @@ func TestConvertJob(t *testing.T) {
 	assert.Equal(t, "my job", out.Resource.Job["my_job"].Name)
 	assert.Len(t, out.Resource.Job["my_job"].JobCluster, 1)
 	assert.Equal(t, "https://github.com/foo/bar", out.Resource.Job["my_job"].GitSource.Url)
+	assert.Len(t, out.Resource.Job["my_job"].Parameter, 2)
+	assert.Equal(t, "param1", out.Resource.Job["my_job"].Parameter[0].Name)
+	assert.Equal(t, "param2", out.Resource.Job["my_job"].Parameter[1].Name)
 	assert.Nil(t, out.Data)
 }
 


### PR DESCRIPTION
## Changes

Another example of singular/plural conversion.

Longer term solution is we do a full sweep of the type using reflection to make sure we cover all fields.

## Tests

Unit test passes.

