### PR TITLE
Fix SQL schema selection in default-sql template

### DIFF
--- a/libs/template/templates/default-sql/template/{{.project_name}}/src/orders_daily.sql.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/src/orders_daily.sql.tmpl
@@ -2,7 +2,7 @@
 {{- /* We can't use a materialized view here since they don't support 'create or refresh' yet.*/}}
 
 USE CATALOG {{"{{"}}catalog{{"}}"}};
-USE {{"{{"}}schema{{"}}"}};
+USE IDENTIFIER({{"{{"}}schema{{"}}"}});
 
 CREATE OR REPLACE VIEW
   orders_daily

--- a/libs/template/templates/default-sql/template/{{.project_name}}/src/orders_raw.sql.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/src/orders_raw.sql.tmpl
@@ -4,7 +4,7 @@
 -- See also https://docs.databricks.com/sql/language-manual/sql-ref-syntax-ddl-create-streaming-table.html
 
 USE CATALOG {{"{{"}}catalog{{"}}"}};
-USE {{"{{"}}schema{{"}}"}};
+USE IDENTIFIER({{"{{"}}schema{{"}}"}});
 
 CREATE OR REFRESH STREAMING TABLE
   orders_raw


### PR DESCRIPTION
## Changes

This fixes a last-minute regression that snuck into https://github.com/databricks/cli/pull/1463: unfortunately we need to use `USE IDENTIFIER('schema')` to select a schema for now. In the future we expect we can just use `USE SCHEMA 'schema'`.