### PR TITLE
Add "output" flag to the bundle sync command

### DIFF
--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -1,7 +1,9 @@
 package bundle
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/databricks/cli/bundle"
@@ -9,6 +11,7 @@ import (
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/sync"
 	"github.com/spf13/cobra"
@@ -18,12 +21,26 @@ type syncFlags struct {
 	interval time.Duration
 	full     bool
 	watch    bool
+	output   flags.Output
 }
 
 func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) (*sync.SyncOptions, error) {
 	opts, err := files.GetSyncOptions(cmd.Context(), bundle.ReadOnly(b))
 	if err != nil {
 		return nil, fmt.Errorf("cannot get sync options: %w", err)
+	}
+
+	if f.output != "" {
+		var outputFunc func(context.Context, <-chan sync.Event, io.Writer)
+		switch f.output {
+		case flags.OutputText:
+			outputFunc = sync.TextOutput
+		case flags.OutputJSON:
+			outputFunc = sync.JsonOutput
+		}
+		opts.OutputHandler = func(ctx context.Context, c <-chan sync.Event) {
+			outputFunc(ctx, c, cmd.OutOrStdout())
+		}
 	}
 
 	opts.Full = f.full
@@ -42,6 +59,7 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().DurationVar(&f.interval, "interval", 1*time.Second, "file system polling interval (for --watch)")
 	cmd.Flags().BoolVar(&f.full, "full", false, "perform full synchronization (default is incremental)")
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
+	cmd.Flags().Var(&f.output, "output", "type of the output format")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -65,6 +83,7 @@ func newSyncCommand() *cobra.Command {
 		if err != nil {
 			return err
 		}
+		defer s.Close()
 
 		log.Infof(ctx, "Remote file sync location: %v", opts.RemotePath)
 


### PR DESCRIPTION
## Changes
We want to use 'bundle sync' in the vscode extension before running a file as an ad-hoc job (or through the context api). Right now we use bundle deploy in these cases, but deploying bundle resources is not always expected when you just want to quickly run a file. Sync make more sense in these cases, but we still want to have verbose output to see what's happening.

In the 'deploy' command we have hidden 'verbose' flag. For the sync I've just added 'output' flag, handling both json and text cases. And the flag is not hidden (although we still don't show any output by default, if the flag is not set). 


## Tests
Manually

