### PR TITLE
Convert between integer and float in normalization

### DIFF
--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -295,9 +295,7 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value, path dyn
 		out = src.MustInt()
 	case dyn.KindFloat:
 		out = int64(src.MustFloat())
-		fstr := fmt.Sprint(src.MustFloat())
-		istr := fmt.Sprint(out)
-		if fstr != istr {
+		if src.MustFloat() != float64(out) {
 			return dyn.InvalidValue, diags.Append(diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  fmt.Sprintf(`cannot accurately represent "%g" as integer due to precision loss`, src.MustFloat()),


### PR DESCRIPTION
## Changes

We currently issue a warning if an integer is used where a floating point number is expected. But if they are convertible, we should convert and not issue a warning. This change fixes normalization if they are convertible between each other. We still produce a warning if the type conversion leads to a loss in precision.

## Tests

Unit tests pass.