### PR TITLE
Customize the prefix assigned to resources deployed in development mode

### DIFF
--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -42,7 +42,7 @@ type Bundle struct {
 	Mode Mode `json:"mode,omitempty" bundle:"readonly"`
 
 	// Prefix for the names of the resources deployed in development mode
-	// The default one is "[dev ${workspace.current_user.userName}]"
+	// The default one is "dev ${workspace.current_user.shortName}"
 	ResourceNamePrefix string `json:"resource_name_prefix,omitempty" bundle:"readonly"`
 
 	// Overrides the compute used for jobs and other supported assets.

--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -41,6 +41,10 @@ type Bundle struct {
 	// Annotated readonly as this should be set at the target level.
 	Mode Mode `json:"mode,omitempty" bundle:"readonly"`
 
+	// Prefix for the names of the resources deployed in development mode
+	// The default one is "[dev ${workspace.current_user.userName}]"
+	ResourceNamePrefix string `json:"resource_name_prefix,omitempty" bundle:"readonly"`
+
 	// Overrides the compute used for jobs and other supported assets.
 	ComputeID string `json:"compute_id,omitempty"`
 }

--- a/bundle/config/mutator/process_target_mode.go
+++ b/bundle/config/mutator/process_target_mode.go
@@ -34,6 +34,9 @@ func transformDevelopmentMode(b *bundle.Bundle) error {
 
 	shortName := b.Config.Workspace.CurrentUser.ShortName
 	prefix := "[dev " + shortName + "] "
+	if b.Config.Bundle.ResourceNamePrefix != "" {
+		prefix = "[" + b.Config.Bundle.ResourceNamePrefix + "] "
+	}
 
 	// Generate a normalized version of the short name that can be used as a tag value.
 	tagValue := b.Tagging.NormalizeValue(shortName)

--- a/bundle/config/mutator/process_target_mode.go
+++ b/bundle/config/mutator/process_target_mode.go
@@ -29,7 +29,7 @@ func (m *processTargetMode) Name() string {
 // Normalize the resource name prefix in order to use it
 // in constrained contexts such as model serving endpoints names
 func normalizeResourceNamePrefix(prefix string) string {
-	return strings.Map(replaceNonAlphanumeric, strings.ToLower(strings.ReplaceAll(prefix, " ", "_") + "_"))
+	return strings.Map(replaceNonAlphanumeric, strings.ToLower(strings.ReplaceAll(prefix, " ", "_")+"_"))
 }
 
 // Mark all resources as being for 'development' purposes, i.e.

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -146,6 +146,20 @@ func TestProcessTargetModeDevelopment(t *testing.T) {
 	assert.Equal(t, "dev_lennart_registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 }
 
+func TestProcessTargetModeDevelopmentCustomResourceNamePrefix(t *testing.T) {
+	b := mockBundle(config.Development)
+	b.Config.Bundle.ResourceNamePrefix = "custom"
+
+	m := ProcessTargetMode()
+	err := bundle.Apply(context.Background(), b, m)
+	require.NoError(t, err)
+
+	// Job 1
+	assert.Equal(t, "[custom] job1", b.Config.Resources.Jobs["job1"].Name)
+	assert.Equal(t, b.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
+	assert.Equal(t, b.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
+}
+
 func TestProcessTargetModeDevelopmentTagNormalizationForAws(t *testing.T) {
 	b := mockBundle(config.Development)
 	b.Tagging = tags.ForCloud(&sdkconfig.Config{

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -148,16 +148,35 @@ func TestProcessTargetModeDevelopment(t *testing.T) {
 
 func TestProcessTargetModeDevelopmentCustomResourceNamePrefix(t *testing.T) {
 	b := mockBundle(config.Development)
-	b.Config.Bundle.ResourceNamePrefix = "custom"
+	b.Config.Bundle.ResourceNamePrefix = "Staging @us-east-1"
 
 	m := ProcessTargetMode()
 	err := bundle.Apply(context.Background(), b, m)
 	require.NoError(t, err)
 
 	// Job 1
-	assert.Equal(t, "[custom] job1", b.Config.Resources.Jobs["job1"].Name)
-	assert.Equal(t, b.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
-	assert.Equal(t, b.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
+	assert.Equal(t, "[Staging @us-east-1] job1", b.Config.Resources.Jobs["job1"].Name)
+
+	// Job 2
+	assert.Equal(t, "[Staging @us-east-1] job2", b.Config.Resources.Jobs["job2"].Name)
+
+	// Pipeline 1
+	assert.Equal(t, "[Staging @us-east-1] pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
+
+	// Experiment 1
+	assert.Equal(t, "/Users/lennart.kats@databricks.com/[Staging @us-east-1] experiment1", b.Config.Resources.Experiments["experiment1"].Name)
+
+	// Experiment 2
+	assert.Equal(t, "[Staging @us-east-1] experiment2", b.Config.Resources.Experiments["experiment2"].Name)
+
+	// Model 1
+	assert.Equal(t, "[Staging @us-east-1] model1", b.Config.Resources.Models["model1"].Name)
+
+	// Model serving endpoint 1
+	assert.Equal(t, "staging__us_east_1_servingendpoint1", b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
+
+	// Registered model 1
+	assert.Equal(t, "staging__us_east_1_registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 }
 
 func TestProcessTargetModeDevelopmentCustomDeploymentTag(t *testing.T) {
@@ -170,8 +189,6 @@ func TestProcessTargetModeDevelopmentCustomDeploymentTag(t *testing.T) {
 
 	// Job 1
 	assert.Equal(t, "[custom] job1", b.Config.Resources.Jobs["job1"].Name)
-	assert.Equal(t, b.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
-	assert.Equal(t, b.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
 }
 
 func TestProcessTargetModeDevelopmentTagNormalizationForAws(t *testing.T) {

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -179,18 +179,6 @@ func TestProcessTargetModeDevelopmentCustomResourceNamePrefix(t *testing.T) {
 	assert.Equal(t, "staging__us_east_1_registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 }
 
-func TestProcessTargetModeDevelopmentCustomDeploymentTag(t *testing.T) {
-	b := mockBundle(config.Development)
-	b.Config.Bundle.ResourceNamePrefix = "custom"
-
-	m := ProcessTargetMode()
-	err := bundle.Apply(context.Background(), b, m)
-	require.NoError(t, err)
-
-	// Job 1
-	assert.Equal(t, "[custom] job1", b.Config.Resources.Jobs["job1"].Name)
-}
-
 func TestProcessTargetModeDevelopmentTagNormalizationForAws(t *testing.T) {
 	b := mockBundle(config.Development)
 	b.Tagging = tags.ForCloud(&sdkconfig.Config{

--- a/bundle/config/mutator/process_target_mode_test.go
+++ b/bundle/config/mutator/process_target_mode_test.go
@@ -160,6 +160,20 @@ func TestProcessTargetModeDevelopmentCustomResourceNamePrefix(t *testing.T) {
 	assert.Equal(t, b.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
 }
 
+func TestProcessTargetModeDevelopmentCustomDeploymentTag(t *testing.T) {
+	b := mockBundle(config.Development)
+	b.Config.Bundle.ResourceNamePrefix = "custom"
+
+	m := ProcessTargetMode()
+	err := bundle.Apply(context.Background(), b, m)
+	require.NoError(t, err)
+
+	// Job 1
+	assert.Equal(t, "[custom] job1", b.Config.Resources.Jobs["job1"].Name)
+	assert.Equal(t, b.Config.Resources.Jobs["job1"].Tags["dev"], "lennart")
+	assert.Equal(t, b.Config.Resources.Jobs["job1"].Schedule.PauseStatus, jobs.PauseStatusPaused)
+}
+
 func TestProcessTargetModeDevelopmentTagNormalizationForAws(t *testing.T) {
 	b := mockBundle(config.Development)
 	b.Tagging = tags.ForCloud(&sdkconfig.Config{

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -227,6 +227,8 @@ func (r *Root) MergeTargetOverrides(target *Target) error {
 		r.RunAs = target.RunAs
 	}
 
+	r.Bundle.ResourceNamePrefix = target.ResourceNamePrefix
+
 	if target.Mode != "" {
 		r.Bundle.Mode = target.Mode
 	}

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -227,7 +227,9 @@ func (r *Root) MergeTargetOverrides(target *Target) error {
 		r.RunAs = target.RunAs
 	}
 
-	r.Bundle.ResourceNamePrefix = target.ResourceNamePrefix
+	if target.ResourceNamePrefix != "" {
+		r.Bundle.ResourceNamePrefix = target.ResourceNamePrefix
+	}
 
 	if target.Mode != "" {
 		r.Bundle.Mode = target.Mode

--- a/bundle/config/target.go
+++ b/bundle/config/target.go
@@ -19,6 +19,10 @@ type Target struct {
 	// development purposes.
 	Mode Mode `json:"mode,omitempty"`
 
+	// Prefix for the names of the resources deployed in development mode
+	// The default one is "[dev ${workspace.current_user.userName}]"
+	ResourceNamePrefix string `json:"resource_name_prefix,omitempty"`
+
 	// Overrides the compute used for jobs and other supported assets.
 	ComputeID string `json:"compute_id,omitempty"`
 

--- a/bundle/config/target.go
+++ b/bundle/config/target.go
@@ -20,7 +20,7 @@ type Target struct {
 	Mode Mode `json:"mode,omitempty"`
 
 	// Prefix for the names of the resources deployed in development mode
-	// The default one is "[dev ${workspace.current_user.userName}]"
+	// The default one is "dev ${workspace.current_user.shortName}"
 	ResourceNamePrefix string `json:"resource_name_prefix,omitempty"`
 
 	// Overrides the compute used for jobs and other supported assets.
@@ -50,7 +50,7 @@ type Target struct {
 
 const (
 	// Development mode: deployments done purely for running things in development.
-	// Any deployed resources will be marked as "dev" and might be hidden or cleaned up.
+	// Any deployed resources will be marked as "dev" (or custom a `tag`) and might be hidden or cleaned up.
 	Development Mode = "development"
 
 	// Production mode: deployments done for production purposes.

--- a/bundle/config/target.go
+++ b/bundle/config/target.go
@@ -50,7 +50,7 @@ type Target struct {
 
 const (
 	// Development mode: deployments done purely for running things in development.
-	// Any deployed resources will be marked as "dev" (or custom a `tag`) and might be hidden or cleaned up.
+	// Any deployed resources will be marked as "dev" and might be hidden or cleaned up.
 	Development Mode = "development"
 
 	// Production mode: deployments done for production purposes.


### PR DESCRIPTION
## Changes

> Note: I went with this approach so everyone can fit it to their needs but IMO it would be enough to just change the process_target_mode module so the **prefix matches the target name** instead of being hard coded as `dev`. I’d gladly rework the PR if this simpler approach is enough.

All the names of the resources (i.e. jobs, pipelines, models endpoints) deployed in development mode are prefixed with `[dev user_name]` which can be confusing when an organization has multiple development environments to choose from.

This pull request adds an **optional** `resource_name_prefix` field to the  bundles `target` object, allowing developers to specify custom prefixes:

```yaml
bundle
  name: test

targets:
  dev:
    # Deployed resources get prefixed with '[hello test]'
    resource_name_prefix: hello ${bundle.name}
    mode: development
```

## Open points

* Is this something you would be open to accept?
* This is the first time I contribute to the project so I could have missed something
* I agree the name of the field might be a bit confusing: I'm open to suggestions

## Tests

* Added a new unit test to the `process_target_mode` module test suite