### PR TITLE
Don't hide commands of services that are already hidden

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -39,6 +39,7 @@ import (
 
 {{define "service"}}
 {{- $excludeMethods := list "put-secret" -}}
+{{- $hideService := .IsPrivatePreview }}
 
 // Slice with functions to override default command behavior.
 // Functions can be added from the `init()` function in manually curated files in this directory.
@@ -57,7 +58,7 @@ func New() *cobra.Command {
 			"package": "{{ .Package.Name }}",
 		},
 		{{- end }}
-		{{- if .IsPrivatePreview }}
+		{{- if $hideService }}
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,
@@ -190,7 +191,8 @@ func new{{.PascalName}}() *cobra.Command {
     {{- end -}}
 	`
 	{{- end }}
-	{{- if .IsPrivatePreview }}
+	{{/* Don't hide commands if the service itself is already hidden. */}}
+	{{- if and (not $hideService) .IsPrivatePreview }}
 
 	// This command is being previewed; hide from help output.
 	cmd.Hidden = true

--- a/cmd/workspace/apps/apps.go
+++ b/cmd/workspace/apps/apps.go
@@ -89,9 +89,6 @@ func newCreate() *cobra.Command {
       characters and hyphens and be between 2 and 30 characters long. It must be
       unique within the workspace.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -192,9 +189,6 @@ func newCreateDeployment() *cobra.Command {
     APP_NAME: The name of the app.
     SOURCE_CODE_PATH: The source code path of the deployment.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -288,9 +282,6 @@ func newDelete() *cobra.Command {
   Arguments:
     NAME: The name of the app.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -348,9 +339,6 @@ func newGet() *cobra.Command {
 
   Arguments:
     NAME: The name of the app.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -412,9 +400,6 @@ func newGetDeployment() *cobra.Command {
     APP_NAME: The name of the app.
     DEPLOYMENT_ID: The unique id of the deployment.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -474,9 +459,6 @@ func newGetEnvironment() *cobra.Command {
   Arguments:
     NAME: The name of the app.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -535,9 +517,6 @@ func newList() *cobra.Command {
   
   Lists all apps in the workspace.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -594,9 +573,6 @@ func newListDeployments() *cobra.Command {
   Arguments:
     APP_NAME: The name of the app.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -651,9 +627,6 @@ func newStop() *cobra.Command {
 
   Arguments:
     NAME: The name of the app.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -718,9 +691,6 @@ func newUpdate() *cobra.Command {
     NAME: The name of the app. The name must contain only lowercase alphanumeric
       characters and hyphens and be between 2 and 30 characters long. It must be
       unique within the workspace.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/consumer-fulfillments/consumer-fulfillments.go
+++ b/cmd/workspace/consumer-fulfillments/consumer-fulfillments.go
@@ -64,9 +64,6 @@ func newGet() *cobra.Command {
   
   Get a high level preview of the metadata of listing installable content.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -125,9 +122,6 @@ func newList() *cobra.Command {
   attached share or git repo. Only one of these fields will be present.
   Personalized installations contain metadata about the attached share or git
   repo, as well as the Delta Sharing recipient type.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/consumer-installations/consumer-installations.go
+++ b/cmd/workspace/consumer-installations/consumer-installations.go
@@ -76,9 +76,6 @@ func newCreate() *cobra.Command {
   
   Install payload associated with a Databricks Marketplace listing.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -140,9 +137,6 @@ func newDelete() *cobra.Command {
   
   Uninstall an installation associated with a Databricks Marketplace listing.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -202,9 +196,6 @@ func newList() *cobra.Command {
   
   List all installations across all listings.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -257,9 +248,6 @@ func newListListingInstallations() *cobra.Command {
 	cmd.Long = `List installations for a listing.
   
   List all installations for a particular listing.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -320,9 +308,6 @@ func newUpdate() *cobra.Command {
   fields not included in the installation table 1. the token will be rotate if
   the rotateToken flag is true 2. the token will be forcibly rotate if the
   rotateToken flag is true and the tokenInfo field is empty`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/consumer-listings/consumer-listings.go
+++ b/cmd/workspace/consumer-listings/consumer-listings.go
@@ -66,9 +66,6 @@ func newGet() *cobra.Command {
   Get a published listing in the Databricks Marketplace that the consumer has
   access to.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -148,9 +145,6 @@ func newList() *cobra.Command {
   List all published listings in the Databricks Marketplace that the consumer
   has access to.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -214,9 +208,6 @@ func newSearch() *cobra.Command {
 
   Arguments:
     QUERY: Fuzzy matches query`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/consumer-personalization-requests/consumer-personalization-requests.go
+++ b/cmd/workspace/consumer-personalization-requests/consumer-personalization-requests.go
@@ -75,9 +75,6 @@ func newCreate() *cobra.Command {
   
   Create a personalization request for a listing.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -142,9 +139,6 @@ func newGet() *cobra.Command {
   Get the personalization request for a listing. Each consumer can make at
   *most* one personalization request for a listing.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -202,9 +196,6 @@ func newList() *cobra.Command {
 	cmd.Long = `List all personalization requests.
   
   List personalization requests for a consumer across all listings.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/consumer-providers/consumer-providers.go
+++ b/cmd/workspace/consumer-providers/consumer-providers.go
@@ -64,9 +64,6 @@ func newGet() *cobra.Command {
   Get a provider in the Databricks Marketplace with at least one visible
   listing.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -138,9 +135,6 @@ func newList() *cobra.Command {
   
   List all providers in the Databricks Marketplace with at least one visible
   listing.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-exchange-filters/provider-exchange-filters.go
+++ b/cmd/workspace/provider-exchange-filters/provider-exchange-filters.go
@@ -68,9 +68,6 @@ func newCreate() *cobra.Command {
   
   Add an exchange filter.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -127,9 +124,6 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete an exchange filter.
   
   Delete an exchange filter`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -201,9 +195,6 @@ func newList() *cobra.Command {
   
   List exchange filter`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -257,9 +248,6 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update exchange filter.
   
   Update an exchange filter.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-exchanges/provider-exchanges.go
+++ b/cmd/workspace/provider-exchanges/provider-exchanges.go
@@ -74,9 +74,6 @@ func newAddListingToExchange() *cobra.Command {
   
   Associate an exchange with a listing`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -152,9 +149,6 @@ func newCreate() *cobra.Command {
   
   Create an exchange`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -212,9 +206,6 @@ func newDelete() *cobra.Command {
   
   This removes a listing from marketplace.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -270,9 +261,6 @@ func newDeleteListingFromExchange() *cobra.Command {
   
   Disassociate an exchange with a listing`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -327,9 +315,6 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get an exchange.
   
   Get an exchange.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -389,9 +374,6 @@ func newList() *cobra.Command {
   
   List exchanges visible to provider`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -444,9 +426,6 @@ func newListExchangesForListing() *cobra.Command {
 	cmd.Long = `List exchanges for listing.
   
   List exchanges associated with a listing`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -503,9 +482,6 @@ func newListListingsForExchange() *cobra.Command {
   
   List listings associated with an exchange`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -559,9 +535,6 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update exchange.
   
   Update an exchange`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-files/provider-files.go
+++ b/cmd/workspace/provider-files/provider-files.go
@@ -72,9 +72,6 @@ func newCreate() *cobra.Command {
   Create a file. Currently, only provider icons and attached notebooks are
   supported.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -131,9 +128,6 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a file.
   
   Delete a file`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -201,9 +195,6 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a file.
   
   Get a file`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -276,9 +267,6 @@ func newList() *cobra.Command {
 	cmd.Long = `List files.
   
   List files attached to a parent entity.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-listings/provider-listings.go
+++ b/cmd/workspace/provider-listings/provider-listings.go
@@ -70,9 +70,6 @@ func newCreate() *cobra.Command {
   
   Create a new listing`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -129,9 +126,6 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete a listing.
   
   Delete a listing`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -199,9 +193,6 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get a listing.
   
   Get a listing`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -273,9 +264,6 @@ func newList() *cobra.Command {
   
   List listings owned by this provider`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -327,9 +315,6 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update listing.
   
   Update a listing`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-personalization-requests/provider-personalization-requests.go
+++ b/cmd/workspace/provider-personalization-requests/provider-personalization-requests.go
@@ -69,9 +69,6 @@ func newList() *cobra.Command {
   List personalization requests to this provider. This will return all
   personalization requests, regardless of which listing they are for.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -127,9 +124,6 @@ func newUpdate() *cobra.Command {
   
   Update personalization request. This method only permits updating the status
   of the request.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-provider-analytics-dashboards/provider-provider-analytics-dashboards.go
+++ b/cmd/workspace/provider-provider-analytics-dashboards/provider-provider-analytics-dashboards.go
@@ -60,9 +60,6 @@ func newCreate() *cobra.Command {
   Create provider analytics dashboard. Returns Marketplace specific id. Not to
   be confused with the Lakeview dashboard id.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -105,9 +102,6 @@ func newGet() *cobra.Command {
   
   Get provider analytics dashboard.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -149,9 +143,6 @@ func newGetLatestVersion() *cobra.Command {
 	cmd.Long = `Get latest version of provider analytics dashboard.
   
   Get latest version of provider analytics dashboard.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -206,9 +197,6 @@ func newUpdate() *cobra.Command {
 
   Arguments:
     ID: id is immutable property and can't be updated.`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 

--- a/cmd/workspace/provider-providers/provider-providers.go
+++ b/cmd/workspace/provider-providers/provider-providers.go
@@ -69,9 +69,6 @@ func newCreate() *cobra.Command {
   
   Create a provider`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.PreRunE = root.MustWorkspaceClient
@@ -128,9 +125,6 @@ func newDelete() *cobra.Command {
 	cmd.Long = `Delete provider.
   
   Delete provider`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -198,9 +192,6 @@ func newGet() *cobra.Command {
 	cmd.Long = `Get provider.
   
   Get provider profile`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 
@@ -272,9 +263,6 @@ func newList() *cobra.Command {
   
   List provider profiles for account.`
 
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
-
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -326,9 +314,6 @@ func newUpdate() *cobra.Command {
 	cmd.Long = `Update provider.
   
   Update provider profile`
-
-	// This command is being previewed; hide from help output.
-	cmd.Hidden = true
 
 	cmd.Annotations = make(map[string]string)
 


### PR DESCRIPTION
## Changes

Currently, the help output of services in preview doesn't show any of their commands because the commands themselves are hidden as well.

This change updates that behavior to not hide commands in preview if the service itself is also in preview. This makes the help output of services in preview actually usable.

## Tests

n/a
