### PR TITLE
Include empty scalars in dynamic representation

### DIFF
--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -28,6 +28,7 @@ func TestAdditional(t *testing.T) {
 		SliceOfPointer []*string          `json:"slice_of_pointer"`
 		NestedStruct   StructType         `json:"nested_struct"`
 		MapOfString    map[string]string  `json:"map_of_string"`
+		MapOfBool      map[string]bool    `json:"map_of_bool"`
 	}
 
 	t.Run("nil", func(t *testing.T) {
@@ -72,6 +73,15 @@ func TestAdditional(t *testing.T) {
 		assertFromTypedToTypedEqual(t, Tmp{
 			MapOfString: map[string]string{
 				"key": "",
+			},
+		})
+	})
+
+	// Without the changes in this PR, this test case would fail
+	t.Run("map with empty val", func(t *testing.T) {
+		assertFromTypedToTypedEqual(t, Tmp{
+			MapOfBool: map[string]bool{
+				"key": false,
 			},
 		})
 	})

--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -27,6 +27,7 @@ func TestAdditional(t *testing.T) {
 		MapToPointer   map[string]*string `json:"map_to_pointer"`
 		SliceOfPointer []*string          `json:"slice_of_pointer"`
 		NestedStruct   StructType         `json:"nested_struct"`
+		MapOfString    map[string]string  `json:"map_of_string"`
 	}
 
 	t.Run("nil", func(t *testing.T) {
@@ -56,6 +57,22 @@ func TestAdditional(t *testing.T) {
 	t.Run("slice with nil value", func(t *testing.T) {
 		assertFromTypedToTypedEqual(t, Tmp{
 			SliceOfPointer: []*string{nil},
+		})
+	})
+
+	t.Run("map with one value", func(t *testing.T) {
+		assertFromTypedToTypedEqual(t, Tmp{
+			MapOfString: map[string]string{
+				"key": "value",
+			},
+		})
+	})
+
+	t.Run("map with empty val", func(t *testing.T) {
+		assertFromTypedToTypedEqual(t, Tmp{
+			MapOfString: map[string]string{
+				"key": "",
+			},
 		})
 	})
 }

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -142,11 +142,6 @@ func fromTypedString(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 
 		return dyn.V(value), nil
 	case dyn.KindNil:
-		// This field is not set in the reference, so we only include it if it has a non-zero value.
-		// Otherwise, we would always include all zero valued fields.
-		if src.IsZero() {
-			return dyn.NilValue, nil
-		}
 		return dyn.V(src.String()), nil
 	}
 


### PR DESCRIPTION
## Changes
I have not taken a deeper look into the implications of carrying the zero value yet and might be misunderstanding the scope of the APIs.  Just wanted to kick off some discussion.

This PR is illustrates the problem where the FromTyped -> ToTyped process does not work for `map[string]string` or any other map[string]scalar
