### PR TITLE
Add debug logs to diagnose flakyiness in extensions filer integration tests

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -364,7 +364,7 @@ func readFile(t *testing.T, name string) string {
 		// stored in ./testdata. This are debugging logs to help diagnose the issue
 		// when it occurs again.
 		origErr := err
-		t.Logf("Error reading file %s: %w", name, err)
+		t.Logf("Error reading file %s: %s", name, err)
 		err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
 			if info.IsDir() {
 				t.Logf("Found directory: %s", path)
@@ -374,9 +374,9 @@ func readFile(t *testing.T, name string) string {
 			return nil
 		})
 		if err != nil {
-			t.Logf("Error walking directory: %w", err)
+			t.Logf("Error walking directory: %s", err)
 		}
-		t.Fatalf("Ending test because of failure to read file %s: %w", name, origErr)
+		t.Fatalf("Ending test because of failure to read file %s: %s", name, origErr)
 		return ""
 	}
 }

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -363,6 +363,7 @@ func readFile(t *testing.T, name string) string {
 		// We have observed flakyness when using this function to read certain notebooks
 		// stored in ./testdata. This are debugging logs to help diagnose the issue
 		// when it occurs again.
+		origErr := err
 		t.Logf("Error reading file %s: %w", name, err)
 		err := filepath.Walk(".", func(path string, info fs.FileInfo, err error) error {
 			if info.IsDir() {
@@ -375,6 +376,8 @@ func readFile(t *testing.T, name string) string {
 		if err != nil {
 			t.Logf("Error walking directory: %w", err)
 		}
+		t.Fatalf("Ending test because of failure to read file %s: %w", name, origErr)
+		return ""
 	}
 }
 


### PR DESCRIPTION
## Changes
We have observed `TestAccWorkspaceFilesExtensionsNotebooksAreNotDeletedAsFiles` and `TestAccFilerWorkspaceFilesExtensionsDeletev` flake with 
```
Error:      	Received unexpected error:
        	            	open testdata/notebooks/py1.ipynb: The system cannot find the path specified.
```

This PR adds some debug logs to diagnose better when the next flake happens since this has been difficult to reproduce otherwise.

