### PR TITLE
Fix DBConnect support in VS Code #3 (SDK)

### DIFF
--- a/libs/template/templates/default-python/template/{{.project_name}}/requirements-dev.txt.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/requirements-dev.txt.tmpl
@@ -3,6 +3,9 @@
 ## For defining dependencies used by jobs in Databricks Workflows, see
 ## https://docs.databricks.com/dev-tools/bundles/library-dependencies.html
 
+## Add code completion support for DLT
+databricks-dlt
+
 ## pytest is the default package used for testing
 pytest
 

--- a/libs/template/templates/default-python/template/{{.project_name}}/scratch/exploration.ipynb.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/scratch/exploration.ipynb.tmpl
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
@@ -22,7 +32,7 @@
     "sys.path.append('../src')\n",
     "from {{.project_name}} import main\n",
     "\n",
-    "main.get_taxis().show(10)"
+    "main.get_taxis(spark).show(10)"
    {{else}}
     "spark.range(10)"
    {{end -}}

--- a/libs/template/templates/default-python/template/{{.project_name}}/src/dlt_pipeline.ipynb.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/src/dlt_pipeline.ipynb.tmpl
@@ -63,7 +63,7 @@
     {{- if (eq .include_python "yes") }}
     "@dlt.view\n",
     "def taxi_raw():\n",
-    "  return main.get_taxis()\n",
+    "  return main.get_taxis(spark)\n",
     {{else}}
     "\n",
     "@dlt.view\n",

--- a/libs/template/templates/default-python/template/{{.project_name}}/src/notebook.ipynb.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/src/notebook.ipynb.tmpl
@@ -19,6 +19,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
@@ -37,7 +47,7 @@
    {{- if (eq .include_python "yes") }}
     "from {{.project_name}} import main\n",
     "\n",
-    "main.get_taxis().show(10)"
+    "main.get_taxis(spark).show(10)"
    {{else}}
     "spark.range(10)"
    {{end -}}

--- a/libs/template/templates/default-python/template/{{.project_name}}/src/{{.project_name}}/main.py.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/src/{{.project_name}}/main.py.tmpl
@@ -3,19 +3,9 @@ from pyspark.sql import SparkSession, DataFrame
 def get_taxis(spark: SparkSession) -> DataFrame:
   return spark.read.table("samples.nyctaxi.trips")
 
-
-# Create a new Databricks Connect session. If this fails,
-# check that you have configured Databricks Connect correctly.
-# See https://docs.databricks.com/dev-tools/databricks-connect.html.
-def get_spark() -> SparkSession:
-  try:
-    from databricks.connect import DatabricksSession
-    return DatabricksSession.builder.getOrCreate()
-  except ImportError:
-    return SparkSession.builder.getOrCreate()
-
 def main():
-  get_taxis(get_spark()).show(5)
+  from databricks.sdk.runtime import spark
+  get_taxis(spark).show(5)
 
 if __name__ == '__main__':
   main()

--- a/libs/template/templates/default-python/template/{{.project_name}}/src/{{.project_name}}/main.py.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/src/{{.project_name}}/main.py.tmpl
@@ -1,12 +1,21 @@
-from pyspark.sql import SparkSession
+from pyspark.sql import SparkSession, DataFrame
 
-def get_taxis(spark: SparkSession):
+def get_taxis(spark: SparkSession) -> DataFrame:
   return spark.read.table("samples.nyctaxi.trips")
 
+
+# Create a new Databricks Connect session. If this fails,
+# check that you have configured Databricks Connect correctly.
+# See https://docs.databricks.com/dev-tools/databricks-connect.html.
+def get_spark() -> SparkSession:
+  try:
+    from databricks.connect import DatabricksSession
+    return DatabricksSession.builder.getOrCreate()
+  except ImportError:
+    return SparkSession.builder.getOrCreate()
+
 def main():
-  from databricks.connect import DatabricksSession as SparkSession
-  spark = SparkSession.builder.getOrCreate()
-  get_taxis(spark).show(5)
+  get_taxis(get_spark()).show(5)
 
 if __name__ == '__main__':
   main()

--- a/libs/template/templates/default-python/template/{{.project_name}}/src/{{.project_name}}/main.py.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/src/{{.project_name}}/main.py.tmpl
@@ -1,16 +1,12 @@
-{{- /*
-We use pyspark.sql rather than DatabricksSession.builder.getOrCreate()
-for compatibility with older runtimes. With a new runtime, it's
-equivalent to DatabricksSession.builder.getOrCreate().
-*/ -}}
 from pyspark.sql import SparkSession
 
-def get_taxis():
-  spark = SparkSession.builder.getOrCreate()
+def get_taxis(spark: SparkSession):
   return spark.read.table("samples.nyctaxi.trips")
 
 def main():
-  get_taxis().show(5)
+  from databricks.connect import DatabricksSession as SparkSession
+  spark = SparkSession.builder.getOrCreate()
+  get_taxis(spark).show(5)
 
 if __name__ == '__main__':
   main()

--- a/libs/template/templates/default-python/template/{{.project_name}}/tests/main_test.py.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/tests/main_test.py.tmpl
@@ -1,15 +1,6 @@
-from pyspark.sql import SparkSession
-from pytest import fixture
-from {{.project_name}}.main import get_taxis, get_spark
+from databricks.sdk.runtime import spark
+from {{.project_name}}.main import get_taxis
 
-
-@fixture(scope="session")
-def spark() -> SparkSession:
-    spark = get_spark()
-    yield spark
-    spark.stop()
-
-
-def test_main(spark: SparkSession):
+def test_main():
     taxis = get_taxis(spark)
     assert taxis.count() > 5

--- a/libs/template/templates/default-python/template/{{.project_name}}/tests/main_test.py.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/tests/main_test.py.tmpl
@@ -1,21 +1,15 @@
-from databricks.connect import DatabricksSession
-from pyspark.sql import SparkSession
+from databricks.connect import DatabricksSession as SparkSession
+from pytest import fixture
 from {{.project_name}} import main
 
-# Create a new Databricks Connect session. If this fails,
-# check that you have configured Databricks Connect correctly.
-# See https://docs.databricks.com/dev-tools/databricks-connect.html.
-{{/*
-  The below works around a problematic error message from Databricks Connect.
-  The standard SparkSession is supported in all configurations (workspace, IDE,
-  all runtime versions, CLI). But on the CLI it currently gives a confusing
-  error message if SPARK_REMOTE is not set. We can't directly use
-  DatabricksSession.builder in main.py, so we're re-assigning it here so
-  everything works out of the box, even for CLI users who don't set SPARK_REMOTE.
-*/}}
-SparkSession.builder = DatabricksSession.builder
-SparkSession.builder.getOrCreate()
 
-def test_main():
-    taxis = main.get_taxis()
+@fixture(scope="session")
+def spark():
+    spark = SparkSession.builder.getOrCreate()
+    yield spark
+    spark.stop()
+
+
+def test_main(spark: SparkSession):
+    taxis = main.get_taxis(spark)
     assert taxis.count() > 5

--- a/libs/template/templates/default-python/template/{{.project_name}}/tests/main_test.py.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/tests/main_test.py.tmpl
@@ -1,15 +1,15 @@
-from databricks.connect import DatabricksSession as SparkSession
+from pyspark.sql import SparkSession
 from pytest import fixture
-from {{.project_name}} import main
+from {{.project_name}}.main import get_taxis, get_spark
 
 
 @fixture(scope="session")
-def spark():
-    spark = SparkSession.builder.getOrCreate()
+def spark() -> SparkSession:
+    spark = get_spark()
     yield spark
     spark.stop()
 
 
 def test_main(spark: SparkSession):
-    taxis = main.get_taxis(spark)
+    taxis = get_taxis(spark)
     assert taxis.count() > 5


### PR DESCRIPTION
## Changes
 This is the same as #1239 except that this code uses the Databricks SDK to get a Spark session. This version also supports older DBRs.

Note that this change requires https://github.com/databricks/databricks-sdk-py/pull/562 to be released.

## Tests
<!-- How is this tested? -->

