### PR TITLE
Fix prefix preset used for UC schemas

### DIFF
--- a/bundle/config/mutator/apply_presets.go
+++ b/bundle/config/mutator/apply_presets.go
@@ -155,8 +155,7 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 
 	// Schemas: Prefix
 	for i := range r.Schemas {
-		prefix = "dev_" + b.Config.Workspace.CurrentUser.ShortName + "_"
-		r.Schemas[i].Name = prefix + r.Schemas[i].Name
+		r.Schemas[i].Name = normalizePrefix(prefix) + r.Schemas[i].Name
 		// HTTP API for schemas doesn't yet support tags. It's only supported in
 		// the Databricks UI and via the SQL API.
 	}

--- a/bundle/config/mutator/apply_presets_test.go
+++ b/bundle/config/mutator/apply_presets_test.go
@@ -77,7 +77,7 @@ func TestApplyPresetsPrefixForUcSchema(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "add prefix to job",
+			name:   "add prefix to schema",
 			prefix: "[prefix]",
 			schema: &resources.Schema{
 				CreateSchema: &catalog.CreateSchema{
@@ -87,7 +87,7 @@ func TestApplyPresetsPrefixForUcSchema(t *testing.T) {
 			want: "prefix_schema1",
 		},
 		{
-			name:   "add empty prefix to job",
+			name:   "add empty prefix to schema",
 			prefix: "",
 			schema: &resources.Schema{
 				CreateSchema: &catalog.CreateSchema{

--- a/bundle/config/mutator/apply_presets_test.go
+++ b/bundle/config/mutator/apply_presets_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/mutator"
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/require"
 )
@@ -64,6 +65,62 @@ func TestApplyPresetsPrefix(t *testing.T) {
 			}
 
 			require.Equal(t, tt.want, b.Config.Resources.Jobs["job1"].Name)
+		})
+	}
+}
+
+func TestApplyPresetsPrefixForUcSchema(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		schema *resources.Schema
+		want   string
+	}{
+		{
+			name:   "add prefix to job",
+			prefix: "[prefix]",
+			schema: &resources.Schema{
+				CreateSchema: &catalog.CreateSchema{
+					Name: "schema1",
+				},
+			},
+			want: "prefix_schema1",
+		},
+		{
+			name:   "add empty prefix to job",
+			prefix: "",
+			schema: &resources.Schema{
+				CreateSchema: &catalog.CreateSchema{
+					Name: "schema1",
+				},
+			},
+			want: "schema1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Schemas: map[string]*resources.Schema{
+							"schema1": tt.schema,
+						},
+					},
+					Presets: config.Presets{
+						NamePrefix: tt.prefix,
+					},
+				},
+			}
+
+			ctx := context.Background()
+			diag := bundle.Apply(ctx, b, mutator.ApplyPresets())
+
+			if diag.HasError() {
+				t.Fatalf("unexpected error: %v", diag)
+			}
+
+			require.Equal(t, tt.want, b.Config.Resources.Schemas["schema1"].Name)
 		})
 	}
 }


### PR DESCRIPTION
## Changes
In https://github.com/databricks/cli/pull/1490 we regressed and started using the development mode prefix for UC schemas regardless of the mode of the bundle target.

This PR fixes the regression and adds a regression test

## Tests
Failing integration tests pass now.
