### PR TITLE
Use `filer.Filer` to write template instantiation

### DIFF
--- a/libs/filer/filer.go
+++ b/libs/filer/filer.go
@@ -18,7 +18,7 @@ type WriteMode int
 const writeModePerm = WriteMode(fs.ModePerm)
 
 const (
-	OverwriteIfExists WriteMode = writeModePerm + 1<<iota
+	OverwriteIfExists WriteMode = (writeModePerm + 1) << iota
 	CreateParentDirectories
 )
 

--- a/libs/filer/filer.go
+++ b/libs/filer/filer.go
@@ -7,13 +7,22 @@ import (
 	"io/fs"
 )
 
+// WriteMode captures intent when writing a file.
+//
+// The first 9 bits are reserved for the [fs.FileMode] permission bits.
+// These are used only by the local filer implementation and have
+// no effect for the other implementations.
 type WriteMode int
 
+// writeModePerm is a mask to extract permission bits from a WriteMode.
+const writeModePerm = WriteMode(fs.ModePerm)
+
 const (
-	OverwriteIfExists WriteMode = 1 << iota
+	OverwriteIfExists WriteMode = writeModePerm + 1<<iota
 	CreateParentDirectories
 )
 
+// DeleteMode captures intent when deleting a file.
 type DeleteMode int
 
 const (

--- a/libs/filer/filer.go
+++ b/libs/filer/filer.go
@@ -18,6 +18,8 @@ type WriteMode int
 const writeModePerm = WriteMode(fs.ModePerm)
 
 const (
+	// Note: these constants are defined as powers of 2 to support combining them using a bit-wise OR.
+	// They starts from the 10th bit (permission mask + 1) to avoid conflicts with the permission bits.
 	OverwriteIfExists WriteMode = (writeModePerm + 1) << iota
 	CreateParentDirectories
 )

--- a/libs/filer/filer_test.go
+++ b/libs/filer/filer_test.go
@@ -8,4 +8,5 @@ import (
 
 func TestWriteMode(t *testing.T) {
 	assert.Equal(t, 512, int(OverwriteIfExists))
+	assert.Equal(t, 1024, int(CreateParentDirectories))
 }

--- a/libs/filer/filer_test.go
+++ b/libs/filer/filer_test.go
@@ -1,0 +1,11 @@
+package filer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteMode(t *testing.T) {
+	assert.Equal(t, 512, int(OverwriteIfExists))
+}

--- a/libs/template/config_test.go
+++ b/libs/template/config_test.go
@@ -83,7 +83,7 @@ func TestTemplateConfigAssignValuesFromDefaultValues(t *testing.T) {
 	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
-	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), "./testdata/empty/template", "./testdata/empty/library", t.TempDir())
+	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), "./testdata/empty/template", "./testdata/empty/library")
 	require.NoError(t, err)
 
 	err = c.assignDefaultValues(r)
@@ -102,7 +102,7 @@ func TestTemplateConfigAssignValuesFromTemplatedDefaultValues(t *testing.T) {
 	c, err := newConfig(ctx, os.DirFS(testDir), "schema.json")
 	require.NoError(t, err)
 
-	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), path.Join(testDir, "template/template"), path.Join(testDir, "template/library"), t.TempDir())
+	r, err := newRenderer(ctx, nil, nil, os.DirFS("."), path.Join(testDir, "template/template"), path.Join(testDir, "template/library"))
 	require.NoError(t, err)
 
 	// Note: only the string value is templated.

--- a/libs/template/file.go
+++ b/libs/template/file.go
@@ -1,53 +1,36 @@
 package template
 
 import (
+	"bytes"
 	"context"
-	"io"
 	"io/fs"
-	"os"
-	"path/filepath"
 	"slices"
+
+	"github.com/databricks/cli/libs/filer"
 )
 
 // Interface representing a file to be materialized from a template into a project
 // instance
 type file interface {
-	// Destination path for file. This is where the file will be created when
-	// PersistToDisk is called.
-	DstPath() *destinationPath
+	// Path of the file relative to the root of the instantiated template.
+	// This is where the file is written to when persisting the template to disk.
+	// Must be slash-separated.
+	RelPath() string
 
 	// Write file to disk at the destination path.
-	Write(ctx context.Context) error
+	Write(ctx context.Context, out filer.Filer) error
 
 	// contents returns the file contents as a byte slice.
 	// This is used for testing purposes.
 	contents() ([]byte, error)
 }
 
-type destinationPath struct {
-	// Root path for the project instance. This path uses the system's default
-	// file separator. For example /foo/bar on Unix and C:\foo\bar on windows
-	root string
-
-	// Unix like file path relative to the "root" of the instantiated project. Is used to
-	// evaluate whether the file should be skipped by comparing it to a list of
-	// skip glob patterns.
-	relPath string
-}
-
-// Absolute path of the file, in the os native format. For example /foo/bar on
-// Unix and C:\foo\bar on windows
-func (f *destinationPath) absPath() string {
-	return filepath.Join(f.root, filepath.FromSlash(f.relPath))
-}
-
 type copyFile struct {
-	ctx context.Context
-
 	// Permissions bits for the destination file
 	perm fs.FileMode
 
-	dstPath *destinationPath
+	// Destination path for the file.
+	relPath string
 
 	// [fs.FS] rooted at template root. Used to read srcPath.
 	srcFS fs.FS
@@ -56,28 +39,17 @@ type copyFile struct {
 	srcPath string
 }
 
-func (f *copyFile) DstPath() *destinationPath {
-	return f.dstPath
+func (f *copyFile) RelPath() string {
+	return f.relPath
 }
 
-func (f *copyFile) Write(ctx context.Context) error {
-	path := f.DstPath().absPath()
-	err := os.MkdirAll(filepath.Dir(path), 0755)
+func (f *copyFile) Write(ctx context.Context, out filer.Filer) error {
+	src, err := f.srcFS.Open(f.srcPath)
 	if err != nil {
 		return err
 	}
-	srcFile, err := f.srcFS.Open(f.srcPath)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-	dstFile, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, f.perm)
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close()
-	_, err = io.Copy(dstFile, srcFile)
-	return err
+	defer src.Close()
+	return out.Write(ctx, f.relPath, src, filer.CreateParentDirectories, filer.WriteMode(f.perm))
 }
 
 func (f *copyFile) contents() ([]byte, error) {
@@ -85,26 +57,22 @@ func (f *copyFile) contents() ([]byte, error) {
 }
 
 type inMemoryFile struct {
-	dstPath *destinationPath
-
-	content []byte
-
 	// Permissions bits for the destination file
 	perm fs.FileMode
+
+	// Destination path for the file.
+	relPath string
+
+	// Contents of the file.
+	content []byte
 }
 
-func (f *inMemoryFile) DstPath() *destinationPath {
-	return f.dstPath
+func (f *inMemoryFile) RelPath() string {
+	return f.relPath
 }
 
-func (f *inMemoryFile) Write(ctx context.Context) error {
-	path := f.DstPath().absPath()
-
-	err := os.MkdirAll(filepath.Dir(path), 0755)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, f.content, f.perm)
+func (f *inMemoryFile) Write(ctx context.Context, out filer.Filer) error {
+	return out.Write(ctx, f.relPath, bytes.NewReader(f.content), filer.CreateParentDirectories, filer.WriteMode(f.perm))
 }
 
 func (f *inMemoryFile) contents() ([]byte, error) {

--- a/libs/template/file.go
+++ b/libs/template/file.go
@@ -17,7 +17,7 @@ type file interface {
 	DstPath() *destinationPath
 
 	// Write file to disk at the destination path.
-	PersistToDisk() error
+	Write(ctx context.Context) error
 
 	// contents returns the file contents as a byte slice.
 	// This is used for testing purposes.
@@ -60,7 +60,7 @@ func (f *copyFile) DstPath() *destinationPath {
 	return f.dstPath
 }
 
-func (f *copyFile) PersistToDisk() error {
+func (f *copyFile) Write(ctx context.Context) error {
 	path := f.DstPath().absPath()
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
@@ -97,7 +97,7 @@ func (f *inMemoryFile) DstPath() *destinationPath {
 	return f.dstPath
 }
 
-func (f *inMemoryFile) PersistToDisk() error {
+func (f *inMemoryFile) Write(ctx context.Context) error {
 	path := f.DstPath().absPath()
 
 	err := os.MkdirAll(filepath.Dir(path), 0755)

--- a/libs/template/file_test.go
+++ b/libs/template/file_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testInMemoryFile(t *testing.T, perm fs.FileMode) {
+func testInMemoryFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
 	tmpDir := t.TempDir()
 
 	f := &inMemoryFile{
@@ -23,14 +23,14 @@ func testInMemoryFile(t *testing.T, perm fs.FileMode) {
 		perm:    perm,
 		content: []byte("123"),
 	}
-	err := f.PersistToDisk()
+	err := f.Write(ctx)
 	assert.NoError(t, err)
 
 	assertFileContent(t, filepath.Join(tmpDir, "a/b/c"), "123")
 	assertFilePermissions(t, filepath.Join(tmpDir, "a/b/c"), perm)
 }
 
-func testCopyFile(t *testing.T, perm fs.FileMode) {
+func testCopyFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
 	tmpDir := t.TempDir()
 	err := os.WriteFile(filepath.Join(tmpDir, "source"), []byte("qwerty"), perm)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func testCopyFile(t *testing.T, perm fs.FileMode) {
 		srcPath: "source",
 		srcFS:   os.DirFS(tmpDir),
 	}
-	err = f.PersistToDisk()
+	err = f.Write(ctx)
 	assert.NoError(t, err)
 
 	assertFileContent(t, filepath.Join(tmpDir, "a/b/c"), "qwerty")
@@ -78,7 +78,8 @@ func TestTemplateInMemoryFilePersistToDisk(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
-	testInMemoryFile(t, 0755)
+	ctx := context.Background()
+	testInMemoryFile(t, ctx, 0755)
 }
 
 func TestTemplateInMemoryFilePersistToDiskForWindows(t *testing.T) {
@@ -87,14 +88,16 @@ func TestTemplateInMemoryFilePersistToDiskForWindows(t *testing.T) {
 	}
 	// we have separate tests for windows because of differences in valid
 	// fs.FileMode values we can use for different operating systems.
-	testInMemoryFile(t, 0666)
+	ctx := context.Background()
+	testInMemoryFile(t, ctx, 0666)
 }
 
 func TestTemplateCopyFilePersistToDisk(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
-	testCopyFile(t, 0644)
+	ctx := context.Background()
+	testCopyFile(t, ctx, 0644)
 }
 
 func TestTemplateCopyFilePersistToDiskForWindows(t *testing.T) {
@@ -103,5 +106,6 @@ func TestTemplateCopyFilePersistToDiskForWindows(t *testing.T) {
 	}
 	// we have separate tests for windows because of differences in valid
 	// fs.FileMode values we can use for different operating systems.
-	testCopyFile(t, 0666)
+	ctx := context.Background()
+	testCopyFile(t, ctx, 0666)
 }

--- a/libs/template/helpers_test.go
+++ b/libs/template/helpers_test.go
@@ -18,11 +18,10 @@ import (
 
 func TestTemplatePrintStringWithoutProcessing(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/print-without-processing/template", "./testdata/print-without-processing/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/print-without-processing/template", "./testdata/print-without-processing/library")
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -35,11 +34,10 @@ func TestTemplatePrintStringWithoutProcessing(t *testing.T) {
 
 func TestTemplateRegexpCompileFunction(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/regexp-compile/template", "./testdata/regexp-compile/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/regexp-compile/template", "./testdata/regexp-compile/library")
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -53,11 +51,10 @@ func TestTemplateRegexpCompileFunction(t *testing.T) {
 
 func TestTemplateRandIntFunction(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/random-int/template", "./testdata/random-int/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/random-int/template", "./testdata/random-int/library")
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -71,11 +68,10 @@ func TestTemplateRandIntFunction(t *testing.T) {
 
 func TestTemplateUuidFunction(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/uuid/template", "./testdata/uuid/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/uuid/template", "./testdata/uuid/library")
 	require.NoError(t, err)
 
 	err = r.walk()
@@ -88,11 +84,10 @@ func TestTemplateUuidFunction(t *testing.T) {
 
 func TestTemplateUrlFunction(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/urlparse-function/template", "./testdata/urlparse-function/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/urlparse-function/template", "./testdata/urlparse-function/library")
 
 	require.NoError(t, err)
 
@@ -105,11 +100,10 @@ func TestTemplateUrlFunction(t *testing.T) {
 
 func TestTemplateMapPairFunction(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	ctx = root.SetWorkspaceClient(ctx, nil)
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/map-pair/template", "./testdata/map-pair/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/map-pair/template", "./testdata/map-pair/library")
 
 	require.NoError(t, err)
 
@@ -122,7 +116,6 @@ func TestTemplateMapPairFunction(t *testing.T) {
 
 func TestWorkspaceHost(t *testing.T) {
 	ctx := context.Background()
-	tmpDir := t.TempDir()
 
 	w := &databricks.WorkspaceClient{
 		Config: &workspaceConfig.Config{
@@ -132,7 +125,7 @@ func TestWorkspaceHost(t *testing.T) {
 	ctx = root.SetWorkspaceClient(ctx, w)
 
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/workspace-host/template", "./testdata/map-pair/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/workspace-host/template", "./testdata/map-pair/library")
 
 	require.NoError(t, err)
 
@@ -149,7 +142,6 @@ func TestWorkspaceHostNotConfigured(t *testing.T) {
 	ctx := context.Background()
 	cmd := cmdio.NewIO(flags.OutputJSON, strings.NewReader(""), os.Stdout, os.Stderr, "", "template")
 	ctx = cmdio.InContext(ctx, cmd)
-	tmpDir := t.TempDir()
 
 	w := &databricks.WorkspaceClient{
 		Config: &workspaceConfig.Config{},
@@ -157,7 +149,7 @@ func TestWorkspaceHostNotConfigured(t *testing.T) {
 	ctx = root.SetWorkspaceClient(ctx, w)
 
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/workspace-host/template", "./testdata/map-pair/library", tmpDir)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/workspace-host/template", "./testdata/map-pair/library")
 
 	assert.NoError(t, err)
 

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -72,7 +72,7 @@ func Materialize(ctx context.Context, configFilePath string, templateFS fs.FS, o
 		return err
 	}
 
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	if err != nil {
 		return err
 	}

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/filer"
 )
 
 const libraryDirName = "library"
@@ -40,7 +41,7 @@ func Materialize(ctx context.Context, configFilePath string, templateFS fs.FS, o
 	}
 
 	helpers := loadHelpers(ctx)
-	r, err := newRenderer(ctx, config.values, helpers, templateFS, templateDirName, libraryDirName, outputDir)
+	r, err := newRenderer(ctx, config.values, helpers, templateFS, templateDirName, libraryDirName)
 	if err != nil {
 		return err
 	}
@@ -72,7 +73,12 @@ func Materialize(ctx context.Context, configFilePath string, templateFS fs.FS, o
 		return err
 	}
 
-	err = r.persistToDisk(ctx)
+	out, err := filer.NewLocalClient(outputDir)
+	if err != nil {
+		return err
+	}
+
+	err = r.persistToDisk(ctx, out)
 	if err != nil {
 		return err
 	}

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -299,7 +299,7 @@ func (r *renderer) walk() error {
 	return nil
 }
 
-func (r *renderer) persistToDisk() error {
+func (r *renderer) persistToDisk(ctx context.Context) error {
 	// Accumulate files which we will persist, skipping files whose path matches
 	// any of the skip patterns
 	filesToPersist := make([]file, 0)
@@ -329,7 +329,7 @@ func (r *renderer) persistToDisk() error {
 
 	// Persist files to disk
 	for _, file := range filesToPersist {
-		err := file.PersistToDisk()
+		err := file.Write(ctx)
 		if err != nil {
 			return err
 		}

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"path"
 	"regexp"
 	"slices"
@@ -14,6 +13,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/databricks/cli/libs/filer"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/logger"
 )
@@ -52,9 +52,6 @@ type renderer struct {
 
 	// [fs.FS] that holds the template's file tree.
 	srcFS fs.FS
-
-	// Root directory for the project instantiated from the template
-	instanceRoot string
 }
 
 func newRenderer(
@@ -64,7 +61,6 @@ func newRenderer(
 	templateFS fs.FS,
 	templateDir string,
 	libraryDir string,
-	instanceRoot string,
 ) (*renderer, error) {
 	// Initialize new template, with helper functions loaded
 	tmpl := template.New("").Funcs(helpers)
@@ -99,7 +95,6 @@ func newRenderer(
 		files:        make([]file, 0),
 		skipPatterns: make([]string, 0),
 		srcFS:        srcFS,
-		instanceRoot: instanceRoot,
 	}, nil
 }
 
@@ -165,12 +160,8 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	// over as is, without treating it as a template
 	if !strings.HasSuffix(relPathTemplate, templateExtension) {
 		return &copyFile{
-			dstPath: &destinationPath{
-				root:    r.instanceRoot,
-				relPath: relPath,
-			},
 			perm:    perm,
-			ctx:     r.ctx,
+			relPath: relPath,
 			srcFS:   r.srcFS,
 			srcPath: relPathTemplate,
 		}, nil
@@ -202,11 +193,8 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 
 	return &inMemoryFile{
-		dstPath: &destinationPath{
-			root:    r.instanceRoot,
-			relPath: relPath,
-		},
 		perm:    perm,
+		relPath: relPath,
 		content: []byte(content),
 	}, nil
 }
@@ -291,7 +279,7 @@ func (r *renderer) walk() error {
 			if err != nil {
 				return err
 			}
-			logger.Infof(r.ctx, "added file to list of possible project files: %s", f.DstPath().relPath)
+			logger.Infof(r.ctx, "added file to list of possible project files: %s", f.RelPath())
 			r.files = append(r.files, f)
 		}
 
@@ -299,17 +287,17 @@ func (r *renderer) walk() error {
 	return nil
 }
 
-func (r *renderer) persistToDisk(ctx context.Context) error {
+func (r *renderer) persistToDisk(ctx context.Context, out filer.Filer) error {
 	// Accumulate files which we will persist, skipping files whose path matches
 	// any of the skip patterns
 	filesToPersist := make([]file, 0)
 	for _, file := range r.files {
-		match, err := isSkipped(file.DstPath().relPath, r.skipPatterns)
+		match, err := isSkipped(file.RelPath(), r.skipPatterns)
 		if err != nil {
 			return err
 		}
 		if match {
-			log.Infof(r.ctx, "skipping file: %s", file.DstPath())
+			log.Infof(r.ctx, "skipping file: %s", file.RelPath())
 			continue
 		}
 		filesToPersist = append(filesToPersist, file)
@@ -317,8 +305,8 @@ func (r *renderer) persistToDisk(ctx context.Context) error {
 
 	// Assert no conflicting files exist
 	for _, file := range filesToPersist {
-		path := file.DstPath().absPath()
-		_, err := os.Stat(path)
+		path := file.RelPath()
+		_, err := out.Stat(ctx, path)
 		if err == nil {
 			return fmt.Errorf("failed to initialize template, one or more files already exist: %s", path)
 		}
@@ -329,7 +317,7 @@ func (r *renderer) persistToDisk(ctx context.Context) error {
 
 	// Persist files to disk
 	for _, file := range filesToPersist {
-		err := file.Write(ctx)
+		err := file.Write(ctx, out)
 		if err != nil {
 			return err
 		}

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -63,7 +63,7 @@ func assertBuiltinTemplateValid(t *testing.T, template string, settings map[stri
 	// Evaluate template
 	err = renderer.walk()
 	require.NoError(t, err)
-	err = renderer.persistToDisk()
+	err = renderer.persistToDisk(ctx)
 	require.NoError(t, err)
 
 	b, err := bundle.Load(ctx, filepath.Join(tempDir, "my_project"))
@@ -187,7 +187,7 @@ func TestRendererWithAssociatedTemplateInLibrary(t *testing.T) {
 	err = r.walk()
 	require.NoError(t, err)
 
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	require.NoError(t, err)
 
 	b, err := os.ReadFile(filepath.Join(tmpDir, "my_email"))
@@ -350,7 +350,7 @@ func TestRendererPersistToDisk(t *testing.T) {
 		},
 	}
 
-	err := r.persistToDisk()
+	err := r.persistToDisk(ctx)
 	require.NoError(t, err)
 
 	assert.NoFileExists(t, filepath.Join(tmpDir, "a", "b", "c"))
@@ -438,7 +438,7 @@ func TestRendererSkipAllFilesInCurrentDirectory(t *testing.T) {
 	// All 3 files are executed and have in memory representations
 	require.Len(t, r.files, 3)
 
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	require.NoError(t, err)
 
 	entries, err := os.ReadDir(tmpDir)
@@ -480,7 +480,7 @@ func TestRendererSkip(t *testing.T) {
 	// This is because "dir2/*" matches the files in dir2, but not dir2 itself
 	assert.Len(t, r.files, 6)
 
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	require.NoError(t, err)
 
 	assert.FileExists(t, filepath.Join(tmpDir, "file1"))
@@ -534,6 +534,7 @@ func TestRendererReadsPermissionsBits(t *testing.T) {
 
 func TestRendererErrorOnConflictingFile(t *testing.T) {
 	tmpDir := t.TempDir()
+	ctx := context.Background()
 
 	f, err := os.Create(filepath.Join(tmpDir, "a"))
 	require.NoError(t, err)
@@ -553,7 +554,7 @@ func TestRendererErrorOnConflictingFile(t *testing.T) {
 			},
 		},
 	}
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	assert.EqualError(t, err, fmt.Sprintf("failed to initialize template, one or more files already exist: %s", filepath.Join(tmpDir, "a")))
 }
 
@@ -580,7 +581,7 @@ func TestRendererNoErrorOnConflictingFileIfSkipped(t *testing.T) {
 			},
 		},
 	}
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	// No error is returned even though a conflicting file exists. This is because
 	// the generated file is being skipped
 	assert.NoError(t, err)
@@ -623,7 +624,7 @@ func TestRendererFileTreeRendering(t *testing.T) {
 	assert.Len(t, r.files, 1)
 	assert.Equal(t, r.files[0].DstPath().absPath(), filepath.Join(tmpDir, "my_directory", "my_file"))
 
-	err = r.persistToDisk()
+	err = r.persistToDisk(ctx)
 	require.NoError(t, err)
 
 	// Assert files and directories are correctly materialized.


### PR DESCRIPTION
## Changes

Prior to this change, the output directory was part of the `renderer` type and passed down to every `file` it produced. Every file knew its absolute destination path. This is incompatible with the use of a filer, where all operations are automatically anchored to some base path.

To make this compatible, this change updates:
* the `file` type to only know its own path relative to the instantiation root,
* the `renderer` type to no longer require or pass along the output directory,
* the `persistToDisk` function to take a context and filer argument,
* the `filer.WriteMode` to represent permission bits

## Tests

* Existing tests pass.
* Manually confirmed template initialization works as expected.
