### PR TITLE
Fix CLI nightlies to run on UC workspaces

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -484,8 +484,9 @@ func TemporaryRepo(t *testing.T, w *databricks.WorkspaceClient) string {
 func GetNodeTypeId(env string) string {
 	if env == "gcp" {
 		return "n1-standard-4"
-	} else if env == "aws" {
-		return "i3.xlarge"
+	} else if env == "azure" {
+		return "Standard_DS4_v2"
 	}
-	return "Standard_DS4_v2"
+	// We default to AWS because our "aws-prod-ucws" test environment has CLOUD_ENV set to "ucws"
+	return "i3.xlarge"
 }

--- a/internal/testutil/cloud.go
+++ b/internal/testutil/cloud.go
@@ -41,6 +41,9 @@ func GetCloud(t *testing.T) Cloud {
 		return Azure
 	case "gcp":
 		return GCP
+	// CLOUD_ENV is set to "ucws" in the "aws-prod-ucws" test environment
+	case "ucws":
+		return AWS
 	default:
 		t.Fatalf("Unknown cloud environment: %s", env)
 	}


### PR DESCRIPTION
This PR fixes some test helper functions so that they work properly on our test environments for AWS and Azure UC workspaces.