### PR TITLE
Allow specifying executable in artifact section and skip bash from WSL

### DIFF
--- a/bundle/config/artifact.go
+++ b/bundle/config/artifact.go
@@ -42,6 +42,8 @@ type Artifact struct {
 	Files        []ArtifactFile `json:"files,omitempty"`
 	BuildCommand string         `json:"build,omitempty"`
 
+	Executable exec.ExecutableType `json:"executable,omitempty"`
+
 	paths.Paths
 }
 
@@ -50,7 +52,13 @@ func (a *Artifact) Build(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("no build property defined")
 	}
 
-	e, err := exec.NewCommandExecutor(a.Path)
+	var e *exec.Executor
+	var err error
+	if a.Executable != "" {
+		e, err = exec.NewCommandExecutorWithExecutable(a.Path, a.Executable)
+	} else {
+		e, err = exec.NewCommandExecutor(a.Path)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/bundle/config/artifact.go
+++ b/bundle/config/artifact.go
@@ -58,6 +58,7 @@ func (a *Artifact) Build(ctx context.Context) ([]byte, error) {
 		e, err = exec.NewCommandExecutorWithExecutable(a.Path, a.Executable)
 	} else {
 		e, err = exec.NewCommandExecutor(a.Path)
+		a.Executable = e.ShellType()
 	}
 	if err != nil {
 		return nil, err

--- a/libs/exec/exec.go
+++ b/libs/exec/exec.go
@@ -77,7 +77,7 @@ func NewCommandExecutor(dir string) (*Executor, error) {
 func NewCommandExecutorWithExecutable(dir string, execType ExecutableType) (*Executor, error) {
 	f, ok := finders[execType]
 	if !ok {
-		return nil, fmt.Errorf("%s is not supported as an artifact executable", execType)
+		return nil, fmt.Errorf("%s is not supported as an artifact executable, options are: %s, %s or %s", execType, BashExecutable, ShExecutable, CmdExecutable)
 	}
 	shell, err := f()
 	if err != nil {

--- a/libs/exec/exec.go
+++ b/libs/exec/exec.go
@@ -128,3 +128,7 @@ func (e *Executor) Exec(ctx context.Context, command string) ([]byte, error) {
 
 	return res, cmd.Wait()
 }
+
+func (e *Executor) ShellType() ExecutableType {
+	return e.shell.getType()
+}

--- a/libs/exec/exec.go
+++ b/libs/exec/exec.go
@@ -16,8 +16,8 @@ const CmdExecutable ExecutableType = `cmd`
 
 var finders map[ExecutableType](func() (shell, error)) = map[ExecutableType](func() (shell, error)){
 	BashExecutable: newBashShell,
-	ShExecutable:   newBashShell,
-	CmdExecutable:  newBashShell,
+	ShExecutable:   newShShell,
+	CmdExecutable:  newCmdShell,
 }
 
 type Command interface {

--- a/libs/exec/shell.go
+++ b/libs/exec/shell.go
@@ -8,6 +8,7 @@ import (
 
 type shell interface {
 	prepare(string) (*execContext, error)
+	getType() ExecutableType
 }
 
 type execContext struct {

--- a/libs/exec/shell.go
+++ b/libs/exec/shell.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"runtime"
 )
 
 type shell interface {
@@ -18,21 +17,11 @@ type execContext struct {
 }
 
 func findShell() (shell, error) {
-	finders := []func() (shell, error){
+	for _, fn := range []func() (shell, error){
 		newBashShell,
 		newShShell,
-	}
-
-	// If on Windows, first try to find and use CMD as a shell
-	if runtime.GOOS == "windows" {
-		finders = []func() (shell, error){
-			newCmdShell,
-			newBashShell,
-			newShShell,
-		}
-	}
-
-	for _, fn := range finders {
+		newCmdShell,
+	} {
 		shell, err := fn()
 		if err != nil {
 			return nil, err

--- a/libs/exec/shell_bash.go
+++ b/libs/exec/shell_bash.go
@@ -41,3 +41,7 @@ func newBashShell() (shell, error) {
 
 	return &bashShell{executable: out}, nil
 }
+
+func (s bashShell) getType() ExecutableType {
+	return BashExecutable
+}

--- a/libs/exec/shell_bash.go
+++ b/libs/exec/shell_bash.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"errors"
 	osexec "os/exec"
+	"strings"
 )
 
 type bashShell struct {
@@ -30,6 +31,11 @@ func newBashShell() (shell, error) {
 
 	// `bash` is not found, return early.
 	if out == "" {
+		return nil, nil
+	}
+
+	// Skipping WSL bash if found one
+	if strings.Contains(out, `\Windows\System32\bash.exe`) || strings.Contains(out, `\Microsoft\WindowsApps\bash.exe`) {
 		return nil, nil
 	}
 

--- a/libs/exec/shell_cmd.go
+++ b/libs/exec/shell_cmd.go
@@ -36,3 +36,7 @@ func newCmdShell() (shell, error) {
 
 	return &cmdShell{executable: out}, nil
 }
+
+func (s cmdShell) getType() ExecutableType {
+	return CmdExecutable
+}

--- a/libs/exec/shell_sh.go
+++ b/libs/exec/shell_sh.go
@@ -35,3 +35,7 @@ func newShShell() (shell, error) {
 
 	return &shShell{executable: out}, nil
 }
+
+func (s shShell) getType() ExecutableType {
+	return ShExecutable
+}


### PR DESCRIPTION
## Changes
Allow specifying executable in artifact section

```
artifacts:
  test:
    type: whl
    executable: bash
    ...
```

We also skip bash found on Windows if it's from WSL because it won't be correctly executed, see the issue above

Fixes #1159

