### PR TITLE
Add docker images for the CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "v0.0.0-test.docker"
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           go-version: 1.21.x
 
+      # Log into the GitHub Container Registry. The goreleaser action will create
+      # the docker images and push them to the GitHub Container Registry.
       - uses: "docker/login-action@v3"
         with:
           registry: "ghcr.io"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-      - "v0.0.0-testdocker"
 
   workflow_dispatch:
 
@@ -47,99 +46,99 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # create-setup-cli-release-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-setup-cli-release-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update setup-cli
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'setup-cli',
-  #             workflow_id: 'release-pr.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #             }
-  #           });
+      - name: Update setup-cli
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'setup-cli',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });
 
-  # create-homebrew-tap-release-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-homebrew-tap-release-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update homebrew-tap
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
-  #           artifacts = artifacts.filter(a => a.type == "Archive")
-  #           artifacts = new Map(
-  #             artifacts.map(a => [
-  #               a.goos + "_" + a.goarch,
-  #               a.extra.Checksum.replace("sha256:", "")
-  #             ])
-  #           )
+      - name: Update homebrew-tap
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
+            artifacts = artifacts.filter(a => a.type == "Archive")
+            artifacts = new Map(
+              artifacts.map(a => [
+                a.goos + "_" + a.goarch,
+                a.extra.Checksum.replace("sha256:", "")
+              ])
+            )
 
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'homebrew-tap',
-  #             workflow_id: 'release-pr.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #               darwin_amd64_sha: artifacts.get('darwin_amd64'),
-  #               darwin_arm64_sha: artifacts.get('darwin_arm64'),
-  #               linux_amd64_sha: artifacts.get('linux_amd64'),
-  #               linux_arm64_sha: artifacts.get('linux_arm64')
-  #             }
-  #           });
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'homebrew-tap',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+                darwin_amd64_sha: artifacts.get('darwin_amd64'),
+                darwin_arm64_sha: artifacts.get('darwin_arm64'),
+                linux_amd64_sha: artifacts.get('linux_amd64'),
+                linux_arm64_sha: artifacts.get('linux_arm64')
+              }
+            });
 
-  # create-vscode-extension-update-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-vscode-extension-update-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update CLI version in the VSCode extension
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'databricks-vscode',
-  #             workflow_id: 'update-cli-version.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #             }
-  #           });
+      - name: Update CLI version in the VSCode extension
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'databricks-vscode',
+              workflow_id: 'update-cli-version.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });
 
-  # publish-to-winget-pkgs:
-  #   needs: goreleaser
-  #   runs-on: windows-latest
-  #   environment: release
-  #   steps:
-  #     - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
-  #       with:
-  #         identifier: Databricks.DatabricksCLI
-  #         installers-regex: 'windows_.*\.zip$' # Only windows releases
-  #         token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-  #         fork-user: eng-dev-ecosystem-bot
+  publish-to-winget-pkgs:
+    needs: goreleaser
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
+        with:
+          identifier: Databricks.DatabricksCLI
+          installers-regex: 'windows_.*\.zip$' # Only windows releases
+          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+          fork-user: eng-dev-ecosystem-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Set up QEMU dependency
+        uses: docker/setup-qemu-action@v3
+
       - name: Run GoReleaser
         id: releaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           go-version: 1.21.x
 
+      - uses: "docker/login-action@v3"
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Run GoReleaser
         id: releaser
         uses: goreleaser/goreleaser-action@v4
@@ -33,99 +39,99 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  create-setup-cli-release-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-setup-cli-release-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update setup-cli
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'setup-cli',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-              }
-            });
+  #     - name: Update setup-cli
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'setup-cli',
+  #             workflow_id: 'release-pr.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #             }
+  #           });
 
-  create-homebrew-tap-release-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-homebrew-tap-release-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update homebrew-tap
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
-            artifacts = artifacts.filter(a => a.type == "Archive")
-            artifacts = new Map(
-              artifacts.map(a => [
-                a.goos + "_" + a.goarch,
-                a.extra.Checksum.replace("sha256:", "")
-              ])
-            )
+  #     - name: Update homebrew-tap
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
+  #           artifacts = artifacts.filter(a => a.type == "Archive")
+  #           artifacts = new Map(
+  #             artifacts.map(a => [
+  #               a.goos + "_" + a.goarch,
+  #               a.extra.Checksum.replace("sha256:", "")
+  #             ])
+  #           )
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'homebrew-tap',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-                darwin_amd64_sha: artifacts.get('darwin_amd64'),
-                darwin_arm64_sha: artifacts.get('darwin_arm64'),
-                linux_amd64_sha: artifacts.get('linux_amd64'),
-                linux_arm64_sha: artifacts.get('linux_arm64')
-              }
-            });
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'homebrew-tap',
+  #             workflow_id: 'release-pr.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #               darwin_amd64_sha: artifacts.get('darwin_amd64'),
+  #               darwin_arm64_sha: artifacts.get('darwin_arm64'),
+  #               linux_amd64_sha: artifacts.get('linux_amd64'),
+  #               linux_arm64_sha: artifacts.get('linux_arm64')
+  #             }
+  #           });
 
-  create-vscode-extension-update-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-vscode-extension-update-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update CLI version in the VSCode extension
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'databricks-vscode',
-              workflow_id: 'update-cli-version.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-              }
-            });
+  #     - name: Update CLI version in the VSCode extension
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'databricks-vscode',
+  #             workflow_id: 'update-cli-version.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #             }
+  #           });
 
-  publish-to-winget-pkgs:
-    needs: goreleaser
-    runs-on: windows-latest
-    environment: release
-    steps:
-      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
-        with:
-          identifier: Databricks.DatabricksCLI
-          installers-regex: 'windows_.*\.zip$' # Only windows releases
-          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-          fork-user: eng-dev-ecosystem-bot
+  # publish-to-winget-pkgs:
+  #   needs: goreleaser
+  #   runs-on: windows-latest
+  #   environment: release
+  #   steps:
+  #     - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
+  #       with:
+  #         identifier: Databricks.DatabricksCLI
+  #         installers-regex: 'windows_.*\.zip$' # Only windows releases
+  #         token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+  #         fork-user: eng-dev-ecosystem-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
 
+      # QEMU is required to build cross platform docker images using buildx.
+      # It's allows virtualization of the CPU architecture in software.
       - name: Set up QEMU dependency
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-      - "v0.0.0-test.docker"
 
   workflow_dispatch:
 
@@ -43,99 +42,99 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # create-setup-cli-release-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-setup-cli-release-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update setup-cli
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'setup-cli',
-  #             workflow_id: 'release-pr.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #             }
-  #           });
+      - name: Update setup-cli
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'setup-cli',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });
 
-  # create-homebrew-tap-release-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-homebrew-tap-release-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update homebrew-tap
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
-  #           artifacts = artifacts.filter(a => a.type == "Archive")
-  #           artifacts = new Map(
-  #             artifacts.map(a => [
-  #               a.goos + "_" + a.goarch,
-  #               a.extra.Checksum.replace("sha256:", "")
-  #             ])
-  #           )
+      - name: Update homebrew-tap
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
+            artifacts = artifacts.filter(a => a.type == "Archive")
+            artifacts = new Map(
+              artifacts.map(a => [
+                a.goos + "_" + a.goarch,
+                a.extra.Checksum.replace("sha256:", "")
+              ])
+            )
 
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'homebrew-tap',
-  #             workflow_id: 'release-pr.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #               darwin_amd64_sha: artifacts.get('darwin_amd64'),
-  #               darwin_arm64_sha: artifacts.get('darwin_arm64'),
-  #               linux_amd64_sha: artifacts.get('linux_amd64'),
-  #               linux_arm64_sha: artifacts.get('linux_arm64')
-  #             }
-  #           });
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'homebrew-tap',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+                darwin_amd64_sha: artifacts.get('darwin_amd64'),
+                darwin_arm64_sha: artifacts.get('darwin_arm64'),
+                linux_amd64_sha: artifacts.get('linux_amd64'),
+                linux_arm64_sha: artifacts.get('linux_arm64')
+              }
+            });
 
-  # create-vscode-extension-update-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-vscode-extension-update-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update CLI version in the VSCode extension
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'databricks-vscode',
-  #             workflow_id: 'update-cli-version.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #             }
-  #           });
+      - name: Update CLI version in the VSCode extension
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'databricks-vscode',
+              workflow_id: 'update-cli-version.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });
 
-  # publish-to-winget-pkgs:
-  #   needs: goreleaser
-  #   runs-on: windows-latest
-  #   environment: release
-  #   steps:
-  #     - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
-  #       with:
-  #         identifier: Databricks.DatabricksCLI
-  #         installers-regex: 'windows_.*\.zip$' # Only windows releases
-  #         token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-  #         fork-user: eng-dev-ecosystem-bot
+  publish-to-winget-pkgs:
+    needs: goreleaser
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
+        with:
+          identifier: Databricks.DatabricksCLI
+          installers-regex: 'windows_.*\.zip$' # Only windows releases
+          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+          fork-user: eng-dev-ecosystem-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       # QEMU is required to build cross platform docker images using buildx.
-      # It's allows virtualization of the CPU architecture in software.
+      # It allows virtualization of the CPU architecture in software.
       - name: Set up QEMU dependency
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "v0.0.0-testdocker"
 
   workflow_dispatch:
 
@@ -46,99 +47,99 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  create-setup-cli-release-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-setup-cli-release-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update setup-cli
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'setup-cli',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-              }
-            });
+  #     - name: Update setup-cli
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'setup-cli',
+  #             workflow_id: 'release-pr.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #             }
+  #           });
 
-  create-homebrew-tap-release-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-homebrew-tap-release-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update homebrew-tap
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
-            artifacts = artifacts.filter(a => a.type == "Archive")
-            artifacts = new Map(
-              artifacts.map(a => [
-                a.goos + "_" + a.goarch,
-                a.extra.Checksum.replace("sha256:", "")
-              ])
-            )
+  #     - name: Update homebrew-tap
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
+  #           artifacts = artifacts.filter(a => a.type == "Archive")
+  #           artifacts = new Map(
+  #             artifacts.map(a => [
+  #               a.goos + "_" + a.goarch,
+  #               a.extra.Checksum.replace("sha256:", "")
+  #             ])
+  #           )
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'homebrew-tap',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-                darwin_amd64_sha: artifacts.get('darwin_amd64'),
-                darwin_arm64_sha: artifacts.get('darwin_arm64'),
-                linux_amd64_sha: artifacts.get('linux_amd64'),
-                linux_arm64_sha: artifacts.get('linux_arm64')
-              }
-            });
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'homebrew-tap',
+  #             workflow_id: 'release-pr.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #               darwin_amd64_sha: artifacts.get('darwin_amd64'),
+  #               darwin_arm64_sha: artifacts.get('darwin_arm64'),
+  #               linux_amd64_sha: artifacts.get('linux_amd64'),
+  #               linux_arm64_sha: artifacts.get('linux_arm64')
+  #             }
+  #           });
 
-  create-vscode-extension-update-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-vscode-extension-update-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update CLI version in the VSCode extension
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'databricks-vscode',
-              workflow_id: 'update-cli-version.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-              }
-            });
+  #     - name: Update CLI version in the VSCode extension
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'databricks-vscode',
+  #             workflow_id: 'update-cli-version.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #             }
+  #           });
 
-  publish-to-winget-pkgs:
-    needs: goreleaser
-    runs-on: windows-latest
-    environment: release
-    steps:
-      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
-        with:
-          identifier: Databricks.DatabricksCLI
-          installers-regex: 'windows_.*\.zip$' # Only windows releases
-          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-          fork-user: eng-dev-ecosystem-bot
+  # publish-to-winget-pkgs:
+  #   needs: goreleaser
+  #   runs-on: windows-latest
+  #   environment: release
+  #   steps:
+  #     - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
+  #       with:
+  #         identifier: Databricks.DatabricksCLI
+  #         installers-regex: 'windows_.*\.zip$' # Only windows releases
+  #         token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+  #         fork-user: eng-dev-ecosystem-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           password: "${{ secrets.GITHUB_TOKEN }}"
 
       # QEMU is required to build cross platform docker images using buildx.
-      # It allows virtualization of the CPU architecture in software.
+      # It allows virtualization of the CPU architecture at the application level.
       - name: Set up QEMU dependency
         uses: docker/setup-qemu-action@v3
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,6 +53,7 @@ dockers:
     image_templates:
       # Docker tags can't have "+" in them, so we replace it with "-"
       - 'ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-arm64'
+      - 'ghcr.io/databricks/cli:latest-arm64'
     build_flag_templates:
       - "--build-arg=ARCH=arm64"
       - "--platform=linux/arm64"
@@ -66,6 +67,7 @@ dockers:
     image_templates:
       # Docker tags can't have "+" in them, so we replace it with "-"
       - 'ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-amd64'
+      - 'ghcr.io/databricks/cli:latest-amd64'
     build_flag_templates:
       - "--build-arg=ARCH=amd64"
       - "--platform=linux/amd64"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,7 @@ archives:
 dockers:
   - id: arm64
     goarch: arm64
+    # We need to use buildx to build arm64 image on a amd64 machine.
     use: buildx
     image_templates:
       # Docker tags can't have "+" in them, so we replace it with "-"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,34 @@ archives:
   # file name then additional logic to clean up older builds would be needed.
   name_template: 'databricks_cli_{{ if not .IsSnapshot }}{{ .Version }}_{{ end }}{{ .Os }}_{{ .Arch }}'
 
+#TODO: Add some documentation / a readme to the docker directory on how to maintain this.
+
+dockers:
+  - id: arm64
+    goarch: arm64
+    image_templates:
+      # Docker tags can't have "+" in them, so we replace it with "-"
+      - 'ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-arm64'
+    build_flag_templates:
+      - "--build-arg=ARCH=arm64"
+      - "--platform=linux/arm64"
+    extra_files:
+      - "./docker/config.tfrc"
+      - "./docker/setup.sh"
+
+  - id: amd64
+    goarch: amd64
+    image_templates:
+      # Docker tags can't have "+" in them, so we replace it with "-"
+      - 'ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-amd64'
+    build_flag_templates:
+      - "--build-arg=ARCH=amd64"
+      - "--platform=linux/amd64"
+    extra_files:
+      - "./docker/config.tfrc"
+      - "./docker/setup.sh"
+
+
 checksum:
   name_template: 'databricks_cli_{{ .Version }}_SHA256SUMS'
   algorithm: sha256

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,8 +45,6 @@ archives:
   # file name then additional logic to clean up older builds would be needed.
   name_template: 'databricks_cli_{{ if not .IsSnapshot }}{{ .Version }}_{{ end }}{{ .Os }}_{{ .Arch }}'
 
-# TODO: Add some documentation / a readme to the docker directory on how to maintain this.
-
 dockers:
   - id: arm64
     goarch: arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ archives:
   # file name then additional logic to clean up older builds would be needed.
   name_template: 'databricks_cli_{{ if not .IsSnapshot }}{{ .Version }}_{{ end }}{{ .Os }}_{{ .Arch }}'
 
-#TODO: Add some documentation / a readme to the docker directory on how to maintain this.
+# TODO: Add some documentation / a readme to the docker directory on how to maintain this.
 
 dockers:
   - id: arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,7 @@ archives:
 dockers:
   - id: arm64
     goarch: arm64
+    use: buildx
     image_templates:
       # Docker tags can't have "+" in them, so we replace it with "-"
       - 'ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-arm64'
@@ -62,6 +63,7 @@ dockers:
 
   - id: amd64
     goarch: amd64
+    use: buildx
     image_templates:
       # Docker tags can't have "+" in them, so we replace it with "-"
       - 'ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-amd64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,12 @@ RUN ["apk", "add", "jq"]
 
 WORKDIR /build
 
-# TODO: Copt the entire repo to the build directory. This is temp for testing.
 COPY ./docker/setup.sh /build/docker/setup.sh
 COPY ./databricks /app/databricks
 COPY ./docker/config.tfrc /app/config/config.tfrc
 
-# TODO: Parameterize this in goreleaser. Make this a build arg and pass it
-# as a positional argument to the setup.sh script.
 ARG ARCH
 RUN /build/docker/setup.sh
-
 
 # Start from a fresh base image, to remove any build artifacts and scripts.
 FROM alpine:3.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:alpine as builder
+
+RUN apk add jq
+
+WORKDIR /build
+
+# # Copy repo to wd
+# COPY . .
+
+# # Build CLI binary
+# RUN go mod download && go mod verify
+# RUN CGO_ENABLED=0 go build -o /build/databricks
+
+COPY ./docker/setup.sh ./docker/setup.sh
+COPY ./databricks ./databricks
+
+ENV BUILD_ARCH "arm64"
+RUN ./docker/setup.sh
+
+# Construct final image
+FROM alpine:3.19
+
+
+
+# # COPY --from=builder /build/databricks /app/databricks
+# # COPY --from=builder /build/bundle/internal/tf/codegen/tmp/bin/terraform /app/terraform/terraform
+# # COPY --from=builder /build/bundle/internal/tf/codegen/tmp/
+
+# # CONTINUE: stop using the Go script. It does not work. Instead rely on a new shell
+# # script that I write.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.19 as builder
 
-RUN apk add jq
+RUN ["apk", "add", "jq"]
 
 WORKDIR /build
 

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -161,9 +161,8 @@ func getEnvVarWithMatchingVersion(ctx context.Context, envVarName string, versio
 		return envValue, nil
 	}
 
-	// If the version environment variable is set, we check if it matches the current version.
-	// If it does not match, we ignore the environment variable.
-	// if it matches, we check if the path exists.
+	// When the version environment variable is set, we check if it matches the current version.
+	// If it does not match, we return an empty string.
 	if versionValue != currentVersion {
 		log.Debugf(ctx, "%s as %s does not match the current version %s, ignoring %s", versionVarName, versionValue, currentVersion, envVarName)
 		return "", nil

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -138,22 +138,35 @@ func inheritEnvVars(ctx context.Context, environ map[string]string) error {
 func getEnvVarWithMatchingVersion(ctx context.Context, envVarName string, versionVarName string, currentVersion string) (string, error) {
 	envValue := env.Get(ctx, envVarName)
 	versionValue := env.Get(ctx, versionVarName)
-	if envValue == "" || versionValue == "" {
-		log.Debugf(ctx, "%s and %s aren't defined", envVarName, versionVarName)
+
+	// return early if the environment variable is not set
+	if envValue == "" {
+		log.Debugf(ctx, "%s is not defined", envVarName)
 		return "", nil
 	}
-	if versionValue != currentVersion {
-		log.Debugf(ctx, "%s as %s does not match the current version %s, ignoring %s", versionVarName, versionValue, currentVersion, envVarName)
-		return "", nil
-	}
+
+	// If the path does not exist, we return early.
 	_, err := os.Stat(envValue)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Debugf(ctx, "%s at %s does not exist, ignoring %s", envVarName, envValue, versionVarName)
+			log.Debugf(ctx, "%s at %s does not exist", envVarName, envValue)
 			return "", nil
 		} else {
 			return "", err
 		}
+	}
+
+	// If the version environment variable is not set, we directly return the value of the environment variable.
+	if versionValue == "" {
+		return envValue, nil
+	}
+
+	// If the version environment variable is set, we check if it matches the current version.
+	// If it does not match, we ignore the environment variable.
+	// if it matches, we check if the path exists.
+	if versionValue != currentVersion {
+		log.Debugf(ctx, "%s as %s does not match the current version %s, ignoring %s", versionVarName, versionValue, currentVersion, envVarName)
+		return "", nil
 	}
 	return envValue, nil
 }

--- a/docker/config.tfrc
+++ b/docker/config.tfrc
@@ -1,0 +1,6 @@
+provider_installation {
+    filesystem_mirror {
+        path = "/app/providers"
+        include = ["registry.terraform.io/databricks/databricks"]
+    }
+}

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -15,18 +15,3 @@ mv zip/terraform/terraform /app/bin/terraform
 TF_PROVIDER_NAME=terraform-provider-databricks_${DATABRICKS_TF_PROVIDER_VERSION}_linux_${ARCH}.zip
 mkdir -p /app/providers/registry.terraform.io/databricks/databricks
 wget https://github.com/databricks/terraform-provider-databricks/releases/download/v${DATABRICKS_TF_PROVIDER_VERSION}/${TF_PROVIDER_NAME} -O /app/providers/registry.terraform.io/databricks/databricks/${TF_PROVIDER_NAME}
-
-
-# TODO: document both the interactive and the non interactive workflows for
-# working with DABs with the docker container. Execing into the container
-# allows for a better iteration loop
-
-# For the interactive devloop:
-# docker run -it --entrypoint /bin/sh cli ...
-
-# For the non-interactive devloop:
-# docker run cli ...
-
-# TODO: End to end test for this image?
-
-# TODO: Final sanity check that the docker image is indeed airgapped.

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -euo pipefail
+
+# TODO: Add assertions that this script is build called from /build
+
+
+
+TF_VERSION=$(/build/databricks bundle debug terraform --output json | jq .terraform.version -r)
+PROVIDER_VERSION=$(/build/databricks bundle debug terraform --output json | jq .terraform.providerVersion -r)
+# BUILD_ARCH="${1:-invalid}"
+
+# TODO: Test this
+# if [ "$BUILD_ARCH" = "invalid" ]; then
+#   exit 1
+# fi
+
+# TODO: add check that build arch is either amd64 or arm64
+mkdir -p zip
+
+# Download the terraform binary
+wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_${BUILD_ARCH}.zip -O zip/terraform.zip
+unzip zip/terraform.zip -d zip/terraform
+
+# Download the databricks terraform provider
+wget https://github.com/databricks/terraform-provider-databricks/releases/download/v${PROVIDER_VERSION}/terraform-provider-databricks_${PROVIDER_VERSION}_linux_${BUILD_ARCH}.zip -O zip/provider.zip
+unzip zip/provider.zip -d zip/provider


### PR DESCRIPTION
## Changes
This PR makes changes to support creating a docker image for the CLI with the `terraform` dependencies built in. This is useful for customers that operate in a network-restricted environment. Normally DABs makes API calls to registry.terraform.io to setup the terraform dependencies, with this setup the CLI/DABs will rely on the provider binaries bundled in the docker image.

### Specifically this PR makes the following changes:
----------------
Modifies the CLI release workflow to publish the docker images in the Github Container Registry. URL: https://github.com/databricks/cli/pkgs/container/cli. 

We use docker support in `goreleaser` to build and publish the images. Using goreleaser ensures the CLI packaged in the docker image is the same release artifact as the normal releases. For more information see:
1. https://goreleaser.com/cookbooks/multi-platform-docker-images
2. https://goreleaser.com/customization/docker/

Other choices made include:
1. Using `alpine` as the base image. The reason is `alpine` is a small and lightweight linux distribution (~5MB) and an industry standard.
2. Not using [docker manifest](https://docs.docker.com/reference/cli/docker/manifest) to create a multi-arch build. This is because the functionality is still experimental. 

------------------

Make the `DATABRICKS_TF_VERSION` and `DATABRICKS_TF_PROVIDER_VERSION` environment variables optional for using the terraform file mirror. While it's not strictly necessary to make the docker image work, it's the "right" behaviour and reduces complexity. The rationale is:
  - These environment variables here are needed so the Databricks CLI does not accidentally use the file mirror bundled with VSCode if it's incompatible. This does not require the env vars to be mandatory. context: https://github.com/databricks/cli/pull/1294
  - This makes the `Dockerfile` and `setup.sh` simpler. We don't need an [entrypoint.sh script to set the version environment variables](https://medium.com/@leonardo5621_66451/learn-how-to-use-entrypoint-scripts-in-docker-images-fede010f172d). This also makes using an interactive terminal with `docker run -it ...` work out of the box.

 
## Tests


Tested manually. 

--------------------

To test the release pipeline I triggered a couple of dummy releases and verified that the images are built successfully and uploaded to Github. 
1. https://github.com/databricks/cli/pkgs/container/cli
3. workflow for release: https://github.com/databricks/cli/actions/runs/8646106333

--------------------

I tested the docker container itself by setting up [Charles](https://www.charlesproxy.com/) as an HTTP proxy and verifying that no HTTP requests are made to `registry.terraform.io`

Before:
FYI, The Charles web proxy is hosted at localhost:8888.
```
shreyas.goenka@THW32HFW6T bundle-playground % rm -r .databricks 
shreyas.goenka@THW32HFW6T bundle-playground %  HTTP_PROXY="http://localhost:8888" HTTPS_PROXY="http://localhost:8888" cli bundle deploy
Uploading bundle files to /Users/shreyas.goenka@databricks.com/.bundle/bundle-playground/default/files...
Deploying resources...
Updating deployment state...
Deployment complete!
```
<img width="1275" alt="Screenshot 2024-04-11 at 3 21 45 PM" src="https://github.com/databricks/cli/assets/88374338/15f37324-afbd-47c0-a40e-330ab232656b">

After:
This time bundle deploy is run from inside the docker container. We use `host.docker.internal` to map to localhost on the host machine, and -v to mount the host file system as a volume.
```
shreyas.goenka@THW32HFW6T bundle-playground % docker run -v ~/projects/bundle-playground:/bundle -v ~/.databrickscfg:/root/.databrickscfg  -it --entrypoint /bin/sh -e HTTP_PROXY="http://host.docker.internal:8888" -e HTTPS_PROXY="http://host.docker.internal:8888" --network host ghcr.io/databricks/cli:latest-arm64           
/ # cd /bundle/
/bundle # rm -r .databricks/
/bundle # databricks bundle deploy
Uploading bundle files to /Users/shreyas.goenka@databricks.com/.bundle/bundle-playground/default/files...
Deploying resources...
Updating deployment state...
Deployment complete!
```

<img width="1275" alt="Screenshot 2024-04-11 at 3 22 54 PM" src="https://github.com/databricks/cli/assets/88374338/2a8f097e-734b-4b3e-8075-c02e98a1b275">




