### PR TITLE
Handle alias types for map keys in toTyped conversion

### DIFF
--- a/libs/dyn/convert/to_typed.go
+++ b/libs/dyn/convert/to_typed.go
@@ -115,12 +115,13 @@ func toTypedMap(dst reflect.Value, src dyn.Value) error {
 		dst.Set(reflect.MakeMapWithSize(dst.Type(), len(m)))
 		for k, v := range m {
 			kv := reflect.ValueOf(k)
+			kt := dst.Type().Key()
 			vv := reflect.New(dst.Type().Elem())
 			err := ToTyped(vv.Interface(), v)
 			if err != nil {
 				return err
 			}
-			dst.SetMapIndex(kv, vv.Elem())
+			dst.SetMapIndex(kv.Convert(kt), vv.Elem())
 		}
 		return nil
 	case dyn.KindNil:

--- a/libs/dyn/convert/to_typed_test.go
+++ b/libs/dyn/convert/to_typed_test.go
@@ -495,3 +495,19 @@ func TestToTypedFloat64FromStringVariableReference(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, float64(0.0), out)
 }
+
+func TestToTypedWithAliasKeyType(t *testing.T) {
+	type custom string
+
+	var out map[custom]string
+	v := dyn.V(map[string]dyn.Value{
+		"foo": dyn.V("bar"),
+		"bar": dyn.V("baz"),
+	})
+
+	err := ToTyped(&out, v)
+	require.NoError(t, err)
+	assert.Len(t, out, 2)
+	assert.Equal(t, "bar", out["foo"])
+	assert.Equal(t, "baz", out["bar"])
+}


### PR DESCRIPTION
## Changes
Handle alias types for map keys in toTyped conversion

## Tests
Added an unit test

