### PR TITLE
Do not emit warning on YAML anchor blocks

### DIFF
--- a/bundle/tests/yaml_anchors_separate_block/databricks.yml
+++ b/bundle/tests/yaml_anchors_separate_block/databricks.yml
@@ -1,0 +1,15 @@
+bundle:
+  name: yaml_anchors_separate_block
+
+tags: &custom_tags
+  Tag1: "Value1"
+  Tag2: "Value2"
+  Tag3: "Value3"
+
+resources:
+  jobs:
+    my_job:
+      tasks:
+      - task_key: yaml_anchors_separate_block
+      tags:
+        <<: *custom_tags

--- a/bundle/tests/yaml_anchors_test.go
+++ b/bundle/tests/yaml_anchors_test.go
@@ -19,6 +19,8 @@ func TestYAMLAnchors(t *testing.T) {
 	require.NotNil(t, t0)
 	require.NotNil(t, t1)
 
+	require.NotNil(t, t0.NewCluster)
+	require.NotNil(t, t1.NewCluster)
 	assert.Equal(t, "10.4.x-scala2.12", t0.NewCluster.SparkVersion)
 	assert.Equal(t, "10.4.x-scala2.12", t1.NewCluster.SparkVersion)
 }

--- a/bundle/tests/yaml_anchors_test.go
+++ b/bundle/tests/yaml_anchors_test.go
@@ -22,3 +22,13 @@ func TestYAMLAnchors(t *testing.T) {
 	assert.Equal(t, "10.4.x-scala2.12", t0.NewCluster.SparkVersion)
 	assert.Equal(t, "10.4.x-scala2.12", t1.NewCluster.SparkVersion)
 }
+
+func TestYAMLAnchorsNoWarnings(t *testing.T) {
+	_, diags := loadTargetWithDiags("./yaml_anchors", "default")
+	assert.Empty(t, diags)
+}
+
+func TestYAMLAnchorsSeparateBlockNoWarnings(t *testing.T) {
+	_, diags := loadTargetWithDiags("./yaml_anchors_separate_block", "default")
+	assert.Empty(t, diags)
+}

--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -90,19 +90,16 @@ func (n normalizeOptions) normalizeStruct(typ reflect.Type, src dyn.Value, seen 
 			pk := pair.Key
 			pv := pair.Value
 
-			// Skip anchor fields.
-			if pv.IsAnchor() {
-				continue
-			}
-
 			index, ok := info.Fields[pk.MustString()]
 			if !ok {
-				diags = diags.Append(diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  fmt.Sprintf("unknown field: %s", pk.MustString()),
-					Location: pk.Location(),
-					Path:     path,
-				})
+				if !pv.IsAnchor() {
+					diags = diags.Append(diag.Diagnostic{
+						Severity: diag.Warning,
+						Summary:  fmt.Sprintf("unknown field: %s", pk.MustString()),
+						Location: pk.Location(),
+						Path:     path,
+					})
+				}
 				continue
 			}
 

--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -89,6 +89,12 @@ func (n normalizeOptions) normalizeStruct(typ reflect.Type, src dyn.Value, seen 
 		for _, pair := range src.MustMap().Pairs() {
 			pk := pair.Key
 			pv := pair.Value
+
+			// Skip anchor fields.
+			if pv.IsAnchor() {
+				continue
+			}
+
 			index, ok := info.Fields[pk.MustString()]
 			if !ok {
 				diags = diags.Append(diag.Diagnostic{

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -659,3 +659,23 @@ func TestNormalizeFloatError(t *testing.T) {
 		Path:     dyn.EmptyPath,
 	}, err[0])
 }
+
+func TestNormalizeAnchors(t *testing.T) {
+	type Tmp struct {
+		Foo string `json:"foo"`
+	}
+
+	var typ Tmp
+	vin := dyn.V(map[string]dyn.Value{
+		"foo":    dyn.V("bar"),
+		"anchor": dyn.V("anchor").MarkAnchor(),
+	})
+
+	vout, err := Normalize(typ, vin)
+	assert.Len(t, err, 0)
+
+	// The field that can be mapped to the struct field is retained.
+	assert.Equal(t, map[string]any{
+		"foo": "bar",
+	}, vout.AsAny())
+}


### PR DESCRIPTION
## Changes
In 0.217.0 we started to emit warning on unknown fields in YAML configuration but wrongly considered YAML anchor blocks as unknown field.

This PR fixes this by skipping normalising of YAML blocks.

## Tests
Added regression tests

