### PR TITLE
Enable Spark JAR task test

### DIFF
--- a/internal/bundle/bundles/spark_jar_task/databricks_template_schema.json
+++ b/internal/bundle/bundles/spark_jar_task/databricks_template_schema.json
@@ -24,6 +24,10 @@
         "artifact_path": {
             "type": "string",
             "description": "Path to the remote base path for artifacts"
+        },
+        "instance_pool_id": {
+            "type": "string",
+            "description": "Instance pool id for job cluster"
         }
     }
 }

--- a/internal/bundle/bundles/spark_jar_task/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/spark_jar_task/template/databricks.yml.tmpl
@@ -22,6 +22,7 @@ resources:
             num_workers: 1
             spark_version: "{{.spark_version}}"
             node_type_id: "{{.node_type_id}}"
+            instance_pool_id: "{{.instance_pool_id}}"
           spark_jar_task:
             main_class_name: PrintArgs
           libraries:


### PR DESCRIPTION
## Changes
Enable Spark JAR task test

## Tests
```

Updating deployment state...
Deleting files...
Destroy complete!
--- PASS: TestAccSparkJarTaskDeployAndRunOnVolumes (194.13s)
PASS
coverage: 51.9% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       194.586s        coverage: 51.9% of statements in ./...
```

