### PR TITLE
Use Go 1.23

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.7
+          go-version: 1.23.2
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.7
+          go-version: 1.23.2
 
           # No need to download cached dependencies when running gofmt.
           cache: false
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.7
+          go-version: 1.23.2
 
       # Github repo: https://github.com/ajv-validator/ajv-cli
       - name: Install ajv-cli

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.7
+          go-version: 1.23.2
 
           # The default cache key for this action considers only the `go.sum` file.
           # We include .goreleaser.yaml here to differentiate from the cache used by the push action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.7
+          go-version: 1.23.2
 
           # The default cache key for this action considers only the `go.sum` file.
           # We include .goreleaser.yaml here to differentiate from the cache used by the push action

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/databricks/cli
 
-go 1.22.0
+go 1.23
 
-toolchain go1.22.7
+toolchain go1.23.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.0 // MIT


### PR DESCRIPTION
## Changes

This was released 2+ months ago so it has baked enough.

Blog post: https://go.dev/blog/go1.23.

## Tests

None other than unit and integration tests.
