### PR TITLE
Use different Go cache key for goreleaser jobs

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -31,7 +31,7 @@ jobs:
           # that runs unit tests. This job produces and uses a different cache.
           cache-dependency-path: |
             go.sum
-            .goreleaser.yml
+            .goreleaser.yaml
 
       - name: Hide snapshot tag to outsmart GoReleaser
         run: git tag -d snapshot || true

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,6 +1,9 @@
 name: release-snapshot
 
 on:
+  pull_request:
+    types: [opened, synchronize]
+
   push:
     branches:
       - "main"
@@ -23,13 +26,21 @@ jobs:
         with:
           go-version: 1.21.x
 
+          # The default cache key for this action considers only the `go.sum` file.
+          # We include .goreleaser.yaml here to differentiate from the cache used by the push action
+          # that runs unit tests. This job produces and uses a different cache.
+          cache-dependency-path: |
+            go.sum
+            .goreleaser.yml
+
       - name: Hide snapshot tag to outsmart GoReleaser
         run: git tag -d snapshot || true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        id: releaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: ~> v2
           args: release --snapshot --skip docker
 
       - name: Upload macOS binaries

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,9 +1,6 @@
 name: release-snapshot
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-
   push:
     branches:
       - "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           go-version: 1.21.x
 
+          # The default cache key for this action considers only the `go.sum` file.
+          # We include .goreleaser.yaml here to differentiate from the cache used by the push action
+          # that runs unit tests. This job produces and uses a different cache.
+          cache-dependency-path: |
+            go.sum
+            .goreleaser.yml
+
       # Log into the GitHub Container Registry. The goreleaser action will create
       # the docker images and push them to the GitHub Container Registry.
       - uses: "docker/login-action@v3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           # that runs unit tests. This job produces and uses a different cache.
           cache-dependency-path: |
             go.sum
-            .goreleaser.yml
+            .goreleaser.yaml
 
       # Log into the GitHub Container Registry. The goreleaser action will create
       # the docker images and push them to the GitHub Container Registry.


### PR DESCRIPTION
## Changes

The goreleaser jobs perform a cross-platform build of the main binary without test files. It should use a different cache than the jobs that run tests for a single platform.

This change also updates the `release-snapshot` job to use the latest goreleaser action, as was done in #1477.

## Tests

Ran `release-snapshot` job from this PR.
