### PR TITLE
Use UserName field to identify if service principal is used

### DIFF
--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -138,7 +138,7 @@ func TestAccBundleInitHelpers(t *testing.T) {
 		},
 		{
 			funcName: "{{is_service_principal}}",
-			expected: strconv.FormatBool(auth.IsServicePrincipal(me.Id)),
+			expected: strconv.FormatBool(auth.IsServicePrincipal(me.UserName)),
 		},
 		{
 			funcName: "{{smallest_node_type}}",

--- a/libs/auth/service_principal.go
+++ b/libs/auth/service_principal.go
@@ -4,12 +4,12 @@ import (
 	"github.com/google/uuid"
 )
 
-// Determines whether a given user id is a service principal.
-// This function uses a heuristic: if the user id is a UUID, then we assume
+// Determines whether a given user name is a service principal.
+// This function uses a heuristic: if the user name is a UUID, then we assume
 // it's a service principal. Unfortunately, the service principal listing API is too
 // slow for our purposes. And the "users" and "service principals get" APIs
 // only allow access by workspace admins.
-func IsServicePrincipal(userId string) bool {
-	_, err := uuid.Parse(userId)
+func IsServicePrincipal(userName string) bool {
+	_, err := uuid.Parse(userName)
 	return err == nil
 }

--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -140,7 +140,7 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 					return false, err
 				}
 			}
-			result := auth.IsServicePrincipal(cachedUser.Id)
+			result := auth.IsServicePrincipal(cachedUser.UserName)
 			cachedIsServicePrincipal = &result
 			return result, nil
 		},


### PR DESCRIPTION
## Changes
Use UserName field to identify if service principal is used

## Tests
Integration test passed

