### PR TITLE
Use clearer error message when no interpolation value is found.

### DIFF
--- a/bundle/config/interpolation/interpolation.go
+++ b/bundle/config/interpolation/interpolation.go
@@ -184,7 +184,7 @@ func (a *accumulator) Resolve(path string, seenPaths []string, fns ...LookupFunc
 	// fetch the string node to resolve
 	field, ok := a.strings[path]
 	if !ok {
-		return fmt.Errorf("could not resolve reference %s", path)
+		return fmt.Errorf("no value found for interpolation query: ${%s}", path)
 	}
 
 	// return early if the string field has no variables to interpolate

--- a/bundle/config/interpolation/interpolation.go
+++ b/bundle/config/interpolation/interpolation.go
@@ -184,7 +184,7 @@ func (a *accumulator) Resolve(path string, seenPaths []string, fns ...LookupFunc
 	// fetch the string node to resolve
 	field, ok := a.strings[path]
 	if !ok {
-		return fmt.Errorf("no value found for interpolation query: ${%s}", path)
+		return fmt.Errorf("no value found for interpolation reference: ${%s}", path)
 	}
 
 	// return early if the string field has no variables to interpolate

--- a/bundle/config/interpolation/interpolation_test.go
+++ b/bundle/config/interpolation/interpolation_test.go
@@ -247,5 +247,5 @@ func TestInterpolationInvalidVariableReference(t *testing.T) {
 	}
 
 	err := expand(&config)
-	assert.ErrorContains(t, err, "could not resolve reference vars.foo")
+	assert.ErrorContains(t, err, "no value found for interpolation query: ${vars.foo}")
 }

--- a/bundle/config/interpolation/interpolation_test.go
+++ b/bundle/config/interpolation/interpolation_test.go
@@ -247,5 +247,5 @@ func TestInterpolationInvalidVariableReference(t *testing.T) {
 	}
 
 	err := expand(&config)
-	assert.ErrorContains(t, err, "no value found for interpolation query: ${vars.foo}")
+	assert.ErrorContains(t, err, "no value found for interpolation reference: ${vars.foo}")
 }


### PR DESCRIPTION
## Changes
This PR makes the error message clearer for when interpolation fails. 

## Tests
Existing unit test and manually
