### PR TITLE
Rewrite local relative path to `requirements.txt` in libraries section

### DIFF
--- a/bundle/config/mutator/translate_paths_jobs.go
+++ b/bundle/config/mutator/translate_paths_jobs.go
@@ -51,6 +51,11 @@ func rewritePatterns(base dyn.Pattern) []jobRewritePattern {
 			translateNoOp,
 			noSkipRewrite,
 		},
+		{
+			base.Append(dyn.Key("libraries"), dyn.AnyIndex(), dyn.Key("requirements")),
+			translateFilePath,
+			noSkipRewrite,
+		},
 	}
 }
 

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -105,6 +105,7 @@ func TestTranslatePaths(t *testing.T) {
 	touchNotebookFile(t, filepath.Join(dir, "my_pipeline_notebook.py"))
 	touchEmptyFile(t, filepath.Join(dir, "my_python_file.py"))
 	touchEmptyFile(t, filepath.Join(dir, "dist", "task.jar"))
+	touchEmptyFile(t, filepath.Join(dir, "my_requirements.txt"))
 
 	b := &bundle.Bundle{
 		RootPath: dir,
@@ -159,6 +160,14 @@ func TestTranslatePaths(t *testing.T) {
 									},
 									Libraries: []compute.Library{
 										{Jar: "dbfs:/bundle/dist/task_remote.jar"},
+									},
+								},
+								{
+									SparkPythonTask: &jobs.SparkPythonTask{
+										PythonFile: "./my_python_file.py",
+									},
+									Libraries: []compute.Library{
+										{Requirements: "./my_requirements.txt"},
 									},
 								},
 							},
@@ -240,6 +249,11 @@ func TestTranslatePaths(t *testing.T) {
 		t,
 		"dbfs:/bundle/dist/task_remote.jar",
 		b.Config.Resources.Jobs["job"].Tasks[6].Libraries[0].Jar,
+	)
+	assert.Equal(
+		t,
+		"/bundle/my_requirements.txt",
+		b.Config.Resources.Jobs["job"].Tasks[7].Libraries[0].Requirements,
 	)
 
 	// Assert that the path in the libraries now refer to the artifact.


### PR DESCRIPTION
## Changes

**Note: this does not work yet. We need to prefix workspace paths with `/Workspace` first.**

Fixes #1517.

## Tests

tbd

