### PR TITLE
Fix summary command when internal terraform config doesn't exist

### DIFF
--- a/bundle/deploy/terraform/pkg.go
+++ b/bundle/deploy/terraform/pkg.go
@@ -1,4 +1,4 @@
 package terraform
 
 const TerraformStateFileName = "terraform.tfstate"
-const TerraformBundleFileName = "bundle.tf.json"
+const TerraformConfigFileName = "bundle.tf.json"

--- a/bundle/deploy/terraform/pkg.go
+++ b/bundle/deploy/terraform/pkg.go
@@ -1,3 +1,4 @@
 package terraform
 
 const TerraformStateFileName = "terraform.tfstate"
+const TerraformBundleFileName = "bundle.tf.json"

--- a/bundle/deploy/terraform/write.go
+++ b/bundle/deploy/terraform/write.go
@@ -32,7 +32,7 @@ func (w *write) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	f, err := os.Create(filepath.Join(dir, "bundle.tf.json"))
+	f, err := os.Create(filepath.Join(dir, TerraformBundleFileName))
 	if err != nil {
 		return err
 	}

--- a/bundle/deploy/terraform/write.go
+++ b/bundle/deploy/terraform/write.go
@@ -32,7 +32,7 @@ func (w *write) Apply(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	f, err := os.Create(filepath.Join(dir, TerraformBundleFileName))
+	f, err := os.Create(filepath.Join(dir, TerraformConfigFileName))
 	if err != nil {
 		return err
 	}

--- a/cmd/bundle/summary.go
+++ b/cmd/bundle/summary.go
@@ -43,8 +43,8 @@ func newSummaryCommand() *cobra.Command {
 			return err
 		}
 		_, stateFileErr := os.Stat(filepath.Join(cacheDir, terraform.TerraformStateFileName))
-		_, bundleFileErr := os.Stat(filepath.Join(cacheDir, terraform.TerraformBundleFileName))
-		noCache := errors.Is(stateFileErr, os.ErrNotExist) || errors.Is(bundleFileErr, os.ErrNotExist)
+		_, configFileErr := os.Stat(filepath.Join(cacheDir, terraform.TerraformConfigFileName))
+		noCache := errors.Is(stateFileErr, os.ErrNotExist) || errors.Is(configFileErr, os.ErrNotExist)
 
 		if forcePull || noCache {
 			err = bundle.Apply(cmd.Context(), b, bundle.Seq(


### PR DESCRIPTION
Check if `bundle.tf.json` doesn't exist and create it before executing `terraform init` (inside `terraform.Load`)

Fixes a problem when during `terraform.Load` it fails with: 
```
Error: Failed to load plugin schemas

Error while loading schemas for plugin components: Failed to obtain provider
schema: Could not load the schema for provider
registry.terraform.io/databricks/databricks: failed to instantiate provider
"registry.terraform.io/databricks/databricks" to obtain schema: unavailable
provider "registry.terraform.io/databricks/databricks"..
```