### PR TITLE
Fixed variable override in target with full variable syntax

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -468,12 +468,10 @@ func rewriteShorthands(v dyn.Value) (dyn.Value, error) {
 				// and configuration is not merged yet.
 				typeV, err := dyn.GetByPath(v, p.Append(dyn.Key("type")))
 				if err == nil && typeV.MustString() == "complex" {
-					if typeV.MustString() == "complex" {
-						return dyn.NewValue(map[string]dyn.Value{
-							"type":    typeV,
-							"default": variable,
-						}, variable.Locations()), nil
-					}
+					return dyn.NewValue(map[string]dyn.Value{
+						"type":    typeV,
+						"default": variable,
+					}, variable.Locations()), nil
 				}
 
 				// If it's a shorthand, rewrite it to a full variable definition.

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -450,7 +450,7 @@ func rewriteShorthands(v dyn.Value) (dyn.Value, error) {
 
 			case dyn.KindMap, dyn.KindSequence:
 				// Check if the original definition of variable has a type field.
-				// If it has a type  field, it means the shorthand is a value of a complex type.
+				// If it has a type field, it means the shorthand is a value of a complex type.
 				// Type might not be found if the variable overriden in a separate file
 				// and configuration is not merged yet.
 				typeV, err := dyn.GetByPath(v, p.Append(dyn.Key("type")))

--- a/bundle/tests/complex_variables_test.go
+++ b/bundle/tests/complex_variables_test.go
@@ -81,9 +81,10 @@ func TestComplexVariablesOverrideWithMultipleFiles(t *testing.T) {
 		),
 	))
 	require.NoError(t, diags.Error())
-
-	require.Equal(t, "14.2.x-scala2.11", b.Config.Resources.Jobs["my_job"].JobClusters[0].NewCluster.SparkVersion)
-	require.Equal(t, "Standard_DS3_v2", b.Config.Resources.Jobs["my_job"].JobClusters[0].NewCluster.NodeTypeId)
-	require.Equal(t, 4, b.Config.Resources.Jobs["my_job"].JobClusters[0].NewCluster.NumWorkers)
-	require.Equal(t, "false", b.Config.Resources.Jobs["my_job"].JobClusters[0].NewCluster.SparkConf["spark.speculation"])
+	for i, cluster := range b.Config.Resources.Jobs["my_job"].JobClusters {
+		require.Equalf(t, "14.2.x-scala2.11", cluster.NewCluster.SparkVersion, "cluster: %v", i)
+		require.Equalf(t, "Standard_DS3_v2", cluster.NewCluster.NodeTypeId, "cluster: %v", i)
+		require.Equalf(t, 4, cluster.NewCluster.NumWorkers, "cluster: %v", i)
+		require.Equalf(t, "false", cluster.NewCluster.SparkConf["spark.speculation"], "cluster: %v", i)
+	}
 }

--- a/bundle/tests/complex_variables_test.go
+++ b/bundle/tests/complex_variables_test.go
@@ -81,10 +81,10 @@ func TestComplexVariablesOverrideWithMultipleFiles(t *testing.T) {
 		),
 	))
 	require.NoError(t, diags.Error())
-	for i, cluster := range b.Config.Resources.Jobs["my_job"].JobClusters {
-		require.Equalf(t, "14.2.x-scala2.11", cluster.NewCluster.SparkVersion, "cluster: %v", i)
-		require.Equalf(t, "Standard_DS3_v2", cluster.NewCluster.NodeTypeId, "cluster: %v", i)
-		require.Equalf(t, 4, cluster.NewCluster.NumWorkers, "cluster: %v", i)
-		require.Equalf(t, "false", cluster.NewCluster.SparkConf["spark.speculation"], "cluster: %v", i)
+	for _, cluster := range b.Config.Resources.Jobs["my_job"].JobClusters {
+		require.Equalf(t, "14.2.x-scala2.11", cluster.NewCluster.SparkVersion, "cluster: %v", cluster.JobClusterKey)
+		require.Equalf(t, "Standard_DS3_v2", cluster.NewCluster.NodeTypeId, "cluster: %v", cluster.JobClusterKey)
+		require.Equalf(t, 4, cluster.NewCluster.NumWorkers, "cluster: %v", cluster.JobClusterKey)
+		require.Equalf(t, "false", cluster.NewCluster.SparkConf["spark.speculation"], "cluster: %v", cluster.JobClusterKey)
 	}
 }

--- a/bundle/tests/variables/complex_multiple_files/databricks.yml
+++ b/bundle/tests/variables/complex_multiple_files/databricks.yml
@@ -5,11 +5,16 @@ resources:
   jobs:
     my_job:
       job_clusters:
-        - job_cluster_key: key
-          new_cluster: ${var.cluster}
+        - job_cluster_key: key§
+          new_cluster: ${var.cluster1}
+        - job_cluster_key: key1
+          new_cluster: ${var.cluster2}
 
 variables:
-  cluster:
+  cluster1:
+    type: complex
+    description: "A cluster definition"
+  cluster2:
     type: complex
     description: "A cluster definition"
 

--- a/bundle/tests/variables/complex_multiple_files/databricks.yml
+++ b/bundle/tests/variables/complex_multiple_files/databricks.yml
@@ -5,9 +5,9 @@ resources:
   jobs:
     my_job:
       job_clusters:
-        - job_cluster_key: key§
-          new_cluster: ${var.cluster1}
         - job_cluster_key: key1
+          new_cluster: ${var.cluster1}
+        - job_cluster_key: key2
           new_cluster: ${var.cluster2}
 
 variables:

--- a/bundle/tests/variables/complex_multiple_files/databricks.yml
+++ b/bundle/tests/variables/complex_multiple_files/databricks.yml
@@ -9,7 +9,10 @@ resources:
           new_cluster: ${var.cluster1}
         - job_cluster_key: key2
           new_cluster: ${var.cluster2}
-
+        - job_cluster_key: key3
+          new_cluster: ${var.cluster3}
+        - job_cluster_key: key4
+          new_cluster: ${var.cluster4}
 variables:
   cluster1:
     type: complex
@@ -17,6 +20,33 @@ variables:
   cluster2:
     type: complex
     description: "A cluster definition"
+  cluster3:
+    type: complex
+    description: "A cluster definition"
+  cluster4:
+    type: complex
+    description: "A cluster definition"
 
 include:
   - ./variables/*.yml
+
+
+targets:
+  default:
+  dev:
+    variables:
+      cluster3:
+        spark_version: "14.2.x-scala2.11"
+        node_type_id: "Standard_DS3_v2"
+        num_workers: 4
+        spark_conf:
+          spark.speculation: false
+          spark.databricks.delta.retentionDurationCheck.enabled: false
+      cluster4:
+        default:
+          spark_version: "14.2.x-scala2.11"
+          node_type_id: "Standard_DS3_v2"
+          num_workers: 4
+          spark_conf:
+            spark.speculation: false
+            spark.databricks.delta.retentionDurationCheck.enabled: false

--- a/bundle/tests/variables/complex_multiple_files/variables/clusters.yml
+++ b/bundle/tests/variables/complex_multiple_files/variables/clusters.yml
@@ -2,10 +2,18 @@ targets:
   default:
   dev:
     variables:
-      cluster:
+      cluster1:
         spark_version: "14.2.x-scala2.11"
         node_type_id: "Standard_DS3_v2"
         num_workers: 4
         spark_conf:
           spark.speculation: false
           spark.databricks.delta.retentionDurationCheck.enabled: false
+      cluster2:
+        default:
+          spark_version: "14.2.x-scala2.11"
+          node_type_id: "Standard_DS3_v2"
+          num_workers: 4
+          spark_conf:
+            spark.speculation: false
+            spark.databricks.delta.retentionDurationCheck.enabled: false


### PR DESCRIPTION
## Changes
This PR makes sure that both of this override syntax for variables work correctly
```
targets:
  dev:
    variables:
      cluster1:
        spark_version: "14.2.x-scala2.11"
        node_type_id: "Standard_DS3_v2"
        num_workers: 4
        spark_conf:
          spark.speculation: false
          spark.databricks.delta.retentionDurationCheck.enabled: false
      cluster2:
        default:
          spark_version: "14.2.x-scala2.11"
          node_type_id: "Standard_DS3_v2"
          num_workers: 4
          spark_conf:
            spark.speculation: false
            spark.databricks.delta.retentionDurationCheck.enabled: false
```
## Tests
Added regression test

