### PR TITLE
Add trailing slash to directory to produce completions for

### DIFF
--- a/internal/completer_test.go
+++ b/internal/completer_test.go
@@ -21,7 +21,7 @@ func TestAccFsCompletion(t *testing.T) {
 	f, tmpDir := setupDbfsFiler(t)
 	setupCompletionFile(t, f)
 
-	stdout, _ := RequireSuccessfulRun(t, "__complete", "fs", "ls", tmpDir)
+	stdout, _ := RequireSuccessfulRun(t, "__complete", "fs", "ls", tmpDir+"/")
 	expectedOutput := fmt.Sprintf("%s/dir1/\n:2\n", tmpDir)
 	assert.Equal(t, expectedOutput, stdout.String())
 }

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -94,10 +94,16 @@ func consumeLines(ctx context.Context, wg *sync.WaitGroup, r io.Reader) <-chan s
 		defer wg.Done()
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
+			// We expect to be able to always send these lines into the channel.
+			// If we can't, it means the channel is full and likely there is a problem
+			// in either the test or the code under test.
 			select {
 			case <-ctx.Done():
 				return
 			case ch <- scanner.Text():
+				continue
+			default:
+				panic("line buffer is full")
 			}
 		}
 	}()


### PR DESCRIPTION
## Changes

The integration test for `fs ls` tried to produce completions for the temporary directory without a trailing slash. The command will list the parent directory to see if there are more directories with the same prefix that are also valid completions. The test intends to test completions for files inside the temporary directory, so we need that trailing slash.

This test was hanging because the parent directory of the temporary DBFS directory has more than 1k entries (on our integration testing workspaces) and the line buffer in the test runner has a capacity of 1k lines. To avoid the same hang in the future, this change modifies the test runner to panic if the line buffer is full.

## Tests

Confirmed the integration test no longer hangs.
