### PR TITLE
Use unique bundle root path for Python E2E test

### DIFF
--- a/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
@@ -7,7 +7,7 @@ workspace:
 resources:
   jobs:
     some_other_job:
-      name: "[${bundle.target}] Test Wheel Job"
+      name: "[${bundle.target}] Test Wheel Job {{.unique_id}}"
       tasks:
         - task_key: TestTask
           new_cluster:

--- a/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
@@ -1,10 +1,13 @@
 bundle:
   name: wheel-task
 
+workspace:
+  root_path: "~/.bundle/{{.unique_id}}"
+
 resources:
   jobs:
     some_other_job:
-      name: "[${bundle.target}] Test Wheel Job {{.unique_id}}"
+      name: "[${bundle.target}] Test Wheel Job"
       tasks:
         - task_key: TestTask
           new_cluster:


### PR DESCRIPTION
## Changes
It helps to make sure jobs in the tests are deployed and executed uniquely and isolated


```
Bundle remote directory is /Users/61b77d30-bc10-4214-9650-29cf5db0e941/.bundle/4b630810-5edc-4d8f-85d1-0eb5baf7bb28
Deleted snapshot file at /var/folders/nt/xjv68qzs45319w4k36dhpylc0000gp/T/TestAccPythonWheelTaskDeployAndRun3933198431/001/.databricks/bundle/default/sync-snapshots/dd9db100465e3d91.json
Successfully deleted files!
--- PASS: TestAccPythonWheelTaskDeployAndRun (346.28s)
PASS
coverage: 93.5% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       346.976s        coverage: 93.5% of statements in ./...
```

