### PR TITLE
Print diagnostics in 'bundle deploy'

### DIFF
--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -142,7 +142,7 @@ func renderDiagnostics(out io.Writer, b *bundle.Bundle, diags diag.Diagnostics) 
 		}
 
 		// Make file relative to bundle root
-		if d.Location.File != "" {
+		if d.Location.File != "" && b != nil {
 			out, err := filepath.Rel(b.RootPath, d.Location.File)
 			// if we can't relativize the path, just use path as-is
 			if err == nil {
@@ -160,16 +160,25 @@ func renderDiagnostics(out io.Writer, b *bundle.Bundle, diags diag.Diagnostics) 
 	return nil
 }
 
+// RenderOptions contains options for rendering diagnostics.
+type RenderOptions struct {
+	// variable to include leading new line
+
+	RenderSummaryTable bool
+}
+
 // RenderTextOutput renders the diagnostics in a human-readable format.
-func RenderTextOutput(out io.Writer, b *bundle.Bundle, diags diag.Diagnostics) error {
+func RenderTextOutput(out io.Writer, b *bundle.Bundle, diags diag.Diagnostics, opts RenderOptions) error {
 	err := renderDiagnostics(out, b, diags)
 	if err != nil {
 		return fmt.Errorf("failed to render diagnostics: %w", err)
 	}
 
-	err = renderSummaryTemplate(out, b, diags)
-	if err != nil {
-		return fmt.Errorf("failed to render summary: %w", err)
+	if opts.RenderSummaryTable {
+		err = renderSummaryTemplate(out, b, diags)
+		if err != nil {
+			return fmt.Errorf("failed to render summary: %w", err)
+		}
 	}
 
 	return nil

--- a/bundle/scripts/scripts.go
+++ b/bundle/scripts/scripts.go
@@ -37,7 +37,7 @@ func (m *script) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 
 	cmd, out, err := executeHook(ctx, executor, b, m.scriptHook)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("failed to execute script: %w", err))
 	}
 	if cmd == nil {
 		log.Debugf(ctx, "No script defined for %s, skipping", m.scriptHook)
@@ -53,7 +53,12 @@ func (m *script) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		line, err = reader.ReadString('\n')
 	}
 
-	return diag.FromErr(cmd.Wait())
+	err = cmd.Wait()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed to execute script: %w", err))
+	}
+
+	return nil
 }
 
 func executeHook(ctx context.Context, executor *exec.Executor, b *bundle.Bundle, hook config.ScriptHook) (exec.Command, io.Reader, error) {

--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -48,11 +48,13 @@ func newDeployCommand() *cobra.Command {
 				return nil
 			})
 
-			diags = bundle.Apply(ctx, b, bundle.Seq(
-				phases.Initialize(),
-				phases.Build(),
-				phases.Deploy(),
-			))
+			diags = diags.Extend(
+				bundle.Apply(ctx, b, bundle.Seq(
+					phases.Initialize(),
+					phases.Build(),
+					phases.Deploy(),
+				)),
+			)
 		}
 
 		err := render.RenderTextOutput(cmd.OutOrStdout(), b, diags)

--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -57,7 +57,8 @@ func newDeployCommand() *cobra.Command {
 			)
 		}
 
-		err := render.RenderTextOutput(cmd.OutOrStdout(), b, diags)
+		renderOpts := render.RenderOptions{RenderSummaryTable: false}
+		err := render.RenderTextOutput(cmd.OutOrStdout(), b, diags, renderOpts)
 		if err != nil {
 			return fmt.Errorf("failed to render output: %w", err)
 		}

--- a/cmd/bundle/validate.go
+++ b/cmd/bundle/validate.go
@@ -53,7 +53,8 @@ func newValidateCommand() *cobra.Command {
 
 		switch root.OutputType(cmd) {
 		case flags.OutputText:
-			err := render.RenderTextOutput(cmd.OutOrStdout(), b, diags)
+			renderOpts := render.RenderOptions{RenderSummaryTable: true}
+			err := render.RenderTextOutput(cmd.OutOrStdout(), b, diags, renderOpts)
 			if err != nil {
 				return fmt.Errorf("failed to render output: %w", err)
 			}


### PR DESCRIPTION
## Changes
Print diagnostics in 'bundle deploy' similar to 'bundle validate'. This way if a bundle has any errors or warnings, they are going to be easy to notice.

NB: due to how we render errors, there is one extra trailing new line in output, preserved in examples below

## Example: No errors or warnings

```
% databricks bundle deploy
Building default...
Deploying resources...
Updating deployment state...
Deployment complete!
```

## Example: Error on load

```
% databricks bundle deploy
Error: Databricks CLI version constraint not satisfied. Required: >= 1337.0.0, current: 0.0.0-dev

```

## Example: Warning on load

```
% databricks bundle deploy
Building default...
Deploying resources...
Updating deployment state...
Deployment complete!
Warning: unknown field: foo
  in databricks.yml:6:1

```

## Example: Error + warning on load

```
% databricks bundle deploy
Warning: unknown field: foo
  in databricks.yml:6:1

Error: something went wrong

```

## Example: Warning on load + error in init

```
% databricks bundle deploy
Warning: unknown field: foo
  in databricks.yml:6:1

Error: Failed to xxx
  in yyy.yml

Detailed explanation
in multiple lines

```

## Tests
Tested manually

