### PR TITLE
Don't attempt auth in `auth profiles --skip-validate`

### DIFF
--- a/cmd/auth/profiles.go
+++ b/cmd/auth/profiles.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -45,13 +44,7 @@ func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
 	}
 
 	if skipValidate {
-		err := cfg.Authenticate(&http.Request{
-			Header: make(http.Header),
-		})
-		if err != nil {
-			return
-		}
-		c.Host = cfg.Host
+		c.Host = cfg.CanonicalHostName()
 		c.AuthType = cfg.AuthType
 		return
 	}

--- a/cmd/auth/profiles_test.go
+++ b/cmd/auth/profiles_test.go
@@ -21,8 +21,9 @@ func TestProfiles(t *testing.T) {
 	err := databrickscfg.SaveToProfile(ctx, &config.Config{
 		ConfigFile: configFile,
 		Profile:    "profile1",
-		Host:       "https://abc.cloud.databricks.com",
+		Host:       "abc.cloud.databricks.com",
 		Token:      "token1",
+		AuthType:   "pat",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This makes the command almost instant, no matter how many profiles cfg file has. One downside is that we don't set AuthType for profiles that don't have it defined.

We can technically infer AuthType based on ConfigAttributes tags, but their names are different from the names of actual auth providers (and some tags cover multiple providers at the same time).



