### PR TITLE
fix: gcp_service_account_key is not available

### DIFF
--- a/cmd/workspace/storage-credentials/overrides.go
+++ b/cmd/workspace/storage-credentials/overrides.go
@@ -8,7 +8,7 @@ import (
 func listOverride(listCmd *cobra.Command) {
 	listCmd.Annotations["template"] = cmdio.Heredoc(`
 	{{header "ID"}}	{{header "Name"}}	{{header "Credentials"}}
-	{{range .}}{{.Id|green}}	{{.Name|cyan}}	{{if .AwsIamRole}}{{.AwsIamRole.RoleArn}}{{end}}{{if .AzureServicePrincipal}}{{.AzureServicePrincipal.ApplicationId}}{{end}}{{if .GcpServiceAccountKey}}{{.Email}}{{end}}
+	{{range .}}{{.Id|green}}	{{.Name|cyan}}	{{if .AwsIamRole}}{{.AwsIamRole.RoleArn}}{{end}}{{if .AzureServicePrincipal}}{{.AzureServicePrincipal.ApplicationId}}{{end}}
 	{{end}}`)
 }
 


### PR DESCRIPTION
`GcpServiceAccountKey` doesn't exist on `StorageCredentialInfo` in the
current SDKs

I ran across this when using AWS backed accounts:

```sh
❯ databricks storage-credentials list
Error: template: command:2:169: executing "command" at <.GcpServiceAccountKey>: can't evaluate field GcpServiceAccountKey in type catalog.StorageCredentialInfo
```

Because of the way OpenAPI changes are applied to the source, I can't tell when this was broken (or if it ever worked).

Some 💡 ideas that might prevent problems in the future.

1. Ensure that OpenAPI updates apply in a way that lets `git diff` and `git blame` remain useful.
2. Have the template be tested against a mock of the OpenAPI object(s) to ensure it doesn't break.
3. Don't use `{{If}}` in templates; they can hide problems like this. If this were a single method that returned a string, then this would have been caught at compile time instead of run time.
