### PR TITLE
Fix `databricks configure` if new profile is specified

### DIFF
--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -42,7 +42,11 @@ func configureInteractive(cmd *cobra.Command, flags *configureFlags, cfg *config
 
 	// Ask user to specify a cluster if not already set.
 	if flags.ConfigureCluster && cfg.ClusterID == "" {
-		w, err := databricks.NewWorkspaceClient((*databricks.Config)(cfg))
+		// Create workspace client with configuration without the profile name set.
+		w, err := databricks.NewWorkspaceClient(&databricks.Config{
+			Host:  cfg.Host,
+			Token: cfg.Token,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Changes

The code included the to-be-created profile in the configuration and that triggered the SDK to try and load it. Instead, we must use the specified host and token directly.

## Tests

Manually. More integration test coverage tbd. 
