### PR TITLE
Do not allow input prompts in Git Bash terminal

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -131,7 +131,7 @@ See https://docs.databricks.com/en/dev-tools/bundles/templates.html for more inf
 			templatePath = args[0]
 		} else {
 			var err error
-			if !cmdio.IsOutTTY(ctx) || !cmdio.IsInTTY(ctx) {
+			if !cmdio.IsPromptSupported(ctx) {
 				return errors.New("please specify a template")
 			}
 			templatePath, err = cmdio.AskSelect(ctx, "Template to use", nativeTemplateOptions())

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -45,7 +45,7 @@ func newRunCommand() *cobra.Command {
 		}
 
 		// If no arguments are specified, prompt the user to select something to run.
-		if len(args) == 0 && cmdio.IsInteractive(ctx) {
+		if len(args) == 0 && cmdio.IsPromptSupported(ctx) {
 			// Invert completions from KEY -> NAME, to NAME -> KEY.
 			inv := make(map[string]string)
 			for k, v := range run.ResourceCompletionMap(b) {

--- a/cmd/labs/project/installer.go
+++ b/cmd/labs/project/installer.go
@@ -157,7 +157,7 @@ func (i *installer) recordVersion(ctx context.Context) error {
 }
 
 func (i *installer) login(ctx context.Context) (*databricks.WorkspaceClient, error) {
-	if !cmdio.IsInteractive(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		log.Debugf(ctx, "Skipping workspace profile prompts in non-interactive mode")
 		return nil, nil
 	}

--- a/cmd/labs/project/login.go
+++ b/cmd/labs/project/login.go
@@ -50,7 +50,7 @@ func (lc *loginConfig) askWorkspaceProfile(ctx context.Context, cfg *config.Conf
 		lc.WorkspaceProfile = cfg.Profile
 		return
 	}
-	if !cmdio.IsInteractive(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return ErrNotInTTY
 	}
 	lc.WorkspaceProfile, err = root.AskForWorkspaceProfile(ctx)
@@ -66,7 +66,7 @@ func (lc *loginConfig) askCluster(ctx context.Context, w *databricks.WorkspaceCl
 		lc.ClusterID = w.Config.ClusterID
 		return
 	}
-	if !cmdio.IsInteractive(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return ErrNotInTTY
 	}
 	clusterID, err := cfgpickers.AskForCluster(ctx, w,
@@ -87,7 +87,7 @@ func (lc *loginConfig) askWarehouse(ctx context.Context, w *databricks.Workspace
 		lc.WarehouseID = w.Config.WarehouseID
 		return
 	}
-	if !cmdio.IsInteractive(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return ErrNotInTTY
 	}
 	lc.WarehouseID, err = cfgpickers.AskForWarehouse(ctx, w,
@@ -99,7 +99,7 @@ func (lc *loginConfig) askAccountProfile(ctx context.Context, cfg *config.Config
 	if !lc.HasAccountLevelCommands() {
 		return nil
 	}
-	if !cmdio.IsInteractive(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return ErrNotInTTY
 	}
 	lc.AccountProfile, err = root.AskForAccountProfile(ctx)

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -41,7 +41,7 @@ func accountClientOrPrompt(ctx context.Context, cfg *config.Config, allowPrompt 
 	}
 
 	prompt := false
-	if allowPrompt && err != nil && cmdio.IsInteractive(ctx) {
+	if allowPrompt && err != nil && cmdio.IsPromptSupported(ctx) {
 		// Prompt to select a profile if the current configuration is not an account client.
 		prompt = prompt || errors.Is(err, databricks.ErrNotAccountClient)
 		// Prompt to select a profile if the current configuration doesn't resolve to a credential provider.
@@ -109,7 +109,7 @@ func workspaceClientOrPrompt(ctx context.Context, cfg *config.Config, allowPromp
 	}
 
 	prompt := false
-	if allowPrompt && err != nil && cmdio.IsInteractive(ctx) {
+	if allowPrompt && err != nil && cmdio.IsPromptSupported(ctx) {
 		// Prompt to select a profile if the current configuration is not a workspace client.
 		prompt = prompt || errors.Is(err, databricks.ErrNotWorkspaceClient)
 		// Prompt to select a profile if the current configuration doesn't resolve to a credential provider.

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -103,7 +103,7 @@ func IsPromptSupported(ctx context.Context) bool {
 
 func IsGitBash(ctx context.Context) bool {
 	// Check if the MSYSTEM environment variable is set to "MINGW64"
-	msystem := os.Getenv("MSYSTEM")
+	msystem := env.Get(ctx, "MSYSTEM")
 	if strings.EqualFold(msystem, "MINGW64") {
 		// Check for typical Git Bash env variable for prompts
 		ps1 := env.Get(ctx, "PS1")

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -104,9 +104,8 @@ func IsGitBash(ctx context.Context) bool {
 	// Check if the MSYSTEM environment variable is set to "MINGW64"
 	msystem := os.Getenv("MSYSTEM")
 	if strings.EqualFold(msystem, "MINGW64") {
-		// Check for typical Git Bash prompt patterns
-		prompt := os.Getenv("PS1")
-		return strings.Contains(prompt, "MINGW")
+		// Check for typical Git Bash env variable for prompts
+		return os.Getenv("PS1") != ""
 	}
 
 	return false

--- a/libs/cmdio/io_test.go
+++ b/libs/cmdio/io_test.go
@@ -1,0 +1,21 @@
+package cmdio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPromptSupportedFalseForGitBash(t *testing.T) {
+	ctx := context.Background()
+	ctx, _ = SetupTest(ctx)
+
+	assert.True(t, IsPromptSupported(ctx))
+
+	ctx = env.Set(ctx, "MSYSTEM", "MINGW64")
+	ctx = env.Set(ctx, "TERM", "xterm")
+	ctx = env.Set(ctx, "PS1", "\\[\033]0;$TITLEPREFIX:$PWD\007\\]\n\\[\033[32m\\]\\u@\\h \\[\033[35m\\]$MSYSTEM \\[\033[33m\\]\\w\\[\033[36m\\]`__git_ps1`\\[\033[0m\\]\n$")
+	assert.False(t, IsPromptSupported(ctx))
+}

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -212,7 +212,7 @@ func (c *config) promptForValues(r *renderer) error {
 // Prompt user for any missing config values. Assign default values if
 // terminal is not TTY
 func (c *config) promptOrAssignDefaultValues(r *renderer) error {
-	if cmdio.IsOutTTY(c.ctx) && cmdio.IsInTTY(c.ctx) {
+	if cmdio.IsPromptSupported(c.ctx) {
 		return c.promptForValues(r)
 	}
 	return c.assignDefaultValues(r)


### PR DESCRIPTION
## Changes

Likely due to fact that Git Bash does not correctly support ANSI escape sequences, we cannot use `promptui` package there. See known issues:

- https://github.com/manifoldco/promptui/issues/208
- https://github.com/chzyer/readline/issues/191

