### PR TITLE
Ignore CLI version check on development builds of the CLI

### DIFF
--- a/bundle/config/mutator/verify_cli_version.go
+++ b/bundle/config/mutator/verify_cli_version.go
@@ -40,6 +40,10 @@ func (v *verifyCliVersion) Apply(ctx context.Context, b *bundle.Bundle) diag.Dia
 	}
 
 	if !c.Check(version) {
+		if version.Prerelease() == "dev" && version.Major() == 0 {
+			return diag.Warningf("Ignoring Databricks CLI version constraint for development build. Required: %s, current: %s", constraint, currentVersion)
+		}
+
 		return diag.Errorf("Databricks CLI version constraint not satisfied. Required: %s, current: %s", constraint, currentVersion)
 	}
 

--- a/bundle/config/mutator/verify_cli_version_test.go
+++ b/bundle/config/mutator/verify_cli_version_test.go
@@ -107,6 +107,11 @@ func TestVerifyCliVersion(t *testing.T) {
 			constraint:     "^0.100",
 			expectedError:  "invalid version constraint \"^0.100\" specified. Please specify the version constraint in the format (>=) 0.0.0(, <= 1.0.0)",
 		},
+		{
+			currentVersion: "0.0.0-dev+06b169284737",
+			constraint:     ">= 0.100.0",
+			expectedError:  "Ignoring Databricks CLI version constraint for development build. Required: >= 0.100.0",
+		},
 	}
 
 	t.Cleanup(func() {
@@ -130,7 +135,7 @@ func TestVerifyCliVersion(t *testing.T) {
 			diags := bundle.Apply(context.Background(), b, VerifyCliVersion())
 			if tc.expectedError != "" {
 				require.NotEmpty(t, diags)
-				require.Equal(t, tc.expectedError, diags.Error().Error())
+				require.Contains(t, diags[0].Summary, tc.expectedError)
 			} else {
 				require.Empty(t, diags)
 			}


### PR DESCRIPTION
## Changes

This changes makes sure we ignore CLI version check on development builds of the CLI.

Before:

```
$ cat databricks.yml | grep cli_version
  databricks_cli_version: ">= 0.223.1"
$ cli bundle deploy
Error: Databricks CLI version constraint not satisfied. Required: >= 0.223.1, current: 0.0.0-dev+06b169284737
```

after

```
...
$ cli bundle deploy
...
Warning: Ignoring Databricks CLI version constraint for development build. Required: >= 0.223.1, current: 0.0.0-dev+d52d6f08fcd5
```


## Tests
<!-- How is this tested? -->

