### PR TITLE
Update filenames used by bundle generate to use `.<resource-type>.yml`

### DIFF
--- a/cmd/bundle/generate/generate_test.go
+++ b/cmd/bundle/generate/generate_test.go
@@ -90,7 +90,7 @@ func TestGeneratePipelineCommand(t *testing.T) {
 	err := cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(filepath.Join(configDir, "test_pipeline.yml"))
+	data, err := os.ReadFile(filepath.Join(configDir, "test_pipeline.pipeline.yml"))
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf(`resources:
   pipelines:
@@ -186,7 +186,7 @@ func TestGenerateJobCommand(t *testing.T) {
 	err := cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(filepath.Join(configDir, "test_job.yml"))
+	data, err := os.ReadFile(filepath.Join(configDir, "test_job.job.yml"))
 	require.NoError(t, err)
 
 	require.Equal(t, fmt.Sprintf(`resources:

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -88,6 +88,9 @@ func NewGenerateJobCommand() *cobra.Command {
 		oldFilename := filepath.Join(configDir, fmt.Sprintf("%s.yml", jobKey))
 		filename := filepath.Join(configDir, fmt.Sprintf("%s.job.yml", jobKey))
 
+		// User might continuously run generate command to update their bundle jobs with any changes made in Databricks UI.
+		// Due to changing in the generated file names, we need to first rename existing resource file to the new name.
+		// Otherwise users can end up with duplicated resources.
 		err = os.Rename(oldFilename, filename)
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("failed to rename file %s. DABs uses the resource type as a sub-extension for generated content, please rename it to %s, err: %w", oldFilename, filename, err)

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -83,7 +83,15 @@ func NewGenerateJobCommand() *cobra.Command {
 			return err
 		}
 
-		filename := filepath.Join(configDir, fmt.Sprintf("%s.yml", jobKey))
+		oldFilename := filepath.Join(configDir, fmt.Sprintf("%s.yml", jobKey))
+		filename := filepath.Join(configDir, fmt.Sprintf("%s.job.yml", jobKey))
+
+		err = os.Rename(oldFilename, filename)
+		if err != nil {
+			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s", oldFilename, filename)
+
+		}
+
 		saver := yamlsaver.NewSaverWithStyle(map[string]yaml.Style{
 			// Including all JobSettings and nested fields which are map[string]string type
 			"spark_conf":  yaml.DoubleQuotedStyle,

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -90,7 +90,7 @@ func NewGenerateJobCommand() *cobra.Command {
 
 		err = os.Rename(oldFilename, filename)
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s, err: %w", oldFilename, filename, err)
+			return fmt.Errorf("failed to rename file %s. DABs uses the resource type as a sub-extension for generated content, please rename it to %s, err: %w", oldFilename, filename, err)
 		}
 
 		saver := yamlsaver.NewSaverWithStyle(map[string]yaml.Style{

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -1,7 +1,9 @@
 package generate
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -87,9 +89,8 @@ func NewGenerateJobCommand() *cobra.Command {
 		filename := filepath.Join(configDir, fmt.Sprintf("%s.job.yml", jobKey))
 
 		err = os.Rename(oldFilename, filename)
-		if err != nil {
-			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s", oldFilename, filename)
-
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s, err: %w", oldFilename, filename, err)
 		}
 
 		saver := yamlsaver.NewSaverWithStyle(map[string]yaml.Style{

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -1,7 +1,9 @@
 package generate
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -87,9 +89,8 @@ func NewGeneratePipelineCommand() *cobra.Command {
 		filename := filepath.Join(configDir, fmt.Sprintf("%s.pipeline.yml", pipelineKey))
 
 		err = os.Rename(oldFilename, filename)
-		if err != nil {
-			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s", oldFilename, filename)
-
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s, err: %w", oldFilename, filename, err)
 		}
 
 		saver := yamlsaver.NewSaverWithStyle(

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -88,9 +88,12 @@ func NewGeneratePipelineCommand() *cobra.Command {
 		oldFilename := filepath.Join(configDir, fmt.Sprintf("%s.yml", pipelineKey))
 		filename := filepath.Join(configDir, fmt.Sprintf("%s.pipeline.yml", pipelineKey))
 
+		// User might continuously run generate command to update their bundle jobs with any changes made in Databricks UI.
+		// Due to changing in the generated file names, we need to first rename existing resource file to the new name.
+		// Otherwise users can end up with duplicated resources.
 		err = os.Rename(oldFilename, filename)
 		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s, err: %w", oldFilename, filename, err)
+			return fmt.Errorf("failed to rename file %s. DABs uses the resource type as a sub-extension for generated content, please rename it to %s, err: %w", oldFilename, filename, err)
 		}
 
 		saver := yamlsaver.NewSaverWithStyle(

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -83,7 +83,15 @@ func NewGeneratePipelineCommand() *cobra.Command {
 			return err
 		}
 
-		filename := filepath.Join(configDir, fmt.Sprintf("%s.yml", pipelineKey))
+		oldFilename := filepath.Join(configDir, fmt.Sprintf("%s.yml", pipelineKey))
+		filename := filepath.Join(configDir, fmt.Sprintf("%s.pipeline.yml", pipelineKey))
+
+		err = os.Rename(oldFilename, filename)
+		if err != nil {
+			return fmt.Errorf("failed to rename file %s. DABs uses resource type as sub extension for generated content, please rename to %s", oldFilename, filename)
+
+		}
+
 		saver := yamlsaver.NewSaverWithStyle(
 			// Including all PipelineSpec and nested fields which are map[string]string type
 			map[string]yaml.Style{

--- a/internal/bundle/bind_resource_test.go
+++ b/internal/bundle/bind_resource_test.go
@@ -166,7 +166,7 @@ func TestAccGenerateAndBind(t *testing.T) {
 	_, err = os.Stat(filepath.Join(bundleRoot, "src", "test.py"))
 	require.NoError(t, err)
 
-	matches, err := filepath.Glob(filepath.Join(bundleRoot, "resources", "test_job_key.yml"))
+	matches, err := filepath.Glob(filepath.Join(bundleRoot, "resources", "test_job_key.job.yml"))
 	require.NoError(t, err)
 
 	require.Len(t, matches, 1)


### PR DESCRIPTION
## Changes
Update filenames used by bundle generate to use '.resource-type.yml'

Similar to [Add sub-extension to resource files in built-in templates by shreyas-goenka · Pull Request #1777 · databricks/cli](https://github.com/databricks/cli/pull/1777)

