### PR TITLE
 Add support for post prompt success message to bundle templates

### DIFF
--- a/libs/cmdio/logger.go
+++ b/libs/cmdio/logger.go
@@ -82,8 +82,8 @@ func LogRaw(ctx context.Context, raw string) error {
 	if !ok {
 		logger = Default()
 	}
-	if logger.Mode != flags.ModeAppend {
-		return fmt.Errorf("logging raw strings is only supported in append mode. Failed to log: %q", raw)
+	if logger.Mode == flags.ModeJson {
+		return fmt.Errorf("logging raw strings is not supported in JSON mode. Failed to log: %q", raw)
 	}
 	logger.Writer.Write([]byte(raw))
 	return nil

--- a/libs/cmdio/logger_test.go
+++ b/libs/cmdio/logger_test.go
@@ -27,13 +27,5 @@ func TestLogRawErrorForJsonMode(t *testing.T) {
 	ctx := NewContext(context.Background(), l)
 
 	err := LogRaw(ctx, "hello world")
-	assert.EqualError(t, err, "logging raw strings is only supported in append mode. Failed to log: \"hello world\"")
-}
-
-func TestLogRawErrorForInplaceMode(t *testing.T) {
-	l := NewLogger(flags.ModeInplace)
-	ctx := NewContext(context.Background(), l)
-
-	err := LogRaw(ctx, "hello world")
-	assert.EqualError(t, err, "logging raw strings is only supported in append mode. Failed to log: \"hello world\"")
+	assert.EqualError(t, err, "logging raw strings is not supported in JSON mode. Failed to log: \"hello world\"")
 }

--- a/libs/cmdio/logger_test.go
+++ b/libs/cmdio/logger_test.go
@@ -21,3 +21,19 @@ func TestAskChoiceFailsInJsonMode(t *testing.T) {
 	_, err := AskSelect(ctx, "what is a question?", []string{"b", "c", "a"})
 	assert.EqualError(t, err, "question prompts are not supported in json mode")
 }
+
+func TestLogRawErrorForJsonMode(t *testing.T) {
+	l := NewLogger(flags.ModeJson)
+	ctx := NewContext(context.Background(), l)
+
+	err := LogRaw(ctx, "hello world")
+	assert.EqualError(t, err, "logging raw strings is only supported in append mode. Failed to log: \"hello world\"")
+}
+
+func TestLogRawErrorForInplaceMode(t *testing.T) {
+	l := NewLogger(flags.ModeInplace)
+	ctx := NewContext(context.Background(), l)
+
+	err := LogRaw(ctx, "hello world")
+	assert.EqualError(t, err, "logging raw strings is only supported in append mode. Failed to log: \"hello world\"")
+}

--- a/libs/jsonschema/extension.go
+++ b/libs/jsonschema/extension.go
@@ -23,4 +23,8 @@ type Extension struct {
 	// If the CLI version is less than this value, then validation for this
 	// schema will fail.
 	MinDatabricksCliVersion string `json:"min_databricks_cli_version,omitempty"`
+
+	// Message displayed after a user enters a value for a prompt and validation
+	// on this value passes.
+	PostPromptSuccessMessage string `json:"post_prompt_success_message,omitempty"`
 }

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -151,6 +151,18 @@ func (c *config) promptForValues(r *renderer) error {
 		if err := c.schema.ValidateInstance(c.values); err != nil {
 			return err
 		}
+
+		// Execute and print post prompt success message
+		if property.PostPromptSuccessMessage != "" {
+			postPromptSuccessMessage, err := r.executeTemplate(property.PostPromptSuccessMessage)
+			if err != nil {
+				return err
+			}
+			err = cmdio.LogRaw(c.ctx, postPromptSuccessMessage)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes
We use promptui for more complex prompt UIs like search and select. Unfortunately promptui only supports single line prompts, overwriting printed lines if multiline questions are passed when printing the prompt. 

This PR introduces the `post_prompt_success_message` field which can now include text that will be printed once the prompt is complete. This enables the prompt text itself to be a single line in cases. 

This will help print new lines in mlops stacks in between prompts. Why does mlops-stack need to print new lines?  
Because they have multiple prompt questions, and the new line formatting helps delineate between different prompt
eg: Note how the first character here is `\n`: https://github.com/databricks/mlops-stacks/blob/5d940d5eda3b139e729b64ab13132c0079c948eb/databricks_template_schema.json#L24

Note: This will unblock usage of enums in mlops-stack, making the UX substancially better.

## Tests
Manually.

Bundle schema config:
```
    "input_project_name": {
      "order": 1,
      "type": "string",
      "default": "my-mlops-project",
      "description": "Welcome to MLOps Stack. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stack/blob/main/README.md. \n\nProject Name",
      "post_prompt_success_message": "-----------\n"
    },
    "input_root_dir": {
      "order": 2,
      "type": "string",
      "default": "my-mlops-project",
      "description": "Root directory name. Use a name different from the project name if you intend to use monorepo",
      "post_prompt_success_message": "xxxxxxxxxxxx\n"
    },
```

Command line output:
```
shreyas.goenka@THW32HFW6T playground % cli bundle init ~/mlops-stack
Welcome to MLOps Stack. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stack/blob/main/README.md. 

Project Name [my-mlops-project]: foo
-----------
Root directory name. Use a name different from the project name if you intend to use monorepo [my-mlops-project]: bar
xxxxxxxxxxxx
Select cloud provider: aws
```
