### PR TITLE
Add URLs for authentication documentation to the auth command help

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -13,7 +13,7 @@ func New() *cobra.Command {
 		Use:   "auth",
 		Short: "Authentication related commands",
 		Long: `Authentication related commands. For more information regarding how
-authentication for tooling works at Databricks please refer to the documentation
+authentication for the Databricks CLI and SDKs work please refer to the documentation
 linked below.
 
 AWS: https://docs.databricks.com/en/dev-tools/auth/index.html

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -12,6 +12,13 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Authentication related commands",
+		Long: `Authentication related commands. For more information regarding how
+authentication for tooling works at Databricks, please refer to the documentation
+linked below.
+
+AWS: https://docs.databricks.com/en/dev-tools/auth/index.html
+Azure: https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth
+GCP: https://docs.gcp.databricks.com/en/dev-tools/auth/index.html`,
 	}
 
 	var perisistentAuth auth.PersistentAuth

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -13,7 +13,7 @@ func New() *cobra.Command {
 		Use:   "auth",
 		Short: "Authentication related commands",
 		Long: `Authentication related commands. For more information regarding how
-authentication for tooling works at Databricks, please refer to the documentation
+authentication for tooling works at Databricks please refer to the documentation
 linked below.
 
 AWS: https://docs.databricks.com/en/dev-tools/auth/index.html


### PR DESCRIPTION
```
➜  cli git:(fix/better-auth-docs) ✗ cli auth -h
Authentication related commands. For more information regarding how
authentication for the Databricks CLI and SDKs work please refer to the documentation
linked below.

AWS: https://docs.databricks.com/en/dev-tools/auth/index.html
Azure: https://learn.microsoft.com/en-us/azure/databricks/dev-tools/auth
GCP: https://docs.gcp.databricks.com/en/dev-tools/auth/index.html
```