### PR TITLE
Fix windows style file paths in fs cp command

### DIFF
--- a/cmd/fs/cp.go
+++ b/cmd/fs/cp.go
@@ -60,7 +60,7 @@ func (c *copy) cpDirToDir(sourceDir, targetDir string) error {
 }
 
 func (c *copy) cpFileToDir(sourcePath, targetDir string) error {
-	fileName := path.Base(sourcePath)
+	fileName := filepath.Base(sourcePath)
 	targetPath := path.Join(targetDir, fileName)
 
 	return c.cpFileToFile(sourcePath, targetPath)

--- a/internal/fs_cp_test.go
+++ b/internal/fs_cp_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -142,7 +142,7 @@ func TestAccFsCpFileToDir(t *testing.T) {
 }
 
 func TestAccFsCpFileToDirForWindowsPaths(t *testing.T) {
-	if os.GOOS != "windows" {
+	if runtime.GOOS != "windows" {
 		t.Skip("Skipping test on non-windows OS")
 	}
 

--- a/internal/fs_cp_test.go
+++ b/internal/fs_cp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -138,6 +139,22 @@ func TestAccFsCpFileToDir(t *testing.T) {
 
 		assertTargetFile(t, ctx, targetFiler, "foo.txt")
 	}
+}
+
+func TestAccFsCpFileToDirForWindowsPaths(t *testing.T) {
+	if os.GOOS != "windows" {
+		t.Skip("Skipping test on non-windows OS")
+	}
+
+	ctx := context.Background()
+	sourceFiler, sourceDir := setupLocalFiler(t)
+	targetFiler, targetDir := setupDbfsFiler(t)
+	setupSourceFile(t, ctx, sourceFiler)
+
+	windowsPath := filepath.Join(filepath.FromSlash(sourceDir), "foo.txt")
+
+	RequireSuccessfulRun(t, "fs", "cp", windowsPath, targetDir)
+	assertTargetFile(t, ctx, targetFiler, "foo.txt")
 }
 
 func TestAccFsCpDirToDirFileNotOverwritten(t *testing.T) {


### PR DESCRIPTION
## Changes
Copying a local file in windows to remote directory in DBFS would fail if the path was specified as a windows style path (compared to a UNIX style path). This PR fixes that.

Note, UNIX style paths will continue to work because `filepath.Base` respects both `/` and `\` as file separators. See: `IsPathSeparator` in https://go.dev/src/os/path_windows.go.

Fixes issue: https://github.com/databricks/cli/issues/1109.

## Tests
Integration test and manually
```
C:\Users\shreyas.goenka>Desktop\cli.exe fs cp .\Desktop\foo.txt dbfs:/Users/shreyas.goenka@databricks.com
.\Desktop\foo.txt -> dbfs:/Users/shreyas.goenka@databricks.com/foo.txt

C:\Users\shreyas.goenka>Desktop\cli.exe fs cat  dbfs:/Users/shreyas.goenka@databricks.com/foo.txt
hello, world
````
