### PR TITLE
Hide `--progress-format` global flag

### DIFF
--- a/cmd/root/progress_logger.go
+++ b/cmd/root/progress_logger.go
@@ -56,7 +56,9 @@ func initProgressLoggerFlag(cmd *cobra.Command, logFlags *logFlags) *progressLog
 		f.Set(v)
 	}
 
-	cmd.PersistentFlags().Var(&f.ProgressLogFormat, "progress-format", "format for progress logs (append, inplace, json)")
+	flags := cmd.PersistentFlags()
+	flags.Var(&f.ProgressLogFormat, "progress-format", "format for progress logs (append, inplace, json)")
+	flags.MarkHidden("progress-format")
 	cmd.RegisterFlagCompletionFunc("progress-format", f.ProgressLogFormat.Complete)
 	return &f
 }


### PR DESCRIPTION
## Changes
At the moment, these flags are mostly used for VSCode integration for bundles, but they're not effective for the majority of commands.

## Tests
<img width="559" alt="image" src="https://github.com/databricks/cli/assets/259697/15ddd322-f746-48ad-b1ce-35c55e664a06">


