### PR TITLE
Fail filer integration test if error is nil

### DIFF
--- a/internal/filer_test.go
+++ b/internal/filer_test.go
@@ -457,7 +457,7 @@ func TestAccFilerWorkspaceNotebook(t *testing.T) {
 
 			// Assert uploading a second time fails due to overwrite mode missing
 			err = f.Write(ctx, tc.name, strings.NewReader(tc.content2))
-			assert.ErrorIs(t, err, fs.ErrExist)
+			require.ErrorIs(t, err, fs.ErrExist)
 			assert.Regexp(t, regexp.MustCompile(`file already exists: .*/`+tc.nameWithoutExt+`$`), err.Error())
 
 			// Try uploading the notebook again with overwrite flag. This time it should succeed.


### PR DESCRIPTION
## Changes

I found a race where this error is nil and the subsequent assert panics on the error being nil. This change makes the test robust against this to fail immediately if the error is different from the one we expect.

## Tests

n/a
