### PR TITLE
Release v0.208.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Version changelog
 
+## 0.208.1
+
+CLI:
+ * Fix rendering of streaming response ([#876](https://github.com/databricks/cli/pull/876)).
+ * Rename MLOps Stack to MLOps Stacks ([#881](https://github.com/databricks/cli/pull/881)).
+ * Support Python wheels larger than 10MB ([#879](https://github.com/databricks/cli/pull/879)).
+ * Improve the output of the `databricks bundle init` command ([#795](https://github.com/databricks/cli/pull/795)).
+
+Bundles:
+ * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
+
+Internal:
+ * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
+
+
+
 ## 0.208.0
 
 Note: this release includes a fix for the issue where zero values (for example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,11 @@
 
 CLI:
  * Fix rendering of streaming response ([#876](https://github.com/databricks/cli/pull/876)).
+
+Bundles:
  * Rename MLOps Stack to MLOps Stacks ([#881](https://github.com/databricks/cli/pull/881)).
  * Support Python wheels larger than 10MB ([#879](https://github.com/databricks/cli/pull/879)).
  * Improve the output of the `databricks bundle init` command ([#795](https://github.com/databricks/cli/pull/795)).
-
-Bundles:
- * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
-
-Internal:
- * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
 
 
 


### PR DESCRIPTION
CLI:
 * Fix rendering of streaming response ([#876](https://github.com/databricks/cli/pull/876)).
 
Bundles:
 * Rename MLOps Stack to MLOps Stacks ([#881](https://github.com/databricks/cli/pull/881)).
 * Support Python wheels larger than 10MB ([#879](https://github.com/databricks/cli/pull/879)).
 * Improve the output of the `databricks bundle init` command ([#795](https://github.com/databricks/cli/pull/795)).



