### PR TITLE
[wip][hackathon] Implement device code flow

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -84,10 +84,13 @@ depends on the existing profiles you have set in your configuration file
 
 	var loginTimeout time.Duration
 	var configureCluster bool
+	var deviceCode bool
 	cmd.Flags().DurationVar(&loginTimeout, "timeout", defaultTimeout,
 		"Timeout for completing login challenge in the browser")
 	cmd.Flags().BoolVar(&configureCluster, "configure-cluster", false,
 		"Prompts to configure cluster")
+	cmd.Flags().BoolVar(&deviceCode, "device-code", false,
+		"Use device code flow for authentication")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -120,7 +123,11 @@ depends on the existing profiles you have set in your configuration file
 		ctx, cancel := context.WithTimeout(ctx, loginTimeout)
 		defer cancel()
 
-		err = persistentAuth.Challenge(ctx)
+		if deviceCode {
+			err = persistentAuth.DeviceCode(ctx)
+		} else {
+			err = persistentAuth.Challenge(ctx)
+		}
 		if err != nil {
 			return err
 		}

--- a/libs/auth/oauth.go
+++ b/libs/auth/oauth.go
@@ -46,9 +46,10 @@ const (
 )
 
 var ( // Databricks SDK API: `databricks OAuth is not` will be checked for presence
-	ErrOAuthNotSupported = errors.New("databricks OAuth is not supported for this host")
-	ErrNotConfigured     = errors.New("databricks OAuth is not configured for this host")
-	ErrFetchCredentials  = errors.New("cannot fetch credentials")
+	ErrOAuthNotSupported      = errors.New("databricks OAuth is not supported for this host")
+	ErrNotConfigured          = errors.New("databricks OAuth is not configured for this host")
+	ErrFetchCredentials       = errors.New("cannot fetch credentials")
+	ErrDeviceCodeNotSupported = errors.New("device code flow is not supported for this host")
 )
 
 type PersistentAuth struct {
@@ -128,6 +129,9 @@ func (a *PersistentAuth) DeviceCode(ctx context.Context) error {
 	cfg, err := a.oauth2Config(ctx)
 	if err != nil {
 		return err
+	}
+	if cfg.Endpoint.DeviceAuthURL == "" {
+		return ErrDeviceCodeNotSupported
 	}
 	ctx = a.http.InContextForOAuth2(ctx)
 	deviceAuthResp, err := cfg.DeviceAuth(ctx)


### PR DESCRIPTION
## Changes
This PR adds support for the device code flow in OAuth, defined in [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628). To use this OAuth flow, users add the `--device-code` flag when invoking `databricks auth login`. They will be presented with a URL to follow and a user code to enter into the browser. After 5 seconds, the CLI will begin polling the /token endpoint with the device code retrieved from the authorization server until the user finishes authorizing the login attempt or the login timeout, default 1 hour, passes.

## Tests
<!-- How is this tested? -->

