### PR TITLE
Update actions/setup-python to v5

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,7 +36,7 @@ jobs:
           go-version: 1.21.x
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 


### PR DESCRIPTION
## Changes

This addresses a Node 16 deprecation warning in our GHA output.