### PR TITLE
Skip `for_each_task` when generating the bundle schema

### DIFF
--- a/bundle/schema/openapi.go
+++ b/bundle/schema/openapi.go
@@ -73,7 +73,7 @@ func (reader *OpenapiReader) safeResolveRefs(root *jsonschema.Schema, tracker *t
 	key := *root.Reference
 
 	// HACK to unblock CLI release (13th Feb 2024). This is temporary until proper
-	// support for recursive types is added to the docs generator.
+	// support for recursive types is added to the docs generator. PR: https://github.com/databricks/cli/pull/1204
 	if strings.Contains(key, "ForEachTask") {
 		return root, nil
 	}

--- a/bundle/schema/openapi.go
+++ b/bundle/schema/openapi.go
@@ -71,6 +71,13 @@ func (reader *OpenapiReader) safeResolveRefs(root *jsonschema.Schema, tracker *t
 		return reader.traverseSchema(root, tracker)
 	}
 	key := *root.Reference
+
+	// HACK to unblock CLI release (13th Feb 2024). This is temporary until proper
+	// support for recursive types is added to the docs generator.
+	if strings.Contains(key, "ForEachTask") {
+		return root, nil
+	}
+
 	if tracker.hasCycle(key) {
 		// self reference loops can be supported however the logic is non-trivial because
 		// cross refernce loops are not allowed (see: http://json-schema.org/understanding-json-schema/structuring.html#recursion)

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -93,7 +93,7 @@ func jsonSchemaType(golangType reflect.Type) (jsonschema.Type, error) {
 //   - tracker: Keeps track of types / traceIds seen during recursive traversal
 func safeToSchema(golangType reflect.Type, docs *Docs, traceId string, tracker *tracker) (*jsonschema.Schema, error) {
 	// HACK to unblock CLI release (13th Feb 2024). This is temporary until proper
-	// support for recursive types is added to the schema generator.
+	// support for recursive types is added to the schema generator. PR: https://github.com/databricks/cli/pull/1204
 	if traceId == "for_each_task" {
 		return nil, nil
 	}

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -92,6 +92,12 @@ func jsonSchemaType(golangType reflect.Type) (jsonschema.Type, error) {
 //
 //   - tracker: Keeps track of types / traceIds seen during recursive traversal
 func safeToSchema(golangType reflect.Type, docs *Docs, traceId string, tracker *tracker) (*jsonschema.Schema, error) {
+	// HACK to unblock CLI release (13th Feb 2024). This is temporary until proper
+	// support for recursive types is added to the schema generator.
+	if traceId == "for_each_task" {
+		return nil, nil
+	}
+
 	// WE ERROR OUT IF THERE ARE CYCLES IN THE JSON SCHEMA
 	// There are mechanisms to deal with cycles though recursive identifiers in json
 	// schema. However if we use them, we would need to make sure we are able to detect


### PR DESCRIPTION
## Changes
Bundle schema generation does not support recursive API fields. This PR skips generation for for_each_task until we add proper support for recursive types in the bundle schema.

## Tests
Manually. This fixes the generation of the CLI and the bundle schema command works as expected, with the sub-schema for `for_each_task` being set to null in the output. 
```
"for_each_task": null,
```