### PR TITLE
Update error checks that use the os package to use errors.Is

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -2,6 +2,8 @@ package bundle
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +16,7 @@ import (
 
 func TestLoadNotExists(t *testing.T) {
 	b, err := Load(context.Background(), "/doesntexist")
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 	assert.Nil(t, b)
 }
 

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"path"
@@ -109,7 +110,7 @@ func (m *translatePaths) rewritePath(
 
 func translateNotebookPath(literal, localFullPath, localRelPath, remotePath string) (string, error) {
 	nb, _, err := notebook.Detect(localFullPath)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("notebook %s not found", literal)
 	}
 	if err != nil {
@@ -125,7 +126,7 @@ func translateNotebookPath(literal, localFullPath, localRelPath, remotePath stri
 
 func translateFilePath(literal, localFullPath, localRelPath, remotePath string) (string, error) {
 	nb, _, err := notebook.Detect(localFullPath)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("file %s not found", literal)
 	}
 	if err != nil {

--- a/bundle/deploy/files/delete.go
+++ b/bundle/deploy/files/delete.go
@@ -2,7 +2,9 @@ package files
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/databricks/cli/bundle"
@@ -67,7 +69,7 @@ func deleteSnapshotFile(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 	err = os.Remove(sp)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to destroy sync snapshot file: %s", err)
 	}
 	return nil

--- a/bundle/deploy/state_pull_test.go
+++ b/bundle/deploy/state_pull_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"testing"
 
@@ -270,7 +272,7 @@ func TestStatePullNoState(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = os.Stat(statePath)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, fs.ErrNotExist))
 }
 
 func TestStatePullOlderState(t *testing.T) {

--- a/bundle/deploy/state_update.go
+++ b/bundle/deploy/state_update.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"time"
 
@@ -95,7 +97,7 @@ func load(ctx context.Context, b *bundle.Bundle) (*DeploymentState, error) {
 	log.Infof(ctx, "Loading deployment state from %s", statePath)
 	f, err := os.Open(statePath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			log.Infof(ctx, "No deployment state file found")
 			return &DeploymentState{
 				Version:    DeploymentStateVersion,

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -2,7 +2,9 @@ package terraform
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +61,7 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 	// If the execPath already exists, return it.
 	execPath := filepath.Join(binDir, product.Terraform.BinaryName())
 	_, err = os.Stat(execPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
 	if err == nil {
@@ -148,7 +150,7 @@ func getEnvVarWithMatchingVersion(ctx context.Context, envVarName string, versio
 	// If the path does not exist, we return early.
 	_, err := os.Stat(envValue)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			log.Debugf(ctx, "%s at %s does not exist", envVarName, envValue)
 			return "", nil
 		} else {

--- a/bundle/internal/tf/codegen/schema/schema.go
+++ b/bundle/internal/tf/codegen/schema/schema.go
@@ -2,6 +2,8 @@ package schema
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -41,7 +43,7 @@ func Load(ctx context.Context) (*tfjson.ProviderSchema, error) {
 	}
 
 	// Generate schema file if it doesn't exist.
-	if _, err := os.Stat(s.ProviderSchemaFile); os.IsNotExist(err) {
+	if _, err := os.Stat(s.ProviderSchemaFile); errors.Is(err, fs.ErrNotExist) {
 		err = s.Generate(ctx)
 		if err != nil {
 			return nil, err

--- a/cmd/auth/profiles.go
+++ b/cmd/auth/profiles.go
@@ -2,8 +2,9 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"sync"
 	"time"
 
@@ -95,7 +96,7 @@ func newProfilesCommand() *cobra.Command {
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		var profiles []*profileMetadata
 		iniFile, err := profile.DefaultProfiler.Get(cmd.Context())
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// return empty list for non-configured machines
 			iniFile = &config.File{
 				File: &ini.File{},

--- a/libs/databrickscfg/loader.go
+++ b/libs/databrickscfg/loader.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"strings"
 
 	"github.com/databricks/cli/libs/log"
@@ -68,7 +68,7 @@ func (l profileFromHostLoader) Configure(cfg *config.Config) error {
 	ctx := context.Background()
 	configFile, err := config.LoadFile(cfg.ConfigFile)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return fmt.Errorf("cannot parse config file: %w", err)

--- a/libs/databrickscfg/ops.go
+++ b/libs/databrickscfg/ops.go
@@ -2,7 +2,9 @@ package databrickscfg
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -29,7 +31,7 @@ func loadOrCreateConfigFile(filename string) (*config.File, error) {
 		filename = fmt.Sprintf("%s%s", homedir, filename[1:])
 	}
 	configFile, err := config.LoadFile(filename)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		file, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileMode)
 		if err != nil {
 			return nil, fmt.Errorf("create %s: %w", filename, err)

--- a/libs/git/config.go
+++ b/libs/git/config.go
@@ -1,8 +1,10 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -88,12 +90,12 @@ func (c config) load(r io.Reader) error {
 	return nil
 }
 
-func (c config) loadFile(fs vfs.Path, path string) error {
-	f, err := fs.Open(path)
+func (c config) loadFile(root vfs.Path, path string) error {
+	f, err := root.Open(path)
 	if err != nil {
 		// If the file doesn't exist it is ignored.
 		// This is the case for both global and repository specific config files.
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return err
@@ -130,7 +132,7 @@ func (c config) coreExcludesFile() (string, error) {
 	// If there are other problems accessing this file we would
 	// run into them at a later point anyway.
 	_, err := os.Stat(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", err
 	}
 

--- a/libs/git/ignore.go
+++ b/libs/git/ignore.go
@@ -1,8 +1,8 @@
 package git
 
 import (
+	"errors"
 	"io/fs"
-	"os"
 	"strings"
 	"time"
 
@@ -74,7 +74,7 @@ func (f *ignoreFile) load() error {
 	// If it doesn't exist, treat it as an empty file.
 	stat, err := fs.Stat(f.root, f.path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil
 		}
 		return err

--- a/libs/git/reference.go
+++ b/libs/git/reference.go
@@ -1,9 +1,9 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"regexp"
 	"strings"
 
@@ -42,7 +42,7 @@ func isSHA1(s string) bool {
 func LoadReferenceFile(root vfs.Path, path string) (*Reference, error) {
 	// read reference file content
 	b, err := fs.ReadFile(root, path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -1,8 +1,9 @@
 package git
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -190,7 +191,7 @@ func NewRepository(path vfs.Path) (*Repository, error) {
 	real := true
 	rootPath, err := vfs.FindLeafInTree(path, GitDirectoryName)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, err
 		}
 		// Cannot find `.git` directory.

--- a/libs/notebook/detect_test.go
+++ b/libs/notebook/detect_test.go
@@ -1,6 +1,8 @@
 package notebook
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,7 +52,7 @@ func TestDetectCallsDetectJupyter(t *testing.T) {
 
 func TestDetectUnknownExtension(t *testing.T) {
 	_, _, err := Detect("./testdata/doesntexist.foobar")
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 
 	nb, _, err := Detect("./testdata/unknown_extension.foobar")
 	require.NoError(t, err)
@@ -59,7 +61,7 @@ func TestDetectUnknownExtension(t *testing.T) {
 
 func TestDetectNoExtension(t *testing.T) {
 	_, _, err := Detect("./testdata/doesntexist")
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
 
 	nb, _, err := Detect("./testdata/no_extension")
 	require.NoError(t, err)

--- a/libs/sync/snapshot.go
+++ b/libs/sync/snapshot.go
@@ -3,7 +3,9 @@ package sync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -88,7 +90,7 @@ func GetFileName(host, remotePath string) string {
 // precisely it's the first 16 characters of md5(concat(host, remotePath))
 func SnapshotPath(opts *SyncOptions) (string, error) {
 	snapshotDir := filepath.Join(opts.SnapshotBasePath, syncSnapshotDirName)
-	if _, err := os.Stat(snapshotDir); os.IsNotExist(err) {
+	if _, err := os.Stat(snapshotDir); errors.Is(err, fs.ErrNotExist) {
 		err = os.MkdirAll(snapshotDir, 0755)
 		if err != nil {
 			return "", fmt.Errorf("failed to create config directory: %s", err)
@@ -145,7 +147,7 @@ func loadOrNewSnapshot(ctx context.Context, opts *SyncOptions) (*Snapshot, error
 	}
 
 	// Snapshot file not found. We return the new copy.
-	if _, err := os.Stat(snapshot.SnapshotPath); os.IsNotExist(err) {
+	if _, err := os.Stat(snapshot.SnapshotPath); errors.Is(err, fs.ErrNotExist) {
 		return snapshot, nil
 	}
 

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -3,6 +3,7 @@ package template
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -44,7 +45,7 @@ func Materialize(ctx context.Context, configFilePath, templateRoot, outputDir st
 	schemaPath := filepath.Join(templateRoot, schemaFileName)
 	helpers := loadHelpers(ctx)
 
-	if _, err := os.Stat(schemaPath); os.IsNotExist(err) {
+	if _, err := os.Stat(schemaPath); errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("not a bundle template: expected to find a template schema file at %s", schemaPath)
 	}
 

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -313,7 +314,7 @@ func (r *renderer) persistToDisk() error {
 		if err == nil {
 			return fmt.Errorf("failed to initialize template, one or more files already exist: %s", path)
 		}
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("error while verifying file %s does not already exist: %w", path, err)
 		}
 	}


### PR DESCRIPTION
## Changes

From the documentation on the functions in the `os` package:
> This function predates errors.Is. It only supports errors returned by the os package. New code should use errors.Is(err, fs.ErrNotExist).

This issue surfaced while working on using a different `vfs.Path` implementation that uses errors from the `fs` package.

## Tests

n/a