### PR TITLE
Use periodic triggers in all templates

### DIFF
--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -3,10 +3,10 @@ resources:
     {{.project_name}}_job:
       name: {{.project_name}}_job
 
-      schedule:
-        # Run every day at 9:27 AM
-        quartz_cron_expression: 21 27 9 * * ?
-        timezone_id: UTC
+      trigger:
+        periodic:
+          interval: 1
+          unit: DAYS
 
       email_notifications:
         on_failure:

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -4,7 +4,7 @@ resources:
       name: {{.project_name}}_job
 
       trigger:
-        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create#trigger
+        # Run this job every day, exactly one day from the last run; see https://docs.databricks.com/api/workspace/jobs/create#trigger
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -4,6 +4,7 @@ resources:
       name: {{.project_name}}_job
 
       trigger:
+        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -4,7 +4,7 @@ resources:
       name: {{.project_name}}_job
 
       trigger:
-        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create
+        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create#trigger
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -10,10 +10,10 @@ resources:
     {{.project_name}}_job:
       name: {{.project_name}}_job
 
-      schedule:
-        # Run every day at 8:37 AM
-        quartz_cron_expression: '44 37 8 * * ?'
-        timezone_id: Europe/Amsterdam
+      trigger:
+        periodic:
+          interval: 1
+          unit: DAYS
 
       {{- if not is_service_principal}}
 

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -11,7 +11,7 @@ resources:
       name: {{.project_name}}_job
 
       trigger:
-        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create
+        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create#trigger
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -11,6 +11,7 @@ resources:
       name: {{.project_name}}_job
 
       trigger:
+        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}_job.yml.tmpl
@@ -11,7 +11,7 @@ resources:
       name: {{.project_name}}_job
 
       trigger:
-        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create#trigger
+        # Run this job every day, exactly one day from the last run; see https://docs.databricks.com/api/workspace/jobs/create#trigger
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
@@ -4,10 +4,10 @@ resources:
     {{.project_name}}_sql_job:
       name: {{.project_name}}_sql_job
 
-      schedule:
-        # Run every day at 7:17 AM
-        quartz_cron_expression: '44 17 7 * * ?'
-        timezone_id: Europe/Amsterdam
+      trigger:
+        periodic:
+          interval: 1
+          unit: DAYS
 
       {{- if not is_service_principal}}
 

--- a/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
@@ -5,6 +5,7 @@ resources:
       name: {{.project_name}}_sql_job
 
       trigger:
+        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
@@ -5,7 +5,7 @@ resources:
       name: {{.project_name}}_sql_job
 
       trigger:
-        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create#trigger
+        # Run this job every day, exactly one day from the last run; see https://docs.databricks.com/api/workspace/jobs/create#trigger
         periodic:
           interval: 1
           unit: DAYS

--- a/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/resources/{{.project_name}}_sql_job.yml.tmpl
@@ -5,7 +5,7 @@ resources:
       name: {{.project_name}}_sql_job
 
       trigger:
-        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create
+        # Run this job every day; see https://docs.databricks.com/api/workspace/jobs/create#trigger
         periodic:
           interval: 1
           unit: DAYS


### PR DESCRIPTION
## Summary

Simplifies template by using the periodic trigger syntax instead of the cron schedule syntax. Periodic triggers are simpler to configure, simpler to read, and make sure that workloads are spread out through the day. We only recommend cron syntax for advanced cases or when more control is needed.

## Testing

* Templates validation via unit tests
* Manual validation that the new triggers work as expected in dev/prod