### PR TITLE
Add NOTICE for using Terraform 1.5.5 licensed under MPL 2.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -36,6 +36,10 @@ hashicorp/terraform-json - https://github.com/hashicorp/terraform-json
 Copyright 2019 HashiCorp, Inc.
 License - https://github.com/hashicorp/terraform-json/blob/main/LICENSE
 
+hashicorp/terraform - https://github.com/hashicorp/terraform
+Copyright 2014 HashiCorp, Inc.
+License - https://github.com/hashicorp/terraform/blob/v1.5.5/LICENSE
+
 ---
 
 This software contains code from the following open source projects, licensed under the BSD (2-clause) license:


### PR DESCRIPTION
We package the terraform 1.5.5 binary in our docker container images for the CLI. This thus needs to be included in our notice for the repository.