### PR TITLE
Use already instantiated WorkspaceClient in sync command

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -13,7 +13,6 @@ import (
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/sync"
-	"github.com/databricks/databricks-sdk-go"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +69,7 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		// The sync code will automatically create this directory if it doesn't
 		// exist and add it to the `.gitignore` file in the root.
 		SnapshotBasePath: filepath.Join(args[0], ".databricks"),
-		WorkspaceClient:  databricks.Must(databricks.NewWorkspaceClient()),
+		WorkspaceClient:  root.WorkspaceClient(cmd.Context()),
 	}
 	return &opts, nil
 }

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -1,12 +1,14 @@
 package sync
 
 import (
+	"context"
 	"flag"
 	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/cmd/root"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,7 +51,9 @@ func TestSyncOptionsFromArgsRequiredTwoArgs(t *testing.T) {
 
 func TestSyncOptionsFromArgs(t *testing.T) {
 	f := syncFlags{}
-	opts, err := f.syncOptionsFromArgs(New(), []string{"/local", "/remote"})
+	cmd := New()
+	cmd.SetContext(root.SetWorkspaceClient(context.Background(), nil))
+	opts, err := f.syncOptionsFromArgs(cmd, []string{"/local", "/remote"})
 	require.NoError(t, err)
 	assert.Equal(t, "/local", opts.LocalPath)
 	assert.Equal(t, "/remote", opts.RemotePath)


### PR DESCRIPTION
## Changes
Since we use `root.MustWorkspaceClient` now, we should use already initialised version of WorkspaceClient instead of instantiating a new one.

Fixes #836 

