### PR TITLE
Add support for multi-arch Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "v0.0.0-docker"
 
   workflow_dispatch:
 
@@ -46,99 +47,99 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  create-setup-cli-release-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-setup-cli-release-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update setup-cli
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'setup-cli',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-              }
-            });
+  #     - name: Update setup-cli
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'setup-cli',
+  #             workflow_id: 'release-pr.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #             }
+  #           });
 
-  create-homebrew-tap-release-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-homebrew-tap-release-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update homebrew-tap
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
-            artifacts = artifacts.filter(a => a.type == "Archive")
-            artifacts = new Map(
-              artifacts.map(a => [
-                a.goos + "_" + a.goarch,
-                a.extra.Checksum.replace("sha256:", "")
-              ])
-            )
+  #     - name: Update homebrew-tap
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
+  #           artifacts = artifacts.filter(a => a.type == "Archive")
+  #           artifacts = new Map(
+  #             artifacts.map(a => [
+  #               a.goos + "_" + a.goarch,
+  #               a.extra.Checksum.replace("sha256:", "")
+  #             ])
+  #           )
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'homebrew-tap',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-                darwin_amd64_sha: artifacts.get('darwin_amd64'),
-                darwin_arm64_sha: artifacts.get('darwin_arm64'),
-                linux_amd64_sha: artifacts.get('linux_amd64'),
-                linux_arm64_sha: artifacts.get('linux_arm64')
-              }
-            });
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'homebrew-tap',
+  #             workflow_id: 'release-pr.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #               darwin_amd64_sha: artifacts.get('darwin_amd64'),
+  #               darwin_arm64_sha: artifacts.get('darwin_arm64'),
+  #               linux_amd64_sha: artifacts.get('linux_amd64'),
+  #               linux_arm64_sha: artifacts.get('linux_arm64')
+  #             }
+  #           });
 
-  create-vscode-extension-update-pr:
-    needs: goreleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set VERSION variable from tag
-        run: |
-          VERSION=${{ github.ref_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  # create-vscode-extension-update-pr:
+  #   needs: goreleaser
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set VERSION variable from tag
+  #       run: |
+  #         VERSION=${{ github.ref_name }}
+  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-      - name: Update CLI version in the VSCode extension
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'databricks',
-              repo: 'databricks-vscode',
-              workflow_id: 'update-cli-version.yml',
-              ref: 'main',
-              inputs: {
-                version: "${{ env.VERSION }}",
-              }
-            });
+  #     - name: Update CLI version in the VSCode extension
+  #       uses: actions/github-script@v6
+  #       with:
+  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'databricks',
+  #             repo: 'databricks-vscode',
+  #             workflow_id: 'update-cli-version.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               version: "${{ env.VERSION }}",
+  #             }
+  #           });
 
-  publish-to-winget-pkgs:
-    needs: goreleaser
-    runs-on: windows-latest
-    environment: release
-    steps:
-      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
-        with:
-          identifier: Databricks.DatabricksCLI
-          installers-regex: 'windows_.*\.zip$' # Only windows releases
-          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-          fork-user: eng-dev-ecosystem-bot
+  # publish-to-winget-pkgs:
+  #   needs: goreleaser
+  #   runs-on: windows-latest
+  #   environment: release
+  #   steps:
+  #     - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
+  #       with:
+  #         identifier: Databricks.DatabricksCLI
+  #         installers-regex: 'windows_.*\.zip$' # Only windows releases
+  #         token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+  #         fork-user: eng-dev-ecosystem-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-      - "v0.0.0-docker"
 
   workflow_dispatch:
 
@@ -47,99 +46,99 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # create-setup-cli-release-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-setup-cli-release-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update setup-cli
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'setup-cli',
-  #             workflow_id: 'release-pr.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #             }
-  #           });
+      - name: Update setup-cli
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'setup-cli',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });
 
-  # create-homebrew-tap-release-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-homebrew-tap-release-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update homebrew-tap
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
-  #           artifacts = artifacts.filter(a => a.type == "Archive")
-  #           artifacts = new Map(
-  #             artifacts.map(a => [
-  #               a.goos + "_" + a.goarch,
-  #               a.extra.Checksum.replace("sha256:", "")
-  #             ])
-  #           )
+      - name: Update homebrew-tap
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            let artifacts = JSON.parse('${{ needs.goreleaser.outputs.artifacts }}')
+            artifacts = artifacts.filter(a => a.type == "Archive")
+            artifacts = new Map(
+              artifacts.map(a => [
+                a.goos + "_" + a.goarch,
+                a.extra.Checksum.replace("sha256:", "")
+              ])
+            )
 
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'homebrew-tap',
-  #             workflow_id: 'release-pr.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #               darwin_amd64_sha: artifacts.get('darwin_amd64'),
-  #               darwin_arm64_sha: artifacts.get('darwin_arm64'),
-  #               linux_amd64_sha: artifacts.get('linux_amd64'),
-  #               linux_arm64_sha: artifacts.get('linux_arm64')
-  #             }
-  #           });
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'homebrew-tap',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+                darwin_amd64_sha: artifacts.get('darwin_amd64'),
+                darwin_arm64_sha: artifacts.get('darwin_arm64'),
+                linux_amd64_sha: artifacts.get('linux_amd64'),
+                linux_arm64_sha: artifacts.get('linux_arm64')
+              }
+            });
 
-  # create-vscode-extension-update-pr:
-  #   needs: goreleaser
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set VERSION variable from tag
-  #       run: |
-  #         VERSION=${{ github.ref_name }}
-  #         echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
+  create-vscode-extension-update-pr:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set VERSION variable from tag
+        run: |
+          VERSION=${{ github.ref_name }}
+          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
-  #     - name: Update CLI version in the VSCode extension
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'databricks',
-  #             repo: 'databricks-vscode',
-  #             workflow_id: 'update-cli-version.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               version: "${{ env.VERSION }}",
-  #             }
-  #           });
+      - name: Update CLI version in the VSCode extension
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'databricks',
+              repo: 'databricks-vscode',
+              workflow_id: 'update-cli-version.yml',
+              ref: 'main',
+              inputs: {
+                version: "${{ env.VERSION }}",
+              }
+            });
 
-  # publish-to-winget-pkgs:
-  #   needs: goreleaser
-  #   runs-on: windows-latest
-  #   environment: release
-  #   steps:
-  #     - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
-  #       with:
-  #         identifier: Databricks.DatabricksCLI
-  #         installers-regex: 'windows_.*\.zip$' # Only windows releases
-  #         token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-  #         fork-user: eng-dev-ecosystem-bot
+  publish-to-winget-pkgs:
+    needs: goreleaser
+    runs-on: windows-latest
+    environment: release
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # https://github.com/vedantmgoyal2009/winget-releaser/releases/tag/v2
+        with:
+          identifier: Databricks.DatabricksCLI
+          installers-regex: 'windows_.*\.zip$' # Only windows releases
+          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
+          fork-user: eng-dev-ecosystem-bot

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,6 +75,16 @@ dockers:
       - "./docker/config.tfrc"
       - "./docker/setup.sh"
 
+docker_manifests:
+  - name_template: ghcr.io/databricks/cli:{{replace .Version "+" "-"}}
+    image_templates:
+      - ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-amd64
+      - ghcr.io/databricks/cli:{{replace .Version "+" "-"}}-arm64
+  - name_template: ghcr.io/databricks/cli:latest
+    image_templates:
+      - ghcr.io/databricks/cli:latest-amd64
+      - ghcr.io/databricks/cli:latest-arm64
+
 
 checksum:
   name_template: 'databricks_cli_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
## Changes
This PR follows instructions in https://goreleaser.com/cookbooks/multi-platform-docker-images/ to create a multi-arch docker CLI image. Thus customers can simply specify `docker pull ghcr.io/databricks/cli:latest` to pull and run the image. 

The current approach uses the `docker manifest` support in goreleaser to create a multi-arch image. This has a couple of pros and cons. TLDR; The changes as is in the PR are good to go and very low risk. The information provided here is just FYI.

pros: 
Fewer configurations/workflows for us to manage/maintain. Goreleaser makes sure the correct CLI binary is in place when building the CLI and also takes care of publishing it to the Github Container Registry. 

cons:
Goreleaser only supports [docker manifest](https://docs.docker.com/reference/cli/docker/manifest/) to create multi-arch images. This has a few minor disadvantages:
1. `goreleaser` pushes all intermediate images (arm64 and and64 specific images) to the registry. This is required for the manifest to reference them. See: https://github.com/goreleaser/goreleaser/issues/2606

Note: We have a migration path here, if someday we stop publishing intermediate images, we can simply tag the "multi-arch" image as both `latest-amd64` and `latest-arm64`. For now, these are separate images. see: https://github.com/databricks/cli/pkgs/container/cli

2. `docker manifest` is technically an experimental command. Though it's been out for multiple years now and the indirect dependency by `goreleaser` should be fine. In any case, we can migrate by moving our docker build process off goreleaser if we need to.

## Tests
Tested manually by publishing a new release for `v0.0.0-docker` in ghcr.io.
1. Package: https://github.com/databricks/cli/pkgs/container/cli
2. Release workflow: https://github.com/databricks/cli/actions/runs/8689359851

Tests the image itself by running it manually:
```
➜  cli git:(feature/multi-arch-docker) docker pull ghcr.io/databricks/cli:latest
latest: Pulling from databricks/cli
bca4290a9639: Already exists 
6d445556910d: Already exists 
Digest: sha256:82eabc500b541a89182aed4d3158c955e57c1e84d9616b76510aceb1d9024425
Status: Downloaded newer image for ghcr.io/databricks/cli:latest
ghcr.io/databricks/cli:latest

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview ghcr.io/databricks/cli:latest
➜  cli git:(feature/multi-arch-docker) docker run ghcr.io/databricks/cli --version
Databricks CLI v0.0.0-docker
```


