### PR TITLE
Update codecov/codecov-action to v4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,7 +56,7 @@ jobs:
         run: make test
 
       - name: Publish test coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

This addresses a Node 16 deprecation warning in our GHA output.

Full release notes of v4 at https://github.com/codecov/codecov-action/releases/tag/v4.0.0