### PR TITLE
Release v0.211.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CLI:
 Bundles:
 * Set metadata fields required to enable break-glass UI for jobs ([#880](https://github.com/databricks/cli/pull/880)).
 * Do not prompt for template values in Git Bash ([#1082](https://github.com/databricks/cli/pull/1082)).
+* Tune output of bundle deploy command ([#1047](https://github.com/databricks/cli/pull/1047)).
 
 API Changes:
  * Changed `databricks connections update` command with new required argument order.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Version changelog
 
+## 0.211.0
+
+CLI:
+ * Upgrade Go SDK to 0.27.0 ([#1064](https://github.com/databricks/cli/pull/1064)).
+ * Skip profile resolution if `DATABRICKS_AUTH_TYPE` is set ([#1068](https://github.com/databricks/cli/pull/1068)).
+ * Test existing behavior when loading non-string spark conf values ([#1071](https://github.com/databricks/cli/pull/1071)).
+ * Do not allow input prompts in Git Bash terminal ([#1069](https://github.com/databricks/cli/pull/1069)).
+ * Added output template for list-secrets command ([#1074](https://github.com/databricks/cli/pull/1074)).
+ * Set metadata fields required to enable break-glass UI for jobs ([#880](https://github.com/databricks/cli/pull/880)).
+ * Revert using IsPromptSupported from promptOrAssignDefaultValues ([#1077](https://github.com/databricks/cli/pull/1077)).
+ * Do not prompt for template values in Git Bash ([#1082](https://github.com/databricks/cli/pull/1082)).
+
+Bundles:
+ * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
+
+Internal:
+ * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
+
+API Changes:
+ * Changed `databricks connections update` command with new required argument order.
+ * Changed `databricks serving-endpoints update-config` command with new required argument order.
+ * Added `databricks serving-endpoints put` command.
+ * Removed `databricks account network-policy` command group.
+
+OpenAPI commit 63caa3cb0c05045e81d3dcf2451fa990d8670f36 (2023-12-12)
+Dependency updates:
+ * Bump github.com/google/uuid from 1.4.0 to 1.5.0 ([#1073](https://github.com/databricks/cli/pull/1073)).
+ * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 ([#1076](https://github.com/databricks/cli/pull/1076)).
+
 ## 0.210.3
 
 Bundles:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,12 @@
 CLI:
  * Upgrade Go SDK to 0.27.0 ([#1064](https://github.com/databricks/cli/pull/1064)).
  * Skip profile resolution if `DATABRICKS_AUTH_TYPE` is set ([#1068](https://github.com/databricks/cli/pull/1068)).
- * Test existing behavior when loading non-string spark conf values ([#1071](https://github.com/databricks/cli/pull/1071)).
  * Do not allow input prompts in Git Bash terminal ([#1069](https://github.com/databricks/cli/pull/1069)).
  * Added output template for list-secrets command ([#1074](https://github.com/databricks/cli/pull/1074)).
- * Set metadata fields required to enable break-glass UI for jobs ([#880](https://github.com/databricks/cli/pull/880)).
- * Revert using IsPromptSupported from promptOrAssignDefaultValues ([#1077](https://github.com/databricks/cli/pull/1077)).
- * Do not prompt for template values in Git Bash ([#1082](https://github.com/databricks/cli/pull/1082)).
 
 Bundles:
- * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
-
-Internal:
- * **FILL THIS IN MANUALLY BY MOVING RELEVANT ITEMS FROM ABOVE LIST**
+* Set metadata fields required to enable break-glass UI for jobs ([#880](https://github.com/databricks/cli/pull/880)).
+* Do not prompt for template values in Git Bash ([#1082](https://github.com/databricks/cli/pull/1082)).
 
 API Changes:
  * Changed `databricks connections update` command with new required argument order.
@@ -25,6 +19,7 @@ API Changes:
  * Removed `databricks account network-policy` command group.
 
 OpenAPI commit 63caa3cb0c05045e81d3dcf2451fa990d8670f36 (2023-12-12)
+
 Dependency updates:
  * Bump github.com/google/uuid from 1.4.0 to 1.5.0 ([#1073](https://github.com/databricks/cli/pull/1073)).
  * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 ([#1076](https://github.com/databricks/cli/pull/1076)).


### PR DESCRIPTION
CLI:
 * Upgrade Go SDK to 0.27.0 ([#1064](https://github.com/databricks/cli/pull/1064)).
 * Skip profile resolution if `DATABRICKS_AUTH_TYPE` is set ([#1068](https://github.com/databricks/cli/pull/1068)).
 * Do not allow input prompts in Git Bash terminal ([#1069](https://github.com/databricks/cli/pull/1069)).
 * Added output template for list-secrets command ([#1074](https://github.com/databricks/cli/pull/1074)).

Bundles:
* Set metadata fields required to enable break-glass UI for jobs ([#880](https://github.com/databricks/cli/pull/880)).
* Do not prompt for template values in Git Bash ([#1082](https://github.com/databricks/cli/pull/1082)).
* Tune output of bundle deploy command ([#1047](https://github.com/databricks/cli/pull/1047)).

API Changes:
 * Changed `databricks connections update` command with new required argument order.
 * Changed `databricks serving-endpoints update-config` command with new required argument order.
 * Added `databricks serving-endpoints put` command.
 * Removed `databricks account network-policy` command group.

OpenAPI commit 63caa3cb0c05045e81d3dcf2451fa990d8670f36 (2023-12-12)

Dependency updates:
 * Bump github.com/google/uuid from 1.4.0 to 1.5.0 ([#1073](https://github.com/databricks/cli/pull/1073)).
 * Bump golang.org/x/crypto from 0.16.0 to 0.17.0 ([#1076](https://github.com/databricks/cli/pull/1076)).

