### PR TITLE
Use `fs.FS` interface to read template

### DIFF
--- a/internal/bundle/helpers.go
+++ b/internal/bundle/helpers.go
@@ -42,7 +42,7 @@ func initTestTemplateWithBundleRoot(t *testing.T, ctx context.Context, templateN
 	cmd := cmdio.NewIO(flags.OutputJSON, strings.NewReader(""), os.Stdout, os.Stderr, "", "bundles")
 	ctx = cmdio.InContext(ctx, cmd)
 
-	err = template.Materialize(ctx, configFilePath, templateRoot, bundleRoot)
+	err = template.Materialize(ctx, configFilePath, os.DirFS(templateRoot), bundleRoot)
 	return bundleRoot, err
 }
 

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -3,7 +3,9 @@ package jsonschema
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 
@@ -255,7 +257,12 @@ func (schema *Schema) validate() error {
 }
 
 func Load(path string) (*Schema, error) {
-	b, err := os.ReadFile(path)
+	dir, file := filepath.Split(path)
+	return LoadFS(os.DirFS(dir), file)
+}
+
+func LoadFS(fsys fs.FS, path string) (*Schema, error) {
+	b, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/jsonschema/schema_test.go
+++ b/libs/jsonschema/schema_test.go
@@ -1,6 +1,7 @@
 package jsonschema
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -303,5 +304,11 @@ func TestValidateSchemaSkippedPropertiesHaveDefaults(t *testing.T) {
 		},
 	}
 	err = s.validate()
+	assert.NoError(t, err)
+}
+
+func TestSchema_LoadFS(t *testing.T) {
+	fsys := os.DirFS("./testdata/schema-load-int")
+	_, err := LoadFS(fsys, "schema-valid.json")
 	assert.NoError(t, err)
 }

--- a/libs/template/builtin.go
+++ b/libs/template/builtin.go
@@ -1,0 +1,47 @@
+package template
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:templates
+var builtinTemplates embed.FS
+
+// BuiltinTemplate represents a template that is built into the CLI.
+type BuiltinTemplate struct {
+	Name string
+	FS   fs.FS
+}
+
+// Builtin returns the list of all built-in templates.
+func Builtin() ([]BuiltinTemplate, error) {
+	templates, err := fs.Sub(builtinTemplates, "templates")
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := fs.ReadDir(templates, ".")
+	if err != nil {
+		return nil, err
+	}
+
+	var out []BuiltinTemplate
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		templateFS, err := fs.Sub(templates, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, BuiltinTemplate{
+			Name: entry.Name(),
+			FS:   templateFS,
+		})
+	}
+
+	return out, nil
+}

--- a/libs/template/builtin_test.go
+++ b/libs/template/builtin_test.go
@@ -1,0 +1,28 @@
+package template
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltin(t *testing.T) {
+	out, err := Builtin()
+	require.NoError(t, err)
+	assert.Len(t, out, 3)
+
+	// Confirm names.
+	assert.Equal(t, "dbt-sql", out[0].Name)
+	assert.Equal(t, "default-python", out[1].Name)
+	assert.Equal(t, "default-sql", out[2].Name)
+
+	// Confirm that the filesystems work.
+	_, err = fs.Stat(out[0].FS, `template/{{.project_name}}/dbt_project.yml.tmpl`)
+	assert.NoError(t, err)
+	_, err = fs.Stat(out[1].FS, `template/{{.project_name}}/tests/main_test.py.tmpl`)
+	assert.NoError(t, err)
+	_, err = fs.Stat(out[2].FS, `template/{{.project_name}}/src/orders_daily.sql.tmpl`)
+	assert.NoError(t, err)
+}

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -29,8 +29,8 @@ type config struct {
 	schema *jsonschema.Schema
 }
 
-func newConfig(ctx context.Context, templateRoot fs.FS, schemaPath string) (*config, error) {
-	schema, err := jsonschema.LoadFS(templateRoot, schemaPath)
+func newConfig(ctx context.Context, templateFS fs.FS, schemaPath string) (*config, error) {
+	schema, err := jsonschema.LoadFS(templateFS, schemaPath)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/jsonschema"
@@ -28,9 +29,8 @@ type config struct {
 	schema *jsonschema.Schema
 }
 
-func newConfig(ctx context.Context, schemaPath string) (*config, error) {
-	// Read config schema
-	schema, err := jsonschema.Load(schemaPath)
+func newConfig(ctx context.Context, templateRoot fs.FS, schemaPath string) (*config, error) {
+	schema, err := jsonschema.LoadFS(templateRoot, schemaPath)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -16,7 +17,7 @@ func TestTemplateConfigAssignValuesFromFile(t *testing.T) {
 	testDir := "./testdata/config-assign-from-file"
 
 	ctx := context.Background()
-	c, err := newConfig(ctx, filepath.Join(testDir, "schema.json"))
+	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
 	err = c.assignValuesFromFile(filepath.Join(testDir, "config.json"))
@@ -32,7 +33,7 @@ func TestTemplateConfigAssignValuesFromFileDoesNotOverwriteExistingConfigs(t *te
 	testDir := "./testdata/config-assign-from-file"
 
 	ctx := context.Background()
-	c, err := newConfig(ctx, filepath.Join(testDir, "schema.json"))
+	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
 	c.values = map[string]any{
@@ -52,7 +53,7 @@ func TestTemplateConfigAssignValuesFromFileForInvalidIntegerValue(t *testing.T) 
 	testDir := "./testdata/config-assign-from-file-invalid-int"
 
 	ctx := context.Background()
-	c, err := newConfig(ctx, filepath.Join(testDir, "schema.json"))
+	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
 	err = c.assignValuesFromFile(filepath.Join(testDir, "config.json"))
@@ -63,7 +64,7 @@ func TestTemplateConfigAssignValuesFromFileFiltersPropertiesNotInTheSchema(t *te
 	testDir := "./testdata/config-assign-from-file-unknown-property"
 
 	ctx := context.Background()
-	c, err := newConfig(ctx, filepath.Join(testDir, "schema.json"))
+	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
 	err = c.assignValuesFromFile(filepath.Join(testDir, "config.json"))
@@ -78,10 +79,10 @@ func TestTemplateConfigAssignValuesFromDefaultValues(t *testing.T) {
 	testDir := "./testdata/config-assign-from-default-value"
 
 	ctx := context.Background()
-	c, err := newConfig(ctx, filepath.Join(testDir, "schema.json"))
+	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
-	r, err := newRenderer(ctx, nil, nil, "./testdata/empty/template", "./testdata/empty/library", t.TempDir())
+	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), "./testdata/empty/template", "./testdata/empty/library", t.TempDir())
 	require.NoError(t, err)
 
 	err = c.assignDefaultValues(r)
@@ -97,10 +98,10 @@ func TestTemplateConfigAssignValuesFromTemplatedDefaultValues(t *testing.T) {
 	testDir := "./testdata/config-assign-from-templated-default-value"
 
 	ctx := context.Background()
-	c, err := newConfig(ctx, filepath.Join(testDir, "schema.json"))
+	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
-	r, err := newRenderer(ctx, nil, nil, filepath.Join(testDir, "template/template"), filepath.Join(testDir, "template/library"), t.TempDir())
+	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), filepath.Join(testDir, "template/template"), filepath.Join(testDir, "template/library"), t.TempDir())
 	require.NoError(t, err)
 
 	// Note: only the string value is templated.
@@ -116,7 +117,7 @@ func TestTemplateConfigAssignValuesFromTemplatedDefaultValues(t *testing.T) {
 
 func TestTemplateConfigValidateValuesDefined(t *testing.T) {
 	ctx := context.Background()
-	c, err := newConfig(ctx, "testdata/config-test-schema/test-schema.json")
+	c, err := newConfig(ctx, os.DirFS("testdata/config-test-schema"), "test-schema.json")
 	require.NoError(t, err)
 
 	c.values = map[string]any{
@@ -131,7 +132,7 @@ func TestTemplateConfigValidateValuesDefined(t *testing.T) {
 
 func TestTemplateConfigValidateTypeForValidConfig(t *testing.T) {
 	ctx := context.Background()
-	c, err := newConfig(ctx, "testdata/config-test-schema/test-schema.json")
+	c, err := newConfig(ctx, os.DirFS("testdata/config-test-schema"), "test-schema.json")
 	require.NoError(t, err)
 
 	c.values = map[string]any{
@@ -147,7 +148,7 @@ func TestTemplateConfigValidateTypeForValidConfig(t *testing.T) {
 
 func TestTemplateConfigValidateTypeForUnknownField(t *testing.T) {
 	ctx := context.Background()
-	c, err := newConfig(ctx, "testdata/config-test-schema/test-schema.json")
+	c, err := newConfig(ctx, os.DirFS("testdata/config-test-schema"), "test-schema.json")
 	require.NoError(t, err)
 
 	c.values = map[string]any{
@@ -164,7 +165,7 @@ func TestTemplateConfigValidateTypeForUnknownField(t *testing.T) {
 
 func TestTemplateConfigValidateTypeForInvalidType(t *testing.T) {
 	ctx := context.Background()
-	c, err := newConfig(ctx, "testdata/config-test-schema/test-schema.json")
+	c, err := newConfig(ctx, os.DirFS("testdata/config-test-schema"), "test-schema.json")
 	require.NoError(t, err)
 
 	c.values = map[string]any{
@@ -271,7 +272,8 @@ func TestTemplateEnumValidation(t *testing.T) {
 }
 
 func TestTemplateSchemaErrorsWithEmptyDescription(t *testing.T) {
-	_, err := newConfig(context.Background(), "./testdata/config-test-schema/invalid-test-schema.json")
+	ctx := context.Background()
+	_, err := newConfig(ctx, os.DirFS("./testdata/config-test-schema"), "invalid-test-schema.json")
 	assert.EqualError(t, err, "template property property-without-description is missing a description")
 }
 

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -101,7 +102,7 @@ func TestTemplateConfigAssignValuesFromTemplatedDefaultValues(t *testing.T) {
 	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
-	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), filepath.Join(testDir, "template/template"), filepath.Join(testDir, "template/library"), t.TempDir())
+	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), path.Join(testDir, "template/template"), path.Join(testDir, "template/library"), t.TempDir())
 	require.NoError(t, err)
 
 	// Note: only the string value is templated.

--- a/libs/template/file_test.go
+++ b/libs/template/file_test.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/databricks/cli/libs/filer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,10 +32,7 @@ func testInMemoryFile(t *testing.T, perm fs.FileMode) {
 
 func testCopyFile(t *testing.T, perm fs.FileMode) {
 	tmpDir := t.TempDir()
-
-	templateFiler, err := filer.NewLocalClient(tmpDir)
-	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(tmpDir, "source"), []byte("qwerty"), perm)
+	err := os.WriteFile(filepath.Join(tmpDir, "source"), []byte("qwerty"), perm)
 	require.NoError(t, err)
 
 	f := &copyFile{
@@ -45,9 +41,9 @@ func testCopyFile(t *testing.T, perm fs.FileMode) {
 			root:    tmpDir,
 			relPath: "a/b/c",
 		},
-		perm:     perm,
-		srcPath:  "source",
-		srcFiler: templateFiler,
+		perm:    perm,
+		srcPath: "source",
+		srcFS:   os.DirFS(tmpDir),
 	}
 	err = f.PersistToDisk()
 	assert.NoError(t, err)

--- a/libs/template/helpers_test.go
+++ b/libs/template/helpers_test.go
@@ -22,7 +22,7 @@ func TestTemplatePrintStringWithoutProcessing(t *testing.T) {
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/print-without-processing/template", "./testdata/print-without-processing/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/print-without-processing/template", "./testdata/print-without-processing/library", tmpDir)
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -39,7 +39,7 @@ func TestTemplateRegexpCompileFunction(t *testing.T) {
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/regexp-compile/template", "./testdata/regexp-compile/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/regexp-compile/template", "./testdata/regexp-compile/library", tmpDir)
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -57,7 +57,7 @@ func TestTemplateRandIntFunction(t *testing.T) {
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/random-int/template", "./testdata/random-int/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/random-int/template", "./testdata/random-int/library", tmpDir)
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -75,7 +75,7 @@ func TestTemplateUuidFunction(t *testing.T) {
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/uuid/template", "./testdata/uuid/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/uuid/template", "./testdata/uuid/library", tmpDir)
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -92,7 +92,7 @@ func TestTemplateUrlFunction(t *testing.T) {
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/urlparse-function/template", "./testdata/urlparse-function/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/urlparse-function/template", "./testdata/urlparse-function/library", tmpDir)
 
 	require.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestTemplateMapPairFunction(t *testing.T) {
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/map-pair/template", "./testdata/map-pair/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/map-pair/template", "./testdata/map-pair/library", tmpDir)
 
 	require.NoError(t, err)
 
@@ -132,7 +132,7 @@ func TestWorkspaceHost(t *testing.T) {
 	ctx = root.SetWorkspaceClient(ctx, w)
 
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/workspace-host/template", "./testdata/map-pair/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/workspace-host/template", "./testdata/map-pair/library", tmpDir)
 
 	require.NoError(t, err)
 
@@ -157,7 +157,7 @@ func TestWorkspaceHostNotConfigured(t *testing.T) {
 	ctx = root.SetWorkspaceClient(ctx, w)
 
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, "./testdata/workspace-host/template", "./testdata/map-pair/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/workspace-host/template", "./testdata/map-pair/library", tmpDir)
 
 	assert.NoError(t, err)
 

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -6,9 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
-	"path"
-	"path/filepath"
 
 	"github.com/databricks/cli/libs/cmdio"
 )
@@ -28,28 +25,12 @@ var builtinTemplates embed.FS
 //	configFilePath: file path containing user defined config values
 //	templateRoot: 	root of the template definition
 //	outputDir: 	root of directory where to initialize the template
-func Materialize(ctx context.Context, configFilePath, templateRoot, outputDir string) error {
-	// Use a temporary directory in case any builtin templates like default-python are used
-	tempDir, err := os.MkdirTemp("", "templates")
-	defer os.RemoveAll(tempDir)
-	if err != nil {
-		return err
-	}
-	templateRoot, err = prepareBuiltinTemplates(templateRoot, tempDir)
-	if err != nil {
-		return err
+func Materialize(ctx context.Context, configFilePath string, templateRoot fs.FS, outputDir string) error {
+	if _, err := fs.Stat(templateRoot, schemaFileName); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("not a bundle template: expected to find a template schema file at %s", schemaFileName)
 	}
 
-	templatePath := filepath.Join(templateRoot, templateDirName)
-	libraryPath := filepath.Join(templateRoot, libraryDirName)
-	schemaPath := filepath.Join(templateRoot, schemaFileName)
-	helpers := loadHelpers(ctx)
-
-	if _, err := os.Stat(schemaPath); errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("not a bundle template: expected to find a template schema file at %s", schemaPath)
-	}
-
-	config, err := newConfig(ctx, schemaPath)
+	config, err := newConfig(ctx, templateRoot, schemaFileName)
 	if err != nil {
 		return err
 	}
@@ -62,7 +43,8 @@ func Materialize(ctx context.Context, configFilePath, templateRoot, outputDir st
 		}
 	}
 
-	r, err := newRenderer(ctx, config.values, helpers, templatePath, libraryPath, outputDir)
+	helpers := loadHelpers(ctx)
+	r, err := newRenderer(ctx, config.values, helpers, templateRoot, templateDirName, libraryDirName, outputDir)
 	if err != nil {
 		return err
 	}
@@ -110,45 +92,4 @@ func Materialize(ctx context.Context, configFilePath, templateRoot, outputDir st
 		cmdio.LogString(ctx, success)
 	}
 	return nil
-}
-
-// If the given templateRoot matches
-func prepareBuiltinTemplates(templateRoot string, tempDir string) (string, error) {
-	// Check that `templateRoot` is a clean basename, i.e. `some_path` and not `./some_path` or "."
-	// Return early if that's not the case.
-	if templateRoot == "." || path.Base(templateRoot) != templateRoot {
-		return templateRoot, nil
-	}
-
-	_, err := fs.Stat(builtinTemplates, path.Join("templates", templateRoot))
-	if err != nil {
-		// The given path doesn't appear to be using out built-in templates
-		return templateRoot, nil
-	}
-
-	// We have a built-in template with the same name as templateRoot!
-	// Now we need to make a fully copy of the builtin templates to a real file system
-	// since template.Parse() doesn't support embed.FS.
-	err = fs.WalkDir(builtinTemplates, "templates", func(path string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		targetPath := filepath.Join(tempDir, path)
-		if entry.IsDir() {
-			return os.Mkdir(targetPath, 0755)
-		} else {
-			content, err := fs.ReadFile(builtinTemplates, path)
-			if err != nil {
-				return err
-			}
-			return os.WriteFile(targetPath, content, 0644)
-		}
-	})
-
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(tempDir, "templates", templateRoot), nil
 }

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -21,12 +21,12 @@ const schemaFileName = "databricks_template_schema.json"
 //	configFilePath: file path containing user defined config values
 //	templateRoot: 	root of the template definition
 //	outputDir: 	root of directory where to initialize the template
-func Materialize(ctx context.Context, configFilePath string, templateRoot fs.FS, outputDir string) error {
-	if _, err := fs.Stat(templateRoot, schemaFileName); errors.Is(err, fs.ErrNotExist) {
+func Materialize(ctx context.Context, configFilePath string, templateFS fs.FS, outputDir string) error {
+	if _, err := fs.Stat(templateFS, schemaFileName); errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("not a bundle template: expected to find a template schema file at %s", schemaFileName)
 	}
 
-	config, err := newConfig(ctx, templateRoot, schemaFileName)
+	config, err := newConfig(ctx, templateFS, schemaFileName)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func Materialize(ctx context.Context, configFilePath string, templateRoot fs.FS,
 	}
 
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, config.values, helpers, templateRoot, templateDirName, libraryDirName, outputDir)
+	r, err := newRenderer(ctx, config.values, helpers, templateFS, templateDirName, libraryDirName, outputDir)
 	if err != nil {
 		return err
 	}

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"context"
-	"embed"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -13,9 +12,6 @@ import (
 const libraryDirName = "library"
 const templateDirName = "template"
 const schemaFileName = "databricks_template_schema.json"
-
-//go:embed all:templates
-var builtinTemplates embed.FS
 
 // This function materializes the input templates as a project, using user defined
 // configurations.

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -19,7 +19,7 @@ const schemaFileName = "databricks_template_schema.json"
 //
 //	ctx: 			context containing a cmdio object. This is used to prompt the user
 //	configFilePath: file path containing user defined config values
-//	templateRoot: 	root of the template definition
+//	templateFS: 	root of the template definition
 //	outputDir: 	root of directory where to initialize the template
 func Materialize(ctx context.Context, configFilePath string, templateFS fs.FS, outputDir string) error {
 	if _, err := fs.Stat(templateFS, schemaFileName); errors.Is(err, fs.ErrNotExist) {

--- a/libs/template/materialize_test.go
+++ b/libs/template/materialize_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/cmd/root"
@@ -21,5 +20,5 @@ func TestMaterializeForNonTemplateDirectory(t *testing.T) {
 
 	// Try to materialize a non-template directory.
 	err = Materialize(ctx, "", os.DirFS(tmpDir), "")
-	assert.EqualError(t, err, fmt.Sprintf("not a bundle template: expected to find a template schema file at %s", filepath.Join(tmpDir, schemaFileName)))
+	assert.EqualError(t, err, fmt.Sprintf("not a bundle template: expected to find a template schema file at %s", schemaFileName))
 }

--- a/libs/template/materialize_test.go
+++ b/libs/template/materialize_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,6 +20,6 @@ func TestMaterializeForNonTemplateDirectory(t *testing.T) {
 	ctx := root.SetWorkspaceClient(context.Background(), w)
 
 	// Try to materialize a non-template directory.
-	err = Materialize(ctx, "", tmpDir, "")
+	err = Materialize(ctx, "", os.DirFS(tmpDir), "")
 	assert.EqualError(t, err, fmt.Sprintf("not a bundle template: expected to find a template schema file at %s", filepath.Join(tmpDir, schemaFileName)))
 }

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -8,14 +8,12 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"slices"
 	"sort"
 	"strings"
 	"text/template"
 
-	"github.com/databricks/cli/libs/filer"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/logger"
 )
@@ -52,32 +50,43 @@ type renderer struct {
 	// do not match any glob patterns from this list
 	skipPatterns []string
 
-	// Filer rooted at template root. The file tree from this root is walked to
+	// [fs.FS] for the template root. The file tree from this root is walked to
 	// generate the project
-	templateFiler filer.Filer
+	templateRoot fs.FS
 
 	// Root directory for the project instantiated from the template
 	instanceRoot string
 }
 
-func newRenderer(ctx context.Context, config map[string]any, helpers template.FuncMap, templateRoot, libraryRoot, instanceRoot string) (*renderer, error) {
+func newRenderer(
+	ctx context.Context,
+	config map[string]any,
+	helpers template.FuncMap,
+	templateFS fs.FS,
+	templateDir string,
+	libraryDir string,
+	instanceRoot string,
+) (*renderer, error) {
 	// Initialize new template, with helper functions loaded
 	tmpl := template.New("").Funcs(helpers)
 
-	// Load user defined associated templates from the library root
-	libraryGlob := filepath.Join(libraryRoot, "*")
-	matches, err := filepath.Glob(libraryGlob)
+	// Find user-defined templates in the library directory
+	matches, err := fs.Glob(templateFS, path.Join(libraryDir, "*"))
 	if err != nil {
 		return nil, err
 	}
+
+	// Parse user-defined templates.
+	// Note: we do not call [ParseFS] with the glob directly because
+	// it returns an error if no files match the pattern.
 	if len(matches) != 0 {
-		tmpl, err = tmpl.ParseFiles(matches...)
+		tmpl, err = tmpl.ParseFS(templateFS, matches...)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	templateFiler, err := filer.NewLocalClient(templateRoot)
+	fsys, err := fs.Sub(templateFS, path.Clean(templateDir))
 	if err != nil {
 		return nil, err
 	}
@@ -85,13 +94,13 @@ func newRenderer(ctx context.Context, config map[string]any, helpers template.Fu
 	ctx = log.NewContext(ctx, log.GetLogger(ctx).With("action", "initialize-template"))
 
 	return &renderer{
-		ctx:           ctx,
-		config:        config,
-		baseTemplate:  tmpl,
-		files:         make([]file, 0),
-		skipPatterns:  make([]string, 0),
-		templateFiler: templateFiler,
-		instanceRoot:  instanceRoot,
+		ctx:          ctx,
+		config:       config,
+		baseTemplate: tmpl,
+		files:        make([]file, 0),
+		skipPatterns: make([]string, 0),
+		templateRoot: fsys,
+		instanceRoot: instanceRoot,
 	}, nil
 }
 
@@ -141,7 +150,7 @@ func (r *renderer) executeTemplate(templateDefinition string) (string, error) {
 
 func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	// read file permissions
-	info, err := r.templateFiler.Stat(r.ctx, relPathTemplate)
+	info, err := fs.Stat(r.templateRoot, relPathTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -161,10 +170,10 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 				root:    r.instanceRoot,
 				relPath: relPath,
 			},
-			perm:     perm,
-			ctx:      r.ctx,
-			srcPath:  relPathTemplate,
-			srcFiler: r.templateFiler,
+			perm:    perm,
+			ctx:     r.ctx,
+			srcFS:   r.templateRoot,
+			srcPath: relPathTemplate,
 		}, nil
 	} else {
 		// Trim the .tmpl suffix from file name, if specified in the template
@@ -173,7 +182,7 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 
 	// read template file's content
-	templateReader, err := r.templateFiler.Read(r.ctx, relPathTemplate)
+	templateReader, err := r.templateRoot.Open(relPathTemplate)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +272,7 @@ func (r *renderer) walk() error {
 		//
 		// 2. For directories: They are appended to a slice, which acts as a queue
 		//     allowing BFS traversal of the template file tree
-		entries, err := r.templateFiler.ReadDir(r.ctx, currentDirectory)
+		entries, err := fs.ReadDir(r.templateRoot, currentDirectory)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Changes

While working on the v2 of #1744, I found that:
* Template initialization first copies built-in templates to a temporary directory before initializing them
* Reading a template's contents goes through a `filer.Filer` but is hardcoded to a local one

This change updates the interface for reading templates to be `fs.FS`. This is compatible with the `embed.FS` type for the built-in templates, so they no longer have to be copied to a temporary directory before being used.

The alternative is to use a `filer.Filer` throughout, but this would have required even more plumbing, and we don't need to _read_ templates, including notebooks, from the workspace filesystem (yet?).

As part of making `template.Materialize` take an `fs.FS` argument, the logic to match a given argument to a particular built-in template in the `init` command has moved to sit next to its implementation.

## Tests

Existing tests pass.