### PR TITLE
Don't merge-in remote resources during depolyments

### DIFF
--- a/bundle/deploy/terraform/check_running_resources_test.go
+++ b/bundle/deploy/terraform/check_running_resources_test.go
@@ -1,12 +1,10 @@
-package deploy
+package terraform
 
 import (
 	"context"
 	"errors"
 	"testing"
 
-	"github.com/databricks/cli/bundle/config"
-	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
@@ -16,15 +14,22 @@ import (
 
 func TestIsAnyResourceRunningWithEmptyState(t *testing.T) {
 	mock := mocks.NewMockWorkspaceClient(t)
-	err := checkAnyResourceRunning(context.Background(), mock.WorkspaceClient, &config.Resources{})
+	err := checkAnyResourceRunning(context.Background(), mock.WorkspaceClient, &resourcesState{})
 	require.NoError(t, err)
 }
 
 func TestIsAnyResourceRunningWithJob(t *testing.T) {
 	m := mocks.NewMockWorkspaceClient(t)
-	resources := &config.Resources{
-		Jobs: map[string]*resources.Job{
-			"job1": {ID: "123"},
+	resources := &resourcesState{
+		Resources: []stateResource{
+			{
+				Type: "databricks_job",
+				Mode: "managed",
+				Name: "job1",
+				Instances: []stateResourceInstance{
+					{Attributes: stateInstanceAttributes{ID: "123"}},
+				},
+			},
 		},
 	}
 
@@ -50,9 +55,16 @@ func TestIsAnyResourceRunningWithJob(t *testing.T) {
 
 func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
 	m := mocks.NewMockWorkspaceClient(t)
-	resources := &config.Resources{
-		Pipelines: map[string]*resources.Pipeline{
-			"pipeline1": {ID: "123"},
+	resources := &resourcesState{
+		Resources: []stateResource{
+			{
+				Type: "databricks_pipeline",
+				Mode: "managed",
+				Name: "pipeline1",
+				Instances: []stateResourceInstance{
+					{Attributes: stateInstanceAttributes{ID: "123"}},
+				},
+			},
 		},
 	}
 
@@ -79,9 +91,16 @@ func TestIsAnyResourceRunningWithPipeline(t *testing.T) {
 
 func TestIsAnyResourceRunningWithAPIFailure(t *testing.T) {
 	m := mocks.NewMockWorkspaceClient(t)
-	resources := &config.Resources{
-		Pipelines: map[string]*resources.Pipeline{
-			"pipeline1": {ID: "123"},
+	resources := &resourcesState{
+		Resources: []stateResource{
+			{
+				Type: "databricks_pipeline",
+				Mode: "managed",
+				Name: "pipeline1",
+				Instances: []stateResourceInstance{
+					{Attributes: stateInstanceAttributes{ID: "123"}},
+				},
+			},
 		},
 	}
 

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -36,8 +36,7 @@ func Deploy() bundle.Mutator {
 				permissions.ApplyWorkspaceRootPermissions(),
 				terraform.Interpolate(),
 				terraform.Write(),
-				terraform.Load(),
-				deploy.CheckRunningResource(),
+				terraform.CheckRunningResource(),
 				bundle.Defer(
 					terraform.Apply(),
 					bundle.Seq(

--- a/internal/bundle/bundles/deploy_then_remove_resources/databricks_template_schema.json
+++ b/internal/bundle/bundles/deploy_then_remove_resources/databricks_template_schema.json
@@ -3,6 +3,14 @@
         "unique_id": {
             "type": "string",
             "description": "Unique ID for pipeline name"
+        },
+        "spark_version": {
+            "type": "string",
+            "description": "Spark version used for job cluster"
+        },
+        "node_type_id": {
+            "type": "string",
+            "description": "Node type id for job cluster"
         }
     }
 }

--- a/internal/bundle/bundles/deploy_then_remove_resources/template/bar.py
+++ b/internal/bundle/bundles/deploy_then_remove_resources/template/bar.py
@@ -1,0 +1,2 @@
+# Databricks notebook source
+print("hello")

--- a/internal/bundle/bundles/deploy_then_remove_resources/template/resources.yml.tmpl
+++ b/internal/bundle/bundles/deploy_then_remove_resources/template/resources.yml.tmpl
@@ -1,4 +1,15 @@
 resources:
+  jobs:
+    foo:
+      name: test-bundle-job-{{.unique_id}}
+      tasks:
+        - task_key: my_notebook_task
+          new_cluster:
+            num_workers: 1
+            spark_version: "{{.spark_version}}"
+            node_type_id: "{{.node_type_id}}"
+          notebook_task:
+            notebook_path: "./bar.py"
   pipelines:
     bar:
       name: test-bundle-pipeline-{{.unique_id}}


### PR DESCRIPTION
## Changes
`check_running_resources` now pulls the remote state without modifying the bundle state, similar to how it was doing before. This avoids a problem when we fail to compute deployment metadata for a deleted job (which we shouldn't do in the first place)

`deploy_then_remove_resources_test` now also deploys and deletes a job (in addition to a pipeline), which catches the error that this PR fixes.

## Tests
Unit and integ tests

