### PR TITLE
Set working directory to files root for Python wheel tasks

### DIFF
--- a/bundle/config/mutator/trampoline.go
+++ b/bundle/config/mutator/trampoline.go
@@ -18,7 +18,7 @@ type TaskWithJobKey struct {
 }
 
 type TrampolineFunctions interface {
-	GetTemplateData(task *jobs.Task) (map[string]any, error)
+	GetTemplateData(b *bundle.Bundle, task *jobs.Task) (map[string]any, error)
 	GetTasks(b *bundle.Bundle) []TaskWithJobKey
 	CleanUp(task *jobs.Task) error
 }
@@ -71,7 +71,7 @@ func (m *trampoline) generateNotebookWrapper(ctx context.Context, b *bundle.Bund
 	}
 	defer f.Close()
 
-	data, err := m.functions.GetTemplateData(task.Task)
+	data, err := m.functions.GetTemplateData(b, task.Task)
 	if err != nil {
 		return err
 	}

--- a/bundle/config/mutator/trampoline_test.go
+++ b/bundle/config/mutator/trampoline_test.go
@@ -29,7 +29,7 @@ func (f *functions) GetTasks(b *bundle.Bundle) []TaskWithJobKey {
 	return tasks
 }
 
-func (f *functions) GetTemplateData(task *jobs.Task) (map[string]any, error) {
+func (f *functions) GetTemplateData(_ *bundle.Bundle, task *jobs.Task) (map[string]any, error) {
 	if task.PythonWheelTask == nil {
 		return nil, fmt.Errorf("PythonWheelTask cannot be nil")
 	}

--- a/internal/bundle/bundles/python_wheel_task/template/{{.project_name}}/__main__.py
+++ b/internal/bundle/bundles/python_wheel_task/template/{{.project_name}}/__main__.py
@@ -3,6 +3,7 @@ The entry point of the Python Wheel
 """
 
 import sys
+import os
 
 
 def main():
@@ -10,6 +11,9 @@ def main():
     print("Hello from my func")
     print("Got arguments:")
     print(sys.argv)
+
+    retval = os.getcwd()
+    print("Directory changed successfully %s" % retval)
 
 
 if __name__ == "__main__":

--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -1,6 +1,8 @@
 package bundle
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/databricks/cli/internal"
@@ -21,9 +23,10 @@ func TestAccPythonWheelTaskDeployAndRun(t *testing.T) {
 		nodeTypeId = "Standard_DS4_v2"
 	}
 
+	id := uuid.New().String()
 	bundleRoot, err := initTestTemplate(t, "python_wheel_task", map[string]any{
 		"node_type_id":  nodeTypeId,
-		"unique_id":     uuid.New().String(),
+		"unique_id":     id,
 		"spark_version": "13.2.x-snapshot-scala2.12",
 	})
 	require.NoError(t, err)
@@ -40,4 +43,5 @@ func TestAccPythonWheelTaskDeployAndRun(t *testing.T) {
 	require.Contains(t, out, "Hello from my func")
 	require.Contains(t, out, "Got arguments:")
 	require.Contains(t, out, "['python', 'one', 'two']")
+	require.Regexp(t, regexp.MustCompile(fmt.Sprintf("Directory changed successfully /Workspace/Users/.*/.bundle/%s/files", id)), out)
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
E2E test passed

```
    helpers.go:163: [databricks stdout]: Directory changed successfully /Workspace/Users/***/.bundle/193a8bf4-eb81-4204-b449-a732e19faff5/files
...
Successfully deleted files!
--- PASS: TestAccPythonWheelTaskDeployAndRun (126.47s)
PASS
coverage: 93.5% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       127.212s        coverage: 93.5% of statements in ./...
```

