### PR TITLE
Use latest patch release of Go toolchain

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.0
+          go-version: 1.21.x
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.0
+          go-version: 1.21.x
 
           # No need to download cached dependencies when running gofmt.
           cache: false

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.0
+          go-version: 1.21.x
 
       - name: Hide snapshot tag to outsmart GoReleaser
         run: git tag -d snapshot || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.0
+          go-version: 1.21.x
 
       - name: Run GoReleaser
         id: releaser


### PR DESCRIPTION
## Changes

This was pinned to 1.21.0 and included a vulnerability as reported in #1150. The vulnerability does not affect the prior CLI releases as it requires a user to execute Go commands from within compromised module directories.

Fixes #1150.
