### PR TITLE
Serialise empty files_path and job.relative_path in the deployment metadata

### DIFF
--- a/bundle/metadata/metadata.go
+++ b/bundle/metadata/metadata.go
@@ -11,7 +11,7 @@ type Bundle struct {
 }
 
 type Workspace struct {
-	FilesPath string `json:"file_path,omitempty"`
+	FilesPath string `json:"file_path"`
 }
 
 type Job struct {
@@ -19,7 +19,7 @@ type Job struct {
 
 	// Relative path from the bundle root to the configuration file that holds
 	// the definition of this resource.
-	RelativePath string `json:"relative_path,omitempty"`
+	RelativePath string `json:"relative_path"`
 }
 
 type Resources struct {


### PR DESCRIPTION
## Changes
The Jobs service expects these fields to always be present in the metadata in their validation logic, which is reasonable. This PR removes the omit empty tags so these fields are always uploaded to the workspace `metadata.json` file.