### PR TITLE
Print non-json logs in `import-dir` and `export-dir` commands

### DIFF
--- a/cmd/workspace/workspace/export_dir.go
+++ b/cmd/workspace/workspace/export_dir.go
@@ -110,8 +110,7 @@ func newExportDir() *cobra.Command {
 		}
 		workspaceFS := filer.NewFS(ctx, workspaceFiler)
 
-		// TODO: print progress events on stderr instead: https://github.com/databricks/cli/issues/448
-		err = cmdio.RenderJson(ctx, newExportStartedEvent(opts.sourceDir))
+		err = cmdio.RenderWithTemplate(ctx, newExportStartedEvent(opts.sourceDir), "", "Exporting files from {{.SourcePath}}")
 		if err != nil {
 			return err
 		}
@@ -120,7 +119,7 @@ func newExportDir() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		return cmdio.RenderJson(ctx, newExportCompletedEvent(opts.targetDir))
+		return cmdio.RenderWithTemplate(ctx, newImportCompletedEvent(opts.targetDir), "", "Exported complete. The files are available at {{.TargetPath}}\n")
 	}
 
 	return cmd

--- a/cmd/workspace/workspace/import_dir.go
+++ b/cmd/workspace/workspace/import_dir.go
@@ -134,8 +134,7 @@ Notebooks will have their extensions (one of .scala, .py, .sql, .ipynb, .r) stri
 			return err
 		}
 
-		// TODO: print progress events on stderr instead: https://github.com/databricks/cli/issues/448
-		err = cmdio.RenderJson(ctx, newImportStartedEvent(opts.sourceDir))
+		err = cmdio.RenderWithTemplate(ctx, newImportStartedEvent(opts.sourceDir), "", "Importing files from {{.SourcePath}}")
 		if err != nil {
 			return err
 		}
@@ -145,7 +144,7 @@ Notebooks will have their extensions (one of .scala, .py, .sql, .ipynb, .r) stri
 		if err != nil {
 			return err
 		}
-		return cmdio.RenderJson(ctx, newImportCompletedEvent(opts.targetDir))
+		return cmdio.RenderWithTemplate(ctx, newImportCompletedEvent(opts.targetDir), "", "Import complete. The files are available at {{.TargetPath}}\n")
 	}
 
 	return cmd


### PR DESCRIPTION
## Changes
In https://github.com/databricks/cli/pull/1202/files#diff-079cc6ade5a744a6b308b134fd47999f57ed7aba4f8ca5623c7a392bfab28436 the semantics of `cmdio.RenderJson` was changes to always render the JSON object. Before we would only render it if `--output json` was specified.

This PR fixes the logs to print human-readable log lines instead of a JSON object.

## Tests
Manually:
```
➜  bundle-playground git:(master) ✗ cli workspace import-dir ./tmp /Users/shreyas.goenka@databricks.com/test-import-1 -p aws-prod-ucws
Importing files from ./tmp
a -> /Users/shreyas.goenka@databricks.com/test-import-1/a
Import complete. The files are available at /Users/shreyas.goenka@databricks.com/test-import-1
```
```
➜  bundle-playground git:(master) ✗ cli workspace export-dir  /Users/shreyas.goenka@databricks.com/test-export-1 ./tmp-2 -p aws-prod-ucws
Exporting files from /Users/shreyas.goenka@databricks.com/test-export-1
/Users/shreyas.goenka@databricks.com/test-export-1/b -> tmp-2/b
Exported complete. The files are available at ./tmp-2
```
