### PR TITLE
Added `env.UserHomeDir(ctx)` for parallel-friendly tests

### DIFF
--- a/cmd/auth/env.go
+++ b/cmd/auth/env.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -68,8 +69,8 @@ func resolveSection(cfg *config.Config, iniFile *config.File) (*ini.Section, err
 	return candidates[0], nil
 }
 
-func loadFromDatabricksCfg(cfg *config.Config) error {
-	iniFile, err := databrickscfg.Get()
+func loadFromDatabricksCfg(ctx context.Context, cfg *config.Config) error {
+	iniFile, err := databrickscfg.Get(ctx)
 	if errors.Is(err, fs.ErrNotExist) {
 		// it's fine not to have ~/.databrickscfg
 		return nil
@@ -110,7 +111,7 @@ func newEnvCommand() *cobra.Command {
 			cfg.Profile = profile
 		} else if cfg.Host == "" {
 			cfg.Profile = "DEFAULT"
-		} else if err := loadFromDatabricksCfg(cfg); err != nil {
+		} else if err := loadFromDatabricksCfg(cmd.Context(), cfg); err != nil {
 			return err
 		}
 		// Go SDK is lazy loaded because of Terraform semantics,

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -128,7 +128,7 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 
 func setHost(ctx context.Context, profileName string, persistentAuth *auth.PersistentAuth, args []string) error {
 	// If the chosen profile has a hostname and the user hasn't specified a host, infer the host from the profile.
-	_, profiles, err := databrickscfg.LoadProfiles(func(p databrickscfg.Profile) bool {
+	_, profiles, err := databrickscfg.LoadProfiles(ctx, func(p databrickscfg.Profile) bool {
 		return p.Name == profileName
 	})
 	if err != nil {

--- a/cmd/auth/profiles.go
+++ b/cmd/auth/profiles.go
@@ -95,7 +95,7 @@ func newProfilesCommand() *cobra.Command {
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		var profiles []*profileMetadata
-		iniFile, err := databrickscfg.Get()
+		iniFile, err := databrickscfg.Get(cmd.Context())
 		if os.IsNotExist(err) {
 			// return empty list for non-configured machines
 			iniFile = &config.File{

--- a/libs/databrickscfg/profiles.go
+++ b/libs/databrickscfg/profiles.go
@@ -108,7 +108,7 @@ func LoadProfiles(ctx context.Context, fn ProfileMatchFunction) (file string, pr
 	// Replace homedir with ~ if applicable.
 	// This is to make the output more readable.
 	file = filepath.Clean(f.Path())
-	homedir := env.UserHomeDir(ctx)
+	homedir := filepath.Clean(env.UserHomeDir(ctx))
 	if strings.HasPrefix(file, homedir) {
 		file = "~" + file[len(homedir):]
 	}

--- a/libs/databrickscfg/profiles.go
+++ b/libs/databrickscfg/profiles.go
@@ -107,7 +107,7 @@ func LoadProfiles(ctx context.Context, fn ProfileMatchFunction) (file string, pr
 
 	// Replace homedir with ~ if applicable.
 	// This is to make the output more readable.
-	file = f.Path()
+	file = filepath.Clean(f.Path())
 	homedir := env.UserHomeDir(ctx)
 	if strings.HasPrefix(file, homedir) {
 		file = "~" + file[len(homedir):]

--- a/libs/databrickscfg/profiles_test.go
+++ b/libs/databrickscfg/profiles_test.go
@@ -2,8 +2,7 @@ package databrickscfg
 
 import (
 	"context"
-	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/libs/env"
@@ -31,20 +30,20 @@ func TestProfilesSearchCaseInsensitive(t *testing.T) {
 
 func TestLoadProfilesReturnsHomedirAsTilde(t *testing.T) {
 	ctx := context.Background()
-	ctx = env.WithUserHomeDir(ctx, "./testdata")
+	ctx = env.WithUserHomeDir(ctx, "testdata")
 	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "./testdata/databrickscfg")
 	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	assertEqualPaths(t, "~/databrickscfg", file)
+	require.Equal(t, filepath.Clean("~/databrickscfg"), file)
 }
 
-func TestLoadProfilesReturnsHomedirAsTildeExoticFIle(t *testing.T) {
+func TestLoadProfilesReturnsHomedirAsTildeExoticFile(t *testing.T) {
 	ctx := context.Background()
 	ctx = env.WithUserHomeDir(ctx, "testdata")
 	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "~/databrickscfg")
 	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	assertEqualPaths(t, "~/databrickscfg", file)
+	require.Equal(t, filepath.Clean("~/databrickscfg"), file)
 }
 
 func TestLoadProfilesReturnsHomedirAsTildeDefaultFile(t *testing.T) {
@@ -52,7 +51,7 @@ func TestLoadProfilesReturnsHomedirAsTildeDefaultFile(t *testing.T) {
 	ctx = env.WithUserHomeDir(ctx, "testdata/sample-home")
 	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	assertEqualPaths(t, "~/.databrickscfg", file)
+	require.Equal(t, filepath.Clean("~/.databrickscfg"), file)
 }
 
 func TestLoadProfilesNoConfiguration(t *testing.T) {
@@ -76,9 +75,4 @@ func TestLoadProfilesMatchAccount(t *testing.T) {
 	_, profiles, err := LoadProfiles(ctx, MatchAccountProfiles)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"acc"}, profiles.Names())
-}
-
-func assertEqualPaths(t *testing.T, expected, actual string) {
-	expected = strings.ReplaceAll(expected, "/", string(os.PathSeparator))
-	assert.Equal(t, expected, actual)
 }

--- a/libs/databrickscfg/profiles_test.go
+++ b/libs/databrickscfg/profiles_test.go
@@ -2,6 +2,8 @@ package databrickscfg
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/databricks/cli/libs/env"
@@ -33,7 +35,7 @@ func TestLoadProfilesReturnsHomedirAsTilde(t *testing.T) {
 	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "./testdata/databrickscfg")
 	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	assert.Equal(t, "~/databrickscfg", file)
+	assertEqualPaths(t, "~/databrickscfg", file)
 }
 
 func TestLoadProfilesReturnsHomedirAsTildeExoticFIle(t *testing.T) {
@@ -42,7 +44,7 @@ func TestLoadProfilesReturnsHomedirAsTildeExoticFIle(t *testing.T) {
 	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "~/databrickscfg")
 	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	assert.Equal(t, "~/databrickscfg", file)
+	assertEqualPaths(t, "~/databrickscfg", file)
 }
 
 func TestLoadProfilesReturnsHomedirAsTildeDefaultFile(t *testing.T) {
@@ -50,7 +52,7 @@ func TestLoadProfilesReturnsHomedirAsTildeDefaultFile(t *testing.T) {
 	ctx = env.WithUserHomeDir(ctx, "testdata/sample-home")
 	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	assert.Equal(t, "~/.databrickscfg", file)
+	assertEqualPaths(t, "~/.databrickscfg", file)
 }
 
 func TestLoadProfilesNoConfiguration(t *testing.T) {
@@ -74,4 +76,9 @@ func TestLoadProfilesMatchAccount(t *testing.T) {
 	_, profiles, err := LoadProfiles(ctx, MatchAccountProfiles)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"acc"}, profiles.Names())
+}
+
+func assertEqualPaths(t *testing.T, expected, actual string) {
+	expected = strings.ReplaceAll(expected, "/", string(os.PathSeparator))
+	assert.Equal(t, expected, actual)
 }

--- a/libs/databrickscfg/profiles_test.go
+++ b/libs/databrickscfg/profiles_test.go
@@ -2,8 +2,6 @@ package databrickscfg
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/databricks/cli/libs/env"
@@ -31,11 +29,35 @@ func TestProfilesSearchCaseInsensitive(t *testing.T) {
 
 func TestLoadProfilesReturnsHomedirAsTilde(t *testing.T) {
 	ctx := context.Background()
-	ctx = env.WithUserHomeDir(ctx, "testdata/sample-home")
-	file, err := Get(ctx)
+	ctx = env.WithUserHomeDir(ctx, "./testdata")
+	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "./testdata/databrickscfg")
+	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
 	require.NoError(t, err)
-	path := strings.ReplaceAll("testdata/sample-home/.databrickscfg", "/", string(os.PathSeparator))
-	assert.Equal(t, path, file.Path())
+	assert.Equal(t, "~/databrickscfg", file)
+}
+
+func TestLoadProfilesReturnsHomedirAsTildeExoticFIle(t *testing.T) {
+	ctx := context.Background()
+	ctx = env.WithUserHomeDir(ctx, "testdata")
+	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "~/databrickscfg")
+	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
+	require.NoError(t, err)
+	assert.Equal(t, "~/databrickscfg", file)
+}
+
+func TestLoadProfilesReturnsHomedirAsTildeDefaultFile(t *testing.T) {
+	ctx := context.Background()
+	ctx = env.WithUserHomeDir(ctx, "testdata/sample-home")
+	file, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
+	require.NoError(t, err)
+	assert.Equal(t, "~/.databrickscfg", file)
+}
+
+func TestLoadProfilesNoConfiguration(t *testing.T) {
+	ctx := context.Background()
+	ctx = env.WithUserHomeDir(ctx, "testdata")
+	_, _, err := LoadProfiles(ctx, func(p Profile) bool { return true })
+	require.ErrorIs(t, err, ErrNoConfiguration)
 }
 
 func TestLoadProfilesMatchWorkspace(t *testing.T) {

--- a/libs/databrickscfg/testdata/sample-home/.databrickscfg
+++ b/libs/databrickscfg/testdata/sample-home/.databrickscfg
@@ -1,0 +1,7 @@
+[DEFAULT]
+host = https://default
+token = default
+
+[acc]
+host = https://accounts.cloud.databricks.com
+account_id = abc

--- a/libs/env/context.go
+++ b/libs/env/context.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -76,7 +77,11 @@ func WithUserHomeDir(ctx context.Context, value string) context.Context {
 }
 
 func UserHomeDir(ctx context.Context) string {
-	return Get(ctx, homeEnvVar())
+	home := Get(ctx, homeEnvVar())
+	if home == "" {
+		panic(fmt.Errorf("$HOME is not set"))
+	}
+	return home
 }
 
 // All returns environment variables that are defined in both os.Environ

--- a/libs/env/context.go
+++ b/libs/env/context.go
@@ -3,6 +3,7 @@ package env
 import (
 	"context"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -61,6 +62,21 @@ func Set(ctx context.Context, key, value string) context.Context {
 	m := copyMap(getMap(ctx))
 	m[key] = value
 	return setMap(ctx, m)
+}
+
+func homeEnvVar() string {
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
+func WithUserHomeDir(ctx context.Context, value string) context.Context {
+	return Set(ctx, homeEnvVar(), value)
+}
+
+func UserHomeDir(ctx context.Context) string {
+	return Get(ctx, homeEnvVar())
 }
 
 // All returns environment variables that are defined in both os.Environ

--- a/libs/env/context_test.go
+++ b/libs/env/context_test.go
@@ -47,3 +47,10 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "x=y", all["BAR"])
 	assert.NotEmpty(t, all["PATH"])
 }
+
+func TestHome(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithUserHomeDir(ctx, "...")
+	home := UserHomeDir(ctx)
+	assert.Equal(t, "...", home)
+}

--- a/libs/env/loader.go
+++ b/libs/env/loader.go
@@ -1,0 +1,50 @@
+package env
+
+import (
+	"context"
+
+	"github.com/databricks/databricks-sdk-go/config"
+)
+
+// NewConfigLoader creates Databricks SDK Config loader that is aware of env.Set variables:
+//
+//	ctx = env.Set(ctx, "DATABRICKS_WAREHOUSE_ID", "...")
+//
+// Usage:
+//
+//	   &config.Config{
+//			Loaders:    []config.Loader{
+//				env.NewConfigLoader(ctx),
+//				config.ConfigAttributes,
+//				config.ConfigFile,
+//			},
+//		}
+func NewConfigLoader(ctx context.Context) *configLoader {
+	return &configLoader{
+		ctx: ctx,
+	}
+}
+
+type configLoader struct {
+	ctx context.Context
+}
+
+func (le *configLoader) Name() string {
+	return "cli-env"
+}
+
+func (le *configLoader) Configure(cfg *config.Config) error {
+	for _, a := range config.ConfigAttributes {
+		if !a.IsZero(cfg) {
+			continue
+		}
+		for _, k := range a.EnvVars {
+			v := Get(le.ctx, k)
+			if v == "" {
+				continue
+			}
+			a.Set(cfg, v)
+		}
+	}
+	return nil
+}

--- a/libs/env/loader_test.go
+++ b/libs/env/loader_test.go
@@ -1,0 +1,26 @@
+package env
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoader(t *testing.T) {
+	ctx := context.Background()
+	ctx = Set(ctx, "DATABRICKS_WAREHOUSE_ID", "...")
+	ctx = Set(ctx, "DATABRICKS_CONFIG_PROFILE", "...")
+	loader := NewConfigLoader(ctx)
+
+	cfg := &config.Config{
+		Profile: "abc",
+	}
+	err := loader.Configure(cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "...", cfg.WarehouseID)
+	assert.Equal(t, "abc", cfg.Profile)
+	assert.Equal(t, "cli-env", loader.Name())
+}


### PR DESCRIPTION
## Changes
`os.Getenv(..)` is not friendly with `libs/env`. This PR makes the relevant changes to places where we need to read user home directory.

## Tests
Mainly done in https://github.com/databricks/cli/pull/914

