### PR TITLE
Fix integration test with invalid configuration

### DIFF
--- a/internal/bundle/bundles/deploy_then_remove_resources/template/resources.yml.tmpl
+++ b/internal/bundle/bundles/deploy_then_remove_resources/template/resources.yml.tmpl
@@ -3,5 +3,5 @@ resources:
     bar:
       name: test-bundle-pipeline-{{.unique_id}}
       libraries:
-        - notebook:
-          path: "./foo.py"
+        - file:
+            path: "./foo.py"


### PR DESCRIPTION
## Changes

The indentation mistake on the `path` field under `notebook` meant the pipeline had a single entry with a `nil` notebook field. This was allowed but incorrect.

While working on the `dyn.Value` approach, this yielded a non-nil but zeroed `notebook` field and a failure to translate an empty path.

## Tests

Correcting the indentation made the test fail because the file is not a notebook. I changed it to a `file` reference and the test now passes.