### PR TITLE
Use short name for tag value in development mode

### DIFF
--- a/bundle/config/mutator/process_target_mode.go
+++ b/bundle/config/mutator/process_target_mode.go
@@ -39,7 +39,9 @@ func transformDevelopmentMode(b *bundle.Bundle) error {
 		if r.Jobs[i].Tags == nil {
 			r.Jobs[i].Tags = make(map[string]string)
 		}
-		r.Jobs[i].Tags["dev"] = b.Config.Workspace.CurrentUser.DisplayName
+		// Note: tag values in jobs must match the following pattern:
+		// ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+		r.Jobs[i].Tags["dev"] = b.Config.Workspace.CurrentUser.ShortName
 		if r.Jobs[i].MaxConcurrentRuns == 0 {
 			r.Jobs[i].MaxConcurrentRuns = developmentConcurrentRuns
 		}
@@ -74,7 +76,7 @@ func transformDevelopmentMode(b *bundle.Bundle) error {
 		} else {
 			r.Experiments[i].Name = dir + "/" + prefix + base
 		}
-		r.Experiments[i].Tags = append(r.Experiments[i].Tags, ml.ExperimentTag{Key: "dev", Value: b.Config.Workspace.CurrentUser.DisplayName})
+		r.Experiments[i].Tags = append(r.Experiments[i].Tags, ml.ExperimentTag{Key: "dev", Value: b.Config.Workspace.CurrentUser.ShortName})
 	}
 
 	for i := range r.ModelServingEndpoints {

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -68,14 +68,29 @@ func TestProcessTargetModeDevelopment(t *testing.T) {
 	m := ProcessTargetMode()
 	err := m.Apply(context.Background(), bundle)
 	require.NoError(t, err)
+
+	// Job 1
 	assert.Equal(t, "[dev lennart] job1", bundle.Config.Resources.Jobs["job1"].Name)
+	assert.Equal(t, bundle.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
+
+	// Pipeline 1
 	assert.Equal(t, "[dev lennart] pipeline1", bundle.Config.Resources.Pipelines["pipeline1"].Name)
+	assert.True(t, bundle.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
+
+	// Experiment 1
 	assert.Equal(t, "/Users/lennart.kats@databricks.com/[dev lennart] experiment1", bundle.Config.Resources.Experiments["experiment1"].Name)
+	assert.Contains(t, bundle.Config.Resources.Experiments["experiment1"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
+
+	// Experiment 2
 	assert.Equal(t, "[dev lennart] experiment2", bundle.Config.Resources.Experiments["experiment2"].Name)
+	assert.Contains(t, bundle.Config.Resources.Experiments["experiment2"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
+
+	// Model 1
 	assert.Equal(t, "[dev lennart] model1", bundle.Config.Resources.Models["model1"].Name)
+
+	// Model serving endpoint 1
 	assert.Equal(t, "dev_lennart_servingendpoint1", bundle.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
 	assert.Equal(t, "dev", bundle.Config.Resources.Experiments["experiment1"].Experiment.Tags[0].Key)
-	assert.True(t, bundle.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
 }
 
 func TestProcessTargetModeDefault(t *testing.T) {


### PR DESCRIPTION
## Changes

The jobs API expects tag values to match the regex `^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`. The display name can contain anything. With this change we modify the tag value to equal the short name as used in the name prefix.

This won't work in all cases because the short name can contain accents but is strictly better than the display name.

A better solution adds a separate property to the user struct with some kind of normalized display name, or normalized tag value name, that always strictly matches the regex above.

## Tests

Tests pass.

