### PR TITLE
Add `--configure-cluster` flag to configure command

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -120,14 +120,11 @@ The host must be specified with the --host flag or the DATABRICKS_HOST environme
 		}
 
 		ctx := cmd.Context()
-		interactive := cmdio.IsInTTY(ctx) && cmdio.IsOutTTY(ctx)
-		var fn func(*cobra.Command, *configureFlags, *config.Config) error
-		if interactive {
-			fn = configureInteractive
+		if cmdio.IsInTTY(ctx) && cmdio.IsOutTTY(ctx) {
+			err = configureInteractive(cmd, &flags, &cfg)
 		} else {
-			fn = configureNonInteractive
+			err = configureNonInteractive(cmd, &flags, &cfg)
 		}
-		err = fn(cmd, &flags, &cfg)
 		if err != nil {
 			return err
 		}

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -61,7 +61,7 @@ func configureNonInteractive(cmd *cobra.Command, flags *configureFlags, cfg *con
 		return fmt.Errorf("host must be set in non-interactive mode")
 	}
 
-	// Check precence of cluster ID before reading token to fail fast.
+	// Check presence of cluster ID before reading token to fail fast.
 	if flags.ConfigureCluster && cfg.ClusterID == "" {
 		return fmt.Errorf("cluster ID must be set in non-interactive mode")
 	}

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -17,7 +17,7 @@ func configureInteractive(cmd *cobra.Command, flags *configureFlags, cfg *config
 	// Ask user to specify the host if not already set.
 	if cfg.Host == "" {
 		prompt := cmdio.Prompt(ctx)
-		prompt.Label = "Databricks Host"
+		prompt.Label = "Databricks host"
 		prompt.Default = "https://"
 		prompt.AllowEdit = true
 		prompt.Validate = validateHost
@@ -31,7 +31,7 @@ func configureInteractive(cmd *cobra.Command, flags *configureFlags, cfg *config
 	// Ask user to specify the token is not already set.
 	if cfg.Token == "" {
 		prompt := cmdio.Prompt(ctx)
-		prompt.Label = "Personal Access Token"
+		prompt.Label = "Personal access token"
 		prompt.Mask = '*'
 		out, err := prompt.Run()
 		if err != nil {

--- a/cmd/configure/flags.go
+++ b/cmd/configure/flags.go
@@ -1,0 +1,38 @@
+package configure
+
+import (
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/spf13/cobra"
+)
+
+type configureFlags struct {
+	Host    string
+	Profile string
+
+	// Flag to request a prompt for cluster configuration.
+	ConfigureCluster bool
+}
+
+// Register flags with command.
+func (f *configureFlags) Register(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.Host, "host", "", "Databricks workspace host.")
+	cmd.Flags().StringVar(&f.Profile, "profile", "DEFAULT", "Name for the connection profile to configure.")
+	cmd.Flags().BoolVar(&f.ConfigureCluster, "configure-cluster", false, "Prompts to configure cluster")
+
+	// Include token flag for compatibility with the legacy CLI.
+	// It doesn't actually do anything because we always use PATs.
+	cmd.Flags().Bool("token", true, "Configure using Databricks Personal Access Token")
+	cmd.Flags().MarkHidden("token")
+}
+
+func (f *configureFlags) PopulateConfig(cfg *config.Config) error {
+	if f.Host != "" {
+		cfg.Host = f.Host
+	}
+
+	if f.Profile != "" {
+		cfg.Profile = f.Profile
+	}
+
+	return nil
+}

--- a/cmd/configure/flags.go
+++ b/cmd/configure/flags.go
@@ -1,7 +1,6 @@
 package configure
 
 import (
-	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/spf13/cobra"
 )
 
@@ -23,16 +22,4 @@ func (f *configureFlags) Register(cmd *cobra.Command) {
 	// It doesn't actually do anything because we always use PATs.
 	cmd.Flags().Bool("token", true, "Configure using Databricks Personal Access Token")
 	cmd.Flags().MarkHidden("token")
-}
-
-func (f *configureFlags) PopulateConfig(cfg *config.Config) error {
-	if f.Host != "" {
-		cfg.Host = f.Host
-	}
-
-	if f.Profile != "" {
-		cfg.Profile = f.Profile
-	}
-
-	return nil
 }

--- a/cmd/configure/flags_test.go
+++ b/cmd/configure/flags_test.go
@@ -1,0 +1,1 @@
+package configure

--- a/cmd/configure/flags_test.go
+++ b/cmd/configure/flags_test.go
@@ -1,1 +1,0 @@
-package configure

--- a/cmd/configure/host.go
+++ b/cmd/configure/host.go
@@ -1,0 +1,20 @@
+package configure
+
+import (
+	"fmt"
+	"net/url"
+)
+
+func validateHost(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+	if u.Host == "" || u.Scheme != "https" {
+		return fmt.Errorf("must start with https://")
+	}
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf("must use empty path")
+	}
+	return nil
+}

--- a/cmd/configure/host_test.go
+++ b/cmd/configure/host_test.go
@@ -1,0 +1,29 @@
+package configure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateHost(t *testing.T) {
+	var err error
+
+	// Must start with https://
+	err = validateHost("/path")
+	assert.ErrorContains(t, err, "must start with https://")
+	err = validateHost("http://host")
+	assert.ErrorContains(t, err, "must start with https://")
+	err = validateHost("ftp://host")
+
+	// Must use empty path
+	assert.ErrorContains(t, err, "must start with https://")
+	err = validateHost("https://host/path")
+	assert.ErrorContains(t, err, "must use empty path")
+
+	// Ignore query params
+	err = validateHost("https://host/?query")
+	assert.NoError(t, err)
+	err = validateHost("https://host/")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Changes

This breaks out the flags into a separate struct to make it easier to pass around.

If specified, the flag calls into the `cfgpicker` to prompt for a cluster to associated with the profile.

## Tests

Existing tests pass; added one for host validation.

