### PR TITLE
Add read-only mode for extension aware workspace filer

### DIFF
--- a/bundle/config/mutator/configure_wsfs.go
+++ b/bundle/config/mutator/configure_wsfs.go
@@ -39,7 +39,7 @@ func (m *configureWSFS) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagno
 	// If so, swap out vfs.Path instance of the sync root with one that
 	// makes all Workspace File System interactions extension aware.
 	p, err := vfs.NewFilerPath(ctx, root, func(path string) (filer.Filer, error) {
-		return filer.NewWorkspaceFilesExtensionsClient(b.WorkspaceClient(), path)
+		return filer.NewReadOnlyWorkspaceFilesExtensionsClient(b.WorkspaceClient(), path)
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/libs/filer/workspace_files_extensions_client.go
+++ b/libs/filer/workspace_files_extensions_client.go
@@ -144,11 +144,11 @@ func (e DuplicatePathError) Error() string {
 	return fmt.Sprintf("failed to read files from the workspace file system. Duplicate paths encountered. Both %s at %s and %s at %s resolve to the same name %s. Changing the name of one of these objects will resolve this issue", e.oi1.ObjectType, e.oi1.Path, e.oi2.ObjectType, e.oi2.Path, e.commonName)
 }
 
-type ReadonlyError struct {
+type ReadOnlyError struct {
 	op string
 }
 
-func (e ReadonlyError) Error() string {
+func (e ReadOnlyError) Error() string {
 	return fmt.Sprintf("failed to %s: filer is in read-only mode", e.op)
 }
 
@@ -237,7 +237,7 @@ func (w *workspaceFilesExtensionsClient) ReadDir(ctx context.Context, name strin
 // method should be careful to avoid such clashes.
 func (w *workspaceFilesExtensionsClient) Write(ctx context.Context, name string, reader io.Reader, mode ...WriteMode) error {
 	if w.readonly {
-		return ReadonlyError{"write"}
+		return ReadOnlyError{"write"}
 	}
 
 	return w.wsfs.Write(ctx, name, reader, mode...)
@@ -274,7 +274,7 @@ func (w *workspaceFilesExtensionsClient) Read(ctx context.Context, name string) 
 // Try to delete the file as a regular file. If the file is not found, try to delete it as a notebook.
 func (w *workspaceFilesExtensionsClient) Delete(ctx context.Context, name string, mode ...DeleteMode) error {
 	if w.readonly {
-		return ReadonlyError{"delete"}
+		return ReadOnlyError{"delete"}
 	}
 
 	err := w.wsfs.Delete(ctx, name, mode...)
@@ -324,7 +324,7 @@ func (w *workspaceFilesExtensionsClient) Stat(ctx context.Context, name string) 
 // method should be careful to avoid such clashes.
 func (w *workspaceFilesExtensionsClient) Mkdir(ctx context.Context, name string) error {
 	if w.readonly {
-		return ReadonlyError{"mkdir"}
+		return ReadOnlyError{"mkdir"}
 	}
 
 	return w.wsfs.Mkdir(ctx, name)


### PR DESCRIPTION
## Changes

By default, construct a read/write instance. If constructed in read-only mode, the underlying filer is wrapped in a readahead cache.

## Tests

* Filer integration tests pass.
* Manual test that caching is enabled when running on WSFS.
