### PR TITLE
Make `file_path` and `artifact_path` fields consistent with json tag

### DIFF
--- a/bundle/artifacts/artifacts.go
+++ b/bundle/artifacts/artifacts.go
@@ -160,7 +160,7 @@ func uploadArtifactFile(ctx context.Context, file string, uploadPath string, cli
 }
 
 func getUploadBasePath(b *bundle.Bundle) (string, error) {
-	artifactPath := b.Config.Workspace.ArtifactsPath
+	artifactPath := b.Config.Workspace.ArtifactPath
 	if artifactPath == "" {
 		return "", fmt.Errorf("remote artifact path not configured")
 	}

--- a/bundle/config/mutator/default_workspace_paths.go
+++ b/bundle/config/mutator/default_workspace_paths.go
@@ -25,12 +25,12 @@ func (m *defineDefaultWorkspacePaths) Apply(ctx context.Context, b *bundle.Bundl
 		return fmt.Errorf("unable to define default workspace paths: workspace root not defined")
 	}
 
-	if b.Config.Workspace.FilesPath == "" {
-		b.Config.Workspace.FilesPath = path.Join(root, "files")
+	if b.Config.Workspace.FilePath == "" {
+		b.Config.Workspace.FilePath = path.Join(root, "files")
 	}
 
-	if b.Config.Workspace.ArtifactsPath == "" {
-		b.Config.Workspace.ArtifactsPath = path.Join(root, "artifacts")
+	if b.Config.Workspace.ArtifactPath == "" {
+		b.Config.Workspace.ArtifactPath = path.Join(root, "artifacts")
 	}
 
 	if b.Config.Workspace.StatePath == "" {

--- a/bundle/config/mutator/default_workspace_paths_test.go
+++ b/bundle/config/mutator/default_workspace_paths_test.go
@@ -21,8 +21,8 @@ func TestDefineDefaultWorkspacePaths(t *testing.T) {
 	}
 	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), bundle)
 	require.NoError(t, err)
-	assert.Equal(t, "/files", bundle.Config.Workspace.FilesPath)
-	assert.Equal(t, "/artifacts", bundle.Config.Workspace.ArtifactsPath)
+	assert.Equal(t, "/files", bundle.Config.Workspace.FilePath)
+	assert.Equal(t, "/artifacts", bundle.Config.Workspace.ArtifactPath)
 	assert.Equal(t, "/state", bundle.Config.Workspace.StatePath)
 }
 
@@ -30,16 +30,16 @@ func TestDefineDefaultWorkspacePathsAlreadySet(t *testing.T) {
 	bundle := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
-				RootPath:      "/",
-				FilesPath:     "/foo/bar",
-				ArtifactsPath: "/foo/bar",
-				StatePath:     "/foo/bar",
+				RootPath:     "/",
+				FilePath:     "/foo/bar",
+				ArtifactPath: "/foo/bar",
+				StatePath:    "/foo/bar",
 			},
 		},
 	}
 	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), bundle)
 	require.NoError(t, err)
-	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.FilesPath)
-	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.ArtifactsPath)
+	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.FilePath)
+	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.ArtifactPath)
 	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.StatePath)
 }

--- a/bundle/config/mutator/process_target_mode.go
+++ b/bundle/config/mutator/process_target_mode.go
@@ -120,11 +120,11 @@ func findIncorrectPath(b *bundle.Bundle, mode config.Mode) string {
 	if strings.Contains(b.Config.Workspace.StatePath, username) != containsExpected {
 		return "state_path"
 	}
-	if strings.Contains(b.Config.Workspace.FilesPath, username) != containsExpected {
-		return "files_path"
+	if strings.Contains(b.Config.Workspace.FilePath, username) != containsExpected {
+		return "file_path"
 	}
-	if strings.Contains(b.Config.Workspace.ArtifactsPath, username) != containsExpected {
-		return "artifacts_path"
+	if strings.Contains(b.Config.Workspace.ArtifactPath, username) != containsExpected {
+		return "artifact_path"
 	}
 	return ""
 }

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -39,9 +39,9 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 						Id:       "1",
 					},
 				},
-				StatePath:     "/Users/lennart@company.com/.bundle/x/y/state",
-				ArtifactsPath: "/Users/lennart@company.com/.bundle/x/y/artifacts",
-				FilesPath:     "/Users/lennart@company.com/.bundle/x/y/files",
+				StatePath:    "/Users/lennart@company.com/.bundle/x/y/state",
+				ArtifactPath: "/Users/lennart@company.com/.bundle/x/y/artifacts",
+				FilePath:     "/Users/lennart@company.com/.bundle/x/y/files",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -190,8 +190,8 @@ func TestProcessTargetModeProduction(t *testing.T) {
 	require.ErrorContains(t, err, "state_path")
 
 	bundle.Config.Workspace.StatePath = "/Shared/.bundle/x/y/state"
-	bundle.Config.Workspace.ArtifactsPath = "/Shared/.bundle/x/y/artifacts"
-	bundle.Config.Workspace.FilesPath = "/Shared/.bundle/x/y/files"
+	bundle.Config.Workspace.ArtifactPath = "/Shared/.bundle/x/y/artifacts"
+	bundle.Config.Workspace.FilePath = "/Shared/.bundle/x/y/files"
 
 	err = validateProductionMode(context.Background(), bundle, false)
 	require.ErrorContains(t, err, "production")

--- a/bundle/config/mutator/trampoline.go
+++ b/bundle/config/mutator/trampoline.go
@@ -90,7 +90,7 @@ func (m *trampoline) generateNotebookWrapper(ctx context.Context, b *bundle.Bund
 	if err != nil {
 		return err
 	}
-	remotePath := path.Join(b.Config.Workspace.FilesPath, filepath.ToSlash(internalDirRel), notebookName)
+	remotePath := path.Join(b.Config.Workspace.FilePath, filepath.ToSlash(internalDirRel), notebookName)
 
 	task.Task.NotebookTask = &jobs.NotebookTask{
 		NotebookPath: remotePath,

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -92,7 +92,7 @@ func (m *translatePaths) rewritePath(
 	}
 
 	// Prefix remote path with its remote root path.
-	remotePath := path.Join(b.Config.Workspace.FilesPath, filepath.ToSlash(localRelPath))
+	remotePath := path.Join(b.Config.Workspace.FilePath, filepath.ToSlash(localRelPath))
 
 	// Convert local path into workspace path via specified function.
 	interp, err := fn(*p, localPath, localRelPath, filepath.ToSlash(remotePath))

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -39,7 +39,7 @@ func TestTranslatePathsSkippedWithGitSource(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -111,7 +111,7 @@ func TestTranslatePaths(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -282,7 +282,7 @@ func TestTranslatePathsInSubdirectories(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -380,7 +380,7 @@ func TestTranslatePathsOutsideBundleRoot(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -539,7 +539,7 @@ func TestJobSparkPythonTaskWithNotebookSourceError(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -574,7 +574,7 @@ func TestJobNotebookTaskWithFileSourceError(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -609,7 +609,7 @@ func TestPipelineNotebookLibraryWithFileSourceError(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
@@ -644,7 +644,7 @@ func TestPipelineFileLibraryWithNotebookSourceError(t *testing.T) {
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
-				FilesPath: "/bundle",
+				FilePath: "/bundle",
 			},
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -52,11 +52,11 @@ type Workspace struct {
 
 	// Remote workspace path to synchronize local files to.
 	// This defaults to "${workspace.root}/files".
-	FilesPath string `json:"file_path,omitempty"`
+	FilePath string `json:"file_path,omitempty"`
 
 	// Remote workspace path for build artifacts.
 	// This defaults to "${workspace.root}/artifacts".
-	ArtifactsPath string `json:"artifact_path,omitempty"`
+	ArtifactPath string `json:"artifact_path,omitempty"`
 
 	// Remote workspace path for deployment state.
 	// This defaults to "${workspace.root}/state".

--- a/bundle/deploy/files/sync.go
+++ b/bundle/deploy/files/sync.go
@@ -21,7 +21,7 @@ func getSync(ctx context.Context, b *bundle.Bundle) (*sync.Sync, error) {
 
 	opts := sync.SyncOptions{
 		LocalPath:  b.Config.Path,
-		RemotePath: b.Config.Workspace.FilesPath,
+		RemotePath: b.Config.Workspace.FilePath,
 		Include:    includes,
 		Exclude:    b.Config.Sync.Exclude,
 

--- a/bundle/deploy/files/upload.go
+++ b/bundle/deploy/files/upload.go
@@ -26,7 +26,7 @@ func (m *upload) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	cmdio.LogString(ctx, fmt.Sprintf("Uploaded bundle files at %s!\n", b.Config.Workspace.FilesPath))
+	cmdio.LogString(ctx, fmt.Sprintf("Uploaded bundle files at %s!\n", b.Config.Workspace.FilePath))
 	return nil
 }
 

--- a/bundle/deploy/metadata/compute.go
+++ b/bundle/deploy/metadata/compute.go
@@ -46,6 +46,6 @@ func (m *compute) Apply(_ context.Context, b *bundle.Bundle) error {
 	b.Metadata.Config.Resources.Jobs = jobsMetadata
 
 	// Set file upload destination of the bundle in metadata
-	b.Metadata.Config.Workspace.FilesPath = b.Config.Workspace.FilesPath
+	b.Metadata.Config.Workspace.FilePath = b.Config.Workspace.FilePath
 	return nil
 }

--- a/bundle/deploy/metadata/compute_test.go
+++ b/bundle/deploy/metadata/compute_test.go
@@ -18,9 +18,9 @@ func TestComputeMetadataMutator(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
-				RootPath:      "/Users/shreyas.goenka@databricks.com",
-				ArtifactsPath: "/Users/shreyas.goenka@databricks.com/artifacts",
-				FilesPath:     "/Users/shreyas.goenka@databricks.com/files",
+				RootPath:     "/Users/shreyas.goenka@databricks.com",
+				ArtifactPath: "/Users/shreyas.goenka@databricks.com/artifacts",
+				FilePath:     "/Users/shreyas.goenka@databricks.com/files",
 			},
 			Bundle: config.Bundle{
 				Name:   "my-bundle",
@@ -68,7 +68,7 @@ func TestComputeMetadataMutator(t *testing.T) {
 		Version: metadata.Version,
 		Config: metadata.Config{
 			Workspace: metadata.Workspace{
-				FilesPath: "/Users/shreyas.goenka@databricks.com/files",
+				FilePath: "/Users/shreyas.goenka@databricks.com/files",
 			},
 			Bundle: metadata.Bundle{
 				Git: config.Git{

--- a/bundle/metadata/metadata.go
+++ b/bundle/metadata/metadata.go
@@ -11,7 +11,7 @@ type Bundle struct {
 }
 
 type Workspace struct {
-	FilesPath string `json:"file_path"`
+	FilePath string `json:"file_path"`
 }
 
 type Job struct {

--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -30,7 +30,7 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) 
 
 	opts := sync.SyncOptions{
 		LocalPath:    b.Config.Path,
-		RemotePath:   b.Config.Workspace.FilesPath,
+		RemotePath:   b.Config.Workspace.FilePath,
 		Include:      includes,
 		Exclude:      b.Config.Sync.Exclude,
 		Full:         f.full,

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -41,7 +41,7 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 
 	opts := sync.SyncOptions{
 		LocalPath:    b.Config.Path,
-		RemotePath:   b.Config.Workspace.FilesPath,
+		RemotePath:   b.Config.Workspace.FilePath,
 		Include:      includes,
 		Exclude:      b.Config.Sync.Exclude,
 		Full:         f.full,

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -24,7 +24,7 @@ func TestSyncOptionsFromBundle(t *testing.T) {
 			},
 
 			Workspace: config.Workspace{
-				FilesPath: "/Users/jane@doe.com/path",
+				FilePath: "/Users/jane@doe.com/path",
 			},
 		},
 	}

--- a/internal/bundle/artifacts_test.go
+++ b/internal/bundle/artifacts_test.go
@@ -54,7 +54,7 @@ func TestAccUploadArtifactFileToCorrectRemotePath(t *testing.T) {
 				Target: "whatever",
 			},
 			Workspace: config.Workspace{
-				ArtifactsPath: wsDir,
+				ArtifactPath: wsDir,
 			},
 			Artifacts: config.Artifacts{
 				"test": artifact,

--- a/internal/bundle/job_metadata_test.go
+++ b/internal/bundle/job_metadata_test.go
@@ -83,7 +83,7 @@ func TestAccJobsMetadataFile(t *testing.T) {
 				},
 			},
 			Workspace: metadata.Workspace{
-				FilesPath: path.Join(root, "files"),
+				FilePath: path.Join(root, "files"),
 			},
 			Resources: metadata.Resources{
 				Jobs: map[string]*metadata.Job{


### PR DESCRIPTION
## Changes
This PR:
1. Renames `FilesPath` -> `FilePath` and `ArtifactsPath` -> `ArtifactPath` in the bundle and metadata configuration to make them consistant with the json tags.
2. Fixes development / production mode error messages to point to `file_path` and `artifact_path`

## Tests
Existing unit tests. This is a strightforward renaming of the fields. 