### PR TITLE
Release v0.221.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Version changelog
 
+## 0.221.1
+
+Bundles:
+
+This releases fixes an issue introduced in v0.221.0 where managing jobs with a single-node cluster would fail.
+
+ * Fix SQL schema selection in default-sql template ([#1471](https://github.com/databricks/cli/pull/1471)).
+ * Copy-editing for SQL templates ([#1474](https://github.com/databricks/cli/pull/1474)).
+ * Upgrade TF provider to 1.47.0 ([#1476](https://github.com/databricks/cli/pull/1476)).
+
+Internal:
+ * Use latest version of goreleaser action ([#1477](https://github.com/databricks/cli/pull/1477)).
+
+
+
 ## 0.221.0
 
 CLI:


### PR DESCRIPTION

Bundles:

This releases fixes an issue introduced in v0.221.0 where managing jobs with a single-node cluster would fail.

 * Fix SQL schema selection in default-sql template ([#1471](https://github.com/databricks/cli/pull/1471)).
 * Copy-editing for SQL templates ([#1474](https://github.com/databricks/cli/pull/1474)).
 * Upgrade TF provider to 1.47.0 ([#1476](https://github.com/databricks/cli/pull/1476)).

Internal:
 * Use latest version of goreleaser action ([#1477](https://github.com/databricks/cli/pull/1477)).



