### PR TITLE
Fix TestAccBundleInitOnMlopsStacks to work on aws-prod-ucws

### DIFF
--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -39,7 +39,8 @@ func TestAccBundleInitErrorOnUnknownFields(t *testing.T) {
 //     skip this test until the MLOps Stacks DAB is updated to work again.
 func TestAccBundleInitOnMlopsStacks(t *testing.T) {
 	t.Parallel()
-	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
+	env := testutil.GetCloud(t).String()
+
 	tmpDir1 := t.TempDir()
 	tmpDir2 := t.TempDir()
 

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/databricks/cli/bundle/config"
@@ -54,7 +55,7 @@ func TestAccBundleInitOnMlopsStacks(t *testing.T) {
 		"input_project_name":                    projectName,
 		"input_root_dir":                        "repo_name",
 		"input_include_models_in_unity_catalog": "no",
-		"input_cloud":                           env,
+		"input_cloud":                           strings.ToLower(env),
 	}
 	b, err := json.Marshal(initConfig)
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes
aws-prod-ucws has CLOUD_ENV set to "ucws" which was failing the validation checks in the template itself. This PR fixes the test.

## Tests
The tests pass now
