### PR TITLE
Pass `USERPROFILE` environment variable to Terraform

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -81,6 +81,13 @@ func inheritEnvVars(ctx context.Context, environ map[string]string) error {
 		environ["HOME"] = home
 	}
 
+	// Include $USERPROFILE in set of environment variables to pass along.
+	// This variable is used by Azure CLI on Windows to find stored credentials and metadata
+	userProfile, ok := env.Lookup(ctx, "USERPROFILE")
+	if ok {
+		environ["USERPROFILE"] = userProfile
+	}
+
 	// Include $PATH in set of environment variables to pass along.
 	// This is necessary to ensure that our Terraform provider can use the
 	// same auxiliary programs (e.g. `az`, or `gcloud`) as the CLI.

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -120,8 +120,6 @@ func setTempDirEnvVars(ctx context.Context, environ map[string]string, b *bundle
 			environ["TMP"] = v
 		} else if v, ok := env.Lookup(ctx, "TEMP"); ok {
 			environ["TEMP"] = v
-		} else if v, ok := env.Lookup(ctx, "USERPROFILE"); ok {
-			environ["USERPROFILE"] = v
 		} else {
 			tmpDir, err := b.CacheDir(ctx, "tmp")
 			if err != nil {

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -290,16 +290,10 @@ func TestInheritEnvVars(t *testing.T) {
 }
 
 func TestSetUserProfileFromInheritEnvVars(t *testing.T) {
-	env := make(map[string]string, 0)
-	err := inheritEnvVars(context.Background(), env)
-	require.NoError(t, err)
-
-	assert.NotContains(t, env, "USERPROFILE")
-
 	t.Setenv("USERPROFILE", "c:\\foo\\c")
 
-	env = make(map[string]string, 0)
-	err = inheritEnvVars(context.Background(), env)
+	env := make(map[string]string, 0)
+	err := inheritEnvVars(context.Background(), env)
 	require.NoError(t, err)
 
 	assert.Contains(t, env, "USERPROFILE")

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -163,36 +163,6 @@ func TestSetTempDirEnvVarsForWindowWithUserProfileAndTempSet(t *testing.T) {
 	}, env)
 }
 
-func TestSetTempDirEnvVarsForWindowWithUserProfileSet(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.SkipNow()
-	}
-
-	b := &bundle.Bundle{
-		Config: config.Root{
-			Path: t.TempDir(),
-			Bundle: config.Bundle{
-				Target: "whatever",
-			},
-		},
-	}
-
-	// Set environment variables
-	unsetEnv(t, "TMP")
-	unsetEnv(t, "TEMP")
-	t.Setenv("USERPROFILE", "c:\\foo\\c")
-
-	// compute env
-	env := make(map[string]string, 0)
-	err := setTempDirEnvVars(context.Background(), env, b)
-	require.NoError(t, err)
-
-	// assert that we pass through the user profile
-	assert.Equal(t, map[string]string{
-		"USERPROFILE": "c:\\foo\\c",
-	}, env)
-}
-
 func TestSetTempDirEnvVarsForWindowsWithoutAnyTempDirEnvVarsSet(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.SkipNow()

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -284,9 +284,24 @@ func TestInheritEnvVars(t *testing.T) {
 
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]string{
-		"HOME":               "/home/testuser",
-		"PATH":               "/foo:/bar",
-		"TF_CLI_CONFIG_FILE": "/tmp/config.tfrc",
-	}, env)
+	require.Equal(t, env["HOME"], "/home/testuser")
+	require.Equal(t, env["PATH"], "/foo:/bar")
+	require.Equal(t, env["TF_CLI_CONFIG_FILE"], "/tmp/config.tfrc")
+}
+
+func TestSetUserProfileFromInheritEnvVars(t *testing.T) {
+	env := make(map[string]string, 0)
+	err := inheritEnvVars(context.Background(), env)
+	require.NoError(t, err)
+
+	assert.NotContains(t, env, "USERPROFILE")
+
+	t.Setenv("USERPROFILE", "c:\\foo\\c")
+
+	env = make(map[string]string, 0)
+	err = inheritEnvVars(context.Background(), env)
+	require.NoError(t, err)
+
+	assert.Contains(t, env, "USERPROFILE")
+	assert.Equal(t, env["USERPROFILE"], "c:\\foo\\c")
 }


### PR DESCRIPTION
## Changes
It appears that `USERPROFILE` env variable indicates where Azure CLI stores configuration data (aka `.azure` folder).
https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file

Passing it to terraform executable allows it to correctly authenticate using Azure CLI.

Fixes #983 

## Tests
Ran deployment on Window VM before and after the fix.

