### PR TITLE
Add `--debug` as shortcut for `--log-level debug`

### DIFF
--- a/cmd/root/logger.go
+++ b/cmd/root/logger.go
@@ -142,7 +142,7 @@ func initLogFlags(cmd *cobra.Command) *logFlags {
 	}
 
 	flags := cmd.PersistentFlags()
-	flags.BoolVar(&f.debug, "debug", false, "enable debug logging. Equivalent to `--log-level debug`")
+	flags.BoolVar(&f.debug, "debug", false, "enable debug logging")
 	flags.Var(&f.file, "log-file", "file to write logs to")
 	flags.Var(&f.level, "log-level", "log level")
 	flags.Var(&f.output, "log-format", "log output format (text or json)")


### PR DESCRIPTION
## Changes
This PR exposes simpler interfaces to end users.

## Tests
<img width="724" alt="image" src="https://github.com/databricks/cli/assets/259697/8bd25110-33f0-4197-8f00-2b8198c4aba6">

