### PR TITLE
Update actions/github-script to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
       - name: Update setup-cli
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
           script: |
@@ -87,7 +87,7 @@ jobs:
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
       - name: Update homebrew-tap
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
           script: |
@@ -124,7 +124,7 @@ jobs:
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
       - name: Update CLI version in the VSCode extension
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Changes

This fixes warnings on the jobs that create PRs after a release:
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/github-script@v6. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

Observed this here: https://github.com/databricks/cli/actions/runs/11599180656

## Tests

The [release notes](https://github.com/actions/github-script/releases/tag/v7.0.0) indicate no major changes besides the upgrade to Node 20.