### PR TITLE
Allow the any type to be set to nil in `convert.FromTyped`

### DIFF
--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -72,6 +72,9 @@ func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, 
 		return fromTypedInt(srcv, ref, options...)
 	case reflect.Float32, reflect.Float64:
 		return fromTypedFloat(srcv, ref, options...)
+	case reflect.Invalid:
+		// If the value is untyped and not set (e.g. any type with nil value), we return nil.
+		return dyn.NilValue, nil
 	}
 
 	return dyn.InvalidValue, fmt.Errorf("unsupported type: %s", srcv.Kind())

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -619,3 +619,11 @@ func TestFromTypedFloatTypeError(t *testing.T) {
 	_, err := FromTyped(src, ref)
 	require.Error(t, err)
 }
+
+func TestFromTypedAnyNil(t *testing.T) {
+	var src any = nil
+	var ref = dyn.NilValue
+	nv, err := FromTyped(src, ref)
+	require.NoError(t, err)
+	assert.Equal(t, dyn.NilValue, nv)
+}


### PR DESCRIPTION
## Changes

This came up in integration testing for #1511. One of the tests converted a `map[string]any` to a dynamic value and encountered a `nil` and errored out. We can safely return a nil in this case.

## Tests

Unit test passes.

