### PR TITLE
`make snapshot` to build file in `.databricks/databricks`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build: vendor
 
 snapshot:
 	@echo "✓ Building dev snapshot"
-	@goreleaser build --snapshot --clean --single-target
+	@go build -o .databricks/databricks
 
 vendor:
 	@echo "✓ Filling vendor folder with library code ..."


### PR DESCRIPTION
Goreleaser builds binary in 10-15 seconds, but go build does it just in 3-5 seconds. Target is `.databricks` folder in the current checkout, which is already in `.gitignore`. Make sure you have the following $PATH:

```
PATH="/path/to/cli/checkout/.databricks:$PATH"
```

