### PR TITLE
Fix relative path resolution for dashboards on Windows

### DIFF
--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -163,7 +163,7 @@ func (t *translateContext) translateNoOp(literal, localFullPath, localRelPath, r
 }
 
 func (t *translateContext) retainLocalAbsoluteFilePath(literal, localFullPath, localRelPath, remotePath string) (string, error) {
-	info, err := t.b.SyncRoot.Stat(localRelPath)
+	info, err := t.b.SyncRoot.Stat(filepath.ToSlash(localRelPath))
 	if errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("file %s not found", literal)
 	}

--- a/bundle/config/mutator/translate_paths_dashboards_test.go
+++ b/bundle/config/mutator/translate_paths_dashboards_test.go
@@ -1,0 +1,54 @@
+package mutator_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/bundletest"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/vfs"
+	"github.com/databricks/databricks-sdk-go/service/dashboards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslatePathsDashboards_FilePathRelativeSubDirectory(t *testing.T) {
+	dir := t.TempDir()
+	touchEmptyFile(t, filepath.Join(dir, "src", "my_dashboard.lvdash.json"))
+
+	b := &bundle.Bundle{
+		SyncRootPath: dir,
+		SyncRoot:     vfs.MustNew(dir),
+		Config: config.Root{
+			Resources: config.Resources{
+				Dashboards: map[string]*resources.Dashboard{
+					"dashboard": {
+						CreateDashboardRequest: &dashboards.CreateDashboardRequest{
+							DisplayName: "My Dashboard",
+						},
+						FilePath: "../src/my_dashboard.lvdash.json",
+					},
+				},
+			},
+		},
+	}
+
+	bundletest.SetLocation(b, "resources.dashboards", []dyn.Location{{
+		File: filepath.Join(dir, "resources/dashboard.yml"),
+	}})
+
+	diags := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
+	require.NoError(t, diags.Error())
+
+	// Assert that the file path for the dashboard has been converted to its local absolute path.
+	assert.Equal(
+		t,
+		filepath.Join(dir, "src", "my_dashboard.lvdash.json"),
+		b.Config.Resources.Dashboards["dashboard"].FilePath,
+	)
+}


### PR DESCRIPTION
## Changes

The file presence check for dashboard files was missing a `filepath.ToSlash`.

This means it didn't work on Windows unless the dashboard was located at a path without slashes (i.e. the bundle root).

Closes #1875.

## Tests

* Added a unit test to cover this case (failed before the fix).
* Manually ran a dashboard deployment on Windows.

