### PR TITLE
Install build dependencies before running bdist_wheel

### DIFF
--- a/bundle/artifacts/whl/infer.go
+++ b/bundle/artifacts/whl/infer.go
@@ -18,7 +18,7 @@ func (m *infer) Apply(ctx context.Context, b *bundle.Bundle) error {
 	if err != nil {
 		return err
 	}
-	artifact.BuildCommand = fmt.Sprintf("%s setup.py bdist_wheel", py)
+	artifact.BuildCommand = fmt.Sprintf("%s -m pip install setuptools wheel && %s setup.py bdist_wheel", py, py)
 
 	return nil
 }


### PR DESCRIPTION
## Changes

On some Python installations, `bdist_wheel` will fail with an error that "wheel" or "setuptools" is not installed. This change makes sure we install them prior to running that command.

Btw, longer-term we should avoid move from "bdist_wheel" command to `python3 -m build` instead. But I'd only make that change once the CLI maintains a .venv that we can run the command from (which makes `python3 -m build` more useful and a lot faster).