### PR TITLE
Skip building docker images in release snapshot workflow

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -6,6 +6,10 @@ on:
       - "main"
       - "demo-*"
 
+  # TODO: Remove before merging. Only to test the workflow.
+  pull_request:
+    types: [synchronize]
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -30,7 +30,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --snapshot
+          args: release --snapshot --skip docker
 
       - name: Upload macOS binaries
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -6,7 +6,6 @@ on:
       - "main"
       - "demo-*"
 
-
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -6,9 +6,6 @@ on:
       - "main"
       - "demo-*"
 
-  # TODO: Remove before merging. Only to test the workflow.
-  pull_request:
-    types: [synchronize]
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Changes
We don't need docker images for the snapshot version of the CLI. 

## Tests
Trigged workflow for snapshot passes. https://github.com/databricks/cli/actions/runs/8703599475/job/23870125852?pr=1367
