### PR TITLE
Ignore environment variables for `auth profiles`

### DIFF
--- a/cmd/auth/profiles.go
+++ b/cmd/auth/profiles.go
@@ -42,9 +42,6 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 		c.Cloud = "gcp"
 	}
 
-	// set host again, this time normalized
-	c.Host = cfg.Host
-
 	if skipValidate {
 		err := cfg.Authenticate(&http.Request{
 			Header: make(http.Header),
@@ -52,6 +49,7 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 		if err != nil {
 			return
 		}
+		c.Host = cfg.Host
 		c.AuthType = cfg.AuthType
 		return
 	}
@@ -62,6 +60,7 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 			return
 		}
 		_, err = a.Workspaces.List(ctx)
+		c.Host = cfg.Host
 		c.AuthType = cfg.AuthType
 		if err != nil {
 			return
@@ -73,6 +72,7 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 			return
 		}
 		_, err = w.CurrentUser.Me(ctx)
+		c.Host = cfg.Host
 		c.AuthType = cfg.AuthType
 		if err != nil {
 			return

--- a/cmd/auth/profiles.go
+++ b/cmd/auth/profiles.go
@@ -29,8 +29,10 @@ func (c *profileMetadata) IsEmpty() bool {
 }
 
 func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
-	// TODO: disable config loaders other than configfile
-	cfg := &config.Config{Profile: c.Name}
+	cfg := &config.Config{
+		Loaders: []config.Loader{config.ConfigFile},
+		Profile: c.Name,
+	}
 	_ = cfg.EnsureResolved()
 	if cfg.IsAws() {
 		c.Cloud = "aws"
@@ -39,6 +41,9 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 	} else if cfg.IsGcp() {
 		c.Cloud = "gcp"
 	}
+
+	// set host again, this time normalized
+	c.Host = cfg.Host
 
 	if skipValidate {
 		err := cfg.Authenticate(&http.Request{
@@ -74,8 +79,6 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 		}
 		c.Valid = true
 	}
-	// set host again, this time normalized
-	c.Host = cfg.Host
 }
 
 func newProfilesCommand() *cobra.Command {

--- a/cmd/auth/profiles_test.go
+++ b/cmd/auth/profiles_test.go
@@ -12,14 +12,12 @@ import (
 )
 
 func TestProfiles(t *testing.T) {
-	var err error
-
 	ctx := context.Background()
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, ".databrickscfg")
 
 	// Create a config file with a profile
-	err = databrickscfg.SaveToProfile(ctx, &config.Config{
+	err := databrickscfg.SaveToProfile(ctx, &config.Config{
 		ConfigFile: configFile,
 		Profile:    "profile1",
 		Host:       "https://abc.cloud.databricks.com",

--- a/cmd/auth/profiles_test.go
+++ b/cmd/auth/profiles_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/databricks/cli/libs/databrickscfg"
@@ -28,6 +29,9 @@ func TestProfiles(t *testing.T) {
 	// Let the environment think we're using another profile
 	t.Setenv("DATABRICKS_HOST", "https://def.cloud.databricks.com")
 	t.Setenv("HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", dir)
+	}
 
 	// Load the profile
 	profile := &profileMetadata{Name: "profile1"}


### PR DESCRIPTION
## Changes

If environment variables related to unified authentication are set and a user runs `auth profiles`, the environment variables will interfere with the output. This change only takes profile data into account for the output.

## Tests

Added a unit test.

