### PR TITLE
Initialize variable definitions that are defined without properties

### DIFF
--- a/bundle/config/mutator/initialize_variables.go
+++ b/bundle/config/mutator/initialize_variables.go
@@ -1,0 +1,30 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config/variable"
+)
+
+type initializeVariables struct{}
+
+// InitializeVariables initializes nil variables to their corresponding zero values.
+func InitializeVariables() bundle.Mutator {
+	return &initializeVariables{}
+}
+
+func (m *initializeVariables) Name() string {
+	return "InitializeVariables"
+}
+
+func (m *initializeVariables) Apply(ctx context.Context, b *bundle.Bundle) error {
+	vars := b.Config.Variables
+	for k, v := range vars {
+		if v == nil {
+			vars[k] = &variable.Variable{}
+		}
+	}
+
+	return nil
+}

--- a/bundle/config/mutator/initialize_variables_test.go
+++ b/bundle/config/mutator/initialize_variables_test.go
@@ -1,0 +1,42 @@
+package mutator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/config/variable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeVariables(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Variables: map[string]*variable.Variable{
+				"foo": nil,
+				"bar": {
+					Description: "This is a description",
+				},
+			},
+		},
+	}
+	err := bundle.Apply(context.Background(), b, mutator.InitializeVariables())
+	require.NoError(t, err)
+	assert.NotNil(t, b.Config.Variables["foo"])
+	assert.NotNil(t, b.Config.Variables["bar"])
+	assert.Equal(t, "This is a description", b.Config.Variables["bar"].Description)
+}
+
+func TestInitializeVariablesWithoutVariables(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Variables: nil,
+		},
+	}
+	err := bundle.Apply(context.Background(), b, mutator.InitializeVariables())
+	require.NoError(t, err)
+	assert.Nil(t, b.Config.Variables)
+}

--- a/bundle/config/mutator/mutator.go
+++ b/bundle/config/mutator/mutator.go
@@ -10,6 +10,7 @@ func DefaultMutators() []bundle.Mutator {
 	return []bundle.Mutator{
 		scripts.Execute(config.ScriptPreInit),
 		ProcessRootIncludes(),
+		InitializeVariables(),
 		DefineDefaultTarget(),
 		LoadGitDetails(),
 	}

--- a/bundle/tests/variables/without_definition/databricks.yml
+++ b/bundle/tests/variables/without_definition/databricks.yml
@@ -1,0 +1,3 @@
+variables:
+  a:
+  b:

--- a/bundle/tests/variables_test.go
+++ b/bundle/tests/variables_test.go
@@ -92,3 +92,15 @@ func TestVariablesTargetsBlockOverrideWithUndefinedVariables(t *testing.T) {
 		)))
 	assert.ErrorContains(t, err, "variable c is not defined but is assigned a value")
 }
+
+func TestVariablesWithoutDefinition(t *testing.T) {
+	t.Setenv("BUNDLE_VAR_a", "foo")
+	t.Setenv("BUNDLE_VAR_b", "bar")
+	b := load(t, "./variables/without_definition")
+	err := bundle.Apply(context.Background(), b, mutator.SetVariables())
+	require.NoError(t, err)
+	require.True(t, b.Config.Variables["a"].HasValue())
+	require.True(t, b.Config.Variables["b"].HasValue())
+	assert.Equal(t, "foo", *b.Config.Variables["a"].Value)
+	assert.Equal(t, "bar", *b.Config.Variables["b"].Value)
+}


### PR DESCRIPTION
## Changes

We can debate whether or not variable definitions without properties are valid, but in no case should this panic the CLI.

Fixes #934.

## Tests

Unit.