### PR TITLE
Extended message for warning when source-linked mode is used outside of the workspace

### DIFF
--- a/bundle/config/mutator/apply_presets.go
+++ b/bundle/config/mutator/apply_presets.go
@@ -227,17 +227,16 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 		if !isDatabricksWorkspace {
 			target := b.Config.Bundle.Target
 			path := dyn.NewPath(dyn.Key("targets"), dyn.Key(target), dyn.Key("presets"), dyn.Key("source_linked_deployment"))
-			diags = diags.Extend(
-				diag.Diagnostics{
-					{
-						Severity: diag.Warning,
-						Summary:  "source-linked deployment is available only in the Databricks Workspace",
-						Paths: []dyn.Path{
-							path,
-						},
-						Locations: b.Config.GetLocations(dyn.NewPath(dyn.Key("presets"), dyn.Key("source_linked_deployment")).String()),
+			diags = diags.Append(
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "source-linked deployment is available only in the Databricks Workspace",
+					Paths: []dyn.Path{
+						path,
 					},
-				})
+					Locations: b.Config.GetLocations(path[2:].String()),
+				},
+			)
 
 			disabled := false
 			b.Config.Presets.SourceLinkedDeployment = &disabled

--- a/bundle/config/mutator/apply_presets.go
+++ b/bundle/config/mutator/apply_presets.go
@@ -231,7 +231,7 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 				diag.Diagnostics{
 					{
 						Severity: diag.Warning,
-						Summary:  "Source-linked deployment is available only in the Databricks Workspace",
+						Summary:  "source-linked deployment is available only in the Databricks Workspace",
 						Paths: []dyn.Path{
 							path,
 						},

--- a/bundle/config/mutator/apply_presets.go
+++ b/bundle/config/mutator/apply_presets.go
@@ -225,9 +225,22 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	if config.IsExplicitlyEnabled((b.Config.Presets.SourceLinkedDeployment)) {
 		isDatabricksWorkspace := dbr.RunsOnRuntime(ctx) && strings.HasPrefix(b.SyncRootPath, "/Workspace/")
 		if !isDatabricksWorkspace {
+			target := b.Config.Bundle.Target
+			path := dyn.NewPath(dyn.Key("targets"), dyn.Key(target), dyn.Key("presets"), dyn.Key("source_linked_deployment"))
+			diags = diags.Extend(
+				diag.Diagnostics{
+					{
+						Severity: diag.Warning,
+						Summary:  "Source-linked deployment is available only in the Databricks Workspace",
+						Paths: []dyn.Path{
+							path,
+						},
+						Locations: b.Config.GetLocations(dyn.NewPath(dyn.Key("presets"), dyn.Key("source_linked_deployment")).String()),
+					},
+				})
+
 			disabled := false
 			b.Config.Presets.SourceLinkedDeployment = &disabled
-			diags = diags.Extend(diag.Warningf("source-linked deployment is available only in the Databricks Workspace"))
 		}
 	}
 

--- a/bundle/config/mutator/apply_presets_test.go
+++ b/bundle/config/mutator/apply_presets_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/mutator"
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/bundletest"
 	"github.com/databricks/cli/libs/dbr"
+	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/require"
@@ -435,6 +437,7 @@ func TestApplyPresetsSourceLinkedDeployment(t *testing.T) {
 				},
 			}
 
+			bundletest.SetLocation(b, "presets.source_linked_deployment", []dyn.Location{{File: "databricks.yml"}})
 			diags := bundle.Apply(tt.ctx, b, mutator.ApplyPresets())
 			if diags.HasError() {
 				t.Fatalf("unexpected error: %v", diags)
@@ -442,6 +445,7 @@ func TestApplyPresetsSourceLinkedDeployment(t *testing.T) {
 
 			if tt.expectedWarning != "" {
 				require.Equal(t, tt.expectedWarning, diags[0].Summary)
+				require.NotEmpty(t, diags[0].Locations)
 			}
 
 			require.Equal(t, tt.expectedValue, b.Config.Presets.SourceLinkedDeployment)


### PR DESCRIPTION
## Changes

Added path and locations to the warning which displayed when source-linked mode is used outside of the workspace