### PR TITLE
Do not include empty output in job run output

### DIFF
--- a/bundle/run/output/job.go
+++ b/bundle/run/output/job.go
@@ -60,7 +60,7 @@ func GetJobOutput(ctx context.Context, w *databricks.WorkspaceClient, runId int6
 		return nil, err
 	}
 	result := &JobOutput{
-		TaskOutputs: make([]TaskOutput, len(jobRun.Tasks)),
+		TaskOutputs: make([]TaskOutput, 0),
 	}
 	for _, task := range jobRun.Tasks {
 		jobRunOutput, err := w.Jobs.GetRunOutput(ctx, jobs.GetRunOutputRequest{
@@ -69,7 +69,11 @@ func GetJobOutput(ctx context.Context, w *databricks.WorkspaceClient, runId int6
 		if err != nil {
 			return nil, err
 		}
-		task := TaskOutput{TaskKey: task.TaskKey, Output: toRunOutput(jobRunOutput), EndTime: task.EndTime}
+		out := toRunOutput(jobRunOutput)
+		if out == nil {
+			continue
+		}
+		task := TaskOutput{TaskKey: task.TaskKey, Output: out, EndTime: task.EndTime}
 		result.TaskOutputs = append(result.TaskOutputs, task)
 	}
 	return result, nil


### PR DESCRIPTION
## Changes
Do not include empty output in job run output

## Tests
Running a job from CLI, the result:
```
andrew.nester@HFW9Y94129 wheel % databricks bundle run some_other_job --output json
Run URL: https://***/?o=6051921418418893#job/780620378804085/run/386695528477456

2023-09-08 11:33:24 "[default] My Wheel Job" TERMINATED SUCCESS 
{
  "task_outputs": [
    {
      "TaskKey": "TestTask",
      "Output": {
        "result": "Hello from my func\nGot arguments v2:\n['python']\n"
      },
      "EndTime": 1694165597474
    }
  ]
```
