### PR TITLE
No need to fetch repository history when running tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
 
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
       - name: Setup Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
Test runs don't need access to the repository history and only need the commit being tested.