### PR TITLE
Fix bug where the account or workspace client could be `nil`

### DIFF
--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -65,7 +65,7 @@ func accountClientOrPrompt(ctx context.Context, cfg *config.Config, allowPrompt 
 			return nil, err
 		}
 	}
-	return a, nil
+	return a, err
 }
 
 func MustAccountClient(cmd *cobra.Command, args []string) error {
@@ -133,7 +133,7 @@ func workspaceClientOrPrompt(ctx context.Context, cfg *config.Config, allowPromp
 			return nil, err
 		}
 	}
-	return w, nil
+	return w, err
 }
 
 func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
@@ -254,6 +254,9 @@ func WorkspaceClient(ctx context.Context) *databricks.WorkspaceClient {
 	if !ok {
 		panic("cannot get *databricks.WorkspaceClient. Please report it as a bug")
 	}
+	if w == nil {
+		panic("workspace client is nil. Please report it as a bug")
+	}
 	return w
 }
 
@@ -261,6 +264,9 @@ func AccountClient(ctx context.Context) *databricks.AccountClient {
 	a, ok := ctx.Value(&accountClient).(*databricks.AccountClient)
 	if !ok {
 		panic("cannot get *databricks.AccountClient. Please report it as a bug")
+	}
+	if a == nil {
+		panic("account client is nil. Please report it as a bug")
 	}
 	return a
 }

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -254,9 +254,6 @@ func WorkspaceClient(ctx context.Context) *databricks.WorkspaceClient {
 	if !ok {
 		panic("cannot get *databricks.WorkspaceClient. Please report it as a bug")
 	}
-	if w == nil {
-		panic("workspace client is nil. Please report it as a bug")
-	}
 	return w
 }
 
@@ -264,9 +261,6 @@ func AccountClient(ctx context.Context) *databricks.AccountClient {
 	a, ok := ctx.Value(&accountClient).(*databricks.AccountClient)
 	if !ok {
 		panic("cannot get *databricks.AccountClient. Please report it as a bug")
-	}
-	if a == nil {
-		panic("account client is nil. Please report it as a bug")
 	}
 	return a
 }


### PR DESCRIPTION
## Changes

We didn't return the error upon creating a workspace or account client. If there is an error, it must always propagate up the stack. The result of this bug was that we were setting a `nil` account or workspace client, which in turn caused SIGSEGVs.

Fixes #913.

## Tests

Manually confirmed this fixes the linked issue. The CLI now correctly returns an error when the client cannot be constructed.

The issue was reproducible using a `.databrickscfg` with a single, incorrectly configured profile.

