### PR TITLE
Fix the generated DABs JSON schema

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -97,10 +97,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # - name: Setup Go
-      #   uses: actions/setup-go@v5
-      #   with:
-      #     go-version: 1.21.x
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
 
       # Github repo: https://github.com/ajv-validator/ajv-cli
       - name: Install ajv-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -97,10 +97,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21.x
+      # - name: Setup Go
+      #   uses: actions/setup-go@v5
+      #   with:
+      #     go-version: 1.21.x
 
       # Github repo: https://github.com/ajv-validator/ajv-cli
       - name: Install ajv-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -102,7 +102,21 @@ jobs:
         with:
           go-version: 1.21.x
 
+      - name: Set go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: test runner
+        run: go run main.go
+
       # Github repo: https://github.com/ajv-validator/ajv-cli
       # TODO: version lock the installation.
       - name: Install ajv-cli
-        run: npm install -g ajv-cli
+        run: npm install -g ajv-cli@5.0.0
+
+      - name: Validate bundle schema
+        run: |
+          echo -e "bundle:\n  name: abcd" > config.yaml
+          go run main.go bundle schema > schema.json
+          ajv -s schema.json -d config.yaml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -107,16 +107,15 @@ jobs:
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
-      - name: test runner
-        run: go run main.go
-
       # Github repo: https://github.com/ajv-validator/ajv-cli
-      # TODO: version lock the installation.
       - name: Install ajv-cli
         run: npm install -g ajv-cli@5.0.0
 
+      # Assert that the generated bundle schema is valid by validating it against
+      # a bare bones DABs config.
+      # go run main.go bundle schema > schema.json
       - name: Validate bundle schema
         run: |
           echo -e "bundle:\n  name: abcd" > config.yaml
-          go run main.go bundle schema > schema.json
+          echo {"foo": "bar"} > schema.json
           ajv -s schema.json -d config.yaml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -117,5 +117,5 @@ jobs:
       - name: Validate bundle schema
         run: |
           echo -e "bundle:\n  name: abcd" > config.yaml
-          echo {"foo": "bar"} > schema.json
+          echo "{'foo': 'bar'}"" > schema.json
           ajv -s schema.json -d config.yaml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -102,11 +102,6 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Set go env
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
       # Github repo: https://github.com/ajv-validator/ajv-cli
       - name: Install ajv-cli
         run: npm install -g ajv-cli@5.0.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,3 +89,20 @@ jobs:
         run: |
           # Exit with status code 1 if there are differences (i.e. unformatted files)
           git diff --exit-code
+
+  validate-bundle-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
+
+      # Github repo: https://github.com/ajv-validator/ajv-cli
+      # TODO: version lock the installation.
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -117,5 +117,5 @@ jobs:
       - name: Validate bundle schema
         run: |
           echo -e "bundle:\n  name: abcd" > config.yaml
-          echo "{'foo': 'bar'}"" > schema.json
+          echo '{"name": "John", "age": 30}' > schema.json
           ajv -s schema.json -d config.yaml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -111,11 +111,13 @@ jobs:
       - name: Install ajv-cli
         run: npm install -g ajv-cli@5.0.0
 
-      # Assert that the generated bundle schema is valid by validating it against
-      # a bare bones DABs config.
-      # go run main.go bundle schema > schema.json
+      # Assert that the generated bundle schema is a valid JSON schema by using
+      # ajv-cli to validate it against a sample configuration file.
+      # By default the ajv-cli runs in strict mode which will fail if the schema
+      # itself is not valid. Strict mode is more strict than the JSON schema
+      # specification. See for details: https://ajv.js.org/options.html#strict-mode-options
       - name: Validate bundle schema
         run: |
           echo -e "bundle:\n  name: abcd" > config.yaml
-          echo '{"name": "John", "age": 30}' > schema.json
+          go run main.go bundle schema > schema.json
           ajv -s schema.json -d config.yaml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -113,6 +113,5 @@ jobs:
       # specification. See for details: https://ajv.js.org/options.html#strict-mode-options
       - name: Validate bundle schema
         run: |
-          echo -e "bundle:\n  name: abcd" > config.yaml
           go run main.go bundle schema > schema.json
-          ajv -s schema.json -d config.yaml
+          ajv -s schema.json -d ./bundle/tests/basic/databricks.yml

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -95,7 +95,9 @@ func safeToSchema(golangType reflect.Type, docs *Docs, traceId string, tracker *
 	// HACK to unblock CLI release (13th Feb 2024). This is temporary until proper
 	// support for recursive types is added to the schema generator. PR: https://github.com/databricks/cli/pull/1204
 	if traceId == "for_each_task" {
-		return nil, nil
+		return &jsonschema.Schema{
+			Type: jsonschema.ObjectType,
+		}, nil
 	}
 
 	// WE ERROR OUT IF THERE ARE CYCLES IN THE JSON SCHEMA


### PR DESCRIPTION
## Changes
This PR fixes bundle schema being broken because `for_each_task: null` was set in the generated schema. This is not valid according to the JSON schema specification and thus the Red Hat YAML VSCode extension was failing to parse the YAML configuration. 

This PR fixes: https://github.com/databricks/cli/issues/1312

## Tests
The fix itself was tested manually. I asserted that the autocompletion works now. This was mistakenly overlooked the first time around when the regression was introduced in https://github.com/databricks/cli/pull/1204 because the YAML extension provides best-effort autocomplete suggestions even if the JSON schema fails to load.

To prevent future regressions we also add a test to assert that the JSON schema generated itself is a valid JSON schema object. This is done via using the `ajv-cli` to validate the schema. This package is also used by the Red Hat YAML extension and thus provides a high fidelity check for ensuring the JSON schema is valid. 

Before, with the old schema:
```
shreyas.goenka@THW32HFW6T cli-versions % ajv validate -s proj/schema-216.json -d ../bundle-playground-3/databricks.yml
schema proj/schema-216.json is invalid
error: schema is invalid: data/properties/resources/properties/jobs/additionalProperties/properties/tasks/items/properties/for_each_task must be object,boolean, data/properties/resources/properties/jobs/additionalProperties/properties/tasks/items must be array, data/properties/resources/properties/jobs/additionalProperties/properties/tasks/items must match a schema in anyOf
```

After, with the new schema:
```
shreyas.goenka@THW32HFW6T cli-versions % ajv validate -s proj/schema-dev.json -d ../bundle-playground-3/databricks.yml
../bundle-playground-3/databricks.yml valid
```

After, autocomplete suggestions:

<img width="600" alt="Screenshot 2024-03-27 at 6 35 57 PM" src="https://github.com/databricks/cli/assets/88374338/d0a62402-e323-4f36-854d-332b33cbeab8">

