### PR TITLE
Make `pydabs/venv_path` optional

### DIFF
--- a/bundle/artifacts/whl/infer.go
+++ b/bundle/artifacts/whl/infer.go
@@ -15,6 +15,8 @@ type infer struct {
 
 func (m *infer) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	artifact := b.Config.Artifacts[m.name]
+
+	// TODO use python.DetectVEnvExecutable once bundle has a way to specify venv path
 	py, err := python.DetectExecutable(ctx)
 	if err != nil {
 		return diag.FromErr(err)

--- a/bundle/config/experimental.go
+++ b/bundle/config/experimental.go
@@ -36,8 +36,8 @@ type PyDABs struct {
 
 	// VEnvPath is path to the virtual environment.
 	//
-	// Required if PyDABs is enabled. PyDABs will load the code in the specified
-	// environment.
+	// If enabled, PyDABs will execute code within this environment. If disabled,
+	// it defaults to using the Python interpreter available in the current shell.
 	VEnvPath string `json:"venv_path,omitempty"`
 }
 

--- a/bundle/config/mutator/python/python_mutator.go
+++ b/bundle/config/mutator/python/python_mutator.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
+	"github.com/databricks/cli/libs/python"
 	"github.com/databricks/databricks-sdk-go/logger"
 
 	"github.com/databricks/cli/bundle/env"
@@ -86,23 +86,15 @@ func (m *pythonMutator) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagno
 		return nil
 	}
 
-	if experimental.PyDABs.VEnvPath == "" {
-		return diag.Errorf("\"experimental.pydabs.enabled\" can only be used when \"experimental.pydabs.venv_path\" is set")
-	}
-
 	// mutateDiags is used because Mutate returns 'error' instead of 'diag.Diagnostics'
 	var mutateDiags diag.Diagnostics
 	var mutateDiagsHasError = errors.New("unexpected error")
 
 	err := b.Config.Mutate(func(leftRoot dyn.Value) (dyn.Value, error) {
-		pythonPath := interpreterPath(experimental.PyDABs.VEnvPath)
+		pythonPath, err := detectExecutable(ctx, experimental.PyDABs.VEnvPath)
 
-		if _, err := os.Stat(pythonPath); err != nil {
-			if os.IsNotExist(err) {
-				return dyn.InvalidValue, fmt.Errorf("can't find %q, check if venv is created", pythonPath)
-			} else {
-				return dyn.InvalidValue, fmt.Errorf("can't find %q: %w", pythonPath, err)
-			}
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf("failed to get Python interpreter path: %w", err)
 		}
 
 		cacheDir, err := createCacheDir(ctx)
@@ -423,11 +415,17 @@ func isOmitemptyDelete(left dyn.Value) bool {
 	}
 }
 
-// interpreterPath returns platform-specific path to Python interpreter in the virtual environment.
-func interpreterPath(venvPath string) string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(venvPath, "Scripts", "python3.exe")
-	} else {
-		return filepath.Join(venvPath, "bin", "python3")
+// detectExecutable lookups Python interpreter in virtual environment, or if not set, in PATH.
+func detectExecutable(ctx context.Context, venvPath string) (string, error) {
+	if venvPath == "" {
+		interpreter, err := python.DetectExecutable(ctx)
+
+		if err != nil {
+			return "", err
+		}
+
+		return interpreter, nil
 	}
+
+	return python.DetectVEnvExecutable(venvPath)
 }

--- a/bundle/config/mutator/python/python_mutator.go
+++ b/bundle/config/mutator/python/python_mutator.go
@@ -419,7 +419,6 @@ func isOmitemptyDelete(left dyn.Value) bool {
 func detectExecutable(ctx context.Context, venvPath string) (string, error) {
 	if venvPath == "" {
 		interpreter, err := python.DetectExecutable(ctx)
-
 		if err != nil {
 			return "", err
 		}

--- a/libs/python/detect.go
+++ b/libs/python/detect.go
@@ -58,7 +58,7 @@ func DetectVEnvExecutable(venvPath string) (string, error) {
 	}
 
 	if _, err := os.Stat(interpreterPath); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return "", fmt.Errorf("can't find %q, check if virtualenv is created", interpreterPath)
 		} else {
 			return "", fmt.Errorf("can't find %q: %w", interpreterPath, err)

--- a/libs/python/detect.go
+++ b/libs/python/detect.go
@@ -67,9 +67,13 @@ func DetectVEnvExecutable(venvPath string) (string, error) {
 
 	// pyvenv.cfg must be always present in correctly configured virtualenv,
 	// read more in https://snarky.ca/how-virtual-environments-work/
-	_, err := os.Stat(filepath.Join(venvPath, "pyvenv.cfg"))
-	if errors.Is(err, fs.ErrNotExist) {
-		return "", fmt.Errorf("expected %q to be virtualenv, but pyenv.cfg is missing", venvPath)
+	pyvenvPath := filepath.Join(venvPath, "pyvenv.cfg")
+	if _, err := os.Stat(pyvenvPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("expected %q to be virtualenv, but pyvenv.cfg is missing", venvPath)
+		} else {
+			return "", fmt.Errorf("can't find %q: %w", pyvenvPath, err)
+		}
 	}
 
 	return interpreterPath, nil

--- a/libs/python/detect.go
+++ b/libs/python/detect.go
@@ -65,6 +65,8 @@ func DetectVEnvExecutable(venvPath string) (string, error) {
 		}
 	}
 
+	// pyvenv.cfg must be always present in correctly configured virtualenv,
+	// read more in https://snarky.ca/how-virtual-environments-work/
 	_, err := os.Stat(filepath.Join(venvPath, "pyvenv.cfg"))
 	if errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("expected %q to be virtualenv, but pyenv.cfg is missing", venvPath)

--- a/libs/python/detect_test.go
+++ b/libs/python/detect_test.go
@@ -1,0 +1,46 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectVEnvExecutable(t *testing.T) {
+	dir := t.TempDir()
+	interpreterPath := interpreterPath(dir)
+
+	err := os.Mkdir(filepath.Dir(interpreterPath), 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(interpreterPath, []byte(""), 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(dir, "pyvenv.cfg"), []byte(""), 0755)
+	require.NoError(t, err)
+
+	executable, err := DetectVEnvExecutable(dir)
+
+	assert.NoError(t, err)
+	assert.Equal(t, interpreterPath, executable)
+}
+
+func TestDetectVEnvExecutable_badLayout(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := DetectVEnvExecutable(dir)
+
+	assert.Errorf(t, err, "can't find %q, check if virtualenv is created", interpreterPath(dir))
+}
+
+func interpreterPath(venvPath string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(venvPath, "Scripts", "python3.exe")
+	} else {
+		return filepath.Join(venvPath, "bin", "python3")
+	}
+}


### PR DESCRIPTION
## Changes
Make `pydabs/venv_path` optional. When not specified, CLI detects the Python interpreter using `python.DetectExecutable`, the same way as for `artifacts`. `python.DetectExecutable` works correctly if a virtual environment is activated or `python3` is available on PATH through other means.

Extract the venv detection code from PyDABs into `libs/python/detect`. This code will be used when we implement the `python/venv_path` section in `databricks.yml`.

## Tests
Unit tests and manually