### PR TITLE
PythonMutator: register product in user agent extra

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -228,7 +228,6 @@ func setUserAgentExtraEnvVar(environ map[string]string, b *bundle.Bundle) error 
 	}
 
 	userAgentExtra := strings.Join(products, " ")
-
 	if userAgentExtra != "" {
 		environ["DATABRICKS_USER_AGENT_EXTRA"] = userAgentExtra
 	}

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -248,6 +248,27 @@ func TestSetProxyEnvVars(t *testing.T) {
 	assert.ElementsMatch(t, []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}, maps.Keys(env))
 }
 
+func TestSetUserAgentExtraEnvVar(t *testing.T) {
+	b := &bundle.Bundle{
+		RootPath: t.TempDir(),
+		Config: config.Root{
+			Experimental: &config.Experimental{
+				PyDABs: config.PyDABs{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	env := make(map[string]string, 0)
+	err := setUserAgentExtraEnvVar(env, b)
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"DATABRICKS_USER_AGENT_EXTRA": "databricks-pydabs/0.0.0",
+	}, env)
+}
+
 func TestInheritEnvVars(t *testing.T) {
 	env := map[string]string{}
 


### PR DESCRIPTION
## Changes
Register user agent product following RFC 9110.

See https://github.com/databricks/terraform-provider-databricks/pull/3520 for Terraform change.

## Tests
Unit tests