### PR TITLE
Remove user credentials specified in the Git origin URL

### DIFF
--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
@@ -100,7 +101,18 @@ func (r *Repository) LatestCommit() (string, error) {
 
 // return origin url if it's defined, otherwise an empty string
 func (r *Repository) OriginUrl() string {
-	return r.config.variables["remote.origin.url"]
+	rawUrl := r.config.variables["remote.origin.url"]
+
+	// Remove username and credentials from the URL.
+	parsedUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return ""
+	}
+	// Setting User to nil removes the username and password from the URL when
+	// .String() is called.
+	// See: https://pkg.go.dev/net/url#URL.String
+	parsedUrl.User = nil
+	return parsedUrl.String()
 }
 
 // loadConfig loads and combines user specific and repository specific configuration files.

--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -103,7 +103,7 @@ func (r *Repository) LatestCommit() (string, error) {
 func (r *Repository) OriginUrl() string {
 	rawUrl := r.config.variables["remote.origin.url"]
 
-	// Remove username and passwork from the URL.
+	// Remove username and password from the URL.
 	parsedUrl, err := url.Parse(rawUrl)
 	if err != nil {
 		// Git supports https URLs and non standard URLs like "ssh://" or "file://".

--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -103,10 +103,14 @@ func (r *Repository) LatestCommit() (string, error) {
 func (r *Repository) OriginUrl() string {
 	rawUrl := r.config.variables["remote.origin.url"]
 
-	// Remove username and credentials from the URL.
+	// Remove username and passwork from the URL.
 	parsedUrl, err := url.Parse(rawUrl)
 	if err != nil {
-		return ""
+		// Git supports https URLs and non standard URLs like "ssh://" or "file://".
+		// Parsing these URLs is not supported by the Go standard library. In case
+		// of an error, we return the raw URL. This is okay because for ssh URLs
+		// because passwords cannot be included in the URL.
+		return rawUrl
 	}
 	// Setting User to nil removes the username and password from the URL when
 	// .String() is called.

--- a/libs/git/repository_test.go
+++ b/libs/git/repository_test.go
@@ -207,3 +207,15 @@ func TestRepositoryGitConfigWhenNotARepo(t *testing.T) {
 	originUrl := repo.OriginUrl()
 	assert.Equal(t, "", originUrl)
 }
+
+func TestRepositoryOriginUrlRemovesUserCreds(t *testing.T) {
+	r := Repository{
+		config: &config{
+			variables: map[string]string{
+				"remote.origin.url": "https://username:token@github.com/databricks/foobar.git",
+			},
+		},
+	}
+
+	assert.Equal(t, "https://github.com/databricks/foobar.git", r.OriginUrl())
+}

--- a/libs/git/repository_test.go
+++ b/libs/git/repository_test.go
@@ -209,13 +209,7 @@ func TestRepositoryGitConfigWhenNotARepo(t *testing.T) {
 }
 
 func TestRepositoryOriginUrlRemovesUserCreds(t *testing.T) {
-	r := Repository{
-		config: &config{
-			variables: map[string]string{
-				"remote.origin.url": "https://username:token@github.com/databricks/foobar.git",
-			},
-		},
-	}
-
-	assert.Equal(t, "https://github.com/databricks/foobar.git", r.OriginUrl())
+	repo := newTestRepository(t)
+	repo.addOriginUrl("https://username:token@github.com/databricks/foobar.git")
+	repo.assertOriginUrl("https://github.com/databricks/foobar.git")
 }


### PR DESCRIPTION
## Changes
We set the origin URL as metadata in any jobs created by DABs. This PR makes sure user credentials do not leak into the set metadata in the job.
 
## Tests
Unit test
