### PR TITLE
[Fix] Cluster permission to use ClusterId not JobId.

### DIFF
--- a/bundle/deploy/terraform/tfdyn/convert_cluster.go
+++ b/bundle/deploy/terraform/tfdyn/convert_cluster.go
@@ -40,7 +40,7 @@ func (clusterConverter) Convert(ctx context.Context, key string, vin dyn.Value, 
 
 	// Configure permissions for this resource.
 	if permissions := convertPermissionsResource(ctx, vin); permissions != nil {
-		permissions.JobId = fmt.Sprintf("${databricks_cluster.%s.id}", key)
+		permissions.ClusterId = fmt.Sprintf("${databricks_cluster.%s.id}", key)
 		out.Permissions["cluster_"+key] = permissions
 	}
 


### PR DESCRIPTION
## Changes
Playing around with the possibility to deploy shared clusters, which was released in v0.229.0 (#1698) it was observed that shared clusters cannot be exposed to other users/service principals/groups by setting appropriate permissions. Debugging this, we found that the produced terraform databricks_permission resource configuration provides the object id through the job_id parameter where the cluster_id parameter would be required, see [terraform databricks cluster permissions documentation](https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/permissions#cluster-usage).

Changing from JobId to ClusterId for the permissions object in bundle/deploy/terraform/tfdyn/convert_cluster.go fixes the observed problem.

**Note**: It is unclear if further changes are required for consistency. bunde/permissions/mutator.go includes structures which do not include clusters at all. Since no issue was observed for the test below, it was concluded that this part of the code is most likely only relevant for top-level permission assignments.

## Tests
Manual test by deploying a shared cluster using a service principle and making it accessible to another user by explicitly setting permissions to one group which the user belongs to. Example:

    resource:
         clusters:
             test_cluster:
                cluster_name: dab_test_cluster
                spark_version: 14.3.x-scala2.12
                node_type_id: Standard_D3_v2
                data_security_mode: USER_ISOLATION
                runtime_engine: STANDARD
                autotermination_minutes: 15
                autoscale:
                  min_workers: 1
                  max_workers: 1
                permissions:
                - group_name: test_group
                  level: CAN_ATTACH_TO