### PR TITLE
Fix integration tests after Go SDK bump

### DIFF
--- a/internal/alerts_test.go
+++ b/internal/alerts_test.go
@@ -9,6 +9,6 @@ import (
 func TestAccAlertsCreateErrWhenNoArguments(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
-	_, _, err := RequireErrorRun(t, "alerts", "create")
+	_, _, err := RequireErrorRun(t, "alerts-legacy", "create")
 	assert.Equal(t, "please provide command input in JSON format by specifying the --json flag", err.Error())
 }

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -87,7 +87,7 @@ type cobraTestRunner struct {
 }
 
 func consumeLines(ctx context.Context, wg *sync.WaitGroup, r io.Reader) <-chan string {
-	ch := make(chan string, 1000)
+	ch := make(chan string, 10000)
 	wg.Add(1)
 	go func() {
 		defer close(ch)


### PR DESCRIPTION
## Changes
These 2 tests failed

`TestAccAlertsCreateErrWhenNoArguments ` -> switched to legacy command for now, new one does not have a required request body (might be an OpenAPI spec issue https://github.com/databricks/databricks-sdk-go/blob/main/service/sql/model.go#L595), will follow up later 

`TestAccClustersList` -> increased channel size because new clusters API returns more clusters

## Tests
Tests are green now

