### PR TITLE
Consolidate bundle configuration loader function

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -76,10 +76,11 @@ func Load(ctx context.Context, path string) (*Bundle, error) {
 		return nil, err
 	}
 	log.Debugf(ctx, "Loading bundle configuration from: %s", configFile)
-	err = bundle.Config.Load(configFile)
+	root, err := config.Load(configFile)
 	if err != nil {
 		return nil, err
 	}
+	bundle.Config = *root
 	return bundle, nil
 }
 

--- a/bundle/config/root_test.go
+++ b/bundle/config/root_test.go
@@ -25,8 +25,7 @@ func TestRootMarshalUnmarshal(t *testing.T) {
 }
 
 func TestRootLoad(t *testing.T) {
-	root := &Root{}
-	err := root.Load("../tests/basic/databricks.yml")
+	root, err := Load("../tests/basic/databricks.yml")
 	require.NoError(t, err)
 	assert.Equal(t, "basic", root.Bundle.Name)
 }
@@ -77,18 +76,15 @@ func TestRootMergeMap(t *testing.T) {
 }
 
 func TestDuplicateIdOnLoadReturnsError(t *testing.T) {
-	root := &Root{}
-	err := root.Load("./testdata/duplicate_resource_names_in_root/databricks.yml")
+	_, err := Load("./testdata/duplicate_resource_names_in_root/databricks.yml")
 	assert.ErrorContains(t, err, "multiple resources named foo (job at ./testdata/duplicate_resource_names_in_root/databricks.yml, pipeline at ./testdata/duplicate_resource_names_in_root/databricks.yml)")
 }
 
 func TestDuplicateIdOnMergeReturnsError(t *testing.T) {
-	root := &Root{}
-	err := root.Load("./testdata/duplicate_resource_name_in_subconfiguration/databricks.yml")
+	root, err := Load("./testdata/duplicate_resource_name_in_subconfiguration/databricks.yml")
 	require.NoError(t, err)
 
-	other := &Root{}
-	err = other.Load("./testdata/duplicate_resource_name_in_subconfiguration/resources.yml")
+	other, err := Load("./testdata/duplicate_resource_name_in_subconfiguration/resources.yml")
 	require.NoError(t, err)
 
 	err = root.Merge(other)


### PR DESCRIPTION
## Changes

There were two functions related to loading a bundle configuration file; one as a package function and one as a member function on the configuration type. Loading the same configuration object twice doesn't make sense and therefore we can consolidate to only using the package function.

The package function would scan for known file names if the specified path was a directory. This functionality was not in use because the top-level bundle loader figures out the filename itself as of #580.

## Tests

Pass.
