### PR TITLE
Rewrite 'interface{} -> any'

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,5 +15,7 @@ linters-settings:
     rewrite-rules:
       - pattern: 'a[b:len(a)]'
         replacement: 'a[b:]'
+      - pattern: 'interface{}'
+        replacement: 'any'
 issues:
   exclude-dirs-use-default: false  # recommended by docs https://golangci-lint.run/usage/false-positives/

--- a/bundle/config/root_test.go
+++ b/bundle/config/root_test.go
@@ -133,7 +133,7 @@ func TestRootMergeTargetOverridesWithVariables(t *testing.T) {
 			"complex": {
 				Type:        variable.VariableTypeComplex,
 				Description: "complex var",
-				Default: map[string]interface{}{
+				Default: map[string]any{
 					"key": "value",
 				},
 			},
@@ -148,7 +148,7 @@ func TestRootMergeTargetOverridesWithVariables(t *testing.T) {
 					"complex": {
 						Type:        "wrong",
 						Description: "wrong",
-						Default: map[string]interface{}{
+						Default: map[string]any{
 							"key1": "value1",
 						},
 					},
@@ -164,7 +164,7 @@ func TestRootMergeTargetOverridesWithVariables(t *testing.T) {
 	assert.Equal(t, "foo2", root.Variables["foo2"].Default)
 	assert.Equal(t, "foo2 var", root.Variables["foo2"].Description)
 
-	assert.Equal(t, map[string]interface{}{
+	assert.Equal(t, map[string]any{
 		"key1": "value1",
 	}, root.Variables["complex"].Default)
 	assert.Equal(t, "complex var", root.Variables["complex"].Description)

--- a/bundle/internal/tf/codegen/schema/generate.go
+++ b/bundle/internal/tf/codegen/schema/generate.go
@@ -15,10 +15,10 @@ import (
 )
 
 func (s *Schema) writeTerraformBlock(_ context.Context) error {
-	var body = map[string]interface{}{
-		"terraform": map[string]interface{}{
-			"required_providers": map[string]interface{}{
-				"databricks": map[string]interface{}{
+	var body = map[string]any{
+		"terraform": map[string]any{
+			"required_providers": map[string]any{
+				"databricks": map[string]any{
 					"source":  "databricks/databricks",
 					"version": ProviderVersion,
 				},

--- a/bundle/internal/tf/schema/root.go
+++ b/bundle/internal/tf/schema/root.go
@@ -25,9 +25,9 @@ const ProviderVersion = "1.58.0"
 
 func NewRoot() *Root {
 	return &Root{
-		Terraform: map[string]interface{}{
-			"required_providers": map[string]interface{}{
-				"databricks": map[string]interface{}{
+		Terraform: map[string]any{
+			"required_providers": map[string]any{
+				"databricks": map[string]any{
 					"source":  ProviderSource,
 					"version": ProviderVersion,
 				},

--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -23,10 +23,10 @@ var renderFuncMap = template.FuncMap{
 	"yellow":  color.YellowString,
 	"magenta": color.MagentaString,
 	"cyan":    color.CyanString,
-	"bold": func(format string, a ...interface{}) string {
+	"bold": func(format string, a ...any) string {
 		return color.New(color.Bold).Sprintf(format, a...)
 	},
-	"italic": func(format string, a ...interface{}) string {
+	"italic": func(format string, a ...any) string {
 		return color.New(color.Italic).Sprintf(format, a...)
 	},
 }

--- a/bundle/run/output/task.go
+++ b/bundle/run/output/task.go
@@ -15,7 +15,7 @@ type LogsOutput struct {
 	LogsTruncated bool   `json:"logs_truncated"`
 }
 
-func structToString(val interface{}) (string, error) {
+func structToString(val any) (string, error) {
 	b, err := json.MarshalIndent(val, "", "  ")
 	if err != nil {
 		return "", err

--- a/bundle/tests/complex_variables_test.go
+++ b/bundle/tests/complex_variables_test.go
@@ -104,5 +104,5 @@ func TestComplexVariablesOverrideWithFullSyntax(t *testing.T) {
 	require.Empty(t, diags)
 
 	complexvar := b.Config.Variables["complexvar"].Value
-	require.Equal(t, map[string]interface{}{"key1": "1", "key2": "2", "key3": "3"}, complexvar)
+	require.Equal(t, map[string]any{"key1": "1", "key2": "2", "key3": "3"}, complexvar)
 }

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -276,7 +276,7 @@ func (t *cobraTestRunner) Run() (bytes.Buffer, bytes.Buffer, error) {
 }
 
 // Like [require.Eventually] but errors if the underlying command has failed.
-func (c *cobraTestRunner) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func (c *cobraTestRunner) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	ch := make(chan bool, 1)
 
 	timer := time.NewTimer(waitFor)

--- a/internal/mocks/libs/filer/mock_filer.go
+++ b/internal/mocks/libs/filer/mock_filer.go
@@ -28,11 +28,11 @@ func (_m *MockFiler) EXPECT() *MockFiler_Expecter {
 
 // Delete provides a mock function with given fields: ctx, path, mode
 func (_m *MockFiler) Delete(ctx context.Context, path string, mode ...filer.DeleteMode) error {
-	_va := make([]interface{}, len(mode))
+	_va := make([]any, len(mode))
 	for _i := range mode {
 		_va[_i] = mode[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, path)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -60,9 +60,9 @@ type MockFiler_Delete_Call struct {
 //   - ctx context.Context
 //   - path string
 //   - mode ...filer.DeleteMode
-func (_e *MockFiler_Expecter) Delete(ctx interface{}, path interface{}, mode ...interface{}) *MockFiler_Delete_Call {
+func (_e *MockFiler_Expecter) Delete(ctx any, path any, mode ...any) *MockFiler_Delete_Call {
 	return &MockFiler_Delete_Call{Call: _e.mock.On("Delete",
-		append([]interface{}{ctx, path}, mode...)...)}
+		append([]any{ctx, path}, mode...)...)}
 }
 
 func (_c *MockFiler_Delete_Call) Run(run func(ctx context.Context, path string, mode ...filer.DeleteMode)) *MockFiler_Delete_Call {
@@ -114,7 +114,7 @@ type MockFiler_Mkdir_Call struct {
 // Mkdir is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockFiler_Expecter) Mkdir(ctx interface{}, path interface{}) *MockFiler_Mkdir_Call {
+func (_e *MockFiler_Expecter) Mkdir(ctx any, path any) *MockFiler_Mkdir_Call {
 	return &MockFiler_Mkdir_Call{Call: _e.mock.On("Mkdir", ctx, path)}
 }
 
@@ -173,7 +173,7 @@ type MockFiler_Read_Call struct {
 // Read is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockFiler_Expecter) Read(ctx interface{}, path interface{}) *MockFiler_Read_Call {
+func (_e *MockFiler_Expecter) Read(ctx any, path any) *MockFiler_Read_Call {
 	return &MockFiler_Read_Call{Call: _e.mock.On("Read", ctx, path)}
 }
 
@@ -232,7 +232,7 @@ type MockFiler_ReadDir_Call struct {
 // ReadDir is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockFiler_Expecter) ReadDir(ctx interface{}, path interface{}) *MockFiler_ReadDir_Call {
+func (_e *MockFiler_Expecter) ReadDir(ctx any, path any) *MockFiler_ReadDir_Call {
 	return &MockFiler_ReadDir_Call{Call: _e.mock.On("ReadDir", ctx, path)}
 }
 
@@ -291,7 +291,7 @@ type MockFiler_Stat_Call struct {
 // Stat is a helper method to define mock.On call
 //   - ctx context.Context
 //   - name string
-func (_e *MockFiler_Expecter) Stat(ctx interface{}, name interface{}) *MockFiler_Stat_Call {
+func (_e *MockFiler_Expecter) Stat(ctx any, name any) *MockFiler_Stat_Call {
 	return &MockFiler_Stat_Call{Call: _e.mock.On("Stat", ctx, name)}
 }
 
@@ -314,11 +314,11 @@ func (_c *MockFiler_Stat_Call) RunAndReturn(run func(context.Context, string) (f
 
 // Write provides a mock function with given fields: ctx, path, reader, mode
 func (_m *MockFiler) Write(ctx context.Context, path string, reader io.Reader, mode ...filer.WriteMode) error {
-	_va := make([]interface{}, len(mode))
+	_va := make([]any, len(mode))
 	for _i := range mode {
 		_va[_i] = mode[_i]
 	}
-	var _ca []interface{}
+	var _ca []any
 	_ca = append(_ca, ctx, path, reader)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
@@ -347,9 +347,9 @@ type MockFiler_Write_Call struct {
 //   - path string
 //   - reader io.Reader
 //   - mode ...filer.WriteMode
-func (_e *MockFiler_Expecter) Write(ctx interface{}, path interface{}, reader interface{}, mode ...interface{}) *MockFiler_Write_Call {
+func (_e *MockFiler_Expecter) Write(ctx any, path any, reader any, mode ...any) *MockFiler_Write_Call {
 	return &MockFiler_Write_Call{Call: _e.mock.On("Write",
-		append([]interface{}{ctx, path, reader}, mode...)...)}
+		append([]any{ctx, path, reader}, mode...)...)}
 }
 
 func (_c *MockFiler_Write_Call) Run(run func(ctx context.Context, path string, reader io.Reader, mode ...filer.WriteMode)) *MockFiler_Write_Call {

--- a/libs/cmdgroup/command.go
+++ b/libs/cmdgroup/command.go
@@ -100,7 +100,7 @@ func trimRightSpace(s string) string {
 }
 
 // tmpl executes the given template text on data, writing the result to w.
-func tmpl(w io.Writer, text string, data interface{}) error {
+func tmpl(w io.Writer, text string, data any) error {
 	t := template.New("top")
 	t.Funcs(templateFuncs)
 	template.Must(t.Parse(text))

--- a/libs/cmdio/render.go
+++ b/libs/cmdio/render.go
@@ -297,10 +297,10 @@ var renderFuncMap = template.FuncMap{
 	"yellow":  color.YellowString,
 	"magenta": color.MagentaString,
 	"cyan":    color.CyanString,
-	"bold": func(format string, a ...interface{}) string {
+	"bold": func(format string, a ...any) string {
 		return color.New(color.Bold).Sprintf(format, a...)
 	},
-	"italic": func(format string, a ...interface{}) string {
+	"italic": func(format string, a ...any) string {
 		return color.New(color.Italic).Sprintf(format, a...)
 	},
 	"replace": strings.ReplaceAll,

--- a/libs/dyn/dynassert/assert.go
+++ b/libs/dyn/dynassert/assert.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Equal(t assert.TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func Equal(t assert.TestingT, expected any, actual any, msgAndArgs ...any) bool {
 	ev, eok := expected.(dyn.Value)
 	av, aok := actual.(dyn.Value)
 	if eok && aok && ev.IsValid() && av.IsValid() {
@@ -32,86 +32,86 @@ func Equal(t assert.TestingT, expected interface{}, actual interface{}, msgAndAr
 	return assert.Equal(t, expected, actual, msgAndArgs...)
 }
 
-func EqualValues(t assert.TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func EqualValues(t assert.TestingT, expected, actual any, msgAndArgs ...any) bool {
 	return assert.EqualValues(t, expected, actual, msgAndArgs...)
 }
 
-func NotEqual(t assert.TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func NotEqual(t assert.TestingT, expected any, actual any, msgAndArgs ...any) bool {
 	return assert.NotEqual(t, expected, actual, msgAndArgs...)
 }
 
-func Len(t assert.TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
+func Len(t assert.TestingT, object any, length int, msgAndArgs ...any) bool {
 	return assert.Len(t, object, length, msgAndArgs...)
 }
 
-func Empty(t assert.TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func Empty(t assert.TestingT, object any, msgAndArgs ...any) bool {
 	return assert.Empty(t, object, msgAndArgs...)
 }
 
-func Nil(t assert.TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func Nil(t assert.TestingT, object any, msgAndArgs ...any) bool {
 	return assert.Nil(t, object, msgAndArgs...)
 }
 
-func NotNil(t assert.TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func NotNil(t assert.TestingT, object any, msgAndArgs ...any) bool {
 	return assert.NotNil(t, object, msgAndArgs...)
 }
 
-func NoError(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+func NoError(t assert.TestingT, err error, msgAndArgs ...any) bool {
 	return assert.NoError(t, err, msgAndArgs...)
 }
 
-func Error(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+func Error(t assert.TestingT, err error, msgAndArgs ...any) bool {
 	return assert.Error(t, err, msgAndArgs...)
 }
 
-func EqualError(t assert.TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+func EqualError(t assert.TestingT, theError error, errString string, msgAndArgs ...any) bool {
 	return assert.EqualError(t, theError, errString, msgAndArgs...)
 }
 
-func ErrorContains(t assert.TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+func ErrorContains(t assert.TestingT, theError error, contains string, msgAndArgs ...any) bool {
 	return assert.ErrorContains(t, theError, contains, msgAndArgs...)
 }
 
-func ErrorIs(t assert.TestingT, theError, target error, msgAndArgs ...interface{}) bool {
+func ErrorIs(t assert.TestingT, theError, target error, msgAndArgs ...any) bool {
 	return assert.ErrorIs(t, theError, target, msgAndArgs...)
 }
 
-func True(t assert.TestingT, value bool, msgAndArgs ...interface{}) bool {
+func True(t assert.TestingT, value bool, msgAndArgs ...any) bool {
 	return assert.True(t, value, msgAndArgs...)
 }
 
-func False(t assert.TestingT, value bool, msgAndArgs ...interface{}) bool {
+func False(t assert.TestingT, value bool, msgAndArgs ...any) bool {
 	return assert.False(t, value, msgAndArgs...)
 }
 
-func Contains(t assert.TestingT, list interface{}, element interface{}, msgAndArgs ...interface{}) bool {
+func Contains(t assert.TestingT, list any, element any, msgAndArgs ...any) bool {
 	return assert.Contains(t, list, element, msgAndArgs...)
 }
 
-func NotContains(t assert.TestingT, list interface{}, element interface{}, msgAndArgs ...interface{}) bool {
+func NotContains(t assert.TestingT, list any, element any, msgAndArgs ...any) bool {
 	return assert.NotContains(t, list, element, msgAndArgs...)
 }
 
-func ElementsMatch(t assert.TestingT, listA, listB interface{}, msgAndArgs ...interface{}) bool {
+func ElementsMatch(t assert.TestingT, listA, listB any, msgAndArgs ...any) bool {
 	return assert.ElementsMatch(t, listA, listB, msgAndArgs...)
 }
 
-func Panics(t assert.TestingT, f func(), msgAndArgs ...interface{}) bool {
+func Panics(t assert.TestingT, f func(), msgAndArgs ...any) bool {
 	return assert.Panics(t, f, msgAndArgs...)
 }
 
-func PanicsWithValue(t assert.TestingT, expected interface{}, f func(), msgAndArgs ...interface{}) bool {
+func PanicsWithValue(t assert.TestingT, expected any, f func(), msgAndArgs ...any) bool {
 	return assert.PanicsWithValue(t, expected, f, msgAndArgs...)
 }
 
-func PanicsWithError(t assert.TestingT, errString string, f func(), msgAndArgs ...interface{}) bool {
+func PanicsWithError(t assert.TestingT, errString string, f func(), msgAndArgs ...any) bool {
 	return assert.PanicsWithError(t, errString, f, msgAndArgs...)
 }
 
-func NotPanics(t assert.TestingT, f func(), msgAndArgs ...interface{}) bool {
+func NotPanics(t assert.TestingT, f func(), msgAndArgs ...any) bool {
 	return assert.NotPanics(t, f, msgAndArgs...)
 }
 
-func JSONEq(t assert.TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+func JSONEq(t assert.TestingT, expected string, actual string, msgAndArgs ...any) bool {
 	return assert.JSONEq(t, expected, actual, msgAndArgs...)
 }

--- a/libs/dyn/yamlloader/loader.go
+++ b/libs/dyn/yamlloader/loader.go
@@ -14,7 +14,7 @@ type loader struct {
 	path string
 }
 
-func errorf(loc dyn.Location, format string, args ...interface{}) error {
+func errorf(loc dyn.Location, format string, args ...any) error {
 	return fmt.Errorf("yaml (%s): %s", loc, fmt.Sprintf(format, args...))
 }
 

--- a/libs/errs/aggregate.go
+++ b/libs/errs/aggregate.go
@@ -59,7 +59,7 @@ func (ec errorChain) Unwrap() error {
 	return ec[1:]
 }
 
-func (ec errorChain) As(target interface{}) bool {
+func (ec errorChain) As(target any) bool {
 	return errors.As(ec[0], target)
 }
 

--- a/libs/jsonschema/from_type_test.go
+++ b/libs/jsonschema/from_type_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestFromTypeBasic(t *testing.T) {
 	type myStruct struct {
-		S             string      `json:"s"`
-		I             *int        `json:"i,omitempty"`
-		V             interface{} `json:"v,omitempty"`
-		TriplePointer ***int      `json:"triple_pointer,omitempty"`
+		S             string `json:"s"`
+		I             *int   `json:"i,omitempty"`
+		V             any    `json:"v,omitempty"`
+		TriplePointer ***int `json:"triple_pointer,omitempty"`
 
 		// These fields should be ignored in the resulting schema.
 		NotAnnotated     string


### PR DESCRIPTION
## Changes

The `any` alias for `interface{}` has been around since Go 1.18.

Now that we're using golangci-lint (#1953), we can lint on it.

Existing commits can be updated with:
```
gofmt -w -r 'interface{} -> any' .
```

## Tests

n/a
