### PR TITLE
Do not allow empty descriptions for bundle template inputs

### DIFF
--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -25,6 +25,13 @@ func newConfig(ctx context.Context, schemaPath string) (*config, error) {
 		return nil, err
 	}
 
+	// Validate that all properties have a description
+	for name, p := range schema.Properties {
+		if p.Description == "" {
+			return nil, fmt.Errorf("template property %s is missing a description", name)
+		}
+	}
+
 	// Do not allow template input variables that are not defined in the schema.
 	schema.AdditionalProperties = false
 

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -189,3 +189,8 @@ func TestAssignDefaultValuesWithTemplatedDefaults(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "my_file", c.values["string_val"])
 }
+
+func TestTemplateSchemaErrorsWithEmptyDescription(t *testing.T) {
+	_, err := newConfig(context.Background(), "./testdata/config-test-schema/invalid-test-schema.json")
+	assert.EqualError(t, err, "template property property-without-description is missing a description")
+}

--- a/libs/template/testdata/config-test-schema/invalid-test-schema.json
+++ b/libs/template/testdata/config-test-schema/invalid-test-schema.json
@@ -1,0 +1,8 @@
+{
+    "properties": {
+        "property-without-description": {
+            "type": "integer",
+            "default": 123
+        }
+    }
+}

--- a/libs/template/testdata/config-test-schema/test-schema.json
+++ b/libs/template/testdata/config-test-schema/test-schema.json
@@ -2,16 +2,20 @@
     "properties": {
         "int_val": {
             "type": "integer",
+            "description": "This is an integer value",
             "default": 123
         },
         "float_val": {
-            "type": "number"
+            "type": "number",
+            "description": "This is a float value"
         },
         "bool_val": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "This is a boolean value"
         },
         "string_val": {
             "type": "string",
+            "description": "This is a string value",
             "default": "{{template \"file_name\"}}"
         }
     }


### PR DESCRIPTION
## Changes
We rely on the descriptions to render the prompts to a user. Thus we should not allow empty descriptions here. Note, both mlops stacks and the default-python template have descriptions for all their properties so this should not be an issue.

## Tests
Unit test
