### PR TITLE
Work around DLT issue with `$PYTHONPATH` not being set correctly

### DIFF
--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_pipeline.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_pipeline.yml.tmpl
@@ -7,3 +7,6 @@ resources:
       libraries:
         - notebook:
             path: ../src/dlt_pipeline.ipynb
+
+      configuration:
+        bundle.sourcePath: /Workspace/${workspace.file_path}/src

--- a/libs/template/templates/default-python/template/{{.project_name}}/src/dlt_pipeline.ipynb.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/src/dlt_pipeline.ipynb.tmpl
@@ -35,6 +35,7 @@
     "# Import DLT and src/{{.project_name}}\n",
     "import dlt\n",
     "import sys\n",
+    "sys.path.append(spark.conf.get(\"bundle.sourcePath\", \".\"))\n",
     "from pyspark.sql.functions import expr\n",
     "from {{.project_name}} import main"
    {{else}}


### PR DESCRIPTION
## Changes

DLT currently doesn't always set `$PYTHONPATH` correctly (ES-947370). This restores the original workaround to make new pipelines work while that issue is being addressed. The workaround was removed in #832.

Manually tested.
