### PR TITLE
fix: In-Place deployment for notebooks without extension

### DIFF
--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -53,6 +53,9 @@ type wsfsFileInfo struct {
 
 	// The export format of a notebook. This is not exposed by the SDK.
 	ReposExportFormat workspace.ExportFormat `json:"repos_export_format,omitempty"`
+
+	// Explicitly added file extension of the notebook based on its language
+	VirtualFileExtension string `json:"virtual_file_extension,omitempty"`
 }
 
 func (info wsfsFileInfo) Name() string {
@@ -86,6 +89,10 @@ func (info wsfsFileInfo) Sys() any {
 
 func (info wsfsFileInfo) WorkspaceObjectInfo() workspace.ObjectInfo {
 	return info.ObjectInfo
+}
+
+func (info wsfsFileInfo) VirtualExtension() string {
+	return info.VirtualFileExtension
 }
 
 // UnmarshalJSON is a custom unmarshaller for the wsfsFileInfo struct.

--- a/libs/filer/workspace_files_extensions_client.go
+++ b/libs/filer/workspace_files_extensions_client.go
@@ -98,6 +98,7 @@ func (w *workspaceFilesExtensionsClient) getNotebookStatByNameWithExt(ctx contex
 	// Modify the stat object path to include the extension. This stat object will be used
 	// to return the fs.FileInfo object in the stat method.
 	stat.Path = stat.Path + ext
+	stat.VirtualFileExtension = ext
 	return &workspaceFileStatus{
 		wsfsFileInfo:        stat,
 		nameForWorkspaceAPI: nameWithoutExt,
@@ -127,6 +128,7 @@ func (w *workspaceFilesExtensionsClient) getNotebookStatByNameWithoutExt(ctx con
 	// Modify the stat object path to include the extension. This stat object will be used
 	// to return the fs.DirEntry object in the ReadDir method.
 	stat.Path = stat.Path + ext
+	stat.VirtualFileExtension = ext
 	return &workspaceFileStatus{
 		wsfsFileInfo:        stat,
 		nameForWorkspaceAPI: name,
@@ -214,7 +216,7 @@ func (w *workspaceFilesExtensionsClient) ReadDir(ctx context.Context, name strin
 				return nil, err
 			}
 			// Replace the entry with the new entry that includes the extension.
-			entries[i] = wsfsDirEntry{wsfsFileInfo{ObjectInfo: stat.ObjectInfo}}
+			entries[i] = wsfsDirEntry{wsfsFileInfo{ObjectInfo: stat.ObjectInfo, VirtualFileExtension: stat.VirtualFileExtension}}
 		}
 
 		// Error if we have seen this path before in the current directory.
@@ -313,7 +315,7 @@ func (w *workspaceFilesExtensionsClient) Stat(ctx context.Context, name string) 
 			return nil, err
 		}
 
-		return wsfsFileInfo{ObjectInfo: stat.ObjectInfo}, nil
+		return wsfsFileInfo{ObjectInfo: stat.ObjectInfo, VirtualFileExtension: stat.VirtualFileExtension}, nil
 	}
 
 	return info, err


### PR DESCRIPTION
## Changes

For in-place deployment trims notebook file extension only if it was added by CLI
 
## Tests

Manually for now
