### PR TITLE
Deserialize path & query parameters when passing the --json flag

### DIFF
--- a/libs/flags/json_flag.go
+++ b/libs/flags/json_flag.go
@@ -1,9 +1,10 @@
 package flags
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/databricks/databricks-sdk-go/marshal"
 )
 
 type JsonFlag struct {
@@ -33,7 +34,9 @@ func (j *JsonFlag) Unmarshal(v any) error {
 	if j.raw == nil {
 		return nil
 	}
-	return json.Unmarshal(j.raw, v)
+	return marshal.UnmarshalCustom(j.raw, v, marshal.UnmarshalOptions{
+		UnmarshalTopLevelIgnoredFields: true,
+	})
 }
 
 func (j *JsonFlag) Type() string {

--- a/libs/flags/json_flag_test.go
+++ b/libs/flags/json_flag_test.go
@@ -70,3 +70,19 @@ func TestJsonFlagFile(t *testing.T) {
 
 	assert.Equal(t, "hello world", request)
 }
+
+func TestJsonFlagUnmarshal_UnmarshalIgnoredFields(t *testing.T) {
+	type Foo struct {
+		A string `json:"a"`
+		B string `json:"-"`
+	}
+
+	raw := `{"a": "foo", "b": "bar"}`
+	var body JsonFlag
+	body.Set(raw)
+
+	var request Foo
+	body.Unmarshal(&request)
+
+	assert.Equal(t, Foo{A: "foo", B: "bar"}, request)
+}


### PR DESCRIPTION
## Changes
Depends on https://github.com/databricks/databricks-sdk-go/pull/772.

The CLI allows users to pass a `--json` flag to provide all parameters needed for executing the request. When a request includes fields annotated with `json:"-"`, those fields are not deserialized. As a result, requests like
```
databricks account workspace-assignment update --json "{\"principal_id\":123, \"permissions\": [\"USER\"],\"workspace_id \":456}"
```
fail because the request made is
```
PUT /api/2.0/accounts/<account-id>/workspaces/0/permissionassignments/principals/0
```

Custom unmarshalling support is added to the Go SDK in https://github.com/databricks/databricks-sdk-go/pull/772, allowing the CLI to unmarshal a JSON object containing fields which are not normally unmarshalled because they don't belong to the request body but are part of the request definition.

## Tests
- [x] Unit test.
- [x] Manual test:
```
$ ./databricks --profile <> account workspace-assignment update --json '{"principal_id":<>, "workspace_id": <>, "permissions":["ADMIN"]}' --debug
10:49:29  INFO start pid=70628 version=0.0.0-dev+3d359319dfa2 args="./databricks, --profile, <>, account, workspace-assignment, update, --json, {\"principal_id\":<>, \"workspace_id\": <>, \"permissions\":[\"ADMIN\"]}, --debug"
10:49:29 DEBUG Loading <> profile from /Users/miles/.databrickscfg pid=70628 sdk=true
10:49:29  INFO Ignoring pat auth, because databricks-cli is preferred pid=70628 sdk=true
10:49:29  INFO Ignoring basic auth, because databricks-cli is preferred pid=70628 sdk=true
10:49:29  INFO Ignoring oauth-m2m auth, because databricks-cli is preferred pid=70628 sdk=true
10:49:29  INFO Refreshed OAuth token from Databricks CLI, expires on 2024-01-17 11:46:04.025043 +0100 CET pid=70628 sdk=true
10:49:29 DEBUG Using Databricks CLI authentication with Databricks OAuth tokens pid=70628 sdk=true
10:49:29  INFO Refreshed OAuth token from Databricks CLI, expires on 2024-01-17 11:46:04.025043 +0100 CET pid=70628 sdk=true
10:49:32 DEBUG PUT /api/2.0/accounts/<>/workspaces/<>/permissionassignments/principals/<>
> {
>   "permissions": [
>     "ADMIN"
>   ]
> }
< HTTP/2.0 200 OK
< {
<   "permissions": [
<     "ADMIN"
<   ],
<   "principal": {
<     "display_name": "<>",
<     "principal_id": <>,
<     "user_name": "<>"
<   }
< } pid=70628 sdk=true
10:49:32  INFO completed execution pid=70628 exit_code=0
```

