### PR TITLE
Only set ComputeID value when `--compute-id` flag provided

### DIFF
--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -32,7 +32,9 @@ func newDeployCommand() *cobra.Command {
 		bundle.ApplyFunc(ctx, b, func(context.Context, *bundle.Bundle) error {
 			b.Config.Bundle.Force = force
 			b.Config.Bundle.Deployment.Lock.Force = forceLock
-			b.Config.Bundle.ComputeID = computeID
+			if cmd.Flag("compute-id").Changed {
+				b.Config.Bundle.ComputeID = computeID
+			}
 
 			if cmd.Flag("fail-on-active-runs").Changed {
 				b.Config.Bundle.Deployment.FailOnActiveRuns = failOnActiveRuns


### PR DESCRIPTION
## Changes
Fixes an issue when `compute_id` is defined in the bundle config, correctly replaced in `validate` command but not used in `deploy` command

Previously when `compute_id` was set in bundle.yml and `bundle deploy` was executed with no --compute-id flag, compute_id from bundle configuration file was reset to an empty string which is unexpected.

Now, the value of `compute_id` from bundle config only changed when the `--compute-id` flag is passed 

## Tests
Manually

