### PR TITLE
Fall back to full Git clone if shallow clone is not supported

### DIFF
--- a/libs/git/clone.go
+++ b/libs/git/clone.go
@@ -84,7 +84,7 @@ func Clone(ctx context.Context, url, reference, targetPath string) error {
 	// a deep clone this time
 	if err != nil && strings.Contains(err.Error(), "dumb http transport does not support shallow capabilities") {
 		opts.Shallow = false
-		err = opts.clone(ctx)
+		return opts.clone(ctx)
 	}
 	return err
 }

--- a/libs/git/clone.go
+++ b/libs/git/clone.go
@@ -73,7 +73,7 @@ func Clone(ctx context.Context, url, reference, targetPath string) error {
 	if err != nil && strings.Contains(cmdErr.String(), "dumb http transport does not support shallow capabilities") {
 		retryCmd := exec.CommandContext(ctx, "git", opts.args(false)...)
 		var retryCmdErr bytes.Buffer
-		cmd.Stderr = &retryCmdErr
+		retryCmd.Stderr = &retryCmdErr
 		retryErr := retryCmd.Run()
 		if retryErr != nil {
 			return fmt.Errorf("git clone failed: %w. %s", retryErr, retryCmdErr.String())

--- a/libs/git/clone_test.go
+++ b/libs/git/clone_test.go
@@ -14,21 +14,24 @@ func TestGitCloneArgs(t *testing.T) {
 		Reference:     "",
 		RepositoryUrl: "abc",
 		TargetPath:    "/def",
-	}.args(true))
+		Shallow:       true,
+	}.args())
 
 	// case: A branch is specified.
 	assert.Equal(t, []string{"clone", "abc", "/def", "--no-tags", "--branch", "my-branch", "--depth=1"}, cloneOptions{
 		Reference:     "my-branch",
 		RepositoryUrl: "abc",
 		TargetPath:    "/def",
-	}.args(true))
+		Shallow:       true,
+	}.args())
 
 	// case: deep cloning
 	assert.Equal(t, []string{"clone", "abc", "/def", "--no-tags"}, cloneOptions{
 		Reference:     "",
 		RepositoryUrl: "abc",
 		TargetPath:    "/def",
-	}.args(false))
+		Shallow:       false,
+	}.args())
 }
 
 func TestGitCloneWithGitNotFound(t *testing.T) {

--- a/libs/git/clone_test.go
+++ b/libs/git/clone_test.go
@@ -10,18 +10,25 @@ import (
 
 func TestGitCloneArgs(t *testing.T) {
 	// case: No branch / tag specified. In this case git clones the default branch
-	assert.Equal(t, []string{"clone", "abc", "/def", "--depth=1", "--no-tags"}, cloneOptions{
+	assert.Equal(t, []string{"clone", "abc", "/def", "--no-tags", "--depth=1"}, cloneOptions{
 		Reference:     "",
 		RepositoryUrl: "abc",
 		TargetPath:    "/def",
-	}.args())
+	}.args(true))
 
 	// case: A branch is specified.
-	assert.Equal(t, []string{"clone", "abc", "/def", "--depth=1", "--no-tags", "--branch", "my-branch"}, cloneOptions{
+	assert.Equal(t, []string{"clone", "abc", "/def", "--no-tags", "--branch", "my-branch", "--depth=1"}, cloneOptions{
 		Reference:     "my-branch",
 		RepositoryUrl: "abc",
 		TargetPath:    "/def",
-	}.args())
+	}.args(true))
+
+	// case: deep cloning
+	assert.Equal(t, []string{"clone", "abc", "/def", "--no-tags"}, cloneOptions{
+		Reference:     "",
+		RepositoryUrl: "abc",
+		TargetPath:    "/def",
+	}.args(false))
 }
 
 func TestGitCloneWithGitNotFound(t *testing.T) {


### PR DESCRIPTION
## Changes
Git repos hosted over HTTP do not support shallow cloning. This PR adds retry logic if we detect shallow cloning is not supported. 

Note I saw the match string `dumb http transport does not support shallow capabilities` being reported in for different hosts on the internet, so this should work accross a large class of git servers. Howerver, it's not strictly necessary to have the `--depth` flag so we can remove it if this issue is reported again.

## Tests
Tested manually. `bundle init` successfully downloads the private HTTP repo reported during by internal user.