### PR TITLE
Tolerate missing .databrickscfg file during `databricks auth login`

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -131,7 +132,8 @@ func setHost(ctx context.Context, profileName string, persistentAuth *auth.Persi
 	_, profiles, err := databrickscfg.LoadProfiles(ctx, func(p databrickscfg.Profile) bool {
 		return p.Name == profileName
 	})
-	if err != nil {
+	// Tolerate ErrNoConfiguration here, as we will write out a configuration as part of the login flow.
+	if !errors.Is(err, databrickscfg.ErrNoConfiguration) {
 		return err
 	}
 	if persistentAuth.Host == "" {

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/libs/auth"
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetHostDoesNotFailWithNoDatabrickscfg(t *testing.T) {
+	ctx := context.Background()
+	ctx = env.Set(ctx, "DATABRICKS_CONFIG_FILE", "./imaginary-file/databrickscfg")
+	err := setHost(ctx, "foo", &auth.PersistentAuth{Host: "test"}, []string{})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Changes
`databricks configure` creates a new .databrickscfg if one doesn't already exist, but `databricks auth login` fails in this case. Because `databricks auth login` anyways writes out the config file, we gracefully handle this error and continue.

## Tests
Unit test.

```
$ ls ~/.databrickscfg*    
/Users/miles/.databrickscfg.bak

$ ./cli auth login
Databricks Profile Name: test
Databricks Host: https://<HOST>
Profile test was successfully saved

$ ls ~/.databrickscfg*
/Users/miles/.databrickscfg     /Users/miles/.databrickscfg.bak

$ cat ~/.databrickscfg
; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
[DEFAULT]

[test]
host      = https://<HOST>
auth_type = databricks-cli
```