### PR TITLE
Always log with text format by default

### DIFF
--- a/cmd/root/logger.go
+++ b/cmd/root/logger.go
@@ -32,16 +32,11 @@ func (f *logFlags) makeLogHandler(opts slog.HandlerOptions) (slog.Handler, error
 	case flags.OutputJSON:
 		return slog.NewJSONHandler(f.file.Writer(), &opts), nil
 	case flags.OutputText:
-		w := f.file.Writer()
-		if cmdio.IsTTY(w) {
-			return handler.NewFriendlyHandler(w, &handler.Options{
-				Color:       true,
-				Level:       opts.Level,
-				ReplaceAttr: opts.ReplaceAttr,
-			}), nil
-		}
-		return slog.NewTextHandler(w, &opts), nil
-
+		return handler.NewFriendlyHandler(w, &handler.Options{
+			Color:       cmdio.IsTTY(w),
+			Level:       opts.Level,
+			ReplaceAttr: opts.ReplaceAttr,
+		}), nil
 	default:
 		return nil, fmt.Errorf("invalid log output mode: %s", f.output)
 	}

--- a/cmd/root/logger.go
+++ b/cmd/root/logger.go
@@ -32,6 +32,7 @@ func (f *logFlags) makeLogHandler(opts slog.HandlerOptions) (slog.Handler, error
 	case flags.OutputJSON:
 		return slog.NewJSONHandler(f.file.Writer(), &opts), nil
 	case flags.OutputText:
+		w := f.file.Writer()
 		return handler.NewFriendlyHandler(w, &handler.Options{
 			Color:       cmdio.IsTTY(w),
 			Level:       opts.Level,


### PR DESCRIPTION
## Changes
The JSON logger is excellent as a machine-readable logger with lots of metadata, but the resulting logs are difficult to read:

<img width="1601" alt="Image_from_Databricks" src="https://github.com/databricks/cli/assets/1850319/76aa852f-756f-4e0a-bc00-3a6e3224296a">

Currently, we only use the friendly log printer when run from a TTY. This PR removes that restriction, so logs will be pretty-printed by default, regardless of TTY or not. If a user needs machine-readable logs, they can still use `--log-format JSON`.

## Tests
Manual test: `databricks current-user me --debug | cat` uses the pretty-printing logger.

![Screenshot_02_01_2024__13_12](https://github.com/databricks/cli/assets/1850319/45fd5587-52f6-4864-b7d2-3708ed2ff87f)
