### PR TITLE
Fix passthrough of pipeline notifications

### DIFF
--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -140,6 +140,12 @@ func BundleToTerraform(config *config.Root) *schema.Root {
 				conv(v, &l)
 				dst.Cluster = append(dst.Cluster, l)
 			}
+
+			for _, v := range src.Notifications {
+				var l schema.ResourcePipelineNotification
+				conv(v, &l)
+				dst.Notification = append(dst.Notification, l)
+			}
 		}
 
 		tfroot.Resource.Pipeline[k] = &dst

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -139,6 +139,26 @@ func TestConvertPipeline(t *testing.T) {
 					},
 				},
 			},
+			Notifications: []pipelines.Notifications{
+				{
+					Alerts: []string{
+						"on-update-fatal-failure",
+					},
+					EmailRecipients: []string{
+						"jane@doe.com",
+					},
+				},
+				{
+					Alerts: []string{
+						"on-update-failure",
+						"on-flow-failure",
+					},
+					EmailRecipients: []string{
+						"jane@doe.com",
+						"john@doe.com",
+					},
+				},
+			},
 		},
 	}
 
@@ -153,6 +173,12 @@ func TestConvertPipeline(t *testing.T) {
 	out := BundleToTerraform(&config)
 	assert.Equal(t, "my pipeline", out.Resource.Pipeline["my_pipeline"].Name)
 	assert.Len(t, out.Resource.Pipeline["my_pipeline"].Library, 2)
+	notifs := out.Resource.Pipeline["my_pipeline"].Notification
+	assert.Len(t, notifs, 2)
+	assert.Equal(t, notifs[0].Alerts, []string{"on-update-fatal-failure"})
+	assert.Equal(t, notifs[0].EmailRecipients, []string{"jane@doe.com"})
+	assert.Equal(t, notifs[1].Alerts, []string{"on-update-failure", "on-flow-failure"})
+	assert.Equal(t, notifs[1].EmailRecipients, []string{"jane@doe.com", "john@doe.com"})
 	assert.Nil(t, out.Data)
 }
 


### PR DESCRIPTION
## Changes

Notifications weren't passed along because of a plural vs singular mismatch.

## Tests

* Added unit test coverage.
* Manually confirmed it now works in an example bundle.
