### PR TITLE
Bump Terraform provider to v1.28.0

### DIFF
--- a/bundle/internal/tf/codegen/schema/version.go
+++ b/bundle/internal/tf/codegen/schema/version.go
@@ -1,3 +1,3 @@
 package schema
 
-const ProviderVersion = "1.23.0"
+const ProviderVersion = "1.28.0"

--- a/bundle/internal/tf/schema/data_source_cluster.go
+++ b/bundle/internal/tf/schema/data_source_cluster.go
@@ -121,6 +121,10 @@ type DataSourceClusterClusterInfoInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type DataSourceClusterClusterInfoInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type DataSourceClusterClusterInfoInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -131,6 +135,7 @@ type DataSourceClusterClusterInfoInitScripts struct {
 	File      *DataSourceClusterClusterInfoInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *DataSourceClusterClusterInfoInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *DataSourceClusterClusterInfoInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *DataSourceClusterClusterInfoInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *DataSourceClusterClusterInfoInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 

--- a/bundle/internal/tf/schema/data_source_current_user.go
+++ b/bundle/internal/tf/schema/data_source_current_user.go
@@ -3,11 +3,12 @@
 package schema
 
 type DataSourceCurrentUser struct {
-	Alphanumeric string `json:"alphanumeric,omitempty"`
-	ExternalId   string `json:"external_id,omitempty"`
-	Home         string `json:"home,omitempty"`
-	Id           string `json:"id,omitempty"`
-	Repos        string `json:"repos,omitempty"`
-	UserName     string `json:"user_name,omitempty"`
-	WorkspaceUrl string `json:"workspace_url,omitempty"`
+	AclPrincipalId string `json:"acl_principal_id,omitempty"`
+	Alphanumeric   string `json:"alphanumeric,omitempty"`
+	ExternalId     string `json:"external_id,omitempty"`
+	Home           string `json:"home,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Repos          string `json:"repos,omitempty"`
+	UserName       string `json:"user_name,omitempty"`
+	WorkspaceUrl   string `json:"workspace_url,omitempty"`
 }

--- a/bundle/internal/tf/schema/data_source_group.go
+++ b/bundle/internal/tf/schema/data_source_group.go
@@ -3,6 +3,7 @@
 package schema
 
 type DataSourceGroup struct {
+	AclPrincipalId          string   `json:"acl_principal_id,omitempty"`
 	AllowClusterCreate      bool     `json:"allow_cluster_create,omitempty"`
 	AllowInstancePoolCreate bool     `json:"allow_instance_pool_create,omitempty"`
 	ChildGroups             []string `json:"child_groups,omitempty"`

--- a/bundle/internal/tf/schema/data_source_job.go
+++ b/bundle/internal/tf/schema/data_source_job.go
@@ -155,6 +155,10 @@ type DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -165,6 +169,7 @@ type DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScripts struct {
 	File      *DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *DataSourceJobJobSettingsSettingsJobClusterNewClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 
@@ -337,6 +342,10 @@ type DataSourceJobJobSettingsSettingsNewClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type DataSourceJobJobSettingsSettingsNewClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type DataSourceJobJobSettingsSettingsNewClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -347,6 +356,7 @@ type DataSourceJobJobSettingsSettingsNewClusterInitScripts struct {
 	File      *DataSourceJobJobSettingsSettingsNewClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *DataSourceJobJobSettingsSettingsNewClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *DataSourceJobJobSettingsSettingsNewClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *DataSourceJobJobSettingsSettingsNewClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *DataSourceJobJobSettingsSettingsNewClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 
@@ -421,6 +431,7 @@ type DataSourceJobJobSettingsSettingsPythonWheelTask struct {
 }
 
 type DataSourceJobJobSettingsSettingsQueue struct {
+	Enabled bool `json:"enabled"`
 }
 
 type DataSourceJobJobSettingsSettingsRunAs struct {
@@ -429,7 +440,7 @@ type DataSourceJobJobSettingsSettingsRunAs struct {
 }
 
 type DataSourceJobJobSettingsSettingsRunJobTask struct {
-	JobId         string            `json:"job_id"`
+	JobId         int               `json:"job_id"`
 	JobParameters map[string]string `json:"job_parameters,omitempty"`
 }
 
@@ -616,6 +627,10 @@ type DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -626,6 +641,7 @@ type DataSourceJobJobSettingsSettingsTaskNewClusterInitScripts struct {
 	File      *DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *DataSourceJobJobSettingsSettingsTaskNewClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 
@@ -696,7 +712,7 @@ type DataSourceJobJobSettingsSettingsTaskPythonWheelTask struct {
 }
 
 type DataSourceJobJobSettingsSettingsTaskRunJobTask struct {
-	JobId         string            `json:"job_id"`
+	JobId         int               `json:"job_id"`
 	JobParameters map[string]string `json:"job_parameters,omitempty"`
 }
 

--- a/bundle/internal/tf/schema/data_source_service_principal.go
+++ b/bundle/internal/tf/schema/data_source_service_principal.go
@@ -3,12 +3,13 @@
 package schema
 
 type DataSourceServicePrincipal struct {
-	Active        bool   `json:"active,omitempty"`
-	ApplicationId string `json:"application_id,omitempty"`
-	DisplayName   string `json:"display_name,omitempty"`
-	ExternalId    string `json:"external_id,omitempty"`
-	Home          string `json:"home,omitempty"`
-	Id            string `json:"id,omitempty"`
-	Repos         string `json:"repos,omitempty"`
-	SpId          string `json:"sp_id,omitempty"`
+	AclPrincipalId string `json:"acl_principal_id,omitempty"`
+	Active         bool   `json:"active,omitempty"`
+	ApplicationId  string `json:"application_id,omitempty"`
+	DisplayName    string `json:"display_name,omitempty"`
+	ExternalId     string `json:"external_id,omitempty"`
+	Home           string `json:"home,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Repos          string `json:"repos,omitempty"`
+	SpId           string `json:"sp_id,omitempty"`
 }

--- a/bundle/internal/tf/schema/data_source_user.go
+++ b/bundle/internal/tf/schema/data_source_user.go
@@ -3,13 +3,14 @@
 package schema
 
 type DataSourceUser struct {
-	Alphanumeric  string `json:"alphanumeric,omitempty"`
-	ApplicationId string `json:"application_id,omitempty"`
-	DisplayName   string `json:"display_name,omitempty"`
-	ExternalId    string `json:"external_id,omitempty"`
-	Home          string `json:"home,omitempty"`
-	Id            string `json:"id,omitempty"`
-	Repos         string `json:"repos,omitempty"`
-	UserId        string `json:"user_id,omitempty"`
-	UserName      string `json:"user_name,omitempty"`
+	AclPrincipalId string `json:"acl_principal_id,omitempty"`
+	Alphanumeric   string `json:"alphanumeric,omitempty"`
+	ApplicationId  string `json:"application_id,omitempty"`
+	DisplayName    string `json:"display_name,omitempty"`
+	ExternalId     string `json:"external_id,omitempty"`
+	Home           string `json:"home,omitempty"`
+	Id             string `json:"id,omitempty"`
+	Repos          string `json:"repos,omitempty"`
+	UserId         string `json:"user_id,omitempty"`
+	UserName       string `json:"user_name,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_catalog.go
+++ b/bundle/internal/tf/schema/resource_catalog.go
@@ -3,15 +3,17 @@
 package schema
 
 type ResourceCatalog struct {
-	Comment       string            `json:"comment,omitempty"`
-	ForceDestroy  bool              `json:"force_destroy,omitempty"`
-	Id            string            `json:"id,omitempty"`
-	IsolationMode string            `json:"isolation_mode,omitempty"`
-	MetastoreId   string            `json:"metastore_id,omitempty"`
-	Name          string            `json:"name"`
-	Owner         string            `json:"owner,omitempty"`
-	Properties    map[string]string `json:"properties,omitempty"`
-	ProviderName  string            `json:"provider_name,omitempty"`
-	ShareName     string            `json:"share_name,omitempty"`
-	StorageRoot   string            `json:"storage_root,omitempty"`
+	Comment        string            `json:"comment,omitempty"`
+	ConnectionName string            `json:"connection_name,omitempty"`
+	ForceDestroy   bool              `json:"force_destroy,omitempty"`
+	Id             string            `json:"id,omitempty"`
+	IsolationMode  string            `json:"isolation_mode,omitempty"`
+	MetastoreId    string            `json:"metastore_id,omitempty"`
+	Name           string            `json:"name"`
+	Options        map[string]string `json:"options,omitempty"`
+	Owner          string            `json:"owner,omitempty"`
+	Properties     map[string]string `json:"properties,omitempty"`
+	ProviderName   string            `json:"provider_name,omitempty"`
+	ShareName      string            `json:"share_name,omitempty"`
+	StorageRoot    string            `json:"storage_root,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_cluster.go
+++ b/bundle/internal/tf/schema/resource_cluster.go
@@ -99,6 +99,10 @@ type ResourceClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type ResourceClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type ResourceClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -109,6 +113,7 @@ type ResourceClusterInitScripts struct {
 	File      *ResourceClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *ResourceClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *ResourceClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *ResourceClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *ResourceClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 

--- a/bundle/internal/tf/schema/resource_external_location.go
+++ b/bundle/internal/tf/schema/resource_external_location.go
@@ -2,15 +2,27 @@
 
 package schema
 
+type ResourceExternalLocationEncryptionDetailsSseEncryptionDetails struct {
+	Algorithm    string `json:"algorithm,omitempty"`
+	AwsKmsKeyArn string `json:"aws_kms_key_arn,omitempty"`
+}
+
+type ResourceExternalLocationEncryptionDetails struct {
+	SseEncryptionDetails *ResourceExternalLocationEncryptionDetailsSseEncryptionDetails `json:"sse_encryption_details,omitempty"`
+}
+
 type ResourceExternalLocation struct {
-	Comment        string `json:"comment,omitempty"`
-	CredentialName string `json:"credential_name"`
-	ForceDestroy   bool   `json:"force_destroy,omitempty"`
-	Id             string `json:"id,omitempty"`
-	MetastoreId    string `json:"metastore_id,omitempty"`
-	Name           string `json:"name"`
-	Owner          string `json:"owner,omitempty"`
-	ReadOnly       bool   `json:"read_only,omitempty"`
-	SkipValidation bool   `json:"skip_validation,omitempty"`
-	Url            string `json:"url"`
+	AccessPoint       string                                     `json:"access_point,omitempty"`
+	Comment           string                                     `json:"comment,omitempty"`
+	CredentialName    string                                     `json:"credential_name"`
+	ForceDestroy      bool                                       `json:"force_destroy,omitempty"`
+	ForceUpdate       bool                                       `json:"force_update,omitempty"`
+	Id                string                                     `json:"id,omitempty"`
+	MetastoreId       string                                     `json:"metastore_id,omitempty"`
+	Name              string                                     `json:"name"`
+	Owner             string                                     `json:"owner,omitempty"`
+	ReadOnly          bool                                       `json:"read_only,omitempty"`
+	SkipValidation    bool                                       `json:"skip_validation,omitempty"`
+	Url               string                                     `json:"url"`
+	EncryptionDetails *ResourceExternalLocationEncryptionDetails `json:"encryption_details,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_grants.go
+++ b/bundle/internal/tf/schema/resource_grants.go
@@ -10,10 +10,12 @@ type ResourceGrantsGrant struct {
 type ResourceGrants struct {
 	Catalog           string                `json:"catalog,omitempty"`
 	ExternalLocation  string                `json:"external_location,omitempty"`
+	ForeignConnection string                `json:"foreign_connection,omitempty"`
 	Function          string                `json:"function,omitempty"`
 	Id                string                `json:"id,omitempty"`
 	MaterializedView  string                `json:"materialized_view,omitempty"`
 	Metastore         string                `json:"metastore,omitempty"`
+	Model             string                `json:"model,omitempty"`
 	Schema            string                `json:"schema,omitempty"`
 	Share             string                `json:"share,omitempty"`
 	StorageCredential string                `json:"storage_credential,omitempty"`

--- a/bundle/internal/tf/schema/resource_job.go
+++ b/bundle/internal/tf/schema/resource_job.go
@@ -155,6 +155,10 @@ type ResourceJobJobClusterNewClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type ResourceJobJobClusterNewClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type ResourceJobJobClusterNewClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -165,6 +169,7 @@ type ResourceJobJobClusterNewClusterInitScripts struct {
 	File      *ResourceJobJobClusterNewClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *ResourceJobJobClusterNewClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *ResourceJobJobClusterNewClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *ResourceJobJobClusterNewClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *ResourceJobJobClusterNewClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 
@@ -337,6 +342,10 @@ type ResourceJobNewClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type ResourceJobNewClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type ResourceJobNewClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -347,6 +356,7 @@ type ResourceJobNewClusterInitScripts struct {
 	File      *ResourceJobNewClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *ResourceJobNewClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *ResourceJobNewClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *ResourceJobNewClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *ResourceJobNewClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 
@@ -421,6 +431,7 @@ type ResourceJobPythonWheelTask struct {
 }
 
 type ResourceJobQueue struct {
+	Enabled bool `json:"enabled"`
 }
 
 type ResourceJobRunAs struct {
@@ -429,7 +440,7 @@ type ResourceJobRunAs struct {
 }
 
 type ResourceJobRunJobTask struct {
-	JobId         string            `json:"job_id"`
+	JobId         int               `json:"job_id"`
 	JobParameters map[string]string `json:"job_parameters,omitempty"`
 }
 
@@ -616,6 +627,10 @@ type ResourceJobTaskNewClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type ResourceJobTaskNewClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type ResourceJobTaskNewClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -626,6 +641,7 @@ type ResourceJobTaskNewClusterInitScripts struct {
 	File      *ResourceJobTaskNewClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *ResourceJobTaskNewClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *ResourceJobTaskNewClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *ResourceJobTaskNewClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *ResourceJobTaskNewClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 
@@ -696,7 +712,7 @@ type ResourceJobTaskPythonWheelTask struct {
 }
 
 type ResourceJobTaskRunJobTask struct {
-	JobId         string            `json:"job_id"`
+	JobId         int               `json:"job_id"`
 	JobParameters map[string]string `json:"job_parameters,omitempty"`
 }
 

--- a/bundle/internal/tf/schema/resource_metastore.go
+++ b/bundle/internal/tf/schema/resource_metastore.go
@@ -13,10 +13,12 @@ type ResourceMetastore struct {
 	ForceDestroy                                bool   `json:"force_destroy,omitempty"`
 	GlobalMetastoreId                           string `json:"global_metastore_id,omitempty"`
 	Id                                          string `json:"id,omitempty"`
+	MetastoreId                                 string `json:"metastore_id,omitempty"`
 	Name                                        string `json:"name"`
 	Owner                                       string `json:"owner,omitempty"`
 	Region                                      string `json:"region,omitempty"`
 	StorageRoot                                 string `json:"storage_root"`
+	StorageRootCredentialId                     string `json:"storage_root_credential_id,omitempty"`
 	UpdatedAt                                   int    `json:"updated_at,omitempty"`
 	UpdatedBy                                   string `json:"updated_by,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_metastore_data_access.go
+++ b/bundle/internal/tf/schema/resource_metastore_data_access.go
@@ -8,6 +8,8 @@ type ResourceMetastoreDataAccessAwsIamRole struct {
 
 type ResourceMetastoreDataAccessAzureManagedIdentity struct {
 	AccessConnectorId string `json:"access_connector_id"`
+	CredentialId      string `json:"credential_id,omitempty"`
+	ManagedIdentityId string `json:"managed_identity_id,omitempty"`
 }
 
 type ResourceMetastoreDataAccessAzureServicePrincipal struct {
@@ -17,7 +19,8 @@ type ResourceMetastoreDataAccessAzureServicePrincipal struct {
 }
 
 type ResourceMetastoreDataAccessDatabricksGcpServiceAccount struct {
-	Email string `json:"email,omitempty"`
+	CredentialId string `json:"credential_id,omitempty"`
+	Email        string `json:"email,omitempty"`
 }
 
 type ResourceMetastoreDataAccessGcpServiceAccountKey struct {
@@ -27,11 +30,14 @@ type ResourceMetastoreDataAccessGcpServiceAccountKey struct {
 }
 
 type ResourceMetastoreDataAccess struct {
-	ConfigurationType           string                                                  `json:"configuration_type,omitempty"`
+	Comment                     string                                                  `json:"comment,omitempty"`
+	ForceDestroy                bool                                                    `json:"force_destroy,omitempty"`
 	Id                          string                                                  `json:"id,omitempty"`
 	IsDefault                   bool                                                    `json:"is_default,omitempty"`
 	MetastoreId                 string                                                  `json:"metastore_id"`
 	Name                        string                                                  `json:"name"`
+	Owner                       string                                                  `json:"owner,omitempty"`
+	ReadOnly                    bool                                                    `json:"read_only,omitempty"`
 	AwsIamRole                  *ResourceMetastoreDataAccessAwsIamRole                  `json:"aws_iam_role,omitempty"`
 	AzureManagedIdentity        *ResourceMetastoreDataAccessAzureManagedIdentity        `json:"azure_managed_identity,omitempty"`
 	AzureServicePrincipal       *ResourceMetastoreDataAccessAzureServicePrincipal       `json:"azure_service_principal,omitempty"`

--- a/bundle/internal/tf/schema/resource_mlflow_model.go
+++ b/bundle/internal/tf/schema/resource_mlflow_model.go
@@ -3,8 +3,8 @@
 package schema
 
 type ResourceMlflowModelTags struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 type ResourceMlflowModel struct {

--- a/bundle/internal/tf/schema/resource_model_serving.go
+++ b/bundle/internal/tf/schema/resource_model_serving.go
@@ -10,6 +10,7 @@ type ResourceModelServingConfigServedModels struct {
 	Name               string            `json:"name,omitempty"`
 	ScaleToZeroEnabled bool              `json:"scale_to_zero_enabled,omitempty"`
 	WorkloadSize       string            `json:"workload_size"`
+	WorkloadType       string            `json:"workload_type,omitempty"`
 }
 
 type ResourceModelServingConfigTrafficConfigRoutes struct {
@@ -26,9 +27,15 @@ type ResourceModelServingConfig struct {
 	TrafficConfig *ResourceModelServingConfigTrafficConfig `json:"traffic_config,omitempty"`
 }
 
+type ResourceModelServingTags struct {
+	Key   string `json:"key"`
+	Value string `json:"value,omitempty"`
+}
+
 type ResourceModelServing struct {
 	Id                string                      `json:"id,omitempty"`
 	Name              string                      `json:"name"`
 	ServingEndpointId string                      `json:"serving_endpoint_id,omitempty"`
 	Config            *ResourceModelServingConfig `json:"config,omitempty"`
+	Tags              []ResourceModelServingTags  `json:"tags,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_pipeline.go
+++ b/bundle/internal/tf/schema/resource_pipeline.go
@@ -77,6 +77,10 @@ type ResourcePipelineClusterInitScriptsS3 struct {
 	Region           string `json:"region,omitempty"`
 }
 
+type ResourcePipelineClusterInitScriptsVolumes struct {
+	Destination string `json:"destination,omitempty"`
+}
+
 type ResourcePipelineClusterInitScriptsWorkspace struct {
 	Destination string `json:"destination,omitempty"`
 }
@@ -87,6 +91,7 @@ type ResourcePipelineClusterInitScripts struct {
 	File      *ResourcePipelineClusterInitScriptsFile      `json:"file,omitempty"`
 	Gcs       *ResourcePipelineClusterInitScriptsGcs       `json:"gcs,omitempty"`
 	S3        *ResourcePipelineClusterInitScriptsS3        `json:"s3,omitempty"`
+	Volumes   *ResourcePipelineClusterInitScriptsVolumes   `json:"volumes,omitempty"`
 	Workspace *ResourcePipelineClusterInitScriptsWorkspace `json:"workspace,omitempty"`
 }
 

--- a/bundle/internal/tf/schema/resource_registered_model.go
+++ b/bundle/internal/tf/schema/resource_registered_model.go
@@ -1,0 +1,12 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type ResourceRegisteredModel struct {
+	CatalogName     string `json:"catalog_name"`
+	Comment         string `json:"comment,omitempty"`
+	Id              string `json:"id,omitempty"`
+	Name            string `json:"name"`
+	SchemaName      string `json:"schema_name"`
+	StorageLocation string `json:"storage_location,omitempty"`
+}

--- a/bundle/internal/tf/schema/resource_share.go
+++ b/bundle/internal/tf/schema/resource_share.go
@@ -32,5 +32,6 @@ type ResourceShare struct {
 	CreatedBy string                `json:"created_by,omitempty"`
 	Id        string                `json:"id,omitempty"`
 	Name      string                `json:"name"`
+	Owner     string                `json:"owner,omitempty"`
 	Object    []ResourceShareObject `json:"object,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_sql_alert.go
+++ b/bundle/internal/tf/schema/resource_sql_alert.go
@@ -3,19 +3,22 @@
 package schema
 
 type ResourceSqlAlertOptions struct {
-	Column        string `json:"column"`
-	CustomBody    string `json:"custom_body,omitempty"`
-	CustomSubject string `json:"custom_subject,omitempty"`
-	Muted         bool   `json:"muted,omitempty"`
-	Op            string `json:"op"`
-	Value         string `json:"value"`
+	Column           string `json:"column"`
+	CustomBody       string `json:"custom_body,omitempty"`
+	CustomSubject    string `json:"custom_subject,omitempty"`
+	EmptyResultState string `json:"empty_result_state,omitempty"`
+	Muted            bool   `json:"muted,omitempty"`
+	Op               string `json:"op"`
+	Value            string `json:"value"`
 }
 
 type ResourceSqlAlert struct {
-	Id      string                   `json:"id,omitempty"`
-	Name    string                   `json:"name"`
-	Parent  string                   `json:"parent,omitempty"`
-	QueryId string                   `json:"query_id"`
-	Rearm   int                      `json:"rearm,omitempty"`
-	Options *ResourceSqlAlertOptions `json:"options,omitempty"`
+	CreatedAt string                   `json:"created_at,omitempty"`
+	Id        string                   `json:"id,omitempty"`
+	Name      string                   `json:"name"`
+	Parent    string                   `json:"parent,omitempty"`
+	QueryId   string                   `json:"query_id"`
+	Rearm     int                      `json:"rearm,omitempty"`
+	UpdatedAt string                   `json:"updated_at,omitempty"`
+	Options   *ResourceSqlAlertOptions `json:"options,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_sql_dashboard.go
+++ b/bundle/internal/tf/schema/resource_sql_dashboard.go
@@ -3,8 +3,11 @@
 package schema
 
 type ResourceSqlDashboard struct {
-	Id     string   `json:"id,omitempty"`
-	Name   string   `json:"name"`
-	Parent string   `json:"parent,omitempty"`
-	Tags   []string `json:"tags,omitempty"`
+	CreatedAt               string   `json:"created_at,omitempty"`
+	DashboardFiltersEnabled bool     `json:"dashboard_filters_enabled,omitempty"`
+	Id                      string   `json:"id,omitempty"`
+	Name                    string   `json:"name"`
+	Parent                  string   `json:"parent,omitempty"`
+	Tags                    []string `json:"tags,omitempty"`
+	UpdatedAt               string   `json:"updated_at,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_sql_query.go
+++ b/bundle/internal/tf/schema/resource_sql_query.go
@@ -118,6 +118,7 @@ type ResourceSqlQuerySchedule struct {
 }
 
 type ResourceSqlQuery struct {
+	CreatedAt    string                      `json:"created_at,omitempty"`
 	DataSourceId string                      `json:"data_source_id"`
 	Description  string                      `json:"description,omitempty"`
 	Id           string                      `json:"id,omitempty"`
@@ -126,6 +127,7 @@ type ResourceSqlQuery struct {
 	Query        string                      `json:"query"`
 	RunAsRole    string                      `json:"run_as_role,omitempty"`
 	Tags         []string                    `json:"tags,omitempty"`
+	UpdatedAt    string                      `json:"updated_at,omitempty"`
 	Parameter    []ResourceSqlQueryParameter `json:"parameter,omitempty"`
 	Schedule     *ResourceSqlQuerySchedule   `json:"schedule,omitempty"`
 }

--- a/bundle/internal/tf/schema/resource_sql_table.go
+++ b/bundle/internal/tf/schema/resource_sql_table.go
@@ -6,7 +6,7 @@ type ResourceSqlTableColumn struct {
 	Comment  string `json:"comment,omitempty"`
 	Name     string `json:"name"`
 	Nullable bool   `json:"nullable,omitempty"`
-	Type     string `json:"type"`
+	Type     string `json:"type,omitempty"`
 }
 
 type ResourceSqlTable struct {

--- a/bundle/internal/tf/schema/resource_storage_credential.go
+++ b/bundle/internal/tf/schema/resource_storage_credential.go
@@ -8,6 +8,8 @@ type ResourceStorageCredentialAwsIamRole struct {
 
 type ResourceStorageCredentialAzureManagedIdentity struct {
 	AccessConnectorId string `json:"access_connector_id"`
+	CredentialId      string `json:"credential_id,omitempty"`
+	ManagedIdentityId string `json:"managed_identity_id,omitempty"`
 }
 
 type ResourceStorageCredentialAzureServicePrincipal struct {
@@ -17,7 +19,8 @@ type ResourceStorageCredentialAzureServicePrincipal struct {
 }
 
 type ResourceStorageCredentialDatabricksGcpServiceAccount struct {
-	Email string `json:"email,omitempty"`
+	CredentialId string `json:"credential_id,omitempty"`
+	Email        string `json:"email,omitempty"`
 }
 
 type ResourceStorageCredentialGcpServiceAccountKey struct {
@@ -28,6 +31,7 @@ type ResourceStorageCredentialGcpServiceAccountKey struct {
 
 type ResourceStorageCredential struct {
 	Comment                     string                                                `json:"comment,omitempty"`
+	ForceDestroy                bool                                                  `json:"force_destroy,omitempty"`
 	Id                          string                                                `json:"id,omitempty"`
 	MetastoreId                 string                                                `json:"metastore_id,omitempty"`
 	Name                        string                                                `json:"name"`

--- a/bundle/internal/tf/schema/resource_system_schema.go
+++ b/bundle/internal/tf/schema/resource_system_schema.go
@@ -1,0 +1,10 @@
+// Generated from Databricks Terraform provider schema. DO NOT EDIT.
+
+package schema
+
+type ResourceSystemSchema struct {
+	Id          string `json:"id,omitempty"`
+	MetastoreId string `json:"metastore_id,omitempty"`
+	Schema      string `json:"schema,omitempty"`
+	State       string `json:"state,omitempty"`
+}

--- a/bundle/internal/tf/schema/resources.go
+++ b/bundle/internal/tf/schema/resources.go
@@ -12,6 +12,7 @@ type Resources struct {
 	CatalogWorkspaceBinding  map[string]*ResourceCatalogWorkspaceBinding  `json:"databricks_catalog_workspace_binding,omitempty"`
 	Cluster                  map[string]*ResourceCluster                  `json:"databricks_cluster,omitempty"`
 	ClusterPolicy            map[string]*ResourceClusterPolicy            `json:"databricks_cluster_policy,omitempty"`
+	Connection               map[string]*ResourceConnection               `json:"databricks_connection,omitempty"`
 	DbfsFile                 map[string]*ResourceDbfsFile                 `json:"databricks_dbfs_file,omitempty"`
 	Directory                map[string]*ResourceDirectory                `json:"databricks_directory,omitempty"`
 	Entitlements             map[string]*ResourceEntitlements             `json:"databricks_entitlements,omitempty"`
@@ -52,6 +53,7 @@ type Resources struct {
 	Pipeline                 map[string]*ResourcePipeline                 `json:"databricks_pipeline,omitempty"`
 	Provider                 map[string]*ResourceProvider                 `json:"databricks_provider,omitempty"`
 	Recipient                map[string]*ResourceRecipient                `json:"databricks_recipient,omitempty"`
+	RegisteredModel          map[string]*ResourceRegisteredModel          `json:"databricks_registered_model,omitempty"`
 	Repo                     map[string]*ResourceRepo                     `json:"databricks_repo,omitempty"`
 	Schema                   map[string]*ResourceSchema                   `json:"databricks_schema,omitempty"`
 	Secret                   map[string]*ResourceSecret                   `json:"databricks_secret,omitempty"`
@@ -71,6 +73,7 @@ type Resources struct {
 	SqlVisualization         map[string]*ResourceSqlVisualization         `json:"databricks_sql_visualization,omitempty"`
 	SqlWidget                map[string]*ResourceSqlWidget                `json:"databricks_sql_widget,omitempty"`
 	StorageCredential        map[string]*ResourceStorageCredential        `json:"databricks_storage_credential,omitempty"`
+	SystemSchema             map[string]*ResourceSystemSchema             `json:"databricks_system_schema,omitempty"`
 	Table                    map[string]*ResourceTable                    `json:"databricks_table,omitempty"`
 	Token                    map[string]*ResourceToken                    `json:"databricks_token,omitempty"`
 	User                     map[string]*ResourceUser                     `json:"databricks_user,omitempty"`
@@ -92,6 +95,7 @@ func NewResources() *Resources {
 		CatalogWorkspaceBinding:  make(map[string]*ResourceCatalogWorkspaceBinding),
 		Cluster:                  make(map[string]*ResourceCluster),
 		ClusterPolicy:            make(map[string]*ResourceClusterPolicy),
+		Connection:               make(map[string]*ResourceConnection),
 		DbfsFile:                 make(map[string]*ResourceDbfsFile),
 		Directory:                make(map[string]*ResourceDirectory),
 		Entitlements:             make(map[string]*ResourceEntitlements),
@@ -132,6 +136,7 @@ func NewResources() *Resources {
 		Pipeline:                 make(map[string]*ResourcePipeline),
 		Provider:                 make(map[string]*ResourceProvider),
 		Recipient:                make(map[string]*ResourceRecipient),
+		RegisteredModel:          make(map[string]*ResourceRegisteredModel),
 		Repo:                     make(map[string]*ResourceRepo),
 		Schema:                   make(map[string]*ResourceSchema),
 		Secret:                   make(map[string]*ResourceSecret),
@@ -151,6 +156,7 @@ func NewResources() *Resources {
 		SqlVisualization:         make(map[string]*ResourceSqlVisualization),
 		SqlWidget:                make(map[string]*ResourceSqlWidget),
 		StorageCredential:        make(map[string]*ResourceStorageCredential),
+		SystemSchema:             make(map[string]*ResourceSystemSchema),
 		Table:                    make(map[string]*ResourceTable),
 		Token:                    make(map[string]*ResourceToken),
 		User:                     make(map[string]*ResourceUser),


### PR DESCRIPTION
## Changes

Regenerate structs for Terraform provider v1.28.0 ([release](https://github.com/databricks/terraform-provider-databricks/releases/tag/v1.28.0)).

## Tests

n/a

