### PR TITLE
Rename variable `bundle -> b`

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -63,7 +63,7 @@ type Bundle struct {
 }
 
 func Load(ctx context.Context, path string) (*Bundle, error) {
-	bundle := &Bundle{}
+	b := &Bundle{}
 	stat, err := os.Stat(path)
 	if err != nil {
 		return nil, err
@@ -74,13 +74,13 @@ func Load(ctx context.Context, path string) (*Bundle, error) {
 		_, hasIncludesEnv := env.Includes(ctx)
 		if hasRootEnv && hasIncludesEnv && stat.IsDir() {
 			log.Debugf(ctx, "No bundle configuration; using bundle root: %s", path)
-			bundle.Config = config.Root{
+			b.Config = config.Root{
 				Path: path,
 				Bundle: config.Bundle{
 					Name: filepath.Base(path),
 				},
 			}
-			return bundle, nil
+			return b, nil
 		}
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func Load(ctx context.Context, path string) (*Bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	bundle.Config = *root
-	return bundle, nil
+	b.Config = *root
+	return b, nil
 }
 
 // MustLoad returns a bundle configuration.

--- a/bundle/config/mutator/default_target_test.go
+++ b/bundle/config/mutator/default_target_test.go
@@ -12,24 +12,24 @@ import (
 )
 
 func TestDefaultTarget(t *testing.T) {
-	bundle := &bundle.Bundle{}
-	err := mutator.DefineDefaultTarget().Apply(context.Background(), bundle)
+	b := &bundle.Bundle{}
+	err := mutator.DefineDefaultTarget().Apply(context.Background(), b)
 	require.NoError(t, err)
-	env, ok := bundle.Config.Targets["default"]
+	env, ok := b.Config.Targets["default"]
 	assert.True(t, ok)
 	assert.Equal(t, &config.Target{}, env)
 }
 
 func TestDefaultTargetAlreadySpecified(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"development": {},
 			},
 		},
 	}
-	err := mutator.DefineDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.DefineDefaultTarget().Apply(context.Background(), b)
 	require.NoError(t, err)
-	_, ok := bundle.Config.Targets["default"]
+	_, ok := b.Config.Targets["default"]
 	assert.False(t, ok)
 }

--- a/bundle/config/mutator/default_workspace_paths_test.go
+++ b/bundle/config/mutator/default_workspace_paths_test.go
@@ -12,22 +12,22 @@ import (
 )
 
 func TestDefineDefaultWorkspacePaths(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				RootPath: "/",
 			},
 		},
 	}
-	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), bundle)
+	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "/files", bundle.Config.Workspace.FilesPath)
-	assert.Equal(t, "/artifacts", bundle.Config.Workspace.ArtifactsPath)
-	assert.Equal(t, "/state", bundle.Config.Workspace.StatePath)
+	assert.Equal(t, "/files", b.Config.Workspace.FilesPath)
+	assert.Equal(t, "/artifacts", b.Config.Workspace.ArtifactsPath)
+	assert.Equal(t, "/state", b.Config.Workspace.StatePath)
 }
 
 func TestDefineDefaultWorkspacePathsAlreadySet(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				RootPath:      "/",
@@ -37,9 +37,9 @@ func TestDefineDefaultWorkspacePathsAlreadySet(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), bundle)
+	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.FilesPath)
-	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.ArtifactsPath)
-	assert.Equal(t, "/foo/bar", bundle.Config.Workspace.StatePath)
+	assert.Equal(t, "/foo/bar", b.Config.Workspace.FilesPath)
+	assert.Equal(t, "/foo/bar", b.Config.Workspace.ArtifactsPath)
+	assert.Equal(t, "/foo/bar", b.Config.Workspace.StatePath)
 }

--- a/bundle/config/mutator/default_workspace_root_test.go
+++ b/bundle/config/mutator/default_workspace_root_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDefaultWorkspaceRoot(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Name:   "name",
@@ -20,7 +20,7 @@ func TestDefaultWorkspaceRoot(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.DefineDefaultWorkspaceRoot().Apply(context.Background(), bundle)
+	err := mutator.DefineDefaultWorkspaceRoot().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "~/.bundle/name/environment", bundle.Config.Workspace.RootPath)
+	assert.Equal(t, "~/.bundle/name/environment", b.Config.Workspace.RootPath)
 }

--- a/bundle/config/mutator/expand_workspace_root_test.go
+++ b/bundle/config/mutator/expand_workspace_root_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestExpandWorkspaceRoot(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				CurrentUser: &config.User{
@@ -25,13 +25,13 @@ func TestExpandWorkspaceRoot(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), bundle)
+	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "/Users/jane@doe.com/foo", bundle.Config.Workspace.RootPath)
+	assert.Equal(t, "/Users/jane@doe.com/foo", b.Config.Workspace.RootPath)
 }
 
 func TestExpandWorkspaceRootDoesNothing(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				CurrentUser: &config.User{
@@ -43,13 +43,13 @@ func TestExpandWorkspaceRootDoesNothing(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), bundle)
+	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "/Users/charly@doe.com/foo", bundle.Config.Workspace.RootPath)
+	assert.Equal(t, "/Users/charly@doe.com/foo", b.Config.Workspace.RootPath)
 }
 
 func TestExpandWorkspaceRootWithoutRoot(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				CurrentUser: &config.User{
@@ -60,18 +60,18 @@ func TestExpandWorkspaceRootWithoutRoot(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), bundle)
+	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
 	require.Error(t, err)
 }
 
 func TestExpandWorkspaceRootWithoutCurrentUser(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				RootPath: "~/foo",
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), bundle)
+	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
 	require.Error(t, err)
 }

--- a/bundle/config/mutator/override_compute_test.go
+++ b/bundle/config/mutator/override_compute_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestOverrideDevelopment(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "")
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Mode:      config.Development,
@@ -47,22 +47,22 @@ func TestOverrideDevelopment(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Nil(t, bundle.Config.Resources.Jobs["job1"].Tasks[0].NewCluster)
-	assert.Equal(t, "newClusterID", bundle.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
-	assert.Equal(t, "newClusterID", bundle.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
-	assert.Equal(t, "newClusterID", bundle.Config.Resources.Jobs["job1"].Tasks[2].ExistingClusterId)
-	assert.Equal(t, "newClusterID", bundle.Config.Resources.Jobs["job1"].Tasks[3].ExistingClusterId)
+	assert.Nil(t, b.Config.Resources.Jobs["job1"].Tasks[0].NewCluster)
+	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
+	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
+	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[2].ExistingClusterId)
+	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[3].ExistingClusterId)
 
-	assert.Nil(t, bundle.Config.Resources.Jobs["job1"].Tasks[0].NewCluster)
-	assert.Empty(t, bundle.Config.Resources.Jobs["job1"].Tasks[2].ComputeKey)
-	assert.Empty(t, bundle.Config.Resources.Jobs["job1"].Tasks[3].JobClusterKey)
+	assert.Nil(t, b.Config.Resources.Jobs["job1"].Tasks[0].NewCluster)
+	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[2].ComputeKey)
+	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[3].JobClusterKey)
 }
 
 func TestOverrideDevelopmentEnv(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "newClusterId")
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -83,14 +83,14 @@ func TestOverrideDevelopmentEnv(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "cluster2", bundle.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
+	assert.Equal(t, "cluster2", b.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
 }
 
 func TestOverridePipelineTask(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "newClusterId")
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -108,13 +108,13 @@ func TestOverridePipelineTask(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Empty(t, bundle.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
+	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
 }
 
 func TestOverrideProduction(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
 				ComputeID: "newClusterID",
@@ -138,13 +138,13 @@ func TestOverrideProduction(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.Error(t, err)
 }
 
 func TestOverrideProductionEnv(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "newClusterId")
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -165,6 +165,6 @@ func TestOverrideProductionEnv(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
 }

--- a/bundle/config/mutator/process_include_test.go
+++ b/bundle/config/mutator/process_include_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestProcessInclude(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: t.TempDir(),
 			Workspace: config.Workspace{
@@ -25,14 +25,14 @@ func TestProcessInclude(t *testing.T) {
 	}
 
 	relPath := "./file.yml"
-	fullPath := filepath.Join(bundle.Config.Path, relPath)
+	fullPath := filepath.Join(b.Config.Path, relPath)
 	f, err := os.Create(fullPath)
 	require.NoError(t, err)
 	fmt.Fprint(f, "workspace:\n  host: bar\n")
 	f.Close()
 
-	assert.Equal(t, "foo", bundle.Config.Workspace.Host)
-	err = mutator.ProcessInclude(fullPath, relPath).Apply(context.Background(), bundle)
+	assert.Equal(t, "foo", b.Config.Workspace.Host)
+	err = mutator.ProcessInclude(fullPath, relPath).Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "bar", bundle.Config.Workspace.Host)
+	assert.Equal(t, "bar", b.Config.Workspace.Host)
 }

--- a/bundle/config/mutator/process_root_includes_test.go
+++ b/bundle/config/mutator/process_root_includes_test.go
@@ -24,12 +24,12 @@ func touch(t *testing.T, path, file string) {
 }
 
 func TestProcessRootIncludesEmpty(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: ".",
 		},
 	}
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.NoError(t, err)
 }
 
@@ -41,7 +41,7 @@ func TestProcessRootIncludesAbs(t *testing.T) {
 		t.Skip("skipping temperorilty to make windows unit tests green")
 	}
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: ".",
 			Include: []string{
@@ -49,13 +49,13 @@ func TestProcessRootIncludesAbs(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be relative paths")
 }
 
 func TestProcessRootIncludesSingleGlob(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: t.TempDir(),
 			Include: []string{
@@ -64,18 +64,18 @@ func TestProcessRootIncludesSingleGlob(t *testing.T) {
 		},
 	}
 
-	touch(t, bundle.Config.Path, "databricks.yml")
-	touch(t, bundle.Config.Path, "a.yml")
-	touch(t, bundle.Config.Path, "b.yml")
+	touch(t, b.Config.Path, "databricks.yml")
+	touch(t, b.Config.Path, "a.yml")
+	touch(t, b.Config.Path, "b.yml")
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"a.yml", "b.yml"}, bundle.Config.Include)
+	assert.Equal(t, []string{"a.yml", "b.yml"}, b.Config.Include)
 }
 
 func TestProcessRootIncludesMultiGlob(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: t.TempDir(),
 			Include: []string{
@@ -85,17 +85,17 @@ func TestProcessRootIncludesMultiGlob(t *testing.T) {
 		},
 	}
 
-	touch(t, bundle.Config.Path, "a1.yml")
-	touch(t, bundle.Config.Path, "b1.yml")
+	touch(t, b.Config.Path, "a1.yml")
+	touch(t, b.Config.Path, "b1.yml")
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"a1.yml", "b1.yml"}, bundle.Config.Include)
+	assert.Equal(t, []string{"a1.yml", "b1.yml"}, b.Config.Include)
 }
 
 func TestProcessRootIncludesRemoveDups(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: t.TempDir(),
 			Include: []string{
@@ -105,15 +105,15 @@ func TestProcessRootIncludesRemoveDups(t *testing.T) {
 		},
 	}
 
-	touch(t, bundle.Config.Path, "a.yml")
+	touch(t, b.Config.Path, "a.yml")
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, []string{"a.yml"}, bundle.Config.Include)
+	assert.Equal(t, []string{"a.yml"}, b.Config.Include)
 }
 
 func TestProcessRootIncludesNotExists(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: t.TempDir(),
 			Include: []string{
@@ -121,7 +121,7 @@ func TestProcessRootIncludesNotExists(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "notexist.yml defined in 'include' section does not match any files")
 }
@@ -132,15 +132,15 @@ func TestProcessRootIncludesExtrasFromEnvVar(t *testing.T) {
 	touch(t, rootPath, testYamlName)
 	t.Setenv(env.IncludesVariable, path.Join(rootPath, testYamlName))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: rootPath,
 		},
 	}
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Contains(t, bundle.Config.Include, testYamlName)
+	assert.Contains(t, b.Config.Include, testYamlName)
 }
 
 func TestProcessRootIncludesDedupExtrasFromEnvVar(t *testing.T) {
@@ -155,13 +155,13 @@ func TestProcessRootIncludesDedupExtrasFromEnvVar(t *testing.T) {
 		string(os.PathListSeparator),
 	))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: rootPath,
 		},
 	}
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), bundle)
+	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, []string{testYamlName}, bundle.Config.Include)
+	assert.Equal(t, []string{testYamlName}, b.Config.Include)
 }

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -89,111 +89,111 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 }
 
 func TestProcessTargetModeDevelopment(t *testing.T) {
-	bundle := mockBundle(config.Development)
+	b := mockBundle(config.Development)
 
 	m := ProcessTargetMode()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	// Job 1
-	assert.Equal(t, "[dev lennart] job1", bundle.Config.Resources.Jobs["job1"].Name)
-	assert.Equal(t, bundle.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
-	assert.Equal(t, bundle.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
+	assert.Equal(t, "[dev lennart] job1", b.Config.Resources.Jobs["job1"].Name)
+	assert.Equal(t, b.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
+	assert.Equal(t, b.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
 
 	// Job 2
-	assert.Equal(t, "[dev lennart] job2", bundle.Config.Resources.Jobs["job2"].Name)
-	assert.Equal(t, bundle.Config.Resources.Jobs["job2"].Tags["dev"], "lennart")
-	assert.Equal(t, bundle.Config.Resources.Jobs["job2"].Schedule.PauseStatus, jobs.PauseStatusUnpaused)
+	assert.Equal(t, "[dev lennart] job2", b.Config.Resources.Jobs["job2"].Name)
+	assert.Equal(t, b.Config.Resources.Jobs["job2"].Tags["dev"], "lennart")
+	assert.Equal(t, b.Config.Resources.Jobs["job2"].Schedule.PauseStatus, jobs.PauseStatusUnpaused)
 
 	// Pipeline 1
-	assert.Equal(t, "[dev lennart] pipeline1", bundle.Config.Resources.Pipelines["pipeline1"].Name)
-	assert.True(t, bundle.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
+	assert.Equal(t, "[dev lennart] pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
+	assert.True(t, b.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
 
 	// Experiment 1
-	assert.Equal(t, "/Users/lennart.kats@databricks.com/[dev lennart] experiment1", bundle.Config.Resources.Experiments["experiment1"].Name)
-	assert.Contains(t, bundle.Config.Resources.Experiments["experiment1"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
-	assert.Equal(t, "dev", bundle.Config.Resources.Experiments["experiment1"].Experiment.Tags[0].Key)
+	assert.Equal(t, "/Users/lennart.kats@databricks.com/[dev lennart] experiment1", b.Config.Resources.Experiments["experiment1"].Name)
+	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
+	assert.Equal(t, "dev", b.Config.Resources.Experiments["experiment1"].Experiment.Tags[0].Key)
 
 	// Experiment 2
-	assert.Equal(t, "[dev lennart] experiment2", bundle.Config.Resources.Experiments["experiment2"].Name)
-	assert.Contains(t, bundle.Config.Resources.Experiments["experiment2"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
+	assert.Equal(t, "[dev lennart] experiment2", b.Config.Resources.Experiments["experiment2"].Name)
+	assert.Contains(t, b.Config.Resources.Experiments["experiment2"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
 
 	// Model 1
-	assert.Equal(t, "[dev lennart] model1", bundle.Config.Resources.Models["model1"].Name)
+	assert.Equal(t, "[dev lennart] model1", b.Config.Resources.Models["model1"].Name)
 
 	// Model serving endpoint 1
-	assert.Equal(t, "dev_lennart_servingendpoint1", bundle.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
+	assert.Equal(t, "dev_lennart_servingendpoint1", b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
 
 	// Registered model 1
-	assert.Equal(t, "dev_lennart_registeredmodel1", bundle.Config.Resources.RegisteredModels["registeredmodel1"].Name)
+	assert.Equal(t, "dev_lennart_registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 }
 
 func TestProcessTargetModeDevelopmentTagNormalizationForAws(t *testing.T) {
-	bundle := mockBundle(config.Development)
-	bundle.Tagging = tags.ForCloud(&sdkconfig.Config{
+	b := mockBundle(config.Development)
+	b.Tagging = tags.ForCloud(&sdkconfig.Config{
 		Host: "https://dbc-XXXXXXXX-YYYY.cloud.databricks.com/",
 	})
 
-	bundle.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
-	err := ProcessTargetMode().Apply(context.Background(), bundle)
+	b.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
+	err := ProcessTargetMode().Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	// Assert that tag normalization took place.
-	assert.Equal(t, "Hello world__", bundle.Config.Resources.Jobs["job1"].Tags["dev"])
+	assert.Equal(t, "Hello world__", b.Config.Resources.Jobs["job1"].Tags["dev"])
 }
 
 func TestProcessTargetModeDevelopmentTagNormalizationForAzure(t *testing.T) {
-	bundle := mockBundle(config.Development)
-	bundle.Tagging = tags.ForCloud(&sdkconfig.Config{
+	b := mockBundle(config.Development)
+	b.Tagging = tags.ForCloud(&sdkconfig.Config{
 		Host: "https://adb-xxx.y.azuredatabricks.net/",
 	})
 
-	bundle.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
-	err := ProcessTargetMode().Apply(context.Background(), bundle)
+	b.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
+	err := ProcessTargetMode().Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	// Assert that tag normalization took place (Azure allows more characters than AWS).
-	assert.Equal(t, "Héllö wörld?!", bundle.Config.Resources.Jobs["job1"].Tags["dev"])
+	assert.Equal(t, "Héllö wörld?!", b.Config.Resources.Jobs["job1"].Tags["dev"])
 }
 
 func TestProcessTargetModeDevelopmentTagNormalizationForGcp(t *testing.T) {
-	bundle := mockBundle(config.Development)
-	bundle.Tagging = tags.ForCloud(&sdkconfig.Config{
+	b := mockBundle(config.Development)
+	b.Tagging = tags.ForCloud(&sdkconfig.Config{
 		Host: "https://123.4.gcp.databricks.com/",
 	})
 
-	bundle.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
-	err := ProcessTargetMode().Apply(context.Background(), bundle)
+	b.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
+	err := ProcessTargetMode().Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	// Assert that tag normalization took place.
-	assert.Equal(t, "Hello_world", bundle.Config.Resources.Jobs["job1"].Tags["dev"])
+	assert.Equal(t, "Hello_world", b.Config.Resources.Jobs["job1"].Tags["dev"])
 }
 
 func TestProcessTargetModeDefault(t *testing.T) {
-	bundle := mockBundle("")
+	b := mockBundle("")
 
 	m := ProcessTargetMode()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "job1", bundle.Config.Resources.Jobs["job1"].Name)
-	assert.Equal(t, "pipeline1", bundle.Config.Resources.Pipelines["pipeline1"].Name)
-	assert.False(t, bundle.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
-	assert.Equal(t, "servingendpoint1", bundle.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
-	assert.Equal(t, "registeredmodel1", bundle.Config.Resources.RegisteredModels["registeredmodel1"].Name)
+	assert.Equal(t, "job1", b.Config.Resources.Jobs["job1"].Name)
+	assert.Equal(t, "pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
+	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
+	assert.Equal(t, "servingendpoint1", b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
+	assert.Equal(t, "registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 }
 
 func TestProcessTargetModeProduction(t *testing.T) {
-	bundle := mockBundle(config.Production)
+	b := mockBundle(config.Production)
 
-	err := validateProductionMode(context.Background(), bundle, false)
+	err := validateProductionMode(context.Background(), b, false)
 	require.ErrorContains(t, err, "state_path")
 
-	bundle.Config.Workspace.StatePath = "/Shared/.bundle/x/y/state"
-	bundle.Config.Workspace.ArtifactsPath = "/Shared/.bundle/x/y/artifacts"
-	bundle.Config.Workspace.FilesPath = "/Shared/.bundle/x/y/files"
+	b.Config.Workspace.StatePath = "/Shared/.bundle/x/y/state"
+	b.Config.Workspace.ArtifactsPath = "/Shared/.bundle/x/y/artifacts"
+	b.Config.Workspace.FilesPath = "/Shared/.bundle/x/y/files"
 
-	err = validateProductionMode(context.Background(), bundle, false)
+	err = validateProductionMode(context.Background(), b, false)
 	require.ErrorContains(t, err, "production")
 
 	permissions := []resources.Permission{
@@ -202,41 +202,41 @@ func TestProcessTargetModeProduction(t *testing.T) {
 			UserName: "user@company.com",
 		},
 	}
-	bundle.Config.Resources.Jobs["job1"].Permissions = permissions
-	bundle.Config.Resources.Jobs["job1"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
-	bundle.Config.Resources.Jobs["job2"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
-	bundle.Config.Resources.Pipelines["pipeline1"].Permissions = permissions
-	bundle.Config.Resources.Experiments["experiment1"].Permissions = permissions
-	bundle.Config.Resources.Experiments["experiment2"].Permissions = permissions
-	bundle.Config.Resources.Models["model1"].Permissions = permissions
-	bundle.Config.Resources.ModelServingEndpoints["servingendpoint1"].Permissions = permissions
+	b.Config.Resources.Jobs["job1"].Permissions = permissions
+	b.Config.Resources.Jobs["job1"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
+	b.Config.Resources.Jobs["job2"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
+	b.Config.Resources.Pipelines["pipeline1"].Permissions = permissions
+	b.Config.Resources.Experiments["experiment1"].Permissions = permissions
+	b.Config.Resources.Experiments["experiment2"].Permissions = permissions
+	b.Config.Resources.Models["model1"].Permissions = permissions
+	b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Permissions = permissions
 
-	err = validateProductionMode(context.Background(), bundle, false)
+	err = validateProductionMode(context.Background(), b, false)
 	require.NoError(t, err)
 
-	assert.Equal(t, "job1", bundle.Config.Resources.Jobs["job1"].Name)
-	assert.Equal(t, "pipeline1", bundle.Config.Resources.Pipelines["pipeline1"].Name)
-	assert.False(t, bundle.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
-	assert.Equal(t, "servingendpoint1", bundle.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
-	assert.Equal(t, "registeredmodel1", bundle.Config.Resources.RegisteredModels["registeredmodel1"].Name)
+	assert.Equal(t, "job1", b.Config.Resources.Jobs["job1"].Name)
+	assert.Equal(t, "pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
+	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].PipelineSpec.Development)
+	assert.Equal(t, "servingendpoint1", b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
+	assert.Equal(t, "registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 }
 
 func TestProcessTargetModeProductionOkForPrincipal(t *testing.T) {
-	bundle := mockBundle(config.Production)
+	b := mockBundle(config.Production)
 
 	// Our target has all kinds of problems when not using service principals ...
-	err := validateProductionMode(context.Background(), bundle, false)
+	err := validateProductionMode(context.Background(), b, false)
 	require.Error(t, err)
 
 	// ... but we're much less strict when a principal is used
-	err = validateProductionMode(context.Background(), bundle, true)
+	err = validateProductionMode(context.Background(), b, true)
 	require.NoError(t, err)
 }
 
 // Make sure that we have test coverage for all resource types
 func TestAllResourcesMocked(t *testing.T) {
-	bundle := mockBundle(config.Development)
-	resources := reflect.ValueOf(bundle.Config.Resources)
+	b := mockBundle(config.Development)
+	resources := reflect.ValueOf(b.Config.Resources)
 
 	for i := 0; i < resources.NumField(); i++ {
 		field := resources.Field(i)
@@ -253,11 +253,11 @@ func TestAllResourcesMocked(t *testing.T) {
 
 // Make sure that we at least rename all resources
 func TestAllResourcesRenamed(t *testing.T) {
-	bundle := mockBundle(config.Development)
-	resources := reflect.ValueOf(bundle.Config.Resources)
+	b := mockBundle(config.Development)
+	resources := reflect.ValueOf(b.Config.Resources)
 
 	m := ProcessTargetMode()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	for i := 0; i < resources.NumField(); i++ {

--- a/bundle/config/mutator/select_default_target_test.go
+++ b/bundle/config/mutator/select_default_target_test.go
@@ -11,30 +11,30 @@ import (
 )
 
 func TestSelectDefaultTargetNoTargets(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, "no targets defined")
 }
 
 func TestSelectDefaultTargetSingleTargets(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"foo": {},
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
 	assert.NoError(t, err)
-	assert.Equal(t, "foo", bundle.Config.Bundle.Target)
+	assert.Equal(t, "foo", b.Config.Bundle.Target)
 }
 
 func TestSelectDefaultTargetNoDefaults(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"foo": {},
@@ -43,12 +43,12 @@ func TestSelectDefaultTargetNoDefaults(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, "please specify target")
 }
 
 func TestSelectDefaultTargetNoDefaultsWithNil(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"foo": nil,
@@ -56,12 +56,12 @@ func TestSelectDefaultTargetNoDefaultsWithNil(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, "please specify target")
 }
 
 func TestSelectDefaultTargetMultipleDefaults(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"foo": {Default: true},
@@ -70,12 +70,12 @@ func TestSelectDefaultTargetMultipleDefaults(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, "multiple targets are marked as default")
 }
 
 func TestSelectDefaultTargetSingleDefault(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"foo": {},
@@ -84,7 +84,7 @@ func TestSelectDefaultTargetSingleDefault(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), bundle)
+	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
 	assert.NoError(t, err)
-	assert.Equal(t, "bar", bundle.Config.Bundle.Target)
+	assert.Equal(t, "bar", b.Config.Bundle.Target)
 }

--- a/bundle/config/mutator/select_target_test.go
+++ b/bundle/config/mutator/select_target_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSelectTarget(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
 				Host: "foo",
@@ -26,19 +26,19 @@ func TestSelectTarget(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectTarget("default").Apply(context.Background(), bundle)
+	err := mutator.SelectTarget("default").Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "bar", bundle.Config.Workspace.Host)
+	assert.Equal(t, "bar", b.Config.Workspace.Host)
 }
 
 func TestSelectTargetNotFound(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Targets: map[string]*config.Target{
 				"default": {},
 			},
 		},
 	}
-	err := mutator.SelectTarget("doesnt-exist").Apply(context.Background(), bundle)
+	err := mutator.SelectTarget("doesnt-exist").Apply(context.Background(), b)
 	require.Error(t, err, "no targets defined")
 }

--- a/bundle/config/mutator/set_variables_test.go
+++ b/bundle/config/mutator/set_variables_test.go
@@ -87,7 +87,7 @@ func TestSetVariablesMutator(t *testing.T) {
 	defaultValForA := "default-a"
 	defaultValForB := "default-b"
 	valForC := "assigned-val-c"
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Variables: map[string]*variable.Variable{
 				"a": {
@@ -108,9 +108,9 @@ func TestSetVariablesMutator(t *testing.T) {
 
 	t.Setenv("BUNDLE_VAR_b", "env-var-b")
 
-	err := SetVariables().Apply(context.Background(), bundle)
+	err := SetVariables().Apply(context.Background(), b)
 	require.NoError(t, err)
-	assert.Equal(t, "default-a", *bundle.Config.Variables["a"].Value)
-	assert.Equal(t, "env-var-b", *bundle.Config.Variables["b"].Value)
-	assert.Equal(t, "assigned-val-c", *bundle.Config.Variables["c"].Value)
+	assert.Equal(t, "default-a", *b.Config.Variables["a"].Value)
+	assert.Equal(t, "env-var-b", *b.Config.Variables["b"].Value)
+	assert.Equal(t, "assigned-val-c", *b.Config.Variables["c"].Value)
 }

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -35,7 +35,7 @@ func touchEmptyFile(t *testing.T, path string) {
 
 func TestTranslatePathsSkippedWithGitSource(t *testing.T) {
 	dir := t.TempDir()
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -80,23 +80,23 @@ func TestTranslatePathsSkippedWithGitSource(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	assert.Equal(
 		t,
 		"my_job_notebook.py",
-		bundle.Config.Resources.Jobs["job"].Tasks[0].NotebookTask.NotebookPath,
+		b.Config.Resources.Jobs["job"].Tasks[0].NotebookTask.NotebookPath,
 	)
 	assert.Equal(
 		t,
 		"foo",
-		bundle.Config.Resources.Jobs["job"].Tasks[1].PythonWheelTask.PackageName,
+		b.Config.Resources.Jobs["job"].Tasks[1].PythonWheelTask.PackageName,
 	)
 	assert.Equal(
 		t,
 		"my_python_file.py",
-		bundle.Config.Resources.Jobs["job"].Tasks[2].SparkPythonTask.PythonFile,
+		b.Config.Resources.Jobs["job"].Tasks[2].SparkPythonTask.PythonFile,
 	)
 }
 
@@ -107,7 +107,7 @@ func TestTranslatePaths(t *testing.T) {
 	touchEmptyFile(t, filepath.Join(dir, "my_python_file.py"))
 	touchEmptyFile(t, filepath.Join(dir, "dist", "task.jar"))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -207,66 +207,66 @@ func TestTranslatePaths(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	// Assert that the path in the tasks now refer to the artifact.
 	assert.Equal(
 		t,
 		"/bundle/my_job_notebook",
-		bundle.Config.Resources.Jobs["job"].Tasks[0].NotebookTask.NotebookPath,
+		b.Config.Resources.Jobs["job"].Tasks[0].NotebookTask.NotebookPath,
 	)
 	assert.Equal(
 		t,
 		filepath.Join("dist", "task.whl"),
-		bundle.Config.Resources.Jobs["job"].Tasks[0].Libraries[0].Whl,
+		b.Config.Resources.Jobs["job"].Tasks[0].Libraries[0].Whl,
 	)
 	assert.Equal(
 		t,
 		"/Users/jane.doe@databricks.com/doesnt_exist.py",
-		bundle.Config.Resources.Jobs["job"].Tasks[1].NotebookTask.NotebookPath,
+		b.Config.Resources.Jobs["job"].Tasks[1].NotebookTask.NotebookPath,
 	)
 	assert.Equal(
 		t,
 		"/bundle/my_job_notebook",
-		bundle.Config.Resources.Jobs["job"].Tasks[2].NotebookTask.NotebookPath,
+		b.Config.Resources.Jobs["job"].Tasks[2].NotebookTask.NotebookPath,
 	)
 	assert.Equal(
 		t,
 		"/bundle/my_python_file.py",
-		bundle.Config.Resources.Jobs["job"].Tasks[4].SparkPythonTask.PythonFile,
+		b.Config.Resources.Jobs["job"].Tasks[4].SparkPythonTask.PythonFile,
 	)
 	assert.Equal(
 		t,
 		"/bundle/dist/task.jar",
-		bundle.Config.Resources.Jobs["job"].Tasks[5].Libraries[0].Jar,
+		b.Config.Resources.Jobs["job"].Tasks[5].Libraries[0].Jar,
 	)
 	assert.Equal(
 		t,
 		"dbfs:/bundle/dist/task_remote.jar",
-		bundle.Config.Resources.Jobs["job"].Tasks[6].Libraries[0].Jar,
+		b.Config.Resources.Jobs["job"].Tasks[6].Libraries[0].Jar,
 	)
 
 	// Assert that the path in the libraries now refer to the artifact.
 	assert.Equal(
 		t,
 		"/bundle/my_pipeline_notebook",
-		bundle.Config.Resources.Pipelines["pipeline"].Libraries[0].Notebook.Path,
+		b.Config.Resources.Pipelines["pipeline"].Libraries[0].Notebook.Path,
 	)
 	assert.Equal(
 		t,
 		"/Users/jane.doe@databricks.com/doesnt_exist.py",
-		bundle.Config.Resources.Pipelines["pipeline"].Libraries[1].Notebook.Path,
+		b.Config.Resources.Pipelines["pipeline"].Libraries[1].Notebook.Path,
 	)
 	assert.Equal(
 		t,
 		"/bundle/my_pipeline_notebook",
-		bundle.Config.Resources.Pipelines["pipeline"].Libraries[2].Notebook.Path,
+		b.Config.Resources.Pipelines["pipeline"].Libraries[2].Notebook.Path,
 	)
 	assert.Equal(
 		t,
 		"/bundle/my_python_file.py",
-		bundle.Config.Resources.Pipelines["pipeline"].Libraries[4].File.Path,
+		b.Config.Resources.Pipelines["pipeline"].Libraries[4].File.Path,
 	)
 }
 
@@ -278,7 +278,7 @@ func TestTranslatePathsInSubdirectories(t *testing.T) {
 	touchEmptyFile(t, filepath.Join(dir, "job", "my_sql_file.sql"))
 	touchEmptyFile(t, filepath.Join(dir, "job", "my_dbt_project", "dbt_project.yml"))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -342,41 +342,41 @@ func TestTranslatePathsInSubdirectories(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	require.NoError(t, err)
 
 	assert.Equal(
 		t,
 		"/bundle/job/my_python_file.py",
-		bundle.Config.Resources.Jobs["job"].Tasks[0].SparkPythonTask.PythonFile,
+		b.Config.Resources.Jobs["job"].Tasks[0].SparkPythonTask.PythonFile,
 	)
 	assert.Equal(
 		t,
 		"/bundle/job/dist/task.jar",
-		bundle.Config.Resources.Jobs["job"].Tasks[1].Libraries[0].Jar,
+		b.Config.Resources.Jobs["job"].Tasks[1].Libraries[0].Jar,
 	)
 	assert.Equal(
 		t,
 		"/bundle/job/my_sql_file.sql",
-		bundle.Config.Resources.Jobs["job"].Tasks[2].SqlTask.File.Path,
+		b.Config.Resources.Jobs["job"].Tasks[2].SqlTask.File.Path,
 	)
 	assert.Equal(
 		t,
 		"/bundle/job/my_dbt_project",
-		bundle.Config.Resources.Jobs["job"].Tasks[3].DbtTask.ProjectDirectory,
+		b.Config.Resources.Jobs["job"].Tasks[3].DbtTask.ProjectDirectory,
 	)
 
 	assert.Equal(
 		t,
 		"/bundle/pipeline/my_python_file.py",
-		bundle.Config.Resources.Pipelines["pipeline"].Libraries[0].File.Path,
+		b.Config.Resources.Pipelines["pipeline"].Libraries[0].File.Path,
 	)
 }
 
 func TestTranslatePathsOutsideBundleRoot(t *testing.T) {
 	dir := t.TempDir()
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -403,14 +403,14 @@ func TestTranslatePathsOutsideBundleRoot(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, "is not contained in bundle root")
 }
 
 func TestJobNotebookDoesNotExistError(t *testing.T) {
 	dir := t.TempDir()
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Resources: config.Resources{
@@ -434,14 +434,14 @@ func TestJobNotebookDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.EqualError(t, err, "notebook ./doesnt_exist.py not found")
 }
 
 func TestJobFileDoesNotExistError(t *testing.T) {
 	dir := t.TempDir()
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Resources: config.Resources{
@@ -465,14 +465,14 @@ func TestJobFileDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.EqualError(t, err, "file ./doesnt_exist.py not found")
 }
 
 func TestPipelineNotebookDoesNotExistError(t *testing.T) {
 	dir := t.TempDir()
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Resources: config.Resources{
@@ -496,14 +496,14 @@ func TestPipelineNotebookDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.EqualError(t, err, "notebook ./doesnt_exist.py not found")
 }
 
 func TestPipelineFileDoesNotExistError(t *testing.T) {
 	dir := t.TempDir()
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Resources: config.Resources{
@@ -527,7 +527,7 @@ func TestPipelineFileDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.EqualError(t, err, "file ./doesnt_exist.py not found")
 }
 
@@ -535,7 +535,7 @@ func TestJobSparkPythonTaskWithNotebookSourceError(t *testing.T) {
 	dir := t.TempDir()
 	touchNotebookFile(t, filepath.Join(dir, "my_notebook.py"))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -562,7 +562,7 @@ func TestJobSparkPythonTaskWithNotebookSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, `expected a file for "tasks.spark_python_task.python_file" but got a notebook`)
 }
 
@@ -570,7 +570,7 @@ func TestJobNotebookTaskWithFileSourceError(t *testing.T) {
 	dir := t.TempDir()
 	touchEmptyFile(t, filepath.Join(dir, "my_file.py"))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -597,7 +597,7 @@ func TestJobNotebookTaskWithFileSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, `expected a notebook for "tasks.notebook_task.notebook_path" but got a file`)
 }
 
@@ -605,7 +605,7 @@ func TestPipelineNotebookLibraryWithFileSourceError(t *testing.T) {
 	dir := t.TempDir()
 	touchEmptyFile(t, filepath.Join(dir, "my_file.py"))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -632,7 +632,7 @@ func TestPipelineNotebookLibraryWithFileSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, `expected a notebook for "libraries.notebook.path" but got a file`)
 }
 
@@ -640,7 +640,7 @@ func TestPipelineFileLibraryWithNotebookSourceError(t *testing.T) {
 	dir := t.TempDir()
 	touchNotebookFile(t, filepath.Join(dir, "my_notebook.py"))
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: dir,
 			Workspace: config.Workspace{
@@ -667,6 +667,6 @@ func TestPipelineFileLibraryWithNotebookSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), bundle)
+	err := mutator.TranslatePaths().Apply(context.Background(), b)
 	assert.ErrorContains(t, err, `expected a file for "libraries.file.path" but got a notebook`)
 }

--- a/bundle/config/mutator/validate_git_details_test.go
+++ b/bundle/config/mutator/validate_git_details_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestValidateGitDetailsMatchingBranches(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Git: config.Git{
@@ -22,13 +22,13 @@ func TestValidateGitDetailsMatchingBranches(t *testing.T) {
 	}
 
 	m := ValidateGitDetails()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 
 	assert.NoError(t, err)
 }
 
 func TestValidateGitDetailsNonMatchingBranches(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Git: config.Git{
@@ -40,14 +40,14 @@ func TestValidateGitDetailsNonMatchingBranches(t *testing.T) {
 	}
 
 	m := ValidateGitDetails()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 
 	expectedError := "not on the right Git branch:\n  expected according to configuration: main\n  actual: feature\nuse --force to override"
 	assert.EqualError(t, err, expectedError)
 }
 
 func TestValidateGitDetailsNotUsingGit(t *testing.T) {
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Git: config.Git{
@@ -59,7 +59,7 @@ func TestValidateGitDetailsNotUsingGit(t *testing.T) {
 	}
 
 	m := ValidateGitDetails()
-	err := m.Apply(context.Background(), bundle)
+	err := m.Apply(context.Background(), b)
 
 	assert.NoError(t, err)
 }

--- a/bundle/context.go
+++ b/bundle/context.go
@@ -26,9 +26,9 @@ func GetOrNil(ctx context.Context) *Bundle {
 // Get returns the bundle as configured on the context.
 // It panics if it isn't configured.
 func Get(ctx context.Context) *Bundle {
-	bundle := GetOrNil(ctx)
-	if bundle == nil {
+	b := GetOrNil(ctx)
+	if b == nil {
 		panic("context not configured with bundle")
 	}
-	return bundle
+	return b
 }

--- a/bundle/deferred_test.go
+++ b/bundle/deferred_test.go
@@ -29,8 +29,8 @@ func TestDeferredMutatorWhenAllMutatorsSucceed(t *testing.T) {
 	cleanup := &testMutator{}
 	deferredMutator := Defer(Seq(m1, m2, m3), cleanup)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, deferredMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, deferredMutator)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, m1.applyCalled)
@@ -46,8 +46,8 @@ func TestDeferredMutatorWhenFirstFails(t *testing.T) {
 	cleanup := &testMutator{}
 	deferredMutator := Defer(Seq(mErr, m1, m2), cleanup)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, deferredMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, deferredMutator)
 	assert.ErrorContains(t, err, "mutator error occurred")
 
 	assert.Equal(t, 1, mErr.applyCalled)
@@ -63,8 +63,8 @@ func TestDeferredMutatorWhenMiddleOneFails(t *testing.T) {
 	cleanup := &testMutator{}
 	deferredMutator := Defer(Seq(m1, mErr, m2), cleanup)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, deferredMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, deferredMutator)
 	assert.ErrorContains(t, err, "mutator error occurred")
 
 	assert.Equal(t, 1, m1.applyCalled)
@@ -80,8 +80,8 @@ func TestDeferredMutatorWhenLastOneFails(t *testing.T) {
 	cleanup := &testMutator{}
 	deferredMutator := Defer(Seq(m1, m2, mErr), cleanup)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, deferredMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, deferredMutator)
 	assert.ErrorContains(t, err, "mutator error occurred")
 
 	assert.Equal(t, 1, m1.applyCalled)
@@ -97,8 +97,8 @@ func TestDeferredMutatorCombinesErrorMessages(t *testing.T) {
 	cleanupErr := &mutatorWithError{errorMsg: "cleanup error occurred"}
 	deferredMutator := Defer(Seq(m1, m2, mErr), cleanupErr)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, deferredMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, deferredMutator)
 	assert.ErrorContains(t, err, "mutator error occurred\ncleanup error occurred")
 
 	assert.Equal(t, 1, m1.applyCalled)

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -27,7 +27,7 @@ func TestInitEnvironmentVariables(t *testing.T) {
 		t.Skipf("cannot find terraform binary: %s", err)
 	}
 
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Path: t.TempDir(),
 			Bundle: config.Bundle{
@@ -43,9 +43,9 @@ func TestInitEnvironmentVariables(t *testing.T) {
 	// TODO(pietern): create test fixture that initializes a mocked client.
 	t.Setenv("DATABRICKS_HOST", "https://x")
 	t.Setenv("DATABRICKS_TOKEN", "foobar")
-	bundle.WorkspaceClient()
+	b.WorkspaceClient()
 
-	err = Initialize().Apply(context.Background(), bundle)
+	err = Initialize().Apply(context.Background(), b)
 	require.NoError(t, err)
 }
 

--- a/bundle/mutator_test.go
+++ b/bundle/mutator_test.go
@@ -34,8 +34,8 @@ func TestMutator(t *testing.T) {
 		},
 	}
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, m)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, m)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, m.applyCalled)

--- a/bundle/python/transform_test.go
+++ b/bundle/python/transform_test.go
@@ -73,7 +73,7 @@ func TestGenerateBoth(t *testing.T) {
 
 func TestTransformFiltersWheelTasksOnly(t *testing.T) {
 	trampoline := pythonTrampoline{}
-	bundle := &bundle.Bundle{
+	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
@@ -106,7 +106,7 @@ func TestTransformFiltersWheelTasksOnly(t *testing.T) {
 		},
 	}
 
-	tasks := trampoline.GetTasks(bundle)
+	tasks := trampoline.GetTasks(b)
 	require.Len(t, tasks, 1)
 	require.Equal(t, "job1", tasks[0].JobKey)
 	require.Equal(t, "key1", tasks[0].Task.TaskKey)

--- a/bundle/seq_test.go
+++ b/bundle/seq_test.go
@@ -13,8 +13,8 @@ func TestSeqMutator(t *testing.T) {
 	m3 := &testMutator{}
 	seqMutator := Seq(m1, m2, m3)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, seqMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, seqMutator)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, m1.applyCalled)
@@ -29,8 +29,8 @@ func TestSeqWithDeferredMutator(t *testing.T) {
 	m4 := &testMutator{}
 	seqMutator := Seq(m1, Defer(m2, m3), m4)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, seqMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, seqMutator)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, m1.applyCalled)
@@ -46,8 +46,8 @@ func TestSeqWithErrorAndDeferredMutator(t *testing.T) {
 	m3 := &testMutator{}
 	seqMutator := Seq(errorMut, Defer(m1, m2), m3)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, seqMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, seqMutator)
 	assert.Error(t, err)
 
 	assert.Equal(t, 1, errorMut.applyCalled)
@@ -63,8 +63,8 @@ func TestSeqWithErrorInsideDeferredMutator(t *testing.T) {
 	m3 := &testMutator{}
 	seqMutator := Seq(m1, Defer(errorMut, m2), m3)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, seqMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, seqMutator)
 	assert.Error(t, err)
 
 	assert.Equal(t, 1, m1.applyCalled)
@@ -80,8 +80,8 @@ func TestSeqWithErrorInsideFinallyStage(t *testing.T) {
 	m3 := &testMutator{}
 	seqMutator := Seq(m1, Defer(m2, errorMut), m3)
 
-	bundle := &Bundle{}
-	err := Apply(context.Background(), bundle, seqMutator)
+	b := &Bundle{}
+	err := Apply(context.Background(), b, seqMutator)
 	assert.Error(t, err)
 
 	assert.Equal(t, 1, m1.applyCalled)


### PR DESCRIPTION
## Changes

All calls to apply a mutator must go through `bundle.Apply`. This conflicts with the existing use of the variable `bundle`. This change un-aliases the variable from the package name by renaming all variables to `b`.

## Tests

Pass.

