### PR TITLE
Escape workspace path string in regexp in artifacts integration test

### DIFF
--- a/internal/bundle/artifacts_test.go
+++ b/internal/bundle/artifacts_test.go
@@ -64,6 +64,6 @@ func TestAccUploadArtifactFileToCorrectRemotePath(t *testing.T) {
 
 	err := bundle.Apply(context.Background(), b, artifacts.BasicUpload("test"))
 	require.NoError(t, err)
-	require.Regexp(t, regexp.MustCompile(path.Join(wsDir, ".internal/[a-z0-9]+/test.whl")), artifact.Files[0].RemotePath)
-	require.Regexp(t, regexp.MustCompile(path.Join("/Workspace", wsDir, ".internal/[a-z0-9]+/test.whl")), artifact.Files[0].Libraries[0].Whl)
+	require.Regexp(t, regexp.MustCompile(path.Join(regexp.QuoteMeta(wsDir), `.internal/[a-z0-9]+/test\.whl`)), artifact.Files[0].RemotePath)
+	require.Regexp(t, regexp.MustCompile(path.Join("/Workspace", regexp.QuoteMeta(wsDir), `.internal/[a-z0-9]+/test\.whl`)), artifact.Files[0].Libraries[0].Whl)
 }


### PR DESCRIPTION
## Changes
Escape workspace path string in regexp in artifacts integration test

## Tests
```
Environment: aws-prod
=== RUN   TestAccUploadArtifactFileToCorrectRemotePath
    artifacts_test.go:29: aws
    helpers.go:356: Creating /Users/serge.smertin+deco@databricks.com/integration-test-wsfs-leakafecllkc
artifacts.Upload(test.whl): Uploading...
artifacts.Upload(test.whl): Upload succeeded
    helpers.go:362: Removing /Users/serge.smertin+deco@databricks.com/integration-test-wsfs-leakafecllkc
--- PASS: TestAccUploadArtifactFileToCorrectRemotePath (2.12s)
PASS
coverage: 0.0% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       2.788s  coverage: 0.0% of statements in ./...
```

