### PR TITLE
Make `bundle.deployment` optional in the bundle schema

### DIFF
--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -42,5 +42,5 @@ type Bundle struct {
 	ComputeID string `json:"compute_id,omitempty"`
 
 	// Deployment section specifies deployment related configuration for bundle
-	Deployment Deployment `json:"deployment"`
+	Deployment Deployment `json:"deployment,omitempty"`
 }


### PR DESCRIPTION
## Changes
Makes the field optional by adding the `omitempty` tag.

This gets rid of the red squiggly lines in the bundle schema.

