### PR TITLE
[Release] Release v0.234.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Version changelog
 
+## [Release] Release v0.234.0
+
+Bundles:
+ * Do not execute build on bundle destroy ([#1882](https://github.com/databricks/cli/pull/1882)).
+ * Add support for non-Python ipynb notebooks to DABs ([#1827](https://github.com/databricks/cli/pull/1827)).
+
+API Changes:
+ * Added `databricks credentials` command group.
+ * Changed `databricks genie execute-message-query` command to type `databricks genie execute-message-query` command.
+ * Changed `databricks lakeview create` command with new required argument order.
+ * Added `databricks aibi-dashboard-embedding-access-policy` command group.
+ * Added `databricks aibi-dashboard-embedding-approved-domains` command group.
+ * Removed `databricks clean-rooms` command group.
+
+OpenAPI commit d25296d2f4aa7bd6195c816fdf82e0f960f775da (2024-11-07)
+Dependency updates:
+ * Upgrade TF provider to 1.58.0 ([#1900](https://github.com/databricks/cli/pull/1900)).
+ * Bump golang.org/x/sync from 0.8.0 to 0.9.0 ([#1892](https://github.com/databricks/cli/pull/1892)).
+ * Bump golang.org/x/text from 0.19.0 to 0.20.0 ([#1893](https://github.com/databricks/cli/pull/1893)).
+ * Bump golang.org/x/mod from 0.21.0 to 0.22.0 ([#1895](https://github.com/databricks/cli/pull/1895)).
+ * Bump golang.org/x/oauth2 from 0.23.0 to 0.24.0 ([#1894](https://github.com/databricks/cli/pull/1894)).
+ * Bump github.com/databricks/databricks-sdk-go from 0.49.0 to 0.51.0 ([#1878](https://github.com/databricks/cli/pull/1878)).
+
 ## [Release] Release v0.233.0
 
 CLI:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ Bundles:
 
 API Changes:
  * Added `databricks credentials` command group.
- * Changed `databricks genie execute-message-query` command to type `databricks genie execute-message-query` command.
  * Changed `databricks lakeview create` command with new required argument order.
- * Added `databricks aibi-dashboard-embedding-access-policy` command group.
- * Added `databricks aibi-dashboard-embedding-approved-domains` command group.
- * Removed `databricks clean-rooms` command group.
 
 OpenAPI commit d25296d2f4aa7bd6195c816fdf82e0f960f775da (2024-11-07)
 Dependency updates:


### PR DESCRIPTION
Bundles:
 * Do not execute build on bundle destroy ([#1882](https://github.com/databricks/cli/pull/1882)).
 * Add support for non-Python ipynb notebooks to DABs ([#1827](https://github.com/databricks/cli/pull/1827)).

API Changes:
 * Added `databricks credentials` command group.
 * Changed `databricks lakeview create` command with new required argument order.

OpenAPI commit d25296d2f4aa7bd6195c816fdf82e0f960f775da (2024-11-07)
Dependency updates:
 * Upgrade TF provider to 1.58.0 ([#1900](https://github.com/databricks/cli/pull/1900)).
 * Bump golang.org/x/sync from 0.8.0 to 0.9.0 ([#1892](https://github.com/databricks/cli/pull/1892)).
 * Bump golang.org/x/text from 0.19.0 to 0.20.0 ([#1893](https://github.com/databricks/cli/pull/1893)).
 * Bump golang.org/x/mod from 0.21.0 to 0.22.0 ([#1895](https://github.com/databricks/cli/pull/1895)).
 * Bump golang.org/x/oauth2 from 0.23.0 to 0.24.0 ([#1894](https://github.com/databricks/cli/pull/1894)).
 * Bump github.com/databricks/databricks-sdk-go from 0.49.0 to 0.51.0 ([#1878](https://github.com/databricks/cli/pull/1878)).

