### PR TITLE
Release Windows packages to winget-pkgs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,14 @@ jobs:
                 version: "${{ env.VERSION }}",
               }
             });
+
+  publish-to-winget-pkgs:
+    needs: goreleaser
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Databricks.DatabricksCLI
+          installers-regex: 'windows_.*\.zip$' # Only windows releases
+          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}


### PR DESCRIPTION
## Changes
This PR adds a release workflow which will automatically publish the CLI to winget-pkgs whenever a release is made. It uses https://github.com/vedantmgoyal2009/winget-releaser to release the windows binaries. @exorcism0666 has been graciously making releases on our behalf, but we can do this automatically ourselves after this PR.

## Tests
<!-- How is this tested? -->

