### PR TITLE
Empty struct should yield empty map in `convert.FromTyped`

### DIFF
--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -84,11 +84,6 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 		}
 	}
 
-	// If the struct was equal to its zero value, emit a nil.
-	if len(out) == 0 {
-		return dyn.NilValue, nil
-	}
-
 	return dyn.NewValue(out, ref.Location()), nil
 }
 

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -19,6 +19,25 @@ func TestFromTypedStructZeroFields(t *testing.T) {
 
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{}), nv)
+}
+
+func TestFromTypedStructPointerZeroFields(t *testing.T) {
+	type Tmp struct {
+		Foo string `json:"foo"`
+		Bar string `json:"bar"`
+	}
+
+	// For an initialized pointer we expect an empty map.
+	src := &Tmp{}
+	nv, err := FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.V(map[string]dyn.Value{}), nv)
+
+	// For a nil pointer we expect nil.
+	src = nil
+	nv, err = FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
 	assert.Equal(t, dyn.NilValue, nv)
 }
 


### PR DESCRIPTION
## Changes

This was an issue in cases where the typed structure contains a non-nil pointer to an empty struct. After conversion to a `dyn.Value` and back to the typed structure, the pointer became nil.

## Tests

Unit tests.

