### PR TITLE
Add the `bundle_uuid` helper function for templates

### DIFF
--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -49,4 +49,8 @@ type Bundle struct {
 
 	// Databricks CLI version constraints required to run the bundle.
 	DatabricksCliVersion string `json:"databricks_cli_version,omitempty"`
+
+	// A stable generated UUID for the bundle. This is normally serialized by
+	// Databricks first party template when a user runs bundle init.
+	Uuid string `json:"uuid,omitempty"`
 }

--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -35,6 +35,13 @@ var cachedUser *iam.User
 var cachedIsServicePrincipal *bool
 var cachedCatalog *string
 
+// UUID that is stable for the duration of the template execution. This can be used
+// to populate the `bundle.uuid` field in databricks.yml by template authors.
+//
+// It's automatically logged in our telemetry logs when `databricks bundle init`
+// is run and can be used to attribute DBU revenue to bundle templates.
+var bundleUuid = uuid.New().String()
+
 func loadHelpers(ctx context.Context) template.FuncMap {
 	w := root.WorkspaceClient(ctx)
 	return template.FuncMap{
@@ -56,6 +63,9 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		// Alias for https://pkg.go.dev/github.com/google/uuid#New. Returns, as a string, a UUID which is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC 4122.
 		"uuid": func() string {
 			return uuid.New().String()
+		},
+		"bundle_uuid": func() string {
+			return bundleUuid
 		},
 		// A key value pair. This is used with the map function to generate maps
 		// to use inside a template

--- a/libs/template/helpers_test.go
+++ b/libs/template/helpers_test.go
@@ -43,9 +43,11 @@ func TestTemplateBundleUuidFunction(t *testing.T) {
 	err = r.walk()
 	assert.NoError(t, err)
 
-	assert.Len(t, r.files, 1)
-	cleanContent := strings.Trim(string(r.files[0].(*inMemoryFile).content), "\n\r")
-	assert.Equal(t, strings.Repeat(bundleUuid, 5), cleanContent)
+	assert.Len(t, r.files, 2)
+	c1 := strings.Trim(string(r.files[0].(*inMemoryFile).content), "\n\r")
+	assert.Equal(t, strings.Repeat(bundleUuid, 3), c1)
+	c2 := strings.Trim(string(r.files[1].(*inMemoryFile).content), "\n\r")
+	assert.Equal(t, strings.Repeat(bundleUuid, 5), c2)
 }
 
 func TestTemplateRegexpCompileFunction(t *testing.T) {

--- a/libs/template/helpers_test.go
+++ b/libs/template/helpers_test.go
@@ -32,6 +32,22 @@ func TestTemplatePrintStringWithoutProcessing(t *testing.T) {
 	assert.Equal(t, `{{ fail "abc" }}`, cleanContent)
 }
 
+func TestTemplateBundleUuidFunction(t *testing.T) {
+	ctx := context.Background()
+
+	ctx = root.SetWorkspaceClient(ctx, nil)
+	helpers := loadHelpers(ctx)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/bundle-uuid/template", "./testdata/bundle-uuid/library")
+	require.NoError(t, err)
+
+	err = r.walk()
+	assert.NoError(t, err)
+
+	assert.Len(t, r.files, 1)
+	cleanContent := strings.Trim(string(r.files[0].(*inMemoryFile).content), "\n\r")
+	assert.Equal(t, strings.Repeat(bundleUuid, 5), cleanContent)
+}
+
 func TestTemplateRegexpCompileFunction(t *testing.T) {
 	ctx := context.Background()
 

--- a/libs/template/testdata/bundle-uuid/template/bar.txt.tmpl
+++ b/libs/template/testdata/bundle-uuid/template/bar.txt.tmpl
@@ -1,0 +1,1 @@
+{{bundle_uuid}}{{bundle_uuid}}{{bundle_uuid}}

--- a/libs/template/testdata/bundle-uuid/template/foo.txt.tmpl
+++ b/libs/template/testdata/bundle-uuid/template/foo.txt.tmpl
@@ -1,0 +1,1 @@
+{{bundle_uuid}}{{bundle_uuid}}{{bundle_uuid}}{{bundle_uuid}}{{bundle_uuid}}


### PR DESCRIPTION
## Changes
This PR adds the `bundle_uuid` helper function that'll return a stable identifier for the bundle for the duration of the `bundle init` command.

This is also the UUID that'll be set in the telemetry event sent during `databricks bundle init` and would be used to correlate revenue from bundle init with resource deployments. 

Template authors should add the uuid field to their `databricks.yml` file they generate:
```
bundle:
  # A stable identified for your DAB project. We use this UUID in the Databricks backend 
  # to correlate and identify multiple deployments of the same DAB project. 
  uuid: {{ bundle_uuid }}
```

## Tests
Unit test
