### PR TITLE
Release v0.224.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Version changelog
 
+## 0.224.1
+
+Bundles:
+ * Add UUID function to bundle template functions  ([#1612](https://github.com/databricks/cli/pull/1612)).
+ * Upgrade TF provider to 1.49.0 ([#1617](https://github.com/databricks/cli/pull/1617)).
+ * Upgrade TF provider to 1.49.1 ([#1626](https://github.com/databricks/cli/pull/1626)).
+ * Support multiple locations for diagnostics ([#1610](https://github.com/databricks/cli/pull/1610)).
+ * Split artifact cleanup into prepare step before build ([#1618](https://github.com/databricks/cli/pull/1618)).
+ * Move to a single prompt during bundle destroy ([#1583](https://github.com/databricks/cli/pull/1583)).
+
+Internal:
+ * Add tests for the Workspace API readahead cache ([#1605](https://github.com/databricks/cli/pull/1605)).
+ * Update Python dependencies before install when upgrading a labs project ([#1624](https://github.com/databricks/cli/pull/1624)).
+
+
+
 ## 0.224.0
 
 CLI:


### PR DESCRIPTION

Bundles:
 * Add UUID function to bundle template functions  ([#1612](https://github.com/databricks/cli/pull/1612)).
 * Upgrade TF provider to 1.49.0 ([#1617](https://github.com/databricks/cli/pull/1617)).
 * Upgrade TF provider to 1.49.1 ([#1626](https://github.com/databricks/cli/pull/1626)).
 * Support multiple locations for diagnostics ([#1610](https://github.com/databricks/cli/pull/1610)).
 * Split artifact cleanup into prepare step before build ([#1618](https://github.com/databricks/cli/pull/1618)).
 * Move to a single prompt during bundle destroy ([#1583](https://github.com/databricks/cli/pull/1583)).

Internal:
 * Add tests for the Workspace API readahead cache ([#1605](https://github.com/databricks/cli/pull/1605)).
 * Update Python dependencies before install when upgrading a labs project ([#1624](https://github.com/databricks/cli/pull/1624)).



