### PR TITLE
Fix wheel task not working with with 13.x clusters

### DIFF
--- a/bundle/python/warning.go
+++ b/bundle/python/warning.go
@@ -79,6 +79,9 @@ func lowerThanExpectedVersion(ctx context.Context, sparkVersion string) bool {
 		return false
 	}
 
+	if parts[1][0] == 'x' { // treat versions like 13.x as the very latest minor (13.99)
+		parts[1] = "99"
+	}
 	v := "v" + parts[0] + "." + parts[1]
 	return semver.Compare(v, "v13.1") < 0
 }

--- a/bundle/python/warning_test.go
+++ b/bundle/python/warning_test.go
@@ -390,6 +390,8 @@ func TestSparkVersionLowerThanExpected(t *testing.T) {
 		"13.3.x-scala2.12":                false,
 		"14.0.x-scala2.12":                false,
 		"14.1.x-scala2.12":                false,
+		"13.x-snapshot-scala-2.12":        false,
+		"13.x-rc-scala-2.12":              false,
 		"10.4.x-aarch64-photon-scala2.12": true,
 		"10.4.x-scala2.12":                true,
 		"13.0.x-scala2.12":                true,


### PR DESCRIPTION
## Changes

This lets us recognize 13.x as "13.1 or higher," making it possible to use wheel tasks on 13.x-snapshot clusters.