### PR TITLE
Define constant for the invalid `dyn.Value`

### DIFF
--- a/libs/dyn/kind.go
+++ b/libs/dyn/kind.go
@@ -1,6 +1,9 @@
 package dyn
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type Kind int
 
@@ -9,12 +12,12 @@ const (
 	KindInvalid Kind = iota
 	KindMap
 	KindSequence
-	KindNil
 	KindString
 	KindBool
 	KindInt
 	KindFloat
 	KindTime
+	KindNil
 )
 
 func kindOf(v any) Kind {
@@ -23,8 +26,6 @@ func kindOf(v any) Kind {
 		return KindMap
 	case []Value:
 		return KindSequence
-	case nil:
-		return KindNil
 	case string:
 		return KindString
 	case bool:
@@ -35,6 +36,8 @@ func kindOf(v any) Kind {
 		return KindFloat
 	case time.Time:
 		return KindTime
+	case nil:
+		return KindNil
 	default:
 		panic("not handled")
 	}
@@ -42,12 +45,12 @@ func kindOf(v any) Kind {
 
 func (k Kind) String() string {
 	switch k {
+	case KindInvalid:
+		return "invalid"
 	case KindMap:
 		return "map"
 	case KindSequence:
 		return "sequence"
-	case KindNil:
-		return "nil"
 	case KindString:
 		return "string"
 	case KindBool:
@@ -58,7 +61,9 @@ func (k Kind) String() string {
 		return "float"
 	case KindTime:
 		return "time"
+	case KindNil:
+		return "nil"
 	default:
-		return "invalid"
+		panic(fmt.Sprintf("invalid kind value: %d", k))
 	}
 }

--- a/libs/dyn/kind_test.go
+++ b/libs/dyn/kind_test.go
@@ -1,0 +1,38 @@
+package dyn_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKindZeroValue(t *testing.T) {
+	// Assert that the zero value of [dyn.Kind] is the invalid kind.
+	var k dyn.Kind
+	assert.Equal(t, dyn.KindInvalid, k)
+}
+
+func TestKindToString(t *testing.T) {
+	for _, tt := range []struct {
+		k dyn.Kind
+		s string
+	}{
+		{dyn.KindInvalid, "invalid"},
+		{dyn.KindMap, "map"},
+		{dyn.KindSequence, "sequence"},
+		{dyn.KindString, "string"},
+		{dyn.KindBool, "bool"},
+		{dyn.KindInt, "int"},
+		{dyn.KindFloat, "float"},
+		{dyn.KindTime, "time"},
+		{dyn.KindNil, "nil"},
+	} {
+		assert.Equal(t, tt.s, tt.k.String())
+	}
+
+	// Panic on unknown kind.
+	assert.PanicsWithValue(t, "invalid kind value: 100", func() {
+		_ = dyn.Kind(100).String()
+	})
+}

--- a/libs/dyn/value.go
+++ b/libs/dyn/value.go
@@ -16,7 +16,12 @@ type Value struct {
 	anchor bool
 }
 
-// NilValue is equal to the zero-value of Value.
+// InvalidValue is equal to the zero-value of Value.
+var InvalidValue = Value{
+	k: KindInvalid,
+}
+
+// NilValue is a convenient constant for a nil value.
 var NilValue = Value{
 	k: KindNil,
 }

--- a/libs/dyn/value_test.go
+++ b/libs/dyn/value_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestInvalidValue(t *testing.T) {
+	// Assert that the zero value of [dyn.Value] is the invalid value.
+	var zero dyn.Value
+	assert.Equal(t, zero, dyn.InvalidValue)
+}
+
 func TestValueIsAnchor(t *testing.T) {
 	var zero dyn.Value
 	assert.False(t, zero.IsAnchor())


### PR DESCRIPTION
## Changes

The nil value is a real valid value that we need to represent. To accommodate this we introduced `dyn.KindInvalid` as the zero-value for `dyn.Kind` (see #904), but did not yet update the comments on `dyn.NilValue` or add tests for `kind.go`.

This also moves `KindNil` to be last in the definition order (least likely to care about it).

## Tests

Tests pass.