### PR TITLE
Fix metadata computation for empty bundle

### DIFF
--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -213,6 +213,11 @@ func BundleToTerraform(config *config.Root) *schema.Root {
 }
 
 func TerraformToBundle(state *tfjson.State, config *config.Root) error {
+	// This is a no-op if the state is empty.
+	if state.Values == nil || state.Values.RootModule == nil {
+		return nil
+	}
+
 	for _, resource := range state.Values.RootModule.Resources {
 		// Limit to resources.
 		if resource.Mode != tfjson.ManagedResourceMode {

--- a/bundle/deploy/terraform/load.go
+++ b/bundle/deploy/terraform/load.go
@@ -38,8 +38,8 @@ func (l *load) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	err = validateState(state)
-	if err != nil && slices.Contains(l.modes, ErrorOnEmptyState) {
+	err = l.validateState(state)
+	if err != nil {
 		return err
 	}
 
@@ -52,9 +52,12 @@ func (l *load) Apply(ctx context.Context, b *bundle.Bundle) error {
 	return nil
 }
 
-func validateState(state *tfjson.State) error {
+func (l *load) validateState(state *tfjson.State) error {
 	if state.Values == nil {
-		return fmt.Errorf("no deployment state. Did you forget to run 'databricks bundle deploy'?")
+		if slices.Contains(l.modes, ErrorOnEmptyState) {
+			return fmt.Errorf("no deployment state. Did you forget to run 'databricks bundle deploy'?")
+		}
+		return nil
 	}
 
 	if state.Values.RootModule == nil {

--- a/bundle/deploy/terraform/load.go
+++ b/bundle/deploy/terraform/load.go
@@ -12,7 +12,7 @@ import (
 
 type loadMode int
 
-const NoErrorOnEmptyState loadMode = 0
+const ErrorOnEmptyState loadMode = 0
 
 type load struct {
 	modes []loadMode
@@ -38,13 +38,8 @@ func (l *load) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	// If state is empty, return early.
-	if state.Values == nil && slices.Contains(l.modes, NoErrorOnEmptyState) {
-		return nil
-	}
-
-	err = ValidateState(state)
-	if err != nil {
+	err = validateState(state)
+	if err != nil && slices.Contains(l.modes, ErrorOnEmptyState) {
 		return err
 	}
 
@@ -57,7 +52,7 @@ func (l *load) Apply(ctx context.Context, b *bundle.Bundle) error {
 	return nil
 }
 
-func ValidateState(state *tfjson.State) error {
+func validateState(state *tfjson.State) error {
 	if state.Values == nil {
 		return fmt.Errorf("no deployment state. Did you forget to run 'databricks bundle deploy'?")
 	}

--- a/bundle/deploy/terraform/load_test.go
+++ b/bundle/deploy/terraform/load_test.go
@@ -34,7 +34,7 @@ func TestLoadWithNoState(t *testing.T) {
 
 	err = bundle.Apply(context.Background(), b, bundle.Seq(
 		Initialize(),
-		Load(),
+		Load(ErrorOnEmptyState),
 	))
 
 	require.ErrorContains(t, err, "Did you forget to run 'databricks bundle deploy'")

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -34,7 +34,7 @@ func Deploy() bundle.Mutator {
 					terraform.Apply(),
 					bundle.Seq(
 						terraform.StatePush(),
-						terraform.Load(),
+						terraform.Load(terraform.NoErrorOnEmptyState),
 						metadata.Compute(),
 						metadata.Upload(),
 					),

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -34,7 +34,7 @@ func Deploy() bundle.Mutator {
 					terraform.Apply(),
 					bundle.Seq(
 						terraform.StatePush(),
-						terraform.Load(terraform.NoErrorOnEmptyState),
+						terraform.Load(),
 						metadata.Compute(),
 						metadata.Upload(),
 					),

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -38,7 +38,7 @@ func newRunCommand() *cobra.Command {
 			terraform.Interpolate(),
 			terraform.Write(),
 			terraform.StatePull(),
-			terraform.Load(),
+			terraform.Load(terraform.ErrorOnEmptyState),
 		))
 		if err != nil {
 			return err


### PR DESCRIPTION
## Changes
This PR fixes metadata computation for empty bundle. Before we would error because the `terraform.Load()` mutator errors on a empty / no state file.

## Tests
Failing integration tests now pass.
