### PR TITLE
Resolve variable references inside variable lookup fields

### DIFF
--- a/bundle/config/mutator/resolve_resource_references.go
+++ b/bundle/config/mutator/resolve_resource_references.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/libs/dyn/dynvar"
 	"github.com/databricks/cli/libs/log"
 	"golang.org/x/sync/errgroup"
 )
@@ -18,6 +21,36 @@ func ResolveResourceReferences() bundle.Mutator {
 
 func (m *resolveResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	errs, errCtx := errgroup.WithContext(ctx)
+	varPath := dyn.NewPath(dyn.Key("var"))
+	p := dyn.NewPattern(
+		dyn.Key("variables"),
+		dyn.AnyKey(),
+		dyn.Key("lookup"),
+	)
+
+	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
+		normalized, _ := convert.Normalize(b.Config, v, convert.IncludeMissingFields)
+
+		// Resolve all variable references in the lookup field.
+		return dyn.MapByPattern(v, p, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+			return dynvar.Resolve(v, func(path dyn.Path) (dyn.Value, error) {
+				// Rewrite the shorthand path ${var.foo} into ${variables.foo.value}.
+				if path.HasPrefix(varPath) && len(path) == 2 {
+					path = dyn.NewPath(
+						dyn.Key("variables"),
+						path[1],
+						dyn.Key("value"),
+					)
+				}
+
+				return dyn.GetByPath(normalized, path)
+			})
+		})
+	})
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	for k := range b.Config.Variables {
 		v := b.Config.Variables[k]

--- a/bundle/config/mutator/resolve_resource_references.go
+++ b/bundle/config/mutator/resolve_resource_references.go
@@ -18,6 +18,7 @@ func ResolveResourceReferences() bundle.Mutator {
 
 func (m *resolveResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	errs, errCtx := errgroup.WithContext(ctx)
+
 	for k := range b.Config.Variables {
 		v := b.Config.Variables[k]
 		if v == nil || v.Lookup == nil {

--- a/bundle/config/mutator/resolve_resource_references_test.go
+++ b/bundle/config/mutator/resolve_resource_references_test.go
@@ -133,3 +133,38 @@ func TestResolveServicePrincipal(t *testing.T) {
 	require.NoError(t, diags.Error())
 	require.Equal(t, "app-1234", *b.Config.Variables["my-sp"].Value)
 }
+
+func TestResolveVariableReferencesInVariableLookups(t *testing.T) {
+	s := func(s string) *string {
+		return &s
+	}
+
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Bundle: config.Bundle{
+				Environment: "dev",
+			},
+			Variables: map[string]*variable.Variable{
+				"foo": {
+					Value: s("bar"),
+				},
+				"lookup": {
+					Lookup: &variable.Lookup{
+						Cluster: "cluster-${var.foo}-${bundle.environment}",
+					},
+				},
+			},
+		},
+	}
+
+	m := mocks.NewMockWorkspaceClient(t)
+	b.SetWorkpaceClient(m.WorkspaceClient)
+	clusterApi := m.GetMockClustersAPI()
+	clusterApi.EXPECT().GetByClusterName(mock.Anything, "cluster-bar-dev").Return(&compute.ClusterDetails{
+		ClusterId: "1234-5678-abcd",
+	}, nil)
+
+	diags := bundle.Apply(context.Background(), b, ResolveResourceReferences())
+	require.NoError(t, diags.Error())
+	require.Equal(t, "cluster-bar-dev", b.Config.Variables["lookup"].Lookup.Cluster)
+}

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -9,7 +9,6 @@ import (
 	"github.com/databricks/cli/bundle/permissions"
 	"github.com/databricks/cli/bundle/python"
 	"github.com/databricks/cli/bundle/scripts"
-	"github.com/databricks/cli/libs/dyn"
 )
 
 // The initialize phase fills in defaults and connects to the workspace.
@@ -29,12 +28,7 @@ func Initialize() bundle.Mutator {
 			mutator.ExpandWorkspaceRoot(),
 			mutator.DefineDefaultWorkspacePaths(),
 			mutator.SetVariables(),
-			mutator.ResolveVariableReferencesFor(
-				dyn.NewPattern(dyn.Key("variables"), dyn.AnyKey(), dyn.Key("lookup")),
-				"bundle",
-				"workspace",
-				"variables",
-			),
+			mutator.ResolveVariableReferencesInLookup(),
 			mutator.ResolveResourceReferences(),
 			mutator.ResolveVariableReferences(
 				"bundle",

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -9,6 +9,7 @@ import (
 	"github.com/databricks/cli/bundle/permissions"
 	"github.com/databricks/cli/bundle/python"
 	"github.com/databricks/cli/bundle/scripts"
+	"github.com/databricks/cli/libs/dyn"
 )
 
 // The initialize phase fills in defaults and connects to the workspace.
@@ -28,6 +29,12 @@ func Initialize() bundle.Mutator {
 			mutator.ExpandWorkspaceRoot(),
 			mutator.DefineDefaultWorkspacePaths(),
 			mutator.SetVariables(),
+			mutator.ResolveVariableReferencesFor(
+				dyn.NewPattern(dyn.Key("variables"), dyn.AnyKey(), dyn.Key("lookup")),
+				"bundle",
+				"workspace",
+				"variables",
+			),
 			mutator.ResolveResourceReferences(),
 			mutator.ResolveVariableReferences(
 				"bundle",


### PR DESCRIPTION
## Changes
Allows for the syntax below

```
variables:
  service_principal_app_id:
    description: 'The app id of the service principal for running workflows as.'
    lookup:
      service_principal: "sp-${bundle.environment}"
```

Fixes #1259

## Tests
Added regression test

