### PR TITLE
Use `fetch-tags` option in release workflows

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Go

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -14,9 +14,8 @@ jobs:
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-tags: true
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -56,7 +55,7 @@ jobs:
       - name: Update snapshot tag
 
         # Snapshot release may only be updated for commits to the main branch.
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
 
         run: |
           git tag snapshot
@@ -65,7 +64,7 @@ jobs:
       - name: Update snapshot release
 
         # Snapshot release may only be updated for commits to the main branch.
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
 
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
 
       - name: Setup Go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,8 @@ jobs:
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-tags: true
 
       - name: Setup Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Changes

The manual unshallow step is superfluous and can be done as part of the `actions/checkout` step.

Companion to #1022.

## Tests

Manual trigger of the snapshot build workflow.
