### PR TITLE
Populate struct field with `config.Value` instance if possible

### DIFF
--- a/libs/config/convert/struct_info_test.go
+++ b/libs/config/convert/struct_info_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/databricks/cli/libs/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -192,5 +193,34 @@ func TestStructInfoFieldValuesAnonymousByPointer(t *testing.T) {
 		si := getStructInfo(reflect.TypeOf(Tmp{}))
 		fv := si.FieldValues(reflect.ValueOf(src))
 		assert.Empty(t, fv)
+	})
+}
+
+func TestStructInfoValueFieldAbsent(t *testing.T) {
+	type Tmp struct {
+		Foo string `json:"foo"`
+	}
+
+	si := getStructInfo(reflect.TypeOf(Tmp{}))
+	assert.Nil(t, si.ValueField)
+}
+
+func TestStructInfoValueFieldPresent(t *testing.T) {
+	type Tmp struct {
+		Foo config.Value
+	}
+
+	si := getStructInfo(reflect.TypeOf(Tmp{}))
+	assert.NotNil(t, si.ValueField)
+}
+
+func TestStructInfoValueFieldMultiple(t *testing.T) {
+	type Tmp struct {
+		Foo config.Value
+		Bar config.Value
+	}
+
+	assert.Panics(t, func() {
+		getStructInfo(reflect.TypeOf(Tmp{}))
 	})
 }

--- a/libs/config/convert/to_typed.go
+++ b/libs/config/convert/to_typed.go
@@ -83,6 +83,12 @@ func toTypedStruct(dst reflect.Value, src config.Value) error {
 			}
 		}
 
+		// Populate field(s) for [config.Value], if any.
+		if info.ValueField != nil {
+			vv := dst.FieldByIndex(info.ValueField)
+			vv.Set(reflect.ValueOf(src))
+		}
+
 		return nil
 	case config.KindNil:
 		dst.SetZero()

--- a/libs/config/convert/to_typed_test.go
+++ b/libs/config/convert/to_typed_test.go
@@ -133,6 +133,24 @@ func TestToTypedStructNilOverwrite(t *testing.T) {
 	assert.Equal(t, Tmp{}, out)
 }
 
+func TestToTypedStructWithValueField(t *testing.T) {
+	type Tmp struct {
+		Foo string `json:"foo"`
+
+		ConfigValue config.Value
+	}
+
+	var out Tmp
+	v := config.V(map[string]config.Value{
+		"foo": config.V("bar"),
+	})
+
+	err := ToTyped(&out, v)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", out.Foo)
+	assert.Equal(t, v, out.ConfigValue)
+}
+
 func TestToTypedMap(t *testing.T) {
 	var out = map[string]string{}
 


### PR DESCRIPTION
## Changes

If a struct has a field of type `config.Value`, then we set it to the source value while converting a `config.Value` instance to a struct as part of a call to `convert.ToTyped`.

This is convenient when dealing with deeply nested structs where functions on inner structs need access to the metadata provided by their corresponding `config.Value` (e.g. where they were defined).

## Tests

Added unit tests pass.

