### PR TITLE
Make bundle and sync fields optional

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -52,7 +52,7 @@ type Root struct {
 
 	// Bundle contains details about this bundle, such as its name,
 	// version of the spec (TODO), default cluster, default warehouse, etc.
-	Bundle Bundle `json:"bundle"`
+	Bundle Bundle `json:"bundle,omitempty"`
 
 	// Include specifies a list of patterns of file names to load and
 	// merge into the this configuration. Only includes defined in the root
@@ -80,7 +80,7 @@ type Root struct {
 	Environments map[string]*Target `json:"environments,omitempty"`
 
 	// Sync section specifies options for files synchronization
-	Sync Sync `json:"sync"`
+	Sync Sync `json:"sync,omitempty"`
 
 	// RunAs section allows to define an execution identity for jobs and pipelines runs
 	RunAs *jobs.JobRunAs `json:"run_as,omitempty"`

--- a/bundle/schema/docs/bundle_descriptions.json
+++ b/bundle/schema/docs/bundle_descriptions.json
@@ -1472,7 +1472,6 @@
                     "config": {
                       "description": "The model serving endpoint configuration.",
                       "properties": {
-                        "description": "",
                         "properties": {
                           "served_models": {
                             "description": "Each block represents a served model for the endpoint to serve. A model serving endpoint can have up to 10 served models.",


### PR DESCRIPTION
## Changes
This PR:
1. Makes the bundle and sync properties optional in the generated schema. 
2. Fixes schema generation that was broken due to a rogue "description" field in the bundle docs.

## Tests
Tested manually. The generated schema no longer has "bundle" and "sync" marked as required. 
