### PR TITLE
Add UUID function to bundle template functions 

### DIFF
--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
+
+	"github.com/google/uuid"
 )
 
 type ErrFail struct {
@@ -50,6 +52,10 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		// Alias for https://pkg.go.dev/math/rand#Intn. Returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n).
 		"random_int": func(n int) int {
 			return rand.Intn(n)
+		},
+		// Alias for https://pkg.go.dev/github.com/google/uuid#New. Returns, as a string, a UUID which is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC 4122.
+		"uuid": func() string {
+			return uuid.New().String()
 		},
 		// A key value pair. This is used with the map function to generate maps
 		// to use inside a template

--- a/libs/template/helpers_test.go
+++ b/libs/template/helpers_test.go
@@ -69,6 +69,23 @@ func TestTemplateRandIntFunction(t *testing.T) {
 	assert.Empty(t, err)
 }
 
+func TestTemplateUuidFunction(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	ctx = root.SetWorkspaceClient(ctx, nil)
+	helpers := loadHelpers(ctx)
+	r, err := newRenderer(ctx, nil, helpers, "./testdata/uuid/template", "./testdata/uuid/library", tmpDir)
+	require.NoError(t, err)
+
+	err = r.walk()
+	assert.NoError(t, err)
+
+	assert.Len(t, r.files, 1)
+	uuid := strings.TrimSpace(string(r.files[0].(*inMemoryFile).content))
+	assert.Regexp(t, "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", uuid)
+}
+
 func TestTemplateUrlFunction(t *testing.T) {
 	ctx := context.Background()
 	tmpDir := t.TempDir()

--- a/libs/template/testdata/uuid/template/hello.tmpl
+++ b/libs/template/testdata/uuid/template/hello.tmpl
@@ -1,0 +1,1 @@
+{{print (uuid)}}


### PR DESCRIPTION
## Changes

Add support for google/uuid.New() to DAB templates.

This is needed to generate UUIDs in downstream templates like MLOps Stacks.

## Tests

Unit tests.