### PR TITLE
Use SetPermissions instead of UpdatePermissions when setting folder permissions based on top-level ones

### DIFF
--- a/bundle/config/validate/folder_permissions.go
+++ b/bundle/config/validate/folder_permissions.go
@@ -23,7 +23,7 @@ func (f *folderPermissions) Apply(ctx context.Context, b bundle.ReadOnlyBundle) 
 		return nil
 	}
 
-	bundlePaths := paths.CollectUniquePaths(b.Config().Workspace)
+	bundlePaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config().Workspace)
 
 	var diags diag.Diagnostics
 	g, ctx := errgroup.WithContext(ctx)

--- a/bundle/libraries/path.go
+++ b/bundle/libraries/path.go
@@ -38,6 +38,7 @@ func IsWorkspaceLibrary(library *compute.Library) bool {
 }
 
 // IsVolumesPath returns true if the specified path indicates that
+// it should be interpreted as a Databricks Volumes path.
 func IsVolumesPath(path string) bool {
 	return strings.HasPrefix(path, "/Volumes/")
 }

--- a/bundle/paths/paths.go
+++ b/bundle/paths/paths.go
@@ -7,7 +7,7 @@ import (
 	"github.com/databricks/cli/bundle/libraries"
 )
 
-func CollectUniquePaths(workspace config.Workspace) []string {
+func CollectUniqueWorkspacePathPrefixes(workspace config.Workspace) []string {
 	rootPath := workspace.RootPath
 	paths := []string{}
 	if !libraries.IsVolumesPath(rootPath) && !libraries.IsWorkspaceSharedPath(rootPath) {

--- a/bundle/paths/paths.go
+++ b/bundle/paths/paths.go
@@ -1,0 +1,39 @@
+package paths
+
+import (
+	"strings"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/libraries"
+)
+
+func CollectUniquePaths(workspace config.Workspace) []string {
+	rootPath := workspace.RootPath
+	paths := []string{}
+	if !libraries.IsVolumesPath(rootPath) && !libraries.IsWorkspaceSharedPath(rootPath) {
+		paths = append(paths, rootPath)
+	}
+
+	if !strings.HasSuffix(rootPath, "/") {
+		rootPath += "/"
+	}
+
+	for _, p := range []string{
+		workspace.ArtifactPath,
+		workspace.FilePath,
+		workspace.StatePath,
+		workspace.ResourcePath,
+	} {
+		if libraries.IsWorkspaceSharedPath(p) || libraries.IsVolumesPath(p) {
+			continue
+		}
+
+		if strings.HasPrefix(p, rootPath) {
+			continue
+		}
+
+		paths = append(paths, p)
+	}
+
+	return paths
+}

--- a/bundle/permissions/workspace_root.go
+++ b/bundle/permissions/workspace_root.go
@@ -54,7 +54,7 @@ func giveAccessForWorkspaceRoot(ctx context.Context, b *bundle.Bundle) error {
 	}
 
 	w := b.WorkspaceClient().Workspace
-	bundlePaths := paths.CollectUniquePaths(b.Config.Workspace)
+	bundlePaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config.Workspace)
 
 	g, ctx := errgroup.WithContext(ctx)
 	for _, p := range bundlePaths {

--- a/bundle/permissions/workspace_root.go
+++ b/bundle/permissions/workspace_root.go
@@ -58,28 +58,34 @@ func giveAccessForWorkspaceRoot(ctx context.Context, b *bundle.Bundle) error {
 		return err
 	}
 
-	if !strings.HasPrefix(b.Config.Workspace.ArtifactPath, b.Config.Workspace.RootPath) {
+	// Adding backslash to the root path
+	rootPath := b.Config.Workspace.RootPath
+	if rootPath[len(rootPath)-1] != '/' {
+		rootPath += "/"
+	}
+
+	if !strings.HasPrefix(b.Config.Workspace.ArtifactPath, rootPath) {
 		err = setPermissions(ctx, w, b.Config.Workspace.ArtifactPath, permissions)
 		if err != nil {
 			return err
 		}
 	}
 
-	if !strings.HasPrefix(b.Config.Workspace.FilePath, b.Config.Workspace.RootPath) {
+	if !strings.HasPrefix(b.Config.Workspace.FilePath, rootPath) {
 		err = setPermissions(ctx, w, b.Config.Workspace.FilePath, permissions)
 		if err != nil {
 			return err
 		}
 	}
 
-	if !strings.HasPrefix(b.Config.Workspace.StatePath, b.Config.Workspace.RootPath) {
+	if !strings.HasPrefix(b.Config.Workspace.StatePath, rootPath) {
 		err = setPermissions(ctx, w, b.Config.Workspace.StatePath, permissions)
 		if err != nil {
 			return err
 		}
 	}
 
-	if !strings.HasPrefix(b.Config.Workspace.ResourcePath, b.Config.Workspace.RootPath) {
+	if !strings.HasPrefix(b.Config.Workspace.ResourcePath, rootPath) {
 		err = setPermissions(ctx, w, b.Config.Workspace.ResourcePath, permissions)
 		if err != nil {
 			return err

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -21,7 +21,11 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Workspace: config.Workspace{
-				RootPath: "/Users/foo@bar.com",
+				RootPath:     "/Users/foo@bar.com",
+				ArtifactPath: "/Users/foo@bar.com/artifacts",
+				FilePath:     "/Users/foo@bar.com/files",
+				StatePath:    "/Users/foo@bar.com/state",
+				ResourcePath: "/Users/foo@bar.com/resources",
 			},
 			Permissions: []resources.Permission{
 				{Level: CAN_MANAGE, UserName: "TestUser"},
@@ -59,7 +63,7 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 	workspaceApi.EXPECT().GetStatusByPath(mock.Anything, "/Users/foo@bar.com").Return(&workspace.ObjectInfo{
 		ObjectId: 1234,
 	}, nil)
-	workspaceApi.EXPECT().UpdatePermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
+	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
 		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
 			{UserName: "TestUser", PermissionLevel: "CAN_MANAGE"},
 			{GroupName: "TestGroup", PermissionLevel: "CAN_READ"},
@@ -71,4 +75,117 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 
 	diags := bundle.Apply(context.Background(), b, bundle.Seq(ValidateSharedRootPermissions(), ApplyWorkspaceRootPermissions()))
 	require.Empty(t, diags)
+}
+
+func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				RootPath:     "/Some/Root/Path",
+				ArtifactPath: "/Users/foo@bar.com/artifacts",
+				FilePath:     "/Users/foo@bar.com/files",
+				StatePath:    "/Users/foo@bar.com/state",
+				ResourcePath: "/Users/foo@bar.com/resources",
+			},
+			Permissions: []resources.Permission{
+				{Level: CAN_MANAGE, UserName: "TestUser"},
+				{Level: CAN_VIEW, GroupName: "TestGroup"},
+				{Level: CAN_RUN, ServicePrincipalName: "TestServicePrincipal"},
+			},
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"job_1": {JobSettings: &jobs.JobSettings{Name: "job_1"}},
+					"job_2": {JobSettings: &jobs.JobSettings{Name: "job_2"}},
+				},
+				Pipelines: map[string]*resources.Pipeline{
+					"pipeline_1": {PipelineSpec: &pipelines.PipelineSpec{}},
+					"pipeline_2": {PipelineSpec: &pipelines.PipelineSpec{}},
+				},
+				Models: map[string]*resources.MlflowModel{
+					"model_1": {Model: &ml.Model{}},
+					"model_2": {Model: &ml.Model{}},
+				},
+				Experiments: map[string]*resources.MlflowExperiment{
+					"experiment_1": {Experiment: &ml.Experiment{}},
+					"experiment_2": {Experiment: &ml.Experiment{}},
+				},
+				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
+					"endpoint_1": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
+					"endpoint_2": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
+				},
+			},
+		},
+	}
+
+	m := mocks.NewMockWorkspaceClient(t)
+	b.SetWorkpaceClient(m.WorkspaceClient)
+	workspaceApi := m.GetMockWorkspaceAPI()
+	workspaceApi.EXPECT().GetStatusByPath(mock.Anything, "/Some/Root/Path").Return(&workspace.ObjectInfo{
+		ObjectId: 1,
+	}, nil)
+	workspaceApi.EXPECT().GetStatusByPath(mock.Anything, "/Users/foo@bar.com/artifacts").Return(&workspace.ObjectInfo{
+		ObjectId: 2,
+	}, nil)
+	workspaceApi.EXPECT().GetStatusByPath(mock.Anything, "/Users/foo@bar.com/files").Return(&workspace.ObjectInfo{
+		ObjectId: 3,
+	}, nil)
+	workspaceApi.EXPECT().GetStatusByPath(mock.Anything, "/Users/foo@bar.com/state").Return(&workspace.ObjectInfo{
+		ObjectId: 4,
+	}, nil)
+	workspaceApi.EXPECT().GetStatusByPath(mock.Anything, "/Users/foo@bar.com/resources").Return(&workspace.ObjectInfo{
+		ObjectId: 5,
+	}, nil)
+
+	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
+		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
+			{UserName: "TestUser", PermissionLevel: "CAN_MANAGE"},
+			{GroupName: "TestGroup", PermissionLevel: "CAN_READ"},
+			{ServicePrincipalName: "TestServicePrincipal", PermissionLevel: "CAN_RUN"},
+		},
+		WorkspaceObjectId:   "1",
+		WorkspaceObjectType: "directories",
+	}).Return(nil, nil)
+
+	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
+		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
+			{UserName: "TestUser", PermissionLevel: "CAN_MANAGE"},
+			{GroupName: "TestGroup", PermissionLevel: "CAN_READ"},
+			{ServicePrincipalName: "TestServicePrincipal", PermissionLevel: "CAN_RUN"},
+		},
+		WorkspaceObjectId:   "2",
+		WorkspaceObjectType: "directories",
+	}).Return(nil, nil)
+
+	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
+		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
+			{UserName: "TestUser", PermissionLevel: "CAN_MANAGE"},
+			{GroupName: "TestGroup", PermissionLevel: "CAN_READ"},
+			{ServicePrincipalName: "TestServicePrincipal", PermissionLevel: "CAN_RUN"},
+		},
+		WorkspaceObjectId:   "3",
+		WorkspaceObjectType: "directories",
+	}).Return(nil, nil)
+
+	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
+		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
+			{UserName: "TestUser", PermissionLevel: "CAN_MANAGE"},
+			{GroupName: "TestGroup", PermissionLevel: "CAN_READ"},
+			{ServicePrincipalName: "TestServicePrincipal", PermissionLevel: "CAN_RUN"},
+		},
+		WorkspaceObjectId:   "4",
+		WorkspaceObjectType: "directories",
+	}).Return(nil, nil)
+
+	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
+		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
+			{UserName: "TestUser", PermissionLevel: "CAN_MANAGE"},
+			{GroupName: "TestGroup", PermissionLevel: "CAN_READ"},
+			{ServicePrincipalName: "TestServicePrincipal", PermissionLevel: "CAN_RUN"},
+		},
+		WorkspaceObjectId:   "5",
+		WorkspaceObjectType: "directories",
+	}).Return(nil, nil)
+
+	diags := bundle.Apply(context.Background(), b, ApplyWorkspaceRootPermissions())
+	require.NoError(t, diags.Error())
 }


### PR DESCRIPTION
## Changes
Changed to use SetPermissions() to configure the permissions which remove other permissions on deployment folders.

## Tests
Added unit test

