### PR TITLE
Allow setting the token cache directory via the DATABRICKS_TOKEN_CACHE_DIR env var

### DIFF
--- a/libs/auth/cache/cache.go
+++ b/libs/auth/cache/cache.go
@@ -74,6 +74,13 @@ func (c *TokenCache) Lookup(key string) (*oauth2.Token, error) {
 }
 
 func (c *TokenCache) location() (string, error) {
+	// Allow users to override the location of the token cache file
+	tokenCacheDirName, exists := os.LookupEnv("DATABRICKS_TOKEN_CACHE_DIR")
+	if exists {
+		return filepath.Join(tokenCacheDirName, tokenCacheFile), nil
+	}
+
+	// Otherwise, default to using the home directory
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("home: %w", err)

--- a/libs/auth/cache/cache_test.go
+++ b/libs/auth/cache/cache_test.go
@@ -103,3 +103,13 @@ func TestStoreOnDev(t *testing.T) {
 	// macOS: read-only file system
 	assert.Error(t, err)
 }
+
+func TestOverrideTokenCacheLocationUsingEnvVar(t *testing.T) {
+	t.Setenv("DATABRICKS_TOKEN_CACHE_DIR", os.TempDir())
+	c := &TokenCache{}
+	err := c.Store("x", &oauth2.Token{
+		AccessToken: "abc",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, c.fileLocation, os.TempDir())
+}


### PR DESCRIPTION
## Changes
Allow setting the token cache directory without modifying HOME env via the DATABRICKS_TOKEN_CACHE_DIR env var.  Previously, there was no way to set the location of the token cache directory, which caused issues when using either multiple DataBricks accounts or Docker environments without a HOME set.

## Tests
Unit tests added to verify that the location reflects the env var.  Tested both locally and via Docker.
