### PR TITLE
Do CheckRunningResource only after terraform.Write

### DIFF
--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -25,7 +25,6 @@ func Deploy() bundle.Mutator {
 			bundle.Seq(
 				terraform.StatePull(),
 				deploy.StatePull(),
-				deploy.CheckRunningResource(),
 				mutator.ValidateGitDetails(),
 				libraries.MatchWithArtifacts(),
 				artifacts.CleanUp(),
@@ -36,6 +35,7 @@ func Deploy() bundle.Mutator {
 				permissions.ApplyWorkspaceRootPermissions(),
 				terraform.Interpolate(),
 				terraform.Write(),
+				deploy.CheckRunningResource(),
 				bundle.Defer(
 					terraform.Apply(),
 					bundle.Seq(

--- a/internal/bundle/basic_test.go
+++ b/internal/bundle/basic_test.go
@@ -1,0 +1,43 @@
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/internal"
+	"github.com/databricks/cli/internal/acc"
+	"github.com/databricks/cli/libs/env"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
+	ctx, _ := acc.WorkspaceTest(t)
+
+	nodeTypeId := internal.GetNodeTypeId(env.Get(ctx, "CLOUD_ENV"))
+	uniqueId := uuid.New().String()
+	root, err := initTestTemplate(t, ctx, "basic", map[string]any{
+		"unique_id":     uniqueId,
+		"node_type_id":  nodeTypeId,
+		"spark_version": "13.2.x-snapshot-scala2.12",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err = destroyBundle(t, ctx, root)
+		require.NoError(t, err)
+	})
+
+	// deploy empty bundle
+	err = deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	require.NoError(t, err)
+
+	// Remove .databricks directory to simulate a fresh deployment
+	err = os.RemoveAll(filepath.Join(root, ".databricks"))
+	require.NoError(t, err)
+
+	// deploy empty bundle again
+	err = deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	require.NoError(t, err)
+}

--- a/internal/bundle/helpers.go
+++ b/internal/bundle/helpers.go
@@ -56,6 +56,15 @@ func deployBundle(t *testing.T, ctx context.Context, path string) error {
 	return err
 }
 
+func deployBundleWithFlags(t *testing.T, ctx context.Context, path string, flags []string) error {
+	t.Setenv("BUNDLE_ROOT", path)
+	args := []string{"bundle", "deploy", "--force-lock"}
+	args = append(args, flags...)
+	c := internal.NewCobraTestRunnerWithContext(t, ctx, args...)
+	_, _, err := c.Run()
+	return err
+}
+
 func runResource(t *testing.T, ctx context.Context, path string, key string) (string, error) {
 	ctx = cmdio.NewContext(ctx, cmdio.Default())
 


### PR DESCRIPTION
## Changes
CheckRunningResource does `terraform.Show` which (I believe) expects valid `bundle.tf.json` which is only written as part of `terraform.Write` later.

With this PR order is changed.

Fixes #1286 

## Tests
Added regression E2E test

