### PR TITLE
Add support for multiline descriptions when using template enums

### DIFF
--- a/libs/cmdio/logger.go
+++ b/libs/cmdio/logger.go
@@ -113,18 +113,34 @@ func AskSelect(ctx context.Context, question string, choices []string) (string, 
 	return logger.AskSelect(question, choices)
 }
 
+func splitAtLastNewLine(s string) (string, string) {
+	// Split at the newline character
+	if i := strings.LastIndex(s, "\n"); i != -1 {
+		return s[:i+1], s[i+1:]
+	}
+	// Return the original string if no newline found
+	return "", s
+}
+
 func (l *Logger) AskSelect(question string, choices []string) (string, error) {
 	if l.Mode == flags.ModeJson {
 		return "", fmt.Errorf("question prompts are not supported in json mode")
 	}
 
+	// Promptui does not support multiline prompts. So we split the question.
+	first, last := splitAtLastNewLine(question)
+	_, err := l.Writer.Write([]byte(first))
+	if err != nil {
+		return "", err
+	}
+
 	prompt := promptui.Select{
-		Label:    question,
+		Label:    last,
 		Items:    choices,
 		HideHelp: true,
 		Templates: &promptui.SelectTemplates{
 			Label:    "{{.}}: ",
-			Selected: fmt.Sprintf("%s: {{.}}", question),
+			Selected: fmt.Sprintf("%s: {{.}}", last),
 		},
 	}
 

--- a/libs/cmdio/logger_test.go
+++ b/libs/cmdio/logger_test.go
@@ -21,3 +21,25 @@ func TestAskChoiceFailsInJsonMode(t *testing.T) {
 	_, err := AskSelect(ctx, "what is a question?", []string{"b", "c", "a"})
 	assert.EqualError(t, err, "question prompts are not supported in json mode")
 }
+
+func TestSplitAtLastNewLine(t *testing.T) {
+	first, last := splitAtLastNewLine("hello\nworld")
+	assert.Equal(t, "hello\n", first)
+	assert.Equal(t, "world", last)
+
+	first, last = splitAtLastNewLine("hello\r\nworld")
+	assert.Equal(t, "hello\r\n", first)
+	assert.Equal(t, "world", last)
+
+	first, last = splitAtLastNewLine("hello world")
+	assert.Equal(t, "", first)
+	assert.Equal(t, "hello world", last)
+
+	first, last = splitAtLastNewLine("hello\nworld\n")
+	assert.Equal(t, "hello\nworld\n", first)
+	assert.Equal(t, "", last)
+
+	first, last = splitAtLastNewLine("\nhello world")
+	assert.Equal(t, "\n", first)
+	assert.Equal(t, "hello world", last)
+}


### PR DESCRIPTION
## Changes
This PR splits the question prompt at the last new line character to make multiline selection prompts work with `promptui`

## Tests
Tested manually


https://github.com/databricks/cli/assets/88374338/027e5210-f7f4-479d-98df-744d15b7a8fb

