### PR TITLE
Added warning when trying to deploy bundle with `--fail-if-running` and running resources

### DIFF
--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -43,4 +43,8 @@ type Bundle struct {
 
 	// Overrides the compute used for jobs and other supported assets.
 	ComputeID string `json:"compute_id,omitempty"`
+
+	// FailIfRunning specifies whether to fail the deployment if there are
+	// running jobs or pipelines in the workspace. Defaults to false.
+	FailIfRunning bool `json:"fail_if_running,omitempty"`
 }

--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -25,9 +25,6 @@ type Bundle struct {
 	// For example, where to find the binary, which version to use, etc.
 	Terraform *Terraform `json:"terraform,omitempty" bundle:"readonly"`
 
-	// Lock configures locking behavior on deployment.
-	Lock Lock `json:"lock" bundle:"readonly"`
-
 	// Force-override Git branch validation.
 	Force bool `json:"force,omitempty" bundle:"readonly"`
 
@@ -44,7 +41,6 @@ type Bundle struct {
 	// Overrides the compute used for jobs and other supported assets.
 	ComputeID string `json:"compute_id,omitempty"`
 
-	// FailIfRunning specifies whether to fail the deployment if there are
-	// running jobs or pipelines in the workspace. Defaults to false.
-	FailIfRunning bool `json:"fail_if_running,omitempty"`
+	// Deployment section specifies deployment related configuration for bundle
+	Deployment Deployment `json:"deployment"`
 }

--- a/bundle/config/deployment.go
+++ b/bundle/config/deployment.go
@@ -1,0 +1,10 @@
+package config
+
+type Deployment struct {
+	// FailOnActiveRuns specifies whether to fail the deployment if there are
+	// running jobs or pipelines in the workspace. Defaults to false.
+	FailOnActiveRuns bool `json:"fail_on_active_runs,omitempty"`
+
+	// Lock configures locking behavior on deployment.
+	Lock Lock `json:"lock" bundle:"readonly"`
+}

--- a/bundle/deploy/check_running_resources.go
+++ b/bundle/deploy/check_running_resources.go
@@ -31,7 +31,7 @@ func (l *checkRunningResources) Name() string {
 }
 
 func (l *checkRunningResources) Apply(ctx context.Context, b *bundle.Bundle) error {
-	if !b.Config.Bundle.FailIfRunning {
+	if !b.Config.Bundle.Deployment.FailOnActiveRuns {
 		return nil
 	}
 

--- a/bundle/deploy/check_running_resources.go
+++ b/bundle/deploy/check_running_resources.go
@@ -1,0 +1,151 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
+	"golang.org/x/sync/errgroup"
+)
+
+type ErrResourceIsRunning struct{}
+
+func (ErrResourceIsRunning) Error() string {
+	return "resource is running"
+}
+
+type checkRunningResources struct {
+}
+
+func (l *checkRunningResources) Name() string {
+	return "check-running-resources"
+}
+
+func (l *checkRunningResources) Apply(ctx context.Context, b *bundle.Bundle) error {
+
+	tf := b.Terraform
+	if tf == nil {
+		return fmt.Errorf("terraform not initialized")
+	}
+
+	err := tf.Init(ctx, tfexec.Upgrade(true))
+	if err != nil {
+		return fmt.Errorf("terraform init: %w", err)
+	}
+
+	state, err := b.Terraform.Show(ctx)
+	if err != nil {
+		return err
+	}
+
+	isRunning := isAnyResourceRunning(ctx, b.WorkspaceClient(), state)
+	if !isRunning {
+		return nil
+	}
+
+	ans, err := cmdio.AskYesOrNo(ctx, `Some of the bundle resources are still running.
+Deploying the bundle can disrupt any jobs or pipelines in progress.
+Do you want to continue?`)
+
+	if err != nil {
+		return err
+	}
+	if !ans {
+		return errors.New("deployment aborted")
+	}
+
+	return nil
+}
+
+func CheckRunningResource() *checkRunningResources {
+	return &checkRunningResources{}
+}
+
+func isAnyResourceRunning(ctx context.Context, w *databricks.WorkspaceClient, state *tfjson.State) bool {
+	if state.Values == nil || state.Values.RootModule == nil {
+		return false
+	}
+
+	errs, errCtx := errgroup.WithContext(ctx)
+
+	for _, resource := range state.Values.RootModule.Resources {
+		// Limit to resources.
+		if resource.Mode != tfjson.ManagedResourceMode {
+			continue
+		}
+
+		value, ok := resource.AttributeValues["id"]
+		if !ok {
+			continue
+		}
+		id, ok := value.(string)
+		if !ok {
+			continue
+		}
+
+		switch resource.Type {
+		case "databricks_job":
+			errs.Go(func() error {
+				isRunning, err := IsJobRunning(errCtx, w, id)
+				// If there's an error retrieving the job, we assume it's not running
+				if err != nil {
+					return err
+				}
+				if isRunning {
+					return &ErrResourceIsRunning{}
+				}
+				return nil
+			})
+		case "databricks_pipeline":
+			errs.Go(func() error {
+				isRunning, err := IsPipelineRunning(errCtx, w, id)
+				// If there's an error retrieving the pipeline, we assume it's not running
+				if err != nil {
+					return nil
+				}
+				if isRunning {
+					return &ErrResourceIsRunning{}
+				}
+				return nil
+			})
+		}
+	}
+
+	err := errs.Wait()
+	return err != nil
+}
+
+func IsJobRunning(ctx context.Context, w *databricks.WorkspaceClient, jobId string) (bool, error) {
+	id, err := strconv.Atoi(jobId)
+	if err != nil {
+		return false, err
+	}
+
+	runs, err := w.Jobs.ListRunsAll(ctx, jobs.ListRunsRequest{JobId: int64(id), ActiveOnly: true})
+	if err != nil {
+		return false, err
+	}
+
+	return len(runs) > 0, nil
+}
+
+func IsPipelineRunning(ctx context.Context, w *databricks.WorkspaceClient, pipelineId string) (bool, error) {
+	resp, err := w.Pipelines.Get(ctx, pipelines.GetPipelineRequest{PipelineId: pipelineId})
+	if err != nil {
+		return false, err
+	}
+	switch resp.State {
+	case pipelines.PipelineStateIdle, pipelines.PipelineStateFailed, pipelines.PipelineStateDeleted:
+		return false, nil
+	default:
+		return true, nil
+	}
+}

--- a/bundle/deploy/check_running_resources.go
+++ b/bundle/deploy/check_running_resources.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
@@ -50,19 +49,8 @@ func (l *checkRunningResources) Apply(ctx context.Context, b *bundle.Bundle) err
 	}
 
 	isRunning := isAnyResourceRunning(ctx, b.WorkspaceClient(), state)
-	if !isRunning {
-		return nil
-	}
-
-	ans, err := cmdio.AskYesOrNo(ctx, `Some of the bundle resources are still running.
-Deploying the bundle can disrupt any jobs or pipelines in progress.
-Do you want to continue?`)
-
-	if err != nil {
-		return err
-	}
-	if !ans {
-		return errors.New("deployment aborted")
+	if isRunning {
+		return errors.New("some of the bundle resources are still running, deployment aborted")
 	}
 
 	return nil

--- a/bundle/deploy/check_running_resources.go
+++ b/bundle/deploy/check_running_resources.go
@@ -30,6 +30,9 @@ func (l *checkRunningResources) Name() string {
 }
 
 func (l *checkRunningResources) Apply(ctx context.Context, b *bundle.Bundle) error {
+	if !b.Config.Bundle.FailIfRunning {
+		return nil
+	}
 
 	tf := b.Terraform
 	if tf == nil {

--- a/bundle/deploy/check_running_resources_test.go
+++ b/bundle/deploy/check_running_resources_test.go
@@ -47,7 +47,7 @@ func TestIsAnyResourceRunningWithJob(t *testing.T) {
 	}, nil).Once()
 
 	err := checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "job 123 is running")
 
 	jobsApi.EXPECT().ListRunsAll(mock.Anything, jobs.ListRunsRequest{
 		JobId:      123,
@@ -85,7 +85,7 @@ func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
 	}, nil).Once()
 
 	err := checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "pipeline 123 is running")
 
 	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
 		PipelineId: "123",

--- a/bundle/deploy/check_running_resources_test.go
+++ b/bundle/deploy/check_running_resources_test.go
@@ -1,0 +1,125 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAnyResourceRunningWithEmptyState(t *testing.T) {
+	mock := mocks.NewMockWorkspaceClient(t)
+	state := &tfjson.State{}
+	isRunning := isAnyResourceRunning(context.Background(), mock.WorkspaceClient, state)
+	require.False(t, isRunning)
+}
+
+func TestIsAnyResourceRunningWithJob(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	state := &tfjson.State{
+		Values: &tfjson.StateValues{
+			RootModule: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Type: "databricks_job",
+						AttributeValues: map[string]interface{}{
+							"id": "123",
+						},
+						Mode: tfjson.ManagedResourceMode,
+					},
+				},
+			},
+		},
+	}
+
+	jobsApi := m.GetMockJobsAPI()
+	jobsApi.EXPECT().ListRunsAll(mock.Anything, jobs.ListRunsRequest{
+		JobId:      123,
+		ActiveOnly: true,
+	}).Return([]jobs.BaseRun{
+		{RunId: 1234},
+	}, nil).Once()
+
+	isRunning := isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.True(t, isRunning)
+
+	jobsApi.EXPECT().ListRunsAll(mock.Anything, jobs.ListRunsRequest{
+		JobId:      123,
+		ActiveOnly: true,
+	}).Return([]jobs.BaseRun{}, nil).Once()
+
+	isRunning = isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.False(t, isRunning)
+}
+
+func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	state := &tfjson.State{
+		Values: &tfjson.StateValues{
+			RootModule: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Type: "databricks_pipeline",
+						AttributeValues: map[string]interface{}{
+							"id": "123",
+						},
+						Mode: tfjson.ManagedResourceMode,
+					},
+				},
+			},
+		},
+	}
+
+	pipelineApi := m.GetMockPipelinesAPI()
+	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
+		PipelineId: "123",
+	}).Return(&pipelines.GetPipelineResponse{
+		PipelineId: "123",
+		State:      pipelines.PipelineStateRunning,
+	}, nil).Once()
+
+	isRunning := isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.True(t, isRunning)
+
+	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
+		PipelineId: "123",
+	}).Return(&pipelines.GetPipelineResponse{
+		PipelineId: "123",
+		State:      pipelines.PipelineStateIdle,
+	}, nil).Once()
+	isRunning = isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.False(t, isRunning)
+}
+
+func TestIsAnyResourceRunningWithAPIFailure(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	state := &tfjson.State{
+		Values: &tfjson.StateValues{
+			RootModule: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Type: "databricks_pipeline",
+						AttributeValues: map[string]interface{}{
+							"id": "123",
+						},
+						Mode: tfjson.ManagedResourceMode,
+					},
+				},
+			},
+		},
+	}
+
+	pipelineApi := m.GetMockPipelinesAPI()
+	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
+		PipelineId: "123",
+	}).Return(nil, errors.New("API failure")).Once()
+
+	isRunning := isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.False(t, isRunning)
+}

--- a/bundle/deploy/check_running_resources_test.go
+++ b/bundle/deploy/check_running_resources_test.go
@@ -16,8 +16,8 @@ import (
 func TestIsAnyResourceRunningWithEmptyState(t *testing.T) {
 	mock := mocks.NewMockWorkspaceClient(t)
 	state := &tfjson.State{}
-	isRunning := isAnyResourceRunning(context.Background(), mock.WorkspaceClient, state)
-	require.False(t, isRunning)
+	err := checkAnyResourceRunning(context.Background(), mock.WorkspaceClient, state)
+	require.NoError(t, err)
 }
 
 func TestIsAnyResourceRunningWithJob(t *testing.T) {
@@ -46,16 +46,16 @@ func TestIsAnyResourceRunningWithJob(t *testing.T) {
 		{RunId: 1234},
 	}, nil).Once()
 
-	isRunning := isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.True(t, isRunning)
+	err := checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.Error(t, err)
 
 	jobsApi.EXPECT().ListRunsAll(mock.Anything, jobs.ListRunsRequest{
 		JobId:      123,
 		ActiveOnly: true,
 	}).Return([]jobs.BaseRun{}, nil).Once()
 
-	isRunning = isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.False(t, isRunning)
+	err = checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.NoError(t, err)
 }
 
 func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
@@ -84,8 +84,8 @@ func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
 		State:      pipelines.PipelineStateRunning,
 	}, nil).Once()
 
-	isRunning := isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.True(t, isRunning)
+	err := checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.Error(t, err)
 
 	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
 		PipelineId: "123",
@@ -93,8 +93,8 @@ func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
 		PipelineId: "123",
 		State:      pipelines.PipelineStateIdle,
 	}, nil).Once()
-	isRunning = isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.False(t, isRunning)
+	err = checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.NoError(t, err)
 }
 
 func TestIsAnyResourceRunningWithAPIFailure(t *testing.T) {
@@ -120,6 +120,6 @@ func TestIsAnyResourceRunningWithAPIFailure(t *testing.T) {
 		PipelineId: "123",
 	}).Return(nil, errors.New("API failure")).Once()
 
-	isRunning := isAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
-	require.False(t, isRunning)
+	err := checkAnyResourceRunning(context.Background(), m.WorkspaceClient, state)
+	require.NoError(t, err)
 }

--- a/bundle/deploy/lock/acquire.go
+++ b/bundle/deploy/lock/acquire.go
@@ -35,7 +35,7 @@ func (m *acquire) init(b *bundle.Bundle) error {
 
 func (m *acquire) Apply(ctx context.Context, b *bundle.Bundle) error {
 	// Return early if locking is disabled.
-	if !b.Config.Bundle.Lock.IsEnabled() {
+	if !b.Config.Bundle.Deployment.Lock.IsEnabled() {
 		log.Infof(ctx, "Skipping; locking is disabled")
 		return nil
 	}
@@ -45,7 +45,7 @@ func (m *acquire) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	force := b.Config.Bundle.Lock.Force
+	force := b.Config.Bundle.Deployment.Lock.Force
 	log.Infof(ctx, "Acquiring deployment lock (force: %v)", force)
 	err = b.Locker.Lock(ctx, force)
 	if err != nil {

--- a/bundle/deploy/lock/release.go
+++ b/bundle/deploy/lock/release.go
@@ -30,7 +30,7 @@ func (m *release) Name() string {
 
 func (m *release) Apply(ctx context.Context, b *bundle.Bundle) error {
 	// Return early if locking is disabled.
-	if !b.Config.Bundle.Lock.IsEnabled() {
+	if !b.Config.Bundle.Deployment.Lock.IsEnabled() {
 		log.Infof(ctx, "Skipping; locking is disabled")
 		return nil
 	}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -23,6 +23,7 @@ func Deploy() bundle.Mutator {
 		lock.Acquire(),
 		bundle.Defer(
 			bundle.Seq(
+				terraform.StatePull(),
 				deploy.CheckRunningResource(),
 				mutator.ValidateGitDetails(),
 				libraries.MatchWithArtifacts(),
@@ -33,7 +34,6 @@ func Deploy() bundle.Mutator {
 				permissions.ApplyWorkspaceRootPermissions(),
 				terraform.Interpolate(),
 				terraform.Write(),
-				terraform.StatePull(),
 				bundle.Defer(
 					terraform.Apply(),
 					bundle.Seq(

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -5,6 +5,7 @@ import (
 	"github.com/databricks/cli/bundle/artifacts"
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/deploy"
 	"github.com/databricks/cli/bundle/deploy/files"
 	"github.com/databricks/cli/bundle/deploy/lock"
 	"github.com/databricks/cli/bundle/deploy/metadata"
@@ -22,6 +23,7 @@ func Deploy() bundle.Mutator {
 		lock.Acquire(),
 		bundle.Defer(
 			bundle.Seq(
+				deploy.CheckRunningResource(),
 				mutator.ValidateGitDetails(),
 				libraries.MatchWithArtifacts(),
 				artifacts.CleanUp(),

--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -15,9 +15,11 @@ func newDeployCommand() *cobra.Command {
 
 	var force bool
 	var forceLock bool
+	var failIfRunning bool
 	var computeID string
 	cmd.Flags().BoolVar(&force, "force", false, "Force-override Git branch validation.")
 	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
+	cmd.Flags().BoolVar(&failIfRunning, "fail-if-running", false, "Fail if there are running jobs or pipelines in the deployment.")
 	cmd.Flags().StringVarP(&computeID, "compute-id", "c", "", "Override compute in the deployment with the given compute ID.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -25,6 +27,7 @@ func newDeployCommand() *cobra.Command {
 
 		b.Config.Bundle.Force = force
 		b.Config.Bundle.Lock.Force = forceLock
+		b.Config.Bundle.FailIfRunning = failIfRunning
 		b.Config.Bundle.ComputeID = computeID
 
 		return bundle.Apply(cmd.Context(), b, bundle.Seq(

--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -15,20 +15,23 @@ func newDeployCommand() *cobra.Command {
 
 	var force bool
 	var forceLock bool
-	var failIfRunning bool
+	var failOnActiveRuns bool
 	var computeID string
 	cmd.Flags().BoolVar(&force, "force", false, "Force-override Git branch validation.")
 	cmd.Flags().BoolVar(&forceLock, "force-lock", false, "Force acquisition of deployment lock.")
-	cmd.Flags().BoolVar(&failIfRunning, "fail-if-running", false, "Fail if there are running jobs or pipelines in the deployment.")
+	cmd.Flags().BoolVar(&failOnActiveRuns, "fail-on-active-runs", false, "Fail if there are running jobs or pipelines in the deployment.")
 	cmd.Flags().StringVarP(&computeID, "compute-id", "c", "", "Override compute in the deployment with the given compute ID.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		b := bundle.Get(cmd.Context())
 
 		b.Config.Bundle.Force = force
-		b.Config.Bundle.Lock.Force = forceLock
-		b.Config.Bundle.FailIfRunning = failIfRunning
+		b.Config.Bundle.Deployment.Lock.Force = forceLock
 		b.Config.Bundle.ComputeID = computeID
+
+		if cmd.Flag("fail-on-active-runs").Changed {
+			b.Config.Bundle.Deployment.FailOnActiveRuns = failOnActiveRuns
+		}
 
 		return bundle.Apply(cmd.Context(), b, bundle.Seq(
 			phases.Initialize(),

--- a/cmd/bundle/destroy.go
+++ b/cmd/bundle/destroy.go
@@ -30,7 +30,7 @@ func newDestroyCommand() *cobra.Command {
 		b := bundle.Get(ctx)
 
 		// If `--force-lock` is specified, force acquisition of the deployment lock.
-		b.Config.Bundle.Lock.Force = forceDestroy
+		b.Config.Bundle.Deployment.Lock.Force = forceDestroy
 
 		// If `--auto-approve`` is specified, we skip confirmation checks
 		b.AutoApprove = autoApprove


### PR DESCRIPTION
## Changes
Deploying bundle when there are bundle resources running at the same time can be disruptive for jobs and pipelines in progress.

With this change during deployment phase (before uploading any resources) if there is `--fail-if-running` specified DABs will check if there are any resources running and if so, will fail the deployment

## Tests
Manual + add tests

