### PR TITLE
Fix python wheel task integration tests

### DIFF
--- a/internal/bundle/bundles/python_wheel_task/databricks_template_schema.json
+++ b/internal/bundle/bundles/python_wheel_task/databricks_template_schema.json
@@ -20,6 +20,10 @@
         "python_wheel_wrapper": {
             "type": "boolean",
             "description": "Whether or not to enable python wheel wrapper"
+        },
+        "instance_pool_id": {
+            "type": "string",
+            "description": "Instance pool id for job cluster"
         }
     }
 }

--- a/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/python_wheel_task/template/databricks.yml.tmpl
@@ -20,6 +20,7 @@ resources:
             spark_version: "{{.spark_version}}"
             node_type_id: "{{.node_type_id}}"
             data_security_mode: USER_ISOLATION
+            instance_pool_id: "{{.instance_pool_id}}"
           python_wheel_task:
             package_name: my_test_code
             entry_point: run

--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -14,11 +14,13 @@ func runPythonWheelTest(t *testing.T, sparkVersion string, pythonWheelWrapper bo
 	ctx, _ := acc.WorkspaceTest(t)
 
 	nodeTypeId := internal.GetNodeTypeId(env.Get(ctx, "CLOUD_ENV"))
+	instancePoolId := env.Get(ctx, "TEST_INSTANCE_POOL_ID")
 	bundleRoot, err := initTestTemplate(t, ctx, "python_wheel_task", map[string]any{
 		"node_type_id":         nodeTypeId,
 		"unique_id":            uuid.New().String(),
 		"spark_version":        sparkVersion,
 		"python_wheel_wrapper": pythonWheelWrapper,
+		"instance_pool_id":     instancePoolId,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes
A new Service Control Policy has removed the `ec2.RunInstances` permission from our service principal for our AWS integration tests. This PR switches over to using the instance pool which does not require creating new clusters.

## Tests
The integration tests pass now.
