### PR TITLE
Update target references to use `${bundle.target}`

### DIFF
--- a/bundle/tests/python_wheel/python_wheel/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel/bundle.yml
@@ -10,7 +10,7 @@ artifacts:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
         - task_key: TestTask
           existing_cluster_id: "0717-132531-5opeqon1"

--- a/bundle/tests/python_wheel/python_wheel_dbfs_lib/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel_dbfs_lib/bundle.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
         - task_key: TestTask
           existing_cluster_id: "0717-132531-5opeqon1"

--- a/bundle/tests/python_wheel/python_wheel_multiple/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel_multiple/bundle.yml
@@ -14,7 +14,7 @@ artifacts:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
         - task_key: TestTask
           existing_cluster_id: "0717-132531-5opeqon1"

--- a/bundle/tests/python_wheel/python_wheel_no_artifact/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel_no_artifact/bundle.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
         - task_key: TestTask
           existing_cluster_id: "0717-aaaaa-bbbbbb"

--- a/bundle/tests/python_wheel/python_wheel_no_artifact_no_setup/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel_no_artifact_no_setup/bundle.yml
@@ -7,7 +7,7 @@ workspace:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
         - task_key: TestTask
           existing_cluster_id: "0717-aaaaa-bbbbbb"

--- a/bundle/tests/python_wheel/python_wheel_no_artifact_notebook/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel_no_artifact_notebook/bundle.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
       - task_key: TestTask
         existing_cluster_id: "0717-aaaaa-bbbbbb"

--- a/bundle/tests/python_wheel/python_wheel_no_build/bundle.yml
+++ b/bundle/tests/python_wheel/python_wheel_no_build/bundle.yml
@@ -4,7 +4,7 @@ bundle:
 resources:
   jobs:
     test_job:
-      name: "[${bundle.environment}] My Wheel Job"
+      name: "[${bundle.target}] My Wheel Job"
       tasks:
         - task_key: TestTask
           existing_cluster_id: "0717-132531-5opeqon1"

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.pipeline.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.pipeline.yml.tmpl
@@ -9,7 +9,7 @@ resources:
       {{- else}}
       catalog: {{default_catalog}}
       {{- end}}
-      target: {{.project_name}}_${bundle.environment}
+      target: {{.project_name}}_${bundle.target}
       libraries:
         - notebook:
             path: ../src/dlt_pipeline.ipynb


### PR DESCRIPTION
## Changes

The built-in template contains a reference to `${bundle.environment}`.

This property has been deprecated in favor of `${bundle.target}` a long time ago (#670), so we should no longer emit it. The environment field will continue to be usable until we cut a new major version in some far away future.

## Tests

* Unit tests
* The test `TestInterpolationWithTarget` still covers correct interpolation of `${bundle.environment}`
