### PR TITLE
Add welcome message to bundle templates

### DIFF
--- a/libs/jsonschema/extension.go
+++ b/libs/jsonschema/extension.go
@@ -12,6 +12,9 @@ type Extension struct {
 	// that do have an order defined.
 	Order *int `json:"order,omitempty"`
 
+	// Welcome message to print before prompting the user for input
+	WelcomeMessage string `json:"welcome_message,omitempty"`
+
 	// The message to print after the template is successfully initalized
 	SuccessMessage string `json:"success_message,omitempty"`
 

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -48,6 +48,12 @@ func Materialize(ctx context.Context, configFilePath, templateRoot, outputDir st
 		return err
 	}
 
+	// Print welcome message
+	welcome := config.schema.WelcomeMessage
+	if welcome != "" {
+		cmdio.LogString(ctx, welcome)
+	}
+
 	// Read and assign config values from file
 	if configFilePath != "" {
 		err = config.assignValuesFromFile(configFilePath)

--- a/libs/template/templates/default-python/databricks_template_schema.json
+++ b/libs/template/templates/default-python/databricks_template_schema.json
@@ -1,4 +1,5 @@
 {
+    "welcome_message": "\nWelcome to the sample Databricks Asset Bundle template! Please enter the following information to initialize your sample DAB.\n",
     "properties": {
         "project_name": {
             "type": "string",


### PR DESCRIPTION
## Changes
Adds a welcome_message field to templates and the default python template.

## Tests
Manually.

Here's the output logs during template init now:
```
shreyas.goenka@THW32HFW6T bricks % cli bundle init                              
Template to use [default-python]: 

Welcome to the sample Databricks Asset Bundle template! Please enter the following information to initialize your sample DAB.

Unique name for this project [my_project]: abcde
Include a stub (sample) notebook in 'abcde/src': no
Include a stub (sample) Delta Live Tables pipeline in 'abcde/src': yes
Include a stub (sample) Python package in 'abcde/src': no

✨ Your new project has been created in the 'abcde' directory!

Please refer to the README.md of your project for further instructions on getting started.
Or read the documentation on Databricks Asset Bundles at https://docs.databricks.com/dev-tools/bundles/index.html.
```
