### PR TITLE
Skip profile resolution if `DATABRICKS_AUTH_TYPE` is set

### DIFF
--- a/libs/databrickscfg/loader.go
+++ b/libs/databrickscfg/loader.go
@@ -108,6 +108,7 @@ func (l profileFromHostLoader) Configure(cfg *config.Config) error {
 }
 
 func (l profileFromHostLoader) isAnyAuthConfigured(cfg *config.Config) bool {
+	// If any of the auth-specific attributes are set, we can skip profile resolution.
 	for _, a := range config.ConfigAttributes {
 		if a.Auth == "" {
 			continue
@@ -116,5 +117,7 @@ func (l profileFromHostLoader) isAnyAuthConfigured(cfg *config.Config) bool {
 			return true
 		}
 	}
-	return false
+	// If the auth type is set, we can skip profile resolution.
+	// For example, to force "azure-cli", only the host and the auth type will be set.
+	return cfg.AuthType != ""
 }

--- a/libs/databrickscfg/loader_test.go
+++ b/libs/databrickscfg/loader_test.go
@@ -32,6 +32,23 @@ func TestLoaderSkipsExistingAuth(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLoaderSkipsExplicitAuthType(t *testing.T) {
+	cfg := config.Config{
+		Loaders: []config.Loader{
+			ResolveProfileFromHost,
+		},
+		ConfigFile: "testdata/databrickscfg",
+		Host:       "https://default",
+		AuthType:   "azure-cli",
+	}
+
+	err := cfg.EnsureResolved()
+	assert.NoError(t, err)
+	assert.Equal(t, "azure-cli", cfg.AuthType)
+	assert.Empty(t, cfg.Profile)
+	assert.Empty(t, cfg.Token)
+}
+
 func TestLoaderSkipsNonExistingConfigFile(t *testing.T) {
 	cfg := config.Config{
 		Loaders: []config.Loader{


### PR DESCRIPTION
## Changes

If a user configures a workspace host in a bundle and wants to use the "azure-cli" authentication type, we would still run profile resolution. If the databrickscfg has a matching profile, we still load it, even though it should be a fallback.

## Tests

* Unit test.
* Manually confirmed that setting `DATABRICKS_AUTH_TYPE=azure-cli` now works as expected.