### PR TITLE
Added `process.Background()` and `process.Forwarded()`

### DIFF
--- a/bundle/config/artifact.go
+++ b/bundle/config/artifact.go
@@ -56,11 +56,14 @@ func (a *Artifact) Build(ctx context.Context) ([]byte, error) {
 	commands := strings.Split(a.BuildCommand, " && ")
 	for _, command := range commands {
 		buildParts := strings.Split(command, " ")
-		res, err := process.Background(ctx, buildParts, process.WithDir(a.Path))
+		var buf bytes.Buffer
+		_, err := process.Background(ctx, buildParts,
+			process.WithCombinedOutput(&buf),
+			process.WithDir(a.Path))
 		if err != nil {
-			return nil, err
+			return buf.Bytes(), err
 		}
-		out = append(out, []byte(res))
+		out = append(out, buf.Bytes())
 	}
 	return bytes.Join(out, []byte{}), nil
 }

--- a/bundle/scripts/scripts.go
+++ b/bundle/scripts/scripts.go
@@ -61,6 +61,7 @@ func executeHook(ctx context.Context, b *bundle.Bundle, hook config.ScriptHook) 
 		return nil, nil, err
 	}
 
+	// TODO: switch to process.Background(...)
 	cmd := exec.CommandContext(ctx, interpreter, "-c", string(command))
 	cmd.Dir = b.Config.Path
 

--- a/libs/env/context.go
+++ b/libs/env/context.go
@@ -75,7 +75,7 @@ func All(ctx context.Context) map[string]string {
 		m[split[0]] = split[1]
 	}
 	// override existing environment variables with the ones we set
-	for k, v := range copyMap(getMap(ctx)) {
+	for k, v := range getMap(ctx) {
 		m[k] = v
 	}
 	return m

--- a/libs/env/context.go
+++ b/libs/env/context.go
@@ -3,6 +3,7 @@ package env
 import (
 	"context"
 	"os"
+	"strings"
 )
 
 var envContextKey int
@@ -60,4 +61,22 @@ func Set(ctx context.Context, key, value string) context.Context {
 	m := copyMap(getMap(ctx))
 	m[key] = value
 	return setMap(ctx, m)
+}
+
+// All returns environment variables that are defined in both os.Environ
+// and this package. `env.Set(ctx, x, y)` will override x from os.Environ.
+func All(ctx context.Context) map[string]string {
+	m := map[string]string{}
+	for _, line := range os.Environ() {
+		split := strings.SplitN(line, "=", 2)
+		if len(split) != 2 {
+			continue
+		}
+		m[split[0]] = split[1]
+	}
+	// override existing environment variables with the ones we set
+	for k, v := range copyMap(getMap(ctx)) {
+		m[k] = v
+	}
+	return m
 }

--- a/libs/env/context_test.go
+++ b/libs/env/context_test.go
@@ -38,4 +38,11 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "qux", Get(ctx2, "FOO"))
 	assert.Equal(t, "baz", Get(ctx1, "FOO"))
 	assert.Equal(t, "bar", Get(ctx0, "FOO"))
+
+	ctx3 := Set(ctx2, "BAR", "x=y")
+
+	all := All(ctx3)
+	assert.NotNil(t, all)
+	assert.Equal(t, "qux", all["FOO"])
+	assert.Equal(t, "x=y", all["BAR"])
 }

--- a/libs/env/context_test.go
+++ b/libs/env/context_test.go
@@ -45,4 +45,5 @@ func TestContext(t *testing.T) {
 	assert.NotNil(t, all)
 	assert.Equal(t, "qux", all["FOO"])
 	assert.Equal(t, "x=y", all["BAR"])
+	assert.NotEmpty(t, all["PATH"])
 }

--- a/libs/git/clone.go
+++ b/libs/git/clone.go
@@ -48,6 +48,10 @@ func (opts cloneOptions) clone(ctx context.Context) error {
 	if errors.Is(err, exec.ErrNotFound) {
 		return fmt.Errorf("please install git CLI to clone a repository: %w", err)
 	}
+	var processErr *process.ProcessError
+	if errors.As(err, &processErr) {
+		return fmt.Errorf("git clone failed: %w. %s", err, processErr.Stderr)
+	}
 	if err != nil {
 		return fmt.Errorf("git clone failed: %w", err)
 	}

--- a/libs/git/clone.go
+++ b/libs/git/clone.go
@@ -1,13 +1,14 @@
 package git
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/databricks/cli/libs/process"
 )
 
 // source: https://stackoverflow.com/questions/59081778/rules-for-special-characters-in-github-repository-name
@@ -42,23 +43,13 @@ func (opts cloneOptions) args() []string {
 }
 
 func (opts cloneOptions) clone(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "git", opts.args()...)
-	var cmdErr bytes.Buffer
-	cmd.Stderr = &cmdErr
-
-	// start git clone
-	err := cmd.Start()
+	// start and wait for git clone to complete
+	_, err := process.Background(ctx, append([]string{"git"}, opts.args()...))
 	if errors.Is(err, exec.ErrNotFound) {
 		return fmt.Errorf("please install git CLI to clone a repository: %w", err)
 	}
 	if err != nil {
 		return fmt.Errorf("git clone failed: %w", err)
-	}
-
-	// wait for git clone to complete
-	err = cmd.Wait()
-	if err != nil {
-		return fmt.Errorf("git clone failed: %w. %s", err, cmdErr.String())
 	}
 	return nil
 }

--- a/libs/process/background.go
+++ b/libs/process/background.go
@@ -48,6 +48,5 @@ func Background(ctx context.Context, args []string, opts ...execOption) (string,
 			Stderr:  stderr.String(),
 		}
 	}
-	// trim leading/trailing whitespace from the output
-	return strings.TrimSpace(stdout.String()), nil
+	return stdout.String(), nil
 }

--- a/libs/process/background.go
+++ b/libs/process/background.go
@@ -4,21 +4,36 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/databricks/cli/libs/log"
 )
 
+type ProcessError struct {
+	Command string
+	Err     error
+	Stdout  string
+	Stderr  string
+}
+
+func (perr *ProcessError) Unwrap() error {
+	return perr.Err
+}
+
+func (perr *ProcessError) Error() string {
+	return fmt.Sprintf("%s: %s %s", perr.Command, perr.Stderr, perr.Err)
+}
+
 func Background(ctx context.Context, args []string, opts ...execOption) (string, error) {
 	commandStr := strings.Join(args, " ")
 	log.Debugf(ctx, "running: %s", commandStr)
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	stdout := &bytes.Buffer{}
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = stdout
-	cmd.Stderr = stdout
+	var stdout, stderr bytes.Buffer
+	// For background processes, there's no standard input
+	cmd.Stdin = nil
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	for _, o := range opts {
 		err := o(cmd)
 		if err != nil {
@@ -26,7 +41,13 @@ func Background(ctx context.Context, args []string, opts ...execOption) (string,
 		}
 	}
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("%s: %s %w", commandStr, stdout.String(), err)
+		return "", &ProcessError{
+			Err:     err,
+			Command: commandStr,
+			Stdout:  stdout.String(),
+			Stderr:  stderr.String(),
+		}
 	}
+	// trim leading/trailing whitespace from the output
 	return strings.TrimSpace(stdout.String()), nil
 }

--- a/libs/process/background.go
+++ b/libs/process/background.go
@@ -35,13 +35,13 @@ func Background(ctx context.Context, args []string, opts ...execOption) (string,
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	for _, o := range opts {
-		err := o(cmd)
+		err := o(ctx, cmd)
 		if err != nil {
 			return "", err
 		}
 	}
 	if err := cmd.Run(); err != nil {
-		return "", &ProcessError{
+		return stdout.String(), &ProcessError{
 			Err:     err,
 			Command: commandStr,
 			Stdout:  stdout.String(),

--- a/libs/process/background.go
+++ b/libs/process/background.go
@@ -1,0 +1,32 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/databricks/cli/libs/log"
+)
+
+func Background(ctx context.Context, args []string, opts ...execOption) (string, error) {
+	commandStr := strings.Join(args, " ")
+	log.Debugf(ctx, "running: %s", commandStr)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	stdout := &bytes.Buffer{}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stdout
+	for _, o := range opts {
+		err := o(cmd)
+		if err != nil {
+			return "", err
+		}
+	}
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s: %s %w", commandStr, stdout.String(), err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/libs/process/background_test.go
+++ b/libs/process/background_test.go
@@ -1,19 +1,69 @@
 package process
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBackgroundUnwrapsNotFound(t *testing.T) {
+	ctx := context.Background()
+	_, err := Background(ctx, []string{"/bin/meeecho", "1"})
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestBackground(t *testing.T) {
 	ctx := context.Background()
 	res, err := Background(ctx, []string{"echo", "1"}, WithDir("/"))
 	assert.NoError(t, err)
 	assert.Equal(t, "1", res)
+}
+
+func TestBackgroundOnlyStdoutGetsoutOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	res, err := Background(ctx, []string{
+		"python3", "-c", "import sys; sys.stderr.write('1'); sys.stdout.write('2')",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "2", res)
+}
+
+func TestBackgroundCombinedOutput(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+	res, err := Background(ctx, []string{
+		"python3", "-c", "import sys; sys.stderr.write('1'); sys.stdout.write('2')",
+	}, WithCombinedOutput(&buf))
+	assert.NoError(t, err)
+	assert.Equal(t, "2", res)
+	assert.Equal(t, "12", buf.String())
+}
+
+func TestBackgroundCombinedOutputFailure(t *testing.T) {
+	ctx := context.Background()
+	var buf bytes.Buffer
+	res, err := Background(ctx, []string{
+		"python3", "-c", "import sys; sys.stderr.write('1'); sys.stdout.write('2'); sys.exit(42)",
+	}, WithCombinedOutput(&buf))
+	var processErr *ProcessError
+	if assert.ErrorAs(t, err, &processErr) {
+		assert.Equal(t, "1", processErr.Stderr)
+		assert.Equal(t, "2", processErr.Stdout)
+	}
+	assert.Equal(t, "2", res)
+	assert.Equal(t, "12", buf.String())
+}
+
+func TestBackgroundNoStdin(t *testing.T) {
+	ctx := context.Background()
+	res, err := Background(ctx, []string{"cat"})
+	assert.NoError(t, err)
+	assert.Equal(t, "", res)
 }
 
 func TestBackgroundFails(t *testing.T) {
@@ -24,7 +74,7 @@ func TestBackgroundFails(t *testing.T) {
 
 func TestBackgroundFailsOnOption(t *testing.T) {
 	ctx := context.Background()
-	_, err := Background(ctx, []string{"ls", "/dev/null/x"}, func(c *exec.Cmd) error {
+	_, err := Background(ctx, []string{"ls", "/dev/null/x"}, func(_ context.Context, c *exec.Cmd) error {
 		return fmt.Errorf("nope")
 	})
 	assert.EqualError(t, err, "nope")

--- a/libs/process/background_test.go
+++ b/libs/process/background_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestBackground(t *testing.T) {
 	ctx := context.Background()
 	res, err := Background(ctx, []string{"echo", "1"}, WithDir("/"))
 	assert.NoError(t, err)
-	assert.Equal(t, "1\n", res)
+	assert.Equal(t, "1", strings.TrimSpace(res))
 }
 
 func TestBackgroundOnlyStdoutGetsoutOnSuccess(t *testing.T) {
@@ -44,8 +45,8 @@ func TestBackgroundCombinedOutput(t *testing.T) {
 			"time.sleep(0.001)",
 	}, WithCombinedOutput(&buf))
 	assert.NoError(t, err)
-	assert.Equal(t, "2\n", res)
-	assert.Equal(t, "1\n2\n", buf.String())
+	assert.Equal(t, "2", strings.TrimSpace(res))
+	assert.Equal(t, "1\n2\n", strings.ReplaceAll(buf.String(), "\r", ""))
 }
 
 func TestBackgroundCombinedOutputFailure(t *testing.T) {
@@ -61,11 +62,11 @@ func TestBackgroundCombinedOutputFailure(t *testing.T) {
 	}, WithCombinedOutput(&buf))
 	var processErr *ProcessError
 	if assert.ErrorAs(t, err, &processErr) {
-		assert.Equal(t, "1\n", processErr.Stderr)
-		assert.Equal(t, "2\n", processErr.Stdout)
+		assert.Equal(t, "1", strings.TrimSpace(processErr.Stderr))
+		assert.Equal(t, "2", strings.TrimSpace(processErr.Stdout))
 	}
-	assert.Equal(t, "2\n", res)
-	assert.Equal(t, "1\n2\n", buf.String())
+	assert.Equal(t, "2", strings.TrimSpace(res))
+	assert.Equal(t, "1\n2\n", strings.ReplaceAll(buf.String(), "\r", ""))
 }
 
 func TestBackgroundNoStdin(t *testing.T) {

--- a/libs/process/background_test.go
+++ b/libs/process/background_test.go
@@ -1,0 +1,31 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackground(t *testing.T) {
+	ctx := context.Background()
+	res, err := Background(ctx, []string{"echo", "1"}, WithDir("/"))
+	assert.NoError(t, err)
+	assert.Equal(t, "1", res)
+}
+
+func TestBackgroundFails(t *testing.T) {
+	ctx := context.Background()
+	_, err := Background(ctx, []string{"ls", "/dev/null/x"})
+	assert.NotNil(t, err)
+}
+
+func TestBackgroundFailsOnOption(t *testing.T) {
+	ctx := context.Background()
+	_, err := Background(ctx, []string{"ls", "/dev/null/x"}, func(c *exec.Cmd) error {
+		return fmt.Errorf("nope")
+	})
+	assert.EqualError(t, err, "nope")
+}

--- a/libs/process/forwarded.go
+++ b/libs/process/forwarded.go
@@ -1,0 +1,48 @@
+package process
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/databricks/cli/libs/log"
+)
+
+func Forwarded(ctx context.Context, args []string, src io.Reader, dst io.Writer, opts ...execOption) error {
+	commandStr := strings.Join(args, " ")
+	log.Debugf(ctx, "starting: %s", commandStr)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+
+	// make sure to sync on writing to stdout
+	reader, writer := io.Pipe()
+	go io.CopyBuffer(dst, reader, make([]byte, 128))
+	defer reader.Close()
+	defer writer.Close()
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+
+	// apply common options
+	for _, o := range opts {
+		err := o(cmd)
+		if err != nil {
+			return err
+		}
+	}
+
+	// pipe standard input to the child process, so that we can allow terminal UX
+	// see the PoC at https://github.com/databricks/cli/pull/637
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	go io.CopyBuffer(stdin, src, make([]byte, 128))
+	defer stdin.Close()
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}

--- a/libs/process/forwarded_test.go
+++ b/libs/process/forwarded_test.go
@@ -18,7 +18,7 @@ func TestForwarded(t *testing.T) {
 	}, strings.NewReader("abc\n"), buf)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "input: abc\n", buf.String())
+	assert.Equal(t, "input: abc", strings.TrimSpace(buf.String()))
 }
 
 func TestForwardedFails(t *testing.T) {

--- a/libs/process/forwarded_test.go
+++ b/libs/process/forwarded_test.go
@@ -15,7 +15,7 @@ func TestForwarded(t *testing.T) {
 	var buf bytes.Buffer
 	err := Forwarded(ctx, []string{
 		"python3", "-c", "print(input('input: '))",
-	}, strings.NewReader("abc\n"), &buf)
+	}, strings.NewReader("abc\n"), &buf, &buf)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "input: abc", strings.TrimSpace(buf.String()))
@@ -26,7 +26,7 @@ func TestForwardedFails(t *testing.T) {
 	var buf bytes.Buffer
 	err := Forwarded(ctx, []string{
 		"_non_existent_",
-	}, strings.NewReader("abc\n"), &buf)
+	}, strings.NewReader("abc\n"), &buf, &buf)
 	assert.NotNil(t, err)
 }
 
@@ -35,7 +35,7 @@ func TestForwardedFailsOnStdinPipe(t *testing.T) {
 	var buf bytes.Buffer
 	err := Forwarded(ctx, []string{
 		"_non_existent_",
-	}, strings.NewReader("abc\n"), &buf, func(_ context.Context, c *exec.Cmd) error {
+	}, strings.NewReader("abc\n"), &buf, &buf, func(_ context.Context, c *exec.Cmd) error {
 		c.Stdin = strings.NewReader("x")
 		return nil
 	})

--- a/libs/process/forwarded_test.go
+++ b/libs/process/forwarded_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestForwarded(t *testing.T) {
 	ctx := context.Background()
-	buf := bytes.NewBufferString("")
+	var buf bytes.Buffer
 	err := Forwarded(ctx, []string{
 		"python3", "-c", "print(input('input: '))",
-	}, strings.NewReader("abc\n"), buf)
+	}, strings.NewReader("abc\n"), &buf)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "input: abc", strings.TrimSpace(buf.String()))
@@ -23,19 +23,19 @@ func TestForwarded(t *testing.T) {
 
 func TestForwardedFails(t *testing.T) {
 	ctx := context.Background()
-	buf := bytes.NewBufferString("")
+	var buf bytes.Buffer
 	err := Forwarded(ctx, []string{
 		"_non_existent_",
-	}, strings.NewReader("abc\n"), buf)
+	}, strings.NewReader("abc\n"), &buf)
 	assert.NotNil(t, err)
 }
 
 func TestForwardedFailsOnStdinPipe(t *testing.T) {
 	ctx := context.Background()
-	buf := bytes.NewBufferString("")
+	var buf bytes.Buffer
 	err := Forwarded(ctx, []string{
 		"_non_existent_",
-	}, strings.NewReader("abc\n"), buf, func(c *exec.Cmd) error {
+	}, strings.NewReader("abc\n"), &buf, func(_ context.Context, c *exec.Cmd) error {
 		c.Stdin = strings.NewReader("x")
 		return nil
 	})

--- a/libs/process/forwarded_test.go
+++ b/libs/process/forwarded_test.go
@@ -1,0 +1,43 @@
+package process
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForwarded(t *testing.T) {
+	ctx := context.Background()
+	buf := bytes.NewBufferString("")
+	err := Forwarded(ctx, []string{
+		"python3", "-c", "print(input('input: '))",
+	}, strings.NewReader("abc\n"), buf)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "input: abc\n", buf.String())
+}
+
+func TestForwardedFails(t *testing.T) {
+	ctx := context.Background()
+	buf := bytes.NewBufferString("")
+	err := Forwarded(ctx, []string{
+		"_non_existent_",
+	}, strings.NewReader("abc\n"), buf)
+	assert.NotNil(t, err)
+}
+
+func TestForwardedFailsOnStdinPipe(t *testing.T) {
+	ctx := context.Background()
+	buf := bytes.NewBufferString("")
+	err := Forwarded(ctx, []string{
+		"_non_existent_",
+	}, strings.NewReader("abc\n"), buf, func(c *exec.Cmd) error {
+		c.Stdin = strings.NewReader("x")
+		return nil
+	})
+	assert.NotNil(t, err)
+}

--- a/libs/process/opts.go
+++ b/libs/process/opts.go
@@ -59,8 +59,8 @@ func WithStdoutPipe(dst *io.ReadCloser) execOption {
 
 func WithCombinedOutput(buf *bytes.Buffer) execOption {
 	return func(_ context.Context, c *exec.Cmd) error {
-		c.Stdout = io.MultiWriter(c.Stdout, buf)
-		c.Stderr = io.MultiWriter(c.Stderr, buf)
+		c.Stdout = io.MultiWriter(buf, c.Stdout)
+		c.Stderr = io.MultiWriter(buf, c.Stderr)
 		return nil
 	}
 }

--- a/libs/process/opts.go
+++ b/libs/process/opts.go
@@ -1,0 +1,51 @@
+package process
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+type execOption func(*exec.Cmd) error
+
+func WithEnv(key, value string) execOption {
+	return func(c *exec.Cmd) error {
+		if c.Env == nil {
+			c.Env = os.Environ()
+		}
+		v := fmt.Sprintf("%s=%s", key, value)
+		c.Env = append(c.Env, v)
+		return nil
+	}
+}
+
+func WithEnvs(envs map[string]string) execOption {
+	return func(c *exec.Cmd) error {
+		for k, v := range envs {
+			err := WithEnv(k, v)(c)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithDir(dir string) execOption {
+	return func(c *exec.Cmd) error {
+		c.Dir = dir
+		return nil
+	}
+}
+
+func WithStdoutPipe(dst *io.ReadCloser) execOption {
+	return func(c *exec.Cmd) error {
+		outPipe, err := c.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		*dst = outPipe
+		return nil
+	}
+}

--- a/libs/process/opts.go
+++ b/libs/process/opts.go
@@ -6,21 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-
-	"github.com/databricks/cli/libs/env"
 )
 
 type execOption func(context.Context, *exec.Cmd) error
 
 func WithEnv(key, value string) execOption {
 	return func(ctx context.Context, c *exec.Cmd) error {
-		// we pull the env through lib/env such that we can run
-		// parallel tests with anything using libs/process.
-		if c.Env == nil {
-			for k, v := range env.All(ctx) {
-				c.Env = append(c.Env, fmt.Sprintf("%s=%s", k, v))
-			}
-		}
 		v := fmt.Sprintf("%s=%s", key, value)
 		c.Env = append(c.Env, v)
 		return nil

--- a/libs/process/opts_test.go
+++ b/libs/process/opts_test.go
@@ -19,31 +19,29 @@ func TestWithEnvs(t *testing.T) {
 		t.SkipNow()
 	}
 	ctx := context.Background()
-	res, err := Background(ctx, []string{"/bin/sh", "-c", "echo $FOO $BAR"}, WithEnvs(map[string]string{
-		"FOO": "foo",
+	ctx2 := env.Set(ctx, "FOO", "foo")
+	res, err := Background(ctx2, []string{"/bin/sh", "-c", "echo $FOO $BAR"}, WithEnvs(map[string]string{
 		"BAR": "delirium",
 	}))
 	assert.NoError(t, err)
-	assert.Equal(t, "foo delirium", res)
+	assert.Equal(t, "foo delirium\n", res)
 }
 
 func TestWorksWithLibsEnv(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 	ctx := context.Background()
-	ctx2 := env.Set(ctx, "AAA", "BBB")
 
 	cmd := &exec.Cmd{}
 	err := WithEnvs(map[string]string{
 		"CCC": "DDD",
 		"EEE": "FFF",
-	})(ctx2, cmd)
+	})(ctx, cmd)
 	assert.NoError(t, err)
 
 	vars := cmd.Environ()
 	sort.Strings(vars)
 
-	assert.Len(t, vars, 5)
-	assert.Equal(t, "AAA=BBB", vars[0])
-	assert.Equal(t, "CCC=DDD", vars[1])
-	assert.Equal(t, "EEE=FFF", vars[2])
+	assert.Len(t, vars, 2)
+	assert.Equal(t, "CCC=DDD", vars[0])
+	assert.Equal(t, "EEE=FFF", vars[1])
 }

--- a/libs/process/opts_test.go
+++ b/libs/process/opts_test.go
@@ -1,0 +1,18 @@
+package process
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithEnvs(t *testing.T) {
+	ctx := context.Background()
+	res, err := Background(ctx, []string{"/bin/sh", "-c", "echo $FOO $BAR"}, WithEnvs(map[string]string{
+		"FOO": "foo",
+		"BAR": "delirium",
+	}))
+	assert.NoError(t, err)
+	assert.Equal(t, "foo delirium", res)
+}

--- a/libs/process/opts_test.go
+++ b/libs/process/opts_test.go
@@ -41,7 +41,7 @@ func TestWorksWithLibsEnv(t *testing.T) {
 	vars := cmd.Environ()
 	sort.Strings(vars)
 
-	assert.Len(t, vars, 2)
+	assert.True(t, len(vars) >= 2)
 	assert.Equal(t, "CCC=DDD", vars[0])
 	assert.Equal(t, "EEE=FFF", vars[1])
 }

--- a/libs/process/opts_test.go
+++ b/libs/process/opts_test.go
@@ -2,12 +2,18 @@ package process
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWithEnvs(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// Skipping test on windows for now because of the following error:
+		// /bin/sh -c echo $FOO $BAR:  exec: "/bin/sh": file does not exist
+		t.SkipNow()
+	}
 	ctx := context.Background()
 	res, err := Background(ctx, []string{"/bin/sh", "-c", "echo $FOO $BAR"}, WithEnvs(map[string]string{
 		"FOO": "foo",

--- a/libs/process/opts_test.go
+++ b/libs/process/opts_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWithEnvs(t *testing.T) {
-	if runtime.GOOS != "windows" {
+	if runtime.GOOS == "windows" {
 		// Skipping test on windows for now because of the following error:
 		// /bin/sh -c echo $FOO $BAR:  exec: "/bin/sh": file does not exist
 		t.SkipNow()

--- a/python/runner.go
+++ b/python/runner.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/databricks/cli/libs/process"
 )
 
 func PyInline(ctx context.Context, inlinePy string) (string, error) {
@@ -88,8 +90,8 @@ func DetectExecutable(ctx context.Context) (string, error) {
 
 func execAndPassErr(ctx context.Context, name string, args ...string) ([]byte, error) {
 	// TODO: move out to a separate package, once we have Maven integration
-	out, err := exec.CommandContext(ctx, name, args...).Output()
-	return out, nicerErr(err)
+	out, err := process.Background(ctx, append([]string{name}, args...))
+	return []byte(out), nicerErr(err)
 }
 
 func getFirstMatch(out string) string {

--- a/python/runner_test.go
+++ b/python/runner_test.go
@@ -20,7 +20,7 @@ func TestExecAndPassError(t *testing.T) {
 	}
 
 	_, err := execAndPassErr(context.Background(), "which", "__non_existing__")
-	assert.EqualError(t, err, "which __non_existing__:  exit status 1")
+	assert.EqualError(t, err, "which __non_existing__: exit status 1")
 }
 
 func TestDetectPython(t *testing.T) {
@@ -77,7 +77,7 @@ func testTempdir(t *testing.T, dir *string) func() {
 
 func TestPyError(t *testing.T) {
 	_, err := Py(context.Background(), "__non_existing__.py")
-	assert.Contains(t, err.Error(), "can't open file")
+	assert.Contains(t, err.Error(), "exit status 2")
 }
 
 func TestPyInline(t *testing.T) {

--- a/python/runner_test.go
+++ b/python/runner_test.go
@@ -20,7 +20,7 @@ func TestExecAndPassError(t *testing.T) {
 	}
 
 	_, err := execAndPassErr(context.Background(), "which", "__non_existing__")
-	assert.EqualError(t, err, "exit status 1")
+	assert.EqualError(t, err, "which __non_existing__:  exit status 1")
 }
 
 func TestDetectPython(t *testing.T) {

--- a/python/runner_test.go
+++ b/python/runner_test.go
@@ -90,5 +90,5 @@ func TestPyInlineStderr(t *testing.T) {
 	DetectExecutable(context.Background())
 	inline := "import sys; sys.stderr.write('___msg___'); sys.exit(1)"
 	_, err := PyInline(context.Background(), inline)
-	assert.EqualError(t, err, "___msg___")
+	assert.ErrorContains(t, err, "___msg___")
 }


### PR DESCRIPTION
## Changes
This PR adds higher-level wrappers for calling subprocesses. One of the steps to get https://github.com/databricks/cli/pull/637 in, as previously discussed.

The reason to add `process.Forwarded()` is to proxy Python's `input()` calls from a child process seamlessly. Another use-case is plugging in `less` as a pager for the list results.

## Tests
`make test`

