### PR TITLE
Update cli version in the vscode extension during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,3 +93,27 @@ jobs:
                 linux_arm64_sha: artifacts.get('linux_arm64')
               }
             });
+
+  create-vscode-extension-update-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+
+      - name: Update CLI version in the VSCode extension
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'databricks-vscode',
+              workflow_id: 'update-cli-version.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });


### PR DESCRIPTION
Similar to how we do it for setup-cli and homebrew-tap repos.

The PR on the extension side: https://github.com/databricks/databricks-vscode/pull/948


