### PR TITLE
Run environment related tests in a pristine environment

### DIFF
--- a/cmd/root/auth_test.go
+++ b/cmd/root/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,8 @@ func expectReturns(t *testing.T, fn promptFn, config *config.Config) {
 }
 
 func TestAccountClientOrPrompt(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, ".databrickscfg")
 	err := os.WriteFile(
@@ -127,6 +130,8 @@ func TestAccountClientOrPrompt(t *testing.T) {
 }
 
 func TestWorkspaceClientOrPrompt(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, ".databrickscfg")
 	err := os.WriteFile(

--- a/cmd/root/bundle_test.go
+++ b/cmd/root/bundle_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/internal/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,6 +57,8 @@ func setup(t *testing.T, cmd *cobra.Command, host string) *bundle.Bundle {
 }
 
 func TestBundleConfigureDefault(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	cmd := emptyCommand(t)
 	b := setup(t, cmd, "https://x.com")
 	assert.NotPanics(t, func() {
@@ -64,6 +67,8 @@ func TestBundleConfigureDefault(t *testing.T) {
 }
 
 func TestBundleConfigureWithMultipleMatches(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	cmd := emptyCommand(t)
 	b := setup(t, cmd, "https://a.com")
 	assert.Panics(t, func() {
@@ -72,6 +77,8 @@ func TestBundleConfigureWithMultipleMatches(t *testing.T) {
 }
 
 func TestBundleConfigureWithNonExistentProfileFlag(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	cmd := emptyCommand(t)
 	cmd.Flag("profile").Value.Set("NOEXIST")
 
@@ -82,6 +89,8 @@ func TestBundleConfigureWithNonExistentProfileFlag(t *testing.T) {
 }
 
 func TestBundleConfigureWithMismatchedProfile(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	cmd := emptyCommand(t)
 	cmd.Flag("profile").Value.Set("PROFILE-1")
 
@@ -92,6 +101,8 @@ func TestBundleConfigureWithMismatchedProfile(t *testing.T) {
 }
 
 func TestBundleConfigureWithCorrectProfile(t *testing.T) {
+	testutil.CleanupEnvironment(t)
+
 	cmd := emptyCommand(t)
 	cmd.Flag("profile").Value.Set("PROFILE-1")
 
@@ -102,10 +113,8 @@ func TestBundleConfigureWithCorrectProfile(t *testing.T) {
 }
 
 func TestBundleConfigureWithMismatchedProfileEnvVariable(t *testing.T) {
+	testutil.CleanupEnvironment(t)
 	t.Setenv("DATABRICKS_CONFIG_PROFILE", "PROFILE-1")
-	t.Cleanup(func() {
-		t.Setenv("DATABRICKS_CONFIG_PROFILE", "")
-	})
 
 	cmd := emptyCommand(t)
 	b := setup(t, cmd, "https://x.com")
@@ -115,10 +124,8 @@ func TestBundleConfigureWithMismatchedProfileEnvVariable(t *testing.T) {
 }
 
 func TestBundleConfigureWithProfileFlagAndEnvVariable(t *testing.T) {
+	testutil.CleanupEnvironment(t)
 	t.Setenv("DATABRICKS_CONFIG_PROFILE", "NOEXIST")
-	t.Cleanup(func() {
-		t.Setenv("DATABRICKS_CONFIG_PROFILE", "")
-	})
 
 	cmd := emptyCommand(t)
 	cmd.Flag("profile").Value.Set("PROFILE-1")

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -30,4 +31,7 @@ func CleanupEnvironment(t *testing.T) {
 	// because of isolation; the environment is scoped to the process.
 	t.Setenv("PATH", path)
 	t.Setenv("HOME", pwd)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", pwd)
+	}
 }


### PR DESCRIPTION
## Changes

If the caller running the test has one or more environment variables that are used in the test already set, they can interfere and make tests fail.

## Tests

Ran tests in `./cmd/root` with Databricks related environment variables set.