### PR TITLE
Pass `DATABRICKS_CONFIG_FILE` env var to sdk config during `auth profiles`

### DIFF
--- a/cmd/auth/profiles.go
+++ b/cmd/auth/profiles.go
@@ -29,10 +29,11 @@ func (c *profileMetadata) IsEmpty() bool {
 	return c.Host == "" && c.AccountID == ""
 }
 
-func (c *profileMetadata) Load(ctx context.Context, skipValidate bool) {
+func (c *profileMetadata) Load(ctx context.Context, configFilePath string, skipValidate bool) {
 	cfg := &config.Config{
-		Loaders: []config.Loader{config.ConfigFile},
-		Profile: c.Name,
+		Loaders:    []config.Loader{config.ConfigFile},
+		ConfigFile: configFilePath,
+		Profile:    c.Name,
 	}
 	_ = cfg.EnsureResolved()
 	if cfg.IsAws() {
@@ -117,7 +118,7 @@ func newProfilesCommand() *cobra.Command {
 			go func() {
 				ctx := cmd.Context()
 				t := time.Now()
-				profile.Load(ctx, skipValidate)
+				profile.Load(ctx, iniFile.Path(), skipValidate)
 				log.Debugf(ctx, "Profile %q took %s to load", profile.Name, time.Since(t))
 				wg.Done()
 			}()

--- a/cmd/auth/profiles_test.go
+++ b/cmd/auth/profiles_test.go
@@ -36,7 +36,7 @@ func TestProfiles(t *testing.T) {
 
 	// Load the profile
 	profile := &profileMetadata{Name: "profile1"}
-	profile.Load(ctx, true)
+	profile.Load(ctx, configFile, true)
 
 	// Check the profile
 	assert.Equal(t, "profile1", profile.Name)


### PR DESCRIPTION
## Changes
* Currently, we use `auth profiles` command with `DATABRICKS_CONFIG_FILE` env var set, the file pointed to by the env var is ONLY used for loading the profile names (ini file sections). It is not passed to go sdk config object. We also don't use env variable loader in the go sdk config object, so this env var is ignored by the config and only default file is read. 
* This PR explicitly sets the config file path in the go sdk config object.

## Tests
* integration tests in vscode
