### PR TITLE
Discontinue 32-bit Windows build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,12 +35,6 @@ builds:
   goarch:
     - amd64
     - arm64
-    - '386'
-  ignore:
-    - goos: darwin
-      goarch: '386'
-    - goos: linux
-      goarch: '386'
   binary: databricks
 archives:
 - format: zip


### PR DESCRIPTION
## Changes

Build failure for 32-bit Windows binary due to integer overflow in the SDK.

We don't test 32-bit anywhere. I propose we stop publishing these builds until we receive evidence they are still useful.

## Tests

n/a

