### PR TITLE
Allow overriding compute for non-development mode targets

### DIFF
--- a/bundle/config/mutator/override_compute.go
+++ b/bundle/config/mutator/override_compute.go
@@ -42,6 +42,7 @@ func (m *overrideCompute) Apply(ctx context.Context, b *bundle.Bundle) diag.Diag
 
 	if b.Config.Bundle.Mode == config.Production {
 		if b.Config.Bundle.ClusterId != "" {
+			// Overriding compute via a command-line flag for production works, but is not recommended.
 			diags = diags.Extend(diag.Warningf("overriding compute for a target that uses 'mode: production' is not recommended"))
 		}
 		if env.Get(ctx, "DATABRICKS_CLUSTER_ID") != "" {

--- a/bundle/config/mutator/override_compute.go
+++ b/bundle/config/mutator/override_compute.go
@@ -44,14 +44,17 @@ func (m *overrideCompute) Apply(ctx context.Context, b *bundle.Bundle) diag.Diag
 	if b.Config.Bundle.Mode == config.Production {
 		if b.Config.Bundle.ClusterId != "" {
 			// Overriding compute via a command-line flag for production works, but is not recommended.
-			diags = diags.Extend(diag.Warningf("Overriding compute for a target that uses 'mode: production' is not recommended"))
+			diags = diags.Extend(diag.Diagnostics{{
+				Summary: "Setting a cluster override for a target that uses 'mode: production' is not recommended",
+				Detail:  "It is recommended to always use the same compute for production target for consistency.",
+			}})
 		}
 	}
 	if v := env.Get(ctx, "DATABRICKS_CLUSTER_ID"); v != "" {
 		// For historical reasons, we allow setting the cluster ID via the DATABRICKS_CLUSTER_ID
 		// when development mode is used. Sometimes, this is done by accident, so we log an info message.
 		if b.Config.Bundle.Mode == config.Development {
-			cmdio.LogString(ctx, "Overriding compute because DATABRICKS_CLUSTER_ID is set. It is recommended to use --cluster-id instead, which works in any target mode.")
+			cmdio.LogString(ctx, "Setting a cluster override because DATABRICKS_CLUSTER_ID is set. It is recommended to use --cluster-id instead, which works in any target mode.")
 		} else {
 			// We don't allow using DATABRICKS_CLUSTER_ID in any other mode, it's too error-prone.
 			return diag.Warningf("The DATABRICKS_CLUSTER_ID variable is set but is ignored since the current target does not use 'mode: development'")

--- a/bundle/config/mutator/override_compute_test.go
+++ b/bundle/config/mutator/override_compute_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOverrideDevelopment(t *testing.T) {
+func TestOverrideComputeModeDevelopment(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "")
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -62,10 +62,13 @@ func TestOverrideDevelopment(t *testing.T) {
 	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[3].JobClusterKey)
 }
 
-func TestOverrideDevelopmentEnv(t *testing.T) {
+func TestOverrideComputeModeDefault(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "newClusterId")
 	b := &bundle.Bundle{
 		Config: config.Root{
+			Bundle: config.Bundle{
+				Mode: "",
+			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {JobSettings: &jobs.JobSettings{
@@ -86,11 +89,12 @@ func TestOverrideDevelopmentEnv(t *testing.T) {
 
 	m := mutator.OverrideCompute()
 	diags := bundle.Apply(context.Background(), b, m)
-	require.NoError(t, diags.Error())
-	assert.Equal(t, "cluster2", b.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
+	require.Empty(t, diags)
+	assert.Equal(t, "newClusterId", b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
+	assert.Equal(t, "newClusterId", b.Config.Resources.Jobs["job1"].Tasks[1].ExistingClusterId)
 }
 
-func TestOverridePipelineTask(t *testing.T) {
+func TestOverrideComputePipelineTask(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "newClusterId")
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -115,7 +119,7 @@ func TestOverridePipelineTask(t *testing.T) {
 	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
 }
 
-func TestOverrideForEachTask(t *testing.T) {
+func TestOverrideComputeForEachTask(t *testing.T) {
 	t.Setenv("DATABRICKS_CLUSTER_ID", "newClusterId")
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -140,10 +144,11 @@ func TestOverrideForEachTask(t *testing.T) {
 	assert.Empty(t, b.Config.Resources.Jobs["job1"].Tasks[0].ForEachTask.Task)
 }
 
-func TestOverrideProduction(t *testing.T) {
+func TesOverrideComputeProductionMode(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Bundle: config.Bundle{
+				Mode:      config.Production,
 				ClusterId: "newClusterID",
 			},
 			Resources: config.Resources{
@@ -167,6 +172,8 @@ func TestOverrideProduction(t *testing.T) {
 	m := mutator.OverrideCompute()
 	diags := bundle.Apply(context.Background(), b, m)
 	require.True(t, diags.HasError())
+	assert.ErrorContains(t, diags.Error(), "overriding compute is not allowed in production mode")
+	assert.Equal(t, "cluster2", b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
 }
 
 func TestOverrideProductionEnv(t *testing.T) {

--- a/bundle/config/mutator/override_compute_test.go
+++ b/bundle/config/mutator/override_compute_test.go
@@ -172,7 +172,7 @@ func TestOverrideComputeModeProduction(t *testing.T) {
 	m := mutator.OverrideCompute()
 	diags := bundle.Apply(context.Background(), b, m)
 	require.Len(t, diags, 1)
-	assert.Equal(t, "Overriding compute for a target that uses 'mode: production' is not recommended", diags[0].Summary)
+	assert.Equal(t, "Setting a cluster override for a target that uses 'mode: production' is not recommended", diags[0].Summary)
 	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
 }
 


### PR DESCRIPTION
## Changes
Allow overriding compute for non-development targets. We previously had a restriction in place where `--cluster-id` was only allowed for targets that use `mode: development`. The intention was to prevent mistakes, but this was overly restrictive.

## Tests
Updated unit tests.
