### PR TITLE
Use profile information when getting a token using the CLI

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -60,19 +60,9 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 			profileName = profile
 		}
 
-		// If the chosen profile has a hostname and the user hasn't specified a host, infer the host from the profile.
-		_, profiles, err := databrickscfg.LoadProfiles(func(p databrickscfg.Profile) bool {
-			return p.Name == profileName
-		})
+		err := setHost(ctx, profileName, persistentAuth, args)
 		if err != nil {
 			return err
-		}
-		if persistentAuth.Host == "" {
-			if len(profiles) > 0 && profiles[0].Host != "" {
-				persistentAuth.Host = profiles[0].Host
-			} else {
-				configureHost(ctx, persistentAuth, args, 0)
-			}
 		}
 		defer persistentAuth.Close()
 
@@ -134,4 +124,22 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 	}
 
 	return cmd
+}
+
+func setHost(ctx context.Context, profileName string, persistentAuth *auth.PersistentAuth, args []string) error {
+	// If the chosen profile has a hostname and the user hasn't specified a host, infer the host from the profile.
+	_, profiles, err := databrickscfg.LoadProfiles(func(p databrickscfg.Profile) bool {
+		return p.Name == profileName
+	})
+	if err != nil {
+		return err
+	}
+	if persistentAuth.Host == "" {
+		if len(profiles) > 0 && profiles[0].Host != "" {
+			persistentAuth.Host = profiles[0].Host
+		} else {
+			configureHost(ctx, persistentAuth, args, 0)
+		}
+	}
+	return nil
 }

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/databricks/cli/libs/auth"
-	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/spf13/cobra"
 )
 
@@ -28,21 +27,11 @@ func newTokenCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 		if profileFlag != nil {
 			profileName = profileFlag.Value.String()
 		}
-		// If the chosen profile has a hostname and the user hasn't specified a host, infer the host from the profile.
-		_, profiles, err := databrickscfg.LoadProfiles(func(p databrickscfg.Profile) bool {
-			return p.Name == profileName
-		})
+
+		err := setHost(ctx, profileName, persistentAuth, args)
 		if err != nil {
 			return err
 		}
-		if persistentAuth.Host == "" {
-			if len(profiles) > 0 && profiles[0].Host != "" {
-				persistentAuth.Host = profiles[0].Host
-			} else {
-				configureHost(ctx, persistentAuth, args, 0)
-			}
-		}
-
 		defer persistentAuth.Close()
 
 		ctx, cancel := context.WithTimeout(ctx, tokenTimeout)

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/databricks/cli/libs/auth"
@@ -26,6 +27,10 @@ func newTokenCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 		profileFlag := cmd.Flag("profile")
 		if profileFlag != nil {
 			profileName = profileFlag.Value.String()
+			// If a profile is provided we read the host from the .databrickscfg file
+			if profileName != "" && len(args) > 0 {
+				return errors.New("providing both a profile and a host parameters is not supported")
+			}
 		}
 
 		err := setHost(ctx, profileName, persistentAuth, args)


### PR DESCRIPTION
## Changes
Use stored profile information when the user provides the profile flag when using the `databricks auth token` command.

## Tests
Run the command with and without the profile flag

```
./cli auth token
Databricks Host: https://e2-dogfood.staging.cloud.databricks.com/
{
  "access_token": "****",
  "token_type": "Bearer",
  "expiry": "2023-10-10T14:24:11.85617+02:00"
}%

./cli auth token --profile DEFAULT
{
  "access_token": "*****",
  "token_type": "Bearer",
  "expiry": "2023-10-10T14:24:11.85617+02:00"
}%

./cli auth token https://e2-dogfood.staging.cloud.databricks.com/
{
  "access_token": "*****",
  "token_type": "Bearer",
  "expiry": "2023-10-11T09:24:55.046029+02:00"
}%   

./cli auth token --profile DEFAULT https://e2-dogfood.staging.cloud.databricks.com/
Error: providing both a profile and a host parameters is not supported
```