### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,9 +1,6 @@
 name: release-snapshot
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-
   push:
     branches:
       - "main"

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -33,21 +33,21 @@ jobs:
           args: release --snapshot --skip docker
 
       - name: Upload macOS binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cli_darwin_snapshot
           path: |
             dist/*_darwin_*/
 
       - name: Upload Linux binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cli_linux_snapshot
           path: |
             dist/*_linux_*/
 
       - name: Upload Windows binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cli_windows_snapshot
           path: |

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,6 +1,9 @@
 name: release-snapshot
 
 on:
+  pull_request:
+    types: [opened, synchronize]
+
   push:
     branches:
       - "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: release
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-
   push:
     tags:
       - "v*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: release
 
 on:
+  pull_request:
+    types: [opened, synchronize]
+
   push:
     tags:
       - "v*"


### PR DESCRIPTION
## Changes

This addresses a deprecation warning in our GHA output.

Full release notes of v4 at https://github.com/actions/upload-artifact/releases/tag/v4.0.0
