### PR TITLE
Stop tracking file paths in ML resources

### DIFF
--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -136,18 +136,6 @@ func (r *Resources) ConfigureConfigFilePath() {
 	for _, e := range r.Pipelines {
 		e.ConfigureConfigFilePath()
 	}
-	for _, e := range r.Models {
-		e.ConfigureConfigFilePath()
-	}
-	for _, e := range r.Experiments {
-		e.ConfigureConfigFilePath()
-	}
-	for _, e := range r.ModelServingEndpoints {
-		e.ConfigureConfigFilePath()
-	}
-	for _, e := range r.RegisteredModels {
-		e.ConfigureConfigFilePath()
-	}
 }
 
 type ConfigResource interface {

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/databricks/cli/bundle/config/paths"
 	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
@@ -10,8 +9,6 @@ type MlflowExperiment struct {
 	ID             string         `json:"id,omitempty" bundle:"readonly"`
 	Permissions    []Permission   `json:"permissions,omitempty"`
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-
-	paths.Paths
 
 	*ml.Experiment
 }

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/databricks/cli/bundle/config/paths"
 	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
@@ -10,8 +9,6 @@ type MlflowModel struct {
 	ID             string         `json:"id,omitempty" bundle:"readonly"`
 	Permissions    []Permission   `json:"permissions,omitempty"`
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-
-	paths.Paths
 
 	*ml.Model
 }

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/databricks/cli/bundle/config/paths"
 	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/serving"
 )
@@ -14,10 +13,6 @@ type ModelServingEndpoint struct {
 	// This represents the id (ie serving_endpoint_id) that can be used
 	// as a reference in other resources. This value is returned by terraform.
 	ID string `json:"id,omitempty" bundle:"readonly"`
-
-	// Path to config file where the resource is defined. All bundle resources
-	// include this for interpolation purposes.
-	paths.Paths
 
 	// This is a resource agnostic implementation of permissions for ACLs.
 	// Implementation could be different based on the resource type.

--- a/bundle/config/resources/registered_model.go
+++ b/bundle/config/resources/registered_model.go
@@ -1,7 +1,6 @@
 package resources
 
 import (
-	"github.com/databricks/cli/bundle/config/paths"
 	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
@@ -15,10 +14,6 @@ type RegisteredModel struct {
 	// (catalog_name.schema_name.model_name) that can be used
 	// as a reference in other resources. This value is returned by terraform.
 	ID string `json:"id,omitempty" bundle:"readonly"`
-
-	// Path to config file where the resource is defined. All bundle resources
-	// include this for interpolation purposes.
-	paths.Paths
 
 	// This represents the input args for terraform, and will get converted
 	// to a HCL representation for CRUD

--- a/bundle/tests/model_serving_endpoint_test.go
+++ b/bundle/tests/model_serving_endpoint_test.go
@@ -1,7 +1,6 @@
 package config_tests
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/bundle/config"
@@ -10,7 +9,6 @@ import (
 )
 
 func assertExpected(t *testing.T, p *resources.ModelServingEndpoint) {
-	assert.Equal(t, "model_serving_endpoint/databricks.yml", filepath.ToSlash(p.ConfigFilePath))
 	assert.Equal(t, "model-name", p.Config.ServedModels[0].ModelName)
 	assert.Equal(t, "1", p.Config.ServedModels[0].ModelVersion)
 	assert.Equal(t, "model-name-1", p.Config.TrafficConfig.Routes[0].ServedModelName)

--- a/bundle/tests/registered_model_test.go
+++ b/bundle/tests/registered_model_test.go
@@ -1,7 +1,6 @@
 package config_tests
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/bundle/config"
@@ -10,7 +9,6 @@ import (
 )
 
 func assertExpectedModel(t *testing.T, p *resources.RegisteredModel) {
-	assert.Equal(t, "registered_model/databricks.yml", filepath.ToSlash(p.ConfigFilePath))
 	assert.Equal(t, "main", p.CatalogName)
 	assert.Equal(t, "default", p.SchemaName)
 	assert.Equal(t, "comment", p.Comment)


### PR DESCRIPTION
## Changes
We probably don't need to track the paths in the ML resources post https://github.com/databricks/cli/pull/1414. The paths will now not be used anywhere for path interpolation in the API fields or any kind of validation.  

Note: Given the use of dynamic typing it's not completely certain whether this change is safe. This will need to be validated.

## Tests
<!-- How is this tested? -->

