### PR TITLE
Skip pushing Terraform state after destroy

### DIFF
--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -83,7 +83,6 @@ func Destroy() bundle.Mutator {
 	// Core destructive mutators for destroy. These require informed user consent.
 	destroyCore := bundle.Seq(
 		terraform.Apply(),
-		terraform.StatePush(),
 		files.Delete(),
 		bundle.LogString("Destroy complete!"),
 	)


### PR DESCRIPTION
## Changes
Following up https://github.com/databricks/cli/pull/1583#discussion_r1681126323.

We can skip pushing because right after `root_path` is deleted, making this a no-op effectively. 
 
## Tests
