### PR TITLE
Remove unnecessary `filepath.FromSlash` calls

### DIFF
--- a/libs/filer/local_client.go
+++ b/libs/filer/local_client.go
@@ -34,7 +34,6 @@ func (w *LocalClient) Write(ctx context.Context, name string, reader io.Reader, 
 		flags |= os.O_EXCL
 	}
 
-	absPath = filepath.FromSlash(absPath)
 	f, err := os.OpenFile(absPath, flags, 0644)
 	if os.IsNotExist(err) && slices.Contains(mode, CreateParentDirectories) {
 		// Create parent directories if they don't exist.
@@ -76,7 +75,6 @@ func (w *LocalClient) Read(ctx context.Context, name string) (io.ReadCloser, err
 	// This stat call serves two purposes:
 	// 1. Checks file at path exists, and throws an error if it does not
 	// 2. Allows us to error out if the path is a directory
-	absPath = filepath.FromSlash(absPath)
 	stat, err := os.Stat(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -103,7 +101,6 @@ func (w *LocalClient) Delete(ctx context.Context, name string, mode ...DeleteMod
 		return CannotDeleteRootError{}
 	}
 
-	absPath = filepath.FromSlash(absPath)
 	err = os.Remove(absPath)
 
 	// Return early on success.
@@ -131,7 +128,6 @@ func (w *LocalClient) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, 
 		return nil, err
 	}
 
-	absPath = filepath.FromSlash(absPath)
 	stat, err := os.Stat(absPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -153,7 +149,6 @@ func (w *LocalClient) Mkdir(ctx context.Context, name string) error {
 		return err
 	}
 
-	dirPath = filepath.FromSlash(dirPath)
 	return os.MkdirAll(dirPath, 0755)
 }
 
@@ -163,7 +158,6 @@ func (w *LocalClient) Stat(ctx context.Context, name string) (fs.FileInfo, error
 		return nil, err
 	}
 
-	absPath = filepath.FromSlash(absPath)
 	stat, err := os.Stat(absPath)
 	if os.IsNotExist(err) {
 		return nil, FileDoesNotExistError{path: absPath}

--- a/libs/filer/local_root_path.go
+++ b/libs/filer/local_root_path.go
@@ -19,7 +19,6 @@ func NewLocalRootPath(root string) localRootPath {
 
 func (rp *localRootPath) Join(name string) (string, error) {
 	absPath := filepath.Join(rp.rootPath, name)
-
 	if !strings.HasPrefix(absPath, rp.rootPath) {
 		return "", fmt.Errorf("relative path escapes root: %s", name)
 	}


### PR DESCRIPTION
## Changes

The prior join call calls `filepath.Join` which returns a cleaned result.

Path cleaning, in turn, calls `filepath.FromSlash`.

## Tests

* Unit tests.