### PR TITLE
Fix listing notebooks in a subdirectory

### DIFF
--- a/libs/filer/fs.go
+++ b/libs/filer/fs.go
@@ -14,7 +14,7 @@ type filerFS struct {
 }
 
 // NewFS returns an fs.FS backed by a filer.
-func NewFS(ctx context.Context, filer Filer) *filerFS {
+func NewFS(ctx context.Context, filer Filer) fs.FS {
 	return &filerFS{ctx: ctx, filer: filer}
 }
 

--- a/libs/filer/fs.go
+++ b/libs/filer/fs.go
@@ -14,7 +14,7 @@ type filerFS struct {
 }
 
 // NewFS returns an fs.FS backed by a filer.
-func NewFS(ctx context.Context, filer Filer) fs.FS {
+func NewFS(ctx context.Context, filer Filer) *filerFS {
 	return &filerFS{ctx: ctx, filer: filer}
 }
 

--- a/libs/filer/workspace_files_extensions_client.go
+++ b/libs/filer/workspace_files_extensions_client.go
@@ -235,7 +235,7 @@ func (w *workspaceFilesExtensionsClient) ReadDir(ctx context.Context, name strin
 
 		// If the object is a notebook, include an extension in the entry.
 		if sysInfo.ObjectType == workspace.ObjectTypeNotebook {
-			stat, err := w.getNotebookStatByNameWithoutExt(ctx, entries[i].Name())
+			stat, err := w.getNotebookStatByNameWithoutExt(ctx, path.Join(name, entries[i].Name()))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Changes

This worked fine if the notebooks are located in the filer's root and didn't if they are nested in a directory.

This change adds test coverage and fixes the underlying issue.

## Tests

Ran integration test manually.