### PR TITLE
Remove global variable from clusters integration test

### DIFF
--- a/internal/clusters_test.go
+++ b/internal/clusters_test.go
@@ -5,10 +5,12 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/databricks/cli/internal/acc"
+	"github.com/databricks/databricks-sdk-go/listing"
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-var clusterId string
 
 func TestAccClustersList(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
@@ -21,13 +23,14 @@ func TestAccClustersList(t *testing.T) {
 	assert.Equal(t, "", stderr.String())
 
 	idRegExp := regexp.MustCompile(`[0-9]{4}\-[0-9]{6}-[a-z0-9]{8}`)
-	clusterId = idRegExp.FindString(outStr)
+	clusterId := idRegExp.FindString(outStr)
 	assert.NotEmpty(t, clusterId)
 }
 
 func TestAccClustersGet(t *testing.T) {
 	t.Log(GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
+	clusterId := findValidClusterID(t)
 	stdout, stderr := RequireSuccessfulRun(t, "clusters", "get", clusterId)
 	outStr := stdout.String()
 	assert.Contains(t, outStr, fmt.Sprintf(`"cluster_id":"%s"`, clusterId))
@@ -37,4 +40,23 @@ func TestAccClustersGet(t *testing.T) {
 func TestClusterCreateErrorWhenNoArguments(t *testing.T) {
 	_, _, err := RequireErrorRun(t, "clusters", "create")
 	assert.Contains(t, err.Error(), "accepts 1 arg(s), received 0")
+}
+
+// findValidClusterID lists clusters in the workspace to find a valid cluster ID.
+func findValidClusterID(t *testing.T) string {
+	ctx, wt := acc.WorkspaceTest(t)
+	it := wt.W.Clusters.List(ctx, compute.ListClustersRequest{
+		FilterBy: &compute.ListClustersFilterBy{
+			ClusterSources: []compute.ClusterSource{
+				compute.ClusterSourceApi,
+				compute.ClusterSourceUi,
+			},
+		},
+	})
+
+	clusterIDs, err := listing.ToSliceN(ctx, it, 1)
+	require.NoError(t, err)
+	require.Len(t, clusterIDs, 1)
+
+	return clusterIDs[0].ClusterId
 }


### PR DESCRIPTION
## Changes

I saw this test fail on rerun because the global wasn't set.

Fix by removing the global and using a different approach to acquire a valid cluster ID.

## Tests

Integration tests.