### PR TITLE
Transform artifact files source patterns in build not upload stage

### DIFF
--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/libs/diag"
 )
 
@@ -33,6 +34,36 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	if !ok {
 		return diag.Errorf("artifact doesn't exist: %s", m.name)
 	}
+
+	// Check if source paths are absolute, if not, make them absolute
+	for k := range artifact.Files {
+		f := &artifact.Files[k]
+		if !filepath.IsAbs(f.Source) {
+			dirPath := filepath.Dir(artifact.ConfigFilePath)
+			f.Source = filepath.Join(dirPath, f.Source)
+		}
+	}
+
+	// Expand any glob reference in files source path
+	files := make([]config.ArtifactFile, 0, len(artifact.Files))
+	for _, f := range artifact.Files {
+		matches, err := filepath.Glob(f.Source)
+		if err != nil {
+			return diag.Errorf("unable to find files for %s: %v", f.Source, err)
+		}
+
+		if len(matches) == 0 {
+			return diag.Errorf("no files found for %s", f.Source)
+		}
+
+		for _, match := range matches {
+			files = append(files, config.ArtifactFile{
+				Source: match,
+			})
+		}
+	}
+
+	artifact.Files = files
 
 	// Skip building if build command is not specified or infered
 	if artifact.BuildCommand == "" {

--- a/bundle/artifacts/upload.go
+++ b/bundle/artifacts/upload.go
@@ -3,10 +3,8 @@ package artifacts
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 )
@@ -44,35 +42,6 @@ func (m *upload) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		return diag.Errorf("artifact source is not configured: %s", m.name)
 	}
 
-	// Check if source paths are absolute, if not, make them absolute
-	for k := range artifact.Files {
-		f := &artifact.Files[k]
-		if !filepath.IsAbs(f.Source) {
-			dirPath := filepath.Dir(artifact.ConfigFilePath)
-			f.Source = filepath.Join(dirPath, f.Source)
-		}
-	}
-
-	// Expand any glob reference in files source path
-	files := make([]config.ArtifactFile, 0, len(artifact.Files))
-	for _, f := range artifact.Files {
-		matches, err := filepath.Glob(f.Source)
-		if err != nil {
-			return diag.Errorf("unable to find files for %s: %v", f.Source, err)
-		}
-
-		if len(matches) == 0 {
-			return diag.Errorf("no files found for %s", f.Source)
-		}
-
-		for _, match := range matches {
-			files = append(files, config.ArtifactFile{
-				Source: match,
-			})
-		}
-	}
-
-	artifact.Files = files
 	return bundle.Apply(ctx, b, getUploadMutator(artifact.Type, m.name))
 }
 

--- a/bundle/artifacts/upload_test.go
+++ b/bundle/artifacts/upload_test.go
@@ -58,7 +58,12 @@ func TestExpandGlobFilesSource(t *testing.T) {
 		return &noop{}
 	}
 
-	diags := bundle.Apply(context.Background(), b, u)
+	bm := &build{"test"}
+	buildMutators[config.ArtifactType("custom")] = func(name string) bundle.Mutator {
+		return &noop{}
+	}
+
+	diags := bundle.Apply(context.Background(), b, bundle.Seq(bm, u))
 	require.NoError(t, diags.Error())
 
 	require.Equal(t, 2, len(b.Config.Artifacts["test"].Files))
@@ -94,6 +99,11 @@ func TestExpandGlobFilesSourceWithNoMatches(t *testing.T) {
 		return &noop{}
 	}
 
-	diags := bundle.Apply(context.Background(), b, u)
+	bm := &build{"test"}
+	buildMutators[config.ArtifactType("custom")] = func(name string) bundle.Mutator {
+		return &noop{}
+	}
+
+	diags := bundle.Apply(context.Background(), b, bundle.Seq(bm, u))
 	require.ErrorContains(t, diags.Error(), "no files found for")
 }


### PR DESCRIPTION
## Changes
Transform artifact files source patterns in build not upload stage

Resolves the following warning
```
artifact section is not defined for file at /Users/andrew.nester/dabs/wheel/target/myjar.jar. Skipping uploading. In order to use the define 'artifacts' section
```

## Tests
Unit test pass

