### PR TITLE
Add alias for mlops-stack template URL

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -18,7 +18,7 @@ var gitUrlPrefixes = []string{
 	"git@",
 }
 
-var aliasedTemplates = map[string]string {
+var aliasedTemplates = map[string]string{
 	"mlops-stack": "https://github.com/databricks/mlops-stack",
 }
 

--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -72,7 +72,7 @@ func newInitCommand() *cobra.Command {
 			}
 		}
 
-		// Expand templatePath if it's an alias for a first party template
+		// Expand templatePath if it's an alias for a known template
 		if _, ok := aliasedTemplates[templatePath]; ok {
 			templatePath = aliasedTemplates[templatePath]
 		}

--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -18,6 +18,10 @@ var gitUrlPrefixes = []string{
 	"git@",
 }
 
+var aliasedTemplates = map[string]string {
+	"mlops-stack": "https://github.com/databricks/mlops-stack",
+}
+
 func isRepoUrl(url string) bool {
 	result := false
 	for _, prefix := range gitUrlPrefixes {
@@ -66,6 +70,11 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+		}
+
+		// Expand templatePath if it's an alias for a first party template
+		if _, ok := aliasedTemplates[templatePath]; ok {
+			templatePath = aliasedTemplates[templatePath]
 		}
 
 		if !isRepoUrl(templatePath) {


### PR DESCRIPTION
## Changes
Allows users to initialize mlops-stack by running `bundle init mlops-stack`

## Tests
Manually

```
shreyas.goenka@THW32HFW6T playground % cli bundle init            
Template to use [default-python]: mlops-stack
Project Name [my-mlops-project]: ^C
shreyas.goenka@THW32HFW6T playground % cli bundle init mlops-stack
Project Name [my-mlops-project]: ^C
```
