### PR TITLE
Fix `TestAccBundleInitOnMlopsStacks`

### DIFF
--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -97,7 +97,7 @@ func TestAccBundleInitOnMlopsStacks(t *testing.T) {
 	require.NoError(t, err)
 	job, err := w.Jobs.GetByJobId(context.Background(), batchJobId)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("dev-%s-batch-inference-job", projectName), job.Settings.Name)
+	assert.Contains(t, job.Settings.Name, fmt.Sprintf("dev-%s-batch-inference-job", projectName))
 }
 
 func TestAccBundleInitHelpers(t *testing.T) {


### PR DESCRIPTION
## Changes
The ML production team modified mlops-stack to use `mode: development` for their development target here: https://github.com/databricks/mlops-stacks/pull/174

This PR makes the integration test assertion agnostic of the prefix to make it pass again. 

## Tests
The test passes now
