### PR TITLE
Ask for host when .databrickscfg doesn't exist

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -133,7 +133,7 @@ func setHost(ctx context.Context, profileName string, persistentAuth *auth.Persi
 		return p.Name == profileName
 	})
 	// Tolerate ErrNoConfiguration here, as we will write out a configuration as part of the login flow.
-	if !errors.Is(err, databrickscfg.ErrNoConfiguration) {
+	if err != nil && !errors.Is(err, databrickscfg.ErrNoConfiguration) {
 		return err
 	}
 	if persistentAuth.Host == "" {


### PR DESCRIPTION
## Changes
Ask for host when .databrickscfg doesn't exist

This fixes a regression introduced by https://github.com/databricks/cli/pull/1003
