### PR TITLE
Clean up unused code

### DIFF
--- a/bundle/config/mutator/mutator.go
+++ b/bundle/config/mutator/mutator.go
@@ -26,10 +26,3 @@ func DefaultMutators() []bundle.Mutator {
 		LoadGitDetails(),
 	}
 }
-
-func DefaultMutatorsForTarget(target string) []bundle.Mutator {
-	return append(
-		DefaultMutators(),
-		SelectTarget(target),
-	)
-}

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -223,10 +223,6 @@ func (s *Sync) GetFileList(ctx context.Context) ([]fileset.File, error) {
 	return all.Iter(), nil
 }
 
-func (s *Sync) SnapshotPath() string {
-	return s.snapshot.SnapshotPath
-}
-
 func (s *Sync) RunContinuous(ctx context.Context) error {
 	ticker := time.NewTicker(s.PollInterval)
 	defer ticker.Stop()


### PR DESCRIPTION
## Changes
1. Removes `DefaultMutatorsForTarget` which is no longer used anywhere
2. Makes SnapshotPath a private field. It's no longer needed by data structures outside its package.

FYI, I also tried finding other instances of dead code but I could not find anything else that was safe to remove. I used https://go.dev/blog/deadcode to search for them, and the other instances either implemented an interface, increased test coverage for some of our other code paths or there was some other reason I could not remove them (like autogenerated functions or used in tests).

Good sign our codebase is mostly clean (at least superficially).