### PR TITLE
Fix flaky tests for the parallel mutator

### DIFF
--- a/bundle/parallel_test.go
+++ b/bundle/parallel_test.go
@@ -18,7 +18,7 @@ type addToContainer struct {
 	err       bool
 
 	// mu is a mutex that protects container. It is used to ensure that the
-	// container is only modified by one goroutine at a time.
+	// container slice is only modified by one goroutine at a time.
 	mu *sync.Mutex
 }
 

--- a/bundle/parallel_test.go
+++ b/bundle/parallel_test.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 
@@ -38,23 +37,7 @@ func (m *addToContainer) Name() string {
 	return "addToContainer"
 }
 
-func TestParallelMutatorWork1000Times(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		t.Run(fmt.Sprintf("iter %v", i), func(t *testing.T) {
-			testParallelMutatorWork(t)
-		})
-	}
-}
-
-func TestParallelMutatorWorkWithErrors1000Times(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		t.Run(fmt.Sprintf("iter %v", i), func(t *testing.T) {
-			testParallelMutatorWorkWithErrors(t)
-		})
-	}
-}
-
-func testParallelMutatorWork(t *testing.T) {
+func TestParallelMutatorWork(t *testing.T) {
 	b := &Bundle{
 		Config: config.Root{},
 	}
@@ -76,7 +59,7 @@ func testParallelMutatorWork(t *testing.T) {
 	require.Contains(t, container, 3)
 }
 
-func testParallelMutatorWorkWithErrors(t *testing.T) {
+func TestParallelMutatorWorkWithErrors(t *testing.T) {
 	b := &Bundle{
 		Config: config.Root{},
 	}


### PR DESCRIPTION
## Changes
Around 0.5% to 1% of the time, the tests would fail due to concurrent access to the underlying slice in the mutator. This PR makes the test thread safe preventing race conditions.

Example of failed run: https://github.com/databricks/cli/actions/runs/9004657555/job/24738145829
