### PR TITLE
Fixed pre-init script order

### DIFF
--- a/bundle/config/mutator/mutator.go
+++ b/bundle/config/mutator/mutator.go
@@ -10,7 +10,7 @@ import (
 func DefaultMutators() []bundle.Mutator {
 	return []bundle.Mutator{
 		// Execute preinit script before loading any configuration files.
-		// It needs to be done before processing cnfiguration files to allow
+		// It needs to be done before processing configuration files to allow
 		// the script to modify the configuration or add own configuration files.
 		scripts.Execute(config.ScriptPreInit),
 

--- a/bundle/config/mutator/mutator.go
+++ b/bundle/config/mutator/mutator.go
@@ -9,14 +9,17 @@ import (
 
 func DefaultMutators() []bundle.Mutator {
 	return []bundle.Mutator{
+		// Execute preinit script before loading any configuration files.
+		// It needs to be done before processing cnfiguration files to allow
+		// the script to modify the configuration or add own configuration files.
+		scripts.Execute(config.ScriptPreInit),
+
 		loader.EntryPoint(),
 		loader.ProcessRootIncludes(),
 
 		// Verify that the CLI version is within the specified range.
 		VerifyCliVersion(),
 
-		// Execute preinit script after loading all configuration files.
-		scripts.Execute(config.ScriptPreInit),
 		EnvironmentsToTargets(),
 		InitializeVariables(),
 		DefineDefaultTarget(),


### PR DESCRIPTION
## Changes
`preinit` script needs to be executed before processing configuration files to allow the script to modify the configuration or add own configuration files.


