### PR TITLE
Add validation for single node clusters

### DIFF
--- a/bundle/config/validate/single_node_cluster.go
+++ b/bundle/config/validate/single_node_cluster.go
@@ -67,31 +67,31 @@ func showSingleNodeClusterWarning(ctx context.Context, v dyn.Value) bool {
 
 	profile, ok := conf.SparkConf["spark.databricks.cluster.profile"]
 	if !ok {
-		log.Warnf(ctx, "spark_conf spark.databricks.cluster.profile not found in single-node cluster spec")
+		log.Debugf(ctx, "spark_conf spark.databricks.cluster.profile not found in single-node cluster spec")
 		return true
 	}
 	if profile != "singleNode" {
-		log.Warnf(ctx, "spark_conf spark.databricks.cluster.profile is not singleNode in single-node cluster spec: %s", profile)
+		log.Debugf(ctx, "spark_conf spark.databricks.cluster.profile is not singleNode in single-node cluster spec: %s", profile)
 		return true
 	}
 
 	master, ok := conf.SparkConf["spark.master"]
 	if !ok {
-		log.Warnf(ctx, "spark_conf spark.master not found in single-node cluster spec")
+		log.Debugf(ctx, "spark_conf spark.master not found in single-node cluster spec")
 		return true
 	}
 	if !strings.HasPrefix(master, "local") {
-		log.Warnf(ctx, "spark_conf spark.master does not start with local in single-node cluster spec: %s", master)
+		log.Debugf(ctx, "spark_conf spark.master does not start with local in single-node cluster spec: %s", master)
 		return true
 	}
 
 	resourceClass, ok := conf.CustomTags["ResourceClass"]
 	if !ok {
-		log.Warnf(ctx, "custom_tag ResourceClass not found in single-node cluster spec")
+		log.Debugf(ctx, "custom_tag ResourceClass not found in single-node cluster spec")
 		return true
 	}
 	if resourceClass != "SingleNode" {
-		log.Warnf(ctx, "custom_tag ResourceClass is not SingleNode in single-node cluster spec: %s", resourceClass)
+		log.Debugf(ctx, "custom_tag ResourceClass is not SingleNode in single-node cluster spec: %s", resourceClass)
 		return true
 	}
 

--- a/bundle/config/validate/single_node_cluster.go
+++ b/bundle/config/validate/single_node_cluster.go
@@ -1,0 +1,174 @@
+package validate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+)
+
+// Validates that any single node clusters defined in the bundle are correctly configured.
+func SingleNodeCluster() bundle.ReadOnlyMutator {
+	return &singleNodeCluster{}
+}
+
+type singleNodeCluster struct{}
+
+func (m *singleNodeCluster) Name() string {
+	return "validate:SingleNodeCluster"
+}
+
+const singleNodeWarningDetail = `num_workers should be 0 only for single-node clusters. To create a
+valid single node cluster please ensure that the following properties
+are correctly set in the cluster specification:
+
+  spark_conf:
+    spark.databricks.cluster.profile: singleNode
+    spark.master: local[*]
+
+  custom_tags:
+    ResourceClass: SingleNode
+  `
+
+const singleNodeWarningSummary = `Single node cluster is not correctly configured`
+
+func validateSingleNodeCluster(spec *compute.ClusterSpec, l []dyn.Location, p dyn.Path) *diag.Diagnostic {
+	if spec == nil {
+		return nil
+	}
+
+	if spec.NumWorkers > 0 || spec.Autoscale != nil {
+		return nil
+	}
+
+	if spec.PolicyId != "" {
+		return nil
+	}
+
+	invalidSingleNodeWarning := &diag.Diagnostic{
+		Severity:  diag.Warning,
+		Summary:   singleNodeWarningSummary,
+		Detail:    singleNodeWarningDetail,
+		Locations: l,
+		Paths:     []dyn.Path{p},
+	}
+	profile, ok := spec.SparkConf["spark.databricks.cluster.profile"]
+	if !ok {
+		return invalidSingleNodeWarning
+	}
+	master, ok := spec.SparkConf["spark.master"]
+	if !ok {
+		return invalidSingleNodeWarning
+	}
+	resourceClass, ok := spec.CustomTags["ResourceClass"]
+	if !ok {
+		return invalidSingleNodeWarning
+	}
+
+	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
+		return nil
+	}
+
+	return invalidSingleNodeWarning
+}
+
+func validateSingleNodePipelineCluster(spec pipelines.PipelineCluster, l []dyn.Location, p dyn.Path) *diag.Diagnostic {
+	if spec.NumWorkers > 0 || spec.Autoscale != nil {
+		return nil
+	}
+
+	if spec.PolicyId != "" {
+		return nil
+	}
+
+	invalidSingleNodeWarning := &diag.Diagnostic{
+		Severity:  diag.Warning,
+		Summary:   singleNodeWarningSummary,
+		Detail:    singleNodeWarningDetail,
+		Locations: l,
+		Paths:     []dyn.Path{p},
+	}
+	profile, ok := spec.SparkConf["spark.databricks.cluster.profile"]
+	if !ok {
+		return invalidSingleNodeWarning
+	}
+	master, ok := spec.SparkConf["spark.master"]
+	if !ok {
+		return invalidSingleNodeWarning
+	}
+	resourceClass, ok := spec.CustomTags["ResourceClass"]
+	if !ok {
+		return invalidSingleNodeWarning
+	}
+
+	if profile == "singleNode" && strings.HasPrefix(master, "local") && resourceClass == "SingleNode" {
+		return nil
+	}
+
+	return invalidSingleNodeWarning
+}
+
+func (m *singleNodeCluster) Apply(ctx context.Context, rb bundle.ReadOnlyBundle) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Interactive clusters
+	for k, r := range rb.Config().Resources.Clusters {
+		p := dyn.NewPath(dyn.Key("resources"), dyn.Key("clusters"), dyn.Key(k))
+		l := rb.Config().GetLocations("resources.clusters." + k)
+
+		d := validateSingleNodeCluster(r.ClusterSpec, l, p)
+		if d != nil {
+			diags = append(diags, *d)
+		}
+	}
+
+	// Job clusters
+	for jobK, jobV := range rb.Config().Resources.Jobs {
+		for i, clusterV := range jobV.JobSettings.JobClusters {
+			p := dyn.NewPath(dyn.Key("resources"), dyn.Key("jobs"), dyn.Key(jobK), dyn.Key("job_clusters"), dyn.Index(i))
+			l := rb.Config().GetLocations(fmt.Sprintf("resources.jobs.%s.job_clusters[%d]", jobK, i))
+
+			d := validateSingleNodeCluster(&clusterV.NewCluster, l, p)
+			if d != nil {
+				diags = append(diags, *d)
+			}
+		}
+	}
+
+	// Job task clusters
+	for jobK, jobV := range rb.Config().Resources.Jobs {
+		for i, taskV := range jobV.JobSettings.Tasks {
+			if taskV.NewCluster == nil {
+				continue
+			}
+
+			p := dyn.NewPath(dyn.Key("resources"), dyn.Key("jobs"), dyn.Key(jobK), dyn.Key("tasks"), dyn.Index(i), dyn.Key("new_cluster"))
+			l := rb.Config().GetLocations(fmt.Sprintf("resources.jobs.%s.tasks[%d].new_cluster", jobK, i))
+
+			d := validateSingleNodeCluster(taskV.NewCluster, l, p)
+			if d != nil {
+				diags = append(diags, *d)
+			}
+		}
+	}
+
+	// Pipeline clusters
+	for pipelineK, pipelineV := range rb.Config().Resources.Pipelines {
+		for i, clusterV := range pipelineV.PipelineSpec.Clusters {
+			p := dyn.NewPath(dyn.Key("resources"), dyn.Key("pipelines"), dyn.Key(pipelineK), dyn.Key("clusters"), dyn.Index(i))
+			l := rb.Config().GetLocations(fmt.Sprintf("resources.pipelines.%s.clusters[%d]", pipelineK, i))
+
+			d := validateSingleNodePipelineCluster(clusterV, l, p)
+			if d != nil {
+				diags = append(diags, *d)
+			}
+		}
+	}
+
+	return diags
+}

--- a/bundle/config/validate/single_node_cluster.go
+++ b/bundle/config/validate/single_node_cluster.go
@@ -71,7 +71,7 @@ func showSingleNodeClusterWarning(ctx context.Context, v dyn.Value) bool {
 		return true
 	}
 	if profile != "singleNode" {
-		log.Warnf(ctx, "spark_conf spark.databricks.cluster.profile is not singleNode in single-node cluster spec")
+		log.Warnf(ctx, "spark_conf spark.databricks.cluster.profile is not singleNode in single-node cluster spec: %s", profile)
 		return true
 	}
 
@@ -81,7 +81,7 @@ func showSingleNodeClusterWarning(ctx context.Context, v dyn.Value) bool {
 		return true
 	}
 	if !strings.HasPrefix(master, "local") {
-		log.Warnf(ctx, "spark_conf spark.master is not local in single-node cluster spec")
+		log.Warnf(ctx, "spark_conf spark.master does not start with local in single-node cluster spec: %s", master)
 		return true
 	}
 
@@ -91,7 +91,7 @@ func showSingleNodeClusterWarning(ctx context.Context, v dyn.Value) bool {
 		return true
 	}
 	if resourceClass != "SingleNode" {
-		log.Warnf(ctx, "custom_tag ResourceClass is not SingleNode in single-node cluster spec")
+		log.Warnf(ctx, "custom_tag ResourceClass is not SingleNode in single-node cluster spec: %s", resourceClass)
 		return true
 	}
 

--- a/bundle/config/validate/single_node_cluster.go
+++ b/bundle/config/validate/single_node_cluster.go
@@ -108,6 +108,8 @@ func (m *singleNodeCluster) Apply(ctx context.Context, rb bundle.ReadOnlyBundle)
 		dyn.NewPattern(dyn.Key("resources"), dyn.Key("jobs"), dyn.AnyKey(), dyn.Key("job_clusters"), dyn.AnyIndex(), dyn.Key("new_cluster")),
 		// Job task clusters
 		dyn.NewPattern(dyn.Key("resources"), dyn.Key("jobs"), dyn.AnyKey(), dyn.Key("tasks"), dyn.AnyIndex(), dyn.Key("new_cluster")),
+		// Job for each task clusters
+		dyn.NewPattern(dyn.Key("resources"), dyn.Key("jobs"), dyn.AnyKey(), dyn.Key("tasks"), dyn.AnyIndex(), dyn.Key("for_each_task"), dyn.Key("task"), dyn.Key("new_cluster")),
 		// Pipeline clusters
 		dyn.NewPattern(dyn.Key("resources"), dyn.Key("pipelines"), dyn.AnyKey(), dyn.Key("clusters"), dyn.AnyIndex()),
 	}

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -16,8 +16,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateSingleNodeClusterFail(t *testing.T) {
-	failCases := []struct {
+func failCases() []struct {
+	name       string
+	sparkConf  map[string]string
+	customTags map[string]string
+} {
+	return []struct {
 		name       string
 		sparkConf  map[string]string
 		customTags map[string]string
@@ -83,11 +87,12 @@ func TestValidateSingleNodeClusterFail(t *testing.T) {
 			customTags: map[string]string{"ResourceClass": "SingleNode"},
 		},
 	}
+}
 
+func TestValidateSingleNodeClusterFailForInteractiveClusters(t *testing.T) {
 	ctx := context.Background()
 
-	// Interactive clusters.
-	for _, tc := range failCases {
+	for _, tc := range failCases() {
 		t.Run("interactive_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -123,9 +128,12 @@ func TestValidateSingleNodeClusterFail(t *testing.T) {
 			}, diags)
 		})
 	}
+}
 
-	// Job clusters.
-	for _, tc := range failCases {
+func TestValidateSingleNodeClusterFailForJobClusters(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range failCases() {
 		t.Run("job_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -170,9 +178,12 @@ func TestValidateSingleNodeClusterFail(t *testing.T) {
 
 		})
 	}
+}
 
-	// Job task clusters.
-	for _, tc := range failCases {
+func TestValidateSingleNodeClusterFailForJobTaskClusters(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range failCases() {
 		t.Run("task_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -216,9 +227,12 @@ func TestValidateSingleNodeClusterFail(t *testing.T) {
 			}, diags)
 		})
 	}
+}
 
-	// Pipeline clusters.
-	for _, tc := range failCases {
+func TestValidateSingleNodeClusterFailForPipelineClusters(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range failCases() {
 		t.Run("pipeline_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -259,14 +273,19 @@ func TestValidateSingleNodeClusterFail(t *testing.T) {
 			}, diags)
 		})
 	}
-
 }
 
-func TestValidateSingleNodeClusterPass(t *testing.T) {
+func passCases() []struct {
+	name       string
+	numWorkers *int
+	sparkConf  map[string]string
+	customTags map[string]string
+	policyId   string
+} {
 	zero := 0
 	one := 1
 
-	passCases := []struct {
+	return []struct {
 		name       string
 		numWorkers *int
 		sparkConf  map[string]string
@@ -297,11 +316,12 @@ func TestValidateSingleNodeClusterPass(t *testing.T) {
 			numWorkers: &zero,
 		},
 	}
+}
 
+func TestValidateSingleNodeClusterPassInteractiveClusters(t *testing.T) {
 	ctx := context.Background()
 
-	// Interactive clusters.
-	for _, tc := range passCases {
+	for _, tc := range passCases() {
 		t.Run("interactive_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -329,9 +349,12 @@ func TestValidateSingleNodeClusterPass(t *testing.T) {
 			assert.Empty(t, diags)
 		})
 	}
+}
 
-	// Job clusters.
-	for _, tc := range passCases {
+func TestValidateSingleNodeClusterPassJobClusters(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range passCases() {
 		t.Run("job_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -366,9 +389,12 @@ func TestValidateSingleNodeClusterPass(t *testing.T) {
 			assert.Empty(t, diags)
 		})
 	}
+}
 
-	// Job task clusters.
-	for _, tc := range passCases {
+func TestValidateSingleNodeClusterPassJobTaskClusters(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range passCases() {
 		t.Run("task_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{
@@ -403,9 +429,12 @@ func TestValidateSingleNodeClusterPass(t *testing.T) {
 			assert.Empty(t, diags)
 		})
 	}
+}
 
-	// Pipeline clusters.
-	for _, tc := range passCases {
+func TestValidateSingleNodeClusterPassPipelineClusters(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range passCases() {
 		t.Run("pipeline_"+tc.name, func(t *testing.T) {
 			b := &bundle.Bundle{
 				Config: config.Root{

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -1,0 +1,470 @@
+package validate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/bundletest"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSingleNodeClusterFail(t *testing.T) {
+	failCases := []struct {
+		name string
+		spec *compute.ClusterSpec
+	}{
+		{
+			name: "no tags or conf",
+			spec: &compute.ClusterSpec{
+				ClusterName: "foo",
+			},
+		},
+		{
+			name: "no tags",
+			spec: &compute.ClusterSpec{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "local[*]",
+				},
+			},
+		},
+		{
+			name: "no conf",
+			spec: &compute.ClusterSpec{
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "invalid spark cluster profile",
+			spec: &compute.ClusterSpec{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "invalid",
+					"spark.master":                     "local[*]",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "invalid spark.master",
+			spec: &compute.ClusterSpec{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "invalid",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "invalid tags",
+			spec: &compute.ClusterSpec{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "local[*]",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "invalid",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	// Test interactive clusters.
+	for _, tc := range failCases {
+		t.Run("interactive_"+tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Clusters: map[string]*resources.Cluster{
+							"foo": {
+								ClusterSpec: tc.spec,
+							},
+						},
+					},
+				},
+			}
+
+			bundletest.SetLocation(b, "resources.clusters.foo", []dyn.Location{{File: "a.yml", Line: 1, Column: 1}})
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Equal(t, diag.Diagnostics{
+				{
+					Severity:  diag.Warning,
+					Summary:   singleNodeWarningSummary,
+					Detail:    singleNodeWarningDetail,
+					Locations: []dyn.Location{{File: "a.yml", Line: 1, Column: 1}},
+					Paths:     []dyn.Path{dyn.NewPath(dyn.Key("resources"), dyn.Key("clusters"), dyn.Key("foo"))},
+				},
+			}, diags)
+		})
+	}
+
+	// Test new job clusters.
+	for _, tc := range failCases {
+		t.Run("job_"+tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Jobs: map[string]*resources.Job{
+							"foo": {
+								JobSettings: &jobs.JobSettings{
+									JobClusters: []jobs.JobCluster{
+										{
+											NewCluster: *tc.spec,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			bundletest.SetLocation(b, "resources.jobs.foo.job_clusters[0]", []dyn.Location{{File: "b.yml", Line: 1, Column: 1}})
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Equal(t, diag.Diagnostics{
+				{
+					Severity:  diag.Warning,
+					Summary:   singleNodeWarningSummary,
+					Detail:    singleNodeWarningDetail,
+					Locations: []dyn.Location{{File: "b.yml", Line: 1, Column: 1}},
+					Paths:     []dyn.Path{dyn.MustPathFromString("resources.jobs.foo.job_clusters[0]")},
+				},
+			}, diags)
+
+		})
+	}
+
+	// Test job task clusters.
+	for _, tc := range failCases {
+		t.Run("task_"+tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Jobs: map[string]*resources.Job{
+							"foo": {
+								JobSettings: &jobs.JobSettings{
+									Tasks: []jobs.Task{
+										{
+											NewCluster: tc.spec,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			bundletest.SetLocation(b, "resources.jobs.foo.tasks[0]", []dyn.Location{{File: "c.yml", Line: 1, Column: 1}})
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Equal(t, diag.Diagnostics{
+				{
+					Severity:  diag.Warning,
+					Summary:   singleNodeWarningSummary,
+					Detail:    singleNodeWarningDetail,
+					Locations: []dyn.Location{{File: "c.yml", Line: 1, Column: 1}},
+					Paths:     []dyn.Path{dyn.MustPathFromString("resources.jobs.foo.tasks[0].new_cluster")},
+				},
+			}, diags)
+		})
+	}
+}
+
+func TestValidateSingleNodeClusterPass(t *testing.T) {
+	passCases := []struct {
+		name string
+		spec *compute.ClusterSpec
+	}{
+		{
+			name: "single node cluster",
+			spec: &compute.ClusterSpec{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "local[*]",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "num workers is not zero",
+			spec: &compute.ClusterSpec{
+				NumWorkers: 1,
+			},
+		},
+		{
+			name: "autoscale is not nil",
+			spec: &compute.ClusterSpec{
+				Autoscale: &compute.AutoScale{
+					MinWorkers: 1,
+				},
+			},
+		},
+		{
+			name: "policy id is not empty",
+			spec: &compute.ClusterSpec{
+				PolicyId: "policy-abc",
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	// Test interactive clusters.
+	for _, tc := range passCases {
+		t.Run("interactive_"+tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Clusters: map[string]*resources.Cluster{
+							"foo": {
+								ClusterSpec: tc.spec,
+							},
+						},
+					},
+				},
+			}
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Empty(t, diags)
+		})
+	}
+
+	// Test new job clusters.
+	for _, tc := range passCases {
+		t.Run("job_"+tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Jobs: map[string]*resources.Job{
+							"foo": {
+								JobSettings: &jobs.JobSettings{
+									JobClusters: []jobs.JobCluster{
+										{
+											NewCluster: *tc.spec,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Empty(t, diags)
+		})
+	}
+
+	// Test job task clusters.
+	for _, tc := range passCases {
+		t.Run("task_"+tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Jobs: map[string]*resources.Job{
+							"foo": {
+								JobSettings: &jobs.JobSettings{
+									Tasks: []jobs.Task{
+										{
+											NewCluster: tc.spec,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Empty(t, diags)
+		})
+	}
+}
+
+func TestValidateSingleNodePipelineClustersFail(t *testing.T) {
+	failCases := []struct {
+		name string
+		spec pipelines.PipelineCluster
+	}{
+		{
+			name: "no tags or conf",
+			spec: pipelines.PipelineCluster{
+				DriverInstancePoolId: "abcd",
+			},
+		},
+		{
+			name: "no tags",
+			spec: pipelines.PipelineCluster{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "local[*]",
+				},
+			},
+		},
+		{
+			name: "no conf",
+			spec: pipelines.PipelineCluster{
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "invalid spark cluster profile",
+			spec: pipelines.PipelineCluster{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "invalid",
+					"spark.master":                     "local[*]",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "invalid spark.master",
+			spec: pipelines.PipelineCluster{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "invalid",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "invalid tags",
+			spec: pipelines.PipelineCluster{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "local[*]",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "invalid",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range failCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Pipelines: map[string]*resources.Pipeline{
+							"foo": {
+								PipelineSpec: &pipelines.PipelineSpec{
+									Clusters: []pipelines.PipelineCluster{
+										tc.spec,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			bundletest.SetLocation(b, "resources.pipelines.foo.clusters[0]", []dyn.Location{{File: "d.yml", Line: 1, Column: 1}})
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Equal(t, diag.Diagnostics{
+				{
+					Severity:  diag.Warning,
+					Summary:   singleNodeWarningSummary,
+					Detail:    singleNodeWarningDetail,
+					Locations: []dyn.Location{{File: "d.yml", Line: 1, Column: 1}},
+					Paths:     []dyn.Path{dyn.MustPathFromString("resources.pipelines.foo.clusters[0]")},
+				},
+			}, diags)
+		})
+	}
+}
+
+func TestValidateSingleNodePipelineClustersPass(t *testing.T) {
+	passCases := []struct {
+		name string
+		spec pipelines.PipelineCluster
+	}{
+		{
+			name: "single node cluster",
+			spec: pipelines.PipelineCluster{
+				SparkConf: map[string]string{
+					"spark.databricks.cluster.profile": "singleNode",
+					"spark.master":                     "local[*]",
+				},
+				CustomTags: map[string]string{
+					"ResourceClass": "SingleNode",
+				},
+			},
+		},
+		{
+			name: "num workers is not zero",
+			spec: pipelines.PipelineCluster{
+				NumWorkers: 1,
+			},
+		},
+		{
+			name: "autoscale is not nil",
+			spec: pipelines.PipelineCluster{
+				Autoscale: &pipelines.PipelineClusterAutoscale{
+					MaxWorkers: 3,
+				},
+			},
+		},
+		{
+			name: "policy id is not empty",
+			spec: pipelines.PipelineCluster{
+				PolicyId: "policy-abc",
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range passCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Resources: config.Resources{
+						Pipelines: map[string]*resources.Pipeline{
+							"foo": {
+								PipelineSpec: &pipelines.PipelineSpec{
+									Clusters: []pipelines.PipelineCluster{
+										tc.spec,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			diags := bundle.ApplyReadOnly(ctx, bundle.ReadOnly(b), SingleNodeCluster())
+			assert.Empty(t, diags)
+		})
+	}
+}

--- a/bundle/config/validate/validate.go
+++ b/bundle/config/validate/validate.go
@@ -36,6 +36,7 @@ func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics
 		ValidateSyncPatterns(),
 		JobTaskClusterSpec(),
 		ValidateFolderPermissions(),
+		SingleNodeCluster(),
 	))
 }
 


### PR DESCRIPTION
## Changes
This PR adds a warning validating that the configuration for a single node cluster is valid for interactive, job, job-task, and pipeline clusters. 

Note: We skip the validation if a cluster policy is configured because the policy is likely to configure `spark_conf` / `custom_tags` itself. 

Note: Terrform originally only had validation for interactive, job, and job-task clusters. This PR adding the validation for pipeline clusters as well is new.

This PR follows the same logic as we used to have in Terraform. The validation was removed from Terraform because we had no way to demote the error to a warning:
https://github.com/databricks/terraform-provider-databricks/pull/4222

### Background
Single-node clusters require `spark_conf` and `custom_tags` to be correctly set in the cluster definition for them to function optimally. The cluster will be created even if incorrectly configured, but its performance will not be great.

 For example, if both `spark_conf` and `custom_tags` are not set and `num_workers` is 0, then only the driver process will be launched on the cluster compute instance thus leading to sub-optimal utilization of available compute resources and no parallelization across worker processes when processing a spark query.

### Issue

This PR addresses some issues reported in https://github.com/databricks/cli/issues/1546

## Tests
Unit tests and manually.

Example output of the warning:
```
➜  bundle-playground git:(master) ✗ cli bundle validate
Warning: Single node cluster is not correctly configured
  at resources.pipelines.bar.clusters[0]
  in databricks.yml:29:11

num_workers should be 0 only for single-node clusters. To create a
valid single node cluster please ensure that the following properties
are correctly set in the cluster specification:

  spark_conf:
    spark.databricks.cluster.profile: singleNode
    spark.master: local[*]

  custom_tags:
    ResourceClass: SingleNode
  

Name: foobar
Target: default
Workspace:
  User: shreyas.goenka@databricks.com
  Path: /Workspace/Users/shreyas.goenka@databricks.com/.bundle/foobar/default

Found 1 warning
```
