### PR TITLE
Fix logic error in #1532

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -98,7 +98,7 @@ func Execute(cmd *cobra.Command) {
 
 	// Run the command
 	cmd, err := cmd.ExecuteContextC(ctx)
-	if err != nil && errors.Is(err, ErrAlreadyPrinted) {
+	if err != nil && !errors.Is(err, ErrAlreadyPrinted) {
 		// If cmdio logger initialization succeeds, then this function logs with the
 		// initialized cmdio logger, otherwise with the default cmdio logger
 		cmdio.LogError(cmd.Context(), err)


### PR DESCRIPTION
## Changes

This snuck into #1532 right before merging. The result is that error output is no longer logged. This includes actual execution errors as well as help output if arguments or flags are incorrectly specified.

We don't have test coverage for the `root.Execute` function. This is to be fixed later.

## Tests

Manually confirmed we observe error output again.