### PR TITLE
Increase timeout waiting for job run to 1 day

### DIFF
--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -86,7 +86,7 @@ func (o *JobOptions) toPayload(jobID int64) (*jobs.RunNow, error) {
 }
 
 // Default timeout for waiting for a job run to complete.
-var jobRunTimeout time.Duration = 2 * time.Hour
+var jobRunTimeout time.Duration = 24 * time.Hour
 
 type jobRunner struct {
 	key


### PR DESCRIPTION
## Changes

It's not uncommon for job runs to take more than 2 hours. On the client side, we should not stop waiting for a job to complete if it is intentionally running for a long time. If a job isn't supposed to run this long, the user can specify a run timeout in the job specification itself.

## Tests

n/a