### PR TITLE
Do not prefill https:// in prompt for Databricks Host

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -28,9 +28,7 @@ func New() *cobra.Command {
 
 func promptForHost(ctx context.Context) (string, error) {
 	prompt := cmdio.Prompt(ctx)
-	prompt.Label = "Databricks Host"
-	prompt.Default = "https://"
-	prompt.AllowEdit = true
+	prompt.Label = "Databricks Host (e.g. https://<databricks-instance>.cloud.databricks.com)"
 	// Validate?
 	host, err := prompt.Run()
 	if err != nil {


### PR DESCRIPTION
## Changes
This PR is a minor UX improvement. By not autofilling the https:// prefix in Databricks Host we allow users to directly copy-paste from their browser.

UX:
```
➜  cli git:(fix/copy-host) cli auth login
Databricks Profile Name: my-profile
Databricks Host (e.g. https://<databricks-instance>.cloud.databricks.com): https://foobar.cloud.databricks.com
Profile my-profile was successfully saved
```

## Tests
Manually.
