### PR TITLE
Add resource path field to bundle workspace configuration

### DIFF
--- a/bundle/config/mutator/default_workspace_paths.go
+++ b/bundle/config/mutator/default_workspace_paths.go
@@ -29,6 +29,10 @@ func (m *defineDefaultWorkspacePaths) Apply(ctx context.Context, b *bundle.Bundl
 		b.Config.Workspace.FilePath = path.Join(root, "files")
 	}
 
+	if b.Config.Workspace.ResourcePath == "" {
+		b.Config.Workspace.ResourcePath = path.Join(root, "resources")
+	}
+
 	if b.Config.Workspace.ArtifactPath == "" {
 		b.Config.Workspace.ArtifactPath = path.Join(root, "artifacts")
 	}

--- a/bundle/config/mutator/default_workspace_paths_test.go
+++ b/bundle/config/mutator/default_workspace_paths_test.go
@@ -22,6 +22,7 @@ func TestDefineDefaultWorkspacePaths(t *testing.T) {
 	diags := bundle.Apply(context.Background(), b, mutator.DefineDefaultWorkspacePaths())
 	require.NoError(t, diags.Error())
 	assert.Equal(t, "/files", b.Config.Workspace.FilePath)
+	assert.Equal(t, "/resources", b.Config.Workspace.ResourcePath)
 	assert.Equal(t, "/artifacts", b.Config.Workspace.ArtifactPath)
 	assert.Equal(t, "/state", b.Config.Workspace.StatePath)
 }
@@ -32,6 +33,7 @@ func TestDefineDefaultWorkspacePathsAlreadySet(t *testing.T) {
 			Workspace: config.Workspace{
 				RootPath:     "/",
 				FilePath:     "/foo/bar",
+				ResourcePath: "/foo/bar",
 				ArtifactPath: "/foo/bar",
 				StatePath:    "/foo/bar",
 			},
@@ -40,6 +42,7 @@ func TestDefineDefaultWorkspacePathsAlreadySet(t *testing.T) {
 	diags := bundle.Apply(context.Background(), b, mutator.DefineDefaultWorkspacePaths())
 	require.NoError(t, diags.Error())
 	assert.Equal(t, "/foo/bar", b.Config.Workspace.FilePath)
+	assert.Equal(t, "/foo/bar", b.Config.Workspace.ResourcePath)
 	assert.Equal(t, "/foo/bar", b.Config.Workspace.ArtifactPath)
 	assert.Equal(t, "/foo/bar", b.Config.Workspace.StatePath)
 }

--- a/bundle/config/mutator/process_target_mode.go
+++ b/bundle/config/mutator/process_target_mode.go
@@ -118,14 +118,17 @@ func findNonUserPath(b *bundle.Bundle) string {
 	if b.Config.Workspace.RootPath != "" && !containsName(b.Config.Workspace.RootPath) {
 		return "root_path"
 	}
-	if b.Config.Workspace.StatePath != "" && !containsName(b.Config.Workspace.StatePath) {
-		return "state_path"
-	}
 	if b.Config.Workspace.FilePath != "" && !containsName(b.Config.Workspace.FilePath) {
 		return "file_path"
 	}
+	if b.Config.Workspace.ResourcePath != "" && !containsName(b.Config.Workspace.ResourcePath) {
+		return "resource_path"
+	}
 	if b.Config.Workspace.ArtifactPath != "" && !containsName(b.Config.Workspace.ArtifactPath) {
 		return "artifact_path"
+	}
+	if b.Config.Workspace.StatePath != "" && !containsName(b.Config.Workspace.StatePath) {
+		return "state_path"
 	}
 	return ""
 }

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -54,6 +54,11 @@ type Workspace struct {
 	// This defaults to "${workspace.root}/files".
 	FilePath string `json:"file_path,omitempty"`
 
+	// Remote workspace path for resources with a presence in the workspace.
+	// These are kept outside [FilePath] to avoid potential naming collisions.
+	// This defaults to "${workspace.root}/resources".
+	ResourcePath string `json:"resource_path,omitempty"`
+
 	// Remote workspace path for build artifacts.
 	// This defaults to "${workspace.root}/artifacts".
 	ArtifactPath string `json:"artifact_path,omitempty"`


### PR DESCRIPTION
## Changes

Default workspace path for resources with a presence in the workspace tree.

Note: this path is **not** created automatically (yet). We need this only for dashboards (so far), so can take care of creation if one or more dashboards are part of a deployment. This saves an API call for deployments where this is not necessary.

## Tests

Expanded existing tests.

