### PR TITLE
Add fork-user to winget release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,3 +128,4 @@ jobs:
           identifier: Databricks.DatabricksCLI
           installers-regex: 'windows_.*\.zip$' # Only windows releases
           token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+          fork-user: eng-dev-ecosystem-bot


### PR DESCRIPTION
## Changes
From https://github.com/vedantmgoyal2009/winget-releaser:

> If you are forking [winget-pkgs](https://github.com/microsoft/winget-pkgs) on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.

This PR makes that change.

## Tests
<!-- How is this tested? -->

