### PR TITLE
Add UUID to uniquely identify a deployment state

### DIFF
--- a/bundle/deploy/state.go
+++ b/bundle/deploy/state.go
@@ -49,7 +49,7 @@ type DeploymentState struct {
 	Files Filelist `json:"files"`
 
 	// UUID uniquely identifying the deployment.
-	Id uuid.UUID `json:"id"`
+	ID uuid.UUID `json:"id"`
 }
 
 // We use this entry type as a proxy to fs.DirEntry.

--- a/bundle/deploy/state.go
+++ b/bundle/deploy/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/fileset"
 	"github.com/databricks/cli/libs/vfs"
+	"github.com/google/uuid"
 )
 
 const DeploymentStateFileName = "deployment.json"
@@ -46,6 +47,9 @@ type DeploymentState struct {
 
 	// Files is a list of files which has been deployed as part of this deployment.
 	Files Filelist `json:"files"`
+
+	// UUID uniquely identifying the deployment.
+	Id uuid.UUID `json:"id"`
 }
 
 // We use this entry type as a proxy to fs.DirEntry.

--- a/bundle/deploy/state_update.go
+++ b/bundle/deploy/state_update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/cli/internal/build"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
+	"github.com/google/uuid"
 )
 
 type stateUpdate struct {
@@ -45,6 +46,11 @@ func (s *stateUpdate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnost
 		return diag.FromErr(err)
 	}
 	state.Files = fl
+
+	// Generate a UUID for the deployment, if one does not already exist
+	if state.Id == uuid.Nil {
+		state.Id = uuid.New()
+	}
 
 	statePath, err := getPathToStateFile(ctx, b)
 	if err != nil {

--- a/bundle/deploy/state_update.go
+++ b/bundle/deploy/state_update.go
@@ -48,8 +48,8 @@ func (s *stateUpdate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnost
 	state.Files = fl
 
 	// Generate a UUID for the deployment, if one does not already exist
-	if state.Id == uuid.Nil {
-		state.Id = uuid.New()
+	if state.ID == uuid.Nil {
+		state.ID = uuid.New()
 	}
 
 	statePath, err := getPathToStateFile(ctx, b)

--- a/bundle/deploy/state_update_test.go
+++ b/bundle/deploy/state_update_test.go
@@ -91,7 +91,7 @@ func TestStateUpdate(t *testing.T) {
 	require.Equal(t, build.GetInfo().Version, state.CliVersion)
 
 	// Valid non-empty UUID is generated.
-	require.NotEqual(t, uuid.Nil, state.Id)
+	require.NotEqual(t, uuid.Nil, state.ID)
 }
 
 func TestStateUpdateWithExistingState(t *testing.T) {
@@ -113,7 +113,7 @@ func TestStateUpdateWithExistingState(t *testing.T) {
 				LocalPath: "bar/t1.py",
 			},
 		},
-		Id: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+		ID: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
 	}
 
 	data, err := json.Marshal(state)
@@ -142,5 +142,5 @@ func TestStateUpdateWithExistingState(t *testing.T) {
 	require.Equal(t, build.GetInfo().Version, state.CliVersion)
 
 	// Existing UUID is not overwritten.
-	require.Equal(t, uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"), state.Id)
+	require.Equal(t, uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"), state.ID)
 }

--- a/bundle/deploy/state_update_test.go
+++ b/bundle/deploy/state_update_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/databricks/cli/libs/fileset"
 	"github.com/databricks/cli/libs/vfs"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,6 +89,9 @@ func TestStateUpdate(t *testing.T) {
 		},
 	})
 	require.Equal(t, build.GetInfo().Version, state.CliVersion)
+
+	// Valid non-empty UUID is generated.
+	require.NotEqual(t, uuid.Nil, state.Id)
 }
 
 func TestStateUpdateWithExistingState(t *testing.T) {
@@ -109,6 +113,7 @@ func TestStateUpdateWithExistingState(t *testing.T) {
 				LocalPath: "bar/t1.py",
 			},
 		},
+		Id: uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
 	}
 
 	data, err := json.Marshal(state)
@@ -135,4 +140,7 @@ func TestStateUpdateWithExistingState(t *testing.T) {
 		},
 	})
 	require.Equal(t, build.GetInfo().Version, state.CliVersion)
+
+	// Existing UUID is not overwritten.
+	require.Equal(t, uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"), state.Id)
 }


### PR DESCRIPTION
## Changes
We need a mechanism to invalidate the locally cached deployment state if a user uses the same working directory to deploy to multiple distinct deployments (separate targets, root_paths or even hosts).

This PR just adds the UUID to the deployment state in preparation for invalidating this cache. The actual invalidation will follow up at a later date (tracked in internal backlog).

## Tests
Unit test. Manually checked the deployment state is actually being written.

