### PR TITLE
Enabled incorrectly skipped tests

### DIFF
--- a/internal/repos_test.go
+++ b/internal/repos_test.go
@@ -43,7 +43,7 @@ func createTemporaryRepo(t *testing.T, w *databricks.WorkspaceClient, ctx contex
 	return repoInfo.Id, repoPath
 }
 
-func TestReposCreateWithProvider(t *testing.T) {
+func TestAccReposCreateWithProvider(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()
@@ -60,7 +60,7 @@ func TestReposCreateWithProvider(t *testing.T) {
 	assert.Equal(t, workspace.ObjectTypeRepo, oi.ObjectType)
 }
 
-func TestReposCreateWithoutProvider(t *testing.T) {
+func TestAccReposCreateWithoutProvider(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()
@@ -77,7 +77,7 @@ func TestReposCreateWithoutProvider(t *testing.T) {
 	assert.Equal(t, workspace.ObjectTypeRepo, oi.ObjectType)
 }
 
-func TestReposGet(t *testing.T) {
+func TestAccReposGet(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()
@@ -106,7 +106,7 @@ func TestReposGet(t *testing.T) {
 	assert.ErrorContains(t, err, "is not a repo")
 }
 
-func TestReposUpdate(t *testing.T) {
+func TestAccReposUpdate(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()
@@ -127,7 +127,7 @@ func TestReposUpdate(t *testing.T) {
 	assert.Equal(t, byIdOutput.String(), byPathOutput.String())
 }
 
-func TestReposDeleteByID(t *testing.T) {
+func TestAccReposDeleteByID(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()
@@ -146,7 +146,7 @@ func TestReposDeleteByID(t *testing.T) {
 	assert.True(t, apierr.IsMissing(err), err)
 }
 
-func TestReposDeleteByPath(t *testing.T) {
+func TestAccReposDeleteByPath(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()

--- a/internal/secrets_test.go
+++ b/internal/secrets_test.go
@@ -61,7 +61,7 @@ func assertSecretBytesValue(t *acc.WorkspaceT, scope, key string, expected []byt
 	assert.Equal(t, expected, decoded)
 }
 
-func TestSecretsPutSecretStringValue(tt *testing.T) {
+func TestAccSecretsPutSecretStringValue(tt *testing.T) {
 	ctx, t := acc.WorkspaceTest(tt)
 	scope := temporarySecretScope(ctx, t)
 	key := "test-key"
@@ -75,7 +75,7 @@ func TestSecretsPutSecretStringValue(tt *testing.T) {
 	assertSecretBytesValue(t, scope, key, []byte(value))
 }
 
-func TestSecretsPutSecretBytesValue(tt *testing.T) {
+func TestAccSecretsPutSecretBytesValue(tt *testing.T) {
 	ctx, t := acc.WorkspaceTest(tt)
 	scope := temporarySecretScope(ctx, t)
 	key := "test-key"

--- a/internal/storage_credentials_test.go
+++ b/internal/storage_credentials_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStorageCredentialsListRendersResponse(t *testing.T) {
+func TestAccStorageCredentialsListRendersResponse(t *testing.T) {
 	_, _ = acc.WorkspaceTest(t)
 	stdout, stderr := RequireSuccessfulRun(t, "storage-credentials", "list")
 	assert.NotEmpty(t, stdout)

--- a/internal/workspace_test.go
+++ b/internal/workspace_test.go
@@ -42,7 +42,7 @@ func TestWorkpaceGetStatusErrorWhenNoArguments(t *testing.T) {
 	assert.Equal(t, "accepts 1 arg(s), received 0", err.Error())
 }
 
-func TestWorkpaceExportPrintsContents(t *testing.T) {
+func TestAccWorkpaceExportPrintsContents(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
 	ctx := context.Background()


### PR DESCRIPTION
## Changes
Some integration tests were missing `TestAcc` prefix therefore were skipped.

## Tests
Running integration tests

