### PR TITLE
Fix dynamic representation of zero values in maps and slices

### DIFF
--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -39,7 +39,7 @@ func TestAdditional(t *testing.T) {
 		})
 	})
 
-	t.Run("map with zero value", func(t *testing.T) {
+	t.Run("map with empty string value", func(t *testing.T) {
 		s := ""
 		assertFromTypedToTypedEqual(t, Tmp{
 			MapToPointer: map[string]*string{

--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -39,6 +39,15 @@ func TestAdditional(t *testing.T) {
 		})
 	})
 
+	t.Run("map with zero value", func(t *testing.T) {
+		s := ""
+		assertFromTypedToTypedEqual(t, Tmp{
+			MapToPointer: map[string]*string{
+				"key": &s,
+			},
+		})
+	})
+
 	t.Run("map with nil value", func(t *testing.T) {
 		assertFromTypedToTypedEqual(t, Tmp{
 			MapToPointer: map[string]*string{

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -171,6 +171,7 @@ func fromTypedString(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 		}
 		return dyn.V(src.String()), nil
 	}
+
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
 }
 
@@ -190,6 +191,7 @@ func fromTypedBool(src reflect.Value, ref dyn.Value, options ...fromTypedOptions
 		}
 		return dyn.V(src.Bool()), nil
 	}
+	
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
 }
 

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -191,7 +191,7 @@ func fromTypedBool(src reflect.Value, ref dyn.Value, options ...fromTypedOptions
 		}
 		return dyn.V(src.Bool()), nil
 	}
-	
+
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
 }
 

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -25,7 +25,13 @@ const (
 
 // FromTyped converts changes made in the typed structure w.r.t. the configuration value
 // back to the configuration value, retaining existing location information where possible.
-func FromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, error) {
+func FromTyped(src any, ref dyn.Value) (dyn.Value, error) {
+	return fromTyped(src, ref)
+}
+
+// Private implementation of FromTyped that allows for additional options not exposed
+// in the public API.
+func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, error) {
 	srcv := reflect.ValueOf(src)
 
 	// Dereference pointer if necessary
@@ -68,7 +74,7 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 	info := getStructInfo(src.Type())
 	for k, v := range info.FieldValues(src) {
 		// Convert the field taking into account the reference value (may be equal to config.NilValue).
-		nv, err := FromTyped(v.Interface(), ref.Get(k))
+		nv, err := fromTyped(v.Interface(), ref.Get(k))
 		if err != nil {
 			return dyn.Value{}, err
 		}
@@ -106,7 +112,7 @@ func fromTypedMap(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 		v := iter.Value()
 
 		// Convert entry taking into account the reference value (may be equal to dyn.NilValue).
-		nv, err := FromTyped(v.Interface(), ref.Get(k), includeZeroValues)
+		nv, err := fromTyped(v.Interface(), ref.Get(k), includeZeroValues)
 		if err != nil {
 			return dyn.Value{}, err
 		}
@@ -137,7 +143,7 @@ func fromTypedSlice(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 		v := src.Index(i)
 
 		// Convert entry taking into account the reference value (may be equal to dyn.NilValue).
-		nv, err := FromTyped(v.Interface(), ref.Index(i), includeZeroValues)
+		nv, err := fromTyped(v.Interface(), ref.Index(i), includeZeroValues)
 		if err != nil {
 			return dyn.Value{}, err
 		}

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -164,11 +164,11 @@ func fromTypedString(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		// This field is not set in the reference. We set it to nil if it's zero
+		// valued in the typed representation and the includeZeroValues option is not set.
 		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
 			return dyn.NilValue, nil
 		}
-		// This field is not set in the reference, so we only include it if it
-		// has a non-zero value or the includeZeroValues option is set.
 		return dyn.V(src.String()), nil
 	}
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
@@ -183,11 +183,11 @@ func fromTypedBool(src reflect.Value, ref dyn.Value, options ...fromTypedOptions
 		}
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		// This field is not set in the reference. We set it to nil if it's zero
+		// valued in the typed representation and the includeZeroValues option is not set.
 		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
 			return dyn.NilValue, nil
 		}
-		// This field is not set in the reference, so we only include it if it
-		// has a non-zero value or the includeZeroValues option is set.
 		return dyn.V(src.Bool()), nil
 	}
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
@@ -202,11 +202,11 @@ func fromTypedInt(src reflect.Value, ref dyn.Value, options ...fromTypedOptions)
 		}
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		// This field is not set in the reference. We set it to nil if it's zero
+		// valued in the typed representation and the includeZeroValues option is not set.
 		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
 			return dyn.NilValue, nil
 		}
-		// This field is not set in the reference, so we only include it if it
-		// has a non-zero value or the includeZeroValues option is set.
 		return dyn.V(src.Int()), nil
 	}
 
@@ -222,11 +222,11 @@ func fromTypedFloat(src reflect.Value, ref dyn.Value, options ...fromTypedOption
 		}
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		// This field is not set in the reference. We set it to nil if it's zero
+		// valued in the typed representation and the includeZeroValues option is not set.
 		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
 			return dyn.NilValue, nil
 		}
-		// This field is not set in the reference, so we only include it if it
-		// has a non-zero value or the includeZeroValues option is set.
 		return dyn.V(src.Float()), nil
 	}
 

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -158,12 +158,12 @@ func fromTypedString(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
+			return dyn.NilValue, nil
+		}
 		// This field is not set in the reference, so we only include it if it
 		// has a non-zero value or the includeZeroValues option is set.
-		if !src.IsZero() || slices.Contains(options, includeZeroValues) {
-			return dyn.V(src.String()), nil
-		}
-		return dyn.NilValue, nil
+		return dyn.V(src.String()), nil
 	}
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
 }
@@ -177,14 +177,13 @@ func fromTypedBool(src reflect.Value, ref dyn.Value, options ...fromTypedOptions
 		}
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
+			return dyn.NilValue, nil
+		}
 		// This field is not set in the reference, so we only include it if it
 		// has a non-zero value or the includeZeroValues option is set.
-		if !src.IsZero() || slices.Contains(options, includeZeroValues) {
-			return dyn.V(src.Bool()), nil
-		}
-		return dyn.NilValue, nil
+		return dyn.V(src.Bool()), nil
 	}
-
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
 }
 
@@ -197,12 +196,12 @@ func fromTypedInt(src reflect.Value, ref dyn.Value, options ...fromTypedOptions)
 		}
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
+			return dyn.NilValue, nil
+		}
 		// This field is not set in the reference, so we only include it if it
 		// has a non-zero value or the includeZeroValues option is set.
-		if !src.IsZero() || slices.Contains(options, includeZeroValues) {
-			return dyn.V(src.Int()), nil
-		}
-		return dyn.NilValue, nil
+		return dyn.V(src.Int()), nil
 	}
 
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())
@@ -217,12 +216,12 @@ func fromTypedFloat(src reflect.Value, ref dyn.Value, options ...fromTypedOption
 		}
 		return dyn.V(value), nil
 	case dyn.KindNil:
+		if src.IsZero() && !slices.Contains(options, includeZeroValues) {
+			return dyn.NilValue, nil
+		}
 		// This field is not set in the reference, so we only include it if it
 		// has a non-zero value or the includeZeroValues option is set.
-		if !src.IsZero() || slices.Contains(options, includeZeroValues) {
-			return dyn.V(src.Float()), nil
-		}
-		return dyn.NilValue, nil
+		return dyn.V(src.Float()), nil
 	}
 
 	return dyn.Value{}, fmt.Errorf("unhandled type: %s", ref.Kind())

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -68,6 +68,190 @@ func TestFromTypedStructSetFieldsRetainLocationIfUnchanged(t *testing.T) {
 	assert.Equal(t, dyn.NewValue("qux", dyn.Location{}), nv.Get("bar"))
 }
 
+func TestFromTypedStringMapWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := map[string]string{
+		"foo": "",
+		"bar": "fuzz",
+	}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(""),
+		"bar": dyn.V("fuzz"),
+	}), nv)
+}
+
+func TestFromTypedStringSliceWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := []string{"a", "", "c"}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V([]dyn.Value{
+		dyn.V("a"), dyn.V(""), dyn.V("c"),
+	}), nv)
+}
+
+func TestFromTypedStringStructWithZeroValue(t *testing.T) {
+	type Tmp struct {
+		Foo string `json:"foo"`
+		Bar string `json:"bar"`
+	}
+
+	ref := dyn.NilValue
+	src := Tmp{
+		Foo: "foo",
+		Bar: "",
+	}
+
+	// Note, the zero value is not included in the output.
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V("foo"),
+	}), nv)
+}
+
+func TestFromTypedBoolMapWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := map[string]bool{
+		"foo": false,
+		"bar": true,
+	}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(false),
+		"bar": dyn.V(true),
+	}), nv)
+}
+
+func TestFromTypedBoolSliceWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := []bool{true, false, true}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V([]dyn.Value{
+		dyn.V(true), dyn.V(false), dyn.V(true),
+	}), nv)
+}
+
+func TestFromTypedBoolStructWithZeroValue(t *testing.T) {
+	type Tmp struct {
+		Foo bool `json:"foo"`
+		Bar bool `json:"bar"`
+	}
+
+	ref := dyn.NilValue
+	src := Tmp{
+		Foo: true,
+		Bar: false,
+	}
+
+	// Note, the zero value is not included in the output.
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(true),
+	}), nv)
+}
+
+func TestFromTypedIntMapWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := map[string]int{
+		"foo": 0,
+		"bar": 1,
+	}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(int64(0)),
+		"bar": dyn.V(int64(1)),
+	}), nv)
+}
+
+func TestFromTypedIntSliceWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := []int{1, 0, 2}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V([]dyn.Value{
+		dyn.V(int64(1)), dyn.V(int64(0)), dyn.V(int64(2)),
+	}), nv)
+}
+
+func TestFromTypedIntStructWithZeroValue(t *testing.T) {
+	type Tmp struct {
+		Foo int `json:"foo"`
+		Bar int `json:"bar"`
+	}
+
+	ref := dyn.NilValue
+	src := Tmp{
+		Foo: 1,
+		Bar: 0,
+	}
+
+	// Note, the zero value is not included in the output.
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(int64(1)),
+	}), nv)
+}
+
+func TestFromTypedFloatMapWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := map[string]float64{
+		"foo": 0.0,
+		"bar": 1.0,
+	}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(0.0),
+		"bar": dyn.V(1.0),
+	}), nv)
+}
+
+func TestFromTypedFloatSliceWithZeroValue(t *testing.T) {
+	ref := dyn.NilValue
+	src := []float64{1.0, 0.0, 2.0}
+
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V([]dyn.Value{
+		dyn.V(1.0), dyn.V(0.0), dyn.V(2.0),
+	}), nv)
+}
+
+func TestFromTypedFloatStructWithZeroValue(t *testing.T) {
+	type Tmp struct {
+		Foo float64 `json:"foo"`
+		Bar float64 `json:"bar"`
+	}
+
+	ref := dyn.NilValue
+	src := Tmp{
+		Foo: 1.0,
+		Bar: 0.0,
+	}
+
+	// Note, the zero value is not included in the output.
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{
+		"foo": dyn.V(1.0),
+	}), nv)
+}
+
 func TestFromTypedMapNil(t *testing.T) {
 	var src map[string]string = nil
 
@@ -139,7 +323,7 @@ func TestFromTypedMapFieldWithZeroValue(t *testing.T) {
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
 	assert.Equal(t, dyn.V(map[string]dyn.Value{
-		"foo": dyn.NilValue,
+		"foo": dyn.V(""),
 	}), nv)
 }
 


### PR DESCRIPTION
## Changes
In the dynamic configuration, the nil value (dyn.NilValue) denotes a value that should not be serialized, ie a value being nil is the same as it not existing in the first place.

This is not true for zero values in maps and slices. This PR fixes the conversion from typed values to dyn.Value, to treat zero values in maps and slices as zero and not nil.

## Tests
Unit tests
