### PR TITLE
Support multiple paths for diagnostics

### DIFF
--- a/bundle/config/mutator/python/python_diagnostics.go
+++ b/bundle/config/mutator/python/python_diagnostics.go
@@ -70,7 +70,7 @@ func parsePythonDiagnostics(input io.Reader) (diag.Diagnostics, error) {
 			Summary:   parsedLine.Summary,
 			Detail:    parsedLine.Detail,
 			Locations: locations,
-			Paths:    paths,
+			Paths:     paths,
 		}
 
 		diags = diags.Append(diag)

--- a/bundle/config/mutator/python/python_diagnostics.go
+++ b/bundle/config/mutator/python/python_diagnostics.go
@@ -60,7 +60,7 @@ func parsePythonDiagnostics(input io.Reader) (diag.Diagnostics, error) {
 			Summary:  parsedLine.Summary,
 			Detail:   parsedLine.Detail,
 			Location: convertPythonLocation(parsedLine.Location),
-			Path:     path,
+			Paths:    []dyn.Path{path},
 		}
 
 		diags = diags.Append(diag)

--- a/bundle/config/mutator/python/python_diagnostics.go
+++ b/bundle/config/mutator/python/python_diagnostics.go
@@ -54,13 +54,17 @@ func parsePythonDiagnostics(input io.Reader) (diag.Diagnostics, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse path: %s", err)
 		}
+		var paths []dyn.Path
+		if path != nil {
+			paths = []dyn.Path{path}
+		}
 
 		diag := diag.Diagnostic{
 			Severity: severity,
 			Summary:  parsedLine.Summary,
 			Detail:   parsedLine.Detail,
 			Location: convertPythonLocation(parsedLine.Location),
-			Paths:    []dyn.Path{path},
+			Paths:    paths,
 		}
 
 		diags = diags.Append(diag)

--- a/bundle/config/mutator/python/python_diagnostics_test.go
+++ b/bundle/config/mutator/python/python_diagnostics_test.go
@@ -54,7 +54,7 @@ func TestParsePythonDiagnostics(t *testing.T) {
 				{
 					Severity: diag.Error,
 					Summary:  "error summary",
-					Path:     dyn.MustPathFromString("resources.jobs.job0.name"),
+					Paths:    []dyn.Path{dyn.MustPathFromString("resources.jobs.job0.name")},
 				},
 			},
 		},

--- a/bundle/config/mutator/run_as.go
+++ b/bundle/config/mutator/run_as.go
@@ -180,7 +180,7 @@ func (m *setRunAs) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 			{
 				Severity:  diag.Warning,
 				Summary:   "You are using the legacy mode of run_as. The support for this mode is experimental and might be removed in a future release of the CLI. In order to run the DLT pipelines in your DAB as the run_as user this mode changes the owners of the pipelines to the run_as identity, which requires the user deploying the bundle to be a workspace admin, and also a Metastore admin if the pipeline target is in UC.",
-				Paths:    []dyn.Path{dyn.MustPathFromString("experimental.use_legacy_run_as")},
+				Paths:     []dyn.Path{dyn.MustPathFromString("experimental.use_legacy_run_as")},
 				Locations: b.Config.GetLocations("experimental.use_legacy_run_as"),
 			},
 		}

--- a/bundle/config/mutator/run_as.go
+++ b/bundle/config/mutator/run_as.go
@@ -180,7 +180,7 @@ func (m *setRunAs) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 			{
 				Severity: diag.Warning,
 				Summary:  "You are using the legacy mode of run_as. The support for this mode is experimental and might be removed in a future release of the CLI. In order to run the DLT pipelines in your DAB as the run_as user this mode changes the owners of the pipelines to the run_as identity, which requires the user deploying the bundle to be a workspace admin, and also a Metastore admin if the pipeline target is in UC.",
-				Path:     dyn.MustPathFromString("experimental.use_legacy_run_as"),
+				Paths:    []dyn.Path{dyn.MustPathFromString("experimental.use_legacy_run_as")},
 				Location: b.Config.GetLocation("experimental.use_legacy_run_as"),
 			},
 		}

--- a/bundle/config/validate/files_to_sync.go
+++ b/bundle/config/validate/files_to_sync.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/deploy/files"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
 )
 
 func FilesToSync() bundle.ReadOnlyMutator {
@@ -46,7 +47,7 @@ func (v *filesToSync) Apply(ctx context.Context, rb bundle.ReadOnlyBundle) diag.
 			Severity: diag.Warning,
 			Summary:  "There are no files to sync, please check your .gitignore and sync.exclude configuration",
 			Location: loc.Location(),
-			Path:     loc.Path(),
+			Paths:    []dyn.Path{loc.Path()},
 		})
 	}
 

--- a/bundle/config/validate/files_to_sync.go
+++ b/bundle/config/validate/files_to_sync.go
@@ -49,7 +49,7 @@ func (v *filesToSync) Apply(ctx context.Context, rb bundle.ReadOnlyBundle) diag.
 			// Show all locations where sync.exclude is defined, since merging
 			// sync.exclude is additive.
 			Locations: loc.Locations(),
-			Paths:    []dyn.Path{loc.Path()},
+			Paths:     []dyn.Path{loc.Path()},
 		})
 	}
 

--- a/bundle/config/validate/job_cluster_key_defined.go
+++ b/bundle/config/validate/job_cluster_key_defined.go
@@ -46,7 +46,7 @@ func (v *jobClusterKeyDefined) Apply(ctx context.Context, rb bundle.ReadOnlyBund
 						// Other associated locations are not relevant since they are
 						// overridden during merging.
 						Locations: []dyn.Location{loc.Location()},
-						Paths:    []dyn.Path{loc.Path()},
+						Paths:     []dyn.Path{loc.Path()},
 					})
 				}
 			}

--- a/bundle/config/validate/job_cluster_key_defined.go
+++ b/bundle/config/validate/job_cluster_key_defined.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
 )
 
 func JobClusterKeyDefined() bundle.ReadOnlyMutator {
@@ -42,7 +43,7 @@ func (v *jobClusterKeyDefined) Apply(ctx context.Context, rb bundle.ReadOnlyBund
 						Severity: diag.Warning,
 						Summary:  fmt.Sprintf("job_cluster_key %s is not defined", task.JobClusterKey),
 						Location: loc.Location(),
-						Path:     loc.Path(),
+						Paths:    []dyn.Path{loc.Path()},
 					})
 				}
 			}

--- a/bundle/config/validate/validate_sync_patterns.go
+++ b/bundle/config/validate/validate_sync_patterns.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/fileset"
 	"golang.org/x/sync/errgroup"
 )
@@ -67,7 +68,7 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 					Severity: diag.Warning,
 					Summary:  fmt.Sprintf("Pattern %s does not match any files", p),
 					Location: loc.Location(),
-					Path:     loc.Path(),
+					Paths:    []dyn.Path{loc.Path()},
 				})
 				mu.Unlock()
 			}

--- a/bundle/config/validate/validate_sync_patterns.go
+++ b/bundle/config/validate/validate_sync_patterns.go
@@ -68,7 +68,7 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 					Severity:  diag.Warning,
 					Summary:   fmt.Sprintf("Pattern %s does not match any files", p),
 					Locations: []dyn.Location{loc.Location()},
-					Paths:    []dyn.Path{loc.Path()},
+					Paths:     []dyn.Path{loc.Path()},
 				})
 				mu.Unlock()
 			}

--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -9,9 +9,28 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/fatih/color"
 )
+
+func printPaths(paths []dyn.Path) string {
+	res := strings.Builder{}
+
+	first := true
+	for _, p := range paths {
+		res.WriteString("\n")
+		if first {
+			res.WriteString("  at ")
+			first = false
+		} else {
+			res.WriteString("     ")
+		}
+
+		res.WriteString(color.GreenString(p.String()))
+	}
+	return res.String()
+}
 
 var renderFuncMap = template.FuncMap{
 	"red":     color.RedString,
@@ -26,12 +45,11 @@ var renderFuncMap = template.FuncMap{
 	"italic": func(format string, a ...interface{}) string {
 		return color.New(color.Italic).Sprintf(format, a...)
 	},
+	"printPaths": printPaths,
 }
 
 const errorTemplate = `{{ "Error" | red }}: {{ .Summary }}
-{{- if .Path.String }}
-  {{ "at " }}{{ .Path.String | green }}
-{{- end }}
+{{- printPaths .Paths -}}
 {{- if .Location.File }}
   {{ "in " }}{{ .Location.String | cyan }}
 {{- end }}
@@ -43,9 +61,7 @@ const errorTemplate = `{{ "Error" | red }}: {{ .Summary }}
 `
 
 const warningTemplate = `{{ "Warning" | yellow }}: {{ .Summary }}
-{{- if .Path.String }}
-  {{ "at " }}{{ .Path.String | green }}
-{{- end }}
+{{- printPaths .Paths -}}
 {{- if .Location.File }}
   {{ "in " }}{{ .Location.String | cyan }}
 {{- end }}

--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -9,28 +9,9 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
-	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/fatih/color"
 )
-
-func printPaths(paths []dyn.Path) string {
-	res := strings.Builder{}
-
-	first := true
-	for _, p := range paths {
-		res.WriteString("\n")
-		if first {
-			res.WriteString("  at ")
-			first = false
-		} else {
-			res.WriteString("     ")
-		}
-
-		res.WriteString(color.GreenString(p.String()))
-	}
-	return res.String()
-}
 
 var renderFuncMap = template.FuncMap{
 	"red":     color.RedString,
@@ -45,11 +26,12 @@ var renderFuncMap = template.FuncMap{
 	"italic": func(format string, a ...interface{}) string {
 		return color.New(color.Italic).Sprintf(format, a...)
 	},
-	"printPaths": printPaths,
 }
 
 const errorTemplate = `{{ "Error" | red }}: {{ .Summary }}
-{{- printPaths .Paths -}}
+{{- range $index, $element := .Paths }}
+  {{ if eq $index 0 }}at {{else}}   {{ end}}{{ $element.String | green }}
+{{- end }}
 {{- if .Location.File }}
   {{ "in " }}{{ .Location.String | cyan }}
 {{- end }}
@@ -61,7 +43,9 @@ const errorTemplate = `{{ "Error" | red }}: {{ .Summary }}
 `
 
 const warningTemplate = `{{ "Warning" | yellow }}: {{ .Summary }}
-{{- printPaths .Paths -}}
+{{- range $index, $element := .Paths }}
+  {{ if eq $index 0 }}at {{else}}   {{ end}}{{ $element.String | green }}
+{{- end }}
 {{- if .Location.File }}
   {{ "in " }}{{ .Location.String | cyan }}
 {{- end }}

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -270,7 +270,7 @@ func TestRenderDiagnostics(t *testing.T) {
 					Severity: diag.Error,
 					Detail:   "'name' is required",
 					Summary:  "failed to load xxx",
-					Path:     dyn.MustPathFromString("resources.jobs.xxx"),
+					Paths:    []dyn.Path{dyn.MustPathFromString("resources.jobs.xxx")},
 				},
 			},
 			expected: "Error: failed to load xxx\n" +

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -278,6 +278,27 @@ func TestRenderDiagnostics(t *testing.T) {
 				"\n" +
 				"'name' is required\n\n",
 		},
+		{
+			name: "error with multiple paths",
+			diags: diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Detail:   "'name' is required",
+					Summary:  "failed to load xxx",
+					Paths: []dyn.Path{
+						dyn.MustPathFromString("resources.jobs.xxx"),
+						dyn.MustPathFromString("resources.jobs.yyy"),
+						dyn.MustPathFromString("resources.jobs.zzz"),
+					},
+				},
+			},
+			expected: "Error: failed to load xxx\n" +
+				"  at resources.jobs.xxx\n" +
+				"     resources.jobs.yyy\n" +
+				"     resources.jobs.zzz\n" +
+				"\n" +
+				"'name' is required\n\n",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/bundle/tests/sync_include_exclude_no_matches_test.go
+++ b/bundle/tests/sync_include_exclude_no_matches_test.go
@@ -24,7 +24,7 @@ func TestSyncIncludeExcludeNoMatchesTest(t *testing.T) {
 	require.Equal(t, diags[0].Location.File, filepath.Join("sync", "override", "databricks.yml"))
 	require.Equal(t, diags[0].Location.Line, 17)
 	require.Equal(t, diags[0].Location.Column, 11)
-	require.Equal(t, diags[0].Path.String(), "sync.exclude[0]")
+	require.Equal(t, diags[0].Paths[0].String(), "sync.exclude[0]")
 
 	summaries := []string{
 		fmt.Sprintf("Pattern %s does not match any files", filepath.Join("src", "*")),

--- a/libs/diag/diagnostic.go
+++ b/libs/diag/diagnostic.go
@@ -21,9 +21,9 @@ type Diagnostic struct {
 	// It may be zero if there is no associated location.
 	Location dyn.Location
 
-	// Path is a path to the value in a configuration tree that the diagnostic is associated with.
-	// It may be nil if there is no associated path.
-	Path dyn.Path
+	// Paths are paths to the values in the configuration tree that the diagnostic is associated with.
+	// It may be nil if there are no associated paths.
+	Paths []dyn.Path
 }
 
 // Errorf creates a new error diagnostic.

--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -68,7 +68,7 @@ func nullWarning(expected dyn.Kind, src dyn.Value, path dyn.Path) diag.Diagnosti
 		Severity:  diag.Warning,
 		Summary:   fmt.Sprintf("expected a %s value, found null", expected),
 		Locations: []dyn.Location{src.Location()},
-		Paths:    []dyn.Path{path},
+		Paths:     []dyn.Path{path},
 	}
 }
 
@@ -77,7 +77,7 @@ func typeMismatch(expected dyn.Kind, src dyn.Value, path dyn.Path) diag.Diagnost
 		Severity:  diag.Warning,
 		Summary:   fmt.Sprintf("expected %s, found %s", expected, src.Kind()),
 		Locations: []dyn.Location{src.Location()},
-		Paths:    []dyn.Path{path},
+		Paths:     []dyn.Path{path},
 	}
 }
 
@@ -100,7 +100,7 @@ func (n normalizeOptions) normalizeStruct(typ reflect.Type, src dyn.Value, seen 
 						Summary:  fmt.Sprintf("unknown field: %s", pk.MustString()),
 						// Show all locations the unknown field is defined at.
 						Locations: pk.Locations(),
-						Paths:    []dyn.Path{path},
+						Paths:     []dyn.Path{path},
 					})
 				}
 				continue
@@ -324,7 +324,7 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value, path dyn
 				Severity:  diag.Warning,
 				Summary:   fmt.Sprintf(`cannot accurately represent "%g" as integer due to precision loss`, src.MustFloat()),
 				Locations: []dyn.Location{src.Location()},
-				Paths:    []dyn.Path{path},
+				Paths:     []dyn.Path{path},
 			})
 		}
 	case dyn.KindString:
@@ -340,7 +340,7 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value, path dyn
 				Severity:  diag.Warning,
 				Summary:   fmt.Sprintf("cannot parse %q as an integer", src.MustString()),
 				Locations: []dyn.Location{src.Location()},
-				Paths:    []dyn.Path{path},
+				Paths:     []dyn.Path{path},
 			})
 		}
 	case dyn.KindNil:
@@ -367,7 +367,7 @@ func (n normalizeOptions) normalizeFloat(typ reflect.Type, src dyn.Value, path d
 				Severity:  diag.Warning,
 				Summary:   fmt.Sprintf(`cannot accurately represent "%d" as floating point number due to precision loss`, src.MustInt()),
 				Locations: []dyn.Location{src.Location()},
-				Paths:    []dyn.Path{path},
+				Paths:     []dyn.Path{path},
 			})
 		}
 	case dyn.KindString:
@@ -383,7 +383,7 @@ func (n normalizeOptions) normalizeFloat(typ reflect.Type, src dyn.Value, path d
 				Severity:  diag.Warning,
 				Summary:   fmt.Sprintf("cannot parse %q as a floating point number", src.MustString()),
 				Locations: []dyn.Location{src.Location()},
-				Paths:    []dyn.Path{path},
+				Paths:     []dyn.Path{path},
 			})
 		}
 	case dyn.KindNil:

--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -68,7 +68,7 @@ func nullWarning(expected dyn.Kind, src dyn.Value, path dyn.Path) diag.Diagnosti
 		Severity: diag.Warning,
 		Summary:  fmt.Sprintf("expected a %s value, found null", expected),
 		Location: src.Location(),
-		Path:     path,
+		Paths:    []dyn.Path{path},
 	}
 }
 
@@ -77,7 +77,7 @@ func typeMismatch(expected dyn.Kind, src dyn.Value, path dyn.Path) diag.Diagnost
 		Severity: diag.Warning,
 		Summary:  fmt.Sprintf("expected %s, found %s", expected, src.Kind()),
 		Location: src.Location(),
-		Path:     path,
+		Paths:    []dyn.Path{path},
 	}
 }
 
@@ -99,7 +99,7 @@ func (n normalizeOptions) normalizeStruct(typ reflect.Type, src dyn.Value, seen 
 						Severity: diag.Warning,
 						Summary:  fmt.Sprintf("unknown field: %s", pk.MustString()),
 						Location: pk.Location(),
-						Path:     path,
+						Paths:    []dyn.Path{path},
 					})
 				}
 				continue
@@ -323,7 +323,7 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value, path dyn
 				Severity: diag.Warning,
 				Summary:  fmt.Sprintf(`cannot accurately represent "%g" as integer due to precision loss`, src.MustFloat()),
 				Location: src.Location(),
-				Path:     path,
+				Paths:    []dyn.Path{path},
 			})
 		}
 	case dyn.KindString:
@@ -339,7 +339,7 @@ func (n normalizeOptions) normalizeInt(typ reflect.Type, src dyn.Value, path dyn
 				Severity: diag.Warning,
 				Summary:  fmt.Sprintf("cannot parse %q as an integer", src.MustString()),
 				Location: src.Location(),
-				Path:     path,
+				Paths:    []dyn.Path{path},
 			})
 		}
 	case dyn.KindNil:
@@ -366,7 +366,7 @@ func (n normalizeOptions) normalizeFloat(typ reflect.Type, src dyn.Value, path d
 				Severity: diag.Warning,
 				Summary:  fmt.Sprintf(`cannot accurately represent "%d" as floating point number due to precision loss`, src.MustInt()),
 				Location: src.Location(),
-				Path:     path,
+				Paths:    []dyn.Path{path},
 			})
 		}
 	case dyn.KindString:
@@ -382,7 +382,7 @@ func (n normalizeOptions) normalizeFloat(typ reflect.Type, src dyn.Value, path d
 				Severity: diag.Warning,
 				Summary:  fmt.Sprintf("cannot parse %q as a floating point number", src.MustString()),
 				Location: src.Location(),
-				Path:     path,
+				Paths:    []dyn.Path{path},
 			})
 		}
 	case dyn.KindNil:

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -43,7 +43,7 @@ func TestNormalizeStructElementDiagnostic(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.NewPath(dyn.Key("bar")),
+		Paths:    []dyn.Path{dyn.NewPath(dyn.Key("bar"))},
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -69,7 +69,7 @@ func TestNormalizeStructUnknownField(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `unknown field: bar`,
 		Location: vin.Get("foo").Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 
 	// The field that can be mapped to the struct field is retained.
@@ -103,7 +103,7 @@ func TestNormalizeStructError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected map, found string`,
 		Location: vin.Get("foo").Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -248,7 +248,7 @@ func TestNormalizeStructRandomStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected map, found string`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -265,7 +265,7 @@ func TestNormalizeStructIntError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected map, found int`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -294,7 +294,7 @@ func TestNormalizeMapElementDiagnostic(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.NewPath(dyn.Key("bar")),
+		Paths:    []dyn.Path{dyn.NewPath(dyn.Key("bar"))},
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -320,7 +320,7 @@ func TestNormalizeMapError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected map, found string`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -375,7 +375,7 @@ func TestNormalizeMapRandomStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected map, found string`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -388,7 +388,7 @@ func TestNormalizeMapIntError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected map, found int`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -418,7 +418,7 @@ func TestNormalizeSliceElementDiagnostic(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.NewPath(dyn.Index(2)),
+		Paths:    []dyn.Path{dyn.NewPath(dyn.Index(2))},
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -442,7 +442,7 @@ func TestNormalizeSliceError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected sequence, found string`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -497,7 +497,7 @@ func TestNormalizeSliceRandomStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected sequence, found string`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -510,7 +510,7 @@ func TestNormalizeSliceIntError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected sequence, found int`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -531,7 +531,7 @@ func TestNormalizeStringNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a string value, found null`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -568,7 +568,7 @@ func TestNormalizeStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected string, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -589,7 +589,7 @@ func TestNormalizeBoolNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a bool value, found null`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -631,7 +631,7 @@ func TestNormalizeBoolFromStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected bool, found string`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -644,7 +644,7 @@ func TestNormalizeBoolError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected bool, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -665,7 +665,7 @@ func TestNormalizeIntNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a int value, found null`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -686,7 +686,7 @@ func TestNormalizeIntFromFloatError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `cannot accurately represent "1.5" as integer due to precision loss`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -715,7 +715,7 @@ func TestNormalizeIntFromStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `cannot parse "abc" as an integer`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -728,7 +728,7 @@ func TestNormalizeIntError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected int, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -749,7 +749,7 @@ func TestNormalizeFloatNil(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected a float value, found null`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -774,7 +774,7 @@ func TestNormalizeFloatFromIntError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `cannot accurately represent "9007199254740993" as floating point number due to precision loss`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -803,7 +803,7 @@ func TestNormalizeFloatFromStringError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `cannot parse "abc" as a floating point number`,
 		Location: vin.Location(),
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -816,7 +816,7 @@ func TestNormalizeFloatError(t *testing.T) {
 		Severity: diag.Warning,
 		Summary:  `expected float, found map`,
 		Location: dyn.Location{},
-		Path:     dyn.EmptyPath,
+		Paths:    []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -40,10 +40,10 @@ func TestNormalizeStructElementDiagnostic(t *testing.T) {
 	vout, err := Normalize(typ, vin)
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
-		Severity: diag.Warning,
-		Summary:  `expected string, found map`,
+		Severity:  diag.Warning,
+		Summary:   `expected string, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.NewPath(dyn.Key("bar"))},
+		Paths:     []dyn.Path{dyn.NewPath(dyn.Key("bar"))},
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -79,7 +79,7 @@ func TestNormalizeStructUnknownField(t *testing.T) {
 			{File: "hello.yaml", Line: 1, Column: 1},
 			{File: "world.yaml", Line: 2, Column: 2},
 		},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths: []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 
 	// The field that can be mapped to the struct field is retained.
@@ -113,7 +113,7 @@ func TestNormalizeStructError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected map, found string`,
 		Locations: []dyn.Location{vin.Get("foo").Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -258,7 +258,7 @@ func TestNormalizeStructRandomStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected map, found string`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -275,7 +275,7 @@ func TestNormalizeStructIntError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected map, found int`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -304,7 +304,7 @@ func TestNormalizeMapElementDiagnostic(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected string, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.NewPath(dyn.Key("bar"))},
+		Paths:     []dyn.Path{dyn.NewPath(dyn.Key("bar"))},
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -330,7 +330,7 @@ func TestNormalizeMapError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected map, found string`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -385,7 +385,7 @@ func TestNormalizeMapRandomStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected map, found string`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -398,7 +398,7 @@ func TestNormalizeMapIntError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected map, found int`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -425,10 +425,10 @@ func TestNormalizeSliceElementDiagnostic(t *testing.T) {
 	vout, err := Normalize(typ, vin)
 	assert.Len(t, err, 1)
 	assert.Equal(t, diag.Diagnostic{
-		Severity: diag.Warning,
-		Summary:  `expected string, found map`,
+		Severity:  diag.Warning,
+		Summary:   `expected string, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.NewPath(dyn.Index(2))},
+		Paths:     []dyn.Path{dyn.NewPath(dyn.Index(2))},
 	}, err[0])
 
 	// Elements that encounter an error during normalization are dropped.
@@ -452,7 +452,7 @@ func TestNormalizeSliceError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected sequence, found string`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -507,7 +507,7 @@ func TestNormalizeSliceRandomStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected sequence, found string`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -520,7 +520,7 @@ func TestNormalizeSliceIntError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected sequence, found int`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -541,7 +541,7 @@ func TestNormalizeStringNil(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected a string value, found null`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -578,7 +578,7 @@ func TestNormalizeStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected string, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -599,7 +599,7 @@ func TestNormalizeBoolNil(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected a bool value, found null`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -641,7 +641,7 @@ func TestNormalizeBoolFromStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected bool, found string`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -654,7 +654,7 @@ func TestNormalizeBoolError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected bool, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -675,7 +675,7 @@ func TestNormalizeIntNil(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected a int value, found null`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -696,7 +696,7 @@ func TestNormalizeIntFromFloatError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `cannot accurately represent "1.5" as integer due to precision loss`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -725,7 +725,7 @@ func TestNormalizeIntFromStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `cannot parse "abc" as an integer`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -738,7 +738,7 @@ func TestNormalizeIntError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected int, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -759,7 +759,7 @@ func TestNormalizeFloatNil(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected a float value, found null`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -784,7 +784,7 @@ func TestNormalizeFloatFromIntError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `cannot accurately represent "9007199254740993" as floating point number due to precision loss`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -813,7 +813,7 @@ func TestNormalizeFloatFromStringError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `cannot parse "abc" as a floating point number`,
 		Locations: []dyn.Location{vin.Location()},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 
@@ -826,7 +826,7 @@ func TestNormalizeFloatError(t *testing.T) {
 		Severity:  diag.Warning,
 		Summary:   `expected float, found map`,
 		Locations: []dyn.Location{{}},
-		Paths:    []dyn.Path{dyn.EmptyPath},
+		Paths:     []dyn.Path{dyn.EmptyPath},
 	}, err[0])
 }
 


### PR DESCRIPTION
## Changes
Some diagnostics can have multiple paths associated with them. For instance, ensuring that unique resource keys are used across all resources. This PR extends `diag.Diagnostic` to accept multiple paths.

This PR is symmetrical to https://github.com/databricks/cli/pull/1610/files

## Tests
Unit tests
