### PR TITLE
Update VS Code settings to match latest value from IDE plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
-    "python.envFile": "${workspaceFolder}/.databricks/.databricks.env",
+    "python.envFile": "${workspaceRoot}/.env",
     "databricks.python.envFile": "${workspaceFolder}/.env",
     "python.analysis.stubPath": ".vscode",
     "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",


### PR DESCRIPTION
## Changes
This updates the `python.envFile` property from VS Code's settings file to use the value that is set by the latest version of the IDE plugin. This change will make it a bit easier for contributors who work on the CLI code base with the plugin enabled.
