### PR TITLE
Clean host URL in the `auth login` command

### DIFF
--- a/libs/auth/oauth.go
+++ b/libs/auth/oauth.go
@@ -144,19 +144,21 @@ func (a *PersistentAuth) Challenge(ctx context.Context) error {
 	return nil
 }
 
-// Best effort to remove url query args and fragments from the host
+// Remove url query and path args and fragments from the host
 func (a *PersistentAuth) cleanHost() {
 	parsedHost, err := url.Parse(a.Host)
 	if err != nil {
 		return
 	}
+	// when either host or scheme is empty, we don't want to clean it. This is because
+	// the Go url library parses a raw "abc" string as the path of a URL and cleaning
+	// it will return thus return an empty string.
+	if parsedHost.Host == "" || parsedHost.Scheme == "" {
+		return
+	}
 	host := url.URL{
 		Scheme: parsedHost.Scheme,
 		Host:   parsedHost.Host,
-
-		// We retain the path, because it may contain the account id for account
-		// logins.
-		Path: parsedHost.Path,
 	}
 	a.Host = host.String()
 }

--- a/libs/auth/oauth.go
+++ b/libs/auth/oauth.go
@@ -144,7 +144,8 @@ func (a *PersistentAuth) Challenge(ctx context.Context) error {
 	return nil
 }
 
-// Remove url query and path args and fragments from the host
+// This function cleans up the host URL by only retaining the scheme and the host.
+// This function thus removes any path, query arguments, or fragments from the URL.
 func (a *PersistentAuth) cleanHost() {
 	parsedHost, err := url.Parse(a.Host)
 	if err != nil {

--- a/libs/auth/oauth.go
+++ b/libs/auth/oauth.go
@@ -150,9 +150,15 @@ func (a *PersistentAuth) cleanHost() {
 	if err != nil {
 		return
 	}
-	parsedHost.RawQuery = ""
-	parsedHost.Fragment = ""
-	a.Host = parsedHost.String()
+	host := url.URL{
+		Scheme: parsedHost.Scheme,
+		Host:   parsedHost.Host,
+
+		// We retain the path, because it may contain the account id for account
+		// logins.
+		Path: parsedHost.Path,
+	}
+	a.Host = host.String()
 }
 
 func (a *PersistentAuth) init(ctx context.Context) error {

--- a/libs/auth/oauth.go
+++ b/libs/auth/oauth.go
@@ -144,15 +144,13 @@ func (a *PersistentAuth) Challenge(ctx context.Context) error {
 	return nil
 }
 
-// Best effort to remove url path, query args and fragments from the host
+// Best effort to remove url query args and fragments from the host
 func (a *PersistentAuth) cleanHost() {
 	parsedHost, err := url.Parse(a.Host)
 	if err != nil {
 		return
 	}
-	parsedHost.RawPath = ""
 	parsedHost.RawQuery = ""
-	parsedHost.Path = ""
 	parsedHost.Fragment = ""
 	a.Host = parsedHost.String()
 }

--- a/libs/auth/oauth_test.go
+++ b/libs/auth/oauth_test.go
@@ -229,7 +229,7 @@ func TestChallengeFailed(t *testing.T) {
 	})
 }
 
-func TestPerisistentAuthCleanHost(t *testing.T) {
+func TestPersistentAuthCleanHost(t *testing.T) {
 	for _, tcases := range []struct {
 		in  string
 		out string

--- a/libs/auth/oauth_test.go
+++ b/libs/auth/oauth_test.go
@@ -234,22 +234,26 @@ func TestPersistentAuthCleanHost(t *testing.T) {
 		in  string
 		out string
 	}{
-
 		{"https://example.com", "https://example.com"},
-		{"https://example.com/path", "https://example.com/path"},
-		{"https://example.com/path/subpath", "https://example.com/path/subpath"},
-		{"https://example.com/path?query=1", "https://example.com/path"},
-		{"https://example.com/path?query=1&other=2", "https://example.com/path"},
-		{"https://example.com/path#fragment", "https://example.com/path"},
-		{"https://example.com/path?query=1#fragment", "https://example.com/path"},
-		{"https://example.com/path?query=1&other=2#fragment", "https://example.com/path"},
-		{"https://example.com/path/subpath?query=1", "https://example.com/path/subpath"},
-		{"https://example.com/path/subpath?query=1&other=2", "https://example.com/path/subpath"},
-		{"https://example.com/path/subpath#fragment", "https://example.com/path/subpath"},
-		{"https://example.com/path/subpath?query=1#fragment", "https://example.com/path/subpath"},
-		{"https://example.com/path/subpath?query=1&other=2#fragment", "https://example.com/path/subpath"},
-		{"https://example.com/path?query=1%20value&other=2%20value", "https://example.com/path"},
-		{"https://example.com/path/subpath?query=1%20value&other=2%20value", "https://example.com/path/subpath"},
+		{"https://example.com/", "https://example.com"},
+		{"https://example.com/path", "https://example.com"},
+		{"https://example.com/path/subpath", "https://example.com"},
+		{"https://example.com/path?query=1", "https://example.com"},
+		{"https://example.com/path?query=1&other=2", "https://example.com"},
+		{"https://example.com/path#fragment", "https://example.com"},
+		{"https://example.com/path?query=1#fragment", "https://example.com"},
+		{"https://example.com/path?query=1&other=2#fragment", "https://example.com"},
+		{"https://example.com/path/subpath?query=1", "https://example.com"},
+		{"https://example.com/path/subpath?query=1&other=2", "https://example.com"},
+		{"https://example.com/path/subpath#fragment", "https://example.com"},
+		{"https://example.com/path/subpath?query=1#fragment", "https://example.com"},
+		{"https://example.com/path/subpath?query=1&other=2#fragment", "https://example.com"},
+		{"https://example.com/path?query=1%20value&other=2%20value", "https://example.com"},
+		{"http://example.com/path/subpath?query=1%20value&other=2%20value", "http://example.com"},
+
+		// URLs without scheme should be left as is
+		{"abc", "abc"},
+		{"abc.com/def", "abc.com/def"},
 	} {
 		p := &PersistentAuth{
 			Host: tcases.in,

--- a/libs/auth/oauth_test.go
+++ b/libs/auth/oauth_test.go
@@ -234,21 +234,22 @@ func TestPerisistentAuthCleanHost(t *testing.T) {
 		in  string
 		out string
 	}{
+
 		{"https://example.com", "https://example.com"},
-		{"https://example.com/", "https://example.com"},
-		{"https://example.com/path", "https://example.com"},
-		{"https://example.com/path?query", "https://example.com"},
-		{"https://example.com/path?query=1&other=2", "https://example.com"},
-		{"https://example.com/path#fragment", "https://example.com"},
-		{"https://example.com/path?query=1#fragment", "https://example.com"},
-		{"https://example.com/path?query=1&other=2#fragment", "https://example.com"},
-		{"https://example.com/path/subpath", "https://example.com"},
-		{"https://example.com/path/subpath?query=1", "https://example.com"},
-		{"https://example.com/path/subpath?query=1&other=2", "https://example.com"},
-		{"https://example.com/path/subpath#fragment", "https://example.com"},
-		{"https://example.com/path/subpath?query=1#fragment", "https://example.com"},
-		{"https://example.com/path/subpath?query=1&other=2#fragment", "https://example.com"},
-		{"https://example.com/path?query=1%20value&other=2%20value", "https://example.com"},
+		{"https://example.com/path", "https://example.com/path"},
+		{"https://example.com/path/subpath", "https://example.com/path/subpath"},
+		{"https://example.com/path?query=1", "https://example.com/path"},
+		{"https://example.com/path?query=1&other=2", "https://example.com/path"},
+		{"https://example.com/path#fragment", "https://example.com/path"},
+		{"https://example.com/path?query=1#fragment", "https://example.com/path"},
+		{"https://example.com/path?query=1&other=2#fragment", "https://example.com/path"},
+		{"https://example.com/path/subpath?query=1", "https://example.com/path/subpath"},
+		{"https://example.com/path/subpath?query=1&other=2", "https://example.com/path/subpath"},
+		{"https://example.com/path/subpath#fragment", "https://example.com/path/subpath"},
+		{"https://example.com/path/subpath?query=1#fragment", "https://example.com/path/subpath"},
+		{"https://example.com/path/subpath?query=1&other=2#fragment", "https://example.com/path/subpath"},
+		{"https://example.com/path?query=1%20value&other=2%20value", "https://example.com/path"},
+		{"https://example.com/path/subpath?query=1%20value&other=2%20value", "https://example.com/path/subpath"},
 	} {
 		p := &PersistentAuth{
 			Host: tcases.in,

--- a/libs/auth/oauth_test.go
+++ b/libs/auth/oauth_test.go
@@ -228,3 +228,32 @@ func TestChallengeFailed(t *testing.T) {
 		assert.EqualError(t, err, "authorize: access_denied: Policy evaluation failed for this request")
 	})
 }
+
+func TestPerisistentAuthCleanHost(t *testing.T) {
+	for _, tcases := range []struct {
+		in  string
+		out string
+	}{
+		{"https://example.com", "https://example.com"},
+		{"https://example.com/", "https://example.com"},
+		{"https://example.com/path", "https://example.com"},
+		{"https://example.com/path?query", "https://example.com"},
+		{"https://example.com/path?query=1&other=2", "https://example.com"},
+		{"https://example.com/path#fragment", "https://example.com"},
+		{"https://example.com/path?query=1#fragment", "https://example.com"},
+		{"https://example.com/path?query=1&other=2#fragment", "https://example.com"},
+		{"https://example.com/path/subpath", "https://example.com"},
+		{"https://example.com/path/subpath?query=1", "https://example.com"},
+		{"https://example.com/path/subpath?query=1&other=2", "https://example.com"},
+		{"https://example.com/path/subpath#fragment", "https://example.com"},
+		{"https://example.com/path/subpath?query=1#fragment", "https://example.com"},
+		{"https://example.com/path/subpath?query=1&other=2#fragment", "https://example.com"},
+		{"https://example.com/path?query=1%20value&other=2%20value", "https://example.com"},
+	} {
+		p := &PersistentAuth{
+			Host: tcases.in,
+		}
+		p.cleanHost()
+		assert.Equal(t, tcases.out, p.Host)
+	}
+}


### PR DESCRIPTION
## Changes
The host URL for databricks workspaces includes the workspaceId by default as a positional arg. Eg: https://e2-dogfood.staging.cloud.databricks.com/?o=1234

Thus a user can't simply copy paste the URL today to the auth login command. They'll see a runtime error:
```
➜  cli git:(main) ✗ databricks auth login --host https://e2-dogfood.staging.cloud.databricks.com/\?o\=xxx --profile new-dg
Error: oidc: fetch .well-known: failed to unmarshal response body: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
GET /login.html
...
```

## Tests
Unit tests and manually. Now auth login works even when the workspace_id is included in the URL.
