### PR TITLE
Fix integration test asserting errors on unknown template parameters

### DIFF
--- a/internal/testdata/init/field-does-not-exist/databricks_template_schema.json
+++ b/internal/testdata/init/field-does-not-exist/databricks_template_schema.json
@@ -2,7 +2,8 @@
     "properties": {
         "foo": {
             "type": "string",
-            "default": "abc"
+            "default": "abc",
+            "description": "foo-bar"
         }
     }
 }


### PR DESCRIPTION
## Changes
Recent descriptions were made mandatory for input parameters so this test started failing.

## Tests
The test passes now.
