### PR TITLE
Remove validation for default value against pattern

### DIFF
--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -168,11 +168,6 @@ func (schema *Schema) validateSchemaPattern() error {
 			return fmt.Errorf("invalid regex pattern %q provided for property %q: %w", pattern, name, err)
 		}
 
-		// validate default value against the pattern
-		if property.Default != nil && !r.MatchString(property.Default.(string)) {
-			return fmt.Errorf("default value %q for property %q does not match specified regex pattern: %q", property.Default, name, pattern)
-		}
-
 		// validate enum values against the pattern
 		for i, enum := range property.Enum {
 			if !r.MatchString(enum.(string)) {

--- a/libs/jsonschema/schema_test.go
+++ b/libs/jsonschema/schema_test.go
@@ -175,24 +175,13 @@ func TestSchemaValidateIncorrectRegex(t *testing.T) {
 	assert.EqualError(t, s.validate(), "invalid regex pattern \"(abc\" provided for property \"foo\": error parsing regexp: missing closing ): `(abc`")
 }
 
-func TestSchemaValidatePatternDefault(t *testing.T) {
+func TestSchemaDefaultValueIsNotValidatedAgainstPattern(t *testing.T) {
 	s := &Schema{
 		Properties: map[string]*Schema{
 			"foo": {
 				Type:    "string",
 				Pattern: "abc",
 				Default: "def",
-			},
-		},
-	}
-	assert.EqualError(t, s.validate(), "default value \"def\" for property \"foo\" does not match specified regex pattern: \"abc\"")
-
-	s = &Schema{
-		Properties: map[string]*Schema{
-			"foo": {
-				Type:    "string",
-				Pattern: "a.*d",
-				Default: "axyzd",
 			},
 		},
 	}


### PR DESCRIPTION
## Changes
This PR removes validation for default value against the regex pattern specified in a JSON schema at schema load time. This is required because https://github.com/databricks/cli/pull/795 introduces parameterising the default value as a Go text template impling that the default value now does not necessarily have to match the pattern at schema load time.

This will also unblock: https://github.com/databricks/mlops-stacks/pull/108

Note, this does not remove runtime validation for input parameters right before template initialization, which happens here: https://github.com/databricks/cli/blob/fb32e78c9b9fb000ce898b8a60b0b47920f487d3/libs/template/materialize.go#L76

## Tests
Changes to existing test.
