### PR TITLE
Include `dyn.Path` in normalization warnings and errors

### DIFF
--- a/libs/diag/diagnostic.go
+++ b/libs/diag/diagnostic.go
@@ -20,6 +20,10 @@ type Diagnostic struct {
 	// Location is a source code location associated with the diagnostic message.
 	// It may be zero if there is no associated location.
 	Location dyn.Location
+
+	// Path is a path to the value in a configuration tree that the diagnostic is associated with.
+	// It may be nil if there is no associated path.
+	Path dyn.Path
 }
 
 // Errorf creates a new error diagnostic.

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -43,6 +43,7 @@ func TestNormalizeStructElementDiagnostic(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.NewPath(dyn.Key("bar")),
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -68,6 +69,7 @@ func TestNormalizeStructUnknownField(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `unknown field: bar`,
 		Location: vin.Get("foo").Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 
 	// The field that can be mapped to the struct field is retained.
@@ -101,6 +103,7 @@ func TestNormalizeStructError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected map, found string`,
 		Location: vin.Get("foo").Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -245,6 +248,7 @@ func TestNormalizeMapElementDiagnostic(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.NewPath(dyn.Key("bar")),
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -270,6 +274,7 @@ func TestNormalizeMapError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected map, found string`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -333,6 +338,7 @@ func TestNormalizeSliceElementDiagnostic(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.NewPath(dyn.Index(2)),
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -356,6 +362,7 @@ func TestNormalizeSliceError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected sequence, found string`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -410,6 +417,7 @@ func TestNormalizeStringNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a string value, found null`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -446,6 +454,7 @@ func TestNormalizeStringError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -466,6 +475,7 @@ func TestNormalizeBoolNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a bool value, found null`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -507,6 +517,7 @@ func TestNormalizeBoolFromStringError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected bool, found string`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -519,6 +530,7 @@ func TestNormalizeBoolError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected bool, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -539,6 +551,7 @@ func TestNormalizeIntNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a int value, found null`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -567,6 +580,7 @@ func TestNormalizeIntFromStringError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `cannot parse "abc" as an integer`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -579,6 +593,7 @@ func TestNormalizeIntError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected int, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -599,6 +614,7 @@ func TestNormalizeFloatNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a float value, found null`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -627,6 +643,7 @@ func TestNormalizeFloatFromStringError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `cannot parse "abc" as a floating point number`,
 		Location: vin.Location(),
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }
 
@@ -639,5 +656,6 @@ func TestNormalizeFloatError(t *testing.T) {
 		Severity: diag.Error,
 		Summary:  `expected float, found map`,
 		Location: dyn.Location{},
+		Path:     dyn.EmptyPath,
 	}, err[0])
 }


### PR DESCRIPTION
## Changes

This adds context to warnings and errors. For example:

* Summary: `unknown field bar`
* Location: `foo.yml:6:10`
* Path: `.targets.dev.workspace`

## Tests

Unit tests.

