### PR TITLE
Run make fmt from fmt job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -73,6 +73,10 @@ jobs:
           # No need to download cached dependencies when running gofmt.
           cache: false
 
+      - name: Install goimports
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+
       - name: Run make fmt
         run: |
           make fmt

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -73,11 +73,9 @@ jobs:
           # No need to download cached dependencies when running gofmt.
           cache: false
 
-      - name: Run gofmt
+      - name: Run make fmt
         run: |
-          # -l: list files that were reformatted
-          # -w: write back formatted files to disk
-          gofmt -l -w ./
+          make fmt
 
       - name: Run go mod tidy
         run: |


### PR DESCRIPTION
## Changes

I noticed we weren't running `goimports` from our formatting job. If we run `make fmt`, we do.

## Tests

The fmt job passes.

