### PR TITLE
Replace direct calls with `bundle.Apply`

### DIFF
--- a/bundle/config/mutator/default_target_test.go
+++ b/bundle/config/mutator/default_target_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDefaultTarget(t *testing.T) {
 	b := &bundle.Bundle{}
-	err := mutator.DefineDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.DefineDefaultTarget())
 	require.NoError(t, err)
 	env, ok := b.Config.Targets["default"]
 	assert.True(t, ok)
@@ -28,7 +28,7 @@ func TestDefaultTargetAlreadySpecified(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.DefineDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.DefineDefaultTarget())
 	require.NoError(t, err)
 	_, ok := b.Config.Targets["default"]
 	assert.False(t, ok)

--- a/bundle/config/mutator/default_workspace_paths_test.go
+++ b/bundle/config/mutator/default_workspace_paths_test.go
@@ -19,7 +19,7 @@ func TestDefineDefaultWorkspacePaths(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.DefineDefaultWorkspacePaths())
 	require.NoError(t, err)
 	assert.Equal(t, "/files", b.Config.Workspace.FilePath)
 	assert.Equal(t, "/artifacts", b.Config.Workspace.ArtifactPath)
@@ -37,7 +37,7 @@ func TestDefineDefaultWorkspacePathsAlreadySet(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.DefineDefaultWorkspacePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.DefineDefaultWorkspacePaths())
 	require.NoError(t, err)
 	assert.Equal(t, "/foo/bar", b.Config.Workspace.FilePath)
 	assert.Equal(t, "/foo/bar", b.Config.Workspace.ArtifactPath)

--- a/bundle/config/mutator/default_workspace_root_test.go
+++ b/bundle/config/mutator/default_workspace_root_test.go
@@ -20,7 +20,7 @@ func TestDefaultWorkspaceRoot(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.DefineDefaultWorkspaceRoot().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.DefineDefaultWorkspaceRoot())
 	require.NoError(t, err)
 	assert.Equal(t, "~/.bundle/name/environment", b.Config.Workspace.RootPath)
 }

--- a/bundle/config/mutator/expand_workspace_root_test.go
+++ b/bundle/config/mutator/expand_workspace_root_test.go
@@ -25,7 +25,7 @@ func TestExpandWorkspaceRoot(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ExpandWorkspaceRoot())
 	require.NoError(t, err)
 	assert.Equal(t, "/Users/jane@doe.com/foo", b.Config.Workspace.RootPath)
 }
@@ -43,7 +43,7 @@ func TestExpandWorkspaceRootDoesNothing(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ExpandWorkspaceRoot())
 	require.NoError(t, err)
 	assert.Equal(t, "/Users/charly@doe.com/foo", b.Config.Workspace.RootPath)
 }
@@ -60,7 +60,7 @@ func TestExpandWorkspaceRootWithoutRoot(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ExpandWorkspaceRoot())
 	require.Error(t, err)
 }
 
@@ -72,6 +72,6 @@ func TestExpandWorkspaceRootWithoutCurrentUser(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ExpandWorkspaceRoot().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ExpandWorkspaceRoot())
 	require.Error(t, err)
 }

--- a/bundle/config/mutator/override_compute_test.go
+++ b/bundle/config/mutator/override_compute_test.go
@@ -47,7 +47,7 @@ func TestOverrideDevelopment(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 	assert.Nil(t, b.Config.Resources.Jobs["job1"].Tasks[0].NewCluster)
 	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
@@ -83,7 +83,7 @@ func TestOverrideDevelopmentEnv(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 	assert.Equal(t, "cluster2", b.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
 }
@@ -108,7 +108,7 @@ func TestOverridePipelineTask(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
 }
@@ -138,7 +138,7 @@ func TestOverrideProduction(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.Error(t, err)
 }
 
@@ -165,6 +165,6 @@ func TestOverrideProductionEnv(t *testing.T) {
 	}
 
 	m := mutator.OverrideCompute()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 }

--- a/bundle/config/mutator/process_include_test.go
+++ b/bundle/config/mutator/process_include_test.go
@@ -32,7 +32,7 @@ func TestProcessInclude(t *testing.T) {
 	f.Close()
 
 	assert.Equal(t, "foo", b.Config.Workspace.Host)
-	err = mutator.ProcessInclude(fullPath, relPath).Apply(context.Background(), b)
+	err = bundle.Apply(context.Background(), b, mutator.ProcessInclude(fullPath, relPath))
 	require.NoError(t, err)
 	assert.Equal(t, "bar", b.Config.Workspace.Host)
 }

--- a/bundle/config/mutator/process_root_includes_test.go
+++ b/bundle/config/mutator/process_root_includes_test.go
@@ -29,7 +29,7 @@ func TestProcessRootIncludesEmpty(t *testing.T) {
 			Path: ".",
 		},
 	}
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.NoError(t, err)
 }
 
@@ -49,7 +49,7 @@ func TestProcessRootIncludesAbs(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be relative paths")
 }
@@ -68,7 +68,7 @@ func TestProcessRootIncludesSingleGlob(t *testing.T) {
 	touch(t, b.Config.Path, "a.yml")
 	touch(t, b.Config.Path, "b.yml")
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"a.yml", "b.yml"}, b.Config.Include)
@@ -88,7 +88,7 @@ func TestProcessRootIncludesMultiGlob(t *testing.T) {
 	touch(t, b.Config.Path, "a1.yml")
 	touch(t, b.Config.Path, "b1.yml")
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"a1.yml", "b1.yml"}, b.Config.Include)
@@ -107,7 +107,7 @@ func TestProcessRootIncludesRemoveDups(t *testing.T) {
 
 	touch(t, b.Config.Path, "a.yml")
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a.yml"}, b.Config.Include)
 }
@@ -121,7 +121,7 @@ func TestProcessRootIncludesNotExists(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "notexist.yml defined in 'include' section does not match any files")
 }
@@ -138,7 +138,7 @@ func TestProcessRootIncludesExtrasFromEnvVar(t *testing.T) {
 		},
 	}
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.NoError(t, err)
 	assert.Contains(t, b.Config.Include, testYamlName)
 }
@@ -161,7 +161,7 @@ func TestProcessRootIncludesDedupExtrasFromEnvVar(t *testing.T) {
 		},
 	}
 
-	err := mutator.ProcessRootIncludes().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.ProcessRootIncludes())
 	require.NoError(t, err)
 	assert.Equal(t, []string{testYamlName}, b.Config.Include)
 }

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -92,7 +92,7 @@ func TestProcessTargetModeDevelopment(t *testing.T) {
 	b := mockBundle(config.Development)
 
 	m := ProcessTargetMode()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 
 	// Job 1
@@ -135,7 +135,7 @@ func TestProcessTargetModeDevelopmentTagNormalizationForAws(t *testing.T) {
 	})
 
 	b.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
-	err := ProcessTargetMode().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, ProcessTargetMode())
 	require.NoError(t, err)
 
 	// Assert that tag normalization took place.
@@ -149,7 +149,7 @@ func TestProcessTargetModeDevelopmentTagNormalizationForAzure(t *testing.T) {
 	})
 
 	b.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
-	err := ProcessTargetMode().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, ProcessTargetMode())
 	require.NoError(t, err)
 
 	// Assert that tag normalization took place (Azure allows more characters than AWS).
@@ -163,7 +163,7 @@ func TestProcessTargetModeDevelopmentTagNormalizationForGcp(t *testing.T) {
 	})
 
 	b.Config.Workspace.CurrentUser.ShortName = "Héllö wörld?!"
-	err := ProcessTargetMode().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, ProcessTargetMode())
 	require.NoError(t, err)
 
 	// Assert that tag normalization took place.
@@ -174,7 +174,7 @@ func TestProcessTargetModeDefault(t *testing.T) {
 	b := mockBundle("")
 
 	m := ProcessTargetMode()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 	assert.Equal(t, "job1", b.Config.Resources.Jobs["job1"].Name)
 	assert.Equal(t, "pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
@@ -257,7 +257,7 @@ func TestAllResourcesRenamed(t *testing.T) {
 	resources := reflect.ValueOf(b.Config.Resources)
 
 	m := ProcessTargetMode()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 
 	for i := 0; i < resources.NumField(); i++ {

--- a/bundle/config/mutator/select_default_target.go
+++ b/bundle/config/mutator/select_default_target.go
@@ -28,7 +28,7 @@ func (m *selectDefaultTarget) Apply(ctx context.Context, b *bundle.Bundle) error
 	// One target means there's only one default.
 	names := maps.Keys(b.Config.Targets)
 	if len(names) == 1 {
-		return SelectTarget(names[0]).Apply(ctx, b)
+		return bundle.Apply(ctx, b, SelectTarget(names[0]))
 	}
 
 	// Multiple targets means we look for the `default` flag.
@@ -50,5 +50,5 @@ func (m *selectDefaultTarget) Apply(ctx context.Context, b *bundle.Bundle) error
 	}
 
 	// One default remaining.
-	return SelectTarget(defaults[0]).Apply(ctx, b)
+	return bundle.Apply(ctx, b, SelectTarget(defaults[0]))
 }

--- a/bundle/config/mutator/select_default_target_test.go
+++ b/bundle/config/mutator/select_default_target_test.go
@@ -16,7 +16,7 @@ func TestSelectDefaultTargetNoTargets(t *testing.T) {
 			Targets: map[string]*config.Target{},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectDefaultTarget())
 	assert.ErrorContains(t, err, "no targets defined")
 }
 
@@ -28,7 +28,7 @@ func TestSelectDefaultTargetSingleTargets(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectDefaultTarget())
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", b.Config.Bundle.Target)
 }
@@ -43,7 +43,7 @@ func TestSelectDefaultTargetNoDefaults(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectDefaultTarget())
 	assert.ErrorContains(t, err, "please specify target")
 }
 
@@ -56,7 +56,7 @@ func TestSelectDefaultTargetNoDefaultsWithNil(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectDefaultTarget())
 	assert.ErrorContains(t, err, "please specify target")
 }
 
@@ -70,7 +70,7 @@ func TestSelectDefaultTargetMultipleDefaults(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectDefaultTarget())
 	assert.ErrorContains(t, err, "multiple targets are marked as default")
 }
 
@@ -84,7 +84,7 @@ func TestSelectDefaultTargetSingleDefault(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectDefaultTarget().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectDefaultTarget())
 	assert.NoError(t, err)
 	assert.Equal(t, "bar", b.Config.Bundle.Target)
 }

--- a/bundle/config/mutator/select_target_test.go
+++ b/bundle/config/mutator/select_target_test.go
@@ -26,7 +26,7 @@ func TestSelectTarget(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectTarget("default").Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectTarget("default"))
 	require.NoError(t, err)
 	assert.Equal(t, "bar", b.Config.Workspace.Host)
 }
@@ -39,6 +39,6 @@ func TestSelectTargetNotFound(t *testing.T) {
 			},
 		},
 	}
-	err := mutator.SelectTarget("doesnt-exist").Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.SelectTarget("doesnt-exist"))
 	require.Error(t, err, "no targets defined")
 }

--- a/bundle/config/mutator/set_variables_test.go
+++ b/bundle/config/mutator/set_variables_test.go
@@ -108,7 +108,7 @@ func TestSetVariablesMutator(t *testing.T) {
 
 	t.Setenv("BUNDLE_VAR_b", "env-var-b")
 
-	err := SetVariables().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, SetVariables())
 	require.NoError(t, err)
 	assert.Equal(t, "default-a", *b.Config.Variables["a"].Value)
 	assert.Equal(t, "env-var-b", *b.Config.Variables["b"].Value)

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -80,7 +80,7 @@ func TestTranslatePathsSkippedWithGitSource(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	require.NoError(t, err)
 
 	assert.Equal(
@@ -207,7 +207,7 @@ func TestTranslatePaths(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	require.NoError(t, err)
 
 	// Assert that the path in the tasks now refer to the artifact.
@@ -342,7 +342,7 @@ func TestTranslatePathsInSubdirectories(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	require.NoError(t, err)
 
 	assert.Equal(
@@ -403,7 +403,7 @@ func TestTranslatePathsOutsideBundleRoot(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.ErrorContains(t, err, "is not contained in bundle root")
 }
 
@@ -434,7 +434,7 @@ func TestJobNotebookDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.EqualError(t, err, "notebook ./doesnt_exist.py not found")
 }
 
@@ -465,7 +465,7 @@ func TestJobFileDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.EqualError(t, err, "file ./doesnt_exist.py not found")
 }
 
@@ -496,7 +496,7 @@ func TestPipelineNotebookDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.EqualError(t, err, "notebook ./doesnt_exist.py not found")
 }
 
@@ -527,7 +527,7 @@ func TestPipelineFileDoesNotExistError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.EqualError(t, err, "file ./doesnt_exist.py not found")
 }
 
@@ -562,7 +562,7 @@ func TestJobSparkPythonTaskWithNotebookSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.ErrorContains(t, err, `expected a file for "tasks.spark_python_task.python_file" but got a notebook`)
 }
 
@@ -597,7 +597,7 @@ func TestJobNotebookTaskWithFileSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.ErrorContains(t, err, `expected a notebook for "tasks.notebook_task.notebook_path" but got a file`)
 }
 
@@ -632,7 +632,7 @@ func TestPipelineNotebookLibraryWithFileSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.ErrorContains(t, err, `expected a notebook for "libraries.notebook.path" but got a file`)
 }
 
@@ -667,6 +667,6 @@ func TestPipelineFileLibraryWithNotebookSourceError(t *testing.T) {
 		},
 	}
 
-	err := mutator.TranslatePaths().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
 	assert.ErrorContains(t, err, `expected a file for "libraries.file.path" but got a notebook`)
 }

--- a/bundle/config/mutator/validate_git_details_test.go
+++ b/bundle/config/mutator/validate_git_details_test.go
@@ -22,7 +22,7 @@ func TestValidateGitDetailsMatchingBranches(t *testing.T) {
 	}
 
 	m := ValidateGitDetails()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 
 	assert.NoError(t, err)
 }
@@ -40,7 +40,7 @@ func TestValidateGitDetailsNonMatchingBranches(t *testing.T) {
 	}
 
 	m := ValidateGitDetails()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 
 	expectedError := "not on the right Git branch:\n  expected according to configuration: main\n  actual: feature\nuse --force to override"
 	assert.EqualError(t, err, expectedError)
@@ -59,7 +59,7 @@ func TestValidateGitDetailsNotUsingGit(t *testing.T) {
 	}
 
 	m := ValidateGitDetails()
-	err := m.Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, m)
 
 	assert.NoError(t, err)
 }

--- a/bundle/deploy/metadata/compute_test.go
+++ b/bundle/deploy/metadata/compute_test.go
@@ -93,7 +93,7 @@ func TestComputeMetadataMutator(t *testing.T) {
 		},
 	}
 
-	err := Compute().Apply(context.Background(), b)
+	err := bundle.Apply(context.Background(), b, Compute())
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedMetadata, b.Metadata)

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -45,7 +45,7 @@ func TestInitEnvironmentVariables(t *testing.T) {
 	t.Setenv("DATABRICKS_TOKEN", "foobar")
 	b.WorkspaceClient()
 
-	err = Initialize().Apply(context.Background(), b)
+	err = bundle.Apply(context.Background(), b, Initialize())
 	require.NoError(t, err)
 }
 

--- a/bundle/tests/bundle/wheel_test.go
+++ b/bundle/tests/bundle/wheel_test.go
@@ -17,7 +17,7 @@ func TestBundlePythonWheelBuild(t *testing.T) {
 	require.NoError(t, err)
 
 	m := phases.Build()
-	err = m.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, m)
 	require.NoError(t, err)
 
 	matches, err := filepath.Glob("python_wheel/my_test_code/dist/my_test_code-*.whl")
@@ -25,7 +25,7 @@ func TestBundlePythonWheelBuild(t *testing.T) {
 	require.Equal(t, 1, len(matches))
 
 	match := libraries.MatchWithArtifacts()
-	err = match.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, match)
 	require.NoError(t, err)
 }
 
@@ -35,7 +35,7 @@ func TestBundlePythonWheelBuildAutoDetect(t *testing.T) {
 	require.NoError(t, err)
 
 	m := phases.Build()
-	err = m.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, m)
 	require.NoError(t, err)
 
 	matches, err := filepath.Glob("python_wheel/my_test_code/dist/my_test_code-*.whl")
@@ -43,7 +43,7 @@ func TestBundlePythonWheelBuildAutoDetect(t *testing.T) {
 	require.Equal(t, 1, len(matches))
 
 	match := libraries.MatchWithArtifacts()
-	err = match.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, match)
 	require.NoError(t, err)
 }
 
@@ -53,11 +53,11 @@ func TestBundlePythonWheelWithDBFSLib(t *testing.T) {
 	require.NoError(t, err)
 
 	m := phases.Build()
-	err = m.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, m)
 	require.NoError(t, err)
 
 	match := libraries.MatchWithArtifacts()
-	err = match.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, match)
 	require.NoError(t, err)
 }
 
@@ -67,11 +67,11 @@ func TestBundlePythonWheelBuildNoBuildJustUpload(t *testing.T) {
 	require.NoError(t, err)
 
 	m := phases.Build()
-	err = m.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, m)
 	require.NoError(t, err)
 
 	match := libraries.MatchWithArtifacts()
-	err = match.Apply(ctx, b)
+	err = bundle.Apply(ctx, b, match)
 	require.ErrorContains(t, err, "./non-existing/*.whl")
 
 	require.NotZero(t, len(b.Config.Artifacts))


### PR DESCRIPTION
## Changes

Some test call sites called directly into the mutator's `Apply` function instead of `bundle.Apply`. Calling into `bundle.Apply` is preferred because that's where we can run pre/post logic common across all mutators.

## Tests

Pass.

