### PR TITLE
Stub out Python virtual environment installation for `labs` commands

### DIFF
--- a/cmd/labs/project/installer_test.go
+++ b/cmd/labs/project/installer_test.go
@@ -197,9 +197,10 @@ func TestInstallerWorksForReleases(t *testing.T) {
 
 	ctx, stub := process.WithStub(ctx)
 	stub.WithStdoutFor(`python[\S]+ --version`, "Python 3.10.5")
+	// on Unix, we call `python3`, but on Windows it is `python.exe`
 	stub.WithStderrFor(`python[\S]+ -m venv .*/.databricks/labs/blueprint/state/venv`, "[mock venv create]")
-	stub.WithStderrFor(`python3 -m pip install .`, "[mock pip install]")
-	stub.WithStdoutFor(`python3 install.py`, "setting up important infrastructure")
+	stub.WithStderrFor(`python[\S]+ -m pip install .`, "[mock pip install]")
+	stub.WithStdoutFor(`python[\S]+ install.py`, "setting up important infrastructure")
 
 	// simulate the case of GitHub Actions
 	ctx = env.Set(ctx, "DATABRICKS_HOST", server.URL)

--- a/libs/process/stub.go
+++ b/libs/process/stub.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -140,7 +139,6 @@ var ErrStubContinue = errors.New("continue executing the stub after callback")
 func (s *processStub) run(cmd *exec.Cmd) error {
 	s.calls = append(s.calls, cmd)
 	for pattern, resp := range s.responses {
-		pattern = strings.ReplaceAll(pattern, string(os.PathSeparator), "/")
 		re := regexp.MustCompile(pattern)
 		norm := s.normCmd(cmd)
 		if !re.MatchString(norm) {

--- a/libs/process/stub.go
+++ b/libs/process/stub.go
@@ -130,7 +130,11 @@ func (s *processStub) normCmd(v *exec.Cmd) string {
 	// "/var/folders/bc/7qf8yghj6v14t40096pdcqy40000gp/T/tmp.03CAcYcbOI/python3" becomes "python3".
 	// Use [processStub.WithCallback] if you need to match against the full executable path.
 	binaryName := filepath.Base(v.Path)
-	args := strings.Join(v.Args[1:], " ")
+	var unixArgs []string
+	for _, arg := range v.Args[1:] {
+		unixArgs = append(unixArgs, filepath.ToSlash(arg))
+	}
+	args := strings.Join(unixArgs, " ")
 	return fmt.Sprintf("%s %s", binaryName, args)
 }
 


### PR DESCRIPTION
This PR removes 15 seconds from `make test` runtime


