### PR TITLE
Fix conversion of zero valued scalar pointers to a dynamic value

### DIFF
--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -78,7 +78,7 @@ func TestAdditional(t *testing.T) {
 		assertFromTypedToTypedEqual(t, s)
 	})
 
-	t.Run("struct with scalar values", func(t *testing.T) {
+	t.Run("pointer to struct with scalar values", func(t *testing.T) {
 		s := ""
 		type foo struct {
 			A string  `json:"a"`
@@ -86,13 +86,13 @@ func TestAdditional(t *testing.T) {
 			C bool    `json:"c"`
 			D *string `json:"d"`
 		}
-		assertFromTypedToTypedEqual(t, foo{
+		assertFromTypedToTypedEqual(t, &foo{
 			A: "a",
 			B: 1,
 			C: true,
 			D: &s,
 		})
-		assertFromTypedToTypedEqual(t, foo{
+		assertFromTypedToTypedEqual(t, &foo{
 			A: "",
 			B: 0,
 			C: false,

--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -72,4 +72,10 @@ func TestAdditional(t *testing.T) {
 		s := ""
 		assertFromTypedToTypedEqual(t, &s)
 	})
+
+
+	t.Run("nil pointer", func(t *testing.T) {
+		var s *string
+		assertFromTypedToTypedEqual(t, s)
+	})
 }

--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -67,4 +67,9 @@ func TestAdditional(t *testing.T) {
 			SliceOfPointer: []*string{nil},
 		})
 	})
+
+	t.Run("pointer to a empty string", func(t *testing.T) {
+		s := ""
+		assertFromTypedToTypedEqual(t, &s)
+	})
 }

--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -73,9 +73,43 @@ func TestAdditional(t *testing.T) {
 		assertFromTypedToTypedEqual(t, &s)
 	})
 
-
 	t.Run("nil pointer", func(t *testing.T) {
 		var s *string
 		assertFromTypedToTypedEqual(t, s)
+	})
+
+	t.Run("struct with scalar values", func(t *testing.T) {
+		s := ""
+		type foo struct {
+			A string  `json:"a"`
+			B int     `json:"b"`
+			C bool    `json:"c"`
+			D *string `json:"d"`
+		}
+		assertFromTypedToTypedEqual(t, foo{
+			A: "a",
+			B: 1,
+			C: true,
+			D: &s,
+		})
+		assertFromTypedToTypedEqual(t, foo{
+			A: "",
+			B: 0,
+			C: false,
+			D: nil,
+		})
+	})
+
+	t.Run("map with scalar values", func(t *testing.T) {
+		assertFromTypedToTypedEqual(t, map[string]string{
+			"a": "a",
+			"b": "b",
+			"c": "",
+		})
+		assertFromTypedToTypedEqual(t, map[string]int{
+			"a": 1,
+			"b": 0,
+			"c": 2,
+		})
 	})
 }

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -36,12 +36,6 @@ func FromTyped(src any, ref dyn.Value) (dyn.Value, error) {
 	return fromTyped(src, ref)
 }
 
-func isScalarValue(v reflect.Value) bool {
-	return v.Kind() == reflect.String || v.Kind() == reflect.Bool ||
-		v.Kind() == reflect.Int || v.Kind() == reflect.Int32 || v.Kind() == reflect.Int64 ||
-		v.Kind() == reflect.Float32 || v.Kind() == reflect.Float64
-}
-
 // Private implementation of FromTyped that allows for additional options not exposed
 // in the public API.
 func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, error) {
@@ -58,7 +52,7 @@ func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, 
 		// that zero value in the dynamic representation.
 		// This is because by default a pointer is nil in Go, and it not being nil
 		// indicates its value was intentionally set to zero.
-		if !slices.Contains(options, includeZeroValuedScalars) && isScalarValue(srcv) {
+		if !slices.Contains(options, includeZeroValuedScalars) {
 			options = append(options, includeZeroValuedScalars)
 		}
 	}

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -41,6 +41,14 @@ func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, 
 			return dyn.NilValue, nil
 		}
 		srcv = srcv.Elem()
+
+		// If a pointer to a scalar type is non-nil but is zero-valued, we should
+		// include its zero value in the dynamic representation. This is because
+		// by default the zero value of a pointer is nil, and it not being nil
+		// indicates it was intentionally set to zero.
+		if !slices.Contains(options, includeZeroValues) {
+			options = append(options, includeZeroValues)
+		}
 	}
 
 	switch srcv.Kind() {

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -46,7 +46,10 @@ func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, 
 		// that zero value in the dynamic representation.
 		// This is because by default a pointer is nil in Go, and it not being nil
 		// indicates its value was intentionally set to zero.
-		if !slices.Contains(options, includeZeroValues) {
+		isScalar := srcv.Kind() == reflect.String || srcv.Kind() == reflect.Bool ||
+			srcv.Kind() == reflect.Int || srcv.Kind() == reflect.Int32 || srcv.Kind() == reflect.Int64 ||
+			srcv.Kind() == reflect.Float32 || srcv.Kind() == reflect.Float64
+		if !slices.Contains(options, includeZeroValues) && isScalar {
 			options = append(options, includeZeroValues)
 		}
 	}

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -42,10 +42,10 @@ func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, 
 		}
 		srcv = srcv.Elem()
 
-		// If a pointer to a scalar type is non-nil but is zero-valued, we should
-		// include its zero value in the dynamic representation. This is because
-		// by default the zero value of a pointer is nil, and it not being nil
-		// indicates it was intentionally set to zero.
+		// If a pointer to a scalar type points to a zero value, we should include
+		// that zero value in the dynamic representation.
+		// This is because by default a pointer is nil in Go, and it not being nil
+		// indicates its value was intentionally set to zero.
 		if !slices.Contains(options, includeZeroValues) {
 			options = append(options, includeZeroValues)
 		}


### PR DESCRIPTION
## Changes
This PR also fixes empty values variable overrides using the --var flag. Now, using `--var="my_variable="` will set the value of `my_variable` to the empty string instead of ignoring the flag altogether.

## Tests
The change using a unit test. Manually verified the `--var` flag works now.