### PR TITLE
Correctly mark PyPI package name specs with multiple specifiers as remote libraries

### DIFF
--- a/bundle/libraries/local_path.go
+++ b/bundle/libraries/local_path.go
@@ -74,14 +74,9 @@ func IsLibraryLocal(dep string) bool {
 // \[.*\])?: Optionally matches any extras specified in square brackets, e.g., [security].
 // ((==|!=|<=|>=|~=|>|<)\d+(\.\d+){0,2}(\.\*)?)?: Optionally matches version specifiers, supporting various operators (==, !=, etc.) followed by a version number (e.g., 2.25.1).
 // Spec for package name and version specifier: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
-var packageRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?\d+(\.\d+){0,2}(\.\*)?)?$`)
+var packageRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?\d+(\.\d+){0,2}(\.\*)?(,)?)*$`)
 
 func isPackage(name string) bool {
-	// If the name contains comma, it's a package name with miultiple version specifiers
-	if strings.Contains(name, ",") {
-		return true
-	}
-
 	if packageRegex.MatchString(name) {
 		return true
 	}

--- a/bundle/libraries/local_path.go
+++ b/bundle/libraries/local_path.go
@@ -72,9 +72,11 @@ func IsLibraryLocal(dep string) bool {
 
 // ^[a-zA-Z0-9\-_]+: Matches the package name, allowing alphanumeric characters, dashes (-), and underscores (_).
 // \[.*\])?: Optionally matches any extras specified in square brackets, e.g., [security].
-// ((==|!=|<=|>=|~=|>|<)\d+(\.\d+){0,2}(\.\*)?)?: Optionally matches version specifiers, supporting various operators (==, !=, etc.) followed by a version number (e.g., 2.25.1).
+// ((==|!=|<=|>=|~=|>|<)\d+(\.\d+){0,2}(\.\*)?): Optionally matches version specifiers, supporting various operators (==, !=, etc.) followed by a version number (e.g., 2.25.1).
+// ,?: Optionally matches a comma (,) at the end of the specifier which is used to separate multiple specifiers.
+// There can be multiple version specifiers separated by commas or no specifiers.
 // Spec for package name and version specifier: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
-var packageRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?\d+(\.\d+){0,2}(\.\*)?(,)?)*$`)
+var packageRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?\d+(\.\d+){0,2}(\.\*)?,?)*$`)
 
 func isPackage(name string) bool {
 	if packageRegex.MatchString(name) {

--- a/bundle/libraries/local_path.go
+++ b/bundle/libraries/local_path.go
@@ -77,6 +77,11 @@ func IsLibraryLocal(dep string) bool {
 var packageRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?\d+(\.\d+){0,2}(\.\*)?)?$`)
 
 func isPackage(name string) bool {
+	// If the name contains comma, it's a package name with miultiple version specifiers
+	if strings.Contains(name, ",") {
+		return true
+	}
+
 	if packageRegex.MatchString(name) {
 		return true
 	}

--- a/bundle/libraries/local_path_test.go
+++ b/bundle/libraries/local_path_test.go
@@ -62,6 +62,8 @@ func TestIsLibraryLocal(t *testing.T) {
 		{path: "beautifulsoup4 ~= 4.12.3", expected: false},
 		{path: "beautifulsoup4[security, tests]", expected: false},
 		{path: "beautifulsoup4[security, tests] ~= 4.12.3", expected: false},
+		{path: "beautifulsoup4>=1.0.0,<2.0.0", expected: false},
+		{path: "beautifulsoup4>=1.0.0,~=1.2.0,<2.0.0", expected: false},
 		{path: "https://github.com/pypa/pip/archive/22.0.2.zip", expected: false},
 		{path: "pip @ https://github.com/pypa/pip/archive/22.0.2.zip", expected: false},
 		{path: "requests [security] @ https://github.com/psf/requests/archive/refs/heads/main.zip", expected: false},


### PR DESCRIPTION
Correctly mark pypi package name specs with multiple specifiers as remote libraries

Fixes this https://github.com/databricks/cli/issues/1728

