### PR TITLE
Rename MLOps Stack to MLOps Stacks

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -19,7 +19,8 @@ var gitUrlPrefixes = []string{
 }
 
 var aliasedTemplates = map[string]string{
-	"mlops-stack": "https://github.com/databricks/mlops-stack",
+	"mlops-stack":  "https://github.com/databricks/mlops-stacks",
+	"mlops-stacks": "https://github.com/databricks/mlops-stacks",
 }
 
 func isRepoUrl(url string) bool {


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Rename `mlops-stack` `bundle init` redirect to `mlops-stacks`.

## Tests
<!-- How is this tested? -->
N/A
