### PR TITLE
Add periodic trigger in trigger options

### DIFF
--- a/bundle/internal/tf/schema/resource_job.go
+++ b/bundle/internal/tf/schema/resource_job.go
@@ -1397,8 +1397,8 @@ type ResourceJobTriggerTableUpdate struct {
 }
 
 type ResourceJobTriggerPeriodic struct {
-	Interval int `json:"interval,omitempty"`
-	Unit string `json:"unit,omitempty"`
+	Interval int    `json:"interval,omitempty"`
+	Unit     string `json:"unit,omitempty"`
 }
 
 type ResourceJobTrigger struct {


### PR DESCRIPTION
## Changes
- Add periodic triggers to trigger options to follow terraform definition

## Tests
- DAB deployment with CLI using periodic triggers

Long term we should look into retiring this manual allowlist, and look into autogenerating from SDK.

