### PR TITLE
Address goreleaser deprecation warning

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -6,6 +6,15 @@ on:
       - "main"
       - "demo-*"
 
+  # Confirm that snapshot builds work if this file is modified.
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - ".github/workflows/release-snapshot.yml"
+
   workflow_dispatch:
 
 jobs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,7 +95,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: '{{ incpatch .Version }}-dev+{{ .ShortCommit }}'
+  version_template: '{{ incpatch .Version }}-dev+{{ .ShortCommit }}'
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Changes

Deprecation of `name_template`:  https://goreleaser.com/deprecations#snapshotnametemplate

Observed in the "Run GoReleaser" step of https://github.com/databricks/cli/actions/runs/11599180656/job/32296748853.

## Tests

* Run `goreleaser check`
* The snapshot build on this PR works
