### PR TITLE
Extend "notebook not found" error to warn about missing extension

### DIFF
--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -150,7 +150,7 @@ file extensions: [%s]`, literal, literalWithExt, strings.Join(extensions, ", "))
 			}
 		}
 
-		// Return a generic error message if no matching possible q is found.
+		// Return a generic error message if no matching possible file is found.
 		return "", fmt.Errorf(`notebook %s not found. Local notebook references are expected
 to contain one of the following file extensions: [%s]`, literal, strings.Join(extensions, ", "))
 	}

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -143,9 +143,7 @@ func (t *translateContext) translateNotebookPath(literal, localFullPath, localRe
 		for _, ext := range extensions {
 			literalWithExt := literal + ext
 			localRelPathWithExt := filepath.ToSlash(localRelPath + ext)
-			// TODO: inline the err call.
-			_, err := fs.Stat(t.b.SyncRoot, localRelPathWithExt)
-			if err == nil {
+			if _, err := fs.Stat(t.b.SyncRoot, localRelPathWithExt); err == nil {
 				return "", fmt.Errorf(`notebook %s not found. Did you mean %s?
 Local notebook references are expected to contain one of the following
 file extensions: [%s]`, literal, literalWithExt, strings.Join(extensions, ", "))

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -126,6 +126,18 @@ func (t *translateContext) rewritePath(
 func (t *translateContext) translateNotebookPath(literal, localFullPath, localRelPath, remotePath string) (string, error) {
 	nb, _, err := notebook.DetectWithFS(t.b.SyncRoot, filepath.ToSlash(localRelPath))
 	if errors.Is(err, fs.ErrNotExist) {
+		if filepath.Ext(localFullPath) == notebook.ExtensionNone {
+			return "", fmt.Errorf(`notebook %s not found. Local notebook references are expected
+to contain one of the following file extensions: [%s]`,
+				literal,
+				strings.Join([]string{
+					notebook.ExtensionPython,
+					notebook.ExtensionR,
+					notebook.ExtensionScala,
+					notebook.ExtensionSql,
+					notebook.ExtensionJupyter}, ", "))
+		}
+
 		return "", fmt.Errorf("notebook %s not found", literal)
 	}
 	if err != nil {

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -126,19 +126,35 @@ func (t *translateContext) rewritePath(
 func (t *translateContext) translateNotebookPath(literal, localFullPath, localRelPath, remotePath string) (string, error) {
 	nb, _, err := notebook.DetectWithFS(t.b.SyncRoot, filepath.ToSlash(localRelPath))
 	if errors.Is(err, fs.ErrNotExist) {
-		if filepath.Ext(localFullPath) == notebook.ExtensionNone {
-			return "", fmt.Errorf(`notebook %s not found. Local notebook references are expected
-to contain one of the following file extensions: [%s]`,
-				literal,
-				strings.Join([]string{
-					notebook.ExtensionPython,
-					notebook.ExtensionR,
-					notebook.ExtensionScala,
-					notebook.ExtensionSql,
-					notebook.ExtensionJupyter}, ", "))
+		if filepath.Ext(localFullPath) != notebook.ExtensionNone {
+			return "", fmt.Errorf("notebook %s not found", literal)
 		}
 
-		return "", fmt.Errorf("notebook %s not found", literal)
+		extensions := []string{
+			notebook.ExtensionPython,
+			notebook.ExtensionR,
+			notebook.ExtensionScala,
+			notebook.ExtensionSql,
+			notebook.ExtensionJupyter,
+		}
+
+		// Check whether a file with a notebook extension already exists. This
+		// way we can provide a more targeted error message.
+		for _, ext := range extensions {
+			literalWithExt := literal + ext
+			localRelPathWithExt := filepath.ToSlash(localRelPath + ext)
+			// TODO: inline the err call.
+			_, err := fs.Stat(t.b.SyncRoot, localRelPathWithExt)
+			if err == nil {
+				return "", fmt.Errorf(`notebook %s not found. Did you mean %s?
+Local notebook references are expected to contain one of the following
+file extensions: [%s]`, literal, literalWithExt, strings.Join(extensions, ", "))
+			}
+		}
+
+		// Return a generic error message if no matching possible q is found.
+		return "", fmt.Errorf(`notebook %s not found. Local notebook references are expected
+to contain one of the following file extensions: [%s]`, literal, strings.Join(extensions, ", "))
 	}
 	if err != nil {
 		return "", fmt.Errorf("unable to determine if %s is a notebook: %w", localFullPath, err)

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -560,33 +560,6 @@ file extensions: [.py, .r, .scala, .sql, .ipynb]`, ext))
 			}
 		})
 	}
-
-	// touchEmptyFile(t, filepath.Join(dir, "doesnt_exist.py"))
-
-	// b := &bundle.Bundle{
-	// 	SyncRootPath: dir,
-	// 	SyncRoot:     vfs.MustNew(dir),
-	// 	Config: config.Root{
-	// 		Resources: config.Resources{
-	// 			Pipelines: map[string]*resources.Pipeline{
-	// 				"pipeline": {
-	// 					PipelineSpec: &pipelines.PipelineSpec{
-	// 						Libraries: []pipelines.PipelineLibrary{
-	// 							{
-	// 								Notebook: &pipelines.NotebookLibrary{
-	// 									Path: "./doesnt_exist",
-	// 								},
-	// 							},
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	},
-	// }
-
-	// bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(dir, "fake.yml")}})
-
 }
 
 func TestPipelineFileDoesNotExistError(t *testing.T) {

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -2,6 +2,7 @@ package mutator_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -509,35 +510,83 @@ func TestPipelineNotebookDoesNotExistError(t *testing.T) {
 }
 
 func TestPipelineNotebookDoesNotExistErrorWithoutExtension(t *testing.T) {
-	dir := t.TempDir()
+	for _, ext := range []string{
+		".py",
+		".r",
+		".scala",
+		".sql",
+		".ipynb",
+		"",
+	} {
+		t.Run("case_"+ext, func(t *testing.T) {
+			dir := t.TempDir()
 
-	b := &bundle.Bundle{
-		SyncRootPath: dir,
-		SyncRoot:     vfs.MustNew(dir),
-		Config: config.Root{
-			Resources: config.Resources{
-				Pipelines: map[string]*resources.Pipeline{
-					"pipeline": {
-						PipelineSpec: &pipelines.PipelineSpec{
-							Libraries: []pipelines.PipelineLibrary{
-								{
-									Notebook: &pipelines.NotebookLibrary{
-										Path: "./doesnt_exist",
+			if ext != "" {
+				touchEmptyFile(t, filepath.Join(dir, "foo"+ext))
+			}
+
+			b := &bundle.Bundle{
+				SyncRootPath: dir,
+				SyncRoot:     vfs.MustNew(dir),
+				Config: config.Root{
+					Resources: config.Resources{
+						Pipelines: map[string]*resources.Pipeline{
+							"pipeline": {
+								PipelineSpec: &pipelines.PipelineSpec{
+									Libraries: []pipelines.PipelineLibrary{
+										{
+											Notebook: &pipelines.NotebookLibrary{
+												Path: "./foo",
+											},
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-		},
+			}
+
+			bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(dir, "fake.yml")}})
+			diags := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
+
+			if ext == "" {
+				assert.EqualError(t, diags.Error(), `notebook ./foo not found. Local notebook references are expected
+to contain one of the following file extensions: [.py, .r, .scala, .sql, .ipynb]`)
+			} else {
+				assert.EqualError(t, diags.Error(), fmt.Sprintf(`notebook ./foo not found. Did you mean ./foo%s?
+Local notebook references are expected to contain one of the following
+file extensions: [.py, .r, .scala, .sql, .ipynb]`, ext))
+			}
+		})
 	}
 
-	bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(dir, "fake.yml")}})
+	// touchEmptyFile(t, filepath.Join(dir, "doesnt_exist.py"))
 
-	diags := bundle.Apply(context.Background(), b, mutator.TranslatePaths())
-	assert.EqualError(t, diags.Error(), `notebook ./doesnt_exist not found. Local notebook references are expected
-to contain one of the following file extensions: [.py, .r, .scala, .sql, .ipynb]`)
+	// b := &bundle.Bundle{
+	// 	SyncRootPath: dir,
+	// 	SyncRoot:     vfs.MustNew(dir),
+	// 	Config: config.Root{
+	// 		Resources: config.Resources{
+	// 			Pipelines: map[string]*resources.Pipeline{
+	// 				"pipeline": {
+	// 					PipelineSpec: &pipelines.PipelineSpec{
+	// 						Libraries: []pipelines.PipelineLibrary{
+	// 							{
+	// 								Notebook: &pipelines.NotebookLibrary{
+	// 									Path: "./doesnt_exist",
+	// 								},
+	// 							},
+	// 						},
+	// 					},
+	// 				},
+	// 			},
+	// 		},
+	// 	},
+	// }
+
+	// bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(dir, "fake.yml")}})
+
 }
 
 func TestPipelineFileDoesNotExistError(t *testing.T) {


### PR DESCRIPTION
## Changes
The full workspace path for a notebook does not contain the notebook's extension. If a user converts that file path to a relative path (like `/Workspace/bundle_root/bar/nb` -> `./bar/nb`), they can be confused as to why the new file path does not work.

The changes in this PR nudge them to add the appropriate file extension (e.g., `./bar/nb.py` or `./bar/nb.ipynb`). We

One common way users can end up in this scenario is by using the view job as YAML functionality in the Databricks UI.

## Tests
Unit test and manually.

```
(.venv) ➜  bundle-playground git:(master) ✗ cli bundle validate 
Error: notebook ./foo not found. Local notebook references are expected
to contain one of the following file extensions: [.py, .r, .scala, .sql, .ipynb]
```

When we detect that a candidate file exists then the error message is more targeted:
```
➜  bundle-playground git:(master) ✗ cli bundle validate
Error: notebook ./foo not found. Did you mean ./foo.py?
Local notebook references are expected to contain one of the following
file extensions: [.py, .r, .scala, .sql, .ipynb]
```
