### PR TITLE
Use interactive prompt to select resource to run if not specified

### DIFF
--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -95,6 +95,10 @@ type jobRunner struct {
 	job    *resources.Job
 }
 
+func (r *jobRunner) Name() string {
+	return r.job.Name
+}
+
 func isFailed(task jobs.RunTask) bool {
 	return task.State.LifeCycleState == jobs.RunLifeCycleStateInternalError ||
 		(task.State.LifeCycleState == jobs.RunLifeCycleStateTerminated &&

--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -96,7 +96,10 @@ type jobRunner struct {
 }
 
 func (r *jobRunner) Name() string {
-	return r.job.Name
+	if r.job == nil || r.job.JobSettings == nil {
+		return ""
+	}
+	return r.job.JobSettings.Name
 }
 
 func isFailed(task jobs.RunTask) bool {

--- a/bundle/run/pipeline.go
+++ b/bundle/run/pipeline.go
@@ -137,7 +137,10 @@ type pipelineRunner struct {
 }
 
 func (r *pipelineRunner) Name() string {
-	return r.pipeline.Name
+	if r.pipeline == nil || r.pipeline.PipelineSpec == nil {
+		return ""
+	}
+	return r.pipeline.PipelineSpec.Name
 }
 
 func (r *pipelineRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, error) {

--- a/bundle/run/pipeline.go
+++ b/bundle/run/pipeline.go
@@ -136,6 +136,10 @@ type pipelineRunner struct {
 	pipeline *resources.Pipeline
 }
 
+func (r *pipelineRunner) Name() string {
+	return r.pipeline.Name
+}
+
 func (r *pipelineRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, error) {
 	var pipelineID = r.pipeline.ID
 

--- a/bundle/run/runner.go
+++ b/bundle/run/runner.go
@@ -21,6 +21,9 @@ type Runner interface {
 	// This is used for showing the user hints w.r.t. disambiguation.
 	Key() string
 
+	// Name returns the resource's name, if defined.
+	Name() string
+
 	// Run the underlying worklow.
 	Run(ctx context.Context, opts *Options) (output.RunOutput, error)
 }


### PR DESCRIPTION
## Changes

Display an interactive prompt with a list of resources to run if one isn't specified and the command is run interactively.

## Tests

Manually confirmed:
* The new prompt works
* Shell completion still works
* Specifying a key argument still works