### PR TITLE
Rename `RootPath` -> `BundleRootPath`

### DIFF
--- a/bundle/artifacts/expand_globs_test.go
+++ b/bundle/artifacts/expand_globs_test.go
@@ -24,7 +24,7 @@ func TestExpandGlobs_Nominal(t *testing.T) {
 	testutil.Touch(t, tmpDir, "bc.txt")
 
 	b := &bundle.Bundle{
-		RootPath: tmpDir,
+		BundleRootPath: tmpDir,
 		Config: config.Root{
 			Artifacts: config.Artifacts{
 				"test": {
@@ -63,7 +63,7 @@ func TestExpandGlobs_InvalidPattern(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	b := &bundle.Bundle{
-		RootPath: tmpDir,
+		BundleRootPath: tmpDir,
 		Config: config.Root{
 			Artifacts: config.Artifacts{
 				"test": {
@@ -111,7 +111,7 @@ func TestExpandGlobs_NoMatches(t *testing.T) {
 	testutil.Touch(t, tmpDir, "b2.txt")
 
 	b := &bundle.Bundle{
-		RootPath: tmpDir,
+		BundleRootPath: tmpDir,
 		Config: config.Root{
 			Artifacts: config.Artifacts{
 				"test": {

--- a/bundle/artifacts/prepare.go
+++ b/bundle/artifacts/prepare.go
@@ -47,7 +47,7 @@ func (m *prepare) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 
 	// If artifact path is not provided, use bundle root dir
 	if artifact.Path == "" {
-		artifact.Path = b.RootPath
+		artifact.Path = b.BundleRootPath
 	}
 
 	if !filepath.IsAbs(artifact.Path) {

--- a/bundle/artifacts/whl/autodetect.go
+++ b/bundle/artifacts/whl/autodetect.go
@@ -35,21 +35,21 @@ func (m *detectPkg) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostic
 	log.Infof(ctx, "Detecting Python wheel project...")
 
 	// checking if there is setup.py in the bundle root
-	setupPy := filepath.Join(b.RootPath, "setup.py")
+	setupPy := filepath.Join(b.BundleRootPath, "setup.py")
 	_, err := os.Stat(setupPy)
 	if err != nil {
 		log.Infof(ctx, "No Python wheel project found at bundle root folder")
 		return nil
 	}
 
-	log.Infof(ctx, fmt.Sprintf("Found Python wheel project at %s", b.RootPath))
+	log.Infof(ctx, fmt.Sprintf("Found Python wheel project at %s", b.BundleRootPath))
 	module := extractModuleName(setupPy)
 
 	if b.Config.Artifacts == nil {
 		b.Config.Artifacts = make(map[string]*config.Artifact)
 	}
 
-	pkgPath, err := filepath.Abs(b.RootPath)
+	pkgPath, err := filepath.Abs(b.BundleRootPath)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -31,9 +31,9 @@ import (
 const internalFolder = ".internal"
 
 type Bundle struct {
-	// RootPath contains the directory path to the root of the bundle.
+	// BundleRootPath contains the directory path to the root of the bundle.
 	// It is set when we instantiate a new bundle instance.
-	RootPath string
+	BundleRootPath string
 
 	// BundleRoot is a virtual filesystem path to the root of the bundle.
 	// Exclusively use this field for filesystem operations.
@@ -84,14 +84,14 @@ type Bundle struct {
 
 func Load(ctx context.Context, path string) (*Bundle, error) {
 	b := &Bundle{
-		RootPath:   filepath.Clean(path),
-		BundleRoot: vfs.MustNew(path),
+		BundleRootPath: filepath.Clean(path),
+		BundleRoot:     vfs.MustNew(path),
 	}
 	configFile, err := config.FileNames.FindInPath(path)
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf(ctx, "Found bundle root at %s (file %s)", b.RootPath, configFile)
+	log.Debugf(ctx, "Found bundle root at %s (file %s)", b.BundleRootPath, configFile)
 	return b, nil
 }
 
@@ -160,7 +160,7 @@ func (b *Bundle) CacheDir(ctx context.Context, paths ...string) (string, error) 
 	if !exists || cacheDirName == "" {
 		cacheDirName = filepath.Join(
 			// Anchor at bundle root directory.
-			b.RootPath,
+			b.BundleRootPath,
 			// Static cache directory.
 			".databricks",
 			"bundle",
@@ -212,7 +212,7 @@ func (b *Bundle) GetSyncIncludePatterns(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	internalDirRel, err := filepath.Rel(b.RootPath, internalDir)
+	internalDirRel, err := filepath.Rel(b.BundleRootPath, internalDir)
 	if err != nil {
 		return nil, err
 	}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -35,7 +35,7 @@ type Bundle struct {
 	// It is set when we instantiate a new bundle instance.
 	BundleRootPath string
 
-	// BundleRoot is a virtual filesystem path [BundleRootPath].
+	// BundleRoot is a virtual filesystem path to [BundleRootPath].
 	// Exclusively use this field for filesystem operations.
 	BundleRoot vfs.Path
 

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -31,22 +31,26 @@ import (
 const internalFolder = ".internal"
 
 type Bundle struct {
-	// BundleRootPath contains the directory path to the root of the bundle.
+	// BundleRootPath is the local path to the root directory of the bundle.
 	// It is set when we instantiate a new bundle instance.
 	BundleRootPath string
 
-	// BundleRoot is a virtual filesystem path to the root of the bundle.
+	// BundleRoot is a virtual filesystem path [BundleRootPath].
 	// Exclusively use this field for filesystem operations.
 	BundleRoot vfs.Path
 
-	// SyncRoot is a virtual filesystem path to the root directory of the files that are synchronized to the workspace.
-	// It can be an ancestor to [BundleRoot], but not a descendant; that is, [SyncRoot] must contain [BundleRoot].
-	SyncRoot vfs.Path
-
 	// SyncRootPath is the local path to the root directory of files that are synchronized to the workspace.
-	// It is equal to `SyncRoot.Native()` and included as dedicated field for convenient access.
+	// By default, it is the same as [BundleRootPath].
+	// If it is different, it must be an ancestor to [BundleRootPath].
+	// That is, [SyncRootPath] must contain [BundleRootPath].
 	SyncRootPath string
 
+	// SyncRoot is a virtual filesystem path to [SyncRootPath].
+	// Exclusively use this field for filesystem operations.
+	SyncRoot vfs.Path
+
+	// Config contains the bundle configuration.
+	// It is loaded from the bundle configuration files and mutators may update it.
 	Config config.Root
 
 	// Metadata about the bundle deployment. This is the interface Databricks services

--- a/bundle/bundle_read_only.go
+++ b/bundle/bundle_read_only.go
@@ -21,7 +21,7 @@ func (r ReadOnlyBundle) Config() config.Root {
 }
 
 func (r ReadOnlyBundle) RootPath() string {
-	return r.b.RootPath
+	return r.b.BundleRootPath
 }
 
 func (r ReadOnlyBundle) BundleRoot() vfs.Path {

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -79,7 +79,7 @@ func TestBundleMustLoadSuccess(t *testing.T) {
 	t.Setenv(env.RootVariable, "./tests/basic")
 	b, err := MustLoad(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "tests/basic", filepath.ToSlash(b.RootPath))
+	assert.Equal(t, "tests/basic", filepath.ToSlash(b.BundleRootPath))
 }
 
 func TestBundleMustLoadFailureWithEnv(t *testing.T) {
@@ -98,7 +98,7 @@ func TestBundleTryLoadSuccess(t *testing.T) {
 	t.Setenv(env.RootVariable, "./tests/basic")
 	b, err := TryLoad(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "tests/basic", filepath.ToSlash(b.RootPath))
+	assert.Equal(t, "tests/basic", filepath.ToSlash(b.BundleRootPath))
 }
 
 func TestBundleTryLoadFailureWithEnv(t *testing.T) {

--- a/bundle/config/loader/entry_point.go
+++ b/bundle/config/loader/entry_point.go
@@ -20,7 +20,7 @@ func (m *entryPoint) Name() string {
 }
 
 func (m *entryPoint) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
-	path, err := config.FileNames.FindInPath(b.RootPath)
+	path, err := config.FileNames.FindInPath(b.BundleRootPath)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/config/loader/entry_point_test.go
+++ b/bundle/config/loader/entry_point_test.go
@@ -18,7 +18,7 @@ func TestEntryPointNoRootPath(t *testing.T) {
 
 func TestEntryPoint(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "testdata",
+		BundleRootPath: "testdata",
 	}
 	diags := bundle.Apply(context.Background(), b, loader.EntryPoint())
 	require.NoError(t, diags.Error())

--- a/bundle/config/loader/process_include_test.go
+++ b/bundle/config/loader/process_include_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestProcessInclude(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "testdata",
+		BundleRootPath: "testdata",
 		Config: config.Root{
 			Workspace: config.Workspace{
 				Host: "foo",
@@ -22,7 +22,7 @@ func TestProcessInclude(t *testing.T) {
 		},
 	}
 
-	m := loader.ProcessInclude(filepath.Join(b.RootPath, "host.yml"), "host.yml")
+	m := loader.ProcessInclude(filepath.Join(b.BundleRootPath, "host.yml"), "host.yml")
 	assert.Equal(t, "ProcessInclude(host.yml)", m.Name())
 
 	// Assert the host value prior to applying the mutator

--- a/bundle/config/loader/process_root_includes.go
+++ b/bundle/config/loader/process_root_includes.go
@@ -47,7 +47,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 		}
 
 		// Anchor includes to the bundle root path.
-		matches, err := filepath.Glob(filepath.Join(b.RootPath, entry))
+		matches, err := filepath.Glob(filepath.Join(b.BundleRootPath, entry))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -61,7 +61,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 		// Filter matches to ones we haven't seen yet.
 		var includes []string
 		for _, match := range matches {
-			rel, err := filepath.Rel(b.RootPath, match)
+			rel, err := filepath.Rel(b.BundleRootPath, match)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -76,7 +76,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 		slices.Sort(includes)
 		files = append(files, includes...)
 		for _, include := range includes {
-			out = append(out, ProcessInclude(filepath.Join(b.RootPath, include), include))
+			out = append(out, ProcessInclude(filepath.Join(b.BundleRootPath, include), include))
 		}
 	}
 

--- a/bundle/config/loader/process_root_includes_test.go
+++ b/bundle/config/loader/process_root_includes_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestProcessRootIncludesEmpty(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: ".",
+		BundleRootPath: ".",
 	}
 	diags := bundle.Apply(context.Background(), b, loader.ProcessRootIncludes())
 	require.NoError(t, diags.Error())
@@ -30,7 +30,7 @@ func TestProcessRootIncludesAbs(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: ".",
+		BundleRootPath: ".",
 		Config: config.Root{
 			Include: []string{
 				"/tmp/*.yml",
@@ -44,7 +44,7 @@ func TestProcessRootIncludesAbs(t *testing.T) {
 
 func TestProcessRootIncludesSingleGlob(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Include: []string{
 				"*.yml",
@@ -52,9 +52,9 @@ func TestProcessRootIncludesSingleGlob(t *testing.T) {
 		},
 	}
 
-	testutil.Touch(t, b.RootPath, "databricks.yml")
-	testutil.Touch(t, b.RootPath, "a.yml")
-	testutil.Touch(t, b.RootPath, "b.yml")
+	testutil.Touch(t, b.BundleRootPath, "databricks.yml")
+	testutil.Touch(t, b.BundleRootPath, "a.yml")
+	testutil.Touch(t, b.BundleRootPath, "b.yml")
 
 	diags := bundle.Apply(context.Background(), b, loader.ProcessRootIncludes())
 	require.NoError(t, diags.Error())
@@ -63,7 +63,7 @@ func TestProcessRootIncludesSingleGlob(t *testing.T) {
 
 func TestProcessRootIncludesMultiGlob(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Include: []string{
 				"a*.yml",
@@ -72,8 +72,8 @@ func TestProcessRootIncludesMultiGlob(t *testing.T) {
 		},
 	}
 
-	testutil.Touch(t, b.RootPath, "a1.yml")
-	testutil.Touch(t, b.RootPath, "b1.yml")
+	testutil.Touch(t, b.BundleRootPath, "a1.yml")
+	testutil.Touch(t, b.BundleRootPath, "b1.yml")
 
 	diags := bundle.Apply(context.Background(), b, loader.ProcessRootIncludes())
 	require.NoError(t, diags.Error())
@@ -82,7 +82,7 @@ func TestProcessRootIncludesMultiGlob(t *testing.T) {
 
 func TestProcessRootIncludesRemoveDups(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Include: []string{
 				"*.yml",
@@ -91,7 +91,7 @@ func TestProcessRootIncludesRemoveDups(t *testing.T) {
 		},
 	}
 
-	testutil.Touch(t, b.RootPath, "a.yml")
+	testutil.Touch(t, b.BundleRootPath, "a.yml")
 
 	diags := bundle.Apply(context.Background(), b, loader.ProcessRootIncludes())
 	require.NoError(t, diags.Error())
@@ -100,7 +100,7 @@ func TestProcessRootIncludesRemoveDups(t *testing.T) {
 
 func TestProcessRootIncludesNotExists(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Include: []string{
 				"notexist.yml",

--- a/bundle/config/mutator/expand_pipeline_glob_paths_test.go
+++ b/bundle/config/mutator/expand_pipeline_glob_paths_test.go
@@ -42,7 +42,7 @@ func TestExpandGlobPathsInPipelines(t *testing.T) {
 	touchEmptyFile(t, filepath.Join(dir, "skip/test7.py"))
 
 	b := &bundle.Bundle{
-		RootPath: dir,
+		BundleRootPath: dir,
 		Config: config.Root{
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -56,7 +56,7 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	}
 
 	// Compute relative path of the bundle root from the Git repo root.
-	absBundlePath, err := filepath.Abs(b.RootPath)
+	absBundlePath, err := filepath.Abs(b.BundleRootPath)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/config/mutator/python/python_mutator.go
+++ b/bundle/config/mutator/python/python_mutator.go
@@ -108,7 +108,7 @@ func (m *pythonMutator) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagno
 			return dyn.InvalidValue, fmt.Errorf("failed to create cache dir: %w", err)
 		}
 
-		rightRoot, diags := m.runPythonMutator(ctx, cacheDir, b.RootPath, pythonPath, leftRoot)
+		rightRoot, diags := m.runPythonMutator(ctx, cacheDir, b.BundleRootPath, pythonPath, leftRoot)
 		mutateDiags = diags
 		if diags.HasError() {
 			return dyn.InvalidValue, mutateDiagsHasError
@@ -228,12 +228,12 @@ func (m *pythonMutator) runPythonMutator(ctx context.Context, cacheDir string, r
 	return output, pythonDiagnostics
 }
 
-const installExplanation = `If using Python wheels, ensure that 'databricks-pydabs' is included in the dependencies, 
+const installExplanation = `If using Python wheels, ensure that 'databricks-pydabs' is included in the dependencies,
 and that the wheel is installed in the Python environment:
 
   $ .venv/bin/pip install -e .
 
-If using a virtual environment, ensure it is specified as the venv_path property in databricks.yml, 
+If using a virtual environment, ensure it is specified as the venv_path property in databricks.yml,
 or activate the environment before running CLI commands:
 
   experimental:

--- a/bundle/config/mutator/rewrite_sync_paths.go
+++ b/bundle/config/mutator/rewrite_sync_paths.go
@@ -45,15 +45,15 @@ func (m *rewriteSyncPaths) makeRelativeTo(root string) dyn.MapFunc {
 func (m *rewriteSyncPaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
 		return dyn.Map(v, "sync", func(_ dyn.Path, v dyn.Value) (nv dyn.Value, err error) {
-			v, err = dyn.Map(v, "paths", dyn.Foreach(m.makeRelativeTo(b.RootPath)))
+			v, err = dyn.Map(v, "paths", dyn.Foreach(m.makeRelativeTo(b.BundleRootPath)))
 			if err != nil {
 				return dyn.InvalidValue, err
 			}
-			v, err = dyn.Map(v, "include", dyn.Foreach(m.makeRelativeTo(b.RootPath)))
+			v, err = dyn.Map(v, "include", dyn.Foreach(m.makeRelativeTo(b.BundleRootPath)))
 			if err != nil {
 				return dyn.InvalidValue, err
 			}
-			v, err = dyn.Map(v, "exclude", dyn.Foreach(m.makeRelativeTo(b.RootPath)))
+			v, err = dyn.Map(v, "exclude", dyn.Foreach(m.makeRelativeTo(b.BundleRootPath)))
 			if err != nil {
 				return dyn.InvalidValue, err
 			}

--- a/bundle/config/mutator/rewrite_sync_paths_test.go
+++ b/bundle/config/mutator/rewrite_sync_paths_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRewriteSyncPathsRelative(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: ".",
+		BundleRootPath: ".",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -54,7 +54,7 @@ func TestRewriteSyncPathsRelative(t *testing.T) {
 
 func TestRewriteSyncPathsAbsolute(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/dir",
+		BundleRootPath: "/tmp/dir",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -94,7 +94,7 @@ func TestRewriteSyncPathsAbsolute(t *testing.T) {
 func TestRewriteSyncPathsErrorPaths(t *testing.T) {
 	t.Run("no sync block", func(t *testing.T) {
 		b := &bundle.Bundle{
-			RootPath: ".",
+			BundleRootPath: ".",
 		}
 
 		diags := bundle.Apply(context.Background(), b, mutator.RewriteSyncPaths())
@@ -103,7 +103,7 @@ func TestRewriteSyncPathsErrorPaths(t *testing.T) {
 
 	t.Run("empty include/exclude blocks", func(t *testing.T) {
 		b := &bundle.Bundle{
-			RootPath: ".",
+			BundleRootPath: ".",
 			Config: config.Root{
 				Sync: config.Sync{
 					Include: []string{},

--- a/bundle/config/mutator/sync_default_path_test.go
+++ b/bundle/config/mutator/sync_default_path_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestSyncDefaultPath_DefaultIfUnset(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/some/dir",
-		Config:   config.Root{},
+		BundleRootPath: "/tmp/some/dir",
+		Config:         config.Root{},
 	}
 
 	ctx := context.Background()
@@ -51,8 +51,8 @@ func TestSyncDefaultPath_SkipIfSet(t *testing.T) {
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
 			b := &bundle.Bundle{
-				RootPath: "/tmp/some/dir",
-				Config:   config.Root{},
+				BundleRootPath: "/tmp/some/dir",
+				Config:         config.Root{},
 			}
 
 			diags := bundle.ApplyFunc(context.Background(), b, func(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {

--- a/bundle/config/mutator/sync_infer_root.go
+++ b/bundle/config/mutator/sync_infer_root.go
@@ -57,7 +57,7 @@ func (m *syncInferRoot) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagno
 	var diags diag.Diagnostics
 
 	// Use the bundle root path as the starting point for inferring the sync root path.
-	bundleRootPath := filepath.Clean(b.RootPath)
+	bundleRootPath := filepath.Clean(b.BundleRootPath)
 
 	// Infer the sync root path by looking at each one of the sync paths.
 	// Every sync path must be a descendant of the final sync root path.

--- a/bundle/config/mutator/sync_infer_root_test.go
+++ b/bundle/config/mutator/sync_infer_root_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSyncInferRoot_NominalAbsolute(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/some/dir",
+		BundleRootPath: "/tmp/some/dir",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -47,7 +47,7 @@ func TestSyncInferRoot_NominalAbsolute(t *testing.T) {
 
 func TestSyncInferRoot_NominalRelative(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "./some/dir",
+		BundleRootPath: "./some/dir",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -78,7 +78,7 @@ func TestSyncInferRoot_NominalRelative(t *testing.T) {
 
 func TestSyncInferRoot_ParentDirectory(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/some/dir",
+		BundleRootPath: "/tmp/some/dir",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -109,7 +109,7 @@ func TestSyncInferRoot_ParentDirectory(t *testing.T) {
 
 func TestSyncInferRoot_ManyParentDirectories(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/some/dir/that/is/very/deeply/nested",
+		BundleRootPath: "/tmp/some/dir/that/is/very/deeply/nested",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -146,7 +146,7 @@ func TestSyncInferRoot_ManyParentDirectories(t *testing.T) {
 
 func TestSyncInferRoot_MultiplePaths(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/some/bundle/root",
+		BundleRootPath: "/tmp/some/bundle/root",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{
@@ -173,7 +173,7 @@ func TestSyncInferRoot_MultiplePaths(t *testing.T) {
 
 func TestSyncInferRoot_Error(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: "/tmp/some/dir",
+		BundleRootPath: "/tmp/some/dir",
 		Config: config.Root{
 			Sync: config.Sync{
 				Paths: []string{

--- a/bundle/config/mutator/trampoline_test.go
+++ b/bundle/config/mutator/trampoline_test.go
@@ -56,8 +56,8 @@ func TestGenerateTrampoline(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath:     filepath.Join(tmpDir, "parent", "my_bundle"),
-		SyncRootPath: filepath.Join(tmpDir, "parent"),
+		BundleRootPath: filepath.Join(tmpDir, "parent", "my_bundle"),
+		SyncRootPath:   filepath.Join(tmpDir, "parent"),
 		Config: config.Root{
 			Workspace: config.Workspace{
 				FilePath: "/Workspace/files",

--- a/bundle/deploy/metadata/compute.go
+++ b/bundle/deploy/metadata/compute.go
@@ -40,7 +40,7 @@ func (m *compute) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 		// Compute config file path the job is defined in, relative to the bundle
 		// root
 		l := b.Config.GetLocation("resources.jobs." + name)
-		relativePath, err := filepath.Rel(b.RootPath, l.File)
+		relativePath, err := filepath.Rel(b.BundleRootPath, l.File)
 		if err != nil {
 			return diag.Errorf("failed to compute relative path for job %s: %v", name, err)
 		}

--- a/bundle/deploy/state_pull_test.go
+++ b/bundle/deploy/state_pull_test.go
@@ -62,8 +62,8 @@ func testStatePull(t *testing.T, opts statePullOpts) {
 
 	tmpDir := t.TempDir()
 	b := &bundle.Bundle{
-		RootPath:   tmpDir,
-		BundleRoot: vfs.MustNew(tmpDir),
+		BundleRootPath: tmpDir,
+		BundleRoot:     vfs.MustNew(tmpDir),
 
 		SyncRootPath: tmpDir,
 		SyncRoot:     vfs.MustNew(tmpDir),
@@ -259,7 +259,7 @@ func TestStatePullNoState(t *testing.T) {
 	}}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",
@@ -447,7 +447,7 @@ func TestStatePullNewerDeploymentStateVersion(t *testing.T) {
 	}}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/bundle/deploy/state_push_test.go
+++ b/bundle/deploy/state_push_test.go
@@ -45,7 +45,7 @@ func TestStatePush(t *testing.T) {
 	}}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/bundle/deploy/state_update_test.go
+++ b/bundle/deploy/state_update_test.go
@@ -27,7 +27,7 @@ func setupBundleForStateUpdate(t *testing.T) *bundle.Bundle {
 	require.NoError(t, err)
 
 	return &bundle.Bundle{
-		RootPath: tmpDir,
+		BundleRootPath: tmpDir,
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -33,7 +33,7 @@ func TestInitEnvironmentVariables(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -60,7 +60,7 @@ func TestSetTempDirEnvVarsForUnixWithTmpDirSet(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -88,7 +88,7 @@ func TestSetTempDirEnvVarsForUnixWithTmpDirNotSet(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -114,7 +114,7 @@ func TestSetTempDirEnvVarsForWindowWithAllTmpDirEnvVarsSet(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -144,7 +144,7 @@ func TestSetTempDirEnvVarsForWindowWithUserProfileAndTempSet(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -174,7 +174,7 @@ func TestSetTempDirEnvVarsForWindowsWithoutAnyTempDirEnvVarsSet(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -202,7 +202,7 @@ func TestSetTempDirEnvVarsForWindowsWithoutAnyTempDirEnvVarsSet(t *testing.T) {
 
 func TestSetProxyEnvVars(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -250,7 +250,7 @@ func TestSetProxyEnvVars(t *testing.T) {
 
 func TestSetUserAgentExtraEnvVar(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Experimental: &config.Experimental{
 				PyDABs: config.PyDABs{
@@ -333,7 +333,7 @@ func TestFindExecPathFromEnvironmentWithWrongVersion(t *testing.T) {
 	ctx := context.Background()
 	m := &initialize{}
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target:    "whatever",
@@ -357,7 +357,7 @@ func TestFindExecPathFromEnvironmentWithCorrectVersionAndNoBinary(t *testing.T) 
 	ctx := context.Background()
 	m := &initialize{}
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target:    "whatever",
@@ -380,7 +380,7 @@ func TestFindExecPathFromEnvironmentWithCorrectVersionAndBinary(t *testing.T) {
 	ctx := context.Background()
 	m := &initialize{}
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target:    "whatever",

--- a/bundle/deploy/terraform/load_test.go
+++ b/bundle/deploy/terraform/load_test.go
@@ -17,7 +17,7 @@ func TestLoadWithNoState(t *testing.T) {
 	}
 
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",

--- a/bundle/deploy/terraform/state_pull_test.go
+++ b/bundle/deploy/terraform/state_pull_test.go
@@ -32,7 +32,7 @@ func mockStateFilerForPull(t *testing.T, contents map[string]any, merr error) fi
 
 func statePullTestBundle(t *testing.T) *bundle.Bundle {
 	return &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/bundle/deploy/terraform/state_push_test.go
+++ b/bundle/deploy/terraform/state_push_test.go
@@ -29,7 +29,7 @@ func mockStateFilerForPush(t *testing.T, fn func(body io.Reader)) filer.Filer {
 
 func statePushTestBundle(t *testing.T) *bundle.Bundle {
 	return &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/bundle/deploy/terraform/util_test.go
+++ b/bundle/deploy/terraform/util_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestParseResourcesStateWithNoFile(t *testing.T) {
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -31,7 +31,7 @@ func TestParseResourcesStateWithNoFile(t *testing.T) {
 func TestParseResourcesStateWithExistingStateFile(t *testing.T) {
 	ctx := context.Background()
 	b := &bundle.Bundle{
-		RootPath: t.TempDir(),
+		BundleRootPath: t.TempDir(),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",

--- a/bundle/python/conditional_transform_test.go
+++ b/bundle/python/conditional_transform_test.go
@@ -17,8 +17,8 @@ func TestNoTransformByDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	b := &bundle.Bundle{
-		RootPath:     filepath.Join(tmpDir, "parent", "my_bundle"),
-		SyncRootPath: filepath.Join(tmpDir, "parent"),
+		BundleRootPath: filepath.Join(tmpDir, "parent", "my_bundle"),
+		SyncRootPath:   filepath.Join(tmpDir, "parent"),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "development",
@@ -66,8 +66,8 @@ func TestTransformWithExperimentalSettingSetToTrue(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	b := &bundle.Bundle{
-		RootPath:     filepath.Join(tmpDir, "parent", "my_bundle"),
-		SyncRootPath: filepath.Join(tmpDir, "parent"),
+		BundleRootPath: filepath.Join(tmpDir, "parent", "my_bundle"),
+		SyncRootPath:   filepath.Join(tmpDir, "parent"),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "development",

--- a/bundle/python/transform_test.go
+++ b/bundle/python/transform_test.go
@@ -115,7 +115,7 @@ func TestTransformFiltersWheelTasksOnly(t *testing.T) {
 func TestNoPanicWithNoPythonWheelTasks(t *testing.T) {
 	tmpDir := t.TempDir()
 	b := &bundle.Bundle{
-		RootPath: tmpDir,
+		BundleRootPath: tmpDir,
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "development",

--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -148,7 +148,7 @@ func renderDiagnostics(out io.Writer, b *bundle.Bundle, diags diag.Diagnostics) 
 
 			// Make location relative to bundle root
 			if d.Locations[i].File != "" {
-				out, err := filepath.Rel(b.RootPath, d.Locations[i].File)
+				out, err := filepath.Rel(b.BundleRootPath, d.Locations[i].File)
 				// if we can't relativize the path, just use path as-is
 				if err == nil {
 					d.Locations[i].File = out

--- a/bundle/scripts/scripts.go
+++ b/bundle/scripts/scripts.go
@@ -30,7 +30,7 @@ func (m *script) Name() string {
 }
 
 func (m *script) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	executor, err := exec.NewCommandExecutor(b.RootPath)
+	executor, err := exec.NewCommandExecutor(b.BundleRootPath)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/scripts/scripts_test.go
+++ b/bundle/scripts/scripts_test.go
@@ -23,7 +23,7 @@ func TestExecutesHook(t *testing.T) {
 		},
 	}
 
-	executor, err := exec.NewCommandExecutor(b.RootPath)
+	executor, err := exec.NewCommandExecutor(b.BundleRootPath)
 	require.NoError(t, err)
 	_, out, err := executeHook(context.Background(), executor, b, config.ScriptPreBuild)
 	require.NoError(t, err)

--- a/cmd/bundle/generate/generate_test.go
+++ b/cmd/bundle/generate/generate_test.go
@@ -24,7 +24,7 @@ func TestGeneratePipelineCommand(t *testing.T) {
 
 	root := t.TempDir()
 	b := &bundle.Bundle{
-		RootPath: root,
+		BundleRootPath: root,
 	}
 
 	m := mocks.NewMockWorkspaceClient(t)
@@ -122,7 +122,7 @@ func TestGenerateJobCommand(t *testing.T) {
 
 	root := t.TempDir()
 	b := &bundle.Bundle{
-		RootPath: root,
+		BundleRootPath: root,
 	}
 
 	m := mocks.NewMockWorkspaceClient(t)

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -17,10 +17,10 @@ import (
 func TestSyncOptionsFromBundle(t *testing.T) {
 	tempDir := t.TempDir()
 	b := &bundle.Bundle{
-		RootPath:     tempDir,
-		BundleRoot:   vfs.MustNew(tempDir),
-		SyncRootPath: tempDir,
-		SyncRoot:     vfs.MustNew(tempDir),
+		BundleRootPath: tempDir,
+		BundleRoot:     vfs.MustNew(tempDir),
+		SyncRootPath:   tempDir,
+		SyncRoot:       vfs.MustNew(tempDir),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/internal/bundle/artifacts_test.go
+++ b/internal/bundle/artifacts_test.go
@@ -36,8 +36,8 @@ func TestAccUploadArtifactFileToCorrectRemotePath(t *testing.T) {
 	wsDir := internal.TemporaryWorkspaceDir(t, w)
 
 	b := &bundle.Bundle{
-		RootPath:     dir,
-		SyncRootPath: dir,
+		BundleRootPath: dir,
+		SyncRootPath:   dir,
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -101,8 +101,8 @@ func TestAccUploadArtifactFileToCorrectRemotePathWithEnvironments(t *testing.T) 
 	wsDir := internal.TemporaryWorkspaceDir(t, w)
 
 	b := &bundle.Bundle{
-		RootPath:     dir,
-		SyncRootPath: dir,
+		BundleRootPath: dir,
+		SyncRootPath:   dir,
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",
@@ -171,8 +171,8 @@ func TestAccUploadArtifactFileToCorrectRemotePathForVolumes(t *testing.T) {
 	touchEmptyFile(t, whlPath)
 
 	b := &bundle.Bundle{
-		RootPath:     dir,
-		SyncRootPath: dir,
+		BundleRootPath: dir,
+		SyncRootPath:   dir,
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "whatever",


### PR DESCRIPTION
## Changes

After introducing the `SyncRootPath` field on the bundle (#1694), the previous `RootPath` became ambiguous. Does it mean the bundle root path or the sync root path? This PR renames to field to `BundleRootPath` to remove the ambiguity.

## Tests

n/a