### PR TITLE
Added test for tasks with python wheel wrapper on

### DIFF
--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func runPythonWheelTest(t *testing.T, pythonWheelWrapper bool) {
+func runPythonWheelTest(t *testing.T, sparkVersion string, pythonWheelWrapper bool) {
 	env := internal.GetEnvOrSkipTest(t, "CLOUD_ENV")
 	t.Log(env)
 
@@ -24,7 +24,7 @@ func runPythonWheelTest(t *testing.T, pythonWheelWrapper bool) {
 	bundleRoot, err := initTestTemplate(t, "python_wheel_task", map[string]any{
 		"node_type_id":         nodeTypeId,
 		"unique_id":            uuid.New().String(),
-		"spark_version":        "13.2.x-snapshot-scala2.12",
+		"spark_version":        sparkVersion,
 		"python_wheel_wrapper": pythonWheelWrapper,
 	})
 	require.NoError(t, err)
@@ -44,9 +44,9 @@ func runPythonWheelTest(t *testing.T, pythonWheelWrapper bool) {
 }
 
 func TestAccPythonWheelTaskDeployAndRunWithoutWrapper(t *testing.T) {
-	runPythonWheelTest(t, false)
+	runPythonWheelTest(t, "13.2.x-snapshot-scala2.12", false)
 }
 
 func TestAccPythonWheelTaskDeployAndRunWithWrapper(t *testing.T) {
-	runPythonWheelTest(t, true)
+	runPythonWheelTest(t, "12.2.x-scala2.12", true)
 }


### PR DESCRIPTION
## Changes
Added test for tasks with python wheel wrapper on

## Tests
```
2023/10/20 16:42:07 [INFO] Listing secrets from ...
=== RUN   TestAccPythonWheelTaskDeployAndRunWithWrapper
    python_wheel_test.go:13: aws
    helpers.go:43: Configuration for template:  {"node_type_id":"i3.xlarge","python_wheel_wrapper":true,"spark_version":"12.2.x-scala2.12","unique_id":"224a58a5-7ecb-4e7a-9c89-c7f5ea57924e"}
 ...
Resource deployment completed!
Run URL: ...

2023-10-20 16:42:33 "[default] Test Wheel Job 224a58a5-7ecb-4e7a-9c89-c7f5ea57924e" RUNNING 
2023-10-20 16:47:27 "[default] Test Wheel Job 224a58a5-7ecb-4e7a-9c89-c7f5ea57924e" TERMINATED SUCCESS 
    helpers.go:169: [databricks stdout]: Hello from my func
    helpers.go:169: [databricks stdout]: Got arguments:
    helpers.go:169: [databricks stdout]: ['my_test_code', 'one', 'two']
...
--- PASS: TestAccPythonWheelTaskDeployAndRunWithWrapper (321.61s)
PASS
coverage: 93.5% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       322.307s        coverage: 93.5% of statements in ./...
```

