### PR TITLE
Add documentation link bundle command group description

### DIFF
--- a/cmd/bundle/bundle.go
+++ b/cmd/bundle/bundle.go
@@ -7,7 +7,7 @@ import (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
-		Short: "Databricks Asset Bundles",
+		Short: "Databricks Asset Bundles.\nDocumentation URL: https://docs.databricks.com/en/dev-tools/bundles",
 	}
 
 	initVariableFlag(cmd)

--- a/cmd/bundle/bundle.go
+++ b/cmd/bundle/bundle.go
@@ -7,7 +7,7 @@ import (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bundle",
-		Short: "Databricks Asset Bundles.\nDocumentation URL: https://docs.databricks.com/en/dev-tools/bundles",
+		Short: "Databricks Asset Bundles\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles",
 	}
 
 	initVariableFlag(cmd)


### PR DESCRIPTION
Help output:
```
shreyas.goenka@THW32HFW6T ~ % cli bundle -h
Databricks Asset Bundles.
Documentation URL: https://docs.databricks.com/en/dev-tools/bundles.

Usage:
  databricks bundle [command]
```