### PR TITLE
Make `databricks configure` save only explicit fields

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -111,8 +111,13 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 		}
 
 		if profileName != "" {
-			cfg.Profile = profileName
-			err = databrickscfg.SaveToProfile(ctx, &cfg)
+			err = databrickscfg.SaveToProfile(ctx, &config.Config{
+				Profile: profileName,
+				Host: cfg.Host,
+				AuthType: cfg.AuthType,
+				AccountID: cfg.AccountID,
+				ClusterID: cfg.ClusterID,
+			})
 			if err != nil {
 				return err
 			}

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -112,9 +112,9 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 
 		if profileName != "" {
 			err = databrickscfg.SaveToProfile(ctx, &config.Config{
-				Profile: profileName,
-				Host: cfg.Host,
-				AuthType: cfg.AuthType,
+				Profile:   profileName,
+				Host:      cfg.Host,
+				AuthType:  cfg.AuthType,
 				AccountID: cfg.AccountID,
 				ClusterID: cfg.ClusterID,
 			})

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -160,7 +160,11 @@ func newConfigureCommand() *cobra.Command {
 		cfg.DatabricksCliPath = ""
 
 		// Save profile to config file.
-		return databrickscfg.SaveToProfile(ctx, &cfg)
+		return databrickscfg.SaveToProfile(ctx, &config.Config{
+			Profile: cfg.Profile,
+			Host:    cfg.Host,
+			Token:   cfg.Token,
+		})
 	}
 
 	return cmd

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -145,6 +145,33 @@ func TestEnvVarsConfigureNoInteractive(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestEnvVarsConfigureNoArgsNoInteractive(t *testing.T) {
+	ctx := context.Background()
+	tempHomeDir := setup(t)
+	cfgPath := filepath.Join(tempHomeDir, ".databrickscfg")
+
+	t.Setenv("DATABRICKS_HOST", "https://host")
+	t.Setenv("DATABRICKS_TOKEN", "secret")
+
+	cmd := cmd.New(ctx)
+	cmd.SetArgs([]string{"configure"})
+
+	err := cmd.ExecuteContext(ctx)
+	assert.NoError(t, err)
+
+	_, err = os.Stat(cfgPath)
+	assert.NoError(t, err)
+
+	cfg, err := ini.Load(cfgPath)
+	assert.NoError(t, err)
+
+	defaultSection, err := cfg.GetSection("DEFAULT")
+	assert.NoError(t, err)
+
+	assertKeyValueInSection(t, defaultSection, "host", "https://host")
+	assertKeyValueInSection(t, defaultSection, "token", "secret")
+}
+
 func TestCustomProfileConfigureNoInteractive(t *testing.T) {
 	ctx := context.Background()
 	tempHomeDir := setup(t)

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -145,7 +145,7 @@ func TestEnvVarsConfigureNoInteractive(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestCustomProfileFromEnvConfigureNoInteractive(t *testing.T) {
+func TestCustomProfileConfigureNoInteractive(t *testing.T) {
 	ctx := context.Background()
 	tempHomeDir := setup(t)
 	cfgPath := filepath.Join(tempHomeDir, ".databrickscfg")


### PR DESCRIPTION
## Changes
Save only explicit fields to the config file
This applies to two commands: `configure` and `auth login`. 
The latter only pulls env vars in the case of the `--configure-cluster` flag

## Tests
Manual, plus additional unit test for the `configure` command

