### PR TITLE
Add `dyn.MapByPattern` to map a function to values with matching paths

### DIFF
--- a/libs/dyn/pattern.go
+++ b/libs/dyn/pattern.go
@@ -1,0 +1,96 @@
+package dyn
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// Pattern represents a matcher for paths in a [Value] configuration tree.
+// It is used by [MapByPattern] to apply a function to the values whose paths match the pattern.
+// Every [Path] is a valid [Pattern] that matches a single unique path.
+// The reverse is not true; not every [Pattern] is a valid [Path], as patterns may contain wildcards.
+type Pattern []patternComponent
+
+// A pattern component can visit a [Value] and recursively call into [visit] for matching elements.
+// Fixed components can match a single key or index, while wildcards can match any key or index.
+type patternComponent interface {
+	visit(v Value, prefix Path, suffix Pattern, opts visitOptions) (Value, error)
+}
+
+// NewPattern returns a new pattern from the given components.
+// The individual components may be created with [Key], [Index], or [Any].
+func NewPattern(cs ...patternComponent) Pattern {
+	return cs
+}
+
+// NewPatternFromPath returns a new pattern from the given path.
+func NewPatternFromPath(p Path) Pattern {
+	cs := make(Pattern, len(p))
+	for i, c := range p {
+		cs[i] = c
+	}
+	return cs
+}
+
+type anyKeyComponent struct{}
+
+// AnyKey returns a pattern component that matches any key.
+func AnyKey() patternComponent {
+	return anyKeyComponent{}
+}
+
+// This function implements the patternComponent interface.
+func (c anyKeyComponent) visit(v Value, prefix Path, suffix Pattern, opts visitOptions) (Value, error) {
+	m, ok := v.AsMap()
+	if !ok {
+		return InvalidValue, fmt.Errorf("expected a map at %q, found %s", prefix, v.Kind())
+	}
+
+	m = maps.Clone(m)
+	for key, value := range m {
+		var err error
+		nv, err := visit(value, prefix.Append(Key(key)), suffix, opts)
+		if err != nil {
+			// Leave the value intact if the suffix pattern didn't match any value.
+			if IsNoSuchKeyError(err) || IsIndexOutOfBoundsError(err) {
+				continue
+			}
+			return InvalidValue, err
+		}
+		m[key] = nv
+	}
+
+	return NewValue(m, v.Location()), nil
+}
+
+type anyIndexComponent struct{}
+
+// AnyIndex returns a pattern component that matches any index.
+func AnyIndex() patternComponent {
+	return anyIndexComponent{}
+}
+
+// This function implements the patternComponent interface.
+func (c anyIndexComponent) visit(v Value, prefix Path, suffix Pattern, opts visitOptions) (Value, error) {
+	s, ok := v.AsSequence()
+	if !ok {
+		return InvalidValue, fmt.Errorf("expected a sequence at %q, found %s", prefix, v.Kind())
+	}
+
+	s = slices.Clone(s)
+	for i, value := range s {
+		var err error
+		nv, err := visit(value, prefix.Append(Index(i)), suffix, opts)
+		if err != nil {
+			// Leave the value intact if the suffix pattern didn't match any value.
+			if IsNoSuchKeyError(err) || IsIndexOutOfBoundsError(err) {
+				continue
+			}
+			return InvalidValue, err
+		}
+		s[i] = nv
+	}
+
+	return NewValue(s, v.Location()), nil
+}

--- a/libs/dyn/pattern_test.go
+++ b/libs/dyn/pattern_test.go
@@ -1,0 +1,28 @@
+package dyn_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPattern(t *testing.T) {
+	pat := dyn.NewPattern(
+		dyn.Key("foo"),
+		dyn.Index(1),
+	)
+
+	assert.Len(t, pat, 2)
+}
+
+func TestNewPatternFromPath(t *testing.T) {
+	path := dyn.NewPath(
+		dyn.Key("foo"),
+		dyn.Index(1),
+	)
+
+	pat1 := dyn.NewPattern(dyn.Key("foo"), dyn.Index(1))
+	pat2 := dyn.NewPatternFromPath(path)
+	assert.Equal(t, pat1, pat2)
+}

--- a/libs/dyn/visit_get.go
+++ b/libs/dyn/visit_get.go
@@ -14,7 +14,7 @@ func Get(v Value, path string) (Value, error) {
 // If the path doesn't exist, it returns InvalidValue and an error.
 func GetByPath(v Value, p Path) (Value, error) {
 	out := InvalidValue
-	_, err := visit(v, EmptyPath, p, visitOptions{
+	_, err := visit(v, EmptyPath, NewPatternFromPath(p), visitOptions{
 		fn: func(_ Path, ev Value) (Value, error) {
 			// Capture the value argument to return it.
 			out = ev

--- a/libs/dyn/visit_map.go
+++ b/libs/dyn/visit_map.go
@@ -40,7 +40,7 @@ func Foreach(fn MapFunc) MapFunc {
 	}
 }
 
-// Map applies the given function to the value at the specified path in the specified value.
+// Map applies a function to the value at the given path in the given value.
 // It is identical to [MapByPath], except that it takes a string path instead of a [Path].
 func Map(v Value, path string, fn MapFunc) (Value, error) {
 	p, err := NewPathFromString(path)
@@ -50,15 +50,21 @@ func Map(v Value, path string, fn MapFunc) (Value, error) {
 	return MapByPath(v, p, fn)
 }
 
-// Map applies the given function to the value at the specified path in the specified value.
+// MapByPath applies a function to the value at the given path in the given value.
+// It is identical to [MapByPattern], except that it takes a [Path] instead of a [Pattern].
+// This means it only matches a single value, not a pattern of values.
+func MapByPath(v Value, p Path, fn MapFunc) (Value, error) {
+	return MapByPattern(v, NewPatternFromPath(p), fn)
+}
+
+// MapByPattern applies a function to the values whose paths match the given pattern in the given value.
 // If successful, it returns the new value with all intermediate values copied and updated.
 //
-// If the path contains a key that doesn't exist, or an index that is out of bounds,
-// it returns the original value and no error. This is because setting a value at a path
-// that doesn't exist is a no-op.
+// If the pattern contains a key that doesn't exist, or an index that is out of bounds,
+// it returns the original value and no error.
 //
-// If the path is invalid for the given value, it returns InvalidValue and an error.
-func MapByPath(v Value, p Path, fn MapFunc) (Value, error) {
+// If the pattern is invalid for the given value, it returns InvalidValue and an error.
+func MapByPattern(v Value, p Pattern, fn MapFunc) (Value, error) {
 	nv, err := visit(v, EmptyPath, p, visitOptions{
 		fn: fn,
 	})

--- a/libs/dyn/visit_map_test.go
+++ b/libs/dyn/visit_map_test.go
@@ -45,7 +45,8 @@ func TestMapFuncOnMap(t *testing.T) {
 
 	// Note: in the test cases below we implicitly test that the original
 	// value is not modified as we repeatedly set values on it.
-	vfoo, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Key("foo")), func(_ dyn.Path, v dyn.Value) (dyn.Value, error) {
+	vfoo, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Key("foo")), func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+		assert.Equal(t, dyn.NewPath(dyn.Key("foo")), p)
 		assert.Equal(t, dyn.V(42), v)
 		return dyn.V(44), nil
 	})
@@ -55,7 +56,8 @@ func TestMapFuncOnMap(t *testing.T) {
 		"bar": 43,
 	}, vfoo.AsAny())
 
-	vbar, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Key("bar")), func(_ dyn.Path, v dyn.Value) (dyn.Value, error) {
+	vbar, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Key("bar")), func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+		assert.Equal(t, dyn.NewPath(dyn.Key("bar")), p)
 		assert.Equal(t, dyn.V(43), v)
 		return dyn.V(45), nil
 	})
@@ -115,14 +117,16 @@ func TestMapFuncOnSequence(t *testing.T) {
 
 	// Note: in the test cases below we implicitly test that the original
 	// value is not modified as we repeatedly set values on it.
-	v0, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Index(0)), func(_ dyn.Path, v dyn.Value) (dyn.Value, error) {
+	v0, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Index(0)), func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+		assert.Equal(t, dyn.NewPath(dyn.Index(0)), p)
 		assert.Equal(t, dyn.V(42), v)
 		return dyn.V(44), nil
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, []any{44, 43}, v0.AsAny())
 
-	v1, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Index(1)), func(_ dyn.Path, v dyn.Value) (dyn.Value, error) {
+	v1, err := dyn.MapByPath(vin, dyn.NewPath(dyn.Index(1)), func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+		assert.Equal(t, dyn.NewPath(dyn.Index(1)), p)
 		assert.Equal(t, dyn.V(43), v)
 		return dyn.V(45), nil
 	})

--- a/libs/dyn/visit_set.go
+++ b/libs/dyn/visit_set.go
@@ -25,10 +25,10 @@ func SetByPath(v Value, p Path, nv Value) (Value, error) {
 		return nv, nil
 	}
 
-	parent := p[:lp-1]
 	component := p[lp-1]
+	p = p[:lp-1]
 
-	return visit(v, EmptyPath, parent, visitOptions{
+	return visit(v, EmptyPath, NewPatternFromPath(p), visitOptions{
 		fn: func(prefix Path, v Value) (Value, error) {
 			path := prefix.Append(component)
 


### PR DESCRIPTION
## Changes

The new `dyn.Pattern` type represents a path pattern that can match one or more paths in a configuration tree. Every `dyn.Path` can be converted to a `dyn.Pattern` that matches only a single path.

To accommodate this change, the visit function needed to be modified to take a `dyn.Pattern` suffix. Every component in the pattern implements an interface to work with the visit function. This function can recurse on the visit function for one or more elements of the value being visited. For patterns derived from a `dyn.Path`, it will work as it did before and select the matching element. For the new pattern components (e.g. `dyn.AnyKey` or `dyn.AnyIndex`), it recurses on all the elements in the container.

## Tests

Unit tests. Confirmed full coverage for the new code.
