### PR TITLE
Update templates to latest LTS DBR

### DIFF
--- a/libs/template/templates/dbt-sql/library/versions.tmpl
+++ b/libs/template/templates/dbt-sql/library/versions.tmpl
@@ -1,7 +1,7 @@
 {{define "latest_lts_dbr_version" -}}
-  13.3.x-scala2.12
+  15.4.x-scala2.12
 {{- end}}
 
 {{define "latest_lts_db_connect_version_spec" -}}
-  >=13.3,<13.4
+  >=15.4,<15.5
 {{- end}}

--- a/libs/template/templates/default-python/library/versions.tmpl
+++ b/libs/template/templates/default-python/library/versions.tmpl
@@ -1,7 +1,7 @@
 {{define "latest_lts_dbr_version" -}}
-  13.3.x-scala2.12
+  15.4.x-scala2.12
 {{- end}}
 
 {{define "latest_lts_db_connect_version_spec" -}}
-  >=13.3,<13.4
+  >=15.4,<15.5
 {{- end}}

--- a/libs/template/templates/default-sql/library/versions.tmpl
+++ b/libs/template/templates/default-sql/library/versions.tmpl
@@ -1,7 +1,7 @@
 {{define "latest_lts_dbr_version" -}}
-  13.3.x-scala2.12
+  15.4.x-scala2.12
 {{- end}}
 
 {{define "latest_lts_db_connect_version_spec" -}}
-  >=13.3,<13.4
+  >=15.4,<15.5
 {{- end}}


### PR DESCRIPTION
## Changes

This updates the templates to use the latest DBR 15 LTS version.

- [x] DB Connect 15.4 must be released + validated before this can go out