### PR TITLE
Fix bundle schema for variables

### DIFF
--- a/bundle/config/mutator/set_variables.go
+++ b/bundle/config/mutator/set_variables.go
@@ -53,8 +53,6 @@ func setVariable(ctx context.Context, v *variable.Variable, name string) diag.Di
 	}
 
 	// We should have had a value to set for the variable at this point.
-	// TODO: use cmdio to request values for unassigned variables if current
-	// terminal is a tty. Tracked in https://github.com/databricks/cli/issues/379
 	return diag.Errorf(`no value assigned to required variable %s. Assignment can be done through the "--var" flag or by setting the %s environment variable`, name, bundleVarPrefix+name)
 }
 

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -48,61 +48,7 @@ func New(golangType reflect.Type, docs *Docs) (*jsonschema.Schema, error) {
 	if err != nil {
 		return nil, tracker.errWithTrace(err.Error(), "root")
 	}
-
-	err = overrideVariables(schema)
-	if err != nil {
-		return nil, err
-	}
-
 	return schema, nil
-}
-
-func overrideVariables(s *jsonschema.Schema) error {
-	// Override schema for default values to allow for multiple primitive types.
-	// These are normalized to strings when converted to the typed representation.
-	err := s.SetByPath("variables.*.default", jsonschema.Schema{
-		AnyOf: []*jsonschema.Schema{
-			{
-				Type: jsonschema.StringType,
-			},
-			{
-				Type: jsonschema.BooleanType,
-			},
-			{
-				Type: jsonschema.NumberType,
-			},
-			{
-				Type: jsonschema.IntegerType,
-			},
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	// Override schema for variables in targets to allow just specifying the value
-	// along side overriding the variable definition if needed.
-	ns, err := s.GetByPath("variables.*")
-	if err != nil {
-		return err
-	}
-	return s.SetByPath("targets.*.variables.*", jsonschema.Schema{
-		AnyOf: []*jsonschema.Schema{
-			{
-				Type: jsonschema.StringType,
-			},
-			{
-				Type: jsonschema.BooleanType,
-			},
-			{
-				Type: jsonschema.NumberType,
-			},
-			{
-				Type: jsonschema.IntegerType,
-			},
-			&ns,
-		},
-	})
 }
 
 func jsonSchemaType(golangType reflect.Type) (jsonschema.Type, error) {

--- a/bundle/schema/schema.go
+++ b/bundle/schema/schema.go
@@ -48,7 +48,61 @@ func New(golangType reflect.Type, docs *Docs) (*jsonschema.Schema, error) {
 	if err != nil {
 		return nil, tracker.errWithTrace(err.Error(), "root")
 	}
+
+	err = overrideVariables(schema)
+	if err != nil {
+		return nil, err
+	}
+
 	return schema, nil
+}
+
+func overrideVariables(s *jsonschema.Schema) error {
+	// Override schema for default values to allow for multiple primitive types.
+	// These are normalized to strings when converted to the typed representation.
+	err := s.SetByPath("variables.*.default", jsonschema.Schema{
+		AnyOf: []*jsonschema.Schema{
+			{
+				Type: jsonschema.StringType,
+			},
+			{
+				Type: jsonschema.BooleanType,
+			},
+			{
+				Type: jsonschema.NumberType,
+			},
+			{
+				Type: jsonschema.IntegerType,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Override schema for variables in targets to allow just specifying the value
+	// along side overriding the variable definition if needed.
+	ns, err := s.GetByPath("variables.*")
+	if err != nil {
+		return err
+	}
+	return s.SetByPath("targets.*.variables.*", jsonschema.Schema{
+		AnyOf: []*jsonschema.Schema{
+			{
+				Type: jsonschema.StringType,
+			},
+			{
+				Type: jsonschema.BooleanType,
+			},
+			{
+				Type: jsonschema.NumberType,
+			},
+			{
+				Type: jsonschema.IntegerType,
+			},
+			&ns,
+		},
+	})
 }
 
 func jsonSchemaType(golangType reflect.Type) (jsonschema.Type, error) {

--- a/cmd/bundle/schema.go
+++ b/cmd/bundle/schema.go
@@ -7,8 +7,57 @@ import (
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/schema"
 	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/jsonschema"
 	"github.com/spf13/cobra"
 )
+
+func overrideVariables(s *jsonschema.Schema) error {
+	// Override schema for default values to allow for multiple primitive types.
+	// These are normalized to strings when converted to the typed representation.
+	err := s.SetByPath("variables.*.default", jsonschema.Schema{
+		AnyOf: []*jsonschema.Schema{
+			{
+				Type: jsonschema.StringType,
+			},
+			{
+				Type: jsonschema.BooleanType,
+			},
+			{
+				Type: jsonschema.NumberType,
+			},
+			{
+				Type: jsonschema.IntegerType,
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Override schema for variables in targets to allow just specifying the value
+	// along side overriding the variable definition if needed.
+	ns, err := s.GetByPath("variables.*")
+	if err != nil {
+		return err
+	}
+	return s.SetByPath("targets.*.variables.*", jsonschema.Schema{
+		AnyOf: []*jsonschema.Schema{
+			{
+				Type: jsonschema.StringType,
+			},
+			{
+				Type: jsonschema.BooleanType,
+			},
+			{
+				Type: jsonschema.NumberType,
+			},
+			{
+				Type: jsonschema.IntegerType,
+			},
+			&ns,
+		},
+	})
+}
 
 func newSchemaCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -26,6 +75,13 @@ func newSchemaCommand() *cobra.Command {
 
 		// Generate the JSON schema from the bundle configuration struct in Go.
 		schema, err := schema.New(reflect.TypeOf(config.Root{}), docs)
+		if err != nil {
+			return err
+		}
+
+		// Override schema for variables to take into account normalization of default
+		// variable values and variable overrides in a target.
+		err = overrideVariables(schema)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Changes
This PR fixes the variable schema to:
1. Allow non-string values in the "default" value of a variable.
2. Allow non-string overrides in a target for a variable. 

## Tests
Manually. There are no longer squiggly lines. 

Before:
<img width="329" alt="Screenshot 2024-04-24 at 3 26 43 PM" src="https://github.com/databricks/cli/assets/88374338/43be02c2-80a4-4f80-bd79-0f3e1e93ee17">


After:
<img width="361" alt="Screenshot 2024-04-24 at 3 26 10 PM" src="https://github.com/databricks/cli/assets/88374338/2c1fb892-a2a2-478b-8d2e-9bda6d844b54">

