### PR TITLE
Prompt for profile only in interactive mode

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -48,7 +48,7 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 		profileFlag := cmd.Flag("profile")
 		if profileFlag != nil && profileFlag.Value.String() != "" {
 			profileName = profileFlag.Value.String()
-		} else {
+		} else if cmdio.IsInTTY(ctx) {
 			prompt := cmdio.Prompt(ctx)
 			prompt.Label = "Databricks Profile Name"
 			prompt.Default = persistentAuth.ProfileName()
@@ -120,13 +120,16 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 			cfg.ClusterID = clusterId
 		}
 
-		cfg.Profile = profileName
-		err = databrickscfg.SaveToProfile(ctx, &cfg)
-		if err != nil {
-			return err
+		if profileName != "" {
+			cfg.Profile = profileName
+			err = databrickscfg.SaveToProfile(ctx, &cfg)
+			if err != nil {
+				return err
+			}
+
+			cmdio.LogString(ctx, fmt.Sprintf("Profile %s was successfully saved", profileName))
 		}
 
-		cmdio.LogString(ctx, fmt.Sprintf("Profile %s was successfully saved", profileName))
 		return nil
 	}
 


### PR DESCRIPTION
## Changes
Do not prompt for profiles if not in interactive mode

## Tests
Running sample Go code

```
cmd := exec.Command("databricks", "auth", "login", "--host", "***")
out, err := cmd.CombinedOutput()
```
Before the change
```
Error: ^D

exit status 1
```

After
```
No error (empty output)
```


