### PR TITLE
Fix link to bundles documentation

### DIFF
--- a/cmd/bundle/bundle.go
+++ b/cmd/bundle/bundle.go
@@ -9,7 +9,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bundle",
 		Short:   "Databricks Asset Bundles let you express data/AI/analytics projects as code.",
-		Long:    "Databricks Asset Bundles let you express data/AI/analytics projects as code.\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles",
+		Long:    "Databricks Asset Bundles let you express data/AI/analytics projects as code.\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles/index",
 		GroupID: "development",
 	}
 

--- a/cmd/bundle/bundle.go
+++ b/cmd/bundle/bundle.go
@@ -9,7 +9,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bundle",
 		Short:   "Databricks Asset Bundles let you express data/AI/analytics projects as code.",
-		Long:    "Databricks Asset Bundles let you express data/AI/analytics projects as code.\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles/index",
+		Long:    "Databricks Asset Bundles let you express data/AI/analytics projects as code.\n\nOnline documentation: https://docs.databricks.com/en/dev-tools/bundles/index.html",
 		GroupID: "development",
 	}
 


### PR DESCRIPTION
## Changes
Given the size of the change I thought it would have been faster to create a PR. I could not find any contributing guidelines, hope that is fine with you.

This fixes the link to the bundles documentation referenced using `databricks bundle --help`

## Tests
No need of testing this change

