### PR TITLE
Set run_as permissions after variable interpolation

### DIFF
--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -22,7 +22,6 @@ func Initialize() bundle.Mutator {
 		[]bundle.Mutator{
 			mutator.InitializeWorkspaceClient(),
 			mutator.PopulateCurrentUser(),
-			mutator.SetRunAs(),
 			mutator.DefineDefaultWorkspaceRoot(),
 			mutator.ExpandWorkspaceRoot(),
 			mutator.DefineDefaultWorkspacePaths(),
@@ -33,6 +32,7 @@ func Initialize() bundle.Mutator {
 				interpolation.IncludeLookupsInPath("workspace"),
 				interpolation.IncludeLookupsInPath(variable.VariableReferencePrefix),
 			),
+			mutator.SetRunAs(),
 			mutator.OverrideCompute(),
 			mutator.ProcessTargetMode(),
 			mutator.ExpandPipelineGlobPaths(),


### PR DESCRIPTION
## Changes

This PR sets run as permissions after variable interpolation.

Terraform does not allow specifying permissions for current user.

The following configuration would fail becuase we would assign a permission block for self, bypassing this check here: https://github.com/databricks/cli/blob/4ee926b8858bf1583fcd8bbe9a5222b1594e72ec/bundle/config/mutator/run_as.go#L47

```
run_as:
  user_name: ${workspace.current_user.userName}
```



## Tests
Manually, setting run_as to ${workspace.current_user.userName} works now