### PR TITLE
Allow binding OAUTH redirect to all IP addresses including public

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -17,7 +17,7 @@ func New() *cobra.Command {
 	var perisistentAuth auth.PersistentAuth
 	cmd.PersistentFlags().StringVar(&perisistentAuth.Host, "host", perisistentAuth.Host, "Databricks Host")
 	cmd.PersistentFlags().StringVar(&perisistentAuth.AccountID, "account-id", perisistentAuth.AccountID, "Databricks Account ID")
-
+	cmd.PersistentFlags().BoolVar(&perisistentAuth.BindPublicAddress, "bind-public", perisistentAuth.BindPublicAddress, "Allow OAUTH redirect to bind to all local IP addresses including public addresses (NOTE: this is less secure)")
 	cmd.AddCommand(newEnvCommand())
 	cmd.AddCommand(newLoginCommand(&perisistentAuth))
 	cmd.AddCommand(newProfilesCommand())


### PR DESCRIPTION
## Changes
Provide a flag on auth commands that allows binding the OAUTH redirec…t address to a port rather than an address, allowing binding to public IP addresses rather than just localhost.  This allows workloads within Docker containers (and other more complex network situations) to allow binding and OAUTH redirect.

## Tests
Tests have been added.  Also tested locally.

