### PR TITLE
Use Go 1.22 to build and test

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
           # No need to download cached dependencies when running gofmt.
           cache: false
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       # Github repo: https://github.com/ajv-validator/ajv-cli
       - name: Install ajv-cli

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Hide snapshot tag to outsmart GoReleaser
         run: git tag -d snapshot || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       # Log into the GitHub Container Registry. The goreleaser action will create
       # the docker images and push them to the GitHub Container Registry.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databricks/cli
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1 // MIT

--- a/libs/process/background_test.go
+++ b/libs/process/background_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -26,8 +25,8 @@ func splitLines(b []byte) (lines []string) {
 
 func TestBackgroundUnwrapsNotFound(t *testing.T) {
 	ctx := context.Background()
-	_, err := Background(ctx, []string{"/bin/meeecho", "1"})
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err := Background(ctx, []string{"meeecho", "1"})
+	assert.ErrorIs(t, err, exec.ErrNotFound)
 }
 
 func TestBackground(t *testing.T) {


### PR DESCRIPTION
## Changes

This has been released for a while. Blog post: https://go.dev/blog/go1.22.

## Tests

None besides the unit tests.