### PR TITLE
Add spinner when downloading templates for bundle init

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -194,17 +194,15 @@ See https://docs.databricks.com/en/dev-tools/bundles/templates.html for more inf
 
 		// start the spinner
 		promptSpinner := cmdio.Spinner(ctx)
-		promptSpinner <- "Downloading the template"
+		promptSpinner <- "Downloading the template\n"
 
 		// TODO: Add automated test that the downloaded git repo is cleaned up.
 		// Clone the repository in the temporary directory
 		err = git.Clone(ctx, templatePath, ref, repoDir)
+		close(promptSpinner)
 		if err != nil {
 			return err
 		}
-
-		// stop the spinner
-		close(promptSpinner)
 
 		// Clean up downloaded repository once the template is materialized.
 		defer os.RemoveAll(repoDir)

--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -191,12 +191,21 @@ See https://docs.databricks.com/en/dev-tools/bundles/templates.html for more inf
 		if err != nil {
 			return err
 		}
+
+		// start the spinner
+		promptSpinner := cmdio.Spinner(ctx)
+		promptSpinner <- "Downloading the template"
+
 		// TODO: Add automated test that the downloaded git repo is cleaned up.
 		// Clone the repository in the temporary directory
 		err = git.Clone(ctx, templatePath, ref, repoDir)
 		if err != nil {
 			return err
 		}
+
+		// stop the spinner
+		close(promptSpinner)
+
 		// Clean up downloaded repository once the template is materialized.
 		defer os.RemoveAll(repoDir)
 		return template.Materialize(ctx, configFile, filepath.Join(repoDir, templateDir), outputDir)


### PR DESCRIPTION
## Changes
Templates can take a long time to download. This PR adds a spinner to give feedback to users.

## Tests
<!-- How is this tested? -->
Manually

https://github.com/databricks/cli/assets/88374338/b453982c-3233-40f4-8d6f-f31606ff0195

