### PR TITLE
Invalidate local terraform state only when lineage match

### DIFF
--- a/bundle/deploy/terraform/state_push_test.go
+++ b/bundle/deploy/terraform/state_push_test.go
@@ -55,7 +55,7 @@ func TestStatePush(t *testing.T) {
 	b := statePushTestBundle(t)
 
 	// Write a stale local state file.
-	writeLocalState(t, ctx, b, map[string]int{"serial": 4})
+	writeLocalState(t, ctx, b, map[string]any{"serial": 4})
 	diags := bundle.Apply(ctx, b, m)
 	assert.NoError(t, diags.Error())
 }

--- a/bundle/deploy/terraform/state_test.go
+++ b/bundle/deploy/terraform/state_test.go
@@ -26,19 +26,19 @@ func localStateFile(t *testing.T, ctx context.Context, b *bundle.Bundle) string 
 	return filepath.Join(dir, TerraformStateFileName)
 }
 
-func readLocalState(t *testing.T, ctx context.Context, b *bundle.Bundle) map[string]int {
+func readLocalState(t *testing.T, ctx context.Context, b *bundle.Bundle) map[string]any {
 	f, err := os.Open(localStateFile(t, ctx, b))
 	require.NoError(t, err)
 	defer f.Close()
 
-	var contents map[string]int
+	var contents map[string]any
 	dec := json.NewDecoder(f)
 	err = dec.Decode(&contents)
 	require.NoError(t, err)
 	return contents
 }
 
-func writeLocalState(t *testing.T, ctx context.Context, b *bundle.Bundle, contents map[string]int) {
+func writeLocalState(t *testing.T, ctx context.Context, b *bundle.Bundle, contents map[string]any) {
 	f, err := os.Create(localStateFile(t, ctx, b))
 	require.NoError(t, err)
 	defer f.Close()

--- a/bundle/deploy/terraform/util.go
+++ b/bundle/deploy/terraform/util.go
@@ -22,10 +22,6 @@ type resourcesState struct {
 
 const SupportedStateVersion = 4
 
-type serialState struct {
-	Serial int `json:"serial"`
-}
-
 type stateResource struct {
 	Type      string                  `json:"type"`
 	Name      string                  `json:"name"`
@@ -41,26 +37,12 @@ type stateInstanceAttributes struct {
 	ID string `json:"id"`
 }
 
-func IsLocalStateStale(local io.Reader, remote io.Reader) bool {
-	localState, err := loadState(local)
-	if err != nil {
-		return true
-	}
-
-	remoteState, err := loadState(remote)
-	if err != nil {
-		return false
-	}
-
-	return localState.Serial < remoteState.Serial
-}
-
-func loadState(input io.Reader) (*serialState, error) {
+func loadState(input io.Reader) (*tfState, error) {
 	content, err := io.ReadAll(input)
 	if err != nil {
 		return nil, err
 	}
-	var s serialState
+	var s tfState
 	err = json.Unmarshal(content, &s)
 	if err != nil {
 		return nil, err

--- a/bundle/deploy/terraform/util_test.go
+++ b/bundle/deploy/terraform/util_test.go
@@ -2,47 +2,56 @@ package terraform
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-	"testing/iotest"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLocalStateIsNewer(t *testing.T) {
-	local := strings.NewReader(`{"serial": 5}`)
-	remote := strings.NewReader(`{"serial": 4}`)
-	assert.False(t, IsLocalStateStale(local, remote))
-}
+// func TestLocalStateIsNewer(t *testing.T) {
+// 	local := strings.NewReader(`{"serial": 5}`)
+// 	remote := strings.NewReader(`{"serial": 4}`)
+// 	assert.False(t, IsLocalStateStale(local, remote))
+// }
 
-func TestLocalStateIsOlder(t *testing.T) {
-	local := strings.NewReader(`{"serial": 5}`)
-	remote := strings.NewReader(`{"serial": 6}`)
-	assert.True(t, IsLocalStateStale(local, remote))
-}
+// func TestLocalStateIsOlder(t *testing.T) {
+// 	local := strings.NewReader(`{"serial": 5}`)
+// 	remote := strings.NewReader(`{"serial": 6}`)
+// 	assert.True(t, IsLocalStateStale(local, remote))
+// }
 
-func TestLocalStateIsTheSame(t *testing.T) {
-	local := strings.NewReader(`{"serial": 5}`)
-	remote := strings.NewReader(`{"serial": 5}`)
-	assert.False(t, IsLocalStateStale(local, remote))
-}
+// func TestLocalStateIsTheSame(t *testing.T) {
+// 	local := strings.NewReader(`{"serial": 5}`)
+// 	remote := strings.NewReader(`{"serial": 5}`)
+// 	assert.False(t, IsLocalStateStale(local, remote))
+// }
 
-func TestLocalStateMarkStaleWhenFailsToLoad(t *testing.T) {
-	local := iotest.ErrReader(fmt.Errorf("Random error"))
-	remote := strings.NewReader(`{"serial": 5}`)
-	assert.True(t, IsLocalStateStale(local, remote))
-}
+// func TestLocalStateMarkStaleWhenFailsToLoad(t *testing.T) {
+// 	local := iotest.ErrReader(fmt.Errorf("Random error"))
+// 	remote := strings.NewReader(`{"serial": 5}`)
+// 	assert.True(t, IsLocalStateStale(local, remote))
+// }
 
-func TestLocalStateMarkNonStaleWhenRemoteFailsToLoad(t *testing.T) {
-	local := strings.NewReader(`{"serial": 5}`)
-	remote := iotest.ErrReader(fmt.Errorf("Random error"))
-	assert.False(t, IsLocalStateStale(local, remote))
-}
+// func TestLocalStateMarkNonStaleWhenRemoteFailsToLoad(t *testing.T) {
+// 	local := strings.NewReader(`{"serial": 5}`)
+// 	remote := iotest.ErrReader(fmt.Errorf("Random error"))
+// 	assert.False(t, IsLocalStateStale(local, remote))
+// }
+
+// func TestLocalStateIsFromAnotherDeployment(t *testing.T) {
+// 	local := strings.NewReader(`{"serial": 5, "lineage": "alice"}`)
+// 	remote := strings.NewReader(`{"serial": 5, "lineage": "bob"}`)
+// 	assert.True(t, IsLocalStateStale(local, remote))
+// }
+
+// func TestLocalStateIsFromTheSameDeployment(t *testing.T) {
+// 	local := strings.NewReader(`{"serial": 5, "lineage": "alice"}`)
+// 	remote := strings.NewReader(`{"serial": 5, "lineage": "alice"}`)
+// 	assert.False(t, IsLocalStateStale(local, remote))
+// }
 
 func TestParseResourcesStateWithNoFile(t *testing.T) {
 	b := &bundle.Bundle{

--- a/bundle/deploy/terraform/util_test.go
+++ b/bundle/deploy/terraform/util_test.go
@@ -11,48 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// func TestLocalStateIsNewer(t *testing.T) {
-// 	local := strings.NewReader(`{"serial": 5}`)
-// 	remote := strings.NewReader(`{"serial": 4}`)
-// 	assert.False(t, IsLocalStateStale(local, remote))
-// }
-
-// func TestLocalStateIsOlder(t *testing.T) {
-// 	local := strings.NewReader(`{"serial": 5}`)
-// 	remote := strings.NewReader(`{"serial": 6}`)
-// 	assert.True(t, IsLocalStateStale(local, remote))
-// }
-
-// func TestLocalStateIsTheSame(t *testing.T) {
-// 	local := strings.NewReader(`{"serial": 5}`)
-// 	remote := strings.NewReader(`{"serial": 5}`)
-// 	assert.False(t, IsLocalStateStale(local, remote))
-// }
-
-// func TestLocalStateMarkStaleWhenFailsToLoad(t *testing.T) {
-// 	local := iotest.ErrReader(fmt.Errorf("Random error"))
-// 	remote := strings.NewReader(`{"serial": 5}`)
-// 	assert.True(t, IsLocalStateStale(local, remote))
-// }
-
-// func TestLocalStateMarkNonStaleWhenRemoteFailsToLoad(t *testing.T) {
-// 	local := strings.NewReader(`{"serial": 5}`)
-// 	remote := iotest.ErrReader(fmt.Errorf("Random error"))
-// 	assert.False(t, IsLocalStateStale(local, remote))
-// }
-
-// func TestLocalStateIsFromAnotherDeployment(t *testing.T) {
-// 	local := strings.NewReader(`{"serial": 5, "lineage": "alice"}`)
-// 	remote := strings.NewReader(`{"serial": 5, "lineage": "bob"}`)
-// 	assert.True(t, IsLocalStateStale(local, remote))
-// }
-
-// func TestLocalStateIsFromTheSameDeployment(t *testing.T) {
-// 	local := strings.NewReader(`{"serial": 5, "lineage": "alice"}`)
-// 	remote := strings.NewReader(`{"serial": 5, "lineage": "alice"}`)
-// 	assert.False(t, IsLocalStateStale(local, remote))
-// }
-
 func TestParseResourcesStateWithNoFile(t *testing.T) {
 	b := &bundle.Bundle{
 		RootPath: t.TempDir(),


### PR DESCRIPTION
## Changes
DABs deployments should be isolated if `root_path` and workspace host are different. This PR fixes a bug where local terraform state gets piggybacked if the same cwd is used to deploy two isolated deployments for the same bundle target. This can happen if:
1. A user switches to a different identity on the same machine. 
2. The workspace host URL the bundle/target points to is changed.
3. A user changes the `root_path` while doing bundle development.

To solve this problem we rely on the lineage field available in the terraform state, which is a uuid identifying unique terraform deployments. There's a 1:1 mapping between a terraform deployment and a bundle deployment.

## Tests
Manually verified that changing the identity or the host URL no longer results in the incorrect terraform state being used. Also new unit tests are added.

