### PR TITLE
Remove resolution of repo names against the Databricks Github account

### DIFF
--- a/internal/git_clone_test.go
+++ b/internal/git_clone_test.go
@@ -32,14 +32,14 @@ func TestAccGitClone(t *testing.T) {
 	assert.Contains(t, string(b), "ide")
 }
 
-func TestAccGitCloneWithOnlyRepoNameOnAlternateBranch(t *testing.T) {
+func TestAccGitCloneOnNonDefaultBranch(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	tmpDir := t.TempDir()
 	ctx := context.Background()
 	var err error
 
-	err = git.Clone(ctx, "notebook-best-practices", "dais-2022", tmpDir)
+	err = git.Clone(ctx, "https://github.com/databricks/notebook-best-practices", "dais-2022", tmpDir)
 
 	// assert on repo content
 	assert.NoError(t, err)
@@ -47,7 +47,7 @@ func TestAccGitCloneWithOnlyRepoNameOnAlternateBranch(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(b), "Software engineering best practices for Databricks notebooks")
 
-	// assert current branch is main, ie default for the repo
+	// assert current branch is dais-2022
 	b, err = os.ReadFile(filepath.Join(tmpDir, ".git/HEAD"))
 	assert.NoError(t, err)
 	assert.Contains(t, string(b), "dais-2022")

--- a/libs/git/clone.go
+++ b/libs/git/clone.go
@@ -5,17 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/databricks/cli/libs/process"
 )
-
-// source: https://stackoverflow.com/questions/59081778/rules-for-special-characters-in-github-repository-name
-var githubRepoRegex = regexp.MustCompile(`^[\w-\.]+$`)
-
-const githubUrl = "https://github.com"
-const databricksOrg = "databricks"
 
 type cloneOptions struct {
 	// Branch or tag to clone
@@ -59,17 +52,9 @@ func (opts cloneOptions) clone(ctx context.Context) error {
 }
 
 func Clone(ctx context.Context, url, reference, targetPath string) error {
-	// We assume only the repository name has been if input does not contain any
-	// `/` characters and the url is only made up of alphanumeric characters and
-	// ".", "_" and "-". This repository is resolved again databricks github account.
-	fullUrl := url
-	if githubRepoRegex.MatchString(url) {
-		fullUrl = strings.Join([]string{githubUrl, databricksOrg, url}, "/")
-	}
-
 	opts := cloneOptions{
 		Reference:     reference,
-		RepositoryUrl: fullUrl,
+		RepositoryUrl: url,
 		TargetPath:    targetPath,
 		Shallow:       true,
 	}


### PR DESCRIPTION
## Changes
This functionality is not exercised (and will not be anytime soon). Instead we use a map to have first party aliases for supported templates. 

https://github.com/databricks/cli/blob/1e46b9f88a7dfe96ddc509b014beaa48ba0efef8/cmd/bundle/init.go#L21 

## Tests
Existing tests and manually, bundle init still works.