### PR TITLE
Allow unknown properties in the config file for template initialization

### DIFF
--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -92,7 +92,7 @@ func (c *config) assignValuesFromFile(path string) error {
 		if _, ok := c.schema.Properties[name]; !ok {
 			continue
 		}
-		// If a value is already assigned, keep it.
+		// If a value is already assigned, keep the original value.
 		if _, ok := c.values[name]; ok {
 			continue
 		}

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -70,6 +70,15 @@ func validateSchema(schema *jsonschema.Schema) error {
 
 // Reads json file at path and assigns values from the file
 func (c *config) assignValuesFromFile(path string) error {
+	// It's valid to set additional properties in the config file that are not
+	// defined in the schema. They are filtered below. For the duration of this
+	// function we disable the additional properties check, to allow those
+	// properties to be loaded.
+	c.schema.AdditionalProperties = true
+	defer func() {
+		c.schema.AdditionalProperties = false
+	}()
+
 	// Load the config file.
 	configFromFile, err := c.schema.LoadInstance(path)
 	if err != nil {
@@ -79,6 +88,11 @@ func (c *config) assignValuesFromFile(path string) error {
 	// Write configs from the file to the input map, not overwriting any existing
 	// configurations.
 	for name, val := range configFromFile {
+		// If a property is not defined in the schema, skip it.
+		if _, ok := c.schema.Properties[name]; !ok {
+			continue
+		}
+		// If a value is already assigned, keep it.
 		if _, ok := c.values[name]; ok {
 			continue
 		}

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -71,16 +71,13 @@ func validateSchema(schema *jsonschema.Schema) error {
 // Reads json file at path and assigns values from the file
 func (c *config) assignValuesFromFile(path string) error {
 	// It's valid to set additional properties in the config file that are not
-	// defined in the schema. They are filtered below. For the duration of this
-	// function we disable the additional properties check, to allow those
-	// properties to be loaded.
+	// defined in the schema. They will be filtered below. Thus for the duration of
+	// the LoadInstance call, we disable the additional properties check,
+	// to allow those properties to be loaded.
 	c.schema.AdditionalProperties = true
-	defer func() {
-		c.schema.AdditionalProperties = false
-	}()
-
-	// Load the config file.
 	configFromFile, err := c.schema.LoadInstance(path)
+	c.schema.AdditionalProperties = false
+
 	if err != nil {
 		return fmt.Errorf("failed to load config from file %s: %w", path, err)
 	}

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -58,7 +58,9 @@ func TestTemplateConfigAssignValuesFromFileFiltersPropertiesNotInTheSchema(t *te
 	err := c.assignValuesFromFile("./testdata/config-assign-from-file-unknown-property/config.json")
 	assert.NoError(t, err)
 
-	assert.Len(t, c.values, 0)
+	// assert only the known property is loaded
+	assert.Len(t, c.values, 1)
+	assert.Equal(t, "i am a known property", c.values["string_val"])
 }
 
 func TestTemplateConfigAssignDefaultValues(t *testing.T) {

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -52,6 +52,15 @@ func TestTemplateConfigAssignValuesFromFileDoesNotOverwriteExistingConfigs(t *te
 	assert.Equal(t, "this-is-not-overwritten", c.values["string_val"])
 }
 
+func TestTemplateConfigAssignValuesFromFileFiltersPropertiesNotInTheSchema(t *testing.T) {
+	c := testConfig(t)
+
+	err := c.assignValuesFromFile("./testdata/config-assign-from-file-unknown-property/config.json")
+	assert.NoError(t, err)
+
+	assert.Len(t, c.values, 0)
+}
+
 func TestTemplateConfigAssignDefaultValues(t *testing.T) {
 	c := testConfig(t)
 

--- a/libs/template/testdata/config-assign-from-file-unknown-property/config.json
+++ b/libs/template/testdata/config-assign-from-file-unknown-property/config.json
@@ -1,3 +1,4 @@
 {
-    "unknown_prop":    123
+    "unknown_prop": 123,
+    "string_val": "i am a known property"
 }


### PR DESCRIPTION
## Changes
Before we would error if a property was defined in the config file, that was not defined in the schema.

## Tests
Unit tests. Also manually that the e2e flow works file.

Before:
```
shreyas.goenka@THW32HFW6T playground % cli bundle init default-python --config-file config.json

Welcome to the default Python template for Databricks Asset Bundles!
Error: failed to load config from file config.json: property include_pytho is not defined in the schema
```

After:
```
shreyas.goenka@THW32HFW6T playground % cli bundle init default-python --config-file config.json

Welcome to the default Python template for Databricks Asset Bundles!
Workspace to use (auto-detected, edit in 'test/databricks.yml'): https://dbc-a39a1eb1-ef95.cloud.databricks.com

✨ Your new project has been created in the 'test' directory!

Please refer to the README.md file for "getting started" instructions.
See also the documentation at https://docs.databricks.com/dev-tools/bundles/index.html.
```
