### PR TITLE
Run tests to verify backend tag validation behavior

### DIFF
--- a/internal/bundle/tags_test.go
+++ b/internal/bundle/tags_test.go
@@ -79,6 +79,14 @@ func TestAccTagKeyAWS(t *testing.T) {
 		require.Contains(t, msg, `The key must match the regular expression ^[\d \w\+\-=\.:\/@]*$.`)
 	})
 
+	t.Run("unicode", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "🍎")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, ` contains non-latin1 characters.`)
+	})
+
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 		err := testTagKey(t, "")
@@ -110,6 +118,14 @@ func TestAccTagKeyAzure(t *testing.T) {
 		require.Contains(t, msg, `The key must match the regular expression ^[^<>\*&%;\\\/\+\?]*$.`)
 	})
 
+	t.Run("unicode", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "🍎")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, ` contains non-latin1 characters.`)
+	})
+
 	t.Run("empty", func(t *testing.T) {
 		t.Parallel()
 		err := testTagKey(t, "")
@@ -138,6 +154,14 @@ func TestAccTagKeyGCP(t *testing.T) {
 		require.Error(t, err)
 		msg := strings.ReplaceAll(err.Error(), "\n", " ")
 		require.Contains(t, msg, `The key must match the regular expression ^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$.`)
+	})
+
+	t.Run("unicode", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "🍎")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, ` contains non-latin1 characters.`)
 	})
 
 	t.Run("empty", func(t *testing.T) {

--- a/internal/bundle/tags_test.go
+++ b/internal/bundle/tags_test.go
@@ -1,0 +1,160 @@
+package bundle
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/internal"
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/stretchr/testify/require"
+)
+
+func testTags(t *testing.T, tags map[string]string) error {
+	var nodeTypeId string
+	switch testutil.GetCloud(t) {
+	case testutil.AWS:
+		nodeTypeId = "i3.xlarge"
+	case testutil.Azure:
+		nodeTypeId = "Standard_DS4_v2"
+	case testutil.GCP:
+		nodeTypeId = "n1-standard-4"
+	}
+
+	w, err := databricks.NewWorkspaceClient()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := w.Jobs.Create(ctx, jobs.CreateJob{
+		Name: internal.RandomName("test-tags-"),
+		Tasks: []jobs.Task{
+			{
+				TaskKey: "test",
+				NewCluster: &compute.ClusterSpec{
+					SparkVersion: "13.3.x-scala2.12",
+					NumWorkers:   1,
+					NodeTypeId:   nodeTypeId,
+				},
+				SparkPythonTask: &jobs.SparkPythonTask{
+					PythonFile: "/doesnt_exist.py",
+				},
+			},
+		},
+		Tags: tags,
+	})
+
+	if resp != nil {
+		t.Cleanup(func() {
+			w.Jobs.DeleteByJobId(ctx, resp.JobId)
+		})
+	}
+
+	return err
+}
+
+func testTagKey(t *testing.T, key string) error {
+	return testTags(t, map[string]string{
+		key: "value",
+	})
+}
+
+func testTagValue(t *testing.T, value string) error {
+	return testTags(t, map[string]string{
+		"key": value,
+	})
+}
+
+func TestAccTagKeyAWS(t *testing.T) {
+	testutil.Require(t, testutil.AWS)
+	t.Parallel()
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "café")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, `The key must match the regular expression ^[\d \w\+\-=\.:\/@]*$.`)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, ` the minimal length is 1, and the maximum length is 127.`)
+	})
+}
+
+func TestAccTagValueAWS(t *testing.T) {
+	testutil.Require(t, testutil.AWS)
+	t.Parallel()
+
+	err := testTagValue(t, "café")
+	require.Error(t, err)
+	msg := strings.ReplaceAll(err.Error(), "\n", " ")
+	require.Contains(t, msg, `The value must match the regular expression ^[\d \w\+\-=\.:/@]*$.`)
+}
+
+func TestAccTagKeyAzure(t *testing.T) {
+	testutil.Require(t, testutil.Azure)
+	t.Parallel()
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "café?")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, `The key must match the regular expression ^[^<>\*&%;\\\/\+\?]*$.`)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, ` the minimal length is 1, and the maximum length is 512.`)
+	})
+}
+
+func TestAccTagValueAzure(t *testing.T) {
+	testutil.Require(t, testutil.Azure)
+	t.Parallel()
+
+	// Azure puts no constraings on tag values.
+	err := testTagValue(t, "café?")
+	require.NoError(t, err)
+}
+
+func TestAccTagKeyGCP(t *testing.T) {
+	testutil.Require(t, testutil.GCP)
+	t.Parallel()
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "café?")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, `The key must match the regular expression ^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$.`)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		err := testTagKey(t, "")
+		require.Error(t, err)
+		msg := strings.ReplaceAll(err.Error(), "\n", " ")
+		require.Contains(t, msg, ` the minimal length is 1, and the maximum length is 63.`)
+	})
+}
+
+func TestAccTagValueGCP(t *testing.T) {
+	testutil.Require(t, testutil.GCP)
+	t.Parallel()
+
+	err := testTagValue(t, "café?")
+	require.Error(t, err)
+	msg := strings.ReplaceAll(err.Error(), "\n", " ")
+	require.Contains(t, msg, `The value must match the regular expression ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$.`)
+}

--- a/internal/tags_test.go
+++ b/internal/tags_test.go
@@ -1,11 +1,10 @@
-package bundle
+package internal
 
 import (
 	"context"
 	"strings"
 	"testing"
 
-	"github.com/databricks/cli/internal"
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
@@ -29,7 +28,7 @@ func testTags(t *testing.T, tags map[string]string) error {
 
 	ctx := context.Background()
 	resp, err := w.Jobs.Create(ctx, jobs.CreateJob{
-		Name: internal.RandomName("test-tags-"),
+		Name: RandomName("test-tags-"),
 		Tasks: []jobs.Task{
 			{
 				TaskKey: "test",

--- a/internal/testutil/cloud.go
+++ b/internal/testutil/cloud.go
@@ -1,0 +1,50 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/internal"
+)
+
+type Cloud int
+
+const (
+	AWS Cloud = iota
+	Azure
+	GCP
+)
+
+// Implement [Requirement].
+func (c Cloud) Verify(t *testing.T) {
+	if c != GetCloud(t) {
+		t.Skipf("Skipping %s-specific test", c)
+	}
+}
+
+func (c Cloud) String() string {
+	switch c {
+	case AWS:
+		return "AWS"
+	case Azure:
+		return "Azure"
+	case GCP:
+		return "GCP"
+	default:
+		return "unknown"
+	}
+}
+
+func GetCloud(t *testing.T) Cloud {
+	env := internal.GetEnvOrSkipTest(t, "CLOUD_ENV")
+	switch env {
+	case "aws":
+		return AWS
+	case "azure":
+		return Azure
+	case "gcp":
+		return GCP
+	default:
+		t.Fatalf("Unknown cloud environment: %s", env)
+	}
+	return -1
+}

--- a/internal/testutil/cloud.go
+++ b/internal/testutil/cloud.go
@@ -2,8 +2,6 @@ package testutil
 
 import (
 	"testing"
-
-	"github.com/databricks/cli/internal"
 )
 
 type Cloud int
@@ -35,7 +33,7 @@ func (c Cloud) String() string {
 }
 
 func GetCloud(t *testing.T) Cloud {
-	env := internal.GetEnvOrSkipTest(t, "CLOUD_ENV")
+	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
 	switch env {
 	case "aws":
 		return AWS

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -35,3 +35,12 @@ func CleanupEnvironment(t *testing.T) {
 		t.Setenv("USERPROFILE", pwd)
 	}
 }
+
+// GetEnvOrSkipTest proceeds with test only with that env variable
+func GetEnvOrSkipTest(t *testing.T, name string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		t.Skipf("Environment variable %s is missing", name)
+	}
+	return value
+}

--- a/internal/testutil/requirement.go
+++ b/internal/testutil/requirement.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"testing"
+)
+
+// Requirement is the interface for test requirements.
+type Requirement interface {
+	Verify(t *testing.T)
+}
+
+// Require should be called at the beginning of a test to ensure that all
+// requirements are met before running the test.
+// If any requirement is not met, the test will be skipped.
+func Require(t *testing.T, requirements ...Requirement) {
+	for _, r := range requirements {
+		r.Verify(t)
+	}
+}


### PR DESCRIPTION
## Changes

Validation rules on tags are different per cloud (they are passed through to the underlying clusters and as such must comply with cloud-specific validation rules). This change adds tests to confirm the current behavior to ensure the normalization we can apply is in line with how the backend behaves.

## Tests

The new integration tests pass (tested locally).

