### PR TITLE
[WIP] Support DATABRICKS_CA_BUNDLE for allowing custom CA Certificates for Proxies

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -60,10 +60,10 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			profileName = profile
+			persistentAuth.Profile = profile
 		}
 
-		err := setHost(ctx, profileName, persistentAuth, args)
+		err := setHost(ctx, persistentAuth, args)
 		if err != nil {
 			return err
 		}
@@ -127,10 +127,10 @@ func newLoginCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 	return cmd
 }
 
-func setHost(ctx context.Context, profileName string, persistentAuth *auth.PersistentAuth, args []string) error {
+func setHost(ctx context.Context, persistentAuth *auth.PersistentAuth, args []string) error {
 	// If the chosen profile has a hostname and the user hasn't specified a host, infer the host from the profile.
 	_, profiles, err := databrickscfg.LoadProfiles(ctx, func(p databrickscfg.Profile) bool {
-		return p.Name == profileName
+		return p.Name == persistentAuth.Profile
 	})
 	// Tolerate ErrNoConfiguration here, as we will write out a configuration as part of the login flow.
 	if err != nil && !errors.Is(err, databrickscfg.ErrNoConfiguration) {

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -26,14 +26,14 @@ func newTokenCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 		var profileName string
 		profileFlag := cmd.Flag("profile")
 		if profileFlag != nil {
-			profileName = profileFlag.Value.String()
+			persistentAuth.Profile = profileFlag.Value.String()
 			// If a profile is provided we read the host from the .databrickscfg file
 			if profileName != "" && len(args) > 0 {
-				return errors.New("providing both a profile and a host parameters is not supported")
+				return errors.New("providing both a profile and a hostname is not supported")
 			}
 		}
 
-		err := setHost(ctx, profileName, persistentAuth, args)
+		err := setHost(ctx, persistentAuth, args)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -69,3 +69,5 @@ require (
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/databricks/databricks-sdk-go => /Users/miles/databricks-sdk-go


### PR DESCRIPTION
## Changes
Demonstration of https://github.com/databricks/databricks-sdk-go/pull/852 for the CLI.

## Tests
Run
```
go run ./examples/http-proxy/proxy --register-certificate
```
in the Go SDK, followed by
```
HTTPS_PROXY=https://localhost:8443 databricks auth token --profile DEFAULT
```
or
```
HTTPS_PROXY=https://localhost:8443 databricks clusters list
```


