### PR TITLE
Change SetVariables mutator to mutate dynamic configuration instead

### DIFF
--- a/bundle/config/mutator/set_variables.go
+++ b/bundle/config/mutator/set_variables.go
@@ -2,10 +2,12 @@ package mutator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/variable"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/env"
 )
 
@@ -21,52 +23,64 @@ func (m *setVariables) Name() string {
 	return "SetVariables"
 }
 
-func setVariable(ctx context.Context, v *variable.Variable, name string) diag.Diagnostics {
+func setVariable(ctx context.Context, v dyn.Value, variable *variable.Variable, name string) (dyn.Value, error) {
 	// case: variable already has value initialized, so skip
-	if v.HasValue() {
-		return nil
+	if variable.HasValue() {
+		return v, nil
 	}
 
 	// case: read and set variable value from process environment
 	envVarName := bundleVarPrefix + name
 	if val, ok := env.Lookup(ctx, envVarName); ok {
-		if v.IsComplex() {
-			return diag.Errorf(`setting via environment variables (%s) is not supported for complex variable %s`, envVarName, name)
+		if variable.IsComplex() {
+			return dyn.InvalidValue, fmt.Errorf(`setting via environment variables (%s) is not supported for complex variable %s`, envVarName, name)
 		}
 
-		err := v.Set(val)
+		v, err := dyn.Set(v, "value", dyn.V(val))
 		if err != nil {
-			return diag.Errorf(`failed to assign value "%s" to variable %s from environment variable %s with error: %v`, val, name, envVarName, err)
+			return dyn.InvalidValue, fmt.Errorf(`failed to assign value "%s" to variable %s from environment variable %s with error: %v`, val, name, envVarName, err)
 		}
-		return nil
+		return v, nil
 	}
 
 	// case: Defined a variable for named lookup for a resource
 	// It will be resolved later in ResolveResourceReferences mutator
-	if v.Lookup != nil {
-		return nil
+	if variable.Lookup != nil {
+		return v, nil
 	}
 
 	// case: Set the variable to its default value
-	if v.HasDefault() {
-		err := v.Set(v.Default)
+	if variable.HasDefault() {
+		vDefault, err := dyn.Get(v, "default")
 		if err != nil {
-			return diag.Errorf(`failed to assign default value from config "%s" to variable %s with error: %v`, v.Default, name, err)
+			return dyn.InvalidValue, fmt.Errorf(`failed to get default value from config "%s" for variable %s with error: %v`, variable.Default, name, err)
 		}
-		return nil
+
+		v, err := dyn.Set(v, "value", vDefault)
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf(`failed to assign default value from config "%s" to variable %s with error: %v`, variable.Default, name, err)
+		}
+		return v, nil
 	}
 
 	// We should have had a value to set for the variable at this point.
-	return diag.Errorf(`no value assigned to required variable %s. Assignment can be done through the "--var" flag or by setting the %s environment variable`, name, bundleVarPrefix+name)
+	return dyn.InvalidValue, fmt.Errorf(`no value assigned to required variable %s. Assignment can be done through the "--var" flag or by setting the %s environment variable`, name, bundleVarPrefix+name)
+
 }
 
 func (m *setVariables) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	var diags diag.Diagnostics
-	for name, variable := range b.Config.Variables {
-		diags = diags.Extend(setVariable(ctx, variable, name))
-		if diags.HasError() {
-			return diags
-		}
-	}
-	return diags
+	// Updating variable "value" locaiton to its variable "default" locaiton
+	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
+		return dyn.Map(v, "variables", dyn.Foreach(func(p dyn.Path, variable dyn.Value) (dyn.Value, error) {
+			name := p[1].Key()
+			v, ok := b.Config.Variables[name]
+			if !ok {
+				return dyn.InvalidValue, fmt.Errorf(`variable "%s" is not defined`, name)
+			}
+
+			return setVariable(ctx, variable, v, name)
+		}))
+	})
+
+	return diag.FromErr(err)
 }

--- a/bundle/config/mutator/set_variables.go
+++ b/bundle/config/mutator/set_variables.go
@@ -69,7 +69,6 @@ func setVariable(ctx context.Context, v dyn.Value, variable *variable.Variable, 
 }
 
 func (m *setVariables) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	// Updating variable "value" locaiton to its variable "default" locaiton
 	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
 		return dyn.Map(v, "variables", dyn.Foreach(func(p dyn.Path, variable dyn.Value) (dyn.Value, error) {
 			name := p[1].Key()

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -751,14 +751,8 @@ func TestTranslatePathWithComplexVariables(t *testing.T) {
 	// Assign the variables to the dynamic configuration.
 	diags := bundle.ApplyFunc(ctx, b, func(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
-			var p dyn.Path
-			var err error
-
-			p = dyn.MustPathFromString("resources.jobs.job.tasks[0]")
-			v, err = dyn.SetByPath(v, p.Append(dyn.Key("libraries")), dyn.V("${var.cluster_libraries}"))
-			require.NoError(t, err)
-
-			return v, nil
+			p := dyn.MustPathFromString("resources.jobs.job.tasks[0]")
+			return dyn.SetByPath(v, p.Append(dyn.Key("libraries")), dyn.V("${var.cluster_libraries}"))
 		})
 		return diag.FromErr(err)
 	})


### PR DESCRIPTION
## Changes
Previously `SetVariables` mutator mutated typed configuration by using `v.Set` for variables. This lead to variables `value` field not having location information.

By using dynamic configuration mutation, we keep the same functionality but also preserve location information for value when it's set from default.

Fixes #1568 #1538

## Tests
Added unit tests

