### PR TITLE
Return `fs.ModeDir` for Git folders in the workspace

### DIFF
--- a/libs/filer/workspace_files_client_test.go
+++ b/libs/filer/workspace_files_client_test.go
@@ -1,0 +1,56 @@
+package filer
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkspaceFilesDirEntry(t *testing.T) {
+	entries := wsfsDirEntriesFromObjectInfos([]workspace.ObjectInfo{
+		{
+			Path:       "/dir",
+			ObjectType: workspace.ObjectTypeDirectory,
+		},
+		{
+			Path:       "/file",
+			ObjectType: workspace.ObjectTypeFile,
+			Size:       42,
+		},
+		{
+			Path:       "/repo",
+			ObjectType: workspace.ObjectTypeRepo,
+		},
+	})
+
+	// Confirm the path is passed through correctly.
+	assert.Equal(t, "dir", entries[0].Name())
+	assert.Equal(t, "file", entries[1].Name())
+	assert.Equal(t, "repo", entries[2].Name())
+
+	// Confirm the type is passed through correctly.
+	assert.Equal(t, fs.ModeDir, entries[0].Type())
+	assert.Equal(t, fs.ModePerm, entries[1].Type())
+	assert.Equal(t, fs.ModeDir, entries[2].Type())
+
+	// Get [fs.FileInfo] from directory entry.
+	i0, err := entries[0].Info()
+	require.NoError(t, err)
+	i1, err := entries[1].Info()
+	require.NoError(t, err)
+	i2, err := entries[2].Info()
+	require.NoError(t, err)
+
+	// Confirm size.
+	assert.Equal(t, int64(0), i0.Size())
+	assert.Equal(t, int64(42), i1.Size())
+	assert.Equal(t, int64(0), i2.Size())
+
+	// Confirm IsDir.
+	assert.True(t, i0.IsDir())
+	assert.False(t, i1.IsDir())
+	assert.True(t, i2.IsDir())
+}


### PR DESCRIPTION
## Changes

Not doing this meant file system traversal ended upon reaching a Git folder. By marking these objects as a directory globbing traverses into these folders as well.

## Tests

Added a unit test for coverage.
