### PR TITLE
Tweak command groups in CLI help

### DIFF
--- a/cmd/bundle/bundle.go
+++ b/cmd/bundle/bundle.go
@@ -6,9 +6,10 @@ import (
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "bundle",
-		Short: "Databricks Asset Bundles",
-		Long:  "Databricks Asset Bundles\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles",
+		Use:     "bundle",
+		Short:   "Databricks Asset Bundles let you express data/AI/analytics projects as code.",
+		Long:    "Databricks Asset Bundles let you express data/AI/analytics projects as code.\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles",
+		GroupID: "development",
 	}
 
 	initVariableFlag(cmd)

--- a/cmd/fs/fs.go
+++ b/cmd/fs/fs.go
@@ -6,9 +6,10 @@ import (
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "fs",
-		Short: "Filesystem related commands",
-		Long:  `Commands to do DBFS operations.`,
+		Use:     "fs",
+		Short:   "Filesystem related commands",
+		Long:    `Commands to do DBFS operations.`,
+		GroupID: "workspace",
 	}
 
 	cmd.AddCommand(

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -76,9 +76,10 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sync [flags] SRC DST",
-		Short: "Synchronize a local directory to a workspace directory",
-		Args:  cobra.MaximumNArgs(2),
+		Use:     "sync [flags] SRC DST",
+		Short:   "Synchronize a local directory to a workspace directory",
+		Args:    cobra.MaximumNArgs(2),
+		GroupID: "development",
 	}
 
 	f := syncFlags{

--- a/cmd/workspace/grants/grants.go
+++ b/cmd/workspace/grants/grants.go
@@ -19,7 +19,7 @@ var cmdOverrides []func(*cobra.Command)
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "grants",
-		Short: `In Unity Catalog, data is secure by default.`,
+		Short: `Manage privileges granted in Unity Catalog.`,
 		Long: `In Unity Catalog, data is secure by default. Initially, users have no access
   to data in a metastore. Access can be granted by either a metastore admin, the
   owner of an object, or the owner of the catalog or schema that contains the

--- a/cmd/workspace/grants/grants.go
+++ b/cmd/workspace/grants/grants.go
@@ -19,7 +19,7 @@ var cmdOverrides []func(*cobra.Command)
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "grants",
-		Short: `Manage privileges granted in Unity Catalog.`,
+		Short: `In Unity Catalog, data is secure by default.`,
 		Long: `In Unity Catalog, data is secure by default. Initially, users have no access
   to data in a metastore. Access can be granted by either a metastore admin, the
   owner of an object, or the owner of the catalog or schema that contains the

--- a/cmd/workspace/groups.go
+++ b/cmd/workspace/groups.go
@@ -18,7 +18,7 @@ func Groups() []cobra.Group {
 		},
 		{
 			ID:    "jobs",
-			Title: "Jobs",
+			Title: "Workflows",
 		},
 		{
 			ID:    "pipelines",
@@ -51,6 +51,10 @@ func Groups() []cobra.Group {
 		{
 			ID:    "settings",
 			Title: "Settings",
+		},
+		{
+			ID:    "development",
+			Title: "Developer Tools",
 		},
 	}
 }


### PR DESCRIPTION
## Changes

This tweaks the help output shown when using `databricks help`:
* make`jobs` appears under `Workflows` (as done in baseline OpenAPI). 
* move `bundle` and `sync` under a new group called `Developer Tools` (similar to what we have in docs)
* minor wording changes
