### PR TITLE
Fix variable overrides in targets for non-string variables

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -408,15 +408,18 @@ func rewriteShorthands(v dyn.Value) (dyn.Value, error) {
 
 		// For each variable, normalize its contents if it is a single string.
 		return dyn.Map(target, "variables", dyn.Foreach(func(_ dyn.Path, variable dyn.Value) (dyn.Value, error) {
-			if variable.Kind() != dyn.KindString {
+			switch variable.Kind() {
+
+			case dyn.KindString, dyn.KindBool, dyn.KindFloat, dyn.KindInt:
+				// Rewrite the variable to a map with a single key called "default".
+				// This conforms to the variable type.
+				return dyn.NewValue(map[string]dyn.Value{
+					"default": variable,
+				}, variable.Location()), nil
+
+			default:
 				return variable, nil
 			}
-
-			// Rewrite the variable to a map with a single key called "default".
-			// This conforms to the variable type.
-			return dyn.NewValue(map[string]dyn.Value{
-				"default": variable,
-			}, variable.Location()), nil
 		}))
 	}))
 }

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -412,7 +412,8 @@ func rewriteShorthands(v dyn.Value) (dyn.Value, error) {
 
 			case dyn.KindString, dyn.KindBool, dyn.KindFloat, dyn.KindInt:
 				// Rewrite the variable to a map with a single key called "default".
-				// This conforms to the variable type.
+				// This conforms to the variable type. Normalization back to the typed
+				// configuration will convert this to a string if necessary.
 				return dyn.NewValue(map[string]dyn.Value{
 					"default": variable,
 				}, variable.Location()), nil

--- a/bundle/tests/variables/variable_overrides_in_target/databricks.yml
+++ b/bundle/tests/variables/variable_overrides_in_target/databricks.yml
@@ -1,0 +1,41 @@
+bundle:
+  name: foobar
+
+resources:
+  pipelines:
+    my_pipeline:
+      name: ${var.foo}
+      continuous: ${var.baz}
+      clusters:
+        - num_workers: ${var.bar}
+
+
+
+variables:
+  foo:
+    default: "a_string"
+    description: "A string variable"
+
+  bar:
+    default: 42
+    description: "An integer variable"
+
+  baz:
+    default: true
+    description: "A boolean variable"
+
+targets:
+  use-default-variable-values:
+
+  override-string-variable:
+    variables:
+      foo: "overridden_string"
+
+  override-int-variable:
+    variables:
+      bar: 43
+
+  override-both-bool-and-string-variables:
+    variables:
+      foo: "overridden_string"
+      baz: false


### PR DESCRIPTION
Before variable overrides that were not string in a target would not work. This PR fixes that. Tested manually and via a unit test.