### PR TITLE
Fix path to repository-wide exclude file

### DIFF
--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -252,8 +252,8 @@ func NewRepository(path vfs.Path) (*Repository, error) {
 		newStringIgnoreRules([]string{
 			".git",
 		}),
-		// Load repository-wide excludes file.
-		repo.newIgnoreFile(".git/info/excludes"),
+		// Load repository-wide exclude file.
+		repo.newIgnoreFile(".git/info/exclude"),
 		// Load root gitignore file.
 		repo.newIgnoreFile(".gitignore"),
 	}


### PR DESCRIPTION
## Changes

This file is at `info/exclude`, and not `info/excludes`.

Also see https://git-scm.com/docs/gitignore.

## Tests

Manually confirmed that these ignore patterns are now picked up. I created a repository with a pattern in this file and ran `sync` to confirm it ignores files matching the pattern.