### PR TITLE
Ensure profile flag is respected for sync command

### DIFF
--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -107,6 +107,13 @@ type noPrompt int
 
 var noPromptKey noPrompt
 
+// NoPrompt allows to skip prompt for profile configuration in MustWorkspaceClient.
+//
+// When calling MustWorkspaceClient we want to be able to customise if to show prompt or not.
+// Since we can't change function interface, in the code we only have an access to `cmd“ object.
+// Command struct does not have any state flag which indicates that it's being called in completion mode and
+// thus the Context object seems to be the only viable option for us to configure prompt behaviour based on
+// the context it's executed from.
 func NoPrompt(ctx context.Context) context.Context {
 	return context.WithValue(ctx, noPromptKey, true)
 }

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -158,8 +158,6 @@ func New() *cobra.Command {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		cmd.SetContext(ctx)
-
 		// No completion in the context of a bundle.
 		// Source and destination paths are taken from bundle configuration.
 		b := bundle.GetOrNil(cmd.Context())


### PR DESCRIPTION
## Changes
Fixes #836 

## Tests
Manually running `sync` command with and without the flag

Integration tests pass as well

```
--- PASS: TestAccSyncFullFileSync (13.38s)
PASS
coverage: 39.1% of statements in ./...
ok      github.com/databricks/cli/internal      14.148s coverage: 39.1% of statements in ./...


--- PASS: TestAccSyncIncrementalFileSync (11.38s)
PASS
coverage: 39.1% of statements in ./...
ok      github.com/databricks/cli/internal      11.674s coverage: 39.1% of statements in ./...
```

