### PR TITLE
Revert using IsPromptSupported from promptOrAssignDefaultValues

### DIFF
--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -212,7 +212,8 @@ func (c *config) promptForValues(r *renderer) error {
 // Prompt user for any missing config values. Assign default values if
 // terminal is not TTY
 func (c *config) promptOrAssignDefaultValues(r *renderer) error {
-	if cmdio.IsPromptSupported(c.ctx) {
+	// TODO: replace with IsPromptSupported call (requires fixing TestAccBundleInitErrorOnUnknownFields test)
+	if cmdio.IsOutTTY(c.ctx) && cmdio.IsInTTY(c.ctx) {
 		return c.promptForValues(r)
 	}
 	return c.assignDefaultValues(r)


### PR DESCRIPTION
## Changes

Fixes nightly test `TestAccBundleInitErrorOnUnknownFields`. 

`TestAccBundleInitErrorOnUnknownFields` has an interactive shell by default so the test fails on waiting for prompt.

This was introduced in #1069.

## Tests

Nightly test succeed.
