### PR TITLE
Print host in `bundle validate` when passed via profile or environment variables

### DIFF
--- a/cmd/bundle/validate.go
+++ b/cmd/bundle/validate.go
@@ -48,7 +48,7 @@ const warningTemplate = `{{ "Warning" | yellow }}: {{ .Summary }}
 const summaryTemplate = `Name: {{ .Config.Bundle.Name | bold }}
 Target: {{ .Config.Bundle.Target | bold }}
 Workspace:
-  Host: {{ .Config.Workspace.Host | bold }}
+  Host: {{ .WorkspaceClient.Config.Host | bold }}
   User: {{ .Config.Workspace.CurrentUser.UserName | bold }}
   Path: {{ .Config.Workspace.RootPath | bold }}
 
@@ -107,8 +107,9 @@ func renderTextOutput(cmd *cobra.Command, b *bundle.Bundle, diags diag.Diagnosti
 	// Print validation summary.
 	t := template.Must(template.New("summary").Funcs(validateFuncMap).Parse(summaryTemplate))
 	err := t.Execute(cmd.OutOrStdout(), map[string]any{
-		"Config":  b.Config,
-		"Trailer": buildTrailer(diags),
+		"Config":          b.Config,
+		"Trailer":         buildTrailer(diags),
+		"WorkspaceClient": b.WorkspaceClient(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Changes
Fixes to get host from the workspace client rather than only printing the host when it's configured in the bundle config.

## Tests
Manually. When a profile was specified for auth.

Before:
```
➜  bundle-playground git:(master) ✗ cli bundle validate
Name: bundle-playground
Target: default
Workspace:
  Host: 
  User: shreyas.goenka@databricks.com
  Path: /Users/shreyas.goenka@databricks.com/.bundle/bundle-playground/default
```


After:
```
➜  bundle-playground git:(master) ✗ cli bundle validate
Name: bundle-playground
Target: default
Workspace:
  Host: https://e2-dogfood.staging.cloud.databricks.com
  User: shreyas.goenka@databricks.com
  Path: /Users/shreyas.goenka@databricks.com/.bundle/bundle-playground/default
```
