### PR TITLE
Use `any` as type for data sources and resources in `tf/schema`

### DIFF
--- a/bundle/internal/tf/codegen/templates/data_sources.go.tmpl
+++ b/bundle/internal/tf/codegen/templates/data_sources.go.tmpl
@@ -4,14 +4,14 @@ package schema
 
 type DataSources struct {
 	{{- range .Blocks }}
-	{{ .FieldName }} map[string]*{{ .TypeName }} `json:"{{ .TerraformName }},omitempty"`
+	{{ .FieldName }} map[string]any `json:"{{ .TerraformName }},omitempty"`
 	{{- end }}
 }
 
 func NewDataSources() *DataSources {
 	return &DataSources{
 		{{- range .Blocks }}
-		{{ .FieldName }}: make(map[string]*{{ .TypeName }}),
+		{{ .FieldName }}: make(map[string]any),
 		{{- end }}
 	}
 }

--- a/bundle/internal/tf/codegen/templates/resources.go.tmpl
+++ b/bundle/internal/tf/codegen/templates/resources.go.tmpl
@@ -4,14 +4,14 @@ package schema
 
 type Resources struct {
 	{{- range .Blocks }}
-	{{ .FieldName }} map[string]*{{ .TypeName }} `json:"{{ .TerraformName }},omitempty"`
+	{{ .FieldName }} map[string]any `json:"{{ .TerraformName }},omitempty"`
 	{{- end }}
 }
 
 func NewResources() *Resources {
 	return &Resources{
         {{- range .Blocks }}
-        {{ .FieldName }}: make(map[string]*{{ .TypeName }}),
+        {{ .FieldName }}: make(map[string]any),
         {{- end }}
 	}
 }

--- a/bundle/internal/tf/schema/data_sources.go
+++ b/bundle/internal/tf/schema/data_sources.go
@@ -3,91 +3,91 @@
 package schema
 
 type DataSources struct {
-	AwsAssumeRolePolicy   map[string]*DataSourceAwsAssumeRolePolicy   `json:"databricks_aws_assume_role_policy,omitempty"`
-	AwsBucketPolicy       map[string]*DataSourceAwsBucketPolicy       `json:"databricks_aws_bucket_policy,omitempty"`
-	AwsCrossaccountPolicy map[string]*DataSourceAwsCrossaccountPolicy `json:"databricks_aws_crossaccount_policy,omitempty"`
-	AwsUnityCatalogPolicy map[string]*DataSourceAwsUnityCatalogPolicy `json:"databricks_aws_unity_catalog_policy,omitempty"`
-	Catalogs              map[string]*DataSourceCatalogs              `json:"databricks_catalogs,omitempty"`
-	Cluster               map[string]*DataSourceCluster               `json:"databricks_cluster,omitempty"`
-	ClusterPolicy         map[string]*DataSourceClusterPolicy         `json:"databricks_cluster_policy,omitempty"`
-	Clusters              map[string]*DataSourceClusters              `json:"databricks_clusters,omitempty"`
-	CurrentConfig         map[string]*DataSourceCurrentConfig         `json:"databricks_current_config,omitempty"`
-	CurrentMetastore      map[string]*DataSourceCurrentMetastore      `json:"databricks_current_metastore,omitempty"`
-	CurrentUser           map[string]*DataSourceCurrentUser           `json:"databricks_current_user,omitempty"`
-	DbfsFile              map[string]*DataSourceDbfsFile              `json:"databricks_dbfs_file,omitempty"`
-	DbfsFilePaths         map[string]*DataSourceDbfsFilePaths         `json:"databricks_dbfs_file_paths,omitempty"`
-	Directory             map[string]*DataSourceDirectory             `json:"databricks_directory,omitempty"`
-	Group                 map[string]*DataSourceGroup                 `json:"databricks_group,omitempty"`
-	InstancePool          map[string]*DataSourceInstancePool          `json:"databricks_instance_pool,omitempty"`
-	InstanceProfiles      map[string]*DataSourceInstanceProfiles      `json:"databricks_instance_profiles,omitempty"`
-	Job                   map[string]*DataSourceJob                   `json:"databricks_job,omitempty"`
-	Jobs                  map[string]*DataSourceJobs                  `json:"databricks_jobs,omitempty"`
-	Metastore             map[string]*DataSourceMetastore             `json:"databricks_metastore,omitempty"`
-	Metastores            map[string]*DataSourceMetastores            `json:"databricks_metastores,omitempty"`
-	MlflowModel           map[string]*DataSourceMlflowModel           `json:"databricks_mlflow_model,omitempty"`
-	MwsCredentials        map[string]*DataSourceMwsCredentials        `json:"databricks_mws_credentials,omitempty"`
-	MwsWorkspaces         map[string]*DataSourceMwsWorkspaces         `json:"databricks_mws_workspaces,omitempty"`
-	NodeType              map[string]*DataSourceNodeType              `json:"databricks_node_type,omitempty"`
-	Notebook              map[string]*DataSourceNotebook              `json:"databricks_notebook,omitempty"`
-	NotebookPaths         map[string]*DataSourceNotebookPaths         `json:"databricks_notebook_paths,omitempty"`
-	Pipelines             map[string]*DataSourcePipelines             `json:"databricks_pipelines,omitempty"`
-	Schemas               map[string]*DataSourceSchemas               `json:"databricks_schemas,omitempty"`
-	ServicePrincipal      map[string]*DataSourceServicePrincipal      `json:"databricks_service_principal,omitempty"`
-	ServicePrincipals     map[string]*DataSourceServicePrincipals     `json:"databricks_service_principals,omitempty"`
-	Share                 map[string]*DataSourceShare                 `json:"databricks_share,omitempty"`
-	Shares                map[string]*DataSourceShares                `json:"databricks_shares,omitempty"`
-	SparkVersion          map[string]*DataSourceSparkVersion          `json:"databricks_spark_version,omitempty"`
-	SqlWarehouse          map[string]*DataSourceSqlWarehouse          `json:"databricks_sql_warehouse,omitempty"`
-	SqlWarehouses         map[string]*DataSourceSqlWarehouses         `json:"databricks_sql_warehouses,omitempty"`
-	Tables                map[string]*DataSourceTables                `json:"databricks_tables,omitempty"`
-	User                  map[string]*DataSourceUser                  `json:"databricks_user,omitempty"`
-	Views                 map[string]*DataSourceViews                 `json:"databricks_views,omitempty"`
-	Volumes               map[string]*DataSourceVolumes               `json:"databricks_volumes,omitempty"`
-	Zones                 map[string]*DataSourceZones                 `json:"databricks_zones,omitempty"`
+	AwsAssumeRolePolicy   map[string]any `json:"databricks_aws_assume_role_policy,omitempty"`
+	AwsBucketPolicy       map[string]any `json:"databricks_aws_bucket_policy,omitempty"`
+	AwsCrossaccountPolicy map[string]any `json:"databricks_aws_crossaccount_policy,omitempty"`
+	AwsUnityCatalogPolicy map[string]any `json:"databricks_aws_unity_catalog_policy,omitempty"`
+	Catalogs              map[string]any `json:"databricks_catalogs,omitempty"`
+	Cluster               map[string]any `json:"databricks_cluster,omitempty"`
+	ClusterPolicy         map[string]any `json:"databricks_cluster_policy,omitempty"`
+	Clusters              map[string]any `json:"databricks_clusters,omitempty"`
+	CurrentConfig         map[string]any `json:"databricks_current_config,omitempty"`
+	CurrentMetastore      map[string]any `json:"databricks_current_metastore,omitempty"`
+	CurrentUser           map[string]any `json:"databricks_current_user,omitempty"`
+	DbfsFile              map[string]any `json:"databricks_dbfs_file,omitempty"`
+	DbfsFilePaths         map[string]any `json:"databricks_dbfs_file_paths,omitempty"`
+	Directory             map[string]any `json:"databricks_directory,omitempty"`
+	Group                 map[string]any `json:"databricks_group,omitempty"`
+	InstancePool          map[string]any `json:"databricks_instance_pool,omitempty"`
+	InstanceProfiles      map[string]any `json:"databricks_instance_profiles,omitempty"`
+	Job                   map[string]any `json:"databricks_job,omitempty"`
+	Jobs                  map[string]any `json:"databricks_jobs,omitempty"`
+	Metastore             map[string]any `json:"databricks_metastore,omitempty"`
+	Metastores            map[string]any `json:"databricks_metastores,omitempty"`
+	MlflowModel           map[string]any `json:"databricks_mlflow_model,omitempty"`
+	MwsCredentials        map[string]any `json:"databricks_mws_credentials,omitempty"`
+	MwsWorkspaces         map[string]any `json:"databricks_mws_workspaces,omitempty"`
+	NodeType              map[string]any `json:"databricks_node_type,omitempty"`
+	Notebook              map[string]any `json:"databricks_notebook,omitempty"`
+	NotebookPaths         map[string]any `json:"databricks_notebook_paths,omitempty"`
+	Pipelines             map[string]any `json:"databricks_pipelines,omitempty"`
+	Schemas               map[string]any `json:"databricks_schemas,omitempty"`
+	ServicePrincipal      map[string]any `json:"databricks_service_principal,omitempty"`
+	ServicePrincipals     map[string]any `json:"databricks_service_principals,omitempty"`
+	Share                 map[string]any `json:"databricks_share,omitempty"`
+	Shares                map[string]any `json:"databricks_shares,omitempty"`
+	SparkVersion          map[string]any `json:"databricks_spark_version,omitempty"`
+	SqlWarehouse          map[string]any `json:"databricks_sql_warehouse,omitempty"`
+	SqlWarehouses         map[string]any `json:"databricks_sql_warehouses,omitempty"`
+	Tables                map[string]any `json:"databricks_tables,omitempty"`
+	User                  map[string]any `json:"databricks_user,omitempty"`
+	Views                 map[string]any `json:"databricks_views,omitempty"`
+	Volumes               map[string]any `json:"databricks_volumes,omitempty"`
+	Zones                 map[string]any `json:"databricks_zones,omitempty"`
 }
 
 func NewDataSources() *DataSources {
 	return &DataSources{
-		AwsAssumeRolePolicy:   make(map[string]*DataSourceAwsAssumeRolePolicy),
-		AwsBucketPolicy:       make(map[string]*DataSourceAwsBucketPolicy),
-		AwsCrossaccountPolicy: make(map[string]*DataSourceAwsCrossaccountPolicy),
-		AwsUnityCatalogPolicy: make(map[string]*DataSourceAwsUnityCatalogPolicy),
-		Catalogs:              make(map[string]*DataSourceCatalogs),
-		Cluster:               make(map[string]*DataSourceCluster),
-		ClusterPolicy:         make(map[string]*DataSourceClusterPolicy),
-		Clusters:              make(map[string]*DataSourceClusters),
-		CurrentConfig:         make(map[string]*DataSourceCurrentConfig),
-		CurrentMetastore:      make(map[string]*DataSourceCurrentMetastore),
-		CurrentUser:           make(map[string]*DataSourceCurrentUser),
-		DbfsFile:              make(map[string]*DataSourceDbfsFile),
-		DbfsFilePaths:         make(map[string]*DataSourceDbfsFilePaths),
-		Directory:             make(map[string]*DataSourceDirectory),
-		Group:                 make(map[string]*DataSourceGroup),
-		InstancePool:          make(map[string]*DataSourceInstancePool),
-		InstanceProfiles:      make(map[string]*DataSourceInstanceProfiles),
-		Job:                   make(map[string]*DataSourceJob),
-		Jobs:                  make(map[string]*DataSourceJobs),
-		Metastore:             make(map[string]*DataSourceMetastore),
-		Metastores:            make(map[string]*DataSourceMetastores),
-		MlflowModel:           make(map[string]*DataSourceMlflowModel),
-		MwsCredentials:        make(map[string]*DataSourceMwsCredentials),
-		MwsWorkspaces:         make(map[string]*DataSourceMwsWorkspaces),
-		NodeType:              make(map[string]*DataSourceNodeType),
-		Notebook:              make(map[string]*DataSourceNotebook),
-		NotebookPaths:         make(map[string]*DataSourceNotebookPaths),
-		Pipelines:             make(map[string]*DataSourcePipelines),
-		Schemas:               make(map[string]*DataSourceSchemas),
-		ServicePrincipal:      make(map[string]*DataSourceServicePrincipal),
-		ServicePrincipals:     make(map[string]*DataSourceServicePrincipals),
-		Share:                 make(map[string]*DataSourceShare),
-		Shares:                make(map[string]*DataSourceShares),
-		SparkVersion:          make(map[string]*DataSourceSparkVersion),
-		SqlWarehouse:          make(map[string]*DataSourceSqlWarehouse),
-		SqlWarehouses:         make(map[string]*DataSourceSqlWarehouses),
-		Tables:                make(map[string]*DataSourceTables),
-		User:                  make(map[string]*DataSourceUser),
-		Views:                 make(map[string]*DataSourceViews),
-		Volumes:               make(map[string]*DataSourceVolumes),
-		Zones:                 make(map[string]*DataSourceZones),
+		AwsAssumeRolePolicy:   make(map[string]any),
+		AwsBucketPolicy:       make(map[string]any),
+		AwsCrossaccountPolicy: make(map[string]any),
+		AwsUnityCatalogPolicy: make(map[string]any),
+		Catalogs:              make(map[string]any),
+		Cluster:               make(map[string]any),
+		ClusterPolicy:         make(map[string]any),
+		Clusters:              make(map[string]any),
+		CurrentConfig:         make(map[string]any),
+		CurrentMetastore:      make(map[string]any),
+		CurrentUser:           make(map[string]any),
+		DbfsFile:              make(map[string]any),
+		DbfsFilePaths:         make(map[string]any),
+		Directory:             make(map[string]any),
+		Group:                 make(map[string]any),
+		InstancePool:          make(map[string]any),
+		InstanceProfiles:      make(map[string]any),
+		Job:                   make(map[string]any),
+		Jobs:                  make(map[string]any),
+		Metastore:             make(map[string]any),
+		Metastores:            make(map[string]any),
+		MlflowModel:           make(map[string]any),
+		MwsCredentials:        make(map[string]any),
+		MwsWorkspaces:         make(map[string]any),
+		NodeType:              make(map[string]any),
+		Notebook:              make(map[string]any),
+		NotebookPaths:         make(map[string]any),
+		Pipelines:             make(map[string]any),
+		Schemas:               make(map[string]any),
+		ServicePrincipal:      make(map[string]any),
+		ServicePrincipals:     make(map[string]any),
+		Share:                 make(map[string]any),
+		Shares:                make(map[string]any),
+		SparkVersion:          make(map[string]any),
+		SqlWarehouse:          make(map[string]any),
+		SqlWarehouses:         make(map[string]any),
+		Tables:                make(map[string]any),
+		User:                  make(map[string]any),
+		Views:                 make(map[string]any),
+		Volumes:               make(map[string]any),
+		Zones:                 make(map[string]any),
 	}
 }

--- a/bundle/internal/tf/schema/resources.go
+++ b/bundle/internal/tf/schema/resources.go
@@ -3,173 +3,173 @@
 package schema
 
 type Resources struct {
-	AccessControlRuleSet     map[string]*ResourceAccessControlRuleSet     `json:"databricks_access_control_rule_set,omitempty"`
-	ArtifactAllowlist        map[string]*ResourceArtifactAllowlist        `json:"databricks_artifact_allowlist,omitempty"`
-	AwsS3Mount               map[string]*ResourceAwsS3Mount               `json:"databricks_aws_s3_mount,omitempty"`
-	AzureAdlsGen1Mount       map[string]*ResourceAzureAdlsGen1Mount       `json:"databricks_azure_adls_gen1_mount,omitempty"`
-	AzureAdlsGen2Mount       map[string]*ResourceAzureAdlsGen2Mount       `json:"databricks_azure_adls_gen2_mount,omitempty"`
-	AzureBlobMount           map[string]*ResourceAzureBlobMount           `json:"databricks_azure_blob_mount,omitempty"`
-	Catalog                  map[string]*ResourceCatalog                  `json:"databricks_catalog,omitempty"`
-	CatalogWorkspaceBinding  map[string]*ResourceCatalogWorkspaceBinding  `json:"databricks_catalog_workspace_binding,omitempty"`
-	Cluster                  map[string]*ResourceCluster                  `json:"databricks_cluster,omitempty"`
-	ClusterPolicy            map[string]*ResourceClusterPolicy            `json:"databricks_cluster_policy,omitempty"`
-	Connection               map[string]*ResourceConnection               `json:"databricks_connection,omitempty"`
-	DbfsFile                 map[string]*ResourceDbfsFile                 `json:"databricks_dbfs_file,omitempty"`
-	DefaultNamespaceSetting  map[string]*ResourceDefaultNamespaceSetting  `json:"databricks_default_namespace_setting,omitempty"`
-	Directory                map[string]*ResourceDirectory                `json:"databricks_directory,omitempty"`
-	Entitlements             map[string]*ResourceEntitlements             `json:"databricks_entitlements,omitempty"`
-	ExternalLocation         map[string]*ResourceExternalLocation         `json:"databricks_external_location,omitempty"`
-	GitCredential            map[string]*ResourceGitCredential            `json:"databricks_git_credential,omitempty"`
-	GlobalInitScript         map[string]*ResourceGlobalInitScript         `json:"databricks_global_init_script,omitempty"`
-	Grant                    map[string]*ResourceGrant                    `json:"databricks_grant,omitempty"`
-	Grants                   map[string]*ResourceGrants                   `json:"databricks_grants,omitempty"`
-	Group                    map[string]*ResourceGroup                    `json:"databricks_group,omitempty"`
-	GroupInstanceProfile     map[string]*ResourceGroupInstanceProfile     `json:"databricks_group_instance_profile,omitempty"`
-	GroupMember              map[string]*ResourceGroupMember              `json:"databricks_group_member,omitempty"`
-	GroupRole                map[string]*ResourceGroupRole                `json:"databricks_group_role,omitempty"`
-	InstancePool             map[string]*ResourceInstancePool             `json:"databricks_instance_pool,omitempty"`
-	InstanceProfile          map[string]*ResourceInstanceProfile          `json:"databricks_instance_profile,omitempty"`
-	IpAccessList             map[string]*ResourceIpAccessList             `json:"databricks_ip_access_list,omitempty"`
-	Job                      map[string]*ResourceJob                      `json:"databricks_job,omitempty"`
-	Library                  map[string]*ResourceLibrary                  `json:"databricks_library,omitempty"`
-	Metastore                map[string]*ResourceMetastore                `json:"databricks_metastore,omitempty"`
-	MetastoreAssignment      map[string]*ResourceMetastoreAssignment      `json:"databricks_metastore_assignment,omitempty"`
-	MetastoreDataAccess      map[string]*ResourceMetastoreDataAccess      `json:"databricks_metastore_data_access,omitempty"`
-	MlflowExperiment         map[string]*ResourceMlflowExperiment         `json:"databricks_mlflow_experiment,omitempty"`
-	MlflowModel              map[string]*ResourceMlflowModel              `json:"databricks_mlflow_model,omitempty"`
-	MlflowWebhook            map[string]*ResourceMlflowWebhook            `json:"databricks_mlflow_webhook,omitempty"`
-	ModelServing             map[string]*ResourceModelServing             `json:"databricks_model_serving,omitempty"`
-	Mount                    map[string]*ResourceMount                    `json:"databricks_mount,omitempty"`
-	MwsCredentials           map[string]*ResourceMwsCredentials           `json:"databricks_mws_credentials,omitempty"`
-	MwsCustomerManagedKeys   map[string]*ResourceMwsCustomerManagedKeys   `json:"databricks_mws_customer_managed_keys,omitempty"`
-	MwsLogDelivery           map[string]*ResourceMwsLogDelivery           `json:"databricks_mws_log_delivery,omitempty"`
-	MwsNetworks              map[string]*ResourceMwsNetworks              `json:"databricks_mws_networks,omitempty"`
-	MwsPermissionAssignment  map[string]*ResourceMwsPermissionAssignment  `json:"databricks_mws_permission_assignment,omitempty"`
-	MwsPrivateAccessSettings map[string]*ResourceMwsPrivateAccessSettings `json:"databricks_mws_private_access_settings,omitempty"`
-	MwsStorageConfigurations map[string]*ResourceMwsStorageConfigurations `json:"databricks_mws_storage_configurations,omitempty"`
-	MwsVpcEndpoint           map[string]*ResourceMwsVpcEndpoint           `json:"databricks_mws_vpc_endpoint,omitempty"`
-	MwsWorkspaces            map[string]*ResourceMwsWorkspaces            `json:"databricks_mws_workspaces,omitempty"`
-	Notebook                 map[string]*ResourceNotebook                 `json:"databricks_notebook,omitempty"`
-	OboToken                 map[string]*ResourceOboToken                 `json:"databricks_obo_token,omitempty"`
-	PermissionAssignment     map[string]*ResourcePermissionAssignment     `json:"databricks_permission_assignment,omitempty"`
-	Permissions              map[string]*ResourcePermissions              `json:"databricks_permissions,omitempty"`
-	Pipeline                 map[string]*ResourcePipeline                 `json:"databricks_pipeline,omitempty"`
-	Provider                 map[string]*ResourceProvider                 `json:"databricks_provider,omitempty"`
-	Recipient                map[string]*ResourceRecipient                `json:"databricks_recipient,omitempty"`
-	RegisteredModel          map[string]*ResourceRegisteredModel          `json:"databricks_registered_model,omitempty"`
-	Repo                     map[string]*ResourceRepo                     `json:"databricks_repo,omitempty"`
-	Schema                   map[string]*ResourceSchema                   `json:"databricks_schema,omitempty"`
-	Secret                   map[string]*ResourceSecret                   `json:"databricks_secret,omitempty"`
-	SecretAcl                map[string]*ResourceSecretAcl                `json:"databricks_secret_acl,omitempty"`
-	SecretScope              map[string]*ResourceSecretScope              `json:"databricks_secret_scope,omitempty"`
-	ServicePrincipal         map[string]*ResourceServicePrincipal         `json:"databricks_service_principal,omitempty"`
-	ServicePrincipalRole     map[string]*ResourceServicePrincipalRole     `json:"databricks_service_principal_role,omitempty"`
-	ServicePrincipalSecret   map[string]*ResourceServicePrincipalSecret   `json:"databricks_service_principal_secret,omitempty"`
-	Share                    map[string]*ResourceShare                    `json:"databricks_share,omitempty"`
-	SqlAlert                 map[string]*ResourceSqlAlert                 `json:"databricks_sql_alert,omitempty"`
-	SqlDashboard             map[string]*ResourceSqlDashboard             `json:"databricks_sql_dashboard,omitempty"`
-	SqlEndpoint              map[string]*ResourceSqlEndpoint              `json:"databricks_sql_endpoint,omitempty"`
-	SqlGlobalConfig          map[string]*ResourceSqlGlobalConfig          `json:"databricks_sql_global_config,omitempty"`
-	SqlPermissions           map[string]*ResourceSqlPermissions           `json:"databricks_sql_permissions,omitempty"`
-	SqlQuery                 map[string]*ResourceSqlQuery                 `json:"databricks_sql_query,omitempty"`
-	SqlTable                 map[string]*ResourceSqlTable                 `json:"databricks_sql_table,omitempty"`
-	SqlVisualization         map[string]*ResourceSqlVisualization         `json:"databricks_sql_visualization,omitempty"`
-	SqlWidget                map[string]*ResourceSqlWidget                `json:"databricks_sql_widget,omitempty"`
-	StorageCredential        map[string]*ResourceStorageCredential        `json:"databricks_storage_credential,omitempty"`
-	SystemSchema             map[string]*ResourceSystemSchema             `json:"databricks_system_schema,omitempty"`
-	Table                    map[string]*ResourceTable                    `json:"databricks_table,omitempty"`
-	Token                    map[string]*ResourceToken                    `json:"databricks_token,omitempty"`
-	User                     map[string]*ResourceUser                     `json:"databricks_user,omitempty"`
-	UserInstanceProfile      map[string]*ResourceUserInstanceProfile      `json:"databricks_user_instance_profile,omitempty"`
-	UserRole                 map[string]*ResourceUserRole                 `json:"databricks_user_role,omitempty"`
-	Volume                   map[string]*ResourceVolume                   `json:"databricks_volume,omitempty"`
-	WorkspaceConf            map[string]*ResourceWorkspaceConf            `json:"databricks_workspace_conf,omitempty"`
-	WorkspaceFile            map[string]*ResourceWorkspaceFile            `json:"databricks_workspace_file,omitempty"`
+	AccessControlRuleSet     map[string]any `json:"databricks_access_control_rule_set,omitempty"`
+	ArtifactAllowlist        map[string]any `json:"databricks_artifact_allowlist,omitempty"`
+	AwsS3Mount               map[string]any `json:"databricks_aws_s3_mount,omitempty"`
+	AzureAdlsGen1Mount       map[string]any `json:"databricks_azure_adls_gen1_mount,omitempty"`
+	AzureAdlsGen2Mount       map[string]any `json:"databricks_azure_adls_gen2_mount,omitempty"`
+	AzureBlobMount           map[string]any `json:"databricks_azure_blob_mount,omitempty"`
+	Catalog                  map[string]any `json:"databricks_catalog,omitempty"`
+	CatalogWorkspaceBinding  map[string]any `json:"databricks_catalog_workspace_binding,omitempty"`
+	Cluster                  map[string]any `json:"databricks_cluster,omitempty"`
+	ClusterPolicy            map[string]any `json:"databricks_cluster_policy,omitempty"`
+	Connection               map[string]any `json:"databricks_connection,omitempty"`
+	DbfsFile                 map[string]any `json:"databricks_dbfs_file,omitempty"`
+	DefaultNamespaceSetting  map[string]any `json:"databricks_default_namespace_setting,omitempty"`
+	Directory                map[string]any `json:"databricks_directory,omitempty"`
+	Entitlements             map[string]any `json:"databricks_entitlements,omitempty"`
+	ExternalLocation         map[string]any `json:"databricks_external_location,omitempty"`
+	GitCredential            map[string]any `json:"databricks_git_credential,omitempty"`
+	GlobalInitScript         map[string]any `json:"databricks_global_init_script,omitempty"`
+	Grant                    map[string]any `json:"databricks_grant,omitempty"`
+	Grants                   map[string]any `json:"databricks_grants,omitempty"`
+	Group                    map[string]any `json:"databricks_group,omitempty"`
+	GroupInstanceProfile     map[string]any `json:"databricks_group_instance_profile,omitempty"`
+	GroupMember              map[string]any `json:"databricks_group_member,omitempty"`
+	GroupRole                map[string]any `json:"databricks_group_role,omitempty"`
+	InstancePool             map[string]any `json:"databricks_instance_pool,omitempty"`
+	InstanceProfile          map[string]any `json:"databricks_instance_profile,omitempty"`
+	IpAccessList             map[string]any `json:"databricks_ip_access_list,omitempty"`
+	Job                      map[string]any `json:"databricks_job,omitempty"`
+	Library                  map[string]any `json:"databricks_library,omitempty"`
+	Metastore                map[string]any `json:"databricks_metastore,omitempty"`
+	MetastoreAssignment      map[string]any `json:"databricks_metastore_assignment,omitempty"`
+	MetastoreDataAccess      map[string]any `json:"databricks_metastore_data_access,omitempty"`
+	MlflowExperiment         map[string]any `json:"databricks_mlflow_experiment,omitempty"`
+	MlflowModel              map[string]any `json:"databricks_mlflow_model,omitempty"`
+	MlflowWebhook            map[string]any `json:"databricks_mlflow_webhook,omitempty"`
+	ModelServing             map[string]any `json:"databricks_model_serving,omitempty"`
+	Mount                    map[string]any `json:"databricks_mount,omitempty"`
+	MwsCredentials           map[string]any `json:"databricks_mws_credentials,omitempty"`
+	MwsCustomerManagedKeys   map[string]any `json:"databricks_mws_customer_managed_keys,omitempty"`
+	MwsLogDelivery           map[string]any `json:"databricks_mws_log_delivery,omitempty"`
+	MwsNetworks              map[string]any `json:"databricks_mws_networks,omitempty"`
+	MwsPermissionAssignment  map[string]any `json:"databricks_mws_permission_assignment,omitempty"`
+	MwsPrivateAccessSettings map[string]any `json:"databricks_mws_private_access_settings,omitempty"`
+	MwsStorageConfigurations map[string]any `json:"databricks_mws_storage_configurations,omitempty"`
+	MwsVpcEndpoint           map[string]any `json:"databricks_mws_vpc_endpoint,omitempty"`
+	MwsWorkspaces            map[string]any `json:"databricks_mws_workspaces,omitempty"`
+	Notebook                 map[string]any `json:"databricks_notebook,omitempty"`
+	OboToken                 map[string]any `json:"databricks_obo_token,omitempty"`
+	PermissionAssignment     map[string]any `json:"databricks_permission_assignment,omitempty"`
+	Permissions              map[string]any `json:"databricks_permissions,omitempty"`
+	Pipeline                 map[string]any `json:"databricks_pipeline,omitempty"`
+	Provider                 map[string]any `json:"databricks_provider,omitempty"`
+	Recipient                map[string]any `json:"databricks_recipient,omitempty"`
+	RegisteredModel          map[string]any `json:"databricks_registered_model,omitempty"`
+	Repo                     map[string]any `json:"databricks_repo,omitempty"`
+	Schema                   map[string]any `json:"databricks_schema,omitempty"`
+	Secret                   map[string]any `json:"databricks_secret,omitempty"`
+	SecretAcl                map[string]any `json:"databricks_secret_acl,omitempty"`
+	SecretScope              map[string]any `json:"databricks_secret_scope,omitempty"`
+	ServicePrincipal         map[string]any `json:"databricks_service_principal,omitempty"`
+	ServicePrincipalRole     map[string]any `json:"databricks_service_principal_role,omitempty"`
+	ServicePrincipalSecret   map[string]any `json:"databricks_service_principal_secret,omitempty"`
+	Share                    map[string]any `json:"databricks_share,omitempty"`
+	SqlAlert                 map[string]any `json:"databricks_sql_alert,omitempty"`
+	SqlDashboard             map[string]any `json:"databricks_sql_dashboard,omitempty"`
+	SqlEndpoint              map[string]any `json:"databricks_sql_endpoint,omitempty"`
+	SqlGlobalConfig          map[string]any `json:"databricks_sql_global_config,omitempty"`
+	SqlPermissions           map[string]any `json:"databricks_sql_permissions,omitempty"`
+	SqlQuery                 map[string]any `json:"databricks_sql_query,omitempty"`
+	SqlTable                 map[string]any `json:"databricks_sql_table,omitempty"`
+	SqlVisualization         map[string]any `json:"databricks_sql_visualization,omitempty"`
+	SqlWidget                map[string]any `json:"databricks_sql_widget,omitempty"`
+	StorageCredential        map[string]any `json:"databricks_storage_credential,omitempty"`
+	SystemSchema             map[string]any `json:"databricks_system_schema,omitempty"`
+	Table                    map[string]any `json:"databricks_table,omitempty"`
+	Token                    map[string]any `json:"databricks_token,omitempty"`
+	User                     map[string]any `json:"databricks_user,omitempty"`
+	UserInstanceProfile      map[string]any `json:"databricks_user_instance_profile,omitempty"`
+	UserRole                 map[string]any `json:"databricks_user_role,omitempty"`
+	Volume                   map[string]any `json:"databricks_volume,omitempty"`
+	WorkspaceConf            map[string]any `json:"databricks_workspace_conf,omitempty"`
+	WorkspaceFile            map[string]any `json:"databricks_workspace_file,omitempty"`
 }
 
 func NewResources() *Resources {
 	return &Resources{
-		AccessControlRuleSet:     make(map[string]*ResourceAccessControlRuleSet),
-		ArtifactAllowlist:        make(map[string]*ResourceArtifactAllowlist),
-		AwsS3Mount:               make(map[string]*ResourceAwsS3Mount),
-		AzureAdlsGen1Mount:       make(map[string]*ResourceAzureAdlsGen1Mount),
-		AzureAdlsGen2Mount:       make(map[string]*ResourceAzureAdlsGen2Mount),
-		AzureBlobMount:           make(map[string]*ResourceAzureBlobMount),
-		Catalog:                  make(map[string]*ResourceCatalog),
-		CatalogWorkspaceBinding:  make(map[string]*ResourceCatalogWorkspaceBinding),
-		Cluster:                  make(map[string]*ResourceCluster),
-		ClusterPolicy:            make(map[string]*ResourceClusterPolicy),
-		Connection:               make(map[string]*ResourceConnection),
-		DbfsFile:                 make(map[string]*ResourceDbfsFile),
-		DefaultNamespaceSetting:  make(map[string]*ResourceDefaultNamespaceSetting),
-		Directory:                make(map[string]*ResourceDirectory),
-		Entitlements:             make(map[string]*ResourceEntitlements),
-		ExternalLocation:         make(map[string]*ResourceExternalLocation),
-		GitCredential:            make(map[string]*ResourceGitCredential),
-		GlobalInitScript:         make(map[string]*ResourceGlobalInitScript),
-		Grant:                    make(map[string]*ResourceGrant),
-		Grants:                   make(map[string]*ResourceGrants),
-		Group:                    make(map[string]*ResourceGroup),
-		GroupInstanceProfile:     make(map[string]*ResourceGroupInstanceProfile),
-		GroupMember:              make(map[string]*ResourceGroupMember),
-		GroupRole:                make(map[string]*ResourceGroupRole),
-		InstancePool:             make(map[string]*ResourceInstancePool),
-		InstanceProfile:          make(map[string]*ResourceInstanceProfile),
-		IpAccessList:             make(map[string]*ResourceIpAccessList),
-		Job:                      make(map[string]*ResourceJob),
-		Library:                  make(map[string]*ResourceLibrary),
-		Metastore:                make(map[string]*ResourceMetastore),
-		MetastoreAssignment:      make(map[string]*ResourceMetastoreAssignment),
-		MetastoreDataAccess:      make(map[string]*ResourceMetastoreDataAccess),
-		MlflowExperiment:         make(map[string]*ResourceMlflowExperiment),
-		MlflowModel:              make(map[string]*ResourceMlflowModel),
-		MlflowWebhook:            make(map[string]*ResourceMlflowWebhook),
-		ModelServing:             make(map[string]*ResourceModelServing),
-		Mount:                    make(map[string]*ResourceMount),
-		MwsCredentials:           make(map[string]*ResourceMwsCredentials),
-		MwsCustomerManagedKeys:   make(map[string]*ResourceMwsCustomerManagedKeys),
-		MwsLogDelivery:           make(map[string]*ResourceMwsLogDelivery),
-		MwsNetworks:              make(map[string]*ResourceMwsNetworks),
-		MwsPermissionAssignment:  make(map[string]*ResourceMwsPermissionAssignment),
-		MwsPrivateAccessSettings: make(map[string]*ResourceMwsPrivateAccessSettings),
-		MwsStorageConfigurations: make(map[string]*ResourceMwsStorageConfigurations),
-		MwsVpcEndpoint:           make(map[string]*ResourceMwsVpcEndpoint),
-		MwsWorkspaces:            make(map[string]*ResourceMwsWorkspaces),
-		Notebook:                 make(map[string]*ResourceNotebook),
-		OboToken:                 make(map[string]*ResourceOboToken),
-		PermissionAssignment:     make(map[string]*ResourcePermissionAssignment),
-		Permissions:              make(map[string]*ResourcePermissions),
-		Pipeline:                 make(map[string]*ResourcePipeline),
-		Provider:                 make(map[string]*ResourceProvider),
-		Recipient:                make(map[string]*ResourceRecipient),
-		RegisteredModel:          make(map[string]*ResourceRegisteredModel),
-		Repo:                     make(map[string]*ResourceRepo),
-		Schema:                   make(map[string]*ResourceSchema),
-		Secret:                   make(map[string]*ResourceSecret),
-		SecretAcl:                make(map[string]*ResourceSecretAcl),
-		SecretScope:              make(map[string]*ResourceSecretScope),
-		ServicePrincipal:         make(map[string]*ResourceServicePrincipal),
-		ServicePrincipalRole:     make(map[string]*ResourceServicePrincipalRole),
-		ServicePrincipalSecret:   make(map[string]*ResourceServicePrincipalSecret),
-		Share:                    make(map[string]*ResourceShare),
-		SqlAlert:                 make(map[string]*ResourceSqlAlert),
-		SqlDashboard:             make(map[string]*ResourceSqlDashboard),
-		SqlEndpoint:              make(map[string]*ResourceSqlEndpoint),
-		SqlGlobalConfig:          make(map[string]*ResourceSqlGlobalConfig),
-		SqlPermissions:           make(map[string]*ResourceSqlPermissions),
-		SqlQuery:                 make(map[string]*ResourceSqlQuery),
-		SqlTable:                 make(map[string]*ResourceSqlTable),
-		SqlVisualization:         make(map[string]*ResourceSqlVisualization),
-		SqlWidget:                make(map[string]*ResourceSqlWidget),
-		StorageCredential:        make(map[string]*ResourceStorageCredential),
-		SystemSchema:             make(map[string]*ResourceSystemSchema),
-		Table:                    make(map[string]*ResourceTable),
-		Token:                    make(map[string]*ResourceToken),
-		User:                     make(map[string]*ResourceUser),
-		UserInstanceProfile:      make(map[string]*ResourceUserInstanceProfile),
-		UserRole:                 make(map[string]*ResourceUserRole),
-		Volume:                   make(map[string]*ResourceVolume),
-		WorkspaceConf:            make(map[string]*ResourceWorkspaceConf),
-		WorkspaceFile:            make(map[string]*ResourceWorkspaceFile),
+		AccessControlRuleSet:     make(map[string]any),
+		ArtifactAllowlist:        make(map[string]any),
+		AwsS3Mount:               make(map[string]any),
+		AzureAdlsGen1Mount:       make(map[string]any),
+		AzureAdlsGen2Mount:       make(map[string]any),
+		AzureBlobMount:           make(map[string]any),
+		Catalog:                  make(map[string]any),
+		CatalogWorkspaceBinding:  make(map[string]any),
+		Cluster:                  make(map[string]any),
+		ClusterPolicy:            make(map[string]any),
+		Connection:               make(map[string]any),
+		DbfsFile:                 make(map[string]any),
+		DefaultNamespaceSetting:  make(map[string]any),
+		Directory:                make(map[string]any),
+		Entitlements:             make(map[string]any),
+		ExternalLocation:         make(map[string]any),
+		GitCredential:            make(map[string]any),
+		GlobalInitScript:         make(map[string]any),
+		Grant:                    make(map[string]any),
+		Grants:                   make(map[string]any),
+		Group:                    make(map[string]any),
+		GroupInstanceProfile:     make(map[string]any),
+		GroupMember:              make(map[string]any),
+		GroupRole:                make(map[string]any),
+		InstancePool:             make(map[string]any),
+		InstanceProfile:          make(map[string]any),
+		IpAccessList:             make(map[string]any),
+		Job:                      make(map[string]any),
+		Library:                  make(map[string]any),
+		Metastore:                make(map[string]any),
+		MetastoreAssignment:      make(map[string]any),
+		MetastoreDataAccess:      make(map[string]any),
+		MlflowExperiment:         make(map[string]any),
+		MlflowModel:              make(map[string]any),
+		MlflowWebhook:            make(map[string]any),
+		ModelServing:             make(map[string]any),
+		Mount:                    make(map[string]any),
+		MwsCredentials:           make(map[string]any),
+		MwsCustomerManagedKeys:   make(map[string]any),
+		MwsLogDelivery:           make(map[string]any),
+		MwsNetworks:              make(map[string]any),
+		MwsPermissionAssignment:  make(map[string]any),
+		MwsPrivateAccessSettings: make(map[string]any),
+		MwsStorageConfigurations: make(map[string]any),
+		MwsVpcEndpoint:           make(map[string]any),
+		MwsWorkspaces:            make(map[string]any),
+		Notebook:                 make(map[string]any),
+		OboToken:                 make(map[string]any),
+		PermissionAssignment:     make(map[string]any),
+		Permissions:              make(map[string]any),
+		Pipeline:                 make(map[string]any),
+		Provider:                 make(map[string]any),
+		Recipient:                make(map[string]any),
+		RegisteredModel:          make(map[string]any),
+		Repo:                     make(map[string]any),
+		Schema:                   make(map[string]any),
+		Secret:                   make(map[string]any),
+		SecretAcl:                make(map[string]any),
+		SecretScope:              make(map[string]any),
+		ServicePrincipal:         make(map[string]any),
+		ServicePrincipalRole:     make(map[string]any),
+		ServicePrincipalSecret:   make(map[string]any),
+		Share:                    make(map[string]any),
+		SqlAlert:                 make(map[string]any),
+		SqlDashboard:             make(map[string]any),
+		SqlEndpoint:              make(map[string]any),
+		SqlGlobalConfig:          make(map[string]any),
+		SqlPermissions:           make(map[string]any),
+		SqlQuery:                 make(map[string]any),
+		SqlTable:                 make(map[string]any),
+		SqlVisualization:         make(map[string]any),
+		SqlWidget:                make(map[string]any),
+		StorageCredential:        make(map[string]any),
+		SystemSchema:             make(map[string]any),
+		Table:                    make(map[string]any),
+		Token:                    make(map[string]any),
+		User:                     make(map[string]any),
+		UserInstanceProfile:      make(map[string]any),
+		UserRole:                 make(map[string]any),
+		Volume:                   make(map[string]any),
+		WorkspaceConf:            make(map[string]any),
+		WorkspaceFile:            make(map[string]any),
 	}
 }


### PR DESCRIPTION
## Changes

We plan to use the any-equivalent of a `dyn.Value` such that we can use variable references for non-string fields (e.g. `${databricks_job.some_job.id}` where an integer is expected), as well as properly emit zero values for primitive types (e.g. 0 for integers or false for booleans).

This change is in preparation for the above.

## Tests

Unit tests.
