### PR TITLE
Improve error when bundle root is not writable

### DIFF
--- a/bundle/deploy/lock/acquire.go
+++ b/bundle/deploy/lock/acquire.go
@@ -51,8 +51,8 @@ func (m *acquire) Apply(ctx context.Context, b *bundle.Bundle) error {
 	if err != nil {
 		log.Errorf(ctx, "Failed to acquire deployment lock: %v", err)
 
-		existError := filer.NoSuchDirectoryError{}
-		if errors.As(err, &existError) {
+		notExistsError := filer.NoSuchDirectoryError{}
+		if errors.As(err, &notExistsError) {
 			// If we get a "doesn't exist" error from the API this indicates
 			// we either don't have permissions or the path is invalid.
 			return fmt.Errorf("cannot write to deployment root (this can indicate a previous deploy was done with a different identity): %s", b.Config.Workspace.RootPath)


### PR DESCRIPTION
## Changes

This improves the error when deploying to a bundle root that the current user doesn't have write access to. This can come up slightly more often since the change of https://github.com/databricks/cli/pull/1091.

Before this change:

```
$ databricks bundle deploy --target prod
Building my_project...
Error: no such directory: /Users/lennart.kats@databricks.com/.bundle/my_project/prod/state
```

After this change:

```
$ databricks bundle deploy --target prod
Building my_project...
Error: cannot write to deployment root (this can indicate a previous deploy was done with a different identity): /Users/lennart.kats@databricks.com/.bundle/my_project/prod
```

Note that this change uses the "no such directory" error returned from the filer. 