### PR TITLE
Release v0.224.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Version changelog
 
+## 0.224.0
+
+CLI:
+ * Do not buffer files in memory when downloading ([#1599](https://github.com/databricks/cli/pull/1599)).
+
+Bundles:
+ * Allow artifacts (JARs, wheels) to be uploaded to UC Volumes ([#1591](https://github.com/databricks/cli/pull/1591)).
+ * Upgrade TF provider to 1.48.3 ([#1600](https://github.com/databricks/cli/pull/1600)).
+ * Fixed job name normalisation for bundle generate ([#1601](https://github.com/databricks/cli/pull/1601)).
+
+Internal:
+ * Add UUID to uniquely identify a deployment state ([#1595](https://github.com/databricks/cli/pull/1595)).
+ * Track multiple locations associated with a `dyn.Value` ([#1510](https://github.com/databricks/cli/pull/1510)).
+ * Attribute Terraform API requests the CLI ([#1598](https://github.com/databricks/cli/pull/1598)).
+ * Implement readahead cache for Workspace API calls ([#1582](https://github.com/databricks/cli/pull/1582)).
+ * Use local Terraform state only when lineage match ([#1588](https://github.com/databricks/cli/pull/1588)).
+
+
+Dependency updates:
+ * Bump github.com/databricks/databricks-sdk-go from 0.43.0 to 0.43.2 ([#1594](https://github.com/databricks/cli/pull/1594)).
+
 ## 0.223.2
 
 Bundles:


### PR DESCRIPTION

CLI:
 * Do not buffer files in memory when downloading ([#1599](https://github.com/databricks/cli/pull/1599)).

Bundles:
 * Allow artifacts (JARs, wheels) to be uploaded to UC Volumes ([#1591](https://github.com/databricks/cli/pull/1591)).
 * Upgrade TF provider to 1.48.3 ([#1600](https://github.com/databricks/cli/pull/1600)).
 * Fixed job name normalisation for bundle generate ([#1601](https://github.com/databricks/cli/pull/1601)).

Internal:
 * Add UUID to uniquely identify a deployment state ([#1595](https://github.com/databricks/cli/pull/1595)).
 * Track multiple locations associated with a `dyn.Value` ([#1510](https://github.com/databricks/cli/pull/1510)).
 * Attribute Terraform API requests the CLI ([#1598](https://github.com/databricks/cli/pull/1598)).
 * Implement readahead cache for Workspace API calls ([#1582](https://github.com/databricks/cli/pull/1582)).
 * Use local Terraform state only when lineage match ([#1588](https://github.com/databricks/cli/pull/1588)).


Dependency updates:
 * Bump github.com/databricks/databricks-sdk-go from 0.43.0 to 0.43.2 ([#1594](https://github.com/databricks/cli/pull/1594)).

