### PR TITLE
Update error message to be clearer when using filer.ReadDir for UC Volumes

### DIFF
--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -63,8 +63,8 @@ type FilesClient struct {
 	root WorkspaceRootPath
 }
 
-func filesNotImplementedError(fn string) error {
-	return fmt.Errorf("filer.%s is not implemented for the Files API", fn)
+func listAPINotAvailableError(fn string) error {
+	return fmt.Errorf("list API is not yet available for UC Volumes")
 }
 
 func NewFilesClient(w *databricks.WorkspaceClient, root string) (Filer, error) {
@@ -192,7 +192,7 @@ func (w *FilesClient) Delete(ctx context.Context, name string, mode ...DeleteMod
 }
 
 func (w *FilesClient) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, error) {
-	return nil, filesNotImplementedError("ReadDir")
+	return nil, listAPINotAvailableError("ReadDir")
 }
 
 func (w *FilesClient) Mkdir(ctx context.Context, name string) error {

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -63,10 +63,6 @@ type FilesClient struct {
 	root WorkspaceRootPath
 }
 
-func listAPINotAvailableError(fn string) error {
-	return fmt.Errorf("list API is not yet available for UC Volumes")
-}
-
 func NewFilesClient(w *databricks.WorkspaceClient, root string) (Filer, error) {
 	apiClient, err := client.New(w.Config)
 	if err != nil {
@@ -192,7 +188,7 @@ func (w *FilesClient) Delete(ctx context.Context, name string, mode ...DeleteMod
 }
 
 func (w *FilesClient) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, error) {
-	return nil, listAPINotAvailableError("ReadDir")
+	return nil, fmt.Errorf("list API is not yet available for UC Volumes")
 }
 
 func (w *FilesClient) Mkdir(ctx context.Context, name string) error {


### PR DESCRIPTION
## Changes
Fixes https://github.com/databricks/cli/issues/1157

```
shreyas.goenka@THW32HFW6T cli % cli fs ls dbfs:/Volumes/                                                        
Error: list API is not yet available for UC Volumes
```

## Tests
Tested manually
