### PR TITLE
Add versioning for bundle templates

### DIFF
--- a/libs/jsonschema/extension.go
+++ b/libs/jsonschema/extension.go
@@ -26,4 +26,8 @@ type Extension struct {
 	// If the CLI version is less than this value, then validation for this
 	// schema will fail.
 	MinDatabricksCliVersion string `json:"min_databricks_cli_version,omitempty"`
+
+	// Version is the version of the schema. This is used to determine
+	// if the schema is compatible with the current CLI version.
+	Version *int `json:"version,omitempty"`
 }

--- a/libs/jsonschema/extension.go
+++ b/libs/jsonschema/extension.go
@@ -27,7 +27,7 @@ type Extension struct {
 	// schema will fail.
 	MinDatabricksCliVersion string `json:"min_databricks_cli_version,omitempty"`
 
-	// Version is the version of the schema. This is used to determine
-	// if the schema is compatible with the current CLI version.
+	// Version of the schema. This is used to determine if the schema is
+	// compatible with the current CLI version.
 	Version *int `json:"version,omitempty"`
 }

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -9,6 +9,9 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// The latest template schema version supported by the CLI
+const latestSchemaVersion = 1
+
 type config struct {
 	ctx    context.Context
 	values map[string]any
@@ -48,6 +51,9 @@ func validateSchema(schema *jsonschema.Schema) error {
 		if v.Type == jsonschema.ArrayType || v.Type == jsonschema.ObjectType {
 			return fmt.Errorf("property type %s is not supported by bundle templates", v.Type)
 		}
+	}
+	if schema.Version != nil && *schema.Version > latestSchemaVersion {
+		return fmt.Errorf("template schema version %d is not supported by this version of the CLI. Please upgrade your CLI to the latest version", *schema.Version)
 	}
 	return nil
 }

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/databricks/cli/cmd/root"
@@ -148,6 +149,40 @@ func TestTemplateValidateSchema(t *testing.T) {
 
 	err = validateSchema(toSchema("array"))
 	assert.EqualError(t, err, "property type array is not supported by bundle templates")
+}
+
+func TestTemplateValidateSchemaVersion(t *testing.T) {
+	version := latestSchemaVersion
+	schema := jsonschema.Schema{
+		Extension: jsonschema.Extension{
+			Version: &version,
+		},
+	}
+	assert.NoError(t, validateSchema(&schema))
+
+	version = latestSchemaVersion + 1
+	schema = jsonschema.Schema{
+		Extension: jsonschema.Extension{
+			Version: &version,
+		},
+	}
+	assert.EqualError(t, validateSchema(&schema), fmt.Sprintf("template schema version %d is not supported by this version of the CLI. Please upgrade your CLI to the latest version", version))
+
+	version = 5000
+	schema = jsonschema.Schema{
+		Extension: jsonschema.Extension{
+			Version: &version,
+		},
+	}
+	assert.EqualError(t, validateSchema(&schema), "template schema version 5000 is not supported by this version of the CLI. Please upgrade your CLI to the latest version")
+
+	version = 0
+	schema = jsonschema.Schema{
+		Extension: jsonschema.Extension{
+			Version: &version,
+		},
+	}
+	assert.NoError(t, validateSchema(&schema))
 }
 
 func TestTemplateEnumValidation(t *testing.T) {


### PR DESCRIPTION
## Changes
This PR adds versioning for bundle templates. Right now there's only logic for the maximum version of templates supported. At some point in the future if we make a breaking template change we can also include a minimum version of template supported by the CLI.

## Tests
Unit tests.
