### PR TITLE
Update Python dependencies before install when upgrading a labs project

### DIFF
--- a/cmd/labs/project/installer.go
+++ b/cmd/labs/project/installer.go
@@ -132,13 +132,13 @@ func (i *installer) Upgrade(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("record version: %w", err)
 	}
-	err = i.runInstallHook(ctx)
-	if err != nil {
-		return fmt.Errorf("installer: %w", err)
-	}
 	err = i.installPythonDependencies(ctx, ".")
 	if err != nil {
 		return fmt.Errorf("python dependencies: %w", err)
+	}
+	err = i.runInstallHook(ctx)
+	if err != nil {
+		return fmt.Errorf("installer: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
The install script might require the up-to-date Python dependencies, explained in more detail in the referenced issue below

Fixes #1623 

## Tests
! Need support with testing !

