### PR TITLE
Add `--key` flag for generate commands to specify resource key

### DIFF
--- a/cmd/bundle/generate.go
+++ b/cmd/bundle/generate.go
@@ -17,6 +17,6 @@ func newGenerateCommand() *cobra.Command {
 
 	cmd.AddCommand(generate.NewGenerateJobCommand())
 	cmd.AddCommand(generate.NewGeneratePipelineCommand())
-	cmd.PersistentFlags().StringVar(&key, "key", "", `Key name to be used for generated resources in the config`)
+	cmd.PersistentFlags().StringVar(&key, "key", "", `resource key to use for the generated configuration`)
 	return cmd
 }

--- a/cmd/bundle/generate.go
+++ b/cmd/bundle/generate.go
@@ -6,6 +6,8 @@ import (
 )
 
 func newGenerateCommand() *cobra.Command {
+	var key string
+
 	cmd := &cobra.Command{
 		Use:     "generate",
 		Short:   "Generate bundle configuration",
@@ -15,5 +17,6 @@ func newGenerateCommand() *cobra.Command {
 
 	cmd.AddCommand(generate.NewGenerateJobCommand())
 	cmd.AddCommand(generate.NewGeneratePipelineCommand())
+	cmd.Flags().StringVar(&key, "key", "", `Key name to be used for generated resources in the config`)
 	return cmd
 }

--- a/cmd/bundle/generate.go
+++ b/cmd/bundle/generate.go
@@ -17,6 +17,6 @@ func newGenerateCommand() *cobra.Command {
 
 	cmd.AddCommand(generate.NewGenerateJobCommand())
 	cmd.AddCommand(generate.NewGeneratePipelineCommand())
-	cmd.Flags().StringVar(&key, "key", "", `Key name to be used for generated resources in the config`)
+	cmd.PersistentFlags().StringVar(&key, "key", "", `Key name to be used for generated resources in the config`)
 	return cmd
 }

--- a/cmd/bundle/generate/generate_test.go
+++ b/cmd/bundle/generate/generate_test.go
@@ -72,14 +72,18 @@ func TestGeneratePipelineCommand(t *testing.T) {
 
 	srcDir := filepath.Join(root, "src")
 	cmd.Flag("source-dir").Value.Set(srcDir)
+
+	var key string
+	cmd.Flags().StringVar(&key, "key", "test_pipeline", "")
+
 	err := cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(filepath.Join(configDir, "pipeline_test_pipeline.yml"))
+	data, err := os.ReadFile(filepath.Join(configDir, "test_pipeline.yml"))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf(`resources:
   pipelines:
-    pipeline_test_pipeline:
+    test_pipeline:
       name: test-pipeline
       libraries:
         - notebook:

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -63,7 +63,13 @@ func NewGenerateJobCommand() *cobra.Command {
 			return err
 		}
 
-		jobKey := fmt.Sprintf("job_%s", textutil.NormalizeString(job.Settings.Name))
+		var jobKey string
+		if cmd.Flag("key").Changed {
+			jobKey = cmd.Flag("key").Value.String()
+		} else {
+			jobKey = textutil.NormalizeString(job.Settings.Name)
+		}
+
 		result := map[string]dyn.Value{
 			"resources": dyn.V(map[string]dyn.Value{
 				"jobs": dyn.V(map[string]dyn.Value{

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -63,10 +63,8 @@ func NewGenerateJobCommand() *cobra.Command {
 			return err
 		}
 
-		var jobKey string
-		if cmd.Flag("key").Changed {
-			jobKey = cmd.Flag("key").Value.String()
-		} else {
+		jobKey := cmd.Flag("key").Value.String()
+		if jobKey == "" {
 			jobKey = textutil.NormalizeString(job.Settings.Name)
 		}
 

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -63,11 +63,17 @@ func NewGeneratePipelineCommand() *cobra.Command {
 			return err
 		}
 
-		jobKey := fmt.Sprintf("pipeline_%s", textutil.NormalizeString(pipeline.Name))
+		var pipelineKey string
+		if cmd.Flag("key").Changed {
+			pipelineKey = cmd.Flag("key").Value.String()
+		} else {
+			pipelineKey = textutil.NormalizeString(pipeline.Name)
+		}
+
 		result := map[string]dyn.Value{
 			"resources": dyn.V(map[string]dyn.Value{
 				"pipelines": dyn.V(map[string]dyn.Value{
-					jobKey: v,
+					pipelineKey: v,
 				}),
 			}),
 		}
@@ -77,7 +83,7 @@ func NewGeneratePipelineCommand() *cobra.Command {
 			return err
 		}
 
-		filename := filepath.Join(configDir, fmt.Sprintf("%s.yml", jobKey))
+		filename := filepath.Join(configDir, fmt.Sprintf("%s.yml", pipelineKey))
 		err = yamlsaver.SaveAsYAML(result, filename, force)
 		if err != nil {
 			return err

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -63,10 +63,8 @@ func NewGeneratePipelineCommand() *cobra.Command {
 			return err
 		}
 
-		var pipelineKey string
-		if cmd.Flag("key").Changed {
-			pipelineKey = cmd.Flag("key").Value.String()
-		} else {
+		pipelineKey := cmd.Flag("key").Value.String()
+		if pipelineKey == "" {
 			pipelineKey = textutil.NormalizeString(pipeline.Name)
 		}
 

--- a/internal/bundle/generate_job_test.go
+++ b/internal/bundle/generate_job_test.go
@@ -46,7 +46,7 @@ func TestAccGenerateFromExistingJobAndDeploy(t *testing.T) {
 	_, err = os.Stat(filepath.Join(bundleRoot, "src", "test.py"))
 	require.NoError(t, err)
 
-	matches, err := filepath.Glob(filepath.Join(bundleRoot, "resources", "job_generated_job_*.yml"))
+	matches, err := filepath.Glob(filepath.Join(bundleRoot, "resources", "generated_job_*.yml"))
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
 

--- a/internal/bundle/generate_pipeline_test.go
+++ b/internal/bundle/generate_pipeline_test.go
@@ -47,7 +47,7 @@ func TestAccGenerateFromExistingPipelineAndDeploy(t *testing.T) {
 	_, err = os.Stat(filepath.Join(bundleRoot, "src", "test.py"))
 	require.NoError(t, err)
 
-	matches, err := filepath.Glob(filepath.Join(bundleRoot, "resources", "pipeline_generated_pipeline_*.yml"))
+	matches, err := filepath.Glob(filepath.Join(bundleRoot, "resources", "generated_pipeline_*.yml"))
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
 


### PR DESCRIPTION
## Changes
Add --key for generate commands to specify resource key.

Also, resource config files are now not prefixed anymore.

## Tests
Integration tests passed

