### PR TITLE
Properly read Git metadata when running inside workspace

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -48,7 +48,10 @@ type Bundle struct {
 	// Exclusively use this field for filesystem operations.
 	SyncRoot vfs.Path
 
-	// Path to the root of git worktree
+	// Path to the root of git worktree containing the bundle.
+	// This is the same as git repository root if worktrees are not used,
+	// otherwise it's a descedant of git repository root.
+	// https://git-scm.com/docs/git-worktree
 	WorktreeRoot vfs.Path
 
 	// Config contains the bundle configuration.

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -49,8 +49,6 @@ type Bundle struct {
 	SyncRoot vfs.Path
 
 	// Path to the root of git worktree containing the bundle.
-	// This is the same as git repository root if worktrees are not used,
-	// otherwise it's a descedant of git repository root.
 	// https://git-scm.com/docs/git-worktree
 	WorktreeRoot vfs.Path
 

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -48,6 +48,9 @@ type Bundle struct {
 	// Exclusively use this field for filesystem operations.
 	SyncRoot vfs.Path
 
+	// Path to root of git worktree
+	WorktreeRoot vfs.Path
+
 	// Config contains the bundle configuration.
 	// It is loaded from the bundle configuration files and mutators may update it.
 	Config config.Root

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -48,7 +48,7 @@ type Bundle struct {
 	// Exclusively use this field for filesystem operations.
 	SyncRoot vfs.Path
 
-	// Path to root of git worktree
+	// Path to the root of git worktree
 	WorktreeRoot vfs.Path
 
 	// Config contains the bundle configuration.

--- a/bundle/bundle_read_only.go
+++ b/bundle/bundle_read_only.go
@@ -32,6 +32,10 @@ func (r ReadOnlyBundle) SyncRoot() vfs.Path {
 	return r.b.SyncRoot
 }
 
+func (r ReadOnlyBundle) WorktreeRoot() vfs.Path {
+	return r.b.WorktreeRoot
+}
+
 func (r ReadOnlyBundle) WorkspaceClient() *databricks.WorkspaceClient {
 	return r.b.WorkspaceClient()
 }

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -7,7 +7,6 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/git"
-	"github.com/databricks/cli/libs/log"
 )
 
 type loadGitDetails struct{}
@@ -21,45 +20,35 @@ func (m *loadGitDetails) Name() string {
 }
 
 func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	// Load relevant git repository
-	repo, err := git.NewRepository(b.BundleRoot)
+	info, err := git.FetchRepositoryInfo(ctx, b.BundleRoot, b.WorkspaceClient())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	// Read branch name of current checkout
-	branch, err := repo.CurrentBranch()
-	if err == nil {
-		b.Config.Bundle.Git.ActualBranch = branch
-		if b.Config.Bundle.Git.Branch == "" {
-			// Only load branch if there's no user defined value
-			b.Config.Bundle.Git.Inferred = true
-			b.Config.Bundle.Git.Branch = branch
-		}
-	} else {
-		log.Warnf(ctx, "failed to load current branch: %s", err)
+	b.WorktreeRoot = info.WorktreeRoot
+
+	b.Config.Bundle.Git.ActualBranch = info.CurrentBranch
+	if b.Config.Bundle.Git.Branch == "" {
+		// Only load branch if there's no user defined value
+		b.Config.Bundle.Git.Inferred = true
+		b.Config.Bundle.Git.Branch = info.CurrentBranch
 	}
 
 	// load commit hash if undefined
 	if b.Config.Bundle.Git.Commit == "" {
-		commit, err := repo.LatestCommit()
-		if err != nil {
-			log.Warnf(ctx, "failed to load latest commit: %s", err)
-		} else {
-			b.Config.Bundle.Git.Commit = commit
-		}
-	}
-	// load origin url if undefined
-	if b.Config.Bundle.Git.OriginURL == "" {
-		remoteUrl := repo.OriginUrl()
-		b.Config.Bundle.Git.OriginURL = remoteUrl
+		b.Config.Bundle.Git.Commit = info.LatestCommit
 	}
 
-	// repo.Root() returns the absolute path of the repo
-	relBundlePath, err := filepath.Rel(repo.Root(), b.BundleRoot.Native())
+	// load origin url if undefined
+	if b.Config.Bundle.Git.OriginURL == "" {
+		b.Config.Bundle.Git.OriginURL = info.OriginURL
+	}
+
+	relBundlePath, err := filepath.Rel(info.WorktreeRoot.Native(), b.BundleRoot.Native())
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	b.Config.Bundle.Git.BundleRootPath = filepath.ToSlash(relBundlePath)
 	return nil
 }

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -7,6 +7,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/git"
+	"github.com/databricks/cli/libs/vfs"
 )
 
 type loadGitDetails struct{}
@@ -26,7 +27,11 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 		diags = append(diags, diag.WarningFromErr(err)...)
 	}
 
-	b.WorktreeRoot = info.GuessedWorktreeRoot
+	if info.WorktreeRoot == "" {
+		b.WorktreeRoot = b.BundleRoot
+	} else {
+		b.WorktreeRoot = vfs.MustNew(info.WorktreeRoot)
+	}
 
 	b.Config.Bundle.Git.ActualBranch = info.CurrentBranch
 	if b.Config.Bundle.Git.Branch == "" {

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -53,8 +53,8 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	relBundlePath, err := filepath.Rel(b.WorktreeRoot.Native(), b.BundleRoot.Native())
 	if err != nil {
 		diags = append(diags, diag.FromErr(err)...)
+	} else {
+		b.Config.Bundle.Git.BundleRootPath = filepath.ToSlash(relBundlePath)
 	}
-
-	b.Config.Bundle.Git.BundleRootPath = filepath.ToSlash(relBundlePath)
 	return diags
 }

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -7,7 +7,6 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/git"
-	"github.com/databricks/cli/libs/vfs"
 )
 
 type loadGitDetails struct{}
@@ -27,11 +26,7 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 		diags = append(diags, diag.WarningFromErr(err)...)
 	}
 
-	if info.WorktreeRoot == "" {
-		b.WorktreeRoot = b.BundleRoot
-	} else {
-		b.WorktreeRoot = vfs.MustNew(info.WorktreeRoot)
-	}
+	b.WorktreeRoot = info.GuessedWorktreeRoot
 
 	b.Config.Bundle.Git.ActualBranch = info.CurrentBranch
 	if b.Config.Bundle.Git.Branch == "" {

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -21,7 +21,7 @@ func (m *loadGitDetails) Name() string {
 
 func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	var diags diag.Diagnostics
-	info, err := git.FetchRepositoryInfo(ctx, b.BundleRoot, b.WorkspaceClient())
+	info, err := git.FetchRepositoryInfo(ctx, b.BundleRoot.Native(), b.WorkspaceClient())
 	if err != nil {
 		diags = append(diags, diag.WarningFromErr(err)...)
 	}

--- a/bundle/config/validate/files_to_sync_test.go
+++ b/bundle/config/validate/files_to_sync_test.go
@@ -44,6 +44,7 @@ func setupBundleForFilesToSyncTest(t *testing.T) *bundle.Bundle {
 		BundleRoot:     vfs.MustNew(dir),
 		SyncRootPath:   dir,
 		SyncRoot:       vfs.MustNew(dir),
+		WorktreeRoot:   vfs.MustNew(dir),
 		Config: config.Root{
 			Bundle: config.Bundle{
 				Target: "default",

--- a/bundle/deploy/files/sync.go
+++ b/bundle/deploy/files/sync.go
@@ -28,10 +28,11 @@ func GetSyncOptions(ctx context.Context, rb bundle.ReadOnlyBundle) (*sync.SyncOp
 	}
 
 	opts := &sync.SyncOptions{
-		LocalRoot: rb.SyncRoot(),
-		Paths:     rb.Config().Sync.Paths,
-		Include:   includes,
-		Exclude:   rb.Config().Sync.Exclude,
+		WorktreeRoot: rb.WorktreeRoot(),
+		LocalRoot:    rb.SyncRoot(),
+		Paths:        rb.Config().Sync.Paths,
+		Include:      includes,
+		Exclude:      rb.Config().Sync.Exclude,
 
 		RemotePath: rb.Config().Workspace.FilePath,
 		Host:       rb.WorkspaceClient().Config.Host,

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -73,12 +73,8 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		log.Warnf(ctx, "Failed to read git info: %s", err)
 	}
 
-	if info.WorktreeRoot == "" {
-		info.WorktreeRoot = localRoot.Native()
-	}
-
 	opts := sync.SyncOptions{
-		WorktreeRoot: vfs.MustNew(info.WorktreeRoot),
+		WorktreeRoot: info.GuessedWorktreeRoot,
 		LocalRoot:    localRoot,
 		Paths:        []string{"."},
 		Include:      nil,

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -67,7 +67,7 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 	client := root.WorkspaceClient(ctx)
 
 	localRoot := vfs.MustNew(args[0])
-	info, err := git.FetchRepositoryInfo(ctx, localRoot, client)
+	info, err := git.FetchRepositoryInfo(ctx, localRoot.Native(), client)
 
 	if err != nil {
 		log.Warnf(ctx, "Failed to read git info: %s", err)

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/files"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/git"
 	"github.com/databricks/cli/libs/sync"
 	"github.com/databricks/cli/libs/vfs"
 	"github.com/spf13/cobra"
@@ -37,6 +38,7 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 
 	opts.Full = f.full
 	opts.PollInterval = f.interval
+	opts.WorktreeRoot = b.WorktreeRoot
 	return opts, nil
 }
 
@@ -60,11 +62,21 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		}
 	}
 
+	ctx := cmd.Context()
+	client := root.WorkspaceClient(ctx)
+
+	localRoot := vfs.MustNew(args[0])
+	info, err := git.FetchRepositoryInfo(ctx, localRoot, client)
+	if err != nil {
+		return nil, err
+	}
+
 	opts := sync.SyncOptions{
-		LocalRoot: vfs.MustNew(args[0]),
-		Paths:     []string{"."},
-		Include:   nil,
-		Exclude:   nil,
+		WorktreeRoot: info.WorktreeRoot,
+		LocalRoot:    localRoot,
+		Paths:        []string{"."},
+		Include:      nil,
+		Exclude:      nil,
 
 		RemotePath:   args[1],
 		Full:         f.full,
@@ -75,7 +87,7 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		// The sync code will automatically create this directory if it doesn't
 		// exist and add it to the `.gitignore` file in the root.
 		SnapshotBasePath: filepath.Join(args[0], ".databricks"),
-		WorkspaceClient:  root.WorkspaceClient(cmd.Context()),
+		WorkspaceClient:  client,
 
 		OutputHandler: outputHandler,
 	}

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -73,16 +73,16 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		log.Warnf(ctx, "Failed to read git info: %s", err)
 	}
 
-	var WorktreeRoot vfs.Path
+	var worktreeRoot vfs.Path
 
 	if info.WorktreeRoot == "" {
-		WorktreeRoot = localRoot
+		worktreeRoot = localRoot
 	} else {
-		WorktreeRoot = vfs.MustNew(info.WorktreeRoot)
+		worktreeRoot = vfs.MustNew(info.WorktreeRoot)
 	}
 
 	opts := sync.SyncOptions{
-		WorktreeRoot: WorktreeRoot,
+		WorktreeRoot: worktreeRoot,
 		LocalRoot:    localRoot,
 		Paths:        []string{"."},
 		Include:      nil,

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -73,8 +73,16 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		log.Warnf(ctx, "Failed to read git info: %s", err)
 	}
 
+	var WorktreeRoot vfs.Path
+
+	if info.WorktreeRoot == "" {
+		WorktreeRoot = localRoot
+	} else {
+		WorktreeRoot = vfs.MustNew(info.WorktreeRoot)
+	}
+
 	opts := sync.SyncOptions{
-		WorktreeRoot: info.GuessedWorktreeRoot,
+		WorktreeRoot: WorktreeRoot,
 		LocalRoot:    localRoot,
 		Paths:        []string{"."},
 		Include:      nil,

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/internal/acc"
+	"github.com/databricks/cli/libs/dbr"
+	"github.com/databricks/cli/libs/git"
+	"github.com/databricks/cli/libs/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const examplesRepoUrl = "https://github.com/databricks/bundle-examples"
+const examplesRepoProvider = "gitHub"
+
+func assertGitInfo(t *testing.T, info git.GitRepositoryInfo, expectedRoot string) {
+	assert.Equal(t, "main", info.CurrentBranch)
+	assert.NotEmpty(t, info.LatestCommit)
+	assert.Equal(t, examplesRepoUrl, info.OriginURL)
+	assert.Equal(t, expectedRoot, info.WorktreeRoot.Native())
+}
+
+func TestFetchRepositoryInfoAPI(t *testing.T) {
+	ctx, wt := acc.WorkspaceTest(t)
+	me, err := wt.W.CurrentUser.Me(ctx)
+	require.NoError(t, err)
+
+	targetPath := acc.RandomName("/Workspace/Users/" + me.UserName + "/testing-clone-bundle-examples-")
+	stdout, stderr := RequireSuccessfulRun(t, "repos", "create", examplesRepoUrl, examplesRepoProvider, "--path", targetPath)
+	defer RequireSuccessfulRun(t, "repos", "delete", targetPath)
+
+	assert.Empty(t, stderr.String())
+	assert.NotEmpty(t, stdout.String())
+	ctx = dbr.MockRuntime(ctx, true)
+
+	for _, inputPath := range []string{
+		targetPath + "/knowledge_base/dashboard_nyc_taxi",
+		targetPath,
+	} {
+		t.Run(inputPath, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(inputPath), wt.W)
+			assert.NoError(t, err)
+			assertGitInfo(t, info, targetPath)
+		})
+	}
+}
+
+func TestFetchRepositoryInfoDotGit(t *testing.T) {
+	ctx, wt := acc.WorkspaceTest(t)
+
+	repo := cloneRepoLocally(t, examplesRepoUrl)
+
+	for _, inputPath := range []string{
+		repo + "/knowledge_base/dashboard_nyc_taxi",
+		repo,
+	} {
+		t.Run(inputPath, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(inputPath), wt.W)
+			assert.NoError(t, err)
+			assertGitInfo(t, info, repo)
+		})
+	}
+}
+
+func cloneRepoLocally(t *testing.T, repoUrl string) string {
+	tempDir := t.TempDir()
+	localRoot := filepath.Join(tempDir, "repo")
+
+	cmd := exec.Command("git", "clone", "--depth=1", examplesRepoUrl, localRoot)
+	err := cmd.Run()
+	require.NoError(t, err)
+	return localRoot
+}

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -16,14 +17,14 @@ import (
 const examplesRepoUrl = "https://github.com/databricks/bundle-examples"
 const examplesRepoProvider = "gitHub"
 
-func assertGitInfo(t *testing.T, info git.GitRepositoryInfo, expectedRoot string) {
+func assertFullGitInfo(t *testing.T, info git.GitRepositoryInfo, expectedRoot string) {
 	assert.Equal(t, "main", info.CurrentBranch)
 	assert.NotEmpty(t, info.LatestCommit)
 	assert.Equal(t, examplesRepoUrl, info.OriginURL)
-	assert.Equal(t, expectedRoot, info.WorktreeRoot.Native())
+	assert.Equal(t, expectedRoot, info.WorktreeRoot)
 }
 
-func TestAccFetchRepositoryInfoAPI(t *testing.T) {
+func TestAccFetchRepositoryInfoAPI_FromRepo(t *testing.T) {
 	ctx, wt := acc.WorkspaceTest(t)
 	me, err := wt.W.CurrentUser.Me(ctx)
 	require.NoError(t, err)
@@ -45,12 +46,62 @@ func TestAccFetchRepositoryInfoAPI(t *testing.T) {
 		t.Run(inputPath, func(t *testing.T) {
 			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(inputPath), wt.W)
 			assert.NoError(t, err)
-			assertGitInfo(t, info, targetPath)
+			assertFullGitInfo(t, info, targetPath)
 		})
 	}
 }
 
-func TestAccFetchRepositoryInfoDotGit(t *testing.T) {
+func TestAccFetchRepositoryInfoAPI_FromNonRepo(t *testing.T) {
+	ctx, wt := acc.WorkspaceTest(t)
+	me, err := wt.W.CurrentUser.Me(ctx)
+	require.NoError(t, err)
+
+	rootPath := acc.RandomName("/Workspace/Users/" + me.UserName + "/testing-nonrepo-")
+	_, stderr := RequireSuccessfulRun(t, "workspace", "mkdirs", rootPath+"/a/b/c")
+	t.Cleanup(func() {
+		RequireSuccessfulRun(t, "workspace", "delete", "--recursive", rootPath)
+	})
+
+	assert.Empty(t, stderr.String())
+	//assert.NotEmpty(t, stdout.String())
+	ctx = dbr.MockRuntime(ctx, true)
+
+	tests := []struct {
+		input string
+		msg   string
+	}{
+		{
+			input: rootPath + "/a/b/c",
+			msg:   "",
+		},
+		{
+			input: rootPath,
+			msg:   "",
+		},
+		{
+			input: rootPath + "/non-existent",
+			msg:   "doesn't exist",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input+" <==> "+test.msg, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(test.input), wt.W)
+			if test.msg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.msg)
+			}
+			assert.Equal(t, "", info.CurrentBranch)
+			assert.Equal(t, "", info.LatestCommit)
+			assert.Equal(t, "", info.OriginURL)
+			assert.Equal(t, "", info.WorktreeRoot)
+		})
+	}
+}
+
+func TestAccFetchRepositoryInfoDotGit_FromGitRepo(t *testing.T) {
 	ctx, wt := acc.WorkspaceTest(t)
 
 	repo := cloneRepoLocally(t, examplesRepoUrl)
@@ -62,7 +113,7 @@ func TestAccFetchRepositoryInfoDotGit(t *testing.T) {
 		t.Run(inputPath, func(t *testing.T) {
 			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(inputPath), wt.W)
 			assert.NoError(t, err)
-			assertGitInfo(t, info, repo)
+			assertFullGitInfo(t, info, repo)
 		})
 	}
 }
@@ -75,4 +126,46 @@ func cloneRepoLocally(t *testing.T, repoUrl string) string {
 	err := cmd.Run()
 	require.NoError(t, err)
 	return localRoot
+}
+
+func TestAccFetchRepositoryInfoDotGit_FromNonGitRepo(t *testing.T) {
+	ctx, wt := acc.WorkspaceTest(t)
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(root+"/a/b/c", 0700))
+
+	tests := []string{
+		root + "/a/b/c",
+		root,
+		root + "/non-existent",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(input), wt.W)
+			assert.NoError(t, err)
+			assert.Equal(t, "", info.CurrentBranch)
+			assert.Equal(t, "", info.LatestCommit)
+			assert.Equal(t, "", info.OriginURL)
+			assert.Equal(t, "", info.WorktreeRoot)
+		})
+	}
+}
+
+func TestAccFetchRepositoryInfoDotGit_FromBrokenGitRepo(t *testing.T) {
+	ctx, wt := acc.WorkspaceTest(t)
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "repo")
+	path := root + "/a/b/c"
+	require.NoError(t, os.MkdirAll(path, 0700))
+	require.NoError(t, os.WriteFile(root+"/.git", []byte(""), 0000))
+
+	info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(path), wt.W)
+	assert.NoError(t, err)
+	assert.Equal(t, root, info.WorktreeRoot)
+	assert.Equal(t, "", info.CurrentBranch)
+	assert.Equal(t, "", info.LatestCommit)
+	assert.Equal(t, "", info.OriginURL)
 }

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/databricks/cli/internal/acc"
 	"github.com/databricks/cli/libs/dbr"
 	"github.com/databricks/cli/libs/git"
-	"github.com/databricks/cli/libs/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +54,7 @@ func TestAccFetchRepositoryInfoAPI_FromRepo(t *testing.T) {
 		targetPath,
 	} {
 		t.Run(inputPath, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(inputPath), wt.W)
+			info, err := git.FetchRepositoryInfo(ctx, inputPath, wt.W)
 			assert.NoError(t, err)
 			assertFullGitInfo(t, targetPath, info)
 		})
@@ -97,7 +96,7 @@ func TestAccFetchRepositoryInfoAPI_FromNonRepo(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input+" <==> "+test.msg, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(test.input), wt.W)
+			info, err := git.FetchRepositoryInfo(ctx, test.input, wt.W)
 			if test.msg == "" {
 				assert.NoError(t, err)
 			} else {
@@ -119,7 +118,7 @@ func TestAccFetchRepositoryInfoDotGit_FromGitRepo(t *testing.T) {
 		repo,
 	} {
 		t.Run(inputPath, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(inputPath), wt.W)
+			info, err := git.FetchRepositoryInfo(ctx, inputPath, wt.W)
 			assert.NoError(t, err)
 			assertFullGitInfo(t, repo, info)
 		})
@@ -151,7 +150,7 @@ func TestAccFetchRepositoryInfoDotGit_FromNonGitRepo(t *testing.T) {
 
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(input), wt.W)
+			info, err := git.FetchRepositoryInfo(ctx, input, wt.W)
 			assert.NoError(t, err)
 			assertEmptyGitInfo(t, info)
 		})
@@ -167,7 +166,7 @@ func TestAccFetchRepositoryInfoDotGit_FromBrokenGitRepo(t *testing.T) {
 	require.NoError(t, os.MkdirAll(path, 0700))
 	require.NoError(t, os.WriteFile(root+"/.git", []byte(""), 0000))
 
-	info, err := git.FetchRepositoryInfo(ctx, vfs.MustNew(path), wt.W)
+	info, err := git.FetchRepositoryInfo(ctx, path, wt.W)
 	assert.NoError(t, err)
 	assertSparseGitInfo(t, root, info)
 }

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -73,7 +73,6 @@ func TestAccFetchRepositoryInfoAPI_FromNonRepo(t *testing.T) {
 	})
 
 	assert.Empty(t, stderr.String())
-	//assert.NotEmpty(t, stdout.String())
 	ctx = dbr.MockRuntime(ctx, true)
 
 	tests := []struct {

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -30,7 +30,9 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 
 	targetPath := acc.RandomName("/Workspace/Users/" + me.UserName + "/testing-clone-bundle-examples-")
 	stdout, stderr := RequireSuccessfulRun(t, "repos", "create", examplesRepoUrl, examplesRepoProvider, "--path", targetPath)
-	defer RequireSuccessfulRun(t, "repos", "delete", targetPath)
+	t.Cleanup(func() {
+		RequireSuccessfulRun(t, "repos", "delete", targetPath)
+	})
 
 	assert.Empty(t, stderr.String())
 	assert.NotEmpty(t, stdout.String())

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -23,7 +23,7 @@ func assertGitInfo(t *testing.T, info git.GitRepositoryInfo, expectedRoot string
 	assert.Equal(t, expectedRoot, info.WorktreeRoot.Native())
 }
 
-func TestFetchRepositoryInfoAPI(t *testing.T) {
+func TestAccFetchRepositoryInfoAPI(t *testing.T) {
 	ctx, wt := acc.WorkspaceTest(t)
 	me, err := wt.W.CurrentUser.Me(ctx)
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 	}
 }
 
-func TestFetchRepositoryInfoDotGit(t *testing.T) {
+func TestAccFetchRepositoryInfoDotGit(t *testing.T) {
 	ctx, wt := acc.WorkspaceTest(t)
 
 	repo := cloneRepoLocally(t, examplesRepoUrl)

--- a/internal/git_fetch_test.go
+++ b/internal/git_fetch_test.go
@@ -16,18 +16,18 @@ import (
 const examplesRepoUrl = "https://github.com/databricks/bundle-examples"
 const examplesRepoProvider = "gitHub"
 
-func assertFullGitInfo(t *testing.T, expectedRoot string, info git.GitRepositoryInfo) {
+func assertFullGitInfo(t *testing.T, expectedRoot string, info git.RepositoryInfo) {
 	assert.Equal(t, "main", info.CurrentBranch)
 	assert.NotEmpty(t, info.LatestCommit)
 	assert.Equal(t, examplesRepoUrl, info.OriginURL)
 	assert.Equal(t, expectedRoot, info.WorktreeRoot)
 }
 
-func assertEmptyGitInfo(t *testing.T, info git.GitRepositoryInfo) {
+func assertEmptyGitInfo(t *testing.T, info git.RepositoryInfo) {
 	assertSparseGitInfo(t, "", info)
 }
 
-func assertSparseGitInfo(t *testing.T, expectedRoot string, info git.GitRepositoryInfo) {
+func assertSparseGitInfo(t *testing.T, expectedRoot string, info git.RepositoryInfo) {
 	assert.Equal(t, "", info.CurrentBranch)
 	assert.Equal(t, "", info.LatestCommit)
 	assert.Equal(t, "", info.OriginURL)

--- a/libs/diag/diagnostic.go
+++ b/libs/diag/diagnostic.go
@@ -53,6 +53,19 @@ func FromErr(err error) Diagnostics {
 	}
 }
 
+// FromErr returns a new warning diagnostic from the specified error, if any.
+func WarningFromErr(err error) Diagnostics {
+	if err == nil {
+		return nil
+	}
+	return []Diagnostic{
+		{
+			Severity: Warning,
+			Summary:  err.Error(),
+		},
+	}
+}
+
 // Warningf creates a new warning diagnostic.
 func Warningf(format string, args ...any) Diagnostics {
 	return []Diagnostic{

--- a/libs/git/fileset.go
+++ b/libs/git/fileset.go
@@ -13,7 +13,7 @@ type FileSet struct {
 	view    *View
 }
 
-// NewFileSet returns [FileSet] for the directory `root` which is contained within Git repository located at `worktreeRoot`.
+// NewFileSet returns [FileSet] for the directory `root` which is contained within Git worktree located at `worktreeRoot`.
 func NewFileSet(worktreeRoot, root vfs.Path, paths ...[]string) (*FileSet, error) {
 	fs := fileset.New(root, paths...)
 	v, err := NewView(worktreeRoot, root)

--- a/libs/git/fileset.go
+++ b/libs/git/fileset.go
@@ -13,10 +13,10 @@ type FileSet struct {
 	view    *View
 }
 
-// NewFileSet returns [FileSet] for the Git repository located at `root`.
-func NewFileSet(root vfs.Path, paths ...[]string) (*FileSet, error) {
+// NewFileSet returns [FileSet] for the directory `root` which is contained within Git repository located at `worktreeRoot`.
+func NewFileSet(worktreeRoot, root vfs.Path, paths ...[]string) (*FileSet, error) {
 	fs := fileset.New(root, paths...)
-	v, err := NewView(root)
+	v, err := NewView(worktreeRoot, root)
 	if err != nil {
 		return nil, err
 	}
@@ -25,6 +25,10 @@ func NewFileSet(root vfs.Path, paths ...[]string) (*FileSet, error) {
 		fileset: fs,
 		view:    v,
 	}, nil
+}
+
+func NewFileSetAtRoot(root vfs.Path, paths ...[]string) (*FileSet, error) {
+	return NewFileSet(root, root, paths...)
 }
 
 func (f *FileSet) IgnoreFile(file string) (bool, error) {

--- a/libs/git/fileset_test.go
+++ b/libs/git/fileset_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testFileSetAll(t *testing.T, root string) {
-	fileSet, err := NewFileSetAtRoot(vfs.MustNew(root))
+func testFileSetAll(t *testing.T, worktreeRoot, root string) {
+	fileSet, err := NewFileSet(vfs.MustNew(worktreeRoot), vfs.MustNew(root))
 	require.NoError(t, err)
 	files, err := fileSet.Files()
 	require.NoError(t, err)
@@ -24,11 +24,21 @@ func testFileSetAll(t *testing.T, root string) {
 }
 
 func TestFileSetListAllInRepo(t *testing.T) {
-	testFileSetAll(t, "./testdata")
+	testFileSetAll(t, "./testdata", "./testdata")
+}
+
+func TestFileSetListAllInRepoDifferentRoot(t *testing.T) {
+	testFileSetAll(t, ".", "./testdata")
 }
 
 func TestFileSetListAllInTempDir(t *testing.T) {
-	testFileSetAll(t, copyTestdata(t, "./testdata"))
+	dir := copyTestdata(t, "./testdata")
+	testFileSetAll(t, dir, dir)
+}
+
+func TestFileSetListAllInTempDirDifferentRoot(t *testing.T) {
+	dir := copyTestdata(t, "./testdata")
+	testFileSetAll(t, filepath.Dir(dir), dir)
 }
 
 func TestFileSetNonCleanRoot(t *testing.T) {

--- a/libs/git/fileset_test.go
+++ b/libs/git/fileset_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func testFileSetAll(t *testing.T, root string) {
-	fileSet, err := NewFileSet(vfs.MustNew(root))
+	fileSet, err := NewFileSetAtRoot(vfs.MustNew(root))
 	require.NoError(t, err)
 	files, err := fileSet.Files()
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestFileSetNonCleanRoot(t *testing.T) {
 	// Test what happens if the root directory can be simplified.
 	// Path simplification is done by most filepath functions.
 	// This should yield the same result as above test.
-	fileSet, err := NewFileSet(vfs.MustNew("./testdata/../testdata"))
+	fileSet, err := NewFileSetAtRoot(vfs.MustNew("./testdata/../testdata"))
 	require.NoError(t, err)
 	files, err := fileSet.Files()
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestFileSetNonCleanRoot(t *testing.T) {
 
 func TestFileSetAddsCacheDirToGitIgnore(t *testing.T) {
 	projectDir := t.TempDir()
-	fileSet, err := NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	fileSet.EnsureValidGitIgnoreExists()
 
@@ -59,7 +59,7 @@ func TestFileSetDoesNotCacheDirToGitIgnoreIfAlreadyPresent(t *testing.T) {
 	projectDir := t.TempDir()
 	gitIgnorePath := filepath.Join(projectDir, ".gitignore")
 
-	fileSet, err := NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	err = os.WriteFile(gitIgnorePath, []byte(".databricks"), 0o644)
 	require.NoError(t, err)

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -154,7 +154,7 @@ func findLeafInTree(p string, leafName string) (string, error) {
 		_, err = os.Stat(filepath.Join(p, leafName))
 
 		if err == nil {
-			// found .git in p
+			// Found [leafName] in p
 			return p, nil
 		}
 

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -34,13 +34,13 @@ type response struct {
 
 func FetchRepositoryInfo(ctx context.Context, path vfs.Path, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
 	if strings.HasPrefix(path.Native(), "/Workspace/") && dbr.RunsOnRuntime(ctx) {
-		return FetchRepositoryInfoAPI(ctx, path, w)
+		return fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
-		return FetchRepositoryInfoDotGit(ctx, path)
+		return fetchRepositoryInfoDotGit(ctx, path)
 	}
 }
 
-func FetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
+func fetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
 	apiClient, err := client.New(w.Config)
 	if err != nil {
 		return GitRepositoryInfo{}, err
@@ -91,7 +91,7 @@ func fixResponsePath(path string) string {
 	return path
 }
 
-func FetchRepositoryInfoDotGit(ctx context.Context, path vfs.Path) (GitRepositoryInfo, error) {
+func fetchRepositoryInfoDotGit(ctx context.Context, path vfs.Path) (GitRepositoryInfo, error) {
 	rootDir, err := vfs.FindLeafInTree(path, GitDirectoryName)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/fs"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/databricks/cli/libs/dbr"
@@ -83,11 +84,11 @@ func fetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.Wo
 	}, nil
 }
 
-func ensureWorkspacePrefix(path string) string {
-	if !strings.HasPrefix(path, "/Workspace/") {
-		return "/Workspace/" + path
+func ensureWorkspacePrefix(p string) string {
+	if !strings.HasPrefix(p, "/Workspace/") {
+		return path.Join("/Workspace", p)
 	}
-	return path
+	return p
 }
 
 func fetchRepositoryInfoDotGit(ctx context.Context, path vfs.Path) (GitRepositoryInfo, error) {

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -67,9 +67,7 @@ func fetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.Wo
 
 	// Check if GitInfo is present and extract relevant fields
 	gi := response.GitInfo
-	if gi == nil {
-		log.Warnf(ctx, "Failed to load git info from %s", apiEndpoint)
-	} else {
+	if gi != nil {
 		fixedPath := ensureWorkspacePrefix(gi.Path)
 		return GitRepositoryInfo{
 			OriginURL:     gi.URL,
@@ -79,6 +77,7 @@ func fetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.Wo
 		}, nil
 	}
 
+	log.Warnf(ctx, "Failed to load git info from %s", apiEndpoint)
 	return GitRepositoryInfo{
 		WorktreeRoot: path,
 	}, nil

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -44,9 +44,9 @@ type response struct {
 //   - If there were any errors when trying to determine git root (e.g. API call returned an error or there were permission issues
 //     reading the file system), all strings fields of GitRepositoryInfo will be "" and err will be non-nil.
 //   - For convenience, GuessedWorktreeRoot parameter will be set to path in the above two cases.
-//   - If we could determine git worktree root but there were errors when reading metadata (origin, branch, commit), those errors will be logged
-//     as warnings, GitRepositoryInfo will have non-empty WorktreeRoot and corresponding GuessedWorktreeRoot.
-//     Other strings fields will be "" and err will be nil.
+//   - If we could determine git worktree root but there were errors when reading metadata (origin, branch, commit), those errors
+//     will be logged as warnings, GitRepositoryInfo is guaranteed to have non-empty WorktreeRoot and corresponding GuessedWorktreeRoot
+//     and other fields on best effort basis. The err will be nil.
 //   - In successful case, all fields are set to proper git repository metadata.
 func FetchRepositoryInfo(ctx context.Context, path vfs.Path, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
 	if strings.HasPrefix(path.Native(), "/Workspace/") && dbr.RunsOnRuntime(ctx) {

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -70,7 +70,7 @@ func fetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.Wo
 	if gi == nil {
 		log.Warnf(ctx, "Failed to load git info from %s", apiEndpoint)
 	} else {
-		fixedPath := fixResponsePath(gi.Path)
+		fixedPath := ensureWorkspacePrefix(gi.Path)
 		return GitRepositoryInfo{
 			OriginURL:     gi.URL,
 			LatestCommit:  gi.HeadCommitID,
@@ -84,7 +84,7 @@ func fetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.Wo
 	}, nil
 }
 
-func fixResponsePath(path string) string {
+func ensureWorkspacePrefix(path string) string {
 	if !strings.HasPrefix(path, "/Workspace/") {
 		return "/Workspace/" + path
 	}

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -1,0 +1,124 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"net/http"
+	"strings"
+
+	"github.com/databricks/cli/libs/dbr"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/vfs"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/client"
+)
+
+type GitRepositoryInfo struct {
+	OriginURL     string
+	LatestCommit  string
+	CurrentBranch string
+	WorktreeRoot  vfs.Path
+}
+
+type gitInfo struct {
+	Branch       string `json:"branch"`
+	HeadCommitID string `json:"head_commit_id"`
+	Path         string `json:"path"`
+	URL          string `json:"url"`
+}
+
+type response struct {
+	GitInfo *gitInfo `json:"git_info,omitempty"`
+}
+
+func FetchRepositoryInfo(ctx context.Context, path vfs.Path, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
+	if strings.HasPrefix(path.Native(), "/Workspace/") && dbr.RunsOnRuntime(ctx) {
+		return FetchRepositoryInfoAPI(ctx, path, w)
+	} else {
+		return FetchRepositoryInfoDotGit(ctx, path)
+	}
+}
+
+func FetchRepositoryInfoAPI(ctx context.Context, path vfs.Path, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
+	apiClient, err := client.New(w.Config)
+	if err != nil {
+		return GitRepositoryInfo{}, err
+	}
+
+	var response response
+	const apiEndpoint = "/api/2.0/workspace/get-status"
+
+	err = apiClient.Do(
+		ctx,
+		http.MethodGet,
+		apiEndpoint,
+		nil,
+		map[string]string{
+			"path":            path.Native(),
+			"return_git_info": "true",
+		},
+		&response,
+	)
+
+	if err != nil {
+		return GitRepositoryInfo{}, err
+	}
+
+	// Check if GitInfo is present and extract relevant fields
+	gi := response.GitInfo
+	if gi == nil {
+		log.Warnf(ctx, "Failed to load git info from %s", apiEndpoint)
+	} else {
+		fixedPath := fixResponsePath(gi.Path)
+		return GitRepositoryInfo{
+			OriginURL:     gi.URL,
+			LatestCommit:  gi.HeadCommitID,
+			CurrentBranch: gi.Branch,
+			WorktreeRoot:  vfs.MustNew(fixedPath),
+		}, nil
+	}
+
+	return GitRepositoryInfo{
+		WorktreeRoot: path,
+	}, nil
+}
+
+func fixResponsePath(path string) string {
+	if !strings.HasPrefix(path, "/Workspace/") {
+		return "/Workspace/" + path
+	}
+	return path
+}
+
+func FetchRepositoryInfoDotGit(ctx context.Context, path vfs.Path) (GitRepositoryInfo, error) {
+	rootDir, err := vfs.FindLeafInTree(path, GitDirectoryName)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return GitRepositoryInfo{}, err
+		}
+		rootDir = path
+	}
+
+	repo, err := NewRepository(rootDir)
+	if err != nil {
+		return GitRepositoryInfo{}, err
+	}
+
+	branch, err := repo.CurrentBranch()
+	if err != nil {
+		return GitRepositoryInfo{}, nil
+	}
+
+	commit, err := repo.LatestCommit()
+	if err != nil {
+		return GitRepositoryInfo{}, nil
+	}
+
+	return GitRepositoryInfo{
+		OriginURL:     repo.OriginUrl(),
+		LatestCommit:  commit,
+		CurrentBranch: branch,
+		WorktreeRoot:  rootDir,
+	}, nil
+}

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -17,7 +17,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/client"
 )
 
-type GitRepositoryInfo struct {
+type RepositoryInfo struct {
 	// Various metadata about the repo. Each could be "" if it could not be read. No error is returned for such case.
 	OriginURL     string
 	LatestCommit  string
@@ -39,13 +39,13 @@ type response struct {
 }
 
 // Fetch repository information either by quering .git or by fetching it from API (for dabs-in-workspace case).
-//   - In case we could not find git repository, all string fields of GitRepositoryInfo will be "" and err will be nil.
+//   - In case we could not find git repository, all string fields of RepositoryInfo will be "" and err will be nil.
 //   - If there were any errors when trying to determine git root (e.g. API call returned an error or there were permission issues
-//     reading the file system), all strings fields of GitRepositoryInfo will be "" and err will be non-nil.
+//     reading the file system), all strings fields of RepositoryInfo will be "" and err will be non-nil.
 //   - If we could determine git worktree root but there were errors when reading metadata (origin, branch, commit), those errors
-//     will be logged as warnings, GitRepositoryInfo is guaranteed to have non-empty WorktreeRoot and other fields on best effort basis.
+//     will be logged as warnings, RepositoryInfo is guaranteed to have non-empty WorktreeRoot and other fields on best effort basis.
 //   - In successful case, all fields are set to proper git repository metadata.
-func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
+func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
 	if strings.HasPrefix(path, "/Workspace/") && dbr.RunsOnRuntime(ctx) {
 		return fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
@@ -53,8 +53,8 @@ func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.Workspa
 	}
 }
 
-func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.WorkspaceClient) (GitRepositoryInfo, error) {
-	result := GitRepositoryInfo{}
+func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
+	result := RepositoryInfo{}
 
 	apiClient, err := client.New(w.Config)
 	if err != nil {
@@ -102,8 +102,8 @@ func ensureWorkspacePrefix(p string) string {
 	return p
 }
 
-func fetchRepositoryInfoDotGit(ctx context.Context, path string) (GitRepositoryInfo, error) {
-	result := GitRepositoryInfo{}
+func fetchRepositoryInfoDotGit(ctx context.Context, path string) (RepositoryInfo, error) {
+	result := RepositoryInfo{}
 
 	rootDir, err := findLeafInTree(path, GitDirectoryName)
 	if rootDir == "" {

--- a/libs/git/repository.go
+++ b/libs/git/repository.go
@@ -1,9 +1,7 @@
 package git
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"net/url"
 	"path"
 	"path/filepath"
@@ -204,17 +202,7 @@ func (r *Repository) Ignore(relPath string) (bool, error) {
 	return false, nil
 }
 
-func NewRepository(path vfs.Path) (*Repository, error) {
-	rootDir, err := vfs.FindLeafInTree(path, GitDirectoryName)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return nil, err
-		}
-		// Cannot find `.git` directory.
-		// Treat the specified path as a potential repository root checkout.
-		rootDir = path
-	}
-
+func NewRepository(rootDir vfs.Path) (*Repository, error) {
 	// Derive $GIT_DIR and $GIT_COMMON_DIR paths if this is a real repository.
 	// If it isn't a real repository, they'll point to the (non-existent) `.git` directory.
 	gitDir, gitCommonDir, err := resolveGitDirs(rootDir)

--- a/libs/git/view.go
+++ b/libs/git/view.go
@@ -72,8 +72,8 @@ func (v *View) IgnoreDirectory(dir string) (bool, error) {
 	return v.Ignore(dir + "/")
 }
 
-func NewView(root vfs.Path) (*View, error) {
-	repo, err := NewRepository(root)
+func NewView(worktreeRoot, root vfs.Path) (*View, error) {
+	repo, err := NewRepository(worktreeRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -94,6 +94,10 @@ func NewView(root vfs.Path) (*View, error) {
 		repo:       repo,
 		targetPath: target,
 	}, nil
+}
+
+func NewViewAtRoot(root vfs.Path) (*View, error) {
+	return NewView(root, root)
 }
 
 func (v *View) EnsureValidGitIgnoreExists() error {

--- a/libs/git/view_test.go
+++ b/libs/git/view_test.go
@@ -90,19 +90,19 @@ func testViewAtRoot(t *testing.T, tv testView) {
 }
 
 func TestViewRootInBricksRepo(t *testing.T) {
-	v, err := NewView(vfs.MustNew("./testdata"))
+	v, err := NewViewAtRoot(vfs.MustNew("./testdata"))
 	require.NoError(t, err)
 	testViewAtRoot(t, testView{t, v})
 }
 
 func TestViewRootInTempRepo(t *testing.T) {
-	v, err := NewView(vfs.MustNew(createFakeRepo(t, "testdata")))
+	v, err := NewViewAtRoot(vfs.MustNew(createFakeRepo(t, "testdata")))
 	require.NoError(t, err)
 	testViewAtRoot(t, testView{t, v})
 }
 
 func TestViewRootInTempDir(t *testing.T) {
-	v, err := NewView(vfs.MustNew(copyTestdata(t, "testdata")))
+	v, err := NewViewAtRoot(vfs.MustNew(copyTestdata(t, "testdata")))
 	require.NoError(t, err)
 	testViewAtRoot(t, testView{t, v})
 }
@@ -125,20 +125,21 @@ func testViewAtA(t *testing.T, tv testView) {
 }
 
 func TestViewAInBricksRepo(t *testing.T) {
-	v, err := NewView(vfs.MustNew("./testdata/a"))
+	v, err := NewView(vfs.MustNew("."), vfs.MustNew("./testdata/a"))
 	require.NoError(t, err)
 	testViewAtA(t, testView{t, v})
 }
 
 func TestViewAInTempRepo(t *testing.T) {
-	v, err := NewView(vfs.MustNew(filepath.Join(createFakeRepo(t, "testdata"), "a")))
+	repo := createFakeRepo(t, "testdata")
+	v, err := NewView(vfs.MustNew(repo), vfs.MustNew(filepath.Join(repo, "a")))
 	require.NoError(t, err)
 	testViewAtA(t, testView{t, v})
 }
 
 func TestViewAInTempDir(t *testing.T) {
 	// Since this is not a fake repo it should not traverse up the tree.
-	v, err := NewView(vfs.MustNew(filepath.Join(copyTestdata(t, "testdata"), "a")))
+	v, err := NewViewAtRoot(vfs.MustNew(filepath.Join(copyTestdata(t, "testdata"), "a")))
 	require.NoError(t, err)
 	tv := testView{t, v}
 
@@ -175,20 +176,21 @@ func testViewAtAB(t *testing.T, tv testView) {
 }
 
 func TestViewABInBricksRepo(t *testing.T) {
-	v, err := NewView(vfs.MustNew("./testdata/a/b"))
+	v, err := NewView(vfs.MustNew("."), vfs.MustNew("./testdata/a/b"))
 	require.NoError(t, err)
 	testViewAtAB(t, testView{t, v})
 }
 
 func TestViewABInTempRepo(t *testing.T) {
-	v, err := NewView(vfs.MustNew(filepath.Join(createFakeRepo(t, "testdata"), "a", "b")))
+	repo := createFakeRepo(t, "testdata")
+	v, err := NewView(vfs.MustNew(repo), vfs.MustNew(filepath.Join(repo, "a", "b")))
 	require.NoError(t, err)
 	testViewAtAB(t, testView{t, v})
 }
 
 func TestViewABInTempDir(t *testing.T) {
 	// Since this is not a fake repo it should not traverse up the tree.
-	v, err := NewView(vfs.MustNew(filepath.Join(copyTestdata(t, "testdata"), "a", "b")))
+	v, err := NewViewAtRoot(vfs.MustNew(filepath.Join(copyTestdata(t, "testdata"), "a", "b")))
 	tv := testView{t, v}
 	require.NoError(t, err)
 
@@ -215,7 +217,7 @@ func TestViewDoesNotChangeGitignoreIfCacheDirAlreadyIgnoredAtRoot(t *testing.T) 
 
 	// Since root .gitignore already has .databricks, there should be no edits
 	// to root .gitignore
-	v, err := NewView(vfs.MustNew(repoPath))
+	v, err := NewViewAtRoot(vfs.MustNew(repoPath))
 	require.NoError(t, err)
 
 	err = v.EnsureValidGitIgnoreExists()
@@ -235,7 +237,7 @@ func TestViewDoesNotChangeGitignoreIfCacheDirAlreadyIgnoredInSubdir(t *testing.T
 
 	// Since root .gitignore already has .databricks, there should be no edits
 	// to a/.gitignore
-	v, err := NewView(vfs.MustNew(filepath.Join(repoPath, "a")))
+	v, err := NewView(vfs.MustNew(repoPath), vfs.MustNew(filepath.Join(repoPath, "a")))
 	require.NoError(t, err)
 
 	err = v.EnsureValidGitIgnoreExists()
@@ -253,7 +255,7 @@ func TestViewAddsGitignoreWithCacheDir(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Since root .gitignore was deleted, new view adds .databricks to root .gitignore
-	v, err := NewView(vfs.MustNew(repoPath))
+	v, err := NewViewAtRoot(vfs.MustNew(repoPath))
 	require.NoError(t, err)
 
 	err = v.EnsureValidGitIgnoreExists()
@@ -271,7 +273,7 @@ func TestViewAddsGitignoreWithCacheDirAtSubdir(t *testing.T) {
 	require.NoError(t, err)
 
 	// Since root .gitignore was deleted, new view adds .databricks to a/.gitignore
-	v, err := NewView(vfs.MustNew(filepath.Join(repoPath, "a")))
+	v, err := NewView(vfs.MustNew(repoPath), vfs.MustNew(filepath.Join(repoPath, "a")))
 	require.NoError(t, err)
 
 	err = v.EnsureValidGitIgnoreExists()
@@ -288,7 +290,7 @@ func TestViewAddsGitignoreWithCacheDirAtSubdir(t *testing.T) {
 func TestViewAlwaysIgnoresCacheDir(t *testing.T) {
 	repoPath := createFakeRepo(t, "testdata")
 
-	v, err := NewView(vfs.MustNew(repoPath))
+	v, err := NewViewAtRoot(vfs.MustNew(repoPath))
 	require.NoError(t, err)
 
 	err = v.EnsureValidGitIgnoreExists()

--- a/libs/sync/snapshot_test.go
+++ b/libs/sync/snapshot_test.go
@@ -30,7 +30,7 @@ func TestDiff(t *testing.T) {
 
 	// Create temp project dir
 	projectDir := t.TempDir()
-	fileSet, err := git.NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := git.NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	state := Snapshot{
 		SnapshotState: &SnapshotState{
@@ -94,7 +94,7 @@ func TestSymlinkDiff(t *testing.T) {
 
 	// Create temp project dir
 	projectDir := t.TempDir()
-	fileSet, err := git.NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := git.NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	state := Snapshot{
 		SnapshotState: &SnapshotState{
@@ -125,7 +125,7 @@ func TestFolderDiff(t *testing.T) {
 
 	// Create temp project dir
 	projectDir := t.TempDir()
-	fileSet, err := git.NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := git.NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	state := Snapshot{
 		SnapshotState: &SnapshotState{
@@ -170,7 +170,7 @@ func TestPythonNotebookDiff(t *testing.T) {
 
 	// Create temp project dir
 	projectDir := t.TempDir()
-	fileSet, err := git.NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := git.NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	state := Snapshot{
 		SnapshotState: &SnapshotState{
@@ -245,7 +245,7 @@ func TestErrorWhenIdenticalRemoteName(t *testing.T) {
 
 	// Create temp project dir
 	projectDir := t.TempDir()
-	fileSet, err := git.NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := git.NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	state := Snapshot{
 		SnapshotState: &SnapshotState{
@@ -282,7 +282,7 @@ func TestNoErrorRenameWithIdenticalRemoteName(t *testing.T) {
 
 	// Create temp project dir
 	projectDir := t.TempDir()
-	fileSet, err := git.NewFileSet(vfs.MustNew(projectDir))
+	fileSet, err := git.NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
 	state := Snapshot{
 		SnapshotState: &SnapshotState{

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -19,10 +19,11 @@ import (
 type OutputHandler func(context.Context, <-chan Event)
 
 type SyncOptions struct {
-	LocalRoot vfs.Path
-	Paths     []string
-	Include   []string
-	Exclude   []string
+	WorktreeRoot vfs.Path
+	LocalRoot    vfs.Path
+	Paths        []string
+	Include      []string
+	Exclude      []string
 
 	RemotePath string
 
@@ -62,7 +63,7 @@ type Sync struct {
 
 // New initializes and returns a new [Sync] instance.
 func New(ctx context.Context, opts SyncOptions) (*Sync, error) {
-	fileSet, err := git.NewFileSet(opts.LocalRoot, opts.Paths)
+	fileSet, err := git.NewFileSet(opts.WorktreeRoot, opts.LocalRoot, opts.Paths)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/sync/sync_test.go
+++ b/libs/sync/sync_test.go
@@ -37,7 +37,7 @@ func TestGetFileSet(t *testing.T) {
 
 	dir := setupFiles(t)
 	root := vfs.MustNew(dir)
-	fileSet, err := git.NewFileSet(root)
+	fileSet, err := git.NewFileSetAtRoot(root)
 	require.NoError(t, err)
 
 	err = fileSet.EnsureValidGitIgnoreExists()
@@ -103,7 +103,7 @@ func TestRecursiveExclude(t *testing.T) {
 
 	dir := setupFiles(t)
 	root := vfs.MustNew(dir)
-	fileSet, err := git.NewFileSet(root)
+	fileSet, err := git.NewFileSetAtRoot(root)
 	require.NoError(t, err)
 
 	err = fileSet.EnsureValidGitIgnoreExists()
@@ -133,7 +133,7 @@ func TestNegateExclude(t *testing.T) {
 
 	dir := setupFiles(t)
 	root := vfs.MustNew(dir)
-	fileSet, err := git.NewFileSet(root)
+	fileSet, err := git.NewFileSetAtRoot(root)
 	require.NoError(t, err)
 
 	err = fileSet.EnsureValidGitIgnoreExists()


### PR DESCRIPTION
## Changes

Since there is no .git directory in Workspace file system, we need to make an API call to api/2.0/workspace/get-status?return_git_info=true to fetch git the root of the repo, current branch, commit and origin.

Added new function FetchRepositoryInfo that either looks up and parses .git or calls remote API depending on env.

Refactor Repository/View/FileSet to accept repository root rather than calculate it. This helps because:
 - Repository is currently created in multiple places and finding the repository root is becoming relatively expensive (API call needed).
 - Repository/FileSet/View do not have access to current Bundle which is where WorkplaceClient is stored.

## Tests

- Tested manually by running "bundle validate --json" inside web terminal within Databricks env.
- Added integration tests for the new API.