### PR TITLE
Remove reference to "dbt" in the default-sql template

### DIFF
--- a/libs/template/templates/default-sql/databricks_template_schema.json
+++ b/libs/template/templates/default-sql/databricks_template_schema.json
@@ -13,7 +13,7 @@
             "type": "string",
             "pattern": "^/sql/.\\../warehouses/[a-z0-9]+$",
             "pattern_match_failure_message": "Path must be of the form /sql/1.0/warehouses/<warehouse id>",
-            "description": "\nPlease provide the HTTP Path of the SQL warehouse you would like to use with dbt during development.\nYou can find this path by clicking on \"Connection details\" for your SQL warehouse.\nhttp_path [example: /sql/1.0/warehouses/abcdef1234567890]",
+            "description": "\nPlease provide the HTTP Path of the SQL warehouse you would like to use during development.\nYou can find this path by clicking on \"Connection details\" for your SQL warehouse.\nhttp_path [example: /sql/1.0/warehouses/abcdef1234567890]",
             "order": 2
         },
         "default_catalog": {


### PR DESCRIPTION
## Changes

The `default-sql` template inadvertently mentioned dbt in one of the prompts. This PR removes that reference.
