### PR TITLE
Allow account client auth with environment variables when no .databrickscfg file present

### DIFF
--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -77,20 +77,6 @@ func MustAccountClient(cmd *cobra.Command, args []string) error {
 		cfg.Profile = profile
 	}
 
-	if cfg.Profile == "" {
-		// account-level CLI was not really done before, so here are the assumptions:
-		// 1. only admins will have account configured
-		// 2. 99% of admins will have access to just one account
-		// hence, we don't need to create a special "DEFAULT_ACCOUNT" profile yet
-		_, profiles, err := databrickscfg.LoadProfiles(cmd.Context(), databrickscfg.MatchAccountProfiles)
-		if err != nil {
-			return err
-		}
-		if len(profiles) == 1 {
-			cfg.Profile = profiles[0].Name
-		}
-	}
-
 	allowPrompt := !hasProfileFlag && !shouldSkipPrompt(cmd.Context())
 	a, err := accountClientOrPrompt(cmd.Context(), cfg, allowPrompt)
 	if err != nil {

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -87,11 +87,9 @@ func MustAccountClient(cmd *cobra.Command, args []string) error {
 			cfg.Profile = profiles[0].Name
 		}
 
-		if err != nil {
-			// if there is no config file, we don't want to fail and instead just skip it
-			if !errors.Is(err, databrickscfg.ErrNoConfiguration) {
-				return err
-			}
+		// if there is no config file, we don't want to fail and instead just skip it
+		if err != nil && !errors.Is(err, databrickscfg.ErrNoConfiguration) {
+			return err
 		}
 	}
 

--- a/cmd/root/auth_test.go
+++ b/cmd/root/auth_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/cmdio"
-	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -199,8 +198,7 @@ func TestMustAccountClientWorksWithDatabricksCfg(t *testing.T) {
 		0755)
 	require.NoError(t, err)
 
-	ctx, _ := cmdio.SetupTest(context.Background())
-	cmd := New(ctx)
+	cmd := New(context.Background())
 
 	t.Setenv("DATABRICKS_CONFIG_FILE", configFile)
 	err = MustAccountClient(cmd, []string{})
@@ -210,10 +208,9 @@ func TestMustAccountClientWorksWithDatabricksCfg(t *testing.T) {
 func TestMustAccountClientWorksWithNoDatabricksCfgButEnvironmentVariables(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
-	ctx := context.Background()
-	cmd := New(context.Background())
-	cmdIO := cmdio.NewIO(flags.OutputText, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), "")
-	cmd.SetContext(cmdio.InContext(ctx, cmdIO))
+	ctx, tt := cmdio.SetupTest(context.Background())
+	t.Cleanup(tt.Done)
+	cmd := New(ctx)
 	t.Setenv("DATABRICKS_HOST", "https://accounts.azuredatabricks.net/")
 	t.Setenv("DATABRICKS_TOKEN", "foobar")
 	t.Setenv("DATABRICKS_ACCOUNT_ID", "1111")
@@ -225,11 +222,10 @@ func TestMustAccountClientWorksWithNoDatabricksCfgButEnvironmentVariables(t *tes
 func TestMustAccountClientErrorsWithNoDatabricksCfg(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
-	ctx := context.Background()
-	cmd := New(context.Background())
-	cmdIO := cmdio.NewIO(flags.OutputText, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), "")
-	cmd.SetContext(cmdio.InContext(ctx, cmdIO))
+	ctx, tt := cmdio.SetupTest(context.Background())
+	t.Cleanup(tt.Done)
+	cmd := New(ctx)
 
 	err := MustAccountClient(cmd, []string{})
-	require.ErrorContains(t, err, "invalid Databricks Account configuration")
+	require.ErrorContains(t, err, "no configuration file found at")
 }


### PR DESCRIPTION
## Changes
Allow account client auth with environment variables when no .databrickscfg file present

Makes the behaviour to be in line with WorkspaceClient auth.
## Tests
Added regression test

