### PR TITLE
Close python wheel directory file descriptor after read

### DIFF
--- a/python/utils.go
+++ b/python/utils.go
@@ -30,6 +30,8 @@ func FindFilesWithSuffixInPath(dir, suffix string) []string {
 		log.Debugf(context.Background(), "open dir %s: %s", dir, err)
 		return nil
 	}
+	defer f.Close()
+
 	entries, err := f.ReadDir(0)
 	if err != nil {
 		log.Debugf(context.Background(), "read dir %s: %s", dir, err)


### PR DESCRIPTION
## Changes
Close python wheel directory file descriptor after read

