### PR TITLE
Fixed typo in error template for auth describe

### DIFF
--- a/cmd/auth/describe.go
+++ b/cmd/auth/describe.go
@@ -23,7 +23,7 @@ var authTemplate = `{{"Host:" | bold}} {{.Status.Details.Host}}
 -----
 ` + configurationTemplate
 
-var errorTemplate = `Unable to authenticate: {{.Error}}
+var errorTemplate = `Unable to authenticate: {{.Status.Error}}
 -----
 ` + configurationTemplate
 


### PR DESCRIPTION
## Changes
Fixed typo in error template for auth describe

## Tests
Manually (regression test will follow up)

