### PR TITLE
Add documentation for positional args in commands generated from the Databricks OpenAPI specification

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -130,7 +130,15 @@ func new{{.PascalName}}() *cobra.Command {
 	cmd.Use = "{{.KebabName}}{{if $hasPosArgs}}{{range .Request.RequiredFields}} {{.ConstantName}}{{end}}{{end}}"
 	{{- if .Description }}
 	cmd.Short = `{{.Summary | without "`"}}`
-	cmd.Long = `{{.Comment  "  " 80 | without "`"}}`
+	cmd.Long = `{{.Comment  "  " 80 | without "`"}}
+	{{- if and $hasPosArgs (gt (len .Request.RequiredFields) 0) }}
+
+  Arguments:
+    {{- range .Request.RequiredFields }}
+    {{ .ConstantName }}: {{.Comment "    " 80 | without "`"}}
+    {{ end }}
+    {{- end -}}
+	`
 	{{- end }}
 	{{- if .IsPrivatePreview }}
 

--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -131,6 +131,7 @@ func new{{.PascalName}}() *cobra.Command {
 		{{- range .Request.RequiredFields -}}
 			{{- if .HasComment -}}
 				{{- $atleastOneArgumentWithDescription = true -}}
+				{{- break -}}
 			{{- end -}}
 		{{- end -}}
 	{{- end -}}

--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -126,12 +126,20 @@ func new{{.PascalName}}() *cobra.Command {
 	{{- $hasRequiredArgs :=  and (not $hasIdPrompt) $hasPosArgs -}}
 	{{- $hasSingleRequiredRequestBodyFieldWithPrompt := and (and $hasIdPrompt .Request) (eq 1 (len .Request.RequiredRequestBodyFields))  -}}
 
+	{{- $atleastOneArgumentWithDescription := false -}}
+	{{- if $hasPosArgs -}}
+		{{- range .Request.RequiredFields -}}
+			{{- if .HasComment -}}
+				{{- $atleastOneArgumentWithDescription = true -}}
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
 
 	cmd.Use = "{{.KebabName}}{{if $hasPosArgs}}{{range .Request.RequiredFields}} {{.ConstantName}}{{end}}{{end}}"
 	{{- if .Description }}
 	cmd.Short = `{{.Summary | without "`"}}`
 	cmd.Long = `{{.Comment  "  " 80 | without "`"}}
-	{{- if and $hasPosArgs (gt (len .Request.RequiredFields) 0) }}
+	{{- if $atleastOneArgumentWithDescription }}
 
   Arguments:
     {{- range .Request.RequiredFields }}

--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -143,8 +143,8 @@ func new{{.PascalName}}() *cobra.Command {
 
   Arguments:
     {{- range .Request.RequiredFields }}
-    {{ .ConstantName }}: {{.Comment "    " 80 | without "`"}}
-    {{ end }}
+    {{ .ConstantName }}: {{.Comment "      " 80 | without "`"}}
+    {{- end -}}
     {{- end -}}
 	`
 	{{- end }}

--- a/.gitattributes
+++ b/.gitattributes
@@ -83,6 +83,3 @@ cmd/workspace/warehouses/warehouses.go linguist-generated=true
 cmd/workspace/workspace-bindings/workspace-bindings.go linguist-generated=true
 cmd/workspace/workspace-conf/workspace-conf.go linguist-generated=true
 cmd/workspace/workspace/workspace.go linguist-generated=true
-
-# Hide diff for Go structs generated from databricks terraform provider schema
-bundle/internal/tf/schema/*.go linguist-generated=true

--- a/cmd/account/access-control/access-control.go
+++ b/cmd/account/access-control/access-control.go
@@ -62,8 +62,7 @@ func newGetAssignableRolesForResource() *cobra.Command {
   role.
 
   Arguments:
-    RESOURCE: The resource name for which assignable roles will be listed.
-    `
+    RESOURCE: The resource name for which assignable roles will be listed.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -130,15 +129,14 @@ func newGetRuleSet() *cobra.Command {
 
   Arguments:
     NAME: The ruleset name associated with the request.
-    
     ETAG: Etag used for versioning. The response is at least as fresh as the eTag
-    provided. Etag is used for optimistic concurrency control as a way to help
-    prevent simultaneous updates of a rule set from overwriting each other. It
-    is strongly suggested that systems make use of the etag in the read ->
-    modify -> write pattern to perform rule set updates in order to avoid race
-    conditions that is get an etag from a GET rule set request, and pass it with
-    the PUT update request to identify the rule set version you are updating.
-    `
+      provided. Etag is used for optimistic concurrency control as a way to help
+      prevent simultaneous updates of a rule set from overwriting each other. It
+      is strongly suggested that systems make use of the etag in the read ->
+      modify -> write pattern to perform rule set updates in order to avoid race
+      conditions that is get an etag from a GET rule set request, and pass it
+      with the PUT update request to identify the rule set version you are
+      updating.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/access-control/access-control.go
+++ b/cmd/account/access-control/access-control.go
@@ -59,7 +59,11 @@ func newGetAssignableRolesForResource() *cobra.Command {
   
   Gets all the roles that can be granted on an account level resource. A role is
   grantable if the rule set on the resource can contain an access rule of the
-  role.`
+  role.
+
+  Arguments:
+    RESOURCE: The resource name for which assignable roles will be listed.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -122,7 +126,19 @@ func newGetRuleSet() *cobra.Command {
   
   Get a rule set by its name. A rule set is always attached to a resource and
   contains a list of access rules on the said resource. Currently only a default
-  rule set for each resource is supported.`
+  rule set for each resource is supported.
+
+  Arguments:
+    NAME: The ruleset name associated with the request.
+    
+    ETAG: Etag used for versioning. The response is at least as fresh as the eTag
+    provided. Etag is used for optimistic concurrency control as a way to help
+    prevent simultaneous updates of a rule set from overwriting each other. It
+    is strongly suggested that systems make use of the etag in the read ->
+    modify -> write pattern to perform rule set updates in order to avoid race
+    conditions that is get an etag from a GET rule set request, and pass it with
+    the PUT update request to identify the rule set version you are updating.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/billable-usage/billable-usage.go
+++ b/cmd/account/billable-usage/billable-usage.go
@@ -67,12 +67,10 @@ func newDownload() *cobra.Command {
   [CSV file schema]: https://docs.databricks.com/administration-guide/account-settings/usage-analysis.html#schema
 
   Arguments:
-    START_MONTH: Format: YYYY-MM. First month to return billable usage logs for. This field
-    is required.
-    
-    END_MONTH: Format: YYYY-MM. Last month to return billable usage logs for. This field
-    is required.
-    `
+    START_MONTH: Format: YYYY-MM. First month to return billable usage logs for. This
+      field is required.
+    END_MONTH: Format: YYYY-MM. Last month to return billable usage logs for. This
+      field is required.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/billable-usage/billable-usage.go
+++ b/cmd/account/billable-usage/billable-usage.go
@@ -64,7 +64,15 @@ func newDownload() *cobra.Command {
   this API may hit a timeout after a few minutes. If you experience this, try to
   mitigate by calling the API with narrower date ranges.
   
-  [CSV file schema]: https://docs.databricks.com/administration-guide/account-settings/usage-analysis.html#schema`
+  [CSV file schema]: https://docs.databricks.com/administration-guide/account-settings/usage-analysis.html#schema
+
+  Arguments:
+    START_MONTH: Format: YYYY-MM. First month to return billable usage logs for. This field
+    is required.
+    
+    END_MONTH: Format: YYYY-MM. Last month to return billable usage logs for. This field
+    is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/budgets/budgets.go
+++ b/cmd/account/budgets/budgets.go
@@ -127,8 +127,7 @@ func newDelete() *cobra.Command {
   Deletes the budget specified by its UUID.
 
   Arguments:
-    BUDGET_ID: Budget ID
-    `
+    BUDGET_ID: Budget ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -205,8 +204,7 @@ func newGet() *cobra.Command {
   day that the budget is configured to include.
 
   Arguments:
-    BUDGET_ID: Budget ID
-    `
+    BUDGET_ID: Budget ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/budgets/budgets.go
+++ b/cmd/account/budgets/budgets.go
@@ -124,7 +124,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete budget.`
 	cmd.Long = `Delete budget.
   
-  Deletes the budget specified by its UUID.`
+  Deletes the budget specified by its UUID.
+
+  Arguments:
+    BUDGET_ID: Budget ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -198,7 +202,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get budget and its status.
   
   Gets the budget specified by its UUID, including noncumulative status for each
-  day that the budget is configured to include.`
+  day that the budget is configured to include.
+
+  Arguments:
+    BUDGET_ID: Budget ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/credentials/credentials.go
+++ b/cmd/account/credentials/credentials.go
@@ -142,8 +142,7 @@ func newDelete() *cobra.Command {
   workspace.
 
   Arguments:
-    CREDENTIALS_ID: Databricks Account API credential configuration ID
-    `
+    CREDENTIALS_ID: Databricks Account API credential configuration ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -220,8 +219,7 @@ func newGet() *cobra.Command {
   specified by ID.
 
   Arguments:
-    CREDENTIALS_ID: Databricks Account API credential configuration ID
-    `
+    CREDENTIALS_ID: Databricks Account API credential configuration ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/credentials/credentials.go
+++ b/cmd/account/credentials/credentials.go
@@ -139,7 +139,11 @@ func newDelete() *cobra.Command {
   
   Deletes a Databricks credential configuration object for an account, both
   specified by ID. You cannot delete a credential that is associated with any
-  workspace.`
+  workspace.
+
+  Arguments:
+    CREDENTIALS_ID: Databricks Account API credential configuration ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -213,7 +217,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get credential configuration.
   
   Gets a Databricks credential configuration object for an account, both
-  specified by ID.`
+  specified by ID.
+
+  Arguments:
+    CREDENTIALS_ID: Databricks Account API credential configuration ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/custom-app-integration/custom-app-integration.go
+++ b/cmd/account/custom-app-integration/custom-app-integration.go
@@ -133,8 +133,7 @@ func newDelete() *cobra.Command {
   oauth app integration via :method:CustomAppIntegration/get.
 
   Arguments:
-    INTEGRATION_ID: The oauth app integration ID.
-    `
+    INTEGRATION_ID: The oauth app integration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -198,8 +197,7 @@ func newGet() *cobra.Command {
   Gets the Custom OAuth App Integration for the given integration id.
 
   Arguments:
-    INTEGRATION_ID: The oauth app integration ID.
-    `
+    INTEGRATION_ID: The oauth app integration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -318,8 +316,7 @@ func newUpdate() *cobra.Command {
   oauth app integration via :method:CustomAppIntegration/get.
 
   Arguments:
-    INTEGRATION_ID: The oauth app integration ID.
-    `
+    INTEGRATION_ID: The oauth app integration ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/custom-app-integration/custom-app-integration.go
+++ b/cmd/account/custom-app-integration/custom-app-integration.go
@@ -130,7 +130,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete Custom OAuth App Integration.
   
   Delete an existing Custom OAuth App Integration. You can retrieve the custom
-  oauth app integration via :method:CustomAppIntegration/get.`
+  oauth app integration via :method:CustomAppIntegration/get.
+
+  Arguments:
+    INTEGRATION_ID: The oauth app integration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -191,7 +195,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get OAuth Custom App Integration.`
 	cmd.Long = `Get OAuth Custom App Integration.
   
-  Gets the Custom OAuth App Integration for the given integration id.`
+  Gets the Custom OAuth App Integration for the given integration id.
+
+  Arguments:
+    INTEGRATION_ID: The oauth app integration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -307,7 +315,11 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Updates Custom OAuth App Integration.
   
   Updates an existing custom OAuth App Integration. You can retrieve the custom
-  oauth app integration via :method:CustomAppIntegration/get.`
+  oauth app integration via :method:CustomAppIntegration/get.
+
+  Arguments:
+    INTEGRATION_ID: The oauth app integration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/encryption-keys/encryption-keys.go
+++ b/cmd/account/encryption-keys/encryption-keys.go
@@ -158,8 +158,7 @@ func newDelete() *cobra.Command {
   delete a configuration that is associated with a running workspace.
 
   Arguments:
-    CUSTOMER_MANAGED_KEY_ID: Databricks encryption key configuration ID.
-    `
+    CUSTOMER_MANAGED_KEY_ID: Databricks encryption key configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -237,8 +236,7 @@ func newGet() *cobra.Command {
   platform.",
 
   Arguments:
-    CUSTOMER_MANAGED_KEY_ID: Databricks encryption key configuration ID.
-    `
+    CUSTOMER_MANAGED_KEY_ID: Databricks encryption key configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/encryption-keys/encryption-keys.go
+++ b/cmd/account/encryption-keys/encryption-keys.go
@@ -155,7 +155,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete encryption key configuration.
   
   Deletes a customer-managed key configuration object for an account. You cannot
-  delete a configuration that is associated with a running workspace.`
+  delete a configuration that is associated with a running workspace.
+
+  Arguments:
+    CUSTOMER_MANAGED_KEY_ID: Databricks encryption key configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -230,7 +234,11 @@ func newGet() *cobra.Command {
   types, subscription types, and AWS regions.
   
   This operation is available only if your account is on the E2 version of the
-  platform.",`
+  platform.",
+
+  Arguments:
+    CUSTOMER_MANAGED_KEY_ID: Databricks encryption key configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/groups/groups.go
+++ b/cmd/account/groups/groups.go
@@ -140,7 +140,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a group.`
 	cmd.Long = `Delete a group.
   
-  Deletes a group from the Databricks account.`
+  Deletes a group from the Databricks account.
+
+  Arguments:
+    ID: Unique ID for a group in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -213,7 +217,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get group details.`
 	cmd.Long = `Get group details.
   
-  Gets the information for a specific group in the Databricks account.`
+  Gets the information for a specific group in the Databricks account.
+
+  Arguments:
+    ID: Unique ID for a group in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -358,7 +366,11 @@ func newPatch() *cobra.Command {
 	cmd.Short = `Update group details.`
 	cmd.Long = `Update group details.
   
-  Partially updates the details of a group.`
+  Partially updates the details of a group.
+
+  Arguments:
+    ID: Unique ID for a group in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -449,7 +461,11 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Replace a group.`
 	cmd.Long = `Replace a group.
   
-  Updates the details of a group by replacing the entire group entity.`
+  Updates the details of a group by replacing the entire group entity.
+
+  Arguments:
+    ID: Databricks group ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/groups/groups.go
+++ b/cmd/account/groups/groups.go
@@ -143,8 +143,7 @@ func newDelete() *cobra.Command {
   Deletes a group from the Databricks account.
 
   Arguments:
-    ID: Unique ID for a group in the Databricks account.
-    `
+    ID: Unique ID for a group in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -220,8 +219,7 @@ func newGet() *cobra.Command {
   Gets the information for a specific group in the Databricks account.
 
   Arguments:
-    ID: Unique ID for a group in the Databricks account.
-    `
+    ID: Unique ID for a group in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -369,8 +367,7 @@ func newPatch() *cobra.Command {
   Partially updates the details of a group.
 
   Arguments:
-    ID: Unique ID for a group in the Databricks account.
-    `
+    ID: Unique ID for a group in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -464,8 +461,7 @@ func newUpdate() *cobra.Command {
   Updates the details of a group by replacing the entire group entity.
 
   Arguments:
-    ID: Databricks group ID
-    `
+    ID: Databricks group ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/ip-access-lists/ip-access-lists.go
+++ b/cmd/account/ip-access-lists/ip-access-lists.go
@@ -154,7 +154,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete access list.`
 	cmd.Long = `Delete access list.
   
-  Deletes an IP access list, specified by its list ID.`
+  Deletes an IP access list, specified by its list ID.
+
+  Arguments:
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -227,7 +231,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get IP access list.`
 	cmd.Long = `Get IP access list.
   
-  Gets an IP access list, specified by its list ID.`
+  Gets an IP access list, specified by its list ID.
+
+  Arguments:
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/ip-access-lists/ip-access-lists.go
+++ b/cmd/account/ip-access-lists/ip-access-lists.go
@@ -157,8 +157,7 @@ func newDelete() *cobra.Command {
   Deletes an IP access list, specified by its list ID.
 
   Arguments:
-    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list.
-    `
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -234,8 +233,7 @@ func newGet() *cobra.Command {
   Gets an IP access list, specified by its list ID.
 
   Arguments:
-    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list.
-    `
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/log-delivery/log-delivery.go
+++ b/cmd/account/log-delivery/log-delivery.go
@@ -208,7 +208,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get log delivery configuration.
   
   Gets a Databricks log delivery configuration object for an account, both
-  specified by ID.`
+  specified by ID.
+
+  Arguments:
+    LOG_DELIVERY_CONFIGURATION_ID: Databricks log delivery configuration ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -351,7 +355,17 @@ func newPatchStatus() *cobra.Command {
   configurations is not supported, so disable log delivery configurations that
   are no longer needed. Note that you can't re-enable a delivery configuration
   if this would violate the delivery configuration limits described under
-  [Create log delivery](:method:LogDelivery/Create).`
+  [Create log delivery](:method:LogDelivery/Create).
+
+  Arguments:
+    LOG_DELIVERY_CONFIGURATION_ID: Databricks log delivery configuration ID
+    
+    STATUS: Status of log delivery configuration. Set to ENABLED (enabled) or
+    DISABLED (disabled). Defaults to ENABLED. You can [enable or disable the
+    configuration](#operation/patch-log-delivery-config-status) later. Deletion
+    of a configuration is not supported, so disable a log delivery configuration
+    that is no longer needed.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/log-delivery/log-delivery.go
+++ b/cmd/account/log-delivery/log-delivery.go
@@ -211,8 +211,7 @@ func newGet() *cobra.Command {
   specified by ID.
 
   Arguments:
-    LOG_DELIVERY_CONFIGURATION_ID: Databricks log delivery configuration ID
-    `
+    LOG_DELIVERY_CONFIGURATION_ID: Databricks log delivery configuration ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -359,13 +358,11 @@ func newPatchStatus() *cobra.Command {
 
   Arguments:
     LOG_DELIVERY_CONFIGURATION_ID: Databricks log delivery configuration ID
-    
     STATUS: Status of log delivery configuration. Set to ENABLED (enabled) or
-    DISABLED (disabled). Defaults to ENABLED. You can [enable or disable the
-    configuration](#operation/patch-log-delivery-config-status) later. Deletion
-    of a configuration is not supported, so disable a log delivery configuration
-    that is no longer needed.
-    `
+      DISABLED (disabled). Defaults to ENABLED. You can [enable or disable
+      the configuration](#operation/patch-log-delivery-config-status) later.
+      Deletion of a configuration is not supported, so disable a log delivery
+      configuration that is no longer needed.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/metastore-assignments/metastore-assignments.go
+++ b/cmd/account/metastore-assignments/metastore-assignments.go
@@ -59,7 +59,13 @@ func newCreate() *cobra.Command {
 	cmd.Short = `Assigns a workspace to a metastore.`
 	cmd.Long = `Assigns a workspace to a metastore.
   
-  Creates an assignment to a metastore for a workspace`
+  Creates an assignment to a metastore for a workspace
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -131,7 +137,13 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a metastore assignment.
   
   Deletes a metastore assignment to a workspace, leaving the workspace with no
-  metastore.`
+  metastore.
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -199,7 +211,11 @@ func newGet() *cobra.Command {
   Gets the metastore assignment, if any, for the workspace specified by ID. If
   the workspace is assigned a metastore, the mappig will be returned. If no
   metastore is assigned to the workspace, the assignment will not be found and a
-  404 returned.`
+  404 returned.
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -264,7 +280,11 @@ func newList() *cobra.Command {
 	cmd.Long = `Get all workspaces assigned to a metastore.
   
   Gets a list of all Databricks workspace IDs that have been assigned to given
-  metastore.`
+  metastore.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -330,7 +350,13 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Updates a metastore assignment to a workspaces.
   
   Updates an assignment to a metastore for a workspace. Currently, only the
-  default catalog may be updated.`
+  default catalog may be updated.
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/metastore-assignments/metastore-assignments.go
+++ b/cmd/account/metastore-assignments/metastore-assignments.go
@@ -63,9 +63,7 @@ func newCreate() *cobra.Command {
 
   Arguments:
     WORKSPACE_ID: Workspace ID.
-    
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -141,9 +139,7 @@ func newDelete() *cobra.Command {
 
   Arguments:
     WORKSPACE_ID: Workspace ID.
-    
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -214,8 +210,7 @@ func newGet() *cobra.Command {
   404 returned.
 
   Arguments:
-    WORKSPACE_ID: Workspace ID.
-    `
+    WORKSPACE_ID: Workspace ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -283,8 +278,7 @@ func newList() *cobra.Command {
   metastore.
 
   Arguments:
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -354,9 +348,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     WORKSPACE_ID: Workspace ID.
-    
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/metastores/metastores.go
+++ b/cmd/account/metastores/metastores.go
@@ -126,7 +126,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a metastore.`
 	cmd.Long = `Delete a metastore.
   
-  Deletes a Unity Catalog metastore for an account, both specified by ID.`
+  Deletes a Unity Catalog metastore for an account, both specified by ID.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -187,7 +191,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a metastore.`
 	cmd.Long = `Get a metastore.
   
-  Gets a Unity Catalog metastore from an account, both specified by ID.`
+  Gets a Unity Catalog metastore from an account, both specified by ID.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -300,7 +308,11 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Update a metastore.`
 	cmd.Long = `Update a metastore.
   
-  Updates an existing Unity Catalog metastore.`
+  Updates an existing Unity Catalog metastore.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/metastores/metastores.go
+++ b/cmd/account/metastores/metastores.go
@@ -129,8 +129,7 @@ func newDelete() *cobra.Command {
   Deletes a Unity Catalog metastore for an account, both specified by ID.
 
   Arguments:
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -194,8 +193,7 @@ func newGet() *cobra.Command {
   Gets a Unity Catalog metastore from an account, both specified by ID.
 
   Arguments:
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -311,8 +309,7 @@ func newUpdate() *cobra.Command {
   Updates an existing Unity Catalog metastore.
 
   Arguments:
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/network-connectivity/network-connectivity.go
+++ b/cmd/account/network-connectivity/network-connectivity.go
@@ -77,7 +77,18 @@ func newCreateNetworkConnectivityConfiguration() *cobra.Command {
   multiple workspaces from the same Azure region within the same Databricks
   account. See [configure serverless secure connectivity].
   
-  [configure serverless secure connectivity]: https://learn.microsoft.com/azure/databricks/security/network/serverless-network-security`
+  [configure serverless secure connectivity]: https://learn.microsoft.com/azure/databricks/security/network/serverless-network-security
+
+  Arguments:
+    NAME: The name of the network connectivity configuration. The name can contain
+    alphanumeric characters, hyphens, and underscores. The length must be
+    between 3 and 30 characters. The name must match the regular expression
+    ^[0-9a-zA-Z-_]{3,30}$.
+    
+    REGION: The Azure region for this network connectivity configuration. Only
+    workspaces in the same Azure region can be attached to this network
+    connectivity configuration.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -167,7 +178,17 @@ func newCreatePrivateEndpointRule() *cobra.Command {
   private endpoint created, make a GET request on the new private endpoint
   rule. See [serverless private link].
   
-  [serverless private link]: https://learn.microsoft.com/azure/databricks/security/network/serverless-network-security/serverless-private-link`
+  [serverless private link]: https://learn.microsoft.com/azure/databricks/security/network/serverless-network-security/serverless-private-link
+
+  Arguments:
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
+    
+    RESOURCE_ID: The Azure resource ID of the target resource.
+    
+    GROUP_ID: The sub-resource type (group ID) of the target resource. Note that to
+    connect to workspace root storage (root DBFS), you need two endpoints, one
+    for blob and one for dfs.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -250,7 +271,11 @@ func newDeleteNetworkConnectivityConfiguration() *cobra.Command {
 	cmd.Short = `Delete a network connectivity configuration.`
 	cmd.Long = `Delete a network connectivity configuration.
   
-  Deletes a network connectivity configuration.`
+  Deletes a network connectivity configuration.
+
+  Arguments:
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -315,7 +340,13 @@ func newDeletePrivateEndpointRule() *cobra.Command {
   deactivated and will be purged after seven days of deactivation. When a
   private endpoint is in deactivated state, deactivated field is set to true
   and the private endpoint is not available to your serverless compute
-  resources.`
+  resources.
+
+  Arguments:
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
+    
+    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -377,7 +408,11 @@ func newGetNetworkConnectivityConfiguration() *cobra.Command {
 	cmd.Short = `Get a network connectivity configuration.`
 	cmd.Long = `Get a network connectivity configuration.
   
-  Gets a network connectivity configuration.`
+  Gets a network connectivity configuration.
+
+  Arguments:
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -438,7 +473,13 @@ func newGetPrivateEndpointRule() *cobra.Command {
 	cmd.Short = `Get a private endpoint rule.`
 	cmd.Long = `Get a private endpoint rule.
   
-  Gets the private endpoint rule.`
+  Gets the private endpoint rule.
+
+  Arguments:
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
+    
+    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -563,7 +604,11 @@ func newListPrivateEndpointRules() *cobra.Command {
 	cmd.Short = `List private endpoint rules.`
 	cmd.Long = `List private endpoint rules.
   
-  Gets an array of private endpoint rules.`
+  Gets an array of private endpoint rules.
+
+  Arguments:
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/network-connectivity/network-connectivity.go
+++ b/cmd/account/network-connectivity/network-connectivity.go
@@ -81,14 +81,12 @@ func newCreateNetworkConnectivityConfiguration() *cobra.Command {
 
   Arguments:
     NAME: The name of the network connectivity configuration. The name can contain
-    alphanumeric characters, hyphens, and underscores. The length must be
-    between 3 and 30 characters. The name must match the regular expression
-    ^[0-9a-zA-Z-_]{3,30}$.
-    
+      alphanumeric characters, hyphens, and underscores. The length must be
+      between 3 and 30 characters. The name must match the regular expression
+      ^[0-9a-zA-Z-_]{3,30}$.
     REGION: The Azure region for this network connectivity configuration. Only
-    workspaces in the same Azure region can be attached to this network
-    connectivity configuration.
-    `
+      workspaces in the same Azure region can be attached to this network
+      connectivity configuration.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -182,13 +180,10 @@ func newCreatePrivateEndpointRule() *cobra.Command {
 
   Arguments:
     NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
-    
     RESOURCE_ID: The Azure resource ID of the target resource.
-    
     GROUP_ID: The sub-resource type (group ID) of the target resource. Note that to
-    connect to workspace root storage (root DBFS), you need two endpoints, one
-    for blob and one for dfs.
-    `
+      connect to workspace root storage (root DBFS), you need two endpoints, one
+      for blob and one for dfs.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -274,8 +269,7 @@ func newDeleteNetworkConnectivityConfiguration() *cobra.Command {
   Deletes a network connectivity configuration.
 
   Arguments:
-    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
-    `
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -344,9 +338,7 @@ func newDeletePrivateEndpointRule() *cobra.Command {
 
   Arguments:
     NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
-    
-    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.
-    `
+    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -411,8 +403,7 @@ func newGetNetworkConnectivityConfiguration() *cobra.Command {
   Gets a network connectivity configuration.
 
   Arguments:
-    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
-    `
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -477,9 +468,7 @@ func newGetPrivateEndpointRule() *cobra.Command {
 
   Arguments:
     NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
-    
-    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.
-    `
+    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -607,8 +596,7 @@ func newListPrivateEndpointRules() *cobra.Command {
   Gets an array of private endpoint rules.
 
   Arguments:
-    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.
-    `
+    NETWORK_CONNECTIVITY_CONFIG_ID: Your Network Connectvity Configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/network-policy/network-policy.go
+++ b/cmd/account/network-policy/network-policy.go
@@ -67,13 +67,12 @@ func newDeleteAccountNetworkPolicy() *cobra.Command {
 
   Arguments:
     ETAG: etag used for versioning. The response is at least as fresh as the eTag
-    provided. This is used for optimistic concurrency control as a way to help
-    prevent simultaneous writes of a setting overwriting each other. It is
-    strongly suggested that systems make use of the etag in the read -> delete
-    pattern to perform setting deletions in order to avoid race conditions. That
-    is, get an etag from a GET request, and pass it with the DELETE request to
-    identify the rule set version you are deleting.
-    `
+      provided. This is used for optimistic concurrency control as a way to help
+      prevent simultaneous writes of a setting overwriting each other. It is
+      strongly suggested that systems make use of the etag in the read -> delete
+      pattern to perform setting deletions in order to avoid race conditions.
+      That is, get an etag from a GET request, and pass it with the DELETE
+      request to identify the rule set version you are deleting.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -138,13 +137,12 @@ func newReadAccountNetworkPolicy() *cobra.Command {
 
   Arguments:
     ETAG: etag used for versioning. The response is at least as fresh as the eTag
-    provided. This is used for optimistic concurrency control as a way to help
-    prevent simultaneous writes of a setting overwriting each other. It is
-    strongly suggested that systems make use of the etag in the read -> delete
-    pattern to perform setting deletions in order to avoid race conditions. That
-    is, get an etag from a GET request, and pass it with the DELETE request to
-    identify the rule set version you are deleting.
-    `
+      provided. This is used for optimistic concurrency control as a way to help
+      prevent simultaneous writes of a setting overwriting each other. It is
+      strongly suggested that systems make use of the etag in the read -> delete
+      pattern to perform setting deletions in order to avoid race conditions.
+      That is, get an etag from a GET request, and pass it with the DELETE
+      request to identify the rule set version you are deleting.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/network-policy/network-policy.go
+++ b/cmd/account/network-policy/network-policy.go
@@ -63,7 +63,17 @@ func newDeleteAccountNetworkPolicy() *cobra.Command {
 	cmd.Short = `Delete Account Network Policy.`
 	cmd.Long = `Delete Account Network Policy.
   
-  Reverts back all the account network policies back to default.`
+  Reverts back all the account network policies back to default.
+
+  Arguments:
+    ETAG: etag used for versioning. The response is at least as fresh as the eTag
+    provided. This is used for optimistic concurrency control as a way to help
+    prevent simultaneous writes of a setting overwriting each other. It is
+    strongly suggested that systems make use of the etag in the read -> delete
+    pattern to perform setting deletions in order to avoid race conditions. That
+    is, get an etag from a GET request, and pass it with the DELETE request to
+    identify the rule set version you are deleting.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -124,7 +134,17 @@ func newReadAccountNetworkPolicy() *cobra.Command {
 	cmd.Short = `Get Account Network Policy.`
 	cmd.Long = `Get Account Network Policy.
   
-  Gets the value of Account level Network Policy.`
+  Gets the value of Account level Network Policy.
+
+  Arguments:
+    ETAG: etag used for versioning. The response is at least as fresh as the eTag
+    provided. This is used for optimistic concurrency control as a way to help
+    prevent simultaneous writes of a setting overwriting each other. It is
+    strongly suggested that systems make use of the etag in the read -> delete
+    pattern to perform setting deletions in order to avoid race conditions. That
+    is, get an etag from a GET request, and pass it with the DELETE request to
+    identify the rule set version you are deleting.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/networks/networks.go
+++ b/cmd/account/networks/networks.go
@@ -66,7 +66,11 @@ func newCreate() *cobra.Command {
   
   Creates a Databricks network configuration that represents an VPC and its
   resources. The VPC will be used for new Databricks clusters. This requires a
-  pre-existing VPC and subnets.`
+  pre-existing VPC and subnets.
+
+  Arguments:
+    NETWORK_NAME: The human-readable name of the network configuration.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -147,7 +151,11 @@ func newDelete() *cobra.Command {
   workspace.
   
   This operation is available only if your account is on the E2 version of the
-  platform.`
+  platform.
+
+  Arguments:
+    NETWORK_ID: Databricks Account API network configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -221,7 +229,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a network configuration.
   
   Gets a Databricks network configuration, which represents a cloud VPC and its
-  resources.`
+  resources.
+
+  Arguments:
+    NETWORK_ID: Databricks Account API network configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/networks/networks.go
+++ b/cmd/account/networks/networks.go
@@ -69,8 +69,7 @@ func newCreate() *cobra.Command {
   pre-existing VPC and subnets.
 
   Arguments:
-    NETWORK_NAME: The human-readable name of the network configuration.
-    `
+    NETWORK_NAME: The human-readable name of the network configuration.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -154,8 +153,7 @@ func newDelete() *cobra.Command {
   platform.
 
   Arguments:
-    NETWORK_ID: Databricks Account API network configuration ID.
-    `
+    NETWORK_ID: Databricks Account API network configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -232,8 +230,7 @@ func newGet() *cobra.Command {
   resources.
 
   Arguments:
-    NETWORK_ID: Databricks Account API network configuration ID.
-    `
+    NETWORK_ID: Databricks Account API network configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/private-access/private-access.go
+++ b/cmd/account/private-access/private-access.go
@@ -75,7 +75,14 @@ func newCreate() *cobra.Command {
   PrivateLink].
   
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
-  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html`
+  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
+
+  Arguments:
+    PRIVATE_ACCESS_SETTINGS_NAME: The human-readable name of the private access settings object.
+    
+    REGION: The cloud region for workspaces associated with this private access settings
+    object.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -161,7 +168,11 @@ func newDelete() *cobra.Command {
   PrivateLink].
   
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
-  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html`
+  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
+
+  Arguments:
+    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -241,7 +252,11 @@ func newGet() *cobra.Command {
   PrivateLink].
   
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
-  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html`
+  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
+
+  Arguments:
+    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -389,7 +404,16 @@ func newReplace() *cobra.Command {
   PrivateLink].
   
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
-  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html`
+  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
+
+  Arguments:
+    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.
+    
+    PRIVATE_ACCESS_SETTINGS_NAME: The human-readable name of the private access settings object.
+    
+    REGION: The cloud region for workspaces associated with this private access settings
+    object.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/private-access/private-access.go
+++ b/cmd/account/private-access/private-access.go
@@ -79,10 +79,8 @@ func newCreate() *cobra.Command {
 
   Arguments:
     PRIVATE_ACCESS_SETTINGS_NAME: The human-readable name of the private access settings object.
-    
-    REGION: The cloud region for workspaces associated with this private access settings
-    object.
-    `
+    REGION: The cloud region for workspaces associated with this private access
+      settings object.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -171,8 +169,7 @@ func newDelete() *cobra.Command {
   [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
 
   Arguments:
-    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.
-    `
+    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -255,8 +252,7 @@ func newGet() *cobra.Command {
   [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
 
   Arguments:
-    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.
-    `
+    PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -408,12 +404,9 @@ func newReplace() *cobra.Command {
 
   Arguments:
     PRIVATE_ACCESS_SETTINGS_ID: Databricks Account API private access settings ID.
-    
     PRIVATE_ACCESS_SETTINGS_NAME: The human-readable name of the private access settings object.
-    
-    REGION: The cloud region for workspaces associated with this private access settings
-    object.
-    `
+    REGION: The cloud region for workspaces associated with this private access
+      settings object.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/published-app-integration/published-app-integration.go
+++ b/cmd/account/published-app-integration/published-app-integration.go
@@ -133,8 +133,7 @@ func newDelete() *cobra.Command {
   published oauth app integration via :method:PublishedAppIntegration/get.
 
   Arguments:
-    INTEGRATION_ID: The oauth app integration ID.
-    `
+    INTEGRATION_ID: The oauth app integration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -198,8 +197,7 @@ func newGet() *cobra.Command {
   Gets the Published OAuth App Integration for the given integration id.
 
   Arguments:
-    INTEGRATION_ID: The oauth app integration ID.
-    `
+    INTEGRATION_ID: The oauth app integration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -317,8 +315,7 @@ func newUpdate() *cobra.Command {
   published oauth app integration via :method:PublishedAppIntegration/get.
 
   Arguments:
-    INTEGRATION_ID: The oauth app integration ID.
-    `
+    INTEGRATION_ID: The oauth app integration ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/published-app-integration/published-app-integration.go
+++ b/cmd/account/published-app-integration/published-app-integration.go
@@ -130,7 +130,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete Published OAuth App Integration.
   
   Delete an existing Published OAuth App Integration. You can retrieve the
-  published oauth app integration via :method:PublishedAppIntegration/get.`
+  published oauth app integration via :method:PublishedAppIntegration/get.
+
+  Arguments:
+    INTEGRATION_ID: The oauth app integration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -191,7 +195,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get OAuth Published App Integration.`
 	cmd.Long = `Get OAuth Published App Integration.
   
-  Gets the Published OAuth App Integration for the given integration id.`
+  Gets the Published OAuth App Integration for the given integration id.
+
+  Arguments:
+    INTEGRATION_ID: The oauth app integration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -306,7 +314,11 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Updates Published OAuth App Integration.
   
   Updates an existing published OAuth App Integration. You can retrieve the
-  published oauth app integration via :method:PublishedAppIntegration/get.`
+  published oauth app integration via :method:PublishedAppIntegration/get.
+
+  Arguments:
+    INTEGRATION_ID: The oauth app integration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/service-principal-secrets/service-principal-secrets.go
+++ b/cmd/account/service-principal-secrets/service-principal-secrets.go
@@ -66,7 +66,11 @@ func newCreate() *cobra.Command {
 	cmd.Short = `Create service principal secret.`
 	cmd.Long = `Create service principal secret.
   
-  Create a secret for the given service principal.`
+  Create a secret for the given service principal.
+
+  Arguments:
+    SERVICE_PRINCIPAL_ID: The service principal ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -130,7 +134,13 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete service principal secret.`
 	cmd.Long = `Delete service principal secret.
   
-  Delete a secret from the given service principal.`
+  Delete a secret from the given service principal.
+
+  Arguments:
+    SERVICE_PRINCIPAL_ID: The service principal ID.
+    
+    SECRET_ID: The secret ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -197,7 +207,11 @@ func newList() *cobra.Command {
   
   List all secrets associated with the given service principal. This operation
   only returns information about the secrets themselves and does not include the
-  secret values.`
+  secret values.
+
+  Arguments:
+    SERVICE_PRINCIPAL_ID: The service principal ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/service-principal-secrets/service-principal-secrets.go
+++ b/cmd/account/service-principal-secrets/service-principal-secrets.go
@@ -69,8 +69,7 @@ func newCreate() *cobra.Command {
   Create a secret for the given service principal.
 
   Arguments:
-    SERVICE_PRINCIPAL_ID: The service principal ID.
-    `
+    SERVICE_PRINCIPAL_ID: The service principal ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -138,9 +137,7 @@ func newDelete() *cobra.Command {
 
   Arguments:
     SERVICE_PRINCIPAL_ID: The service principal ID.
-    
-    SECRET_ID: The secret ID.
-    `
+    SECRET_ID: The secret ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -210,8 +207,7 @@ func newList() *cobra.Command {
   secret values.
 
   Arguments:
-    SERVICE_PRINCIPAL_ID: The service principal ID.
-    `
+    SERVICE_PRINCIPAL_ID: The service principal ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/service-principals/service-principals.go
+++ b/cmd/account/service-principals/service-principals.go
@@ -138,7 +138,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a service principal.`
 	cmd.Long = `Delete a service principal.
   
-  Delete a single service principal in the Databricks account.`
+  Delete a single service principal in the Databricks account.
+
+  Arguments:
+    ID: Unique ID for a service principal in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -212,7 +216,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get service principal details.
   
   Gets the details for a single service principal define in the Databricks
-  account.`
+  account.
+
+  Arguments:
+    ID: Unique ID for a service principal in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -358,7 +366,11 @@ func newPatch() *cobra.Command {
 	cmd.Long = `Update service principal details.
   
   Partially updates the details of a single service principal in the Databricks
-  account.`
+  account.
+
+  Arguments:
+    ID: Unique ID for a service principal in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -451,7 +463,11 @@ func newUpdate() *cobra.Command {
   
   Updates the details of a single service principal.
   
-  This action replaces the existing service principal with the same name.`
+  This action replaces the existing service principal with the same name.
+
+  Arguments:
+    ID: Databricks service principal ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/service-principals/service-principals.go
+++ b/cmd/account/service-principals/service-principals.go
@@ -141,8 +141,7 @@ func newDelete() *cobra.Command {
   Delete a single service principal in the Databricks account.
 
   Arguments:
-    ID: Unique ID for a service principal in the Databricks account.
-    `
+    ID: Unique ID for a service principal in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -219,8 +218,7 @@ func newGet() *cobra.Command {
   account.
 
   Arguments:
-    ID: Unique ID for a service principal in the Databricks account.
-    `
+    ID: Unique ID for a service principal in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -369,8 +367,7 @@ func newPatch() *cobra.Command {
   account.
 
   Arguments:
-    ID: Unique ID for a service principal in the Databricks account.
-    `
+    ID: Unique ID for a service principal in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -466,8 +463,7 @@ func newUpdate() *cobra.Command {
   This action replaces the existing service principal with the same name.
 
   Arguments:
-    ID: Databricks service principal ID.
-    `
+    ID: Databricks service principal ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/settings/settings.go
+++ b/cmd/account/settings/settings.go
@@ -68,13 +68,12 @@ func newDeletePersonalComputeSetting() *cobra.Command {
 
   Arguments:
     ETAG: etag used for versioning. The response is at least as fresh as the eTag
-    provided. This is used for optimistic concurrency control as a way to help
-    prevent simultaneous writes of a setting overwriting each other. It is
-    strongly suggested that systems make use of the etag in the read -> delete
-    pattern to perform setting deletions in order to avoid race conditions. That
-    is, get an etag from a GET request, and pass it with the DELETE request to
-    identify the rule set version you are deleting.
-    `
+      provided. This is used for optimistic concurrency control as a way to help
+      prevent simultaneous writes of a setting overwriting each other. It is
+      strongly suggested that systems make use of the etag in the read -> delete
+      pattern to perform setting deletions in order to avoid race conditions.
+      That is, get an etag from a GET request, and pass it with the DELETE
+      request to identify the rule set version you are deleting.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -139,13 +138,12 @@ func newReadPersonalComputeSetting() *cobra.Command {
 
   Arguments:
     ETAG: etag used for versioning. The response is at least as fresh as the eTag
-    provided. This is used for optimistic concurrency control as a way to help
-    prevent simultaneous writes of a setting overwriting each other. It is
-    strongly suggested that systems make use of the etag in the read -> delete
-    pattern to perform setting deletions in order to avoid race conditions. That
-    is, get an etag from a GET request, and pass it with the DELETE request to
-    identify the rule set version you are deleting.
-    `
+      provided. This is used for optimistic concurrency control as a way to help
+      prevent simultaneous writes of a setting overwriting each other. It is
+      strongly suggested that systems make use of the etag in the read -> delete
+      pattern to perform setting deletions in order to avoid race conditions.
+      That is, get an etag from a GET request, and pass it with the DELETE
+      request to identify the rule set version you are deleting.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/settings/settings.go
+++ b/cmd/account/settings/settings.go
@@ -64,7 +64,17 @@ func newDeletePersonalComputeSetting() *cobra.Command {
 	cmd.Short = `Delete Personal Compute setting.`
 	cmd.Long = `Delete Personal Compute setting.
   
-  Reverts back the Personal Compute setting value to default (ON)`
+  Reverts back the Personal Compute setting value to default (ON)
+
+  Arguments:
+    ETAG: etag used for versioning. The response is at least as fresh as the eTag
+    provided. This is used for optimistic concurrency control as a way to help
+    prevent simultaneous writes of a setting overwriting each other. It is
+    strongly suggested that systems make use of the etag in the read -> delete
+    pattern to perform setting deletions in order to avoid race conditions. That
+    is, get an etag from a GET request, and pass it with the DELETE request to
+    identify the rule set version you are deleting.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -125,7 +135,17 @@ func newReadPersonalComputeSetting() *cobra.Command {
 	cmd.Short = `Get Personal Compute setting.`
 	cmd.Long = `Get Personal Compute setting.
   
-  Gets the value of the Personal Compute setting.`
+  Gets the value of the Personal Compute setting.
+
+  Arguments:
+    ETAG: etag used for versioning. The response is at least as fresh as the eTag
+    provided. This is used for optimistic concurrency control as a way to help
+    prevent simultaneous writes of a setting overwriting each other. It is
+    strongly suggested that systems make use of the etag in the read -> delete
+    pattern to perform setting deletions in order to avoid race conditions. That
+    is, get an etag from a GET request, and pass it with the DELETE request to
+    identify the rule set version you are deleting.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/storage-credentials/storage-credentials.go
+++ b/cmd/account/storage-credentials/storage-credentials.go
@@ -66,8 +66,7 @@ func newCreate() *cobra.Command {
   **CREATE_STORAGE_CREDENTIAL** privilege on the metastore.
 
   Arguments:
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -141,9 +140,7 @@ func newDelete() *cobra.Command {
 
   Arguments:
     METASTORE_ID: Unity Catalog metastore ID
-    
-    STORAGE_CREDENTIAL_NAME: Name of the storage credential.
-    `
+    STORAGE_CREDENTIAL_NAME: Name of the storage credential.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -211,9 +208,7 @@ func newGet() *cobra.Command {
 
   Arguments:
     METASTORE_ID: Unity Catalog metastore ID
-    
-    STORAGE_CREDENTIAL_NAME: Name of the storage credential.
-    `
+    STORAGE_CREDENTIAL_NAME: Name of the storage credential.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -279,8 +274,7 @@ func newList() *cobra.Command {
   metastore.
 
   Arguments:
-    METASTORE_ID: Unity Catalog metastore ID
-    `
+    METASTORE_ID: Unity Catalog metastore ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -351,9 +345,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     METASTORE_ID: Unity Catalog metastore ID
-    
-    STORAGE_CREDENTIAL_NAME: Name of the storage credential.
-    `
+    STORAGE_CREDENTIAL_NAME: Name of the storage credential.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/storage-credentials/storage-credentials.go
+++ b/cmd/account/storage-credentials/storage-credentials.go
@@ -63,7 +63,11 @@ func newCreate() *cobra.Command {
   credentials * **GcpServiceAcountKey** for GCP credentials.
   
   The caller must be a metastore admin and have the
-  **CREATE_STORAGE_CREDENTIAL** privilege on the metastore.`
+  **CREATE_STORAGE_CREDENTIAL** privilege on the metastore.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -133,7 +137,13 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a storage credential.
   
   Deletes a storage credential from the metastore. The caller must be an owner
-  of the storage credential.`
+  of the storage credential.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    
+    STORAGE_CREDENTIAL_NAME: Name of the storage credential.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -197,7 +207,13 @@ func newGet() *cobra.Command {
   
   Gets a storage credential from the metastore. The caller must be a metastore
   admin, the owner of the storage credential, or have a level of privilege on
-  the storage credential.`
+  the storage credential.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    
+    STORAGE_CREDENTIAL_NAME: Name of the storage credential.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -260,7 +276,11 @@ func newList() *cobra.Command {
 	cmd.Long = `Get all storage credentials assigned to a metastore.
   
   Gets a list of all storage credentials that have been assigned to given
-  metastore.`
+  metastore.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -327,7 +347,13 @@ func newUpdate() *cobra.Command {
   
   Updates a storage credential on the metastore. The caller must be the owner of
   the storage credential. If the caller is a metastore admin, only the __owner__
-  credential can be changed.`
+  credential can be changed.
+
+  Arguments:
+    METASTORE_ID: Unity Catalog metastore ID
+    
+    STORAGE_CREDENTIAL_NAME: Name of the storage credential.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/storage/storage.go
+++ b/cmd/account/storage/storage.go
@@ -138,8 +138,7 @@ func newDelete() *cobra.Command {
   configuration that is associated with any workspace.
 
   Arguments:
-    STORAGE_CONFIGURATION_ID: Databricks Account API storage configuration ID.
-    `
+    STORAGE_CONFIGURATION_ID: Databricks Account API storage configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -215,8 +214,7 @@ func newGet() *cobra.Command {
   Gets a Databricks storage configuration for an account, both specified by ID.
 
   Arguments:
-    STORAGE_CONFIGURATION_ID: Databricks Account API storage configuration ID.
-    `
+    STORAGE_CONFIGURATION_ID: Databricks Account API storage configuration ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/storage/storage.go
+++ b/cmd/account/storage/storage.go
@@ -135,7 +135,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete storage configuration.
   
   Deletes a Databricks storage configuration. You cannot delete a storage
-  configuration that is associated with any workspace.`
+  configuration that is associated with any workspace.
+
+  Arguments:
+    STORAGE_CONFIGURATION_ID: Databricks Account API storage configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -208,7 +212,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get storage configuration.`
 	cmd.Long = `Get storage configuration.
   
-  Gets a Databricks storage configuration for an account, both specified by ID.`
+  Gets a Databricks storage configuration for an account, both specified by ID.
+
+  Arguments:
+    STORAGE_CONFIGURATION_ID: Databricks Account API storage configuration ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/users/users.go
+++ b/cmd/account/users/users.go
@@ -150,8 +150,7 @@ func newDelete() *cobra.Command {
   associated with the user.
 
   Arguments:
-    ID: Unique ID for a user in the Databricks account.
-    `
+    ID: Unique ID for a user in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -235,8 +234,7 @@ func newGet() *cobra.Command {
   Gets information for a specific user in Databricks account.
 
   Arguments:
-    ID: Unique ID for a user in the Databricks account.
-    `
+    ID: Unique ID for a user in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -385,8 +383,7 @@ func newPatch() *cobra.Command {
   specific user attributes.
 
   Arguments:
-    ID: Unique ID for a user in the Databricks account.
-    `
+    ID: Unique ID for a user in the Databricks account.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -483,8 +480,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     ID: Databricks user ID. This is automatically set by Databricks. Any value
-    provided by the client will be ignored.
-    `
+      provided by the client will be ignored.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/users/users.go
+++ b/cmd/account/users/users.go
@@ -147,7 +147,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a user.
   
   Deletes a user. Deleting a user from a Databricks account also removes objects
-  associated with the user.`
+  associated with the user.
+
+  Arguments:
+    ID: Unique ID for a user in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -228,7 +232,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get user details.`
 	cmd.Long = `Get user details.
   
-  Gets information for a specific user in Databricks account.`
+  Gets information for a specific user in Databricks account.
+
+  Arguments:
+    ID: Unique ID for a user in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -374,7 +382,11 @@ func newPatch() *cobra.Command {
 	cmd.Long = `Update user details.
   
   Partially updates a user resource by applying the supplied operations on
-  specific user attributes.`
+  specific user attributes.
+
+  Arguments:
+    ID: Unique ID for a user in the Databricks account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -467,7 +479,12 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Replace a user.`
 	cmd.Long = `Replace a user.
   
-  Replaces a user's information with the data supplied in request.`
+  Replaces a user's information with the data supplied in request.
+
+  Arguments:
+    ID: Databricks user ID. This is automatically set by Databricks. Any value
+    provided by the client will be ignored.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/vpc-endpoints/vpc-endpoints.go
+++ b/cmd/account/vpc-endpoints/vpc-endpoints.go
@@ -73,7 +73,11 @@ func newCreate() *cobra.Command {
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
   [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
   [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html
-  [endpoint service]: https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html`
+  [endpoint service]: https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html
+
+  Arguments:
+    VPC_ENDPOINT_NAME: The human-readable name of the storage configuration.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -157,7 +161,11 @@ func newDelete() *cobra.Command {
   
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
   [AWS VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
-  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html`
+  [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
+
+  Arguments:
+    VPC_ENDPOINT_ID: Databricks VPC endpoint ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -234,7 +242,11 @@ func newGet() *cobra.Command {
   AWS used to communicate privately with Databricks over [AWS PrivateLink].
   
   [AWS PrivateLink]: https://aws.amazon.com/privatelink
-  [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html`
+  [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
+
+  Arguments:
+    VPC_ENDPOINT_ID: Databricks VPC endpoint ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/vpc-endpoints/vpc-endpoints.go
+++ b/cmd/account/vpc-endpoints/vpc-endpoints.go
@@ -76,8 +76,7 @@ func newCreate() *cobra.Command {
   [endpoint service]: https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html
 
   Arguments:
-    VPC_ENDPOINT_NAME: The human-readable name of the storage configuration.
-    `
+    VPC_ENDPOINT_NAME: The human-readable name of the storage configuration.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -164,8 +163,7 @@ func newDelete() *cobra.Command {
   [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
 
   Arguments:
-    VPC_ENDPOINT_ID: Databricks VPC endpoint ID.
-    `
+    VPC_ENDPOINT_ID: Databricks VPC endpoint ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -245,8 +243,7 @@ func newGet() *cobra.Command {
   [VPC endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html
 
   Arguments:
-    VPC_ENDPOINT_ID: Databricks VPC endpoint ID.
-    `
+    VPC_ENDPOINT_ID: Databricks VPC endpoint ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/workspace-assignment/workspace-assignment.go
+++ b/cmd/account/workspace-assignment/workspace-assignment.go
@@ -61,9 +61,7 @@ func newDelete() *cobra.Command {
 
   Arguments:
     WORKSPACE_ID: The workspace ID.
-    
-    PRINCIPAL_ID: The ID of the user, service principal, or group.
-    `
+    PRINCIPAL_ID: The ID of the user, service principal, or group.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -134,8 +132,7 @@ func newGet() *cobra.Command {
   Get an array of workspace permissions for the specified account and workspace.
 
   Arguments:
-    WORKSPACE_ID: The workspace ID.
-    `
+    WORKSPACE_ID: The workspace ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -203,8 +200,7 @@ func newList() *cobra.Command {
   Databricks workspace.
 
   Arguments:
-    WORKSPACE_ID: The workspace ID for the account.
-    `
+    WORKSPACE_ID: The workspace ID for the account.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/workspace-assignment/workspace-assignment.go
+++ b/cmd/account/workspace-assignment/workspace-assignment.go
@@ -57,7 +57,13 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete permissions assignment.
   
   Deletes the workspace permissions assignment in a given account and workspace
-  for the specified principal.`
+  for the specified principal.
+
+  Arguments:
+    WORKSPACE_ID: The workspace ID.
+    
+    PRINCIPAL_ID: The ID of the user, service principal, or group.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -125,7 +131,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `List workspace permissions.`
 	cmd.Long = `List workspace permissions.
   
-  Get an array of workspace permissions for the specified account and workspace.`
+  Get an array of workspace permissions for the specified account and workspace.
+
+  Arguments:
+    WORKSPACE_ID: The workspace ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -190,7 +200,11 @@ func newList() *cobra.Command {
 	cmd.Long = `Get permission assignments.
   
   Get the permission assignments for the specified Databricks account and
-  Databricks workspace.`
+  Databricks workspace.
+
+  Arguments:
+    WORKSPACE_ID: The workspace ID for the account.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/workspaces/workspaces.go
+++ b/cmd/account/workspaces/workspaces.go
@@ -97,8 +97,7 @@ func newCreate() *cobra.Command {
   workspace becomes available when the status changes to RUNNING.
 
   Arguments:
-    WORKSPACE_NAME: The workspace's human-readable name.
-    `
+    WORKSPACE_NAME: The workspace's human-readable name.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -196,8 +195,7 @@ func newDelete() *cobra.Command {
   account.
 
   Arguments:
-    WORKSPACE_ID: Workspace ID.
-    `
+    WORKSPACE_ID: Workspace ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -289,8 +287,7 @@ func newGet() *cobra.Command {
   [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
 
   Arguments:
-    WORKSPACE_ID: Workspace ID.
-    `
+    WORKSPACE_ID: Workspace ID.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -549,8 +546,7 @@ func newUpdate() *cobra.Command {
   [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
 
   Arguments:
-    WORKSPACE_ID: Workspace ID.
-    `
+    WORKSPACE_ID: Workspace ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/account/workspaces/workspaces.go
+++ b/cmd/account/workspaces/workspaces.go
@@ -94,7 +94,11 @@ func newCreate() *cobra.Command {
   workspace status is typically PROVISIONING. Use the workspace ID
   (workspace_id) field in the response to identify the new workspace and make
   repeated GET requests with the workspace ID and check its status. The
-  workspace becomes available when the status changes to RUNNING.`
+  workspace becomes available when the status changes to RUNNING.
+
+  Arguments:
+    WORKSPACE_NAME: The workspace's human-readable name.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -189,7 +193,11 @@ func newDelete() *cobra.Command {
   
   This operation is available only if your account is on the E2 version of the
   platform or on a select custom plan that allows multiple workspaces per
-  account.`
+  account.
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -278,7 +286,11 @@ func newGet() *cobra.Command {
   platform or on a select custom plan that allows multiple workspaces per
   account.
   
-  [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html`
+  [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -534,7 +546,11 @@ func newUpdate() *cobra.Command {
   account.
   
   [Account Console]: https://docs.databricks.com/administration-guide/account-settings-e2/account-console-e2.html
-  [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html`
+  [Create a new workspace using the Account API]: http://docs.databricks.com/administration-guide/account-api/new-workspace.html
+
+  Arguments:
+    WORKSPACE_ID: Workspace ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/alerts/alerts.go
+++ b/cmd/workspace/alerts/alerts.go
@@ -131,11 +131,7 @@ func newDelete() *cobra.Command {
   
   Deletes an alert. Deleted alerts are no longer accessible and cannot be
   restored. **Note:** Unlike queries and dashboards, alerts cannot be moved to
-  the trash.
-
-  Arguments:
-    ALERT_ID: 
-    `
+  the trash.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -208,11 +204,7 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get an alert.`
 	cmd.Long = `Get an alert.
   
-  Gets an alert.
-
-  Arguments:
-    ALERT_ID: 
-    `
+  Gets an alert.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/alerts/alerts.go
+++ b/cmd/workspace/alerts/alerts.go
@@ -131,7 +131,11 @@ func newDelete() *cobra.Command {
   
   Deletes an alert. Deleted alerts are no longer accessible and cannot be
   restored. **Note:** Unlike queries and dashboards, alerts cannot be moved to
-  the trash.`
+  the trash.
+
+  Arguments:
+    ALERT_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -204,7 +208,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get an alert.`
 	cmd.Long = `Get an alert.
   
-  Gets an alert.`
+  Gets an alert.
+
+  Arguments:
+    ALERT_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/apps/apps.go
+++ b/cmd/workspace/apps/apps.go
@@ -130,8 +130,7 @@ func newDeleteApp() *cobra.Command {
   Delete an application definition
 
   Arguments:
-    NAME: The name of an application. This field is required.
-    `
+    NAME: The name of an application. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -195,8 +194,7 @@ func newGetApp() *cobra.Command {
   Get an application definition
 
   Arguments:
-    NAME: The name of an application. This field is required.
-    `
+    NAME: The name of an application. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -262,8 +260,7 @@ func newGetAppDeploymentStatus() *cobra.Command {
   Get deployment status for an application
 
   Arguments:
-    DEPLOYMENT_ID: The deployment id for an application. This field is required.
-    `
+    DEPLOYMENT_ID: The deployment id for an application. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -375,8 +372,7 @@ func newGetEvents() *cobra.Command {
   Get deployment events for an application
 
   Arguments:
-    NAME: The name of an application. This field is required.
-    `
+    NAME: The name of an application. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/apps/apps.go
+++ b/cmd/workspace/apps/apps.go
@@ -127,7 +127,11 @@ func newDeleteApp() *cobra.Command {
 	cmd.Short = `Delete an application.`
 	cmd.Long = `Delete an application.
   
-  Delete an application definition`
+  Delete an application definition
+
+  Arguments:
+    NAME: The name of an application. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -188,7 +192,11 @@ func newGetApp() *cobra.Command {
 	cmd.Short = `Get definition for an application.`
 	cmd.Long = `Get definition for an application.
   
-  Get an application definition`
+  Get an application definition
+
+  Arguments:
+    NAME: The name of an application. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -251,7 +259,11 @@ func newGetAppDeploymentStatus() *cobra.Command {
 	cmd.Short = `Get deployment status for an application.`
 	cmd.Long = `Get deployment status for an application.
   
-  Get deployment status for an application`
+  Get deployment status for an application
+
+  Arguments:
+    DEPLOYMENT_ID: The deployment id for an application. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -360,7 +372,11 @@ func newGetEvents() *cobra.Command {
 	cmd.Short = `Get deployment events for an application.`
 	cmd.Long = `Get deployment events for an application.
   
-  Get deployment events for an application`
+  Get deployment events for an application
+
+  Arguments:
+    NAME: The name of an application. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/artifact-allowlists/artifact-allowlists.go
+++ b/cmd/workspace/artifact-allowlists/artifact-allowlists.go
@@ -61,8 +61,7 @@ func newGet() *cobra.Command {
   metastore admin or have the **MANAGE ALLOWLIST** privilege on the metastore.
 
   Arguments:
-    ARTIFACT_TYPE: The artifact type of the allowlist.
-    `
+    ARTIFACT_TYPE: The artifact type of the allowlist.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/artifact-allowlists/artifact-allowlists.go
+++ b/cmd/workspace/artifact-allowlists/artifact-allowlists.go
@@ -58,7 +58,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get an artifact allowlist.
   
   Get the artifact allowlist of a certain artifact type. The caller must be a
-  metastore admin or have the **MANAGE ALLOWLIST** privilege on the metastore.`
+  metastore admin or have the **MANAGE ALLOWLIST** privilege on the metastore.
+
+  Arguments:
+    ARTIFACT_TYPE: The artifact type of the allowlist.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/catalogs/catalogs.go
+++ b/cmd/workspace/catalogs/catalogs.go
@@ -76,8 +76,7 @@ func newCreate() *cobra.Command {
   metastore admin or has the **CREATE_CATALOG** privilege.
 
   Arguments:
-    NAME: Name of catalog.
-    `
+    NAME: Name of catalog.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -159,8 +158,7 @@ func newDelete() *cobra.Command {
   metastore admin or the owner of the catalog.
 
   Arguments:
-    NAME: The name of the catalog.
-    `
+    NAME: The name of the catalog.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -226,8 +224,7 @@ func newGet() *cobra.Command {
   privilege set for their account.
 
   Arguments:
-    NAME: The name of the catalog.
-    `
+    NAME: The name of the catalog.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -354,8 +351,7 @@ func newUpdate() *cobra.Command {
   of the catalog).
 
   Arguments:
-    NAME: Name of catalog.
-    `
+    NAME: Name of catalog.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/catalogs/catalogs.go
+++ b/cmd/workspace/catalogs/catalogs.go
@@ -73,7 +73,11 @@ func newCreate() *cobra.Command {
 	cmd.Long = `Create a catalog.
   
   Creates a new catalog instance in the parent metastore if the caller is a
-  metastore admin or has the **CREATE_CATALOG** privilege.`
+  metastore admin or has the **CREATE_CATALOG** privilege.
+
+  Arguments:
+    NAME: Name of catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -152,7 +156,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a catalog.
   
   Deletes the catalog that matches the supplied name. The caller must be a
-  metastore admin or the owner of the catalog.`
+  metastore admin or the owner of the catalog.
+
+  Arguments:
+    NAME: The name of the catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -215,7 +223,11 @@ func newGet() *cobra.Command {
   
   Gets the specified catalog in a metastore. The caller must be a metastore
   admin, the owner of the catalog, or a user that has the **USE_CATALOG**
-  privilege set for their account.`
+  privilege set for their account.
+
+  Arguments:
+    NAME: The name of the catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -339,7 +351,11 @@ func newUpdate() *cobra.Command {
   
   Updates the catalog that matches the supplied name. The caller must be either
   the owner of the catalog, or a metastore admin (when changing the owner field
-  of the catalog).`
+  of the catalog).
+
+  Arguments:
+    NAME: Name of catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/clean-rooms/clean-rooms.go
+++ b/cmd/workspace/clean-rooms/clean-rooms.go
@@ -132,7 +132,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a clean room.
   
   Deletes a data object clean room from the metastore. The caller must be an
-  owner of the clean room.`
+  owner of the clean room.
+
+  Arguments:
+    NAME_ARG: The name of the clean room.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -196,7 +200,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a clean room.
   
   Gets a data object clean room from the metastore. The caller must be a
-  metastore admin or the owner of the clean room.`
+  metastore admin or the owner of the clean room.
+
+  Arguments:
+    NAME_ARG: The name of the clean room.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -341,7 +349,11 @@ func newUpdate() *cobra.Command {
   indefinitely for recipients to be able to access the table. Typically, you
   should use a group as the clean room owner.
   
-  Table removals through **update** do not require additional privileges.`
+  Table removals through **update** do not require additional privileges.
+
+  Arguments:
+    NAME_ARG: The name of the clean room.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/clean-rooms/clean-rooms.go
+++ b/cmd/workspace/clean-rooms/clean-rooms.go
@@ -135,8 +135,7 @@ func newDelete() *cobra.Command {
   owner of the clean room.
 
   Arguments:
-    NAME_ARG: The name of the clean room.
-    `
+    NAME_ARG: The name of the clean room.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -203,8 +202,7 @@ func newGet() *cobra.Command {
   metastore admin or the owner of the clean room.
 
   Arguments:
-    NAME_ARG: The name of the clean room.
-    `
+    NAME_ARG: The name of the clean room.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -352,8 +350,7 @@ func newUpdate() *cobra.Command {
   Table removals through **update** do not require additional privileges.
 
   Arguments:
-    NAME_ARG: The name of the clean room.
-    `
+    NAME_ARG: The name of the clean room.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/cluster-policies/cluster-policies.go
+++ b/cmd/workspace/cluster-policies/cluster-policies.go
@@ -89,8 +89,7 @@ func newCreate() *cobra.Command {
 
   Arguments:
     NAME: Cluster Policy name requested by the user. This has to be unique. Length
-    must be between 1 and 100 characters.
-    `
+      must be between 1 and 100 characters.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -172,8 +171,7 @@ func newDelete() *cobra.Command {
   but cannot be edited.
 
   Arguments:
-    POLICY_ID: The ID of the policy to delete.
-    `
+    POLICY_ID: The ID of the policy to delete.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -267,10 +265,8 @@ func newEdit() *cobra.Command {
 
   Arguments:
     POLICY_ID: The ID of the policy to update.
-    
     NAME: Cluster Policy name requested by the user. This has to be unique. Length
-    must be between 1 and 100 characters.
-    `
+      must be between 1 and 100 characters.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -352,8 +348,7 @@ func newGet() *cobra.Command {
   Get a cluster policy entity. Creation and editing is available to admins only.
 
   Arguments:
-    POLICY_ID: Canonical unique identifier for the cluster policy.
-    `
+    POLICY_ID: Canonical unique identifier for the cluster policy.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -429,8 +424,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
-    `
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -507,8 +501,7 @@ func newGetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
-    `
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -651,8 +644,7 @@ func newSetPermissions() *cobra.Command {
   from their root object.
 
   Arguments:
-    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
-    `
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -739,8 +731,7 @@ func newUpdatePermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
-    `
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/cluster-policies/cluster-policies.go
+++ b/cmd/workspace/cluster-policies/cluster-policies.go
@@ -85,7 +85,12 @@ func newCreate() *cobra.Command {
 	cmd.Short = `Create a new policy.`
 	cmd.Long = `Create a new policy.
   
-  Creates a new policy with prescribed settings.`
+  Creates a new policy with prescribed settings.
+
+  Arguments:
+    NAME: Cluster Policy name requested by the user. This has to be unique. Length
+    must be between 1 and 100 characters.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -164,7 +169,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a cluster policy.
   
   Delete a policy for a cluster. Clusters governed by this policy can still run,
-  but cannot be edited.`
+  but cannot be edited.
+
+  Arguments:
+    POLICY_ID: The ID of the policy to delete.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -254,7 +263,14 @@ func newEdit() *cobra.Command {
 	cmd.Long = `Update a cluster policy.
   
   Update an existing policy for cluster. This operation may make some clusters
-  governed by the previous policy invalid.`
+  governed by the previous policy invalid.
+
+  Arguments:
+    POLICY_ID: The ID of the policy to update.
+    
+    NAME: Cluster Policy name requested by the user. This has to be unique. Length
+    must be between 1 and 100 characters.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -333,7 +349,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a cluster policy.`
 	cmd.Long = `Get a cluster policy.
   
-  Get a cluster policy entity. Creation and editing is available to admins only.`
+  Get a cluster policy entity. Creation and editing is available to admins only.
+
+  Arguments:
+    POLICY_ID: Canonical unique identifier for the cluster policy.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -406,7 +426,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get cluster policy permission levels.`
 	cmd.Long = `Get cluster policy permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -480,7 +504,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get cluster policy permissions.
   
   Gets the permissions of a cluster policy. Cluster policies can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -620,7 +648,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set cluster policy permissions.
   
   Sets permissions on a cluster policy. Cluster policies can inherit permissions
-  from their root object.`
+  from their root object.
+
+  Arguments:
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -704,7 +736,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update cluster policy permissions.
   
   Updates the permissions on a cluster policy. Cluster policies can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    CLUSTER_POLICY_ID: The cluster policy for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/clusters/clusters.go
+++ b/cmd/workspace/clusters/clusters.go
@@ -89,9 +89,7 @@ func newChangeOwner() *cobra.Command {
 
   Arguments:
     CLUSTER_ID: <needs content added>
-    
-    OWNER_USERNAME: New owner of the cluster_id after this RPC.
-    `
+    OWNER_USERNAME: New owner of the cluster_id after this RPC.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -216,9 +214,8 @@ func newCreate() *cobra.Command {
 
   Arguments:
     SPARK_VERSION: The Spark version of the cluster, e.g. 3.3.x-scala2.11. A list of
-    available Spark versions can be retrieved by using the
-    :method:clusters/sparkVersions API call.
-    `
+      available Spark versions can be retrieved by using the
+      :method:clusters/sparkVersions API call.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -319,8 +316,7 @@ func newDelete() *cobra.Command {
   TERMINATED state, nothing will happen.
 
   Arguments:
-    CLUSTER_ID: The cluster to be terminated.
-    `
+    CLUSTER_ID: The cluster to be terminated.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -462,11 +458,9 @@ func newEdit() *cobra.Command {
 
   Arguments:
     CLUSTER_ID: ID of the cluser
-    
     SPARK_VERSION: The Spark version of the cluster, e.g. 3.3.x-scala2.11. A list of
-    available Spark versions can be retrieved by using the
-    :method:clusters/sparkVersions API call.
-    `
+      available Spark versions can be retrieved by using the
+      :method:clusters/sparkVersions API call.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -571,8 +565,7 @@ func newEvents() *cobra.Command {
   nparameters necessary to request the next page of events.
 
   Arguments:
-    CLUSTER_ID: The ID of the cluster to retrieve events about.
-    `
+    CLUSTER_ID: The ID of the cluster to retrieve events about.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -661,8 +654,7 @@ func newGet() *cobra.Command {
   described while they are running, or up to 60 days after they are terminated.
 
   Arguments:
-    CLUSTER_ID: The cluster about which to retrieve information.
-    `
+    CLUSTER_ID: The cluster about which to retrieve information.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -738,8 +730,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    CLUSTER_ID: The cluster for which to get or manage permissions.
-    `
+    CLUSTER_ID: The cluster for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -816,8 +807,7 @@ func newGetPermissions() *cobra.Command {
   root object.
 
   Arguments:
-    CLUSTER_ID: The cluster for which to get or manage permissions.
-    `
+    CLUSTER_ID: The cluster for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1067,8 +1057,7 @@ func newPermanentDelete() *cobra.Command {
   deleted clusters.
 
   Arguments:
-    CLUSTER_ID: The cluster to be deleted.
-    `
+    CLUSTER_ID: The cluster to be deleted.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1155,8 +1144,7 @@ func newPin() *cobra.Command {
   effect. This API can only be called by workspace admins.
 
   Arguments:
-    CLUSTER_ID: <needs content added>
-    `
+    CLUSTER_ID: <needs content added>`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1250,8 +1238,7 @@ func newResize() *cobra.Command {
   the cluster is in a RUNNING state.
 
   Arguments:
-    CLUSTER_ID: The cluster to be resized.
-    `
+    CLUSTER_ID: The cluster to be resized.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1356,8 +1343,7 @@ func newRestart() *cobra.Command {
   in a RUNNING state, nothing will happen.
 
   Arguments:
-    CLUSTER_ID: The cluster to be started.
-    `
+    CLUSTER_ID: The cluster to be started.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1457,8 +1443,7 @@ func newSetPermissions() *cobra.Command {
   root object.
 
   Arguments:
-    CLUSTER_ID: The cluster for which to get or manage permissions.
-    `
+    CLUSTER_ID: The cluster for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1603,8 +1588,7 @@ func newStart() *cobra.Command {
   happen. * Clusters launched to run a job cannot be started.
 
   Arguments:
-    CLUSTER_ID: The cluster to be started.
-    `
+    CLUSTER_ID: The cluster to be started.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1703,8 +1687,7 @@ func newUnpin() *cobra.Command {
   This API can only be called by workspace admins.
 
   Arguments:
-    CLUSTER_ID: <needs content added>
-    `
+    CLUSTER_ID: <needs content added>`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1792,8 +1775,7 @@ func newUpdatePermissions() *cobra.Command {
   their root object.
 
   Arguments:
-    CLUSTER_ID: The cluster for which to get or manage permissions.
-    `
+    CLUSTER_ID: The cluster for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/clusters/clusters.go
+++ b/cmd/workspace/clusters/clusters.go
@@ -85,7 +85,13 @@ func newChangeOwner() *cobra.Command {
 	cmd.Long = `Change cluster owner.
   
   Change the owner of the cluster. You must be an admin to perform this
-  operation.`
+  operation.
+
+  Arguments:
+    CLUSTER_ID: <needs content added>
+    
+    OWNER_USERNAME: New owner of the cluster_id after this RPC.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -206,7 +212,13 @@ func newCreate() *cobra.Command {
   
   If Databricks acquires at least 85% of the requested on-demand nodes, cluster
   creation will succeed. Otherwise the cluster will terminate with an
-  informative error message.`
+  informative error message.
+
+  Arguments:
+    SPARK_VERSION: The Spark version of the cluster, e.g. 3.3.x-scala2.11. A list of
+    available Spark versions can be retrieved by using the
+    :method:clusters/sparkVersions API call.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -304,7 +316,11 @@ func newDelete() *cobra.Command {
   Terminates the Spark cluster with the specified ID. The cluster is removed
   asynchronously. Once the termination has completed, the cluster will be in a
   TERMINATED state. If the cluster is already in a TERMINATING or
-  TERMINATED state, nothing will happen.`
+  TERMINATED state, nothing will happen.
+
+  Arguments:
+    CLUSTER_ID: The cluster to be terminated.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -442,7 +458,15 @@ func newEdit() *cobra.Command {
   new attributes will take effect. Any attempt to update a cluster in any other
   state will be rejected with an INVALID_STATE error code.
   
-  Clusters created by the Databricks Jobs service cannot be edited.`
+  Clusters created by the Databricks Jobs service cannot be edited.
+
+  Arguments:
+    CLUSTER_ID: ID of the cluser
+    
+    SPARK_VERSION: The Spark version of the cluster, e.g. 3.3.x-scala2.11. A list of
+    available Spark versions can be retrieved by using the
+    :method:clusters/sparkVersions API call.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -544,7 +568,11 @@ func newEvents() *cobra.Command {
   
   Retrieves a list of events about the activity of a cluster. This API is
   paginated. If there are more events to read, the response includes all the
-  nparameters necessary to request the next page of events.`
+  nparameters necessary to request the next page of events.
+
+  Arguments:
+    CLUSTER_ID: The ID of the cluster to retrieve events about.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -630,7 +658,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get cluster info.
   
   Retrieves the information for a cluster given its identifier. Clusters can be
-  described while they are running, or up to 60 days after they are terminated.`
+  described while they are running, or up to 60 days after they are terminated.
+
+  Arguments:
+    CLUSTER_ID: The cluster about which to retrieve information.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -703,7 +735,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get cluster permission levels.`
 	cmd.Long = `Get cluster permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    CLUSTER_ID: The cluster for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -777,7 +813,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get cluster permissions.
   
   Gets the permissions of a cluster. Clusters can inherit permissions from their
-  root object.`
+  root object.
+
+  Arguments:
+    CLUSTER_ID: The cluster for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1024,7 +1064,11 @@ func newPermanentDelete() *cobra.Command {
   
   In addition, users will no longer see permanently deleted clusters in the
   cluster list, and API users can no longer perform any action on permanently
-  deleted clusters.`
+  deleted clusters.
+
+  Arguments:
+    CLUSTER_ID: The cluster to be deleted.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1108,7 +1152,11 @@ func newPin() *cobra.Command {
   
   Pinning a cluster ensures that the cluster will always be returned by the
   ListClusters API. Pinning a cluster that is already pinned will have no
-  effect. This API can only be called by workspace admins.`
+  effect. This API can only be called by workspace admins.
+
+  Arguments:
+    CLUSTER_ID: <needs content added>
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1199,7 +1247,11 @@ func newResize() *cobra.Command {
 	cmd.Long = `Resize cluster.
   
   Resizes a cluster to have a desired number of workers. This will fail unless
-  the cluster is in a RUNNING state.`
+  the cluster is in a RUNNING state.
+
+  Arguments:
+    CLUSTER_ID: The cluster to be resized.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1301,7 +1353,11 @@ func newRestart() *cobra.Command {
 	cmd.Long = `Restart cluster.
   
   Restarts a Spark cluster with the supplied ID. If the cluster is not currently
-  in a RUNNING state, nothing will happen.`
+  in a RUNNING state, nothing will happen.
+
+  Arguments:
+    CLUSTER_ID: The cluster to be started.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1398,7 +1454,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set cluster permissions.
   
   Sets permissions on a cluster. Clusters can inherit permissions from their
-  root object.`
+  root object.
+
+  Arguments:
+    CLUSTER_ID: The cluster for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1540,7 +1600,11 @@ func newStart() *cobra.Command {
   with the last specified cluster size. * If the previous cluster was an
   autoscaling cluster, the current cluster starts with the minimum number of
   nodes. * If the cluster is not currently in a TERMINATED state, nothing will
-  happen. * Clusters launched to run a job cannot be started.`
+  happen. * Clusters launched to run a job cannot be started.
+
+  Arguments:
+    CLUSTER_ID: The cluster to be started.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1636,7 +1700,11 @@ func newUnpin() *cobra.Command {
   
   Unpinning a cluster will allow the cluster to eventually be removed from the
   ListClusters API. Unpinning a cluster that is not pinned will have no effect.
-  This API can only be called by workspace admins.`
+  This API can only be called by workspace admins.
+
+  Arguments:
+    CLUSTER_ID: <needs content added>
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1721,7 +1789,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update cluster permissions.
   
   Updates the permissions on a cluster. Clusters can inherit permissions from
-  their root object.`
+  their root object.
+
+  Arguments:
+    CLUSTER_ID: The cluster for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/connections/connections.go
+++ b/cmd/workspace/connections/connections.go
@@ -138,7 +138,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a connection.`
 	cmd.Long = `Delete a connection.
   
-  Deletes the connection that matches the supplied name.`
+  Deletes the connection that matches the supplied name.
+
+  Arguments:
+    NAME_ARG: The name of the connection to be deleted.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -211,7 +215,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a connection.`
 	cmd.Long = `Get a connection.
   
-  Gets a connection from it's name.`
+  Gets a connection from it's name.
+
+  Arguments:
+    NAME_ARG: Name of the connection.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/connections/connections.go
+++ b/cmd/workspace/connections/connections.go
@@ -141,8 +141,7 @@ func newDelete() *cobra.Command {
   Deletes the connection that matches the supplied name.
 
   Arguments:
-    NAME_ARG: The name of the connection to be deleted.
-    `
+    NAME_ARG: The name of the connection to be deleted.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -218,8 +217,7 @@ func newGet() *cobra.Command {
   Gets a connection from it's name.
 
   Arguments:
-    NAME_ARG: Name of the connection.
-    `
+    NAME_ARG: Name of the connection.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/dashboard-widgets/dashboard-widgets.go
+++ b/cmd/workspace/dashboard-widgets/dashboard-widgets.go
@@ -121,7 +121,11 @@ func newDelete() *cobra.Command {
 
 	cmd.Use = "delete ID"
 	cmd.Short = `Remove widget.`
-	cmd.Long = `Remove widget.`
+	cmd.Long = `Remove widget.
+
+  Arguments:
+    ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/dashboard-widgets/dashboard-widgets.go
+++ b/cmd/workspace/dashboard-widgets/dashboard-widgets.go
@@ -121,11 +121,7 @@ func newDelete() *cobra.Command {
 
 	cmd.Use = "delete ID"
 	cmd.Short = `Remove widget.`
-	cmd.Long = `Remove widget.
-
-  Arguments:
-    ID: 
-    `
+	cmd.Long = `Remove widget.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/dashboards/dashboards.go
+++ b/cmd/workspace/dashboards/dashboards.go
@@ -124,11 +124,7 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Remove a dashboard.
   
   Moves a dashboard to the trash. Trashed dashboards do not appear in list views
-  or searches, and cannot be shared.
-
-  Arguments:
-    DASHBOARD_ID: 
-    `
+  or searches, and cannot be shared.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -202,11 +198,7 @@ func newGet() *cobra.Command {
 	cmd.Long = `Retrieve a definition.
   
   Returns a JSON representation of a dashboard object, including its
-  visualization and query objects.
-
-  Arguments:
-    DASHBOARD_ID: 
-    `
+  visualization and query objects.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -343,11 +335,7 @@ func newRestore() *cobra.Command {
 	cmd.Short = `Restore a dashboard.`
 	cmd.Long = `Restore a dashboard.
   
-  A restored dashboard appears in list views and searches and can be shared.
-
-  Arguments:
-    DASHBOARD_ID: 
-    `
+  A restored dashboard appears in list views and searches and can be shared.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/dashboards/dashboards.go
+++ b/cmd/workspace/dashboards/dashboards.go
@@ -124,7 +124,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Remove a dashboard.
   
   Moves a dashboard to the trash. Trashed dashboards do not appear in list views
-  or searches, and cannot be shared.`
+  or searches, and cannot be shared.
+
+  Arguments:
+    DASHBOARD_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -198,7 +202,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Retrieve a definition.
   
   Returns a JSON representation of a dashboard object, including its
-  visualization and query objects.`
+  visualization and query objects.
+
+  Arguments:
+    DASHBOARD_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -335,7 +343,11 @@ func newRestore() *cobra.Command {
 	cmd.Short = `Restore a dashboard.`
 	cmd.Long = `Restore a dashboard.
   
-  A restored dashboard appears in list views and searches and can be shared.`
+  A restored dashboard appears in list views and searches and can be shared.
+
+  Arguments:
+    DASHBOARD_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/experiments/experiments.go
+++ b/cmd/workspace/experiments/experiments.go
@@ -73,7 +73,11 @@ func newCreateExperiment() *cobra.Command {
   already exist and fails if another experiment with the same name already
   exists.
   
-  Throws RESOURCE_ALREADY_EXISTS if a experiment with the given name exists.`
+  Throws RESOURCE_ALREADY_EXISTS if a experiment with the given name exists.
+
+  Arguments:
+    NAME: Experiment name.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -229,7 +233,11 @@ func newDeleteExperiment() *cobra.Command {
   
   Marks an experiment and associated metadata, runs, metrics, params, and tags
   for deletion. If the experiment uses FileStore, artifacts associated with
-  experiment are also deleted.`
+  experiment are also deleted.
+
+  Arguments:
+    EXPERIMENT_ID: ID of the associated experiment.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -307,7 +315,11 @@ func newDeleteRun() *cobra.Command {
 	cmd.Short = `Delete a run.`
 	cmd.Long = `Delete a run.
   
-  Marks a run for deletion.`
+  Marks a run for deletion.
+
+  Arguments:
+    RUN_ID: ID of the run to delete.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -388,7 +400,14 @@ func newDeleteRuns() *cobra.Command {
 	cmd.Long = `Delete runs by creation time.
   
   Bulk delete runs in an experiment that were created prior to or at the
-  specified timestamp. Deletes at most max_runs per request.`
+  specified timestamp. Deletes at most max_runs per request.
+
+  Arguments:
+    EXPERIMENT_ID: The ID of the experiment containing the runs to delete.
+    
+    MAX_TIMESTAMP_MILLIS: The maximum creation timestamp in milliseconds since the UNIX epoch for
+    deleting runs. Only runs created prior to or at this timestamp are deleted.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -473,7 +492,13 @@ func newDeleteTag() *cobra.Command {
 	cmd.Long = `Delete a tag.
   
   Deletes a tag on a run. Tags are run metadata that can be updated during a run
-  and after a run completes.`
+  and after a run completes.
+
+  Arguments:
+    RUN_ID: ID of the run that the tag was logged under. Must be provided.
+    
+    KEY: Name of the tag. Maximum size is 255 bytes. Must be provided.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -560,7 +585,11 @@ func newGetByName() *cobra.Command {
   them.
   
   Throws RESOURCE_DOES_NOT_EXIST if no experiment with the specified name
-  exists.`
+  exists.
+
+  Arguments:
+    EXPERIMENT_NAME: Name of the associated experiment.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -621,7 +650,11 @@ func newGetExperiment() *cobra.Command {
 	cmd.Short = `Get an experiment.`
 	cmd.Long = `Get an experiment.
   
-  Gets metadata for an experiment. This method works on deleted experiments.`
+  Gets metadata for an experiment. This method works on deleted experiments.
+
+  Arguments:
+    EXPERIMENT_ID: ID of the associated experiment.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -687,7 +720,11 @@ func newGetHistory() *cobra.Command {
 	cmd.Short = `Get history of a given metric within a run.`
 	cmd.Long = `Get history of a given metric within a run.
   
-  Gets a list of all values for the specified metric for a given run.`
+  Gets a list of all values for the specified metric for a given run.
+
+  Arguments:
+    METRIC_KEY: Name of the metric.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -748,7 +785,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get experiment permission levels.`
 	cmd.Long = `Get experiment permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -810,7 +851,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get experiment permissions.
   
   Gets the permissions of an experiment. Experiments can inherit permissions
-  from their root object.`
+  from their root object.
+
+  Arguments:
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -878,7 +923,11 @@ func newGetRun() *cobra.Command {
   with the latest timestamp.
   
   If there are multiple values with the latest timestamp, return the maximum of
-  these values.`
+  these values.
+
+  Arguments:
+    RUN_ID: ID of the run to fetch. Must be provided.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1256,7 +1305,15 @@ func newLogMetric() *cobra.Command {
   
   Logs a metric for a run. A metric is a key-value pair (string key, float
   value) with an associated timestamp. Examples include the various metrics that
-  represent ML model accuracy. A metric can be logged multiple times.`
+  represent ML model accuracy. A metric can be logged multiple times.
+
+  Arguments:
+    KEY: Name of the metric.
+    
+    VALUE: Double value of the metric being logged.
+    
+    TIMESTAMP: Unix timestamp in milliseconds at the time metric was logged.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1424,7 +1481,13 @@ func newLogParam() *cobra.Command {
   Logs a param used for a run. A param is a key-value pair (string key, string
   value). Examples include hyperparameters used for ML model training and
   constant dates and values used in an ETL pipeline. A param can be logged only
-  once for a run.`
+  once for a run.
+
+  Arguments:
+    KEY: Name of the param. Maximum size is 255 bytes.
+    
+    VALUE: String value of the param being logged. Maximum size is 500 bytes.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1510,7 +1573,11 @@ func newRestoreExperiment() *cobra.Command {
   underlying artifacts associated with experiment are also restored.
   
   Throws RESOURCE_DOES_NOT_EXIST if experiment was never created or was
-  permanently deleted.`
+  permanently deleted.
+
+  Arguments:
+    EXPERIMENT_ID: ID of the associated experiment.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1588,7 +1655,11 @@ func newRestoreRun() *cobra.Command {
 	cmd.Short = `Restore a run.`
 	cmd.Long = `Restore a run.
   
-  Restores a deleted run.`
+  Restores a deleted run.
+
+  Arguments:
+    RUN_ID: ID of the run to restore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1669,7 +1740,15 @@ func newRestoreRuns() *cobra.Command {
 	cmd.Long = `Restore runs by deletion time.
   
   Bulk restore runs in an experiment that were deleted no earlier than the
-  specified timestamp. Restores at most max_runs per request.`
+  specified timestamp. Restores at most max_runs per request.
+
+  Arguments:
+    EXPERIMENT_ID: The ID of the experiment containing the runs to restore.
+    
+    MIN_TIMESTAMP_MILLIS: The minimum deletion timestamp in milliseconds since the UNIX epoch for
+    restoring runs. Only runs deleted no earlier than this timestamp are
+    restored.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1904,7 +1983,18 @@ func newSetExperimentTag() *cobra.Command {
 	cmd.Short = `Set a tag.`
 	cmd.Long = `Set a tag.
   
-  Sets a tag on an experiment. Experiment tags are metadata that can be updated.`
+  Sets a tag on an experiment. Experiment tags are metadata that can be updated.
+
+  Arguments:
+    EXPERIMENT_ID: ID of the experiment under which to log the tag. Must be provided.
+    
+    KEY: Name of the tag. Maximum size depends on storage backend. All storage
+    backends are guaranteed to support key values up to 250 bytes in size.
+    
+    VALUE: String value of the tag being logged. Maximum size depends on storage
+    backend. All storage backends are guaranteed to support key values up to
+    5000 bytes in size.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1991,7 +2081,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set experiment permissions.
   
   Sets permissions on an experiment. Experiments can inherit permissions from
-  their root object.`
+  their root object.
+
+  Arguments:
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2064,7 +2158,16 @@ func newSetTag() *cobra.Command {
 	cmd.Long = `Set a tag.
   
   Sets a tag on a run. Tags are run metadata that can be updated during a run
-  and after a run completes.`
+  and after a run completes.
+
+  Arguments:
+    KEY: Name of the tag. Maximum size depends on storage backend. All storage
+    backends are guaranteed to support key values up to 250 bytes in size.
+    
+    VALUE: String value of the tag being logged. Maximum size depends on storage
+    backend. All storage backends are guaranteed to support key values up to
+    5000 bytes in size.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2147,7 +2250,11 @@ func newUpdateExperiment() *cobra.Command {
 	cmd.Short = `Update an experiment.`
 	cmd.Long = `Update an experiment.
   
-  Updates experiment metadata.`
+  Updates experiment metadata.
+
+  Arguments:
+    EXPERIMENT_ID: ID of the associated experiment.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2228,7 +2335,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update experiment permissions.
   
   Updates the permissions on an experiment. Experiments can inherit permissions
-  from their root object.`
+  from their root object.
+
+  Arguments:
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/experiments/experiments.go
+++ b/cmd/workspace/experiments/experiments.go
@@ -76,8 +76,7 @@ func newCreateExperiment() *cobra.Command {
   Throws RESOURCE_ALREADY_EXISTS if a experiment with the given name exists.
 
   Arguments:
-    NAME: Experiment name.
-    `
+    NAME: Experiment name.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -236,8 +235,7 @@ func newDeleteExperiment() *cobra.Command {
   experiment are also deleted.
 
   Arguments:
-    EXPERIMENT_ID: ID of the associated experiment.
-    `
+    EXPERIMENT_ID: ID of the associated experiment.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -318,8 +316,7 @@ func newDeleteRun() *cobra.Command {
   Marks a run for deletion.
 
   Arguments:
-    RUN_ID: ID of the run to delete.
-    `
+    RUN_ID: ID of the run to delete.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -404,10 +401,9 @@ func newDeleteRuns() *cobra.Command {
 
   Arguments:
     EXPERIMENT_ID: The ID of the experiment containing the runs to delete.
-    
     MAX_TIMESTAMP_MILLIS: The maximum creation timestamp in milliseconds since the UNIX epoch for
-    deleting runs. Only runs created prior to or at this timestamp are deleted.
-    `
+      deleting runs. Only runs created prior to or at this timestamp are
+      deleted.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -496,9 +492,7 @@ func newDeleteTag() *cobra.Command {
 
   Arguments:
     RUN_ID: ID of the run that the tag was logged under. Must be provided.
-    
-    KEY: Name of the tag. Maximum size is 255 bytes. Must be provided.
-    `
+    KEY: Name of the tag. Maximum size is 255 bytes. Must be provided.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -588,8 +582,7 @@ func newGetByName() *cobra.Command {
   exists.
 
   Arguments:
-    EXPERIMENT_NAME: Name of the associated experiment.
-    `
+    EXPERIMENT_NAME: Name of the associated experiment.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -653,8 +646,7 @@ func newGetExperiment() *cobra.Command {
   Gets metadata for an experiment. This method works on deleted experiments.
 
   Arguments:
-    EXPERIMENT_ID: ID of the associated experiment.
-    `
+    EXPERIMENT_ID: ID of the associated experiment.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -723,8 +715,7 @@ func newGetHistory() *cobra.Command {
   Gets a list of all values for the specified metric for a given run.
 
   Arguments:
-    METRIC_KEY: Name of the metric.
-    `
+    METRIC_KEY: Name of the metric.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -788,8 +779,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    EXPERIMENT_ID: The experiment for which to get or manage permissions.
-    `
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -854,8 +844,7 @@ func newGetPermissions() *cobra.Command {
   from their root object.
 
   Arguments:
-    EXPERIMENT_ID: The experiment for which to get or manage permissions.
-    `
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -926,8 +915,7 @@ func newGetRun() *cobra.Command {
   these values.
 
   Arguments:
-    RUN_ID: ID of the run to fetch. Must be provided.
-    `
+    RUN_ID: ID of the run to fetch. Must be provided.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1309,11 +1297,8 @@ func newLogMetric() *cobra.Command {
 
   Arguments:
     KEY: Name of the metric.
-    
     VALUE: Double value of the metric being logged.
-    
-    TIMESTAMP: Unix timestamp in milliseconds at the time metric was logged.
-    `
+    TIMESTAMP: Unix timestamp in milliseconds at the time metric was logged.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1485,9 +1470,7 @@ func newLogParam() *cobra.Command {
 
   Arguments:
     KEY: Name of the param. Maximum size is 255 bytes.
-    
-    VALUE: String value of the param being logged. Maximum size is 500 bytes.
-    `
+    VALUE: String value of the param being logged. Maximum size is 500 bytes.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1576,8 +1559,7 @@ func newRestoreExperiment() *cobra.Command {
   permanently deleted.
 
   Arguments:
-    EXPERIMENT_ID: ID of the associated experiment.
-    `
+    EXPERIMENT_ID: ID of the associated experiment.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1658,8 +1640,7 @@ func newRestoreRun() *cobra.Command {
   Restores a deleted run.
 
   Arguments:
-    RUN_ID: ID of the run to restore.
-    `
+    RUN_ID: ID of the run to restore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1744,11 +1725,9 @@ func newRestoreRuns() *cobra.Command {
 
   Arguments:
     EXPERIMENT_ID: The ID of the experiment containing the runs to restore.
-    
     MIN_TIMESTAMP_MILLIS: The minimum deletion timestamp in milliseconds since the UNIX epoch for
-    restoring runs. Only runs deleted no earlier than this timestamp are
-    restored.
-    `
+      restoring runs. Only runs deleted no earlier than this timestamp are
+      restored.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1987,14 +1966,11 @@ func newSetExperimentTag() *cobra.Command {
 
   Arguments:
     EXPERIMENT_ID: ID of the experiment under which to log the tag. Must be provided.
-    
     KEY: Name of the tag. Maximum size depends on storage backend. All storage
-    backends are guaranteed to support key values up to 250 bytes in size.
-    
+      backends are guaranteed to support key values up to 250 bytes in size.
     VALUE: String value of the tag being logged. Maximum size depends on storage
-    backend. All storage backends are guaranteed to support key values up to
-    5000 bytes in size.
-    `
+      backend. All storage backends are guaranteed to support key values up to
+      5000 bytes in size.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2084,8 +2060,7 @@ func newSetPermissions() *cobra.Command {
   their root object.
 
   Arguments:
-    EXPERIMENT_ID: The experiment for which to get or manage permissions.
-    `
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2162,12 +2137,10 @@ func newSetTag() *cobra.Command {
 
   Arguments:
     KEY: Name of the tag. Maximum size depends on storage backend. All storage
-    backends are guaranteed to support key values up to 250 bytes in size.
-    
+      backends are guaranteed to support key values up to 250 bytes in size.
     VALUE: String value of the tag being logged. Maximum size depends on storage
-    backend. All storage backends are guaranteed to support key values up to
-    5000 bytes in size.
-    `
+      backend. All storage backends are guaranteed to support key values up to
+      5000 bytes in size.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2253,8 +2226,7 @@ func newUpdateExperiment() *cobra.Command {
   Updates experiment metadata.
 
   Arguments:
-    EXPERIMENT_ID: ID of the associated experiment.
-    `
+    EXPERIMENT_ID: ID of the associated experiment.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2338,8 +2310,7 @@ func newUpdatePermissions() *cobra.Command {
   from their root object.
 
   Arguments:
-    EXPERIMENT_ID: The experiment for which to get or manage permissions.
-    `
+    EXPERIMENT_ID: The experiment for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/external-locations/external-locations.go
+++ b/cmd/workspace/external-locations/external-locations.go
@@ -81,11 +81,8 @@ func newCreate() *cobra.Command {
 
   Arguments:
     NAME: Name of the external location.
-    
     URL: Path URL of the external location.
-    
-    CREDENTIAL_NAME: Name of the storage credential used with this location.
-    `
+    CREDENTIAL_NAME: Name of the storage credential used with this location.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -173,8 +170,7 @@ func newDelete() *cobra.Command {
   the owner of the external location.
 
   Arguments:
-    NAME: Name of the external location.
-    `
+    NAME: Name of the external location.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -240,8 +236,7 @@ func newGet() *cobra.Command {
   privilege on the external location.
 
   Arguments:
-    NAME: Name of the external location.
-    `
+    NAME: Name of the external location.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -371,8 +366,7 @@ func newUpdate() *cobra.Command {
   can only update the name of the external location.
 
   Arguments:
-    NAME: Name of the external location.
-    `
+    NAME: Name of the external location.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/external-locations/external-locations.go
+++ b/cmd/workspace/external-locations/external-locations.go
@@ -77,7 +77,15 @@ func newCreate() *cobra.Command {
   
   Creates a new external location entry in the metastore. The caller must be a
   metastore admin or have the **CREATE_EXTERNAL_LOCATION** privilege on both the
-  metastore and the associated storage credential.`
+  metastore and the associated storage credential.
+
+  Arguments:
+    NAME: Name of the external location.
+    
+    URL: Path URL of the external location.
+    
+    CREDENTIAL_NAME: Name of the storage credential used with this location.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -162,7 +170,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete an external location.
   
   Deletes the specified external location from the metastore. The caller must be
-  the owner of the external location.`
+  the owner of the external location.
+
+  Arguments:
+    NAME: Name of the external location.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -225,7 +237,11 @@ func newGet() *cobra.Command {
   
   Gets an external location from the metastore. The caller must be either a
   metastore admin, the owner of the external location, or a user that has some
-  privilege on the external location.`
+  privilege on the external location.
+
+  Arguments:
+    NAME: Name of the external location.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -352,7 +368,11 @@ func newUpdate() *cobra.Command {
   
   Updates an external location in the metastore. The caller must be the owner of
   the external location, or be a metastore admin. In the second case, the admin
-  can only update the name of the external location.`
+  can only update the name of the external location.
+
+  Arguments:
+    NAME: Name of the external location.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/functions/functions.go
+++ b/cmd/workspace/functions/functions.go
@@ -136,7 +136,12 @@ func newDelete() *cobra.Command {
   of the function's parent catalog - Is the owner of the function's parent
   schema and have the **USE_CATALOG** privilege on its parent catalog - Is the
   owner of the function itself and have both the **USE_CATALOG** privilege on
-  its parent catalog and the **USE_SCHEMA** privilege on its parent schema`
+  its parent catalog and the **USE_SCHEMA** privilege on its parent schema
+
+  Arguments:
+    NAME: The fully-qualified name of the function (of the form
+    __catalog_name__.__schema_name__.__function__name__).
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -215,7 +220,12 @@ func newGet() *cobra.Command {
   **USE_CATALOG** privilege on the function's parent catalog and be the owner of
   the function - Have the **USE_CATALOG** privilege on the function's parent
   catalog, the **USE_SCHEMA** privilege on the function's parent schema, and the
-  **EXECUTE** privilege on the function itself`
+  **EXECUTE** privilege on the function itself
+
+  Arguments:
+    NAME: The fully-qualified name of the function (of the form
+    __catalog_name__.__schema_name__.__function__name__).
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -294,7 +304,13 @@ func newList() *cobra.Command {
   **USE_SCHEMA** privilege on the schema, and the output list contains only
   functions for which either the user has the **EXECUTE** privilege or the user
   is the owner. There is no guarantee of a specific ordering of the elements in
-  the array.`
+  the array.
+
+  Arguments:
+    CATALOG_NAME: Name of parent catalog for functions of interest.
+    
+    SCHEMA_NAME: Parent schema of functions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -367,7 +383,12 @@ func newUpdate() *cobra.Command {
   function's parent schema and has the **USE_CATALOG** privilege on its parent
   catalog - Is the owner of the function itself and has the **USE_CATALOG**
   privilege on its parent catalog as well as the **USE_SCHEMA** privilege on the
-  function's parent schema.`
+  function's parent schema.
+
+  Arguments:
+    NAME: The fully-qualified name of the function (of the form
+    __catalog_name__.__schema_name__.__function__name__).
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/functions/functions.go
+++ b/cmd/workspace/functions/functions.go
@@ -140,8 +140,7 @@ func newDelete() *cobra.Command {
 
   Arguments:
     NAME: The fully-qualified name of the function (of the form
-    __catalog_name__.__schema_name__.__function__name__).
-    `
+      __catalog_name__.__schema_name__.__function__name__).`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -224,8 +223,7 @@ func newGet() *cobra.Command {
 
   Arguments:
     NAME: The fully-qualified name of the function (of the form
-    __catalog_name__.__schema_name__.__function__name__).
-    `
+      __catalog_name__.__schema_name__.__function__name__).`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -308,9 +306,7 @@ func newList() *cobra.Command {
 
   Arguments:
     CATALOG_NAME: Name of parent catalog for functions of interest.
-    
-    SCHEMA_NAME: Parent schema of functions.
-    `
+    SCHEMA_NAME: Parent schema of functions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -387,8 +383,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     NAME: The fully-qualified name of the function (of the form
-    __catalog_name__.__schema_name__.__function__name__).
-    `
+      __catalog_name__.__schema_name__.__function__name__).`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/git-credentials/git-credentials.go
+++ b/cmd/workspace/git-credentials/git-credentials.go
@@ -72,9 +72,8 @@ func newCreate() *cobra.Command {
 
   Arguments:
     GIT_PROVIDER: Git provider. This field is case-insensitive. The available Git providers
-    are gitHub, bitbucketCloud, gitLab, azureDevOpsServices, gitHubEnterprise,
-    bitbucketServer, gitLabEnterpriseEdition and awsCodeCommit.
-    `
+      are gitHub, bitbucketCloud, gitLab, azureDevOpsServices, gitHubEnterprise,
+      bitbucketServer, gitLabEnterpriseEdition and awsCodeCommit.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -153,8 +152,7 @@ func newDelete() *cobra.Command {
   Deletes the specified Git credential.
 
   Arguments:
-    CREDENTIAL_ID: The ID for the corresponding credential to access.
-    `
+    CREDENTIAL_ID: The ID for the corresponding credential to access.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -233,8 +231,7 @@ func newGet() *cobra.Command {
   Gets the Git credential with the specified credential ID.
 
   Arguments:
-    CREDENTIAL_ID: The ID for the corresponding credential to access.
-    `
+    CREDENTIAL_ID: The ID for the corresponding credential to access.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -368,8 +365,7 @@ func newUpdate() *cobra.Command {
   Updates the specified Git credential.
 
   Arguments:
-    CREDENTIAL_ID: The ID for the corresponding credential to access.
-    `
+    CREDENTIAL_ID: The ID for the corresponding credential to access.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/git-credentials/git-credentials.go
+++ b/cmd/workspace/git-credentials/git-credentials.go
@@ -68,7 +68,13 @@ func newCreate() *cobra.Command {
   Creates a Git credential entry for the user. Only one Git credential per user
   is supported, so any attempts to create credentials if an entry already exists
   will fail. Use the PATCH endpoint to update existing credentials, or the
-  DELETE endpoint to delete existing credentials.`
+  DELETE endpoint to delete existing credentials.
+
+  Arguments:
+    GIT_PROVIDER: Git provider. This field is case-insensitive. The available Git providers
+    are gitHub, bitbucketCloud, gitLab, azureDevOpsServices, gitHubEnterprise,
+    bitbucketServer, gitLabEnterpriseEdition and awsCodeCommit.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -144,7 +150,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a credential.`
 	cmd.Long = `Delete a credential.
   
-  Deletes the specified Git credential.`
+  Deletes the specified Git credential.
+
+  Arguments:
+    CREDENTIAL_ID: The ID for the corresponding credential to access.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -220,7 +230,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a credential entry.`
 	cmd.Long = `Get a credential entry.
   
-  Gets the Git credential with the specified credential ID.`
+  Gets the Git credential with the specified credential ID.
+
+  Arguments:
+    CREDENTIAL_ID: The ID for the corresponding credential to access.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -351,7 +365,11 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Update a credential.`
 	cmd.Long = `Update a credential.
   
-  Updates the specified Git credential.`
+  Updates the specified Git credential.
+
+  Arguments:
+    CREDENTIAL_ID: The ID for the corresponding credential to access.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/global-init-scripts/global-init-scripts.go
+++ b/cmd/workspace/global-init-scripts/global-init-scripts.go
@@ -68,7 +68,13 @@ func newCreate() *cobra.Command {
 	cmd.Short = `Create init script.`
 	cmd.Long = `Create init script.
   
-  Creates a new global init script in this workspace.`
+  Creates a new global init script in this workspace.
+
+  Arguments:
+    NAME: The name of the script
+    
+    SCRIPT: The Base64-encoded content of the script.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -147,7 +153,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete init script.`
 	cmd.Long = `Delete init script.
   
-  Deletes a global init script.`
+  Deletes a global init script.
+
+  Arguments:
+    SCRIPT_ID: The ID of the global init script.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -220,7 +230,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get an init script.`
 	cmd.Long = `Get an init script.
   
-  Gets all the details of a script, including its Base64-encoded contents.`
+  Gets all the details of a script, including its Base64-encoded contents.
+
+  Arguments:
+    SCRIPT_ID: The ID of the global init script.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -350,7 +364,15 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update init script.
   
   Updates a global init script, specifying only the fields to change. All fields
-  are optional. Unspecified fields retain their current value.`
+  are optional. Unspecified fields retain their current value.
+
+  Arguments:
+    SCRIPT_ID: The ID of the global init script.
+    
+    NAME: The name of the script
+    
+    SCRIPT: The Base64-encoded content of the script.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/global-init-scripts/global-init-scripts.go
+++ b/cmd/workspace/global-init-scripts/global-init-scripts.go
@@ -72,9 +72,7 @@ func newCreate() *cobra.Command {
 
   Arguments:
     NAME: The name of the script
-    
-    SCRIPT: The Base64-encoded content of the script.
-    `
+    SCRIPT: The Base64-encoded content of the script.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -156,8 +154,7 @@ func newDelete() *cobra.Command {
   Deletes a global init script.
 
   Arguments:
-    SCRIPT_ID: The ID of the global init script.
-    `
+    SCRIPT_ID: The ID of the global init script.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -233,8 +230,7 @@ func newGet() *cobra.Command {
   Gets all the details of a script, including its Base64-encoded contents.
 
   Arguments:
-    SCRIPT_ID: The ID of the global init script.
-    `
+    SCRIPT_ID: The ID of the global init script.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -368,11 +364,8 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     SCRIPT_ID: The ID of the global init script.
-    
     NAME: The name of the script
-    
-    SCRIPT: The Base64-encoded content of the script.
-    `
+    SCRIPT: The Base64-encoded content of the script.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/grants/grants.go
+++ b/cmd/workspace/grants/grants.go
@@ -71,9 +71,7 @@ func newGet() *cobra.Command {
 
   Arguments:
     SECURABLE_TYPE: Type of securable.
-    
-    FULL_NAME: Full name of securable.
-    `
+    FULL_NAME: Full name of securable.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -144,9 +142,7 @@ func newGetEffective() *cobra.Command {
 
   Arguments:
     SECURABLE_TYPE: Type of securable.
-    
-    FULL_NAME: Full name of securable.
-    `
+    FULL_NAME: Full name of securable.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -219,9 +215,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     SECURABLE_TYPE: Type of securable.
-    
-    FULL_NAME: Full name of securable.
-    `
+    FULL_NAME: Full name of securable.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/grants/grants.go
+++ b/cmd/workspace/grants/grants.go
@@ -67,7 +67,13 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get permissions.`
 	cmd.Long = `Get permissions.
   
-  Gets the permissions for a securable.`
+  Gets the permissions for a securable.
+
+  Arguments:
+    SECURABLE_TYPE: Type of securable.
+    
+    FULL_NAME: Full name of securable.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -134,7 +140,13 @@ func newGetEffective() *cobra.Command {
 	cmd.Short = `Get effective permissions.`
 	cmd.Long = `Get effective permissions.
   
-  Gets the effective permissions for a securable.`
+  Gets the effective permissions for a securable.
+
+  Arguments:
+    SECURABLE_TYPE: Type of securable.
+    
+    FULL_NAME: Full name of securable.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -203,7 +215,13 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Update permissions.`
 	cmd.Long = `Update permissions.
   
-  Updates the permissions for a securable.`
+  Updates the permissions for a securable.
+
+  Arguments:
+    SECURABLE_TYPE: Type of securable.
+    
+    FULL_NAME: Full name of securable.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/groups/groups.go
+++ b/cmd/workspace/groups/groups.go
@@ -143,8 +143,7 @@ func newDelete() *cobra.Command {
   Deletes a group from the Databricks workspace.
 
   Arguments:
-    ID: Unique ID for a group in the Databricks workspace.
-    `
+    ID: Unique ID for a group in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -220,8 +219,7 @@ func newGet() *cobra.Command {
   Gets the information for a specific group in the Databricks workspace.
 
   Arguments:
-    ID: Unique ID for a group in the Databricks workspace.
-    `
+    ID: Unique ID for a group in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -369,8 +367,7 @@ func newPatch() *cobra.Command {
   Partially updates the details of a group.
 
   Arguments:
-    ID: Unique ID for a group in the Databricks workspace.
-    `
+    ID: Unique ID for a group in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -464,8 +461,7 @@ func newUpdate() *cobra.Command {
   Updates the details of a group by replacing the entire group entity.
 
   Arguments:
-    ID: Databricks group ID
-    `
+    ID: Databricks group ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/groups/groups.go
+++ b/cmd/workspace/groups/groups.go
@@ -140,7 +140,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a group.`
 	cmd.Long = `Delete a group.
   
-  Deletes a group from the Databricks workspace.`
+  Deletes a group from the Databricks workspace.
+
+  Arguments:
+    ID: Unique ID for a group in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -213,7 +217,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get group details.`
 	cmd.Long = `Get group details.
   
-  Gets the information for a specific group in the Databricks workspace.`
+  Gets the information for a specific group in the Databricks workspace.
+
+  Arguments:
+    ID: Unique ID for a group in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -358,7 +366,11 @@ func newPatch() *cobra.Command {
 	cmd.Short = `Update group details.`
 	cmd.Long = `Update group details.
   
-  Partially updates the details of a group.`
+  Partially updates the details of a group.
+
+  Arguments:
+    ID: Unique ID for a group in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -449,7 +461,11 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Replace a group.`
 	cmd.Long = `Replace a group.
   
-  Updates the details of a group by replacing the entire group entity.`
+  Updates the details of a group by replacing the entire group entity.
+
+  Arguments:
+    ID: Databricks group ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/instance-pools/instance-pools.go
+++ b/cmd/workspace/instance-pools/instance-pools.go
@@ -90,14 +90,12 @@ func newCreate() *cobra.Command {
 
   Arguments:
     INSTANCE_POOL_NAME: Pool name requested by the user. Pool name must be unique. Length must be
-    between 1 and 100 characters.
-    
-    NODE_TYPE_ID: This field encodes, through a single value, the resources available to each
-    of the Spark nodes in this cluster. For example, the Spark nodes can be
-    provisioned and optimized for memory or compute intensive workloads. A list
-    of available node types can be retrieved by using the
-    :method:clusters/listNodeTypes API call.
-    `
+      between 1 and 100 characters.
+    NODE_TYPE_ID: This field encodes, through a single value, the resources available to
+      each of the Spark nodes in this cluster. For example, the Spark nodes can
+      be provisioned and optimized for memory or compute intensive workloads. A
+      list of available node types can be retrieved by using the
+      :method:clusters/listNodeTypes API call.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -182,8 +180,7 @@ func newDelete() *cobra.Command {
   terminated asynchronously.
 
   Arguments:
-    INSTANCE_POOL_ID: The instance pool to be terminated.
-    `
+    INSTANCE_POOL_ID: The instance pool to be terminated.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -274,16 +271,13 @@ func newEdit() *cobra.Command {
 
   Arguments:
     INSTANCE_POOL_ID: Instance pool ID
-    
     INSTANCE_POOL_NAME: Pool name requested by the user. Pool name must be unique. Length must be
-    between 1 and 100 characters.
-    
-    NODE_TYPE_ID: This field encodes, through a single value, the resources available to each
-    of the Spark nodes in this cluster. For example, the Spark nodes can be
-    provisioned and optimized for memory or compute intensive workloads. A list
-    of available node types can be retrieved by using the
-    :method:clusters/listNodeTypes API call.
-    `
+      between 1 and 100 characters.
+    NODE_TYPE_ID: This field encodes, through a single value, the resources available to
+      each of the Spark nodes in this cluster. For example, the Spark nodes can
+      be provisioned and optimized for memory or compute intensive workloads. A
+      list of available node types can be retrieved by using the
+      :method:clusters/listNodeTypes API call.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -368,8 +362,7 @@ func newGet() *cobra.Command {
   Retrieve the information for an instance pool based on its identifier.
 
   Arguments:
-    INSTANCE_POOL_ID: The canonical unique identifier for the instance pool.
-    `
+    INSTANCE_POOL_ID: The canonical unique identifier for the instance pool.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -445,8 +438,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
-    `
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -523,8 +515,7 @@ func newGetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
-    `
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -653,8 +644,7 @@ func newSetPermissions() *cobra.Command {
   from their root object.
 
   Arguments:
-    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
-    `
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -741,8 +731,7 @@ func newUpdatePermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
-    `
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/instance-pools/instance-pools.go
+++ b/cmd/workspace/instance-pools/instance-pools.go
@@ -86,7 +86,18 @@ func newCreate() *cobra.Command {
 	cmd.Short = `Create a new instance pool.`
 	cmd.Long = `Create a new instance pool.
   
-  Creates a new instance pool using idle and ready-to-use cloud instances.`
+  Creates a new instance pool using idle and ready-to-use cloud instances.
+
+  Arguments:
+    INSTANCE_POOL_NAME: Pool name requested by the user. Pool name must be unique. Length must be
+    between 1 and 100 characters.
+    
+    NODE_TYPE_ID: This field encodes, through a single value, the resources available to each
+    of the Spark nodes in this cluster. For example, the Spark nodes can be
+    provisioned and optimized for memory or compute intensive workloads. A list
+    of available node types can be retrieved by using the
+    :method:clusters/listNodeTypes API call.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -168,7 +179,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete an instance pool.
   
   Deletes the instance pool permanently. The idle instances in the pool are
-  terminated asynchronously.`
+  terminated asynchronously.
+
+  Arguments:
+    INSTANCE_POOL_ID: The instance pool to be terminated.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -255,7 +270,20 @@ func newEdit() *cobra.Command {
 	cmd.Short = `Edit an existing instance pool.`
 	cmd.Long = `Edit an existing instance pool.
   
-  Modifies the configuration of an existing instance pool.`
+  Modifies the configuration of an existing instance pool.
+
+  Arguments:
+    INSTANCE_POOL_ID: Instance pool ID
+    
+    INSTANCE_POOL_NAME: Pool name requested by the user. Pool name must be unique. Length must be
+    between 1 and 100 characters.
+    
+    NODE_TYPE_ID: This field encodes, through a single value, the resources available to each
+    of the Spark nodes in this cluster. For example, the Spark nodes can be
+    provisioned and optimized for memory or compute intensive workloads. A list
+    of available node types can be retrieved by using the
+    :method:clusters/listNodeTypes API call.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -337,7 +365,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get instance pool information.`
 	cmd.Long = `Get instance pool information.
   
-  Retrieve the information for an instance pool based on its identifier.`
+  Retrieve the information for an instance pool based on its identifier.
+
+  Arguments:
+    INSTANCE_POOL_ID: The canonical unique identifier for the instance pool.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -410,7 +442,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get instance pool permission levels.`
 	cmd.Long = `Get instance pool permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -484,7 +520,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get instance pool permissions.
   
   Gets the permissions of an instance pool. Instance pools can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -610,7 +650,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set instance pool permissions.
   
   Sets permissions on an instance pool. Instance pools can inherit permissions
-  from their root object.`
+  from their root object.
+
+  Arguments:
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -694,7 +738,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update instance pool permissions.
   
   Updates the permissions on an instance pool. Instance pools can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    INSTANCE_POOL_ID: The instance pool for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/instance-profiles/instance-profiles.go
+++ b/cmd/workspace/instance-profiles/instance-profiles.go
@@ -70,9 +70,8 @@ func newAdd() *cobra.Command {
   API is only available to admin users.
 
   Arguments:
-    INSTANCE_PROFILE_ARN: The AWS ARN of the instance profile to register with Databricks. This field
-    is required.
-    `
+    INSTANCE_PROFILE_ARN: The AWS ARN of the instance profile to register with Databricks. This
+      field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -170,9 +169,8 @@ func newEdit() *cobra.Command {
   [Enable serverless SQL warehouses]: https://docs.databricks.com/sql/admin/serverless.html
 
   Arguments:
-    INSTANCE_PROFILE_ARN: The AWS ARN of the instance profile to register with Databricks. This field
-    is required.
-    `
+    INSTANCE_PROFILE_ARN: The AWS ARN of the instance profile to register with Databricks. This
+      field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -306,8 +304,7 @@ func newRemove() *cobra.Command {
   This API is only accessible to admin users.
 
   Arguments:
-    INSTANCE_PROFILE_ARN: The ARN of the instance profile to remove. This field is required.
-    `
+    INSTANCE_PROFILE_ARN: The ARN of the instance profile to remove. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/instance-profiles/instance-profiles.go
+++ b/cmd/workspace/instance-profiles/instance-profiles.go
@@ -67,7 +67,12 @@ func newAdd() *cobra.Command {
 	cmd.Long = `Register an instance profile.
   
   In the UI, you can select the instance profile when launching clusters. This
-  API is only available to admin users.`
+  API is only available to admin users.
+
+  Arguments:
+    INSTANCE_PROFILE_ARN: The AWS ARN of the instance profile to register with Databricks. This field
+    is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -162,7 +167,12 @@ func newEdit() *cobra.Command {
   This API is only available to admin users.
   
   [Databricks SQL Serverless]: https://docs.databricks.com/sql/admin/serverless.html
-  [Enable serverless SQL warehouses]: https://docs.databricks.com/sql/admin/serverless.html`
+  [Enable serverless SQL warehouses]: https://docs.databricks.com/sql/admin/serverless.html
+
+  Arguments:
+    INSTANCE_PROFILE_ARN: The AWS ARN of the instance profile to register with Databricks. This field
+    is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -293,7 +303,11 @@ func newRemove() *cobra.Command {
   Remove the instance profile with the provided ARN. Existing clusters with this
   instance profile will continue to function.
   
-  This API is only accessible to admin users.`
+  This API is only accessible to admin users.
+
+  Arguments:
+    INSTANCE_PROFILE_ARN: The ARN of the instance profile to remove. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/ip-access-lists/ip-access-lists.go
+++ b/cmd/workspace/ip-access-lists/ip-access-lists.go
@@ -155,7 +155,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete access list.`
 	cmd.Long = `Delete access list.
   
-  Deletes an IP access list, specified by its list ID.`
+  Deletes an IP access list, specified by its list ID.
+
+  Arguments:
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list to modify.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -228,7 +232,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get access list.`
 	cmd.Long = `Get access list.
   
-  Gets an IP access list, specified by its list ID.`
+  Gets an IP access list, specified by its list ID.
+
+  Arguments:
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list to modify.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/ip-access-lists/ip-access-lists.go
+++ b/cmd/workspace/ip-access-lists/ip-access-lists.go
@@ -158,8 +158,7 @@ func newDelete() *cobra.Command {
   Deletes an IP access list, specified by its list ID.
 
   Arguments:
-    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list to modify.
-    `
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list to modify.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -235,8 +234,7 @@ func newGet() *cobra.Command {
   Gets an IP access list, specified by its list ID.
 
   Arguments:
-    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list to modify.
-    `
+    IP_ACCESS_LIST_ID: The ID for the corresponding IP access list to modify.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/jobs/jobs.go
+++ b/cmd/workspace/jobs/jobs.go
@@ -153,7 +153,11 @@ func newCancelRun() *cobra.Command {
 	cmd.Long = `Cancel a run.
   
   Cancels a job run or a task run. The run is canceled asynchronously, so it may
-  still be running when this request completes.`
+  still be running when this request completes.
+
+  Arguments:
+    RUN_ID: This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -322,7 +326,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a job.`
 	cmd.Long = `Delete a job.
   
-  Deletes a job.`
+  Deletes a job.
+
+  Arguments:
+    JOB_ID: The canonical identifier of the job to delete. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -407,7 +415,11 @@ func newDeleteRun() *cobra.Command {
 	cmd.Short = `Delete a job run.`
 	cmd.Long = `Delete a job run.
   
-  Deletes a non-active run. Returns an error if the run is active.`
+  Deletes a non-active run. Returns an error if the run is active.
+
+  Arguments:
+    RUN_ID: The canonical identifier of the run for which to retrieve the metadata.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -492,7 +504,11 @@ func newExportRun() *cobra.Command {
 	cmd.Short = `Export and retrieve a job run.`
 	cmd.Long = `Export and retrieve a job run.
   
-  Export and retrieve the job run task.`
+  Export and retrieve the job run task.
+
+  Arguments:
+    RUN_ID: The canonical identifier for the run. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -568,7 +584,12 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a single job.`
 	cmd.Long = `Get a single job.
   
-  Retrieves the details for a single job.`
+  Retrieves the details for a single job.
+
+  Arguments:
+    JOB_ID: The canonical identifier of the job to retrieve information about. This
+    field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -644,7 +665,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get job permission levels.`
 	cmd.Long = `Get job permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    JOB_ID: The job for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -718,7 +743,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get job permissions.
   
   Gets the permissions of a job. Jobs can inherit permissions from their root
-  object.`
+  object.
+
+  Arguments:
+    JOB_ID: The job for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -799,7 +828,12 @@ func newGetRun() *cobra.Command {
 	cmd.Short = `Get a single job run.`
 	cmd.Long = `Get a single job run.
   
-  Retrieve the metadata of a run.`
+  Retrieve the metadata of a run.
+
+  Arguments:
+    RUN_ID: The canonical identifier of the run for which to retrieve the metadata. This
+    field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -884,7 +918,11 @@ func newGetRunOutput() *cobra.Command {
   This endpoint validates that the __run_id__ parameter is valid and returns an
   HTTP status code 400 if the __run_id__ parameter is invalid. Runs are
   automatically removed after 60 days. If you to want to reference them beyond
-  60 days, you must save old run results before they expire.`
+  60 days, you must save old run results before they expire.
+
+  Arguments:
+    RUN_ID: The canonical identifier for the run. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1118,7 +1156,11 @@ func newRepairRun() *cobra.Command {
   
   Re-run one or more tasks. Tasks are re-run as part of the original job run.
   They use the current job and task settings, and can be viewed in the history
-  for the original job run.`
+  for the original job run.
+
+  Arguments:
+    RUN_ID: The job run ID of the run to repair. The run must not be in progress.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1305,7 +1347,11 @@ func newRunNow() *cobra.Command {
 	cmd.Short = `Trigger a new job run.`
 	cmd.Long = `Trigger a new job run.
   
-  Run a job and return the run_id of the triggered run.`
+  Run a job and return the run_id of the triggered run.
+
+  Arguments:
+    JOB_ID: The ID of the job to be executed
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1412,7 +1458,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set job permissions.
   
   Sets permissions on a job. Jobs can inherit permissions from their root
-  object.`
+  object.
+
+  Arguments:
+    JOB_ID: The job for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1604,7 +1654,11 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Partially update a job.
   
   Add, update, or remove specific settings of an existing job. Use the ResetJob
-  to overwrite all job settings.`
+  to overwrite all job settings.
+
+  Arguments:
+    JOB_ID: The canonical identifier of the job to update. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1692,7 +1746,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update job permissions.
   
   Updates the permissions on a job. Jobs can inherit permissions from their root
-  object.`
+  object.
+
+  Arguments:
+    JOB_ID: The job for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/jobs/jobs.go
+++ b/cmd/workspace/jobs/jobs.go
@@ -156,8 +156,7 @@ func newCancelRun() *cobra.Command {
   still be running when this request completes.
 
   Arguments:
-    RUN_ID: This field is required.
-    `
+    RUN_ID: This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -329,8 +328,7 @@ func newDelete() *cobra.Command {
   Deletes a job.
 
   Arguments:
-    JOB_ID: The canonical identifier of the job to delete. This field is required.
-    `
+    JOB_ID: The canonical identifier of the job to delete. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -418,8 +416,7 @@ func newDeleteRun() *cobra.Command {
   Deletes a non-active run. Returns an error if the run is active.
 
   Arguments:
-    RUN_ID: The canonical identifier of the run for which to retrieve the metadata.
-    `
+    RUN_ID: The canonical identifier of the run for which to retrieve the metadata.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -507,8 +504,7 @@ func newExportRun() *cobra.Command {
   Export and retrieve the job run task.
 
   Arguments:
-    RUN_ID: The canonical identifier for the run. This field is required.
-    `
+    RUN_ID: The canonical identifier for the run. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -588,8 +584,7 @@ func newGet() *cobra.Command {
 
   Arguments:
     JOB_ID: The canonical identifier of the job to retrieve information about. This
-    field is required.
-    `
+      field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -668,8 +663,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    JOB_ID: The job for which to get or manage permissions.
-    `
+    JOB_ID: The job for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -746,8 +740,7 @@ func newGetPermissions() *cobra.Command {
   object.
 
   Arguments:
-    JOB_ID: The job for which to get or manage permissions.
-    `
+    JOB_ID: The job for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -831,9 +824,8 @@ func newGetRun() *cobra.Command {
   Retrieve the metadata of a run.
 
   Arguments:
-    RUN_ID: The canonical identifier of the run for which to retrieve the metadata. This
-    field is required.
-    `
+    RUN_ID: The canonical identifier of the run for which to retrieve the metadata.
+      This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -921,8 +913,7 @@ func newGetRunOutput() *cobra.Command {
   60 days, you must save old run results before they expire.
 
   Arguments:
-    RUN_ID: The canonical identifier for the run. This field is required.
-    `
+    RUN_ID: The canonical identifier for the run. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1159,8 +1150,7 @@ func newRepairRun() *cobra.Command {
   for the original job run.
 
   Arguments:
-    RUN_ID: The job run ID of the run to repair. The run must not be in progress.
-    `
+    RUN_ID: The job run ID of the run to repair. The run must not be in progress.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1350,8 +1340,7 @@ func newRunNow() *cobra.Command {
   Run a job and return the run_id of the triggered run.
 
   Arguments:
-    JOB_ID: The ID of the job to be executed
-    `
+    JOB_ID: The ID of the job to be executed`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1461,8 +1450,7 @@ func newSetPermissions() *cobra.Command {
   object.
 
   Arguments:
-    JOB_ID: The job for which to get or manage permissions.
-    `
+    JOB_ID: The job for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1657,8 +1645,7 @@ func newUpdate() *cobra.Command {
   to overwrite all job settings.
 
   Arguments:
-    JOB_ID: The canonical identifier of the job to update. This field is required.
-    `
+    JOB_ID: The canonical identifier of the job to update. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1749,8 +1736,7 @@ func newUpdatePermissions() *cobra.Command {
   object.
 
   Arguments:
-    JOB_ID: The job for which to get or manage permissions.
-    `
+    JOB_ID: The job for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/libraries/libraries.go
+++ b/cmd/workspace/libraries/libraries.go
@@ -138,7 +138,11 @@ func newClusterStatus() *cobra.Command {
   
   3. Libraries that were previously requested on this cluster or on all
   clusters, but now marked for removal. Within this group there is no order
-  guarantee.`
+  guarantee.
+
+  Arguments:
+    CLUSTER_ID: Unique identifier of the cluster whose status should be retrieved.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/libraries/libraries.go
+++ b/cmd/workspace/libraries/libraries.go
@@ -141,8 +141,7 @@ func newClusterStatus() *cobra.Command {
   guarantee.
 
   Arguments:
-    CLUSTER_ID: Unique identifier of the cluster whose status should be retrieved.
-    `
+    CLUSTER_ID: Unique identifier of the cluster whose status should be retrieved.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/metastores/metastores.go
+++ b/cmd/workspace/metastores/metastores.go
@@ -75,11 +75,8 @@ func newAssign() *cobra.Command {
 
   Arguments:
     WORKSPACE_ID: A workspace ID.
-    
     METASTORE_ID: The unique ID of the metastore.
-    
-    DEFAULT_CATALOG_NAME: The name of the default catalog in the metastore.
-    `
+    DEFAULT_CATALOG_NAME: The name of the default catalog in the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -174,8 +171,7 @@ func newCreate() *cobra.Command {
   System User instead.
 
   Arguments:
-    NAME: The user-specified name of the metastore.
-    `
+    NAME: The user-specified name of the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -304,8 +300,7 @@ func newDelete() *cobra.Command {
   Deletes a metastore. The caller must be a metastore admin.
 
   Arguments:
-    ID: Unique ID of the metastore.
-    `
+    ID: Unique ID of the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -382,8 +377,7 @@ func newGet() *cobra.Command {
   admin to retrieve this info.
 
   Arguments:
-    ID: Unique ID of the metastore.
-    `
+    ID: Unique ID of the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -559,9 +553,7 @@ func newUnassign() *cobra.Command {
 
   Arguments:
     WORKSPACE_ID: A workspace ID.
-    
-    METASTORE_ID: Query for the ID of the metastore to delete.
-    `
+    METASTORE_ID: Query for the ID of the metastore to delete.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -641,8 +633,7 @@ func newUpdate() *cobra.Command {
   ownership is updated to the System User.
 
   Arguments:
-    ID: Unique ID of the metastore.
-    `
+    ID: Unique ID of the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -732,8 +723,7 @@ func newUpdateAssignment() *cobra.Command {
   to update __metastore_id__; otherwise, the caller can be a Workspace admin.
 
   Arguments:
-    WORKSPACE_ID: A workspace ID.
-    `
+    WORKSPACE_ID: A workspace ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/metastores/metastores.go
+++ b/cmd/workspace/metastores/metastores.go
@@ -71,7 +71,15 @@ func newAssign() *cobra.Command {
   
   Creates a new metastore assignment. If an assignment for the same
   __workspace_id__ exists, it will be overwritten by the new __metastore_id__
-  and __default_catalog_name__. The caller must be an account admin.`
+  and __default_catalog_name__. The caller must be an account admin.
+
+  Arguments:
+    WORKSPACE_ID: A workspace ID.
+    
+    METASTORE_ID: The unique ID of the metastore.
+    
+    DEFAULT_CATALOG_NAME: The name of the default catalog in the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -163,7 +171,11 @@ func newCreate() *cobra.Command {
   path. By default (if the __owner__ field is not set), the owner of the new
   metastore is the user calling the __createMetastore__ API. If the __owner__
   field is set to the empty string (**""**), the ownership is assigned to the
-  System User instead.`
+  System User instead.
+
+  Arguments:
+    NAME: The user-specified name of the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -289,7 +301,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a metastore.`
 	cmd.Long = `Delete a metastore.
   
-  Deletes a metastore. The caller must be a metastore admin.`
+  Deletes a metastore. The caller must be a metastore admin.
+
+  Arguments:
+    ID: Unique ID of the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -363,7 +379,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a metastore.
   
   Gets a metastore that matches the supplied ID. The caller must be a metastore
-  admin to retrieve this info.`
+  admin to retrieve this info.
+
+  Arguments:
+    ID: Unique ID of the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -535,7 +555,13 @@ func newUnassign() *cobra.Command {
 	cmd.Short = `Delete an assignment.`
 	cmd.Long = `Delete an assignment.
   
-  Deletes a metastore assignment. The caller must be an account administrator.`
+  Deletes a metastore assignment. The caller must be an account administrator.
+
+  Arguments:
+    WORKSPACE_ID: A workspace ID.
+    
+    METASTORE_ID: Query for the ID of the metastore to delete.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -612,7 +638,11 @@ func newUpdate() *cobra.Command {
   
   Updates information for a specific metastore. The caller must be a metastore
   admin. If the __owner__ field is set to the empty string (**""**), the
-  ownership is updated to the System User.`
+  ownership is updated to the System User.
+
+  Arguments:
+    ID: Unique ID of the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -699,7 +729,11 @@ func newUpdateAssignment() *cobra.Command {
   Updates a metastore assignment. This operation can be used to update
   __metastore_id__ or __default_catalog_name__ for a specified Workspace, if the
   Workspace is already assigned a metastore. The caller must be an account admin
-  to update __metastore_id__; otherwise, the caller can be a Workspace admin.`
+  to update __metastore_id__; otherwise, the caller can be a Workspace admin.
+
+  Arguments:
+    WORKSPACE_ID: A workspace ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/model-registry/model-registry.go
+++ b/cmd/workspace/model-registry/model-registry.go
@@ -627,11 +627,7 @@ func newDeleteComment() *cobra.Command {
 	cmd.Short = `Delete a comment.`
 	cmd.Long = `Delete a comment.
   
-  Deletes a comment on a model version.
-
-  Arguments:
-    ID: 
-    `
+  Deletes a comment on a model version.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/model-registry/model-registry.go
+++ b/cmd/workspace/model-registry/model-registry.go
@@ -70,21 +70,18 @@ func newApproveTransitionRequest() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
     VERSION: Version of the model.
-    
     STAGE: Target stage of the transition. Valid values are:
-    
-    * None: The initial stage of a model version.
-    
-    * Staging: Staging or pre-production stage.
-    
-    * Production: Production stage.
-    
-    * Archived: Archived stage.
-    
-    ARCHIVE_EXISTING_VERSIONS: Specifies whether to archive all current model versions in the target stage.
-    `
+      
+      * None: The initial stage of a model version.
+      
+      * Staging: Staging or pre-production stage.
+      
+      * Production: Production stage.
+      
+      * Archived: Archived stage.
+    ARCHIVE_EXISTING_VERSIONS: Specifies whether to archive all current model versions in the target
+      stage.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -183,11 +180,8 @@ func newCreateComment() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
     VERSION: Version of the model.
-    
-    COMMENT: User-provided comment on the action.
-    `
+    COMMENT: User-provided comment on the action.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -280,8 +274,7 @@ func newCreateModel() *cobra.Command {
   exists.
 
   Arguments:
-    NAME: Register models under this name
-    `
+    NAME: Register models under this name`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -368,9 +361,7 @@ func newCreateModelVersion() *cobra.Command {
 
   Arguments:
     NAME: Register model under this name
-    
-    SOURCE: URI indicating the location of the model artifacts.
-    `
+    SOURCE: URI indicating the location of the model artifacts.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -457,19 +448,16 @@ func newCreateTransitionRequest() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
     VERSION: Version of the model.
-    
     STAGE: Target stage of the transition. Valid values are:
-    
-    * None: The initial stage of a model version.
-    
-    * Staging: Staging or pre-production stage.
-    
-    * Production: Production stage.
-    
-    * Archived: Archived stage.
-    `
+      
+      * None: The initial stage of a model version.
+      
+      * Staging: Staging or pre-production stage.
+      
+      * Production: Production stage.
+      
+      * Archived: Archived stage.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -691,8 +679,7 @@ func newDeleteModel() *cobra.Command {
   Deletes a registered model.
 
   Arguments:
-    NAME: Registered model unique name identifier.
-    `
+    NAME: Registered model unique name identifier.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -757,10 +744,8 @@ func newDeleteModelTag() *cobra.Command {
 
   Arguments:
     NAME: Name of the registered model that the tag was logged under.
-    
-    KEY: Name of the tag. The name must be an exact match; wild-card deletion is not
-    supported. Maximum size is 250 bytes.
-    `
+    KEY: Name of the tag. The name must be an exact match; wild-card deletion is
+      not supported. Maximum size is 250 bytes.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -826,9 +811,7 @@ func newDeleteModelVersion() *cobra.Command {
 
   Arguments:
     NAME: Name of the registered model
-    
-    VERSION: Model version number
-    `
+    VERSION: Model version number`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -894,12 +877,9 @@ func newDeleteModelVersionTag() *cobra.Command {
 
   Arguments:
     NAME: Name of the registered model that the tag was logged under.
-    
     VERSION: Model version number that the tag was logged under.
-    
-    KEY: Name of the tag. The name must be an exact match; wild-card deletion is not
-    supported. Maximum size is 250 bytes.
-    `
+    KEY: Name of the tag. The name must be an exact match; wild-card deletion is
+      not supported. Maximum size is 250 bytes.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -968,23 +948,19 @@ func newDeleteTransitionRequest() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
     VERSION: Version of the model.
-    
     STAGE: Target stage of the transition request. Valid values are:
-    
-    * None: The initial stage of a model version.
-    
-    * Staging: Staging or pre-production stage.
-    
-    * Production: Production stage.
-    
-    * Archived: Archived stage.
-    
+      
+      * None: The initial stage of a model version.
+      
+      * Staging: Staging or pre-production stage.
+      
+      * Production: Production stage.
+      
+      * Archived: Archived stage.
     CREATOR: Username of the user who created this request. Of the transition requests
-    matching the specified details, only the one transition created by this user
-    will be deleted.
-    `
+      matching the specified details, only the one transition created by this
+      user will be deleted.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1121,8 +1097,7 @@ func newGetLatestVersions() *cobra.Command {
   Gets the latest version of a registered model.
 
   Arguments:
-    NAME: Registered model unique name identifier.
-    `
+    NAME: Registered model unique name identifier.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1205,8 +1180,7 @@ func newGetModel() *cobra.Command {
   [MLflow endpoint]: https://www.mlflow.org/docs/latest/rest-api.html#get-registeredmodel
 
   Arguments:
-    NAME: Registered model unique name identifier.
-    `
+    NAME: Registered model unique name identifier.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1271,9 +1245,7 @@ func newGetModelVersion() *cobra.Command {
 
   Arguments:
     NAME: Name of the registered model
-    
-    VERSION: Model version number
-    `
+    VERSION: Model version number`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1339,9 +1311,7 @@ func newGetModelVersionDownloadUri() *cobra.Command {
 
   Arguments:
     NAME: Name of the registered model
-    
-    VERSION: Model version number
-    `
+    VERSION: Model version number`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1406,8 +1376,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
-    `
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1472,8 +1441,7 @@ func newGetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
-    `
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1601,9 +1569,7 @@ func newListTransitionRequests() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
-    VERSION: Version of the model.
-    `
+    VERSION: Version of the model.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1738,19 +1704,16 @@ func newRejectTransitionRequest() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
     VERSION: Version of the model.
-    
     STAGE: Target stage of the transition. Valid values are:
-    
-    * None: The initial stage of a model version.
-    
-    * Staging: Staging or pre-production stage.
-    
-    * Production: Production stage.
-    
-    * Archived: Archived stage.
-    `
+      
+      * None: The initial stage of a model version.
+      
+      * Staging: Staging or pre-production stage.
+      
+      * Production: Production stage.
+      
+      * Archived: Archived stage.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1842,8 +1805,7 @@ func newRenameModel() *cobra.Command {
   Renames a registered model.
 
   Arguments:
-    NAME: Registered model unique name identifier.
-    `
+    NAME: Registered model unique name identifier.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2053,16 +2015,13 @@ func newSetModelTag() *cobra.Command {
 
   Arguments:
     NAME: Unique name of the model.
-    
-    KEY: Name of the tag. Maximum size depends on storage backend. If a tag with this
-    name already exists, its preexisting value will be replaced by the specified
-    value. All storage backends are guaranteed to support key values up to 250
-    bytes in size.
-    
+    KEY: Name of the tag. Maximum size depends on storage backend. If a tag with
+      this name already exists, its preexisting value will be replaced by the
+      specified value. All storage backends are guaranteed to support key
+      values up to 250 bytes in size.
     VALUE: String value of the tag being logged. Maximum size depends on storage
-    backend. All storage backends are guaranteed to support key values up to
-    5000 bytes in size.
-    `
+      backend. All storage backends are guaranteed to support key values up to
+      5000 bytes in size.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2150,18 +2109,14 @@ func newSetModelVersionTag() *cobra.Command {
 
   Arguments:
     NAME: Unique name of the model.
-    
     VERSION: Model version number.
-    
-    KEY: Name of the tag. Maximum size depends on storage backend. If a tag with this
-    name already exists, its preexisting value will be replaced by the specified
-    value. All storage backends are guaranteed to support key values up to 250
-    bytes in size.
-    
+    KEY: Name of the tag. Maximum size depends on storage backend. If a tag with
+      this name already exists, its preexisting value will be replaced by the
+      specified value. All storage backends are guaranteed to support key
+      values up to 250 bytes in size.
     VALUE: String value of the tag being logged. Maximum size depends on storage
-    backend. All storage backends are guaranteed to support key values up to
-    5000 bytes in size.
-    `
+      backend. All storage backends are guaranteed to support key values up to
+      5000 bytes in size.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2254,8 +2209,7 @@ func newSetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
-    `
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2331,8 +2285,7 @@ func newTestRegistryWebhook() *cobra.Command {
   Tests a registry webhook.
 
   Arguments:
-    ID: Webhook ID
-    `
+    ID: Webhook ID`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2420,21 +2373,18 @@ func newTransitionStage() *cobra.Command {
 
   Arguments:
     NAME: Name of the model.
-    
     VERSION: Version of the model.
-    
     STAGE: Target stage of the transition. Valid values are:
-    
-    * None: The initial stage of a model version.
-    
-    * Staging: Staging or pre-production stage.
-    
-    * Production: Production stage.
-    
-    * Archived: Archived stage.
-    
-    ARCHIVE_EXISTING_VERSIONS: Specifies whether to archive all current model versions in the target stage.
-    `
+      
+      * None: The initial stage of a model version.
+      
+      * Staging: Staging or pre-production stage.
+      
+      * Production: Production stage.
+      
+      * Archived: Archived stage.
+    ARCHIVE_EXISTING_VERSIONS: Specifies whether to archive all current model versions in the target
+      stage.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2531,9 +2481,7 @@ func newUpdateComment() *cobra.Command {
 
   Arguments:
     ID: Unique identifier of an activity
-    
-    COMMENT: User-provided comment on the action.
-    `
+    COMMENT: User-provided comment on the action.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2619,8 +2567,7 @@ func newUpdateModel() *cobra.Command {
   Updates a registered model.
 
   Arguments:
-    NAME: Registered model unique name identifier.
-    `
+    NAME: Registered model unique name identifier.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2704,9 +2651,7 @@ func newUpdateModelVersion() *cobra.Command {
 
   Arguments:
     NAME: Name of the registered model
-    
-    VERSION: Model version number
-    `
+    VERSION: Model version number`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2793,8 +2738,7 @@ func newUpdatePermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
-    `
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2874,8 +2818,7 @@ func newUpdateWebhook() *cobra.Command {
   Updates a registry webhook.
 
   Arguments:
-    ID: Webhook ID
-    `
+    ID: Webhook ID`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/model-registry/model-registry.go
+++ b/cmd/workspace/model-registry/model-registry.go
@@ -66,7 +66,25 @@ func newApproveTransitionRequest() *cobra.Command {
 	cmd.Short = `Approve transition request.`
 	cmd.Long = `Approve transition request.
   
-  Approves a model version stage transition request.`
+  Approves a model version stage transition request.
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    
+    STAGE: Target stage of the transition. Valid values are:
+    
+    * None: The initial stage of a model version.
+    
+    * Staging: Staging or pre-production stage.
+    
+    * Production: Production stage.
+    
+    * Archived: Archived stage.
+    
+    ARCHIVE_EXISTING_VERSIONS: Specifies whether to archive all current model versions in the target stage.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -161,7 +179,15 @@ func newCreateComment() *cobra.Command {
   
   Posts a comment on a model version. A comment can be submitted either by a
   user or programmatically to display relevant information about the model. For
-  example, test results or deployment errors.`
+  example, test results or deployment errors.
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    
+    COMMENT: User-provided comment on the action.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -251,7 +277,11 @@ func newCreateModel() *cobra.Command {
   Creates a new registered model with the name specified in the request body.
   
   Throws RESOURCE_ALREADY_EXISTS if a registered model with the given name
-  exists.`
+  exists.
+
+  Arguments:
+    NAME: Register models under this name
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -334,7 +364,13 @@ func newCreateModelVersion() *cobra.Command {
 	cmd.Short = `Create a model version.`
 	cmd.Long = `Create a model version.
   
-  Creates a model version.`
+  Creates a model version.
+
+  Arguments:
+    NAME: Register model under this name
+    
+    SOURCE: URI indicating the location of the model artifacts.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -417,7 +453,23 @@ func newCreateTransitionRequest() *cobra.Command {
 	cmd.Short = `Make a transition request.`
 	cmd.Long = `Make a transition request.
   
-  Creates a model version stage transition request.`
+  Creates a model version stage transition request.
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    
+    STAGE: Target stage of the transition. Valid values are:
+    
+    * None: The initial stage of a model version.
+    
+    * Staging: Staging or pre-production stage.
+    
+    * Production: Production stage.
+    
+    * Archived: Archived stage.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -575,7 +627,11 @@ func newDeleteComment() *cobra.Command {
 	cmd.Short = `Delete a comment.`
 	cmd.Long = `Delete a comment.
   
-  Deletes a comment on a model version.`
+  Deletes a comment on a model version.
+
+  Arguments:
+    ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -636,7 +692,11 @@ func newDeleteModel() *cobra.Command {
 	cmd.Short = `Delete a model.`
 	cmd.Long = `Delete a model.
   
-  Deletes a registered model.`
+  Deletes a registered model.
+
+  Arguments:
+    NAME: Registered model unique name identifier.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -697,7 +757,14 @@ func newDeleteModelTag() *cobra.Command {
 	cmd.Short = `Delete a model tag.`
 	cmd.Long = `Delete a model tag.
   
-  Deletes the tag for a registered model.`
+  Deletes the tag for a registered model.
+
+  Arguments:
+    NAME: Name of the registered model that the tag was logged under.
+    
+    KEY: Name of the tag. The name must be an exact match; wild-card deletion is not
+    supported. Maximum size is 250 bytes.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -759,7 +826,13 @@ func newDeleteModelVersion() *cobra.Command {
 	cmd.Short = `Delete a model version.`
 	cmd.Long = `Delete a model version.
   
-  Deletes a model version.`
+  Deletes a model version.
+
+  Arguments:
+    NAME: Name of the registered model
+    
+    VERSION: Model version number
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -821,7 +894,16 @@ func newDeleteModelVersionTag() *cobra.Command {
 	cmd.Short = `Delete a model version tag.`
 	cmd.Long = `Delete a model version tag.
   
-  Deletes a model version tag.`
+  Deletes a model version tag.
+
+  Arguments:
+    NAME: Name of the registered model that the tag was logged under.
+    
+    VERSION: Model version number that the tag was logged under.
+    
+    KEY: Name of the tag. The name must be an exact match; wild-card deletion is not
+    supported. Maximum size is 250 bytes.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -886,7 +968,27 @@ func newDeleteTransitionRequest() *cobra.Command {
 	cmd.Short = `Delete a transition request.`
 	cmd.Long = `Delete a transition request.
   
-  Cancels a model version stage transition request.`
+  Cancels a model version stage transition request.
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    
+    STAGE: Target stage of the transition request. Valid values are:
+    
+    * None: The initial stage of a model version.
+    
+    * Staging: Staging or pre-production stage.
+    
+    * Production: Production stage.
+    
+    * Archived: Archived stage.
+    
+    CREATOR: Username of the user who created this request. Of the transition requests
+    matching the specified details, only the one transition created by this user
+    will be deleted.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1020,7 +1122,11 @@ func newGetLatestVersions() *cobra.Command {
 	cmd.Short = `Get the latest version.`
 	cmd.Long = `Get the latest version.
   
-  Gets the latest version of a registered model.`
+  Gets the latest version of a registered model.
+
+  Arguments:
+    NAME: Registered model unique name identifier.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1100,7 +1206,11 @@ func newGetModel() *cobra.Command {
   [MLflow endpoint] that also returns the model's Databricks workspace ID and
   the permission level of the requesting user on the model.
   
-  [MLflow endpoint]: https://www.mlflow.org/docs/latest/rest-api.html#get-registeredmodel`
+  [MLflow endpoint]: https://www.mlflow.org/docs/latest/rest-api.html#get-registeredmodel
+
+  Arguments:
+    NAME: Registered model unique name identifier.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1161,7 +1271,13 @@ func newGetModelVersion() *cobra.Command {
 	cmd.Short = `Get a model version.`
 	cmd.Long = `Get a model version.
   
-  Get a model version.`
+  Get a model version.
+
+  Arguments:
+    NAME: Name of the registered model
+    
+    VERSION: Model version number
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1223,7 +1339,13 @@ func newGetModelVersionDownloadUri() *cobra.Command {
 	cmd.Short = `Get a model version URI.`
 	cmd.Long = `Get a model version URI.
   
-  Gets a URI to download the model version.`
+  Gets a URI to download the model version.
+
+  Arguments:
+    NAME: Name of the registered model
+    
+    VERSION: Model version number
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1285,7 +1407,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get registered model permission levels.`
 	cmd.Long = `Get registered model permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1347,7 +1473,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get registered model permissions.
   
   Gets the permissions of a registered model. Registered models can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1471,7 +1601,13 @@ func newListTransitionRequests() *cobra.Command {
 	cmd.Short = `List transition requests.`
 	cmd.Long = `List transition requests.
   
-  Gets a list of all open stage transition requests for the model version.`
+  Gets a list of all open stage transition requests for the model version.
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1602,7 +1738,23 @@ func newRejectTransitionRequest() *cobra.Command {
 	cmd.Short = `Reject a transition request.`
 	cmd.Long = `Reject a transition request.
   
-  Rejects a model version stage transition request.`
+  Rejects a model version stage transition request.
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    
+    STAGE: Target stage of the transition. Valid values are:
+    
+    * None: The initial stage of a model version.
+    
+    * Staging: Staging or pre-production stage.
+    
+    * Production: Production stage.
+    
+    * Archived: Archived stage.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1691,7 +1843,11 @@ func newRenameModel() *cobra.Command {
 	cmd.Short = `Rename a model.`
 	cmd.Long = `Rename a model.
   
-  Renames a registered model.`
+  Renames a registered model.
+
+  Arguments:
+    NAME: Registered model unique name identifier.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1897,7 +2053,20 @@ func newSetModelTag() *cobra.Command {
 	cmd.Short = `Set a tag.`
 	cmd.Long = `Set a tag.
   
-  Sets a tag on a registered model.`
+  Sets a tag on a registered model.
+
+  Arguments:
+    NAME: Unique name of the model.
+    
+    KEY: Name of the tag. Maximum size depends on storage backend. If a tag with this
+    name already exists, its preexisting value will be replaced by the specified
+    value. All storage backends are guaranteed to support key values up to 250
+    bytes in size.
+    
+    VALUE: String value of the tag being logged. Maximum size depends on storage
+    backend. All storage backends are guaranteed to support key values up to
+    5000 bytes in size.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1981,7 +2150,22 @@ func newSetModelVersionTag() *cobra.Command {
 	cmd.Short = `Set a version tag.`
 	cmd.Long = `Set a version tag.
   
-  Sets a model version tag.`
+  Sets a model version tag.
+
+  Arguments:
+    NAME: Unique name of the model.
+    
+    VERSION: Model version number.
+    
+    KEY: Name of the tag. Maximum size depends on storage backend. If a tag with this
+    name already exists, its preexisting value will be replaced by the specified
+    value. All storage backends are guaranteed to support key values up to 250
+    bytes in size.
+    
+    VALUE: String value of the tag being logged. Maximum size depends on storage
+    backend. All storage backends are guaranteed to support key values up to
+    5000 bytes in size.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2071,7 +2255,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set registered model permissions.
   
   Sets permissions on a registered model. Registered models can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2144,7 +2332,11 @@ func newTestRegistryWebhook() *cobra.Command {
   
   **NOTE:** This endpoint is in Public Preview.
   
-  Tests a registry webhook.`
+  Tests a registry webhook.
+
+  Arguments:
+    ID: Webhook ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2228,7 +2420,25 @@ func newTransitionStage() *cobra.Command {
   the [MLflow endpoint] that also accepts a comment associated with the
   transition to be recorded.",
   
-  [MLflow endpoint]: https://www.mlflow.org/docs/latest/rest-api.html#transition-modelversion-stage`
+  [MLflow endpoint]: https://www.mlflow.org/docs/latest/rest-api.html#transition-modelversion-stage
+
+  Arguments:
+    NAME: Name of the model.
+    
+    VERSION: Version of the model.
+    
+    STAGE: Target stage of the transition. Valid values are:
+    
+    * None: The initial stage of a model version.
+    
+    * Staging: Staging or pre-production stage.
+    
+    * Production: Production stage.
+    
+    * Archived: Archived stage.
+    
+    ARCHIVE_EXISTING_VERSIONS: Specifies whether to archive all current model versions in the target stage.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2321,7 +2531,13 @@ func newUpdateComment() *cobra.Command {
 	cmd.Short = `Update a comment.`
 	cmd.Long = `Update a comment.
   
-  Post an edit to a comment on a model version.`
+  Post an edit to a comment on a model version.
+
+  Arguments:
+    ID: Unique identifier of an activity
+    
+    COMMENT: User-provided comment on the action.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2404,7 +2620,11 @@ func newUpdateModel() *cobra.Command {
 	cmd.Short = `Update model.`
 	cmd.Long = `Update model.
   
-  Updates a registered model.`
+  Updates a registered model.
+
+  Arguments:
+    NAME: Registered model unique name identifier.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2484,7 +2704,13 @@ func newUpdateModelVersion() *cobra.Command {
 	cmd.Short = `Update model version.`
 	cmd.Long = `Update model version.
   
-  Updates the model version.`
+  Updates the model version.
+
+  Arguments:
+    NAME: Name of the registered model
+    
+    VERSION: Model version number
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2568,7 +2794,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update registered model permissions.
   
   Updates the permissions on a registered model. Registered models can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    REGISTERED_MODEL_ID: The registered model for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -2645,7 +2875,11 @@ func newUpdateWebhook() *cobra.Command {
   
   **NOTE:** This endpoint is in Public Preview.
   
-  Updates a registry webhook.`
+  Updates a registry webhook.
+
+  Arguments:
+    ID: Webhook ID
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/model-versions/model-versions.go
+++ b/cmd/workspace/model-versions/model-versions.go
@@ -67,7 +67,13 @@ func newDelete() *cobra.Command {
   The caller must be a metastore admin or an owner of the parent registered
   model. For the latter case, the caller must also be the owner or have the
   **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-  privilege on the parent schema.`
+  privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the model version
+    
+    VERSION: The integer version number of the model version
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -137,7 +143,13 @@ func newGet() *cobra.Command {
   The caller must be a metastore admin or an owner of (or have the **EXECUTE**
   privilege on) the parent registered model. For the latter case, the caller
   must also be the owner or have the **USE_CATALOG** privilege on the parent
-  catalog and the **USE_SCHEMA** privilege on the parent schema.`
+  catalog and the **USE_SCHEMA** privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the model version
+    
+    VERSION: The integer version number of the model version
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -207,7 +219,13 @@ func newGetByAlias() *cobra.Command {
   The caller must be a metastore admin or an owner of (or have the **EXECUTE**
   privilege on) the registered model. For the latter case, the caller must also
   be the owner or have the **USE_CATALOG** privilege on the parent catalog and
-  the **USE_SCHEMA** privilege on the parent schema.`
+  the **USE_SCHEMA** privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the registered model
+    
+    ALIAS: The name of the alias
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -283,7 +301,12 @@ func newList() *cobra.Command {
   privilege on the parent catalog and the **USE_SCHEMA** privilege on the parent
   schema.
   
-  There is no guarantee of a specific ordering of the elements in the response.`
+  There is no guarantee of a specific ordering of the elements in the response.
+
+  Arguments:
+    FULL_NAME: The full three-level name of the registered model under which to list model
+    versions
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -355,7 +378,13 @@ func newUpdate() *cobra.Command {
   **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
   privilege on the parent schema.
   
-  Currently only the comment of the model version can be updated.`
+  Currently only the comment of the model version can be updated.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the model version
+    
+    VERSION: The integer version number of the model version
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/model-versions/model-versions.go
+++ b/cmd/workspace/model-versions/model-versions.go
@@ -71,9 +71,7 @@ func newDelete() *cobra.Command {
 
   Arguments:
     FULL_NAME: The three-level (fully qualified) name of the model version
-    
-    VERSION: The integer version number of the model version
-    `
+    VERSION: The integer version number of the model version`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -147,9 +145,7 @@ func newGet() *cobra.Command {
 
   Arguments:
     FULL_NAME: The three-level (fully qualified) name of the model version
-    
-    VERSION: The integer version number of the model version
-    `
+    VERSION: The integer version number of the model version`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -223,9 +219,7 @@ func newGetByAlias() *cobra.Command {
 
   Arguments:
     FULL_NAME: The three-level (fully qualified) name of the registered model
-    
-    ALIAS: The name of the alias
-    `
+    ALIAS: The name of the alias`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -304,9 +298,8 @@ func newList() *cobra.Command {
   There is no guarantee of a specific ordering of the elements in the response.
 
   Arguments:
-    FULL_NAME: The full three-level name of the registered model under which to list model
-    versions
-    `
+    FULL_NAME: The full three-level name of the registered model under which to list
+      model versions`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -382,9 +375,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     FULL_NAME: The three-level (fully qualified) name of the model version
-    
-    VERSION: The integer version number of the model version
-    `
+    VERSION: The integer version number of the model version`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/permissions/permissions.go
+++ b/cmd/workspace/permissions/permissions.go
@@ -104,9 +104,7 @@ func newGet() *cobra.Command {
 
   Arguments:
     REQUEST_OBJECT_TYPE: <needs content>
-    
-    REQUEST_OBJECT_ID: 
-    `
+    REQUEST_OBJECT_ID: `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -172,9 +170,7 @@ func newGetPermissionLevels() *cobra.Command {
 
   Arguments:
     REQUEST_OBJECT_TYPE: <needs content>
-    
-    REQUEST_OBJECT_ID: <needs content>
-    `
+    REQUEST_OBJECT_ID: <needs content>`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -245,9 +241,7 @@ func newSet() *cobra.Command {
 
   Arguments:
     REQUEST_OBJECT_TYPE: <needs content>
-    
-    REQUEST_OBJECT_ID: 
-    `
+    REQUEST_OBJECT_ID: `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -324,9 +318,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     REQUEST_OBJECT_TYPE: <needs content>
-    
-    REQUEST_OBJECT_ID: 
-    `
+    REQUEST_OBJECT_ID: `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/permissions/permissions.go
+++ b/cmd/workspace/permissions/permissions.go
@@ -100,7 +100,13 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get object permissions.
   
   Gets the permissions of an object. Objects can inherit permissions from their
-  parent objects or root object.`
+  parent objects or root object.
+
+  Arguments:
+    REQUEST_OBJECT_TYPE: <needs content>
+    
+    REQUEST_OBJECT_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -162,7 +168,13 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get object permission levels.`
 	cmd.Long = `Get object permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    REQUEST_OBJECT_TYPE: <needs content>
+    
+    REQUEST_OBJECT_ID: <needs content>
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -229,7 +241,13 @@ func newSet() *cobra.Command {
 	cmd.Long = `Set object permissions.
   
   Sets permissions on an object. Objects can inherit permissions from their
-  parent objects or root object.`
+  parent objects or root object.
+
+  Arguments:
+    REQUEST_OBJECT_TYPE: <needs content>
+    
+    REQUEST_OBJECT_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -302,7 +320,13 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update object permissions.
   
   Updates the permissions on an object. Objects can inherit permissions from
-  their parent objects or root object.`
+  their parent objects or root object.
+
+  Arguments:
+    REQUEST_OBJECT_TYPE: <needs content>
+    
+    REQUEST_OBJECT_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/pipelines/pipelines.go
+++ b/cmd/workspace/pipelines/pipelines.go
@@ -287,8 +287,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    PIPELINE_ID: The pipeline for which to get or manage permissions.
-    `
+    PIPELINE_ID: The pipeline for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -365,8 +364,7 @@ func newGetPermissions() *cobra.Command {
   their root object.
 
   Arguments:
-    PIPELINE_ID: The pipeline for which to get or manage permissions.
-    `
+    PIPELINE_ID: The pipeline for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -443,9 +441,7 @@ func newGetUpdate() *cobra.Command {
 
   Arguments:
     PIPELINE_ID: The ID of the pipeline.
-    
-    UPDATE_ID: The ID of the update.
-    `
+    UPDATE_ID: The ID of the update.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -656,8 +652,7 @@ func newListUpdates() *cobra.Command {
   List updates for an active pipeline.
 
   Arguments:
-    PIPELINE_ID: The pipeline to return updates for.
-    `
+    PIPELINE_ID: The pipeline to return updates for.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -828,8 +823,7 @@ func newSetPermissions() *cobra.Command {
   root object.
 
   Arguments:
-    PIPELINE_ID: The pipeline for which to get or manage permissions.
-    `
+    PIPELINE_ID: The pipeline for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1112,8 +1106,7 @@ func newUpdate() *cobra.Command {
   Updates a pipeline with the supplied configuration.
 
   Arguments:
-    PIPELINE_ID: Unique identifier for this pipeline.
-    `
+    PIPELINE_ID: Unique identifier for this pipeline.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1200,8 +1193,7 @@ func newUpdatePermissions() *cobra.Command {
   their root object.
 
   Arguments:
-    PIPELINE_ID: The pipeline for which to get or manage permissions.
-    `
+    PIPELINE_ID: The pipeline for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/pipelines/pipelines.go
+++ b/cmd/workspace/pipelines/pipelines.go
@@ -135,11 +135,7 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a pipeline.`
 	cmd.Long = `Delete a pipeline.
   
-  Deletes a pipeline.
-
-  Arguments:
-    PIPELINE_ID: 
-    `
+  Deletes a pipeline.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -215,11 +211,7 @@ func newGet() *cobra.Command {
 
 	cmd.Use = "get PIPELINE_ID"
 	cmd.Short = `Get a pipeline.`
-	cmd.Long = `Get a pipeline.
-
-  Arguments:
-    PIPELINE_ID: 
-    `
+	cmd.Long = `Get a pipeline.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -520,11 +512,7 @@ func newListPipelineEvents() *cobra.Command {
 	cmd.Short = `List pipeline events.`
 	cmd.Long = `List pipeline events.
   
-  Retrieves events for a pipeline.
-
-  Arguments:
-    PIPELINE_ID: 
-    `
+  Retrieves events for a pipeline.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -747,11 +735,7 @@ func newReset() *cobra.Command {
 	cmd.Short = `Reset a pipeline.`
 	cmd.Long = `Reset a pipeline.
   
-  Resets a pipeline.
-
-  Arguments:
-    PIPELINE_ID: 
-    `
+  Resets a pipeline.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -932,11 +916,7 @@ func newStartUpdate() *cobra.Command {
 	cmd.Long = `Start a pipeline.
   
   Starts a new update for the pipeline. If there is already an active update for
-  the pipeline, the request will fail and the active update will remain running.
-
-  Arguments:
-    PIPELINE_ID: 
-    `
+  the pipeline, the request will fail and the active update will remain running.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1021,11 +1001,7 @@ func newStop() *cobra.Command {
 	cmd.Long = `Stop a pipeline.
   
   Stops the pipeline by canceling the active update. If there is no active
-  update for the pipeline, this request is a no-op.
-
-  Arguments:
-    PIPELINE_ID: 
-    `
+  update for the pipeline, this request is a no-op.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/pipelines/pipelines.go
+++ b/cmd/workspace/pipelines/pipelines.go
@@ -135,7 +135,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a pipeline.`
 	cmd.Long = `Delete a pipeline.
   
-  Deletes a pipeline.`
+  Deletes a pipeline.
+
+  Arguments:
+    PIPELINE_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -211,7 +215,11 @@ func newGet() *cobra.Command {
 
 	cmd.Use = "get PIPELINE_ID"
 	cmd.Short = `Get a pipeline.`
-	cmd.Long = `Get a pipeline.`
+	cmd.Long = `Get a pipeline.
+
+  Arguments:
+    PIPELINE_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -284,7 +292,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get pipeline permission levels.`
 	cmd.Long = `Get pipeline permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    PIPELINE_ID: The pipeline for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -358,7 +370,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get pipeline permissions.
   
   Gets the permissions of a pipeline. Pipelines can inherit permissions from
-  their root object.`
+  their root object.
+
+  Arguments:
+    PIPELINE_ID: The pipeline for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -431,7 +447,13 @@ func newGetUpdate() *cobra.Command {
 	cmd.Short = `Get a pipeline update.`
 	cmd.Long = `Get a pipeline update.
   
-  Gets an update from an active pipeline.`
+  Gets an update from an active pipeline.
+
+  Arguments:
+    PIPELINE_ID: The ID of the pipeline.
+    
+    UPDATE_ID: The ID of the update.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -498,7 +520,11 @@ func newListPipelineEvents() *cobra.Command {
 	cmd.Short = `List pipeline events.`
 	cmd.Long = `List pipeline events.
   
-  Retrieves events for a pipeline.`
+  Retrieves events for a pipeline.
+
+  Arguments:
+    PIPELINE_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -639,7 +665,11 @@ func newListUpdates() *cobra.Command {
 	cmd.Short = `List pipeline updates.`
 	cmd.Long = `List pipeline updates.
   
-  List updates for an active pipeline.`
+  List updates for an active pipeline.
+
+  Arguments:
+    PIPELINE_ID: The pipeline to return updates for.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -717,7 +747,11 @@ func newReset() *cobra.Command {
 	cmd.Short = `Reset a pipeline.`
 	cmd.Long = `Reset a pipeline.
   
-  Resets a pipeline.`
+  Resets a pipeline.
+
+  Arguments:
+    PIPELINE_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -807,7 +841,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set pipeline permissions.
   
   Sets permissions on a pipeline. Pipelines can inherit permissions from their
-  root object.`
+  root object.
+
+  Arguments:
+    PIPELINE_ID: The pipeline for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -894,7 +932,11 @@ func newStartUpdate() *cobra.Command {
 	cmd.Long = `Start a pipeline.
   
   Starts a new update for the pipeline. If there is already an active update for
-  the pipeline, the request will fail and the active update will remain running.`
+  the pipeline, the request will fail and the active update will remain running.
+
+  Arguments:
+    PIPELINE_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -979,7 +1021,11 @@ func newStop() *cobra.Command {
 	cmd.Long = `Stop a pipeline.
   
   Stops the pipeline by canceling the active update. If there is no active
-  update for the pipeline, this request is a no-op.`
+  update for the pipeline, this request is a no-op.
+
+  Arguments:
+    PIPELINE_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1087,7 +1133,11 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Edit a pipeline.`
 	cmd.Long = `Edit a pipeline.
   
-  Updates a pipeline with the supplied configuration.`
+  Updates a pipeline with the supplied configuration.
+
+  Arguments:
+    PIPELINE_ID: Unique identifier for this pipeline.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1171,7 +1221,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update pipeline permissions.
   
   Updates the permissions on a pipeline. Pipelines can inherit permissions from
-  their root object.`
+  their root object.
+
+  Arguments:
+    PIPELINE_ID: The pipeline for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/policy-families/policy-families.go
+++ b/cmd/workspace/policy-families/policy-families.go
@@ -60,7 +60,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get policy family information.`
 	cmd.Long = `Get policy family information.
   
-  Retrieve the information for an policy family based on its identifier.`
+  Retrieve the information for an policy family based on its identifier.
+
+  Arguments:
+    POLICY_FAMILY_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/policy-families/policy-families.go
+++ b/cmd/workspace/policy-families/policy-families.go
@@ -60,11 +60,7 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get policy family information.`
 	cmd.Long = `Get policy family information.
   
-  Retrieve the information for an policy family based on its identifier.
-
-  Arguments:
-    POLICY_FAMILY_ID: 
-    `
+  Retrieve the information for an policy family based on its identifier.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/providers/providers.go
+++ b/cmd/workspace/providers/providers.go
@@ -67,9 +67,7 @@ func newCreate() *cobra.Command {
 
   Arguments:
     NAME: The name of the Provider.
-    
-    AUTHENTICATION_TYPE: The delta sharing authentication type.
-    `
+    AUTHENTICATION_TYPE: The delta sharing authentication type.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -155,8 +153,7 @@ func newDelete() *cobra.Command {
   the owner of the provider.
 
   Arguments:
-    NAME: Name of the provider.
-    `
+    NAME: Name of the provider.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -234,8 +231,7 @@ func newGet() *cobra.Command {
   provider.
 
   Arguments:
-    NAME: Name of the provider.
-    `
+    NAME: Name of the provider.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -377,8 +373,7 @@ func newListShares() *cobra.Command {
   * the caller is a metastore admin, or * the caller is the owner.
 
   Arguments:
-    NAME: Name of the provider in which to list shares.
-    `
+    NAME: Name of the provider in which to list shares.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -464,8 +459,7 @@ func newUpdate() *cobra.Command {
   provider.
 
   Arguments:
-    NAME: The name of the Provider.
-    `
+    NAME: The name of the Provider.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/providers/providers.go
+++ b/cmd/workspace/providers/providers.go
@@ -63,7 +63,13 @@ func newCreate() *cobra.Command {
 	cmd.Long = `Create an auth provider.
   
   Creates a new authentication provider minimally based on a name and
-  authentication type. The caller must be an admin on the metastore.`
+  authentication type. The caller must be an admin on the metastore.
+
+  Arguments:
+    NAME: The name of the Provider.
+    
+    AUTHENTICATION_TYPE: The delta sharing authentication type.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -146,7 +152,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a provider.
   
   Deletes an authentication provider, if the caller is a metastore admin or is
-  the owner of the provider.`
+  the owner of the provider.
+
+  Arguments:
+    NAME: Name of the provider.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -221,7 +231,11 @@ func newGet() *cobra.Command {
   
   Gets a specific authentication provider. The caller must supply the name of
   the provider, and must either be a metastore admin or the owner of the
-  provider.`
+  provider.
+
+  Arguments:
+    NAME: Name of the provider.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -360,7 +374,11 @@ func newListShares() *cobra.Command {
   
   Gets an array of a specified provider's shares within the metastore where:
   
-  * the caller is a metastore admin, or * the caller is the owner.`
+  * the caller is a metastore admin, or * the caller is the owner.
+
+  Arguments:
+    NAME: Name of the provider in which to list shares.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -443,7 +461,11 @@ func newUpdate() *cobra.Command {
   Updates the information for an authentication provider, if the caller is a
   metastore admin or is the owner of the provider. If the update changes the
   provider name, the caller must be both a metastore admin and the owner of the
-  provider.`
+  provider.
+
+  Arguments:
+    NAME: The name of the Provider.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/queries/queries.go
+++ b/cmd/workspace/queries/queries.go
@@ -133,11 +133,7 @@ func newDelete() *cobra.Command {
   
   Moves a query to the trash. Trashed queries immediately disappear from
   searches and list views, and they cannot be used for alerts. The trash is
-  deleted after 30 days.
-
-  Arguments:
-    QUERY_ID: 
-    `
+  deleted after 30 days.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -211,11 +207,7 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a query definition.
   
   Retrieve a query object definition along with contextual permissions
-  information about the currently authenticated user.
-
-  Arguments:
-    QUERY_ID: 
-    `
+  information about the currently authenticated user.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -354,11 +346,7 @@ func newRestore() *cobra.Command {
 	cmd.Long = `Restore a query.
   
   Restore a query that has been moved to the trash. A restored query appears in
-  list views and searches. You can use restored queries for alerts.
-
-  Arguments:
-    QUERY_ID: 
-    `
+  list views and searches. You can use restored queries for alerts.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -441,11 +429,7 @@ func newUpdate() *cobra.Command {
   
   Modify this query definition.
   
-  **Note**: You cannot undo this operation.
-
-  Arguments:
-    QUERY_ID: 
-    `
+  **Note**: You cannot undo this operation.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/queries/queries.go
+++ b/cmd/workspace/queries/queries.go
@@ -133,7 +133,11 @@ func newDelete() *cobra.Command {
   
   Moves a query to the trash. Trashed queries immediately disappear from
   searches and list views, and they cannot be used for alerts. The trash is
-  deleted after 30 days.`
+  deleted after 30 days.
+
+  Arguments:
+    QUERY_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -207,7 +211,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a query definition.
   
   Retrieve a query object definition along with contextual permissions
-  information about the currently authenticated user.`
+  information about the currently authenticated user.
+
+  Arguments:
+    QUERY_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -346,7 +354,11 @@ func newRestore() *cobra.Command {
 	cmd.Long = `Restore a query.
   
   Restore a query that has been moved to the trash. A restored query appears in
-  list views and searches. You can use restored queries for alerts.`
+  list views and searches. You can use restored queries for alerts.
+
+  Arguments:
+    QUERY_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -429,7 +441,11 @@ func newUpdate() *cobra.Command {
   
   Modify this query definition.
   
-  **Note**: You cannot undo this operation.`
+  **Note**: You cannot undo this operation.
+
+  Arguments:
+    QUERY_ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/query-visualizations/query-visualizations.go
+++ b/cmd/workspace/query-visualizations/query-visualizations.go
@@ -121,7 +121,11 @@ func newDelete() *cobra.Command {
 
 	cmd.Use = "delete ID"
 	cmd.Short = `Remove visualization.`
-	cmd.Long = `Remove visualization.`
+	cmd.Long = `Remove visualization.
+
+  Arguments:
+    ID: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/query-visualizations/query-visualizations.go
+++ b/cmd/workspace/query-visualizations/query-visualizations.go
@@ -121,11 +121,7 @@ func newDelete() *cobra.Command {
 
 	cmd.Use = "delete ID"
 	cmd.Short = `Remove visualization.`
-	cmd.Long = `Remove visualization.
-
-  Arguments:
-    ID: 
-    `
+	cmd.Long = `Remove visualization.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/recipient-activation/recipient-activation.go
+++ b/cmd/workspace/recipient-activation/recipient-activation.go
@@ -61,7 +61,11 @@ func newGetActivationUrlInfo() *cobra.Command {
 	cmd.Short = `Get a share activation URL.`
 	cmd.Long = `Get a share activation URL.
   
-  Gets an activation URL for a share.`
+  Gets an activation URL for a share.
+
+  Arguments:
+    ACTIVATION_URL: The one time activation url. It also accepts activation token.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -123,7 +127,11 @@ func newRetrieveToken() *cobra.Command {
 	cmd.Long = `Get an access token.
   
   Retrieve access token with an activation url. This is a public API without any
-  authentication.`
+  authentication.
+
+  Arguments:
+    ACTIVATION_URL: The one time activation url. It also accepts activation token.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/recipient-activation/recipient-activation.go
+++ b/cmd/workspace/recipient-activation/recipient-activation.go
@@ -64,8 +64,7 @@ func newGetActivationUrlInfo() *cobra.Command {
   Gets an activation URL for a share.
 
   Arguments:
-    ACTIVATION_URL: The one time activation url. It also accepts activation token.
-    `
+    ACTIVATION_URL: The one time activation url. It also accepts activation token.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -130,8 +129,7 @@ func newRetrieveToken() *cobra.Command {
   authentication.
 
   Arguments:
-    ACTIVATION_URL: The one time activation url. It also accepts activation token.
-    `
+    ACTIVATION_URL: The one time activation url. It also accepts activation token.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/recipients/recipients.go
+++ b/cmd/workspace/recipients/recipients.go
@@ -82,7 +82,13 @@ func newCreate() *cobra.Command {
   
   Creates a new recipient with the delta sharing authentication type in the
   metastore. The caller must be a metastore admin or has the
-  **CREATE_RECIPIENT** privilege on the metastore.`
+  **CREATE_RECIPIENT** privilege on the metastore.
+
+  Arguments:
+    NAME: Name of Recipient.
+    
+    AUTHENTICATION_TYPE: The delta sharing authentication type.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -165,7 +171,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a share recipient.
   
   Deletes the specified recipient from the metastore. The caller must be the
-  owner of the recipient.`
+  owner of the recipient.
+
+  Arguments:
+    NAME: Name of the recipient.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -240,7 +250,11 @@ func newGet() *cobra.Command {
   
   Gets a share recipient from the metastore if:
   
-  * the caller is the owner of the share recipient, or: * is a metastore admin`
+  * the caller is the owner of the share recipient, or: * is a metastore admin
+
+  Arguments:
+    NAME: Name of the recipient.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -380,7 +394,16 @@ func newRotateToken() *cobra.Command {
 	cmd.Long = `Rotate a token.
   
   Refreshes the specified recipient's delta sharing authentication token with
-  the provided token info. The caller must be the owner of the recipient.`
+  the provided token info. The caller must be the owner of the recipient.
+
+  Arguments:
+    NAME: The name of the recipient.
+    
+    EXISTING_TOKEN_EXPIRE_IN_SECONDS: The expiration time of the bearer token in ISO 8601 format. This will set
+    the expiration_time of existing token only to a smaller timestamp, it cannot
+    extend the expiration_time. Use 0 to expire the existing token immediately,
+    negative number will return an error.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -461,7 +484,11 @@ func newSharePermissions() *cobra.Command {
 	cmd.Long = `Get recipient share permissions.
   
   Gets the share permissions for the specified Recipient. The caller must be a
-  metastore admin or the owner of the Recipient.`
+  metastore admin or the owner of the Recipient.
+
+  Arguments:
+    NAME: The name of the Recipient.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -544,7 +571,11 @@ func newUpdate() *cobra.Command {
   
   Updates an existing recipient in the metastore. The caller must be a metastore
   admin or the owner of the recipient. If the recipient name will be updated,
-  the user must be both a metastore admin and the owner of the recipient.`
+  the user must be both a metastore admin and the owner of the recipient.
+
+  Arguments:
+    NAME: Name of Recipient.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/recipients/recipients.go
+++ b/cmd/workspace/recipients/recipients.go
@@ -86,9 +86,7 @@ func newCreate() *cobra.Command {
 
   Arguments:
     NAME: Name of Recipient.
-    
-    AUTHENTICATION_TYPE: The delta sharing authentication type.
-    `
+    AUTHENTICATION_TYPE: The delta sharing authentication type.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -174,8 +172,7 @@ func newDelete() *cobra.Command {
   owner of the recipient.
 
   Arguments:
-    NAME: Name of the recipient.
-    `
+    NAME: Name of the recipient.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -253,8 +250,7 @@ func newGet() *cobra.Command {
   * the caller is the owner of the share recipient, or: * is a metastore admin
 
   Arguments:
-    NAME: Name of the recipient.
-    `
+    NAME: Name of the recipient.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -398,12 +394,10 @@ func newRotateToken() *cobra.Command {
 
   Arguments:
     NAME: The name of the recipient.
-    
     EXISTING_TOKEN_EXPIRE_IN_SECONDS: The expiration time of the bearer token in ISO 8601 format. This will set
-    the expiration_time of existing token only to a smaller timestamp, it cannot
-    extend the expiration_time. Use 0 to expire the existing token immediately,
-    negative number will return an error.
-    `
+      the expiration_time of existing token only to a smaller timestamp, it
+      cannot extend the expiration_time. Use 0 to expire the existing token
+      immediately, negative number will return an error.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -487,8 +481,7 @@ func newSharePermissions() *cobra.Command {
   metastore admin or the owner of the Recipient.
 
   Arguments:
-    NAME: The name of the Recipient.
-    `
+    NAME: The name of the Recipient.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -574,8 +567,7 @@ func newUpdate() *cobra.Command {
   the user must be both a metastore admin and the owner of the recipient.
 
   Arguments:
-    NAME: Name of Recipient.
-    `
+    NAME: Name of Recipient.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/registered-models/registered-models.go
+++ b/cmd/workspace/registered-models/registered-models.go
@@ -99,7 +99,15 @@ func newCreate() *cobra.Command {
   parent catalog and schema, or have the **USE_CATALOG** privilege on the parent
   catalog and the **USE_SCHEMA** privilege on the parent schema. - The caller
   must have the **CREATE MODEL** or **CREATE FUNCTION** privilege on the parent
-  schema.`
+  schema.
+
+  Arguments:
+    CATALOG_NAME: The name of the catalog where the schema and the registered model reside
+    
+    SCHEMA_NAME: The name of the schema where the registered model resides
+    
+    NAME: The name of the registered model
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -187,7 +195,11 @@ func newDelete() *cobra.Command {
   The caller must be a metastore admin or an owner of the registered model. For
   the latter case, the caller must also be the owner or have the **USE_CATALOG**
   privilege on the parent catalog and the **USE_SCHEMA** privilege on the parent
-  schema.`
+  schema.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the registered model
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -265,7 +277,13 @@ func newDeleteAlias() *cobra.Command {
   The caller must be a metastore admin or an owner of the registered model. For
   the latter case, the caller must also be the owner or have the **USE_CATALOG**
   privilege on the parent catalog and the **USE_SCHEMA** privilege on the parent
-  schema.`
+  schema.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the registered model
+    
+    ALIAS: The name of the alias
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -332,7 +350,11 @@ func newGet() *cobra.Command {
   The caller must be a metastore admin or an owner of (or have the **EXECUTE**
   privilege on) the registered model. For the latter case, the caller must also
   be the owner or have the **USE_CATALOG** privilege on the parent catalog and
-  the **USE_SCHEMA** privilege on the parent schema.`
+  the **USE_SCHEMA** privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the registered model
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -487,7 +509,15 @@ func newSetAlias() *cobra.Command {
   The caller must be a metastore admin or an owner of the registered model. For
   the latter case, the caller must also be the owner or have the **USE_CATALOG**
   privilege on the parent catalog and the **USE_SCHEMA** privilege on the parent
-  schema.`
+  schema.
+
+  Arguments:
+    FULL_NAME: Full name of the registered model
+    
+    ALIAS: The name of the alias
+    
+    VERSION_NUM: The version number of the model version to which the alias points
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -582,7 +612,11 @@ func newUpdate() *cobra.Command {
   schema.
   
   Currently only the name, the owner or the comment of the registered model can
-  be updated.`
+  be updated.
+
+  Arguments:
+    FULL_NAME: The three-level (fully qualified) name of the registered model
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/registered-models/registered-models.go
+++ b/cmd/workspace/registered-models/registered-models.go
@@ -103,11 +103,8 @@ func newCreate() *cobra.Command {
 
   Arguments:
     CATALOG_NAME: The name of the catalog where the schema and the registered model reside
-    
     SCHEMA_NAME: The name of the schema where the registered model resides
-    
-    NAME: The name of the registered model
-    `
+    NAME: The name of the registered model`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -198,8 +195,7 @@ func newDelete() *cobra.Command {
   schema.
 
   Arguments:
-    FULL_NAME: The three-level (fully qualified) name of the registered model
-    `
+    FULL_NAME: The three-level (fully qualified) name of the registered model`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -281,9 +277,7 @@ func newDeleteAlias() *cobra.Command {
 
   Arguments:
     FULL_NAME: The three-level (fully qualified) name of the registered model
-    
-    ALIAS: The name of the alias
-    `
+    ALIAS: The name of the alias`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -353,8 +347,7 @@ func newGet() *cobra.Command {
   the **USE_SCHEMA** privilege on the parent schema.
 
   Arguments:
-    FULL_NAME: The three-level (fully qualified) name of the registered model
-    `
+    FULL_NAME: The three-level (fully qualified) name of the registered model`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -513,11 +506,8 @@ func newSetAlias() *cobra.Command {
 
   Arguments:
     FULL_NAME: Full name of the registered model
-    
     ALIAS: The name of the alias
-    
-    VERSION_NUM: The version number of the model version to which the alias points
-    `
+    VERSION_NUM: The version number of the model version to which the alias points`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -615,8 +605,7 @@ func newUpdate() *cobra.Command {
   be updated.
 
   Arguments:
-    FULL_NAME: The three-level (fully qualified) name of the registered model
-    `
+    FULL_NAME: The three-level (fully qualified) name of the registered model`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/repos/repos.go
+++ b/cmd/workspace/repos/repos.go
@@ -71,7 +71,15 @@ func newCreate() *cobra.Command {
   
   Creates a repo in the workspace and links it to the remote Git repo specified.
   Note that repos created programmatically must be linked to a remote Git repo,
-  unlike repos created in the browser.`
+  unlike repos created in the browser.
+
+  Arguments:
+    URL: URL of the Git repository to be linked.
+    
+    PROVIDER: Git provider. This field is case-insensitive. The available Git providers
+    are gitHub, bitbucketCloud, gitLab, azureDevOpsServices, gitHubEnterprise,
+    bitbucketServer, gitLabEnterpriseEdition and awsCodeCommit.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -150,7 +158,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a repo.`
 	cmd.Long = `Delete a repo.
   
-  Deletes the specified repo.`
+  Deletes the specified repo.
+
+  Arguments:
+    REPO_ID: The ID for the corresponding repo to access.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -226,7 +238,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a repo.`
 	cmd.Long = `Get a repo.
   
-  Returns the repo with the given repo ID.`
+  Returns the repo with the given repo ID.
+
+  Arguments:
+    REPO_ID: The ID for the corresponding repo to access.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -302,7 +318,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get repo permission levels.`
 	cmd.Long = `Get repo permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    REPO_ID: The repo for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -376,7 +396,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get repo permissions.
   
   Gets the permissions of a repo. Repos can inherit permissions from their root
-  object.`
+  object.
+
+  Arguments:
+    REPO_ID: The repo for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -517,7 +541,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set repo permissions.
   
   Sets permissions on a repo. Repos can inherit permissions from their root
-  object.`
+  object.
+
+  Arguments:
+    REPO_ID: The repo for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -603,7 +631,11 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update a repo.
   
   Updates the repo to a different branch or tag, or updates the repo to the
-  latest commit on the same branch.`
+  latest commit on the same branch.
+
+  Arguments:
+    REPO_ID: The ID for the corresponding repo to access.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -690,7 +722,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update repo permissions.
   
   Updates the permissions on a repo. Repos can inherit permissions from their
-  root object.`
+  root object.
+
+  Arguments:
+    REPO_ID: The repo for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/repos/repos.go
+++ b/cmd/workspace/repos/repos.go
@@ -75,11 +75,9 @@ func newCreate() *cobra.Command {
 
   Arguments:
     URL: URL of the Git repository to be linked.
-    
     PROVIDER: Git provider. This field is case-insensitive. The available Git providers
-    are gitHub, bitbucketCloud, gitLab, azureDevOpsServices, gitHubEnterprise,
-    bitbucketServer, gitLabEnterpriseEdition and awsCodeCommit.
-    `
+      are gitHub, bitbucketCloud, gitLab, azureDevOpsServices, gitHubEnterprise,
+      bitbucketServer, gitLabEnterpriseEdition and awsCodeCommit.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -161,8 +159,7 @@ func newDelete() *cobra.Command {
   Deletes the specified repo.
 
   Arguments:
-    REPO_ID: The ID for the corresponding repo to access.
-    `
+    REPO_ID: The ID for the corresponding repo to access.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -241,8 +238,7 @@ func newGet() *cobra.Command {
   Returns the repo with the given repo ID.
 
   Arguments:
-    REPO_ID: The ID for the corresponding repo to access.
-    `
+    REPO_ID: The ID for the corresponding repo to access.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -321,8 +317,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    REPO_ID: The repo for which to get or manage permissions.
-    `
+    REPO_ID: The repo for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -399,8 +394,7 @@ func newGetPermissions() *cobra.Command {
   object.
 
   Arguments:
-    REPO_ID: The repo for which to get or manage permissions.
-    `
+    REPO_ID: The repo for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -544,8 +538,7 @@ func newSetPermissions() *cobra.Command {
   object.
 
   Arguments:
-    REPO_ID: The repo for which to get or manage permissions.
-    `
+    REPO_ID: The repo for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -634,8 +627,7 @@ func newUpdate() *cobra.Command {
   latest commit on the same branch.
 
   Arguments:
-    REPO_ID: The ID for the corresponding repo to access.
-    `
+    REPO_ID: The ID for the corresponding repo to access.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -725,8 +717,7 @@ func newUpdatePermissions() *cobra.Command {
   root object.
 
   Arguments:
-    REPO_ID: The repo for which to get or manage permissions.
-    `
+    REPO_ID: The repo for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/schemas/schemas.go
+++ b/cmd/workspace/schemas/schemas.go
@@ -67,7 +67,13 @@ func newCreate() *cobra.Command {
   
   Creates a new schema for catalog in the Metatastore. The caller must be a
   metastore admin, or have the **CREATE_SCHEMA** privilege in the parent
-  catalog.`
+  catalog.
+
+  Arguments:
+    NAME: Name of schema, relative to parent catalog.
+    
+    CATALOG_NAME: Name of parent catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -147,7 +153,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a schema.
   
   Deletes the specified schema from the parent catalog. The caller must be the
-  owner of the schema or an owner of the parent catalog.`
+  owner of the schema or an owner of the parent catalog.
+
+  Arguments:
+    FULL_NAME: Full name of the schema.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -222,7 +232,11 @@ func newGet() *cobra.Command {
   
   Gets the specified schema within the metastore. The caller must be a metastore
   admin, the owner of the schema, or a user that has the **USE_SCHEMA**
-  privilege on the schema.`
+  privilege on the schema.
+
+  Arguments:
+    FULL_NAME: Full name of the schema.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -299,7 +313,11 @@ func newList() *cobra.Command {
   metastore admin or the owner of the parent catalog, all schemas for the
   catalog will be retrieved. Otherwise, only schemas owned by the caller (or for
   which the caller has the **USE_SCHEMA** privilege) will be retrieved. There is
-  no guarantee of a specific ordering of the elements in the array.`
+  no guarantee of a specific ordering of the elements in the array.
+
+  Arguments:
+    CATALOG_NAME: Parent catalog for schemas of interest.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -372,7 +390,11 @@ func newUpdate() *cobra.Command {
   a metastore admin. If the caller is a metastore admin, only the __owner__
   field can be changed in the update. If the __name__ field must be updated, the
   caller must be a metastore admin or have the **CREATE_SCHEMA** privilege on
-  the parent catalog.`
+  the parent catalog.
+
+  Arguments:
+    FULL_NAME: Full name of the schema.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/schemas/schemas.go
+++ b/cmd/workspace/schemas/schemas.go
@@ -71,9 +71,7 @@ func newCreate() *cobra.Command {
 
   Arguments:
     NAME: Name of schema, relative to parent catalog.
-    
-    CATALOG_NAME: Name of parent catalog.
-    `
+    CATALOG_NAME: Name of parent catalog.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -156,8 +154,7 @@ func newDelete() *cobra.Command {
   owner of the schema or an owner of the parent catalog.
 
   Arguments:
-    FULL_NAME: Full name of the schema.
-    `
+    FULL_NAME: Full name of the schema.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -235,8 +232,7 @@ func newGet() *cobra.Command {
   privilege on the schema.
 
   Arguments:
-    FULL_NAME: Full name of the schema.
-    `
+    FULL_NAME: Full name of the schema.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -316,8 +312,7 @@ func newList() *cobra.Command {
   no guarantee of a specific ordering of the elements in the array.
 
   Arguments:
-    CATALOG_NAME: Parent catalog for schemas of interest.
-    `
+    CATALOG_NAME: Parent catalog for schemas of interest.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -393,8 +388,7 @@ func newUpdate() *cobra.Command {
   the parent catalog.
 
   Arguments:
-    FULL_NAME: Full name of the schema.
-    `
+    FULL_NAME: Full name of the schema.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/secrets/secrets.go
+++ b/cmd/workspace/secrets/secrets.go
@@ -77,8 +77,7 @@ func newCreateScope() *cobra.Command {
   in a workspace is 100.
 
   Arguments:
-    SCOPE: Scope name requested by the user. Scope names are unique.
-    `
+    SCOPE: Scope name requested by the user. Scope names are unique.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -165,9 +164,7 @@ func newDeleteAcl() *cobra.Command {
 
   Arguments:
     SCOPE: The name of the scope to remove permissions from.
-    
-    PRINCIPAL: The principal to remove an existing ACL from.
-    `
+    PRINCIPAL: The principal to remove an existing ACL from.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -255,8 +252,7 @@ func newDeleteScope() *cobra.Command {
   call.
 
   Arguments:
-    SCOPE: Name of the scope to delete.
-    `
+    SCOPE: Name of the scope to delete.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -343,9 +339,7 @@ func newDeleteSecret() *cobra.Command {
 
   Arguments:
     SCOPE: The name of the scope that contains the secret to delete.
-    
-    KEY: Name of the secret to delete.
-    `
+    KEY: Name of the secret to delete.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -433,9 +427,7 @@ func newGetAcl() *cobra.Command {
 
   Arguments:
     SCOPE: The name of the scope to fetch ACL information from.
-    
-    PRINCIPAL: The principal to fetch ACL information for.
-    `
+    PRINCIPAL: The principal to fetch ACL information for.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -512,9 +504,7 @@ func newGetSecret() *cobra.Command {
 
   Arguments:
     SCOPE: The name of the scope to fetch secret information from.
-    
-    KEY: The key to fetch secret for.
-    `
+    KEY: The key to fetch secret for.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -584,8 +574,7 @@ func newListAcls() *cobra.Command {
   call.
 
   Arguments:
-    SCOPE: The name of the scope to fetch ACL information from.
-    `
+    SCOPE: The name of the scope to fetch ACL information from.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -707,8 +696,7 @@ func newListSecrets() *cobra.Command {
   call.
 
   Arguments:
-    SCOPE: The name of the scope to list secrets within.
-    `
+    SCOPE: The name of the scope to list secrets within.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -800,11 +788,8 @@ func newPutAcl() *cobra.Command {
 
   Arguments:
     SCOPE: The name of the scope to apply permissions to.
-    
     PRINCIPAL: The principal in which the permission is applied.
-    
-    PERMISSION: The permission level applied to the principal.
-    `
+    PERMISSION: The permission level applied to the principal.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/secrets/secrets.go
+++ b/cmd/workspace/secrets/secrets.go
@@ -74,7 +74,11 @@ func newCreateScope() *cobra.Command {
   
   The scope name must consist of alphanumeric characters, dashes, underscores,
   and periods, and may not exceed 128 characters. The maximum number of scopes
-  in a workspace is 100.`
+  in a workspace is 100.
+
+  Arguments:
+    SCOPE: Scope name requested by the user. Scope names are unique.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -157,7 +161,13 @@ func newDeleteAcl() *cobra.Command {
   Users must have the MANAGE permission to invoke this API. Throws
   RESOURCE_DOES_NOT_EXIST if no such secret scope, principal, or ACL exists.
   Throws PERMISSION_DENIED if the user does not have permission to make this
-  API call.`
+  API call.
+
+  Arguments:
+    SCOPE: The name of the scope to remove permissions from.
+    
+    PRINCIPAL: The principal to remove an existing ACL from.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -242,7 +252,11 @@ func newDeleteScope() *cobra.Command {
   
   Throws RESOURCE_DOES_NOT_EXIST if the scope does not exist. Throws
   PERMISSION_DENIED if the user does not have permission to make this API
-  call.`
+  call.
+
+  Arguments:
+    SCOPE: Name of the scope to delete.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -325,7 +339,13 @@ func newDeleteSecret() *cobra.Command {
   
   Throws RESOURCE_DOES_NOT_EXIST if no such secret scope or secret exists.
   Throws PERMISSION_DENIED if the user does not have permission to make this
-  API call.`
+  API call.
+
+  Arguments:
+    SCOPE: The name of the scope that contains the secret to delete.
+    
+    KEY: Name of the secret to delete.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -409,7 +429,13 @@ func newGetAcl() *cobra.Command {
   
   Throws RESOURCE_DOES_NOT_EXIST if no such secret scope exists. Throws
   PERMISSION_DENIED if the user does not have permission to make this API
-  call.`
+  call.
+
+  Arguments:
+    SCOPE: The name of the scope to fetch ACL information from.
+    
+    PRINCIPAL: The principal to fetch ACL information for.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -482,7 +508,13 @@ func newGetSecret() *cobra.Command {
   
   Throws PERMISSION_DENIED if the user does not have permission to make this
   API call. Throws RESOURCE_DOES_NOT_EXIST if no such secret or secret scope
-  exists.`
+  exists.
+
+  Arguments:
+    SCOPE: The name of the scope to fetch secret information from.
+    
+    KEY: The key to fetch secret for.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -549,7 +581,11 @@ func newListAcls() *cobra.Command {
   
   Throws RESOURCE_DOES_NOT_EXIST if no such secret scope exists. Throws
   PERMISSION_DENIED if the user does not have permission to make this API
-  call.`
+  call.
+
+  Arguments:
+    SCOPE: The name of the scope to fetch ACL information from.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -668,7 +704,11 @@ func newListSecrets() *cobra.Command {
   The lastUpdatedTimestamp returned is in milliseconds since epoch. Throws
   RESOURCE_DOES_NOT_EXIST if no such secret scope exists. Throws
   PERMISSION_DENIED if the user does not have permission to make this API
-  call.`
+  call.
+
+  Arguments:
+    SCOPE: The name of the scope to list secrets within.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -756,7 +796,15 @@ func newPutAcl() *cobra.Command {
   RESOURCE_ALREADY_EXISTS if a permission for the principal already exists.
   Throws INVALID_PARAMETER_VALUE if the permission or principal is invalid.
   Throws PERMISSION_DENIED if the user does not have permission to make this
-  API call.`
+  API call.
+
+  Arguments:
+    SCOPE: The name of the scope to apply permissions to.
+    
+    PRINCIPAL: The principal in which the permission is applied.
+    
+    PERMISSION: The permission level applied to the principal.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/service-principals/service-principals.go
+++ b/cmd/workspace/service-principals/service-principals.go
@@ -141,8 +141,7 @@ func newDelete() *cobra.Command {
   Delete a single service principal in the Databricks workspace.
 
   Arguments:
-    ID: Unique ID for a service principal in the Databricks workspace.
-    `
+    ID: Unique ID for a service principal in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -219,8 +218,7 @@ func newGet() *cobra.Command {
   workspace.
 
   Arguments:
-    ID: Unique ID for a service principal in the Databricks workspace.
-    `
+    ID: Unique ID for a service principal in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -369,8 +367,7 @@ func newPatch() *cobra.Command {
   workspace.
 
   Arguments:
-    ID: Unique ID for a service principal in the Databricks workspace.
-    `
+    ID: Unique ID for a service principal in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -466,8 +463,7 @@ func newUpdate() *cobra.Command {
   This action replaces the existing service principal with the same name.
 
   Arguments:
-    ID: Databricks service principal ID.
-    `
+    ID: Databricks service principal ID.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/service-principals/service-principals.go
+++ b/cmd/workspace/service-principals/service-principals.go
@@ -138,7 +138,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a service principal.`
 	cmd.Long = `Delete a service principal.
   
-  Delete a single service principal in the Databricks workspace.`
+  Delete a single service principal in the Databricks workspace.
+
+  Arguments:
+    ID: Unique ID for a service principal in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -212,7 +216,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get service principal details.
   
   Gets the details for a single service principal define in the Databricks
-  workspace.`
+  workspace.
+
+  Arguments:
+    ID: Unique ID for a service principal in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -358,7 +366,11 @@ func newPatch() *cobra.Command {
 	cmd.Long = `Update service principal details.
   
   Partially updates the details of a single service principal in the Databricks
-  workspace.`
+  workspace.
+
+  Arguments:
+    ID: Unique ID for a service principal in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -451,7 +463,11 @@ func newUpdate() *cobra.Command {
   
   Updates the details of a single service principal.
   
-  This action replaces the existing service principal with the same name.`
+  This action replaces the existing service principal with the same name.
+
+  Arguments:
+    ID: Databricks service principal ID.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/serving-endpoints/serving-endpoints.go
+++ b/cmd/workspace/serving-endpoints/serving-endpoints.go
@@ -73,11 +73,9 @@ func newBuildLogs() *cobra.Command {
 
   Arguments:
     NAME: The name of the serving endpoint that the served model belongs to. This
-    field is required.
-    
+      field is required.
     SERVED_MODEL_NAME: The name of the served model that build logs will be retrieved for. This
-    field is required.
-    `
+      field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -223,8 +221,7 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a serving endpoint.
 
   Arguments:
-    NAME: The name of the serving endpoint. This field is required.
-    `
+    NAME: The name of the serving endpoint. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -290,8 +287,7 @@ func newExportMetrics() *cobra.Command {
 
   Arguments:
     NAME: The name of the serving endpoint to retrieve metrics for. This field is
-    required.
-    `
+      required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -355,8 +351,7 @@ func newGet() *cobra.Command {
   Retrieves the details for a single serving endpoint.
 
   Arguments:
-    NAME: The name of the serving endpoint. This field is required.
-    `
+    NAME: The name of the serving endpoint. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -420,8 +415,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
-    `
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -486,8 +480,7 @@ func newGetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
-    `
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -599,11 +592,9 @@ func newLogs() *cobra.Command {
 
   Arguments:
     NAME: The name of the serving endpoint that the served model belongs to. This
-    field is required.
-    
-    SERVED_MODEL_NAME: The name of the served model that logs will be retrieved for. This field is
-    required.
-    `
+      field is required.
+    SERVED_MODEL_NAME: The name of the served model that logs will be retrieved for. This field
+      is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -675,8 +666,7 @@ func newPatch() *cobra.Command {
 
   Arguments:
     NAME: The name of the serving endpoint who's tags to patch. This field is
-    required.
-    `
+      required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -751,8 +741,7 @@ func newQuery() *cobra.Command {
 	cmd.Long = `Query a serving endpoint with provided model input.
 
   Arguments:
-    NAME: The name of the serving endpoint. This field is required.
-    `
+    NAME: The name of the serving endpoint. This field is required.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -827,8 +816,7 @@ func newSetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
-    `
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -991,8 +979,7 @@ func newUpdatePermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
-    `
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/serving-endpoints/serving-endpoints.go
+++ b/cmd/workspace/serving-endpoints/serving-endpoints.go
@@ -69,7 +69,15 @@ func newBuildLogs() *cobra.Command {
 	cmd.Long = `Retrieve the logs associated with building the model's environment for a given
   serving endpoint's served model.
   
-  Retrieves the build logs associated with the provided served model.`
+  Retrieves the build logs associated with the provided served model.
+
+  Arguments:
+    NAME: The name of the serving endpoint that the served model belongs to. This
+    field is required.
+    
+    SERVED_MODEL_NAME: The name of the served model that build logs will be retrieved for. This
+    field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -212,7 +220,11 @@ func newDelete() *cobra.Command {
 
 	cmd.Use = "delete NAME"
 	cmd.Short = `Delete a serving endpoint.`
-	cmd.Long = `Delete a serving endpoint.`
+	cmd.Long = `Delete a serving endpoint.
+
+  Arguments:
+    NAME: The name of the serving endpoint. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -274,7 +286,12 @@ func newExportMetrics() *cobra.Command {
 	cmd.Long = `Retrieve the metrics associated with a serving endpoint.
   
   Retrieves the metrics associated with the provided serving endpoint in either
-  Prometheus or OpenMetrics exposition format.`
+  Prometheus or OpenMetrics exposition format.
+
+  Arguments:
+    NAME: The name of the serving endpoint to retrieve metrics for. This field is
+    required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -335,7 +352,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get a single serving endpoint.`
 	cmd.Long = `Get a single serving endpoint.
   
-  Retrieves the details for a single serving endpoint.`
+  Retrieves the details for a single serving endpoint.
+
+  Arguments:
+    NAME: The name of the serving endpoint. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -396,7 +417,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get serving endpoint permission levels.`
 	cmd.Long = `Get serving endpoint permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -458,7 +483,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get serving endpoint permissions.
   
   Gets the permissions of a serving endpoint. Serving endpoints can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -566,7 +595,15 @@ func newLogs() *cobra.Command {
 	cmd.Long = `Retrieve the most recent log lines associated with a given serving endpoint's
   served model.
   
-  Retrieves the service logs associated with the provided served model.`
+  Retrieves the service logs associated with the provided served model.
+
+  Arguments:
+    NAME: The name of the serving endpoint that the served model belongs to. This
+    field is required.
+    
+    SERVED_MODEL_NAME: The name of the served model that logs will be retrieved for. This field is
+    required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -634,7 +671,12 @@ func newPatch() *cobra.Command {
 	cmd.Long = `Patch the tags of a serving endpoint.
   
   Used to batch add and delete tags from a serving endpoint with a single API
-  call.`
+  call.
+
+  Arguments:
+    NAME: The name of the serving endpoint who's tags to patch. This field is
+    required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -706,7 +748,11 @@ func newQuery() *cobra.Command {
 
 	cmd.Use = "query NAME"
 	cmd.Short = `Query a serving endpoint with provided model input.`
-	cmd.Long = `Query a serving endpoint with provided model input.`
+	cmd.Long = `Query a serving endpoint with provided model input.
+
+  Arguments:
+    NAME: The name of the serving endpoint. This field is required.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -778,7 +824,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set serving endpoint permissions.
   
   Sets permissions on a serving endpoint. Serving endpoints can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -938,7 +988,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update serving endpoint permissions.
   
   Updates the permissions on a serving endpoint. Serving endpoints can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    SERVING_ENDPOINT_ID: The serving endpoint for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/settings/settings.go
+++ b/cmd/workspace/settings/settings.go
@@ -68,7 +68,17 @@ func newDeleteDefaultWorkspaceNamespace() *cobra.Command {
   be provided in DELETE requests (as a query parameter). The etag can be
   retrieved by making a GET request before the DELETE request. If the setting is
   updated/deleted concurrently, DELETE will fail with 409 and the request will
-  need to be retried by using the fresh etag in the 409 response.`
+  need to be retried by using the fresh etag in the 409 response.
+
+  Arguments:
+    ETAG: etag used for versioning. The response is at least as fresh as the eTag
+    provided. This is used for optimistic concurrency control as a way to help
+    prevent simultaneous writes of a setting overwriting each other. It is
+    strongly suggested that systems make use of the etag in the read -> delete
+    pattern to perform setting deletions in order to avoid race conditions. That
+    is, get an etag from a GET request, and pass it with the DELETE request to
+    identify the rule set version you are deleting.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -129,7 +139,17 @@ func newReadDefaultWorkspaceNamespace() *cobra.Command {
 	cmd.Short = `Get the default namespace setting.`
 	cmd.Long = `Get the default namespace setting.
   
-  Gets the default namespace setting.`
+  Gets the default namespace setting.
+
+  Arguments:
+    ETAG: etag used for versioning. The response is at least as fresh as the eTag
+    provided. This is used for optimistic concurrency control as a way to help
+    prevent simultaneous writes of a setting overwriting each other. It is
+    strongly suggested that systems make use of the etag in the read -> delete
+    pattern to perform setting deletions in order to avoid race conditions. That
+    is, get an etag from a GET request, and pass it with the DELETE request to
+    identify the rule set version you are deleting.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/settings/settings.go
+++ b/cmd/workspace/settings/settings.go
@@ -72,13 +72,12 @@ func newDeleteDefaultWorkspaceNamespace() *cobra.Command {
 
   Arguments:
     ETAG: etag used for versioning. The response is at least as fresh as the eTag
-    provided. This is used for optimistic concurrency control as a way to help
-    prevent simultaneous writes of a setting overwriting each other. It is
-    strongly suggested that systems make use of the etag in the read -> delete
-    pattern to perform setting deletions in order to avoid race conditions. That
-    is, get an etag from a GET request, and pass it with the DELETE request to
-    identify the rule set version you are deleting.
-    `
+      provided. This is used for optimistic concurrency control as a way to help
+      prevent simultaneous writes of a setting overwriting each other. It is
+      strongly suggested that systems make use of the etag in the read -> delete
+      pattern to perform setting deletions in order to avoid race conditions.
+      That is, get an etag from a GET request, and pass it with the DELETE
+      request to identify the rule set version you are deleting.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -143,13 +142,12 @@ func newReadDefaultWorkspaceNamespace() *cobra.Command {
 
   Arguments:
     ETAG: etag used for versioning. The response is at least as fresh as the eTag
-    provided. This is used for optimistic concurrency control as a way to help
-    prevent simultaneous writes of a setting overwriting each other. It is
-    strongly suggested that systems make use of the etag in the read -> delete
-    pattern to perform setting deletions in order to avoid race conditions. That
-    is, get an etag from a GET request, and pass it with the DELETE request to
-    identify the rule set version you are deleting.
-    `
+      provided. This is used for optimistic concurrency control as a way to help
+      prevent simultaneous writes of a setting overwriting each other. It is
+      strongly suggested that systems make use of the etag in the read -> delete
+      pattern to perform setting deletions in order to avoid race conditions.
+      That is, get an etag from a GET request, and pass it with the DELETE
+      request to identify the rule set version you are deleting.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/shares/shares.go
+++ b/cmd/workspace/shares/shares.go
@@ -68,8 +68,7 @@ func newCreate() *cobra.Command {
   **CREATE_SHARE** privilege on the metastore.
 
   Arguments:
-    NAME: Name of the share.
-    `
+    NAME: Name of the share.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -149,8 +148,7 @@ func newDelete() *cobra.Command {
   the share.
 
   Arguments:
-    NAME: The name of the share.
-    `
+    NAME: The name of the share.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -217,8 +215,7 @@ func newGet() *cobra.Command {
   admin or the owner of the share.
 
   Arguments:
-    NAME: The name of the share.
-    `
+    NAME: The name of the share.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -333,8 +330,7 @@ func newSharePermissions() *cobra.Command {
   metastore admin or the owner of the share.
 
   Arguments:
-    NAME: The name of the share.
-    `
+    NAME: The name of the share.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -418,8 +414,7 @@ func newUpdate() *cobra.Command {
   Table removals through **update** do not require additional privileges.
 
   Arguments:
-    NAME: Name of the share.
-    `
+    NAME: Name of the share.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -497,8 +492,7 @@ func newUpdatePermissions() *cobra.Command {
   recipient revocations do not require additional privileges.
 
   Arguments:
-    NAME: The name of the share.
-    `
+    NAME: The name of the share.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/shares/shares.go
+++ b/cmd/workspace/shares/shares.go
@@ -65,7 +65,11 @@ func newCreate() *cobra.Command {
   
   Creates a new share for data objects. Data objects can be added after creation
   with **update**. The caller must be a metastore admin or have the
-  **CREATE_SHARE** privilege on the metastore.`
+  **CREATE_SHARE** privilege on the metastore.
+
+  Arguments:
+    NAME: Name of the share.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -142,7 +146,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a share.
   
   Deletes a data object share from the metastore. The caller must be an owner of
-  the share.`
+  the share.
+
+  Arguments:
+    NAME: The name of the share.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -206,7 +214,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a share.
   
   Gets a data object share from the metastore. The caller must be a metastore
-  admin or the owner of the share.`
+  admin or the owner of the share.
+
+  Arguments:
+    NAME: The name of the share.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -318,7 +330,11 @@ func newSharePermissions() *cobra.Command {
 	cmd.Long = `Get permissions.
   
   Gets the permissions for a data share from the metastore. The caller must be a
-  metastore admin or the owner of the share.`
+  metastore admin or the owner of the share.
+
+  Arguments:
+    NAME: The name of the share.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -399,7 +415,11 @@ func newUpdate() *cobra.Command {
   indefinitely for recipients to be able to access the table. Typically, you
   should use a group as the share owner.
   
-  Table removals through **update** do not require additional privileges.`
+  Table removals through **update** do not require additional privileges.
+
+  Arguments:
+    NAME: Name of the share.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -474,7 +494,11 @@ func newUpdatePermissions() *cobra.Command {
   a metastore admin or an owner of the share.
   
   For new recipient grants, the user must also be the owner of the recipients.
-  recipient revocations do not require additional privileges.`
+  recipient revocations do not require additional privileges.
+
+  Arguments:
+    NAME: The name of the share.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/storage-credentials/storage-credentials.go
+++ b/cmd/workspace/storage-credentials/storage-credentials.go
@@ -80,8 +80,7 @@ func newCreate() *cobra.Command {
   Creates a new storage credential.
 
   Arguments:
-    NAME: The credential name. The name must be unique within the metastore.
-    `
+    NAME: The credential name. The name must be unique within the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -163,8 +162,7 @@ func newDelete() *cobra.Command {
   of the storage credential.
 
   Arguments:
-    NAME: Name of the storage credential.
-    `
+    NAME: Name of the storage credential.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -242,8 +240,7 @@ func newGet() *cobra.Command {
   storage credential.
 
   Arguments:
-    NAME: Name of the storage credential.
-    `
+    NAME: Name of the storage credential.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -384,8 +381,7 @@ func newUpdate() *cobra.Command {
   Updates a storage credential on the metastore.
 
   Arguments:
-    NAME: The credential name. The name must be unique within the metastore.
-    `
+    NAME: The credential name. The name must be unique within the metastore.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/storage-credentials/storage-credentials.go
+++ b/cmd/workspace/storage-credentials/storage-credentials.go
@@ -77,7 +77,11 @@ func newCreate() *cobra.Command {
 	cmd.Short = `Create a storage credential.`
 	cmd.Long = `Create a storage credential.
   
-  Creates a new storage credential.`
+  Creates a new storage credential.
+
+  Arguments:
+    NAME: The credential name. The name must be unique within the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -156,7 +160,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a credential.
   
   Deletes a storage credential from the metastore. The caller must be an owner
-  of the storage credential.`
+  of the storage credential.
+
+  Arguments:
+    NAME: Name of the storage credential.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -231,7 +239,11 @@ func newGet() *cobra.Command {
   
   Gets a storage credential from the metastore. The caller must be a metastore
   admin, the owner of the storage credential, or have some permission on the
-  storage credential.`
+  storage credential.
+
+  Arguments:
+    NAME: Name of the storage credential.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -369,7 +381,11 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Update a credential.`
 	cmd.Long = `Update a credential.
   
-  Updates a storage credential on the metastore.`
+  Updates a storage credential on the metastore.
+
+  Arguments:
+    NAME: The credential name. The name must be unique within the metastore.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/system-schemas/system-schemas.go
+++ b/cmd/workspace/system-schemas/system-schemas.go
@@ -57,7 +57,13 @@ func newDisable() *cobra.Command {
 	cmd.Long = `Disable a system schema.
   
   Disables the system schema and removes it from the system catalog. The caller
-  must be an account admin or a metastore admin.`
+  must be an account admin or a metastore admin.
+
+  Arguments:
+    METASTORE_ID: The metastore ID under which the system schema lives.
+    
+    SCHEMA_NAME: Full name of the system schema.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -123,7 +129,13 @@ func newEnable() *cobra.Command {
 	cmd.Long = `Enable a system schema.
   
   Enables the system schema and adds it to the system catalog. The caller must
-  be an account admin or a metastore admin.`
+  be an account admin or a metastore admin.
+
+  Arguments:
+    METASTORE_ID: The metastore ID under which the system schema lives.
+    
+    SCHEMA_NAME: Full name of the system schema.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -189,7 +201,11 @@ func newList() *cobra.Command {
 	cmd.Long = `List system schemas.
   
   Gets an array of system schemas for a metastore. The caller must be an account
-  admin or a metastore admin.`
+  admin or a metastore admin.
+
+  Arguments:
+    METASTORE_ID: The ID for the metastore in which the system schema resides.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/system-schemas/system-schemas.go
+++ b/cmd/workspace/system-schemas/system-schemas.go
@@ -61,9 +61,7 @@ func newDisable() *cobra.Command {
 
   Arguments:
     METASTORE_ID: The metastore ID under which the system schema lives.
-    
-    SCHEMA_NAME: Full name of the system schema.
-    `
+    SCHEMA_NAME: Full name of the system schema.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -133,9 +131,7 @@ func newEnable() *cobra.Command {
 
   Arguments:
     METASTORE_ID: The metastore ID under which the system schema lives.
-    
-    SCHEMA_NAME: Full name of the system schema.
-    `
+    SCHEMA_NAME: Full name of the system schema.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -204,8 +200,7 @@ func newList() *cobra.Command {
   admin or a metastore admin.
 
   Arguments:
-    METASTORE_ID: The ID for the metastore in which the system schema resides.
-    `
+    METASTORE_ID: The ID for the metastore in which the system schema resides.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/table-constraints/table-constraints.go
+++ b/cmd/workspace/table-constraints/table-constraints.go
@@ -153,13 +153,10 @@ func newDelete() *cobra.Command {
 
   Arguments:
     FULL_NAME: Full name of the table referenced by the constraint.
-    
     CONSTRAINT_NAME: The name of the constraint to delete.
-    
     CASCADE: If true, try deleting all child constraints of the current constraint. If
-    false, reject this operation if the current constraint has any child
-    constraints.
-    `
+      false, reject this operation if the current constraint has any child
+      constraints.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/table-constraints/table-constraints.go
+++ b/cmd/workspace/table-constraints/table-constraints.go
@@ -149,7 +149,17 @@ func newDelete() *cobra.Command {
   schema, and be the owner of the table. - if __cascade__ argument is **true**,
   the user must have the following permissions on all of the child tables: the
   **USE_CATALOG** privilege on the table's catalog, the **USE_SCHEMA** privilege
-  on the table's schema, and be the owner of the table.`
+  on the table's schema, and be the owner of the table.
+
+  Arguments:
+    FULL_NAME: Full name of the table referenced by the constraint.
+    
+    CONSTRAINT_NAME: The name of the constraint to delete.
+    
+    CASCADE: If true, try deleting all child constraints of the current constraint. If
+    false, reject this operation if the current constraint has any child
+    constraints.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/tables/tables.go
+++ b/cmd/workspace/tables/tables.go
@@ -67,7 +67,11 @@ func newDelete() *cobra.Command {
   be the owner of the parent catalog, have the **USE_CATALOG** privilege on the
   parent catalog and be the owner of the parent schema, or be the owner of the
   table and have the **USE_CATALOG** privilege on the parent catalog and the
-  **USE_SCHEMA** privilege on the parent schema.`
+  **USE_SCHEMA** privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME: Full name of the table.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -146,7 +150,11 @@ func newGet() *cobra.Command {
   must be a metastore admin, be the owner of the table and have the
   **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
   privilege on the parent schema, or be the owner of the table and have the
-  **SELECT** privilege on it as well.`
+  **SELECT** privilege on it as well.
+
+  Arguments:
+    FULL_NAME: Full name of the table.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -228,7 +236,13 @@ func newList() *cobra.Command {
   **SELECT** privilege on) the table. For the latter case, the caller must also
   be the owner or have the **USE_CATALOG** privilege on the parent catalog and
   the **USE_SCHEMA** privilege on the parent schema. There is no guarantee of a
-  specific ordering of the elements in the array.`
+  specific ordering of the elements in the array.
+
+  Arguments:
+    CATALOG_NAME: Name of parent catalog for tables of interest.
+    
+    SCHEMA_NAME: Parent schema of tables.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -305,7 +319,11 @@ func newListSummaries() *cobra.Command {
   or **USE_SCHEMA** privilege on the schema, provided that the user also has
   ownership or the **USE_CATALOG** privilege on the parent catalog.
   
-  There is no guarantee of a specific ordering of the elements in the array.`
+  There is no guarantee of a specific ordering of the elements in the array.
+
+  Arguments:
+    CATALOG_NAME: Name of parent catalog for tables of interest.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -386,7 +404,11 @@ func newUpdate() *cobra.Command {
   catalog, have the **USE_CATALOG** privilege on the parent catalog and be the
   owner of the parent schema, or be the owner of the table and have the
   **USE_CATALOG** privilege on the parent catalog and the **USE_SCHEMA**
-  privilege on the parent schema.`
+  privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME: Full name of the table.
+    `
 
 	// This command is being previewed; hide from help output.
 	cmd.Hidden = true

--- a/cmd/workspace/tables/tables.go
+++ b/cmd/workspace/tables/tables.go
@@ -70,8 +70,7 @@ func newDelete() *cobra.Command {
   **USE_SCHEMA** privilege on the parent schema.
 
   Arguments:
-    FULL_NAME: Full name of the table.
-    `
+    FULL_NAME: Full name of the table.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -153,8 +152,7 @@ func newGet() *cobra.Command {
   **SELECT** privilege on it as well.
 
   Arguments:
-    FULL_NAME: Full name of the table.
-    `
+    FULL_NAME: Full name of the table.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -240,9 +238,7 @@ func newList() *cobra.Command {
 
   Arguments:
     CATALOG_NAME: Name of parent catalog for tables of interest.
-    
-    SCHEMA_NAME: Parent schema of tables.
-    `
+    SCHEMA_NAME: Parent schema of tables.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -322,8 +318,7 @@ func newListSummaries() *cobra.Command {
   There is no guarantee of a specific ordering of the elements in the array.
 
   Arguments:
-    CATALOG_NAME: Name of parent catalog for tables of interest.
-    `
+    CATALOG_NAME: Name of parent catalog for tables of interest.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -407,8 +402,7 @@ func newUpdate() *cobra.Command {
   privilege on the parent schema.
 
   Arguments:
-    FULL_NAME: Full name of the table.
-    `
+    FULL_NAME: Full name of the table.`
 
 	// This command is being previewed; hide from help output.
 	cmd.Hidden = true

--- a/cmd/workspace/token-management/token-management.go
+++ b/cmd/workspace/token-management/token-management.go
@@ -61,7 +61,13 @@ func newCreateOboToken() *cobra.Command {
 	cmd.Short = `Create on-behalf token.`
 	cmd.Long = `Create on-behalf token.
   
-  Creates a token on behalf of a service principal.`
+  Creates a token on behalf of a service principal.
+
+  Arguments:
+    APPLICATION_ID: Application ID of the service principal.
+    
+    LIFETIME_SECONDS: The number of seconds before the token expires.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -143,7 +149,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a token.`
 	cmd.Long = `Delete a token.
   
-  Deletes a token, specified by its ID.`
+  Deletes a token, specified by its ID.
+
+  Arguments:
+    TOKEN_ID: The ID of the token to get.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -216,7 +226,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get token info.`
 	cmd.Long = `Get token info.
   
-  Gets information about a token, specified by its ID.`
+  Gets information about a token, specified by its ID.
+
+  Arguments:
+    TOKEN_ID: The ID of the token to get.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/token-management/token-management.go
+++ b/cmd/workspace/token-management/token-management.go
@@ -65,9 +65,7 @@ func newCreateOboToken() *cobra.Command {
 
   Arguments:
     APPLICATION_ID: Application ID of the service principal.
-    
-    LIFETIME_SECONDS: The number of seconds before the token expires.
-    `
+    LIFETIME_SECONDS: The number of seconds before the token expires.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -152,8 +150,7 @@ func newDelete() *cobra.Command {
   Deletes a token, specified by its ID.
 
   Arguments:
-    TOKEN_ID: The ID of the token to get.
-    `
+    TOKEN_ID: The ID of the token to get.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -229,8 +226,7 @@ func newGet() *cobra.Command {
   Gets information about a token, specified by its ID.
 
   Arguments:
-    TOKEN_ID: The ID of the token to get.
-    `
+    TOKEN_ID: The ID of the token to get.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/tokens/tokens.go
+++ b/cmd/workspace/tokens/tokens.go
@@ -135,7 +135,11 @@ func newDelete() *cobra.Command {
   Revokes an access token.
   
   If a token with the specified ID is not valid, this call returns an error
-  **RESOURCE_DOES_NOT_EXIST**.`
+  **RESOURCE_DOES_NOT_EXIST**.
+
+  Arguments:
+    TOKEN_ID: The ID of the token to be revoked.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/tokens/tokens.go
+++ b/cmd/workspace/tokens/tokens.go
@@ -138,8 +138,7 @@ func newDelete() *cobra.Command {
   **RESOURCE_DOES_NOT_EXIST**.
 
   Arguments:
-    TOKEN_ID: The ID of the token to be revoked.
-    `
+    TOKEN_ID: The ID of the token to be revoked.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/users/users.go
+++ b/cmd/workspace/users/users.go
@@ -150,8 +150,7 @@ func newDelete() *cobra.Command {
   objects associated with the user.
 
   Arguments:
-    ID: Unique ID for a user in the Databricks workspace.
-    `
+    ID: Unique ID for a user in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -235,8 +234,7 @@ func newGet() *cobra.Command {
   Gets information for a specific user in Databricks workspace.
 
   Arguments:
-    ID: Unique ID for a user in the Databricks workspace.
-    `
+    ID: Unique ID for a user in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -482,8 +480,7 @@ func newPatch() *cobra.Command {
   specific user attributes.
 
   Arguments:
-    ID: Unique ID for a user in the Databricks workspace.
-    `
+    ID: Unique ID for a user in the Databricks workspace.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -651,8 +648,7 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     ID: Databricks user ID. This is automatically set by Databricks. Any value
-    provided by the client will be ignored.
-    `
+      provided by the client will be ignored.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/users/users.go
+++ b/cmd/workspace/users/users.go
@@ -147,7 +147,11 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a user.
   
   Deletes a user. Deleting a user from a Databricks workspace also removes
-  objects associated with the user.`
+  objects associated with the user.
+
+  Arguments:
+    ID: Unique ID for a user in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -228,7 +232,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get user details.`
 	cmd.Long = `Get user details.
   
-  Gets information for a specific user in Databricks workspace.`
+  Gets information for a specific user in Databricks workspace.
+
+  Arguments:
+    ID: Unique ID for a user in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -471,7 +479,11 @@ func newPatch() *cobra.Command {
 	cmd.Long = `Update user details.
   
   Partially updates a user resource by applying the supplied operations on
-  specific user attributes.`
+  specific user attributes.
+
+  Arguments:
+    ID: Unique ID for a user in the Databricks workspace.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -635,7 +647,12 @@ func newUpdate() *cobra.Command {
 	cmd.Short = `Replace a user.`
 	cmd.Long = `Replace a user.
   
-  Replaces a user's information with the data supplied in request.`
+  Replaces a user's information with the data supplied in request.
+
+  Arguments:
+    ID: Databricks user ID. This is automatically set by Databricks. Any value
+    provided by the client will be ignored.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/volumes/volumes.go
+++ b/cmd/workspace/volumes/volumes.go
@@ -84,7 +84,17 @@ func newCreate() *cobra.Command {
   must have **CREATE EXTERNAL VOLUME** privilege on the external location. -
   There are no other tables, nor volumes existing in the specified storage
   location. - The specified storage location is not under the location of other
-  tables, nor volumes, or catalogs or schemas.`
+  tables, nor volumes, or catalogs or schemas.
+
+  Arguments:
+    CATALOG_NAME: The name of the catalog where the schema and the volume are
+    
+    SCHEMA_NAME: The name of the schema where the volume is
+    
+    NAME: The name of the volume
+    
+    VOLUME_TYPE: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -176,7 +186,11 @@ func newDelete() *cobra.Command {
   
   The caller must be a metastore admin or an owner of the volume. For the latter
   case, the caller must also be the owner or have the **USE_CATALOG** privilege
-  on the parent catalog and the **USE_SCHEMA** privilege on the parent schema.`
+  on the parent catalog and the **USE_SCHEMA** privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME_ARG: The three-level (fully qualified) name of the volume
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -259,7 +273,13 @@ func newList() *cobra.Command {
   also be the owner or have the **USE_CATALOG** privilege on the parent catalog
   and the **USE_SCHEMA** privilege on the parent schema.
   
-  There is no guarantee of a specific ordering of the elements in the array.`
+  There is no guarantee of a specific ordering of the elements in the array.
+
+  Arguments:
+    CATALOG_NAME: The identifier of the catalog
+    
+    SCHEMA_NAME: The identifier of the schema
+    `
 
 	// This command is being previewed; hide from help output.
 	cmd.Hidden = true
@@ -329,7 +349,11 @@ func newRead() *cobra.Command {
   The caller must be a metastore admin or an owner of (or have the **READ
   VOLUME** privilege on) the volume. For the latter case, the caller must also
   be the owner or have the **USE_CATALOG** privilege on the parent catalog and
-  the **USE_SCHEMA** privilege on the parent schema.`
+  the **USE_SCHEMA** privilege on the parent schema.
+
+  Arguments:
+    FULL_NAME_ARG: The three-level (fully qualified) name of the volume
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -415,7 +439,11 @@ func newUpdate() *cobra.Command {
   on the parent catalog and the **USE_SCHEMA** privilege on the parent schema.
   
   Currently only the name, the owner or the comment of the volume could be
-  updated.`
+  updated.
+
+  Arguments:
+    FULL_NAME_ARG: The three-level (fully qualified) name of the volume
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/volumes/volumes.go
+++ b/cmd/workspace/volumes/volumes.go
@@ -88,13 +88,9 @@ func newCreate() *cobra.Command {
 
   Arguments:
     CATALOG_NAME: The name of the catalog where the schema and the volume are
-    
     SCHEMA_NAME: The name of the schema where the volume is
-    
     NAME: The name of the volume
-    
-    VOLUME_TYPE: 
-    `
+    VOLUME_TYPE: `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -189,8 +185,7 @@ func newDelete() *cobra.Command {
   on the parent catalog and the **USE_SCHEMA** privilege on the parent schema.
 
   Arguments:
-    FULL_NAME_ARG: The three-level (fully qualified) name of the volume
-    `
+    FULL_NAME_ARG: The three-level (fully qualified) name of the volume`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -277,9 +272,7 @@ func newList() *cobra.Command {
 
   Arguments:
     CATALOG_NAME: The identifier of the catalog
-    
-    SCHEMA_NAME: The identifier of the schema
-    `
+    SCHEMA_NAME: The identifier of the schema`
 
 	// This command is being previewed; hide from help output.
 	cmd.Hidden = true
@@ -352,8 +345,7 @@ func newRead() *cobra.Command {
   the **USE_SCHEMA** privilege on the parent schema.
 
   Arguments:
-    FULL_NAME_ARG: The three-level (fully qualified) name of the volume
-    `
+    FULL_NAME_ARG: The three-level (fully qualified) name of the volume`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -442,8 +434,7 @@ func newUpdate() *cobra.Command {
   updated.
 
   Arguments:
-    FULL_NAME_ARG: The three-level (fully qualified) name of the volume
-    `
+    FULL_NAME_ARG: The three-level (fully qualified) name of the volume`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/warehouses/warehouses.go
+++ b/cmd/workspace/warehouses/warehouses.go
@@ -167,8 +167,7 @@ func newDelete() *cobra.Command {
   Deletes a SQL warehouse.
 
   Arguments:
-    ID: Required. Id of the SQL warehouse.
-    `
+    ID: Required. Id of the SQL warehouse.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -265,8 +264,7 @@ func newEdit() *cobra.Command {
   Updates the configuration for a SQL warehouse.
 
   Arguments:
-    ID: Required. Id of the warehouse to configure.
-    `
+    ID: Required. Id of the warehouse to configure.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -372,8 +370,7 @@ func newGet() *cobra.Command {
   Gets the information for a single SQL warehouse.
 
   Arguments:
-    ID: Required. Id of the SQL warehouse.
-    `
+    ID: Required. Id of the SQL warehouse.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -449,8 +446,7 @@ func newGetPermissionLevels() *cobra.Command {
   Gets the permission levels that a user can have on an object.
 
   Arguments:
-    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
-    `
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -527,8 +523,7 @@ func newGetPermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
-    `
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -719,8 +714,7 @@ func newSetPermissions() *cobra.Command {
   from their root object.
 
   Arguments:
-    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
-    `
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -886,8 +880,7 @@ func newStart() *cobra.Command {
   Starts a SQL warehouse.
 
   Arguments:
-    ID: Required. Id of the SQL warehouse.
-    `
+    ID: Required. Id of the SQL warehouse.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -987,8 +980,7 @@ func newStop() *cobra.Command {
   Stops a SQL warehouse.
 
   Arguments:
-    ID: Required. Id of the SQL warehouse.
-    `
+    ID: Required. Id of the SQL warehouse.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1088,8 +1080,7 @@ func newUpdatePermissions() *cobra.Command {
   permissions from their root object.
 
   Arguments:
-    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
-    `
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/warehouses/warehouses.go
+++ b/cmd/workspace/warehouses/warehouses.go
@@ -164,7 +164,11 @@ func newDelete() *cobra.Command {
 	cmd.Short = `Delete a warehouse.`
 	cmd.Long = `Delete a warehouse.
   
-  Deletes a SQL warehouse.`
+  Deletes a SQL warehouse.
+
+  Arguments:
+    ID: Required. Id of the SQL warehouse.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -258,7 +262,11 @@ func newEdit() *cobra.Command {
 	cmd.Short = `Update a warehouse.`
 	cmd.Long = `Update a warehouse.
   
-  Updates the configuration for a SQL warehouse.`
+  Updates the configuration for a SQL warehouse.
+
+  Arguments:
+    ID: Required. Id of the warehouse to configure.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -361,7 +369,11 @@ func newGet() *cobra.Command {
 	cmd.Short = `Get warehouse info.`
 	cmd.Long = `Get warehouse info.
   
-  Gets the information for a single SQL warehouse.`
+  Gets the information for a single SQL warehouse.
+
+  Arguments:
+    ID: Required. Id of the SQL warehouse.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -434,7 +446,11 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get SQL warehouse permission levels.`
 	cmd.Long = `Get SQL warehouse permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -508,7 +524,11 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get SQL warehouse permissions.
   
   Gets the permissions of a SQL warehouse. SQL warehouses can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -696,7 +716,11 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set SQL warehouse permissions.
   
   Sets permissions on a SQL warehouse. SQL warehouses can inherit permissions
-  from their root object.`
+  from their root object.
+
+  Arguments:
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -859,7 +883,11 @@ func newStart() *cobra.Command {
 	cmd.Short = `Start a warehouse.`
 	cmd.Long = `Start a warehouse.
   
-  Starts a SQL warehouse.`
+  Starts a SQL warehouse.
+
+  Arguments:
+    ID: Required. Id of the SQL warehouse.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -956,7 +984,11 @@ func newStop() *cobra.Command {
 	cmd.Short = `Stop a warehouse.`
 	cmd.Long = `Stop a warehouse.
   
-  Stops a SQL warehouse.`
+  Stops a SQL warehouse.
+
+  Arguments:
+    ID: Required. Id of the SQL warehouse.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -1053,7 +1085,11 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update SQL warehouse permissions.
   
   Updates the permissions on a SQL warehouse. SQL warehouses can inherit
-  permissions from their root object.`
+  permissions from their root object.
+
+  Arguments:
+    WAREHOUSE_ID: The SQL warehouse for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/workspace-bindings/workspace-bindings.go
+++ b/cmd/workspace/workspace-bindings/workspace-bindings.go
@@ -74,8 +74,7 @@ func newGet() *cobra.Command {
   or an owner of the catalog.
 
   Arguments:
-    NAME: The name of the catalog.
-    `
+    NAME: The name of the catalog.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -141,9 +140,7 @@ func newGetBindings() *cobra.Command {
 
   Arguments:
     SECURABLE_TYPE: The type of the securable.
-    
-    SECURABLE_NAME: The name of the securable.
-    `
+    SECURABLE_NAME: The name of the securable.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -214,8 +211,7 @@ func newUpdate() *cobra.Command {
   admin or an owner of the catalog.
 
   Arguments:
-    NAME: The name of the catalog.
-    `
+    NAME: The name of the catalog.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -292,9 +288,7 @@ func newUpdateBindings() *cobra.Command {
 
   Arguments:
     SECURABLE_TYPE: The type of the securable.
-    
-    SECURABLE_NAME: The name of the securable.
-    `
+    SECURABLE_NAME: The name of the securable.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/workspace-bindings/workspace-bindings.go
+++ b/cmd/workspace/workspace-bindings/workspace-bindings.go
@@ -71,7 +71,11 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get catalog workspace bindings.
   
   Gets workspace bindings of the catalog. The caller must be a metastore admin
-  or an owner of the catalog.`
+  or an owner of the catalog.
+
+  Arguments:
+    NAME: The name of the catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -133,7 +137,13 @@ func newGetBindings() *cobra.Command {
 	cmd.Long = `Get securable workspace bindings.
   
   Gets workspace bindings of the securable. The caller must be a metastore admin
-  or an owner of the securable.`
+  or an owner of the securable.
+
+  Arguments:
+    SECURABLE_TYPE: The type of the securable.
+    
+    SECURABLE_NAME: The name of the securable.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -201,7 +211,11 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update catalog workspace bindings.
   
   Updates workspace bindings of the catalog. The caller must be a metastore
-  admin or an owner of the catalog.`
+  admin or an owner of the catalog.
+
+  Arguments:
+    NAME: The name of the catalog.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -274,7 +288,13 @@ func newUpdateBindings() *cobra.Command {
 	cmd.Long = `Update securable workspace bindings.
   
   Updates workspace bindings of the securable. The caller must be a metastore
-  admin or an owner of the securable.`
+  admin or an owner of the securable.
+
+  Arguments:
+    SECURABLE_TYPE: The type of the securable.
+    
+    SECURABLE_NAME: The name of the securable.
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/workspace-conf/workspace-conf.go
+++ b/cmd/workspace/workspace-conf/workspace-conf.go
@@ -52,11 +52,7 @@ func newGetStatus() *cobra.Command {
 	cmd.Short = `Check configuration status.`
 	cmd.Long = `Check configuration status.
   
-  Gets the configuration status for a workspace.
-
-  Arguments:
-    KEYS: 
-    `
+  Gets the configuration status for a workspace.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/workspace-conf/workspace-conf.go
+++ b/cmd/workspace/workspace-conf/workspace-conf.go
@@ -52,7 +52,11 @@ func newGetStatus() *cobra.Command {
 	cmd.Short = `Check configuration status.`
 	cmd.Long = `Check configuration status.
   
-  Gets the configuration status for a workspace.`
+  Gets the configuration status for a workspace.
+
+  Arguments:
+    KEYS: 
+    `
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/workspace/workspace.go
+++ b/cmd/workspace/workspace/workspace.go
@@ -73,8 +73,7 @@ func newDelete() *cobra.Command {
   atomic.
 
   Arguments:
-    PATH: The absolute path of the notebook or directory.
-    `
+    PATH: The absolute path of the notebook or directory.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -166,9 +165,8 @@ func newExport() *cobra.Command {
   library.
 
   Arguments:
-    PATH: The absolute path of the object or directory. Exporting a directory is only
-    supported for the DBC, SOURCE, and AUTO format.
-    `
+    PATH: The absolute path of the object or directory. Exporting a directory is
+      only supported for the DBC, SOURCE, and AUTO format.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -245,9 +243,7 @@ func newGetPermissionLevels() *cobra.Command {
 
   Arguments:
     WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
-    
-    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
-    `
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -314,9 +310,7 @@ func newGetPermissions() *cobra.Command {
 
   Arguments:
     WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
-    
-    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
-    `
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -382,8 +376,7 @@ func newGetStatus() *cobra.Command {
   call returns an error RESOURCE_DOES_NOT_EXIST.
 
   Arguments:
-    PATH: The absolute path of the notebook or directory.
-    `
+    PATH: The absolute path of the notebook or directory.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -459,9 +452,8 @@ func newImport() *cobra.Command {
   language field.
 
   Arguments:
-    PATH: The absolute path of the object or directory. Importing a directory is only
-    supported for the DBC and SOURCE formats.
-    `
+    PATH: The absolute path of the object or directory. Importing a directory is
+      only supported for the DBC and SOURCE formats.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -544,8 +536,7 @@ func newList() *cobra.Command {
   RESOURCE_DOES_NOT_EXIST.
 
   Arguments:
-    PATH: The absolute path of the notebook or directory.
-    `
+    PATH: The absolute path of the notebook or directory.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -616,10 +607,9 @@ func newMkdirs() *cobra.Command {
   the necessary parent directories.
 
   Arguments:
-    PATH: The absolute path of the directory. If the parent directories do not exist,
-    it will also create them. If the directory already exists, this command will
-    do nothing and succeed.
-    `
+    PATH: The absolute path of the directory. If the parent directories do not
+      exist, it will also create them. If the directory already exists, this
+      command will do nothing and succeed.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -708,9 +698,7 @@ func newSetPermissions() *cobra.Command {
 
   Arguments:
     WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
-    
-    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
-    `
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 
@@ -787,9 +775,7 @@ func newUpdatePermissions() *cobra.Command {
 
   Arguments:
     WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
-    
-    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
-    `
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.`
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/workspace/workspace.go
+++ b/cmd/workspace/workspace/workspace.go
@@ -70,7 +70,11 @@ func newDelete() *cobra.Command {
   DIRECTORY_NOT_EMPTY.
   
   Object deletion cannot be undone and deleting a directory recursively is not
-  atomic.`
+  atomic.
+
+  Arguments:
+    PATH: The absolute path of the notebook or directory.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -159,7 +163,12 @@ func newExport() *cobra.Command {
   
   If the exported data would exceed size limit, this call returns
   MAX_NOTEBOOK_SIZE_EXCEEDED. Currently, this API does not support exporting a
-  library.`
+  library.
+
+  Arguments:
+    PATH: The absolute path of the object or directory. Exporting a directory is only
+    supported for the DBC, SOURCE, and AUTO format.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -232,7 +241,13 @@ func newGetPermissionLevels() *cobra.Command {
 	cmd.Short = `Get workspace object permission levels.`
 	cmd.Long = `Get workspace object permission levels.
   
-  Gets the permission levels that a user can have on an object.`
+  Gets the permission levels that a user can have on an object.
+
+  Arguments:
+    WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
+    
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -295,7 +310,13 @@ func newGetPermissions() *cobra.Command {
 	cmd.Long = `Get workspace object permissions.
   
   Gets the permissions of a workspace object. Workspace objects can inherit
-  permissions from their parent objects or root object.`
+  permissions from their parent objects or root object.
+
+  Arguments:
+    WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
+    
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -358,7 +379,11 @@ func newGetStatus() *cobra.Command {
 	cmd.Long = `Get status.
   
   Gets the status of an object or a directory. If path does not exist, this
-  call returns an error RESOURCE_DOES_NOT_EXIST.`
+  call returns an error RESOURCE_DOES_NOT_EXIST.
+
+  Arguments:
+    PATH: The absolute path of the notebook or directory.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -431,7 +456,12 @@ func newImport() *cobra.Command {
   false, this call returns an error RESOURCE_ALREADY_EXISTS. To import a
   directory, you can use either the DBC format or the SOURCE format with the
   language field unset. To import a single file as SOURCE, you must set the
-  language field.`
+  language field.
+
+  Arguments:
+    PATH: The absolute path of the object or directory. Importing a directory is only
+    supported for the DBC and SOURCE formats.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -511,7 +541,11 @@ func newList() *cobra.Command {
   
   Lists the contents of a directory, or the object if it is not a directory. If
   the input path does not exist, this call returns an error
-  RESOURCE_DOES_NOT_EXIST.`
+  RESOURCE_DOES_NOT_EXIST.
+
+  Arguments:
+    PATH: The absolute path of the notebook or directory.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -579,7 +613,13 @@ func newMkdirs() *cobra.Command {
   path, this call returns an error RESOURCE_ALREADY_EXISTS.
   
   Note that if this operation fails it may have succeeded in creating some of
-  the necessary parent directories.`
+  the necessary parent directories.
+
+  Arguments:
+    PATH: The absolute path of the directory. If the parent directories do not exist,
+    it will also create them. If the directory already exists, this command will
+    do nothing and succeed.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -664,7 +704,13 @@ func newSetPermissions() *cobra.Command {
 	cmd.Long = `Set workspace object permissions.
   
   Sets permissions on a workspace object. Workspace objects can inherit
-  permissions from their parent objects or root object.`
+  permissions from their parent objects or root object.
+
+  Arguments:
+    WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
+    
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 
@@ -737,7 +783,13 @@ func newUpdatePermissions() *cobra.Command {
 	cmd.Long = `Update workspace object permissions.
   
   Updates the permissions on a workspace object. Workspace objects can inherit
-  permissions from their parent objects or root object.`
+  permissions from their parent objects or root object.
+
+  Arguments:
+    WORKSPACE_OBJECT_TYPE: The workspace object type for which to get or manage permissions.
+    
+    WORKSPACE_OBJECT_ID: The workspace object for which to get or manage permissions.
+    `
 
 	cmd.Annotations = make(map[string]string)
 


### PR DESCRIPTION
## Changes
This PR adds documentation for positional arguments in commands that are generated from the openapi spec.

Note: the changes to `.gitattributes` will be revert / properly fixed in https://github.com/databricks/cli/pull/1012


