### PR TITLE
Added E2E test to run Python wheels on interactive cluster created in bundle

### DIFF
--- a/internal/bundle/bundles/python_wheel_task_with_cluster/databricks_template_schema.json
+++ b/internal/bundle/bundles/python_wheel_task_with_cluster/databricks_template_schema.json
@@ -1,0 +1,25 @@
+{
+    "properties": {
+        "project_name": {
+            "type": "string",
+            "default": "my_test_code",
+            "description": "Unique name for this project"
+        },
+        "spark_version": {
+            "type": "string",
+            "description": "Spark version used for job cluster"
+        },
+        "node_type_id": {
+            "type": "string",
+            "description": "Node type id for job cluster"
+        },
+        "unique_id": {
+            "type": "string",
+            "description": "Unique ID for job name"
+        },
+        "instance_pool_id": {
+            "type": "string",
+            "description": "Instance pool id for job cluster"
+        }
+    }
+}

--- a/internal/bundle/bundles/python_wheel_task_with_cluster/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/python_wheel_task_with_cluster/template/databricks.yml.tmpl
@@ -1,0 +1,29 @@
+bundle:
+  name: wheel-task
+
+workspace:
+  root_path: "~/.bundle/{{.unique_id}}"
+
+resources:
+  clusters:
+    test_cluster:
+      cluster_name: "test-cluster-{{.unique_id}}"
+      spark_version: "{{.spark_version}}"
+      node_type_id: "{{.node_type_id}}"
+      num_workers: 1
+      data_security_mode: USER_ISOLATION
+
+  jobs:
+    some_other_job:
+      name: "[${bundle.target}] Test Wheel Job {{.unique_id}}"
+      tasks:
+        - task_key: TestTask
+          existing_cluster_id: "${resources.clusters.test_cluster.cluster_id}"
+          python_wheel_task:
+            package_name: my_test_code
+            entry_point: run
+            parameters:
+              - "one"
+              - "two"
+          libraries:
+            - whl: ./dist/*.whl

--- a/internal/bundle/bundles/python_wheel_task_with_cluster/template/setup.py.tmpl
+++ b/internal/bundle/bundles/python_wheel_task_with_cluster/template/setup.py.tmpl
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+import {{.project_name}}
+
+setup(
+    name="{{.project_name}}",
+    version={{.project_name}}.__version__,
+    author={{.project_name}}.__author__,
+    url="https://databricks.com",
+    author_email="john.doe@databricks.com",
+    description="my example wheel",
+    packages=find_packages(include=["{{.project_name}}"]),
+    entry_points={"group1": "run={{.project_name}}.__main__:main"},
+    install_requires=["setuptools"],
+)

--- a/internal/bundle/bundles/python_wheel_task_with_cluster/template/{{.project_name}}/__init__.py
+++ b/internal/bundle/bundles/python_wheel_task_with_cluster/template/{{.project_name}}/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "0.0.1"
+__author__ = "Databricks"

--- a/internal/bundle/bundles/python_wheel_task_with_cluster/template/{{.project_name}}/__main__.py
+++ b/internal/bundle/bundles/python_wheel_task_with_cluster/template/{{.project_name}}/__main__.py
@@ -1,0 +1,16 @@
+"""
+The entry point of the Python Wheel
+"""
+
+import sys
+
+
+def main():
+    # This method will print the provided arguments
+    print("Hello from my func")
+    print("Got arguments:")
+    print(sys.argv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes
Added E2E test to run python wheels on interactive cluster created in bundle.

We had a gap in testing wheel on all purpose clusters, so this PR addresses the gap

