### PR TITLE
Return warning for nil primitive types during normalization

### DIFF
--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -61,6 +61,14 @@ func (n normalizeOptions) normalizeType(typ reflect.Type, src dyn.Value, seen []
 	return dyn.InvalidValue, diag.Errorf("unsupported type: %s", typ.Kind())
 }
 
+func nilWarning(expected dyn.Kind, src dyn.Value) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("expected a %s value, found null", expected),
+		Location: src.Location(),
+	}
+}
+
 func typeMismatch(expected dyn.Kind, src dyn.Value) diag.Diagnostic {
 	return diag.Diagnostic{
 		Severity: diag.Error,
@@ -229,6 +237,9 @@ func (n normalizeOptions) normalizeString(typ reflect.Type, src dyn.Value) (dyn.
 		out = strconv.FormatInt(src.MustInt(), 10)
 	case dyn.KindFloat:
 		out = strconv.FormatFloat(src.MustFloat(), 'f', -1, 64)
+	case dyn.KindNil:
+		// Return a warning if the field is present but has a null value.
+		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindString, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindString, src))
 	}
@@ -259,6 +270,9 @@ func (n normalizeOptions) normalizeBool(typ reflect.Type, src dyn.Value) (dyn.Va
 			// Cannot interpret as a boolean.
 			return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindBool, src))
 		}
+	case dyn.KindNil:
+		// Return a warning if the field is present but has a null value.
+		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindBool, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindBool, src))
 	}
@@ -288,6 +302,9 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value) (dyn.Val
 				Location: src.Location(),
 			})
 		}
+	case dyn.KindNil:
+		// Return a warning if the field is present but has a null value.
+		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindInt, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindInt, src))
 	}
@@ -317,6 +334,9 @@ func (n normalizeOptions) normalizeFloat(typ reflect.Type, src dyn.Value) (dyn.V
 				Location: src.Location(),
 			})
 		}
+	case dyn.KindNil:
+		// Return a warning if the field is present but has a null value.
+		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindFloat, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindFloat, src))
 	}

--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -61,7 +61,7 @@ func (n normalizeOptions) normalizeType(typ reflect.Type, src dyn.Value, seen []
 	return dyn.InvalidValue, diag.Errorf("unsupported type: %s", typ.Kind())
 }
 
-func nilWarning(expected dyn.Kind, src dyn.Value) diag.Diagnostic {
+func nullWarning(expected dyn.Kind, src dyn.Value) diag.Diagnostic {
 	return diag.Diagnostic{
 		Severity: diag.Warning,
 		Summary:  fmt.Sprintf("expected a %s value, found null", expected),
@@ -239,7 +239,7 @@ func (n normalizeOptions) normalizeString(typ reflect.Type, src dyn.Value) (dyn.
 		out = strconv.FormatFloat(src.MustFloat(), 'f', -1, 64)
 	case dyn.KindNil:
 		// Return a warning if the field is present but has a null value.
-		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindString, src))
+		return dyn.InvalidValue, diags.Append(nullWarning(dyn.KindString, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindString, src))
 	}
@@ -272,7 +272,7 @@ func (n normalizeOptions) normalizeBool(typ reflect.Type, src dyn.Value) (dyn.Va
 		}
 	case dyn.KindNil:
 		// Return a warning if the field is present but has a null value.
-		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindBool, src))
+		return dyn.InvalidValue, diags.Append(nullWarning(dyn.KindBool, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindBool, src))
 	}
@@ -304,7 +304,7 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value) (dyn.Val
 		}
 	case dyn.KindNil:
 		// Return a warning if the field is present but has a null value.
-		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindInt, src))
+		return dyn.InvalidValue, diags.Append(nullWarning(dyn.KindInt, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindInt, src))
 	}
@@ -336,7 +336,7 @@ func (n normalizeOptions) normalizeFloat(typ reflect.Type, src dyn.Value) (dyn.V
 		}
 	case dyn.KindNil:
 		// Return a warning if the field is present but has a null value.
-		return dyn.InvalidValue, diags.Append(nilWarning(dyn.KindFloat, src))
+		return dyn.InvalidValue, diags.Append(nullWarning(dyn.KindFloat, src))
 	default:
 		return dyn.InvalidValue, diags.Append(typeMismatch(dyn.KindFloat, src))
 	}

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -408,7 +408,7 @@ func TestNormalizeStringNil(t *testing.T) {
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
 		Severity: diag.Warning,
-		Summary:  `expected a string value, found nil`,
+		Summary:  `expected a string value, found null`,
 		Location: vin.Location(),
 	}, err[0])
 }
@@ -464,7 +464,7 @@ func TestNormalizeBoolNil(t *testing.T) {
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
 		Severity: diag.Warning,
-		Summary:  `expected a bool value, found nil`,
+		Summary:  `expected a bool value, found null`,
 		Location: vin.Location(),
 	}, err[0])
 }

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -407,8 +407,8 @@ func TestNormalizeStringNil(t *testing.T) {
 	_, err := Normalize(&typ, vin)
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
-		Severity: diag.Error,
-		Summary:  `expected string, found nil`,
+		Severity: diag.Warning,
+		Summary:  `expected a string value, found nil`,
 		Location: vin.Location(),
 	}, err[0])
 }
@@ -463,8 +463,8 @@ func TestNormalizeBoolNil(t *testing.T) {
 	_, err := Normalize(&typ, vin)
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
-		Severity: diag.Error,
-		Summary:  `expected bool, found nil`,
+		Severity: diag.Warning,
+		Summary:  `expected a bool value, found nil`,
 		Location: vin.Location(),
 	}, err[0])
 }
@@ -536,8 +536,8 @@ func TestNormalizeIntNil(t *testing.T) {
 	_, err := Normalize(&typ, vin)
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
-		Severity: diag.Error,
-		Summary:  `expected int, found nil`,
+		Severity: diag.Warning,
+		Summary:  `expected a int value, found null`,
 		Location: vin.Location(),
 	}, err[0])
 }
@@ -596,8 +596,8 @@ func TestNormalizeFloatNil(t *testing.T) {
 	_, err := Normalize(&typ, vin)
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
-		Severity: diag.Error,
-		Summary:  `expected float, found nil`,
+		Severity: diag.Warning,
+		Summary:  `expected a float value, found null`,
 		Location: vin.Location(),
 	}, err[0])
 }


### PR DESCRIPTION
## Changes

It's not necessary to error out if a configuration field is present but not set.

For example, the following would error out, but after this change only produces a warning:
```yaml
workspace:
  # This is a string field, but if not specified, it ends up being a null.
  host:
```

## Tests

Updated the unit tests to match the new behavior.