### PR TITLE
Attribute Terraform API requests the CLI

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -220,12 +220,12 @@ func setProxyEnvVars(ctx context.Context, environ map[string]string, b *bundle.B
 }
 
 func setUserAgentExtraEnvVar(environ map[string]string, b *bundle.Bundle) error {
-	// Add databricks-dabs to the user agent with the version of the CLI. This
-	// allows us to attribute HTTP request made by the Databricks Terraform provider
-	// to DABs.
-	dabsVersion := fmt.Sprintf("databricks-dabs/%s", build.GetInfo().Version)
+	// Add "cli" to the user agent in set by the Databricks Terraform provider.
+	// This will allow us to attribute downstream requests made by the Databricks
+	// Terraform provider to the CLI.
+	cliVersion := fmt.Sprintf("cli/%s", build.GetInfo().Version)
 
-	products := []string{dabsVersion}
+	products := []string{cliVersion}
 	if experimental := b.Config.Experimental; experimental != nil {
 		if experimental.PyDABs.Enabled {
 			products = append(products, "databricks-pydabs/0.0.0")

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -223,9 +223,7 @@ func setUserAgentExtraEnvVar(environ map[string]string, b *bundle.Bundle) error 
 	// Add "cli" to the user agent in set by the Databricks Terraform provider.
 	// This will allow us to attribute downstream requests made by the Databricks
 	// Terraform provider to the CLI.
-	cliVersion := fmt.Sprintf("cli/%s", build.GetInfo().Version)
-
-	products := []string{cliVersion}
+	products := []string{fmt.Sprintf("cli/%s", build.GetInfo().Version)}
 	if experimental := b.Config.Experimental; experimental != nil {
 		if experimental.PyDABs.Enabled {
 			products = append(products, "databricks-pydabs/0.0.0")

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -15,6 +15,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/internal/tf/schema"
+	"github.com/databricks/cli/internal/build"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
@@ -219,8 +220,12 @@ func setProxyEnvVars(ctx context.Context, environ map[string]string, b *bundle.B
 }
 
 func setUserAgentExtraEnvVar(environ map[string]string, b *bundle.Bundle) error {
-	var products []string
+	// Add databricks-dabs to the user agent with the version of the CLI. This
+	// allows us to attribute HTTP request made by the Databricks Terraform provider
+	// to DABs.
+	dabsVersion := fmt.Sprintf("databricks-dabs/%s", build.GetInfo().Version)
 
+	products := []string{dabsVersion}
 	if experimental := b.Config.Experimental; experimental != nil {
 		if experimental.PyDABs.Enabled {
 			products = append(products, "databricks-pydabs/0.0.0")

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -264,7 +264,7 @@ func TestSetUserAgentExtraEnvVar(t *testing.T) {
 	err := setUserAgentExtraEnvVar(env, b)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"DATABRICKS_USER_AGENT_EXTRA": "databricks-dabs/0.0.0-dev databricks-pydabs/0.0.0",
+		"DATABRICKS_USER_AGENT_EXTRA": "cli/0.0.0-dev databricks-pydabs/0.0.0",
 	}, env)
 }
 

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -262,10 +262,9 @@ func TestSetUserAgentExtraEnvVar(t *testing.T) {
 
 	env := make(map[string]string, 0)
 	err := setUserAgentExtraEnvVar(env, b)
-
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"DATABRICKS_USER_AGENT_EXTRA": "databricks-pydabs/0.0.0",
+		"DATABRICKS_USER_AGENT_EXTRA": "databricks-dabs/0.0.0-dev databricks-pydabs/0.0.0",
 	}, env)
 }
 


### PR DESCRIPTION
## Changes
This PR adds cli to the user agent sent downstream to the databricks terraform provider when invoked via DABs.
 
## Tests
Unit tests. Based on the comment here (https://github.com/databricks/cli/blob/10fe02075fec0b2e18d2eacf7412816d6e81d6bc/bundle/config/mutator/verify_cli_version_test.go#L113) we don't need to set the version to make the test assertion work correctly. This is likely because we use `go test` to run the tests while the CLI is compiled and the version is set via `goreleaser`.
