### PR TITLE
Errcheck tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,9 +2,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    # errcheck and govet are part of default setup and should be included but give too many errors now
-    # once errors are fixed, they should be enabled here:
-    #- errcheck
+    - errcheck
     - gosimple
     #- govet
     - ineffassign
@@ -20,3 +18,7 @@ linters-settings:
         replacement: 'any'
 issues:
   exclude-dirs-use-default: false  # recommended by docs https://golangci-lint.run/usage/false-positives/
+  exclude-rules:
+    - path-except: _test\.go
+      linters:
+        - errcheck

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -110,7 +110,8 @@ func TestInitializeURLs(t *testing.T) {
 		"dashboard1":       "https://mycompany.databricks.com/dashboardsv3/01ef8d56871e1d50ae30ce7375e42478/published?o=123456",
 	}
 
-	initializeForWorkspace(b, "123456", "https://mycompany.databricks.com/")
+	err := initializeForWorkspace(b, "123456", "https://mycompany.databricks.com/")
+	require.NoError(t, err)
 
 	for _, group := range b.Config.Resources.AllResources() {
 		for key, r := range group.Resources {
@@ -133,7 +134,8 @@ func TestInitializeURLsWithoutOrgId(t *testing.T) {
 		},
 	}
 
-	initializeForWorkspace(b, "123456", "https://adb-123456.azuredatabricks.net/")
+	err := initializeForWorkspace(b, "123456", "https://adb-123456.azuredatabricks.net/")
+	require.NoError(t, err)
 
 	require.Equal(t, "https://adb-123456.azuredatabricks.net/jobs/1", b.Config.Resources.Jobs["job1"].URL)
 }

--- a/bundle/config/mutator/resolve_resource_references_test.go
+++ b/bundle/config/mutator/resolve_resource_references_test.go
@@ -108,7 +108,8 @@ func TestNoLookupIfVariableIsSet(t *testing.T) {
 	m := mocks.NewMockWorkspaceClient(t)
 	b.SetWorkpaceClient(m.WorkspaceClient)
 
-	b.Config.Variables["my-cluster-id"].Set("random value")
+	err := b.Config.Variables["my-cluster-id"].Set("random value")
+	require.NoError(t, err)
 
 	diags := bundle.Apply(context.Background(), b, ResolveResourceReferences())
 	require.NoError(t, diags.Error())

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -28,7 +28,8 @@ import (
 func touchNotebookFile(t *testing.T, path string) {
 	f, err := os.Create(path)
 	require.NoError(t, err)
-	f.WriteString("# Databricks notebook source\n")
+	_, err = f.WriteString("# Databricks notebook source\n")
+	require.NoError(t, err)
 	f.Close()
 }
 

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -49,7 +49,8 @@ func TestCustomMarshallerIsImplemented(t *testing.T) {
 		// Eg: resource.Job implements MarshalJSON
 		v := reflect.Zero(vt.Elem()).Interface()
 		assert.NotPanics(t, func() {
-			json.Marshal(v)
+			_, err := json.Marshal(v)
+			assert.NoError(t, err)
 		}, "Resource %s does not have a custom marshaller", field.Name)
 
 		// Unmarshalling a *resourceStruct will panic if the resource does not have a custom unmarshaller
@@ -58,7 +59,8 @@ func TestCustomMarshallerIsImplemented(t *testing.T) {
 		// Eg: *resource.Job implements UnmarshalJSON
 		v = reflect.New(vt.Elem()).Interface()
 		assert.NotPanics(t, func() {
-			json.Unmarshal([]byte("{}"), v)
+			err := json.Unmarshal([]byte("{}"), v)
+			assert.NoError(t, err)
 		}, "Resource %s does not have a custom unmarshaller", field.Name)
 	}
 }

--- a/bundle/config/root_test.go
+++ b/bundle/config/root_test.go
@@ -100,7 +100,8 @@ func TestRootMergeTargetOverridesWithMode(t *testing.T) {
 			},
 		},
 	}
-	root.initializeDynamicValue()
+	err := root.initializeDynamicValue()
+	require.NoError(t, err)
 	require.NoError(t, root.MergeTargetOverrides("development"))
 	assert.Equal(t, Development, root.Bundle.Mode)
 }
@@ -156,7 +157,9 @@ func TestRootMergeTargetOverridesWithVariables(t *testing.T) {
 			},
 		},
 	}
-	root.initializeDynamicValue()
+	if err := root.initializeDynamicValue(); err != nil {
+		t.Fatal(err)
+	}
 	require.NoError(t, root.MergeTargetOverrides("development"))
 	assert.Equal(t, "bar", root.Variables["foo"].Default)
 	assert.Equal(t, "foo var", root.Variables["foo"].Description)

--- a/bundle/config/root_test.go
+++ b/bundle/config/root_test.go
@@ -100,8 +100,7 @@ func TestRootMergeTargetOverridesWithMode(t *testing.T) {
 			},
 		},
 	}
-	err := root.initializeDynamicValue()
-	require.NoError(t, err)
+	require.NoError(t, root.initializeDynamicValue())
 	require.NoError(t, root.MergeTargetOverrides("development"))
 	assert.Equal(t, Development, root.Bundle.Mode)
 }
@@ -157,9 +156,8 @@ func TestRootMergeTargetOverridesWithVariables(t *testing.T) {
 			},
 		},
 	}
-	if err := root.initializeDynamicValue(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, root.initializeDynamicValue())
+
 	require.NoError(t, root.MergeTargetOverrides("development"))
 	assert.Equal(t, "bar", root.Variables["foo"].Default)
 	assert.Equal(t, "foo var", root.Variables["foo"].Description)

--- a/bundle/config/workspace_test.go
+++ b/bundle/config/workspace_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setupWorkspaceTest(t *testing.T) string {
@@ -42,11 +43,12 @@ func TestWorkspaceResolveProfileFromHost(t *testing.T) {
 		setupWorkspaceTest(t)
 
 		// This works if there is a config file with a matching profile.
-		databrickscfg.SaveToProfile(context.Background(), &config.Config{
+		err := databrickscfg.SaveToProfile(context.Background(), &config.Config{
 			Profile: "default",
 			Host:    "https://abc.cloud.databricks.com",
 			Token:   "123",
 		})
+		require.NoError(t, err)
 
 		client, err := w.Client()
 		assert.NoError(t, err)
@@ -57,12 +59,13 @@ func TestWorkspaceResolveProfileFromHost(t *testing.T) {
 		home := setupWorkspaceTest(t)
 
 		// This works if there is a config file with a matching profile.
-		databrickscfg.SaveToProfile(context.Background(), &config.Config{
+		err := databrickscfg.SaveToProfile(context.Background(), &config.Config{
 			ConfigFile: filepath.Join(home, "customcfg"),
 			Profile:    "custom",
 			Host:       "https://abc.cloud.databricks.com",
 			Token:      "123",
 		})
+		require.NoError(t, err)
 
 		t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
 		client, err := w.Client()
@@ -90,12 +93,13 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		setupWorkspaceTest(t)
 
 		// This works if there is a config file with a matching profile.
-		databrickscfg.SaveToProfile(context.Background(), &config.Config{
+		err := databrickscfg.SaveToProfile(context.Background(), &config.Config{
 			Profile: "abc",
 			Host:    "https://abc.cloud.databricks.com",
 		})
+		require.NoError(t, err)
 
-		_, err := w.Client()
+		_, err = w.Client()
 		assert.NoError(t, err)
 	})
 
@@ -103,12 +107,13 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		setupWorkspaceTest(t)
 
 		// This works if there is a config file with a matching profile.
-		databrickscfg.SaveToProfile(context.Background(), &config.Config{
+		err := databrickscfg.SaveToProfile(context.Background(), &config.Config{
 			Profile: "abc",
 			Host:    "https://def.cloud.databricks.com",
 		})
+		require.NoError(t, err)
 
-		_, err := w.Client()
+		_, err = w.Client()
 		assert.ErrorContains(t, err, "config host mismatch")
 	})
 
@@ -116,14 +121,15 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		home := setupWorkspaceTest(t)
 
 		// This works if there is a config file with a matching profile.
-		databrickscfg.SaveToProfile(context.Background(), &config.Config{
+		err := databrickscfg.SaveToProfile(context.Background(), &config.Config{
 			ConfigFile: filepath.Join(home, "customcfg"),
 			Profile:    "abc",
 			Host:       "https://abc.cloud.databricks.com",
 		})
+		require.NoError(t, err)
 
 		t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
-		_, err := w.Client()
+		_, err = w.Client()
 		assert.NoError(t, err)
 	})
 
@@ -131,14 +137,15 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		home := setupWorkspaceTest(t)
 
 		// This works if there is a config file with a matching profile.
-		databrickscfg.SaveToProfile(context.Background(), &config.Config{
+		err := databrickscfg.SaveToProfile(context.Background(), &config.Config{
 			ConfigFile: filepath.Join(home, "customcfg"),
 			Profile:    "abc",
 			Host:       "https://def.cloud.databricks.com",
 		})
+		require.NoError(t, err)
 
 		t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
-		_, err := w.Client()
+		_, err = w.Client()
 		assert.ErrorContains(t, err, "config host mismatch")
 	})
 }

--- a/bundle/internal/bundletest/location.go
+++ b/bundle/internal/bundletest/location.go
@@ -10,7 +10,7 @@ import (
 // with the path it is loaded from.
 func SetLocation(b *bundle.Bundle, prefix string, locations []dyn.Location) {
 	start := dyn.MustPathFromString(prefix)
-	_ = b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
 		return dyn.Walk(root, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 			// If the path has the given prefix, set the location.
 			if p.HasPrefix(start) {
@@ -27,4 +27,7 @@ func SetLocation(b *bundle.Bundle, prefix string, locations []dyn.Location) {
 			return v, dyn.ErrSkip
 		})
 	})
+	if err != nil {
+		panic("Mutate() failed: " + err.Error())
+	}
 }

--- a/bundle/internal/bundletest/location.go
+++ b/bundle/internal/bundletest/location.go
@@ -10,7 +10,7 @@ import (
 // with the path it is loaded from.
 func SetLocation(b *bundle.Bundle, prefix string, locations []dyn.Location) {
 	start := dyn.MustPathFromString(prefix)
-	b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+	_ = b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
 		return dyn.Walk(root, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 			// If the path has the given prefix, set the location.
 			if p.HasPrefix(start) {

--- a/bundle/libraries/upload_test.go
+++ b/bundle/libraries/upload_test.go
@@ -23,7 +23,7 @@ func TestArtifactUploadForWorkspace(t *testing.T) {
 	tmpDir := t.TempDir()
 	whlFolder := filepath.Join(tmpDir, "whl")
 	testutil.Touch(t, whlFolder, "source.whl")
-	whlLocalPath := filepath.Join(whlFolder, "source.whl")
+	_ = filepath.Join(whlFolder, "source.whl")
 
 	b := &bundle.Bundle{
 		SyncRootPath: tmpDir,
@@ -32,10 +32,10 @@ func TestArtifactUploadForWorkspace(t *testing.T) {
 				ArtifactPath: "/foo/bar/artifacts",
 			},
 			Artifacts: config.Artifacts{
-				"whl": {
+				"whl": &config.Artifact{
 					Type: config.ArtifactPythonWheel,
 					Files: []config.ArtifactFile{
-						{Source: whlLocalPath},
+						{Source: filepath.Join(whlFolder, "source.whl")},
 					},
 				},
 			},
@@ -111,7 +111,7 @@ func TestArtifactUploadForVolumes(t *testing.T) {
 	tmpDir := t.TempDir()
 	whlFolder := filepath.Join(tmpDir, "whl")
 	testutil.Touch(t, whlFolder, "source.whl")
-	whlLocalPath := filepath.Join(whlFolder, "source.whl")
+	_ = filepath.Join(whlFolder, "source.whl")
 
 	b := &bundle.Bundle{
 		SyncRootPath: tmpDir,
@@ -120,10 +120,10 @@ func TestArtifactUploadForVolumes(t *testing.T) {
 				ArtifactPath: "/Volumes/foo/bar/artifacts",
 			},
 			Artifacts: config.Artifacts{
-				"whl": {
+				"whl": &config.Artifact{
 					Type: config.ArtifactPythonWheel,
 					Files: []config.ArtifactFile{
-						{Source: whlLocalPath},
+						{Source: filepath.Join(whlFolder, "source.whl")},
 					},
 				},
 			},

--- a/bundle/libraries/upload_test.go
+++ b/bundle/libraries/upload_test.go
@@ -23,7 +23,7 @@ func TestArtifactUploadForWorkspace(t *testing.T) {
 	tmpDir := t.TempDir()
 	whlFolder := filepath.Join(tmpDir, "whl")
 	testutil.Touch(t, whlFolder, "source.whl")
-	_ = filepath.Join(whlFolder, "source.whl")
+	whlLocalPath := filepath.Join(whlFolder, "source.whl")
 
 	b := &bundle.Bundle{
 		SyncRootPath: tmpDir,
@@ -32,10 +32,10 @@ func TestArtifactUploadForWorkspace(t *testing.T) {
 				ArtifactPath: "/foo/bar/artifacts",
 			},
 			Artifacts: config.Artifacts{
-				"whl": &config.Artifact{
+				"whl": {
 					Type: config.ArtifactPythonWheel,
 					Files: []config.ArtifactFile{
-						{Source: filepath.Join(whlFolder, "source.whl")},
+						{Source: whlLocalPath},
 					},
 				},
 			},
@@ -111,7 +111,7 @@ func TestArtifactUploadForVolumes(t *testing.T) {
 	tmpDir := t.TempDir()
 	whlFolder := filepath.Join(tmpDir, "whl")
 	testutil.Touch(t, whlFolder, "source.whl")
-	_ = filepath.Join(whlFolder, "source.whl")
+	whlLocalPath := filepath.Join(whlFolder, "source.whl")
 
 	b := &bundle.Bundle{
 		SyncRootPath: tmpDir,
@@ -120,10 +120,10 @@ func TestArtifactUploadForVolumes(t *testing.T) {
 				ArtifactPath: "/Volumes/foo/bar/artifacts",
 			},
 			Artifacts: config.Artifacts{
-				"whl": &config.Artifact{
+				"whl": {
 					Type: config.ArtifactPythonWheel,
 					Files: []config.ArtifactFile{
-						{Source: filepath.Join(whlFolder, "source.whl")},
+						{Source: whlLocalPath},
 					},
 				},
 			},

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -489,7 +489,8 @@ func TestRenderSummaryTemplate_nilBundle(t *testing.T) {
 	err := renderSummaryHeaderTemplate(writer, nil)
 	require.NoError(t, err)
 
-	io.WriteString(writer, buildTrailer(nil))
+	_, err = io.WriteString(writer, buildTrailer(nil))
+	require.NoError(t, err)
 
 	assert.Equal(t, "Validation OK!\n", writer.String())
 }

--- a/bundle/run/job_test.go
+++ b/bundle/run/job_test.go
@@ -42,7 +42,8 @@ func TestConvertPythonParams(t *testing.T) {
 	opts := &Options{
 		Job: JobOptions{},
 	}
-	runner.convertPythonParams(opts)
+	err := runner.convertPythonParams(opts)
+	require.NoError(t, err)
 	require.NotContains(t, opts.Job.notebookParams, "__python_params")
 
 	opts = &Options{
@@ -50,7 +51,8 @@ func TestConvertPythonParams(t *testing.T) {
 			pythonParams: []string{"param1", "param2", "param3"},
 		},
 	}
-	runner.convertPythonParams(opts)
+	err = runner.convertPythonParams(opts)
+	require.NoError(t, err)
 	require.Contains(t, opts.Job.notebookParams, "__python_params")
 	require.Equal(t, opts.Job.notebookParams["__python_params"], `["param1","param2","param3"]`)
 }

--- a/cmd/auth/describe_test.go
+++ b/cmd/auth/describe_test.go
@@ -31,7 +31,8 @@ func TestGetWorkspaceAuthStatus(t *testing.T) {
 
 	cmd.Flags().String("host", "", "")
 	cmd.Flags().String("profile", "", "")
-	cmd.Flag("profile").Value.Set("my-profile")
+	err := cmd.Flag("profile").Value.Set("my-profile")
+	require.NoError(t, err)
 	cmd.Flag("profile").Changed = true
 
 	cfg := &config.Config{
@@ -39,10 +40,11 @@ func TestGetWorkspaceAuthStatus(t *testing.T) {
 	}
 	m.WorkspaceClient.Config = cfg
 	t.Setenv("DATABRICKS_AUTH_TYPE", "azure-cli")
-	config.ConfigAttributes.Configure(cfg)
+	err = config.ConfigAttributes.Configure(cfg)
+	require.NoError(t, err)
 
 	status, err := getAuthStatus(cmd, []string{}, showSensitive, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
-		config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
+		_ = config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
 			"host":      "https://test.com",
 			"token":     "test-token",
 			"auth_type": "azure-cli",
@@ -81,7 +83,8 @@ func TestGetWorkspaceAuthStatusError(t *testing.T) {
 
 	cmd.Flags().String("host", "", "")
 	cmd.Flags().String("profile", "", "")
-	cmd.Flag("profile").Value.Set("my-profile")
+	err := cmd.Flag("profile").Value.Set("my-profile")
+	require.NoError(t, err)
 	cmd.Flag("profile").Changed = true
 
 	cfg := &config.Config{
@@ -89,10 +92,11 @@ func TestGetWorkspaceAuthStatusError(t *testing.T) {
 	}
 	m.WorkspaceClient.Config = cfg
 	t.Setenv("DATABRICKS_AUTH_TYPE", "azure-cli")
-	config.ConfigAttributes.Configure(cfg)
+	err = config.ConfigAttributes.Configure(cfg)
+	require.NoError(t, err)
 
 	status, err := getAuthStatus(cmd, []string{}, showSensitive, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
-		config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
+		err = config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
 			"host":      "https://test.com",
 			"token":     "test-token",
 			"auth_type": "azure-cli",
@@ -128,7 +132,8 @@ func TestGetWorkspaceAuthStatusSensitive(t *testing.T) {
 
 	cmd.Flags().String("host", "", "")
 	cmd.Flags().String("profile", "", "")
-	cmd.Flag("profile").Value.Set("my-profile")
+	err := cmd.Flag("profile").Value.Set("my-profile")
+	require.NoError(t, err)
 	cmd.Flag("profile").Changed = true
 
 	cfg := &config.Config{
@@ -136,10 +141,11 @@ func TestGetWorkspaceAuthStatusSensitive(t *testing.T) {
 	}
 	m.WorkspaceClient.Config = cfg
 	t.Setenv("DATABRICKS_AUTH_TYPE", "azure-cli")
-	config.ConfigAttributes.Configure(cfg)
+	err = config.ConfigAttributes.Configure(cfg)
+	require.NoError(t, err)
 
 	status, err := getAuthStatus(cmd, []string{}, showSensitive, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
-		config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
+		err = config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
 			"host":      "https://test.com",
 			"token":     "test-token",
 			"auth_type": "azure-cli",
@@ -171,7 +177,8 @@ func TestGetAccountAuthStatus(t *testing.T) {
 
 	cmd.Flags().String("host", "", "")
 	cmd.Flags().String("profile", "", "")
-	cmd.Flag("profile").Value.Set("my-profile")
+	err := cmd.Flag("profile").Value.Set("my-profile")
+	require.NoError(t, err)
 	cmd.Flag("profile").Changed = true
 
 	cfg := &config.Config{
@@ -179,13 +186,14 @@ func TestGetAccountAuthStatus(t *testing.T) {
 	}
 	m.AccountClient.Config = cfg
 	t.Setenv("DATABRICKS_AUTH_TYPE", "azure-cli")
-	config.ConfigAttributes.Configure(cfg)
+	err = config.ConfigAttributes.Configure(cfg)
+	require.NoError(t, err)
 
 	wsApi := m.GetMockWorkspacesAPI()
 	wsApi.EXPECT().List(mock.Anything).Return(nil, nil)
 
 	status, err := getAuthStatus(cmd, []string{}, showSensitive, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
-		config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
+		err = config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
 			"account_id": "test-account-id",
 			"username":   "test-user",
 			"host":       "https://test.com",

--- a/cmd/bundle/generate/dashboard_test.go
+++ b/cmd/bundle/generate/dashboard_test.go
@@ -67,10 +67,13 @@ func TestDashboard_ExistingID_Nominal(t *testing.T) {
 	ctx := bundle.Context(context.Background(), b)
 	cmd := NewGenerateDashboardCommand()
 	cmd.SetContext(ctx)
-	cmd.Flag("existing-id").Value.Set("f00dcafe")
+	if err := cmd.Flag("existing-id").Value.Set("f00dcafe"); err != nil {
+		require.NoError(t, err)
+	}
 
-	err := cmd.RunE(cmd, []string{})
-	require.NoError(t, err)
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		require.NoError(t, err)
+	}
 
 	// Assert the contents of the generated configuration
 	data, err := os.ReadFile(filepath.Join(root, "resources", "this_is_a_test_dashboard.dashboard.yml"))
@@ -105,9 +108,10 @@ func TestDashboard_ExistingID_NotFound(t *testing.T) {
 	ctx := bundle.Context(context.Background(), b)
 	cmd := NewGenerateDashboardCommand()
 	cmd.SetContext(ctx)
-	cmd.Flag("existing-id").Value.Set("f00dcafe")
+	err := cmd.Flag("existing-id").Value.Set("f00dcafe")
+	require.NoError(t, err)
 
-	err := cmd.RunE(cmd, []string{})
+	err = cmd.RunE(cmd, []string{})
 	require.Error(t, err)
 }
 
@@ -137,9 +141,11 @@ func TestDashboard_ExistingPath_Nominal(t *testing.T) {
 	ctx := bundle.Context(context.Background(), b)
 	cmd := NewGenerateDashboardCommand()
 	cmd.SetContext(ctx)
-	cmd.Flag("existing-path").Value.Set("/path/to/dashboard")
+	var err error
+	err = cmd.Flag("existing-path").Value.Set("/path/to/dashboard")
+	require.NoError(t, err)
 
-	err := cmd.RunE(cmd, []string{})
+	err = cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
 	// Assert the contents of the generated configuration
@@ -175,8 +181,11 @@ func TestDashboard_ExistingPath_NotFound(t *testing.T) {
 	ctx := bundle.Context(context.Background(), b)
 	cmd := NewGenerateDashboardCommand()
 	cmd.SetContext(ctx)
-	cmd.Flag("existing-path").Value.Set("/path/to/dashboard")
+	if err := cmd.Flag("existing-path").Value.Set("/path/to/dashboard"); err != nil {
+		require.NoError(t, err)
+	}
 
-	err := cmd.RunE(cmd, []string{})
-	require.Error(t, err)
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		require.Error(t, err)
+	}
 }

--- a/cmd/bundle/generate/generate_test.go
+++ b/cmd/bundle/generate/generate_test.go
@@ -78,18 +78,21 @@ func TestGeneratePipelineCommand(t *testing.T) {
 	workspaceApi.EXPECT().Download(mock.Anything, "/test/file.py", mock.Anything).Return(pyContent, nil)
 
 	cmd.SetContext(bundle.Context(context.Background(), b))
-	cmd.Flag("existing-pipeline-id").Value.Set("test-pipeline")
+	err := cmd.Flag("existing-pipeline-id").Value.Set("test-pipeline")
+	require.NoError(t, err)
 
 	configDir := filepath.Join(root, "resources")
-	cmd.Flag("config-dir").Value.Set(configDir)
+	err = cmd.Flag("config-dir").Value.Set(configDir)
+	require.NoError(t, err)
 
 	srcDir := filepath.Join(root, "src")
-	cmd.Flag("source-dir").Value.Set(srcDir)
+	err = cmd.Flag("source-dir").Value.Set(srcDir)
+	require.NoError(t, err)
 
 	var key string
 	cmd.Flags().StringVar(&key, "key", "test_pipeline", "")
 
-	err := cmd.RunE(cmd, []string{})
+	err = cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(configDir, "test_pipeline.pipeline.yml"))
@@ -174,18 +177,21 @@ func TestGenerateJobCommand(t *testing.T) {
 	workspaceApi.EXPECT().Download(mock.Anything, "/test/notebook", mock.Anything).Return(notebookContent, nil)
 
 	cmd.SetContext(bundle.Context(context.Background(), b))
-	cmd.Flag("existing-job-id").Value.Set("1234")
+	err := cmd.Flag("existing-job-id").Value.Set("1234")
+	require.NoError(t, err)
 
 	configDir := filepath.Join(root, "resources")
-	cmd.Flag("config-dir").Value.Set(configDir)
+	err = cmd.Flag("config-dir").Value.Set(configDir)
+	require.NoError(t, err)
 
 	srcDir := filepath.Join(root, "src")
-	cmd.Flag("source-dir").Value.Set(srcDir)
+	err = cmd.Flag("source-dir").Value.Set(srcDir)
+	require.NoError(t, err)
 
 	var key string
 	cmd.Flags().StringVar(&key, "key", "test_job", "")
 
-	err := cmd.RunE(cmd, []string{})
+	err = cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(configDir, "test_job.job.yml"))
@@ -279,13 +285,16 @@ func TestGenerateJobCommandOldFileRename(t *testing.T) {
 	workspaceApi.EXPECT().Download(mock.Anything, "/test/notebook", mock.Anything).Return(notebookContent, nil)
 
 	cmd.SetContext(bundle.Context(context.Background(), b))
-	cmd.Flag("existing-job-id").Value.Set("1234")
+	err := cmd.Flag("existing-job-id").Value.Set("1234")
+	require.NoError(t, err)
 
 	configDir := filepath.Join(root, "resources")
-	cmd.Flag("config-dir").Value.Set(configDir)
+	err = cmd.Flag("config-dir").Value.Set(configDir)
+	require.NoError(t, err)
 
 	srcDir := filepath.Join(root, "src")
-	cmd.Flag("source-dir").Value.Set(srcDir)
+	err = cmd.Flag("source-dir").Value.Set(srcDir)
+	require.NoError(t, err)
 
 	var key string
 	cmd.Flags().StringVar(&key, "key", "test_job", "")
@@ -295,9 +304,10 @@ func TestGenerateJobCommandOldFileRename(t *testing.T) {
 	touchEmptyFile(t, oldFilename)
 
 	// Having an existing files require --force flag to regenerate them
-	cmd.Flag("force").Value.Set("true")
+	err = cmd.Flag("force").Value.Set("true")
+	require.NoError(t, err)
 
-	err := cmd.RunE(cmd, []string{})
+	err = cmd.RunE(cmd, []string{})
 	require.NoError(t, err)
 
 	// Make sure file do not exists after the run

--- a/cmd/labs/github/ref_test.go
+++ b/cmd/labs/github/ref_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFileFromRef(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/databrickslabs/ucx/main/README.md" {
-			w.Write([]byte(`abc`))
+			_, err := w.Write([]byte(`abc`))
+			require.NoError(t, err)
 			return
 		}
 		t.Logf("Requested: %s", r.URL.Path)
@@ -31,7 +33,8 @@ func TestFileFromRef(t *testing.T) {
 func TestDownloadZipball(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/repos/databrickslabs/ucx/zipball/main" {
-			w.Write([]byte(`abc`))
+			_, err := w.Write([]byte(`abc`))
+			require.NoError(t, err)
 			return
 		}
 		t.Logf("Requested: %s", r.URL.Path)

--- a/cmd/labs/github/releases_test.go
+++ b/cmd/labs/github/releases_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadsReleasesForCLI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/repos/databricks/cli/releases" {
-			w.Write([]byte(`[{"tag_name": "v1.2.3"}, {"tag_name": "v1.2.2"}]`))
+			_, err := w.Write([]byte(`[{"tag_name": "v1.2.3"}, {"tag_name": "v1.2.2"}]`))
+			require.NoError(t, err)
 			return
 		}
 		t.Logf("Requested: %s", r.URL.Path)

--- a/cmd/labs/github/repositories_test.go
+++ b/cmd/labs/github/repositories_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepositories(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/users/databrickslabs/repos" {
-			w.Write([]byte(`[{"name": "x"}]`))
+			_, err := w.Write([]byte(`[{"name": "x"}]`))
+			require.NoError(t, err)
 			return
 		}
 		t.Logf("Requested: %s", r.URL.Path)

--- a/cmd/labs/project/installer_test.go
+++ b/cmd/labs/project/installer_test.go
@@ -120,7 +120,10 @@ func respondWithJSON(t *testing.T, w http.ResponseWriter, v any) {
 	if err != nil {
 		require.NoError(t, err)
 	}
-	w.Write(raw)
+	_, err = w.Write(raw)
+	if err != nil {
+		panic(err)
+	}
 }
 
 type fileTree struct {
@@ -170,7 +173,12 @@ func TestInstallerWorksForReleases(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			w.Write(raw)
+			_, err = w.Write(raw)
+			require.NoError(t, err)
+			require.NoError(t, err)
+			if err != nil {
+				panic(err)
+			}
 			return
 		}
 		if r.URL.Path == "/repos/databrickslabs/blueprint/zipball/v0.3.15" {
@@ -179,7 +187,10 @@ func TestInstallerWorksForReleases(t *testing.T) {
 				panic(err)
 			}
 			w.Header().Add("Content-Type", "application/octet-stream")
-			w.Write(raw)
+			_, err = w.Write(raw)
+			if err != nil {
+				panic(err)
+			}
 			return
 		}
 		if r.URL.Path == "/api/2.1/clusters/get" {
@@ -314,7 +325,12 @@ func TestInstallerWorksForDevelopment(t *testing.T) {
 	defer server.Close()
 
 	wd, _ := os.Getwd()
-	defer os.Chdir(wd)
+	defer func() {
+		err := os.Chdir(wd)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	devDir := copyTestdata(t, "testdata/installed-in-home/.databricks/labs/blueprint/lib")
 	err := os.Chdir(devDir)
@@ -376,7 +392,8 @@ func TestUpgraderWorksForReleases(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			w.Write(raw)
+			_, err = w.Write(raw)
+			require.NoError(t, err)
 			return
 		}
 		if r.URL.Path == "/repos/databrickslabs/blueprint/zipball/v0.4.0" {
@@ -385,7 +402,8 @@ func TestUpgraderWorksForReleases(t *testing.T) {
 				panic(err)
 			}
 			w.Header().Add("Content-Type", "application/octet-stream")
-			w.Write(raw)
+			_, err = w.Write(raw)
+			require.NoError(t, err)
 			return
 		}
 		if r.URL.Path == "/api/2.1/clusters/get" {

--- a/cmd/root/bundle_test.go
+++ b/cmd/root/bundle_test.go
@@ -91,8 +91,7 @@ func TestBundleConfigureWithMultipleMatches(t *testing.T) {
 	cmd := emptyCommand(t)
 	b := setupWithHost(t, cmd, "https://a.com")
 
-	var err error
-	_, err = b.InitializeWorkspaceClient()
+	_, err := b.InitializeWorkspaceClient()
 	assert.ErrorContains(t, err, "multiple profiles matched: PROFILE-1, PROFILE-2")
 }
 

--- a/cmd/root/bundle_test.go
+++ b/cmd/root/bundle_test.go
@@ -91,7 +91,8 @@ func TestBundleConfigureWithMultipleMatches(t *testing.T) {
 	cmd := emptyCommand(t)
 	b := setupWithHost(t, cmd, "https://a.com")
 
-	_, err := b.InitializeWorkspaceClient()
+	var err error
+	_, err = b.InitializeWorkspaceClient()
 	assert.ErrorContains(t, err, "multiple profiles matched: PROFILE-1, PROFILE-2")
 }
 
@@ -99,10 +100,11 @@ func TestBundleConfigureWithNonExistentProfileFlag(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
 	cmd := emptyCommand(t)
-	cmd.Flag("profile").Value.Set("NOEXIST")
+	err := cmd.Flag("profile").Value.Set("NOEXIST")
+	require.NoError(t, err)
 	b := setupWithHost(t, cmd, "https://x.com")
 
-	_, err := b.InitializeWorkspaceClient()
+	_, err = b.InitializeWorkspaceClient()
 	assert.ErrorContains(t, err, "has no NOEXIST profile configured")
 }
 
@@ -110,10 +112,11 @@ func TestBundleConfigureWithMismatchedProfile(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
 	cmd := emptyCommand(t)
-	cmd.Flag("profile").Value.Set("PROFILE-1")
+	err := cmd.Flag("profile").Value.Set("PROFILE-1")
+	require.NoError(t, err)
 	b := setupWithHost(t, cmd, "https://x.com")
 
-	_, err := b.InitializeWorkspaceClient()
+	_, err = b.InitializeWorkspaceClient()
 	assert.ErrorContains(t, err, "config host mismatch: profile uses host https://a.com, but CLI configured to use https://x.com")
 }
 
@@ -121,7 +124,8 @@ func TestBundleConfigureWithCorrectProfile(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
 	cmd := emptyCommand(t)
-	cmd.Flag("profile").Value.Set("PROFILE-1")
+	err := cmd.Flag("profile").Value.Set("PROFILE-1")
+	require.NoError(t, err)
 	b := setupWithHost(t, cmd, "https://a.com")
 
 	client, err := b.InitializeWorkspaceClient()
@@ -146,7 +150,8 @@ func TestBundleConfigureWithProfileFlagAndEnvVariable(t *testing.T) {
 
 	t.Setenv("DATABRICKS_CONFIG_PROFILE", "NOEXIST")
 	cmd := emptyCommand(t)
-	cmd.Flag("profile").Value.Set("PROFILE-1")
+	err := cmd.Flag("profile").Value.Set("PROFILE-1")
+	require.NoError(t, err)
 	b := setupWithHost(t, cmd, "https://a.com")
 
 	client, err := b.InitializeWorkspaceClient()
@@ -174,7 +179,8 @@ func TestBundleConfigureProfileFlag(t *testing.T) {
 
 	// The --profile flag takes precedence over the profile in the databricks.yml file
 	cmd := emptyCommand(t)
-	cmd.Flag("profile").Value.Set("PROFILE-2")
+	err := cmd.Flag("profile").Value.Set("PROFILE-2")
+	require.NoError(t, err)
 	b := setupWithProfile(t, cmd, "PROFILE-1")
 
 	client, err := b.InitializeWorkspaceClient()
@@ -205,7 +211,8 @@ func TestBundleConfigureProfileFlagAndEnvVariable(t *testing.T) {
 	// The --profile flag takes precedence over the DATABRICKS_CONFIG_PROFILE environment variable
 	t.Setenv("DATABRICKS_CONFIG_PROFILE", "NOEXIST")
 	cmd := emptyCommand(t)
-	cmd.Flag("profile").Value.Set("PROFILE-2")
+	err := cmd.Flag("profile").Value.Set("PROFILE-2")
+	require.NoError(t, err)
 	b := setupWithProfile(t, cmd, "PROFILE-1")
 
 	client, err := b.InitializeWorkspaceClient()

--- a/cmd/root/progress_logger_test.go
+++ b/cmd/root/progress_logger_test.go
@@ -33,27 +33,27 @@ func initializeProgressLoggerTest(t *testing.T) (
 
 func TestInitializeErrorOnIncompatibleConfig(t *testing.T) {
 	plt, logLevel, logFile, progressFormat := initializeProgressLoggerTest(t)
-	logLevel.Set("info")
-	logFile.Set("stderr")
-	progressFormat.Set("inplace")
+	require.NoError(t, logLevel.Set("info"))
+	require.NoError(t, logFile.Set("stderr"))
+	require.NoError(t, progressFormat.Set("inplace"))
 	_, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	assert.ErrorContains(t, err, "inplace progress logging cannot be used when log-file is stderr")
 }
 
 func TestNoErrorOnDisabledLogLevel(t *testing.T) {
 	plt, logLevel, logFile, progressFormat := initializeProgressLoggerTest(t)
-	logLevel.Set("disabled")
-	logFile.Set("stderr")
-	progressFormat.Set("inplace")
+	require.NoError(t, logLevel.Set("disabled"))
+	require.NoError(t, logFile.Set("stderr"))
+	require.NoError(t, progressFormat.Set("inplace"))
 	_, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestNoErrorOnNonStderrLogFile(t *testing.T) {
 	plt, logLevel, logFile, progressFormat := initializeProgressLoggerTest(t)
-	logLevel.Set("info")
-	logFile.Set("stdout")
-	progressFormat.Set("inplace")
+	require.NoError(t, logLevel.Set("info"))
+	require.NoError(t, logFile.Set("stdout"))
+	require.NoError(t, progressFormat.Set("inplace"))
 	_, err := plt.progressLoggerFlag.initializeContext(context.Background())
 	assert.NoError(t, err)
 }

--- a/internal/bundle/bind_resource_test.go
+++ b/internal/bundle/bind_resource_test.go
@@ -99,7 +99,8 @@ func TestAccAbortBind(t *testing.T) {
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {
 		gt.destroyJob(ctx, jobId)
-		destroyBundle(t, ctx, bundleRoot)
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	// Bind should fail because prompting is not possible.

--- a/internal/bundle/deploy_test.go
+++ b/internal/bundle/deploy_test.go
@@ -33,7 +33,8 @@ func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.Worksp
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	// Assert the schema is created
@@ -190,7 +191,8 @@ func TestAccBundlePipelineRecreateWithoutAutoApprove(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	// Assert the pipeline is created
@@ -258,7 +260,8 @@ func TestAccDeployUcVolume(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	// Assert the volume is created successfully

--- a/internal/bundle/deployment_state_test.go
+++ b/internal/bundle/deployment_state_test.go
@@ -46,7 +46,7 @@ func TestAccFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
 	})
 
 	remoteRoot := getBundleRemoteRootPath(w, t, uniqueId)

--- a/internal/bundle/environments_test.go
+++ b/internal/bundle/environments_test.go
@@ -22,7 +22,8 @@ func TestAccPythonWheelTaskWithEnvironmentsDeployAndRun(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "some_other_job")

--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -29,7 +29,8 @@ func runPythonWheelTest(t *testing.T, templateName string, sparkVersion string, 
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "some_other_job")

--- a/internal/bundle/spark_jar_test.go
+++ b/internal/bundle/spark_jar_test.go
@@ -31,7 +31,8 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion strin
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
+		err := destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, err)
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "jar_job")

--- a/internal/bundle/spark_jar_test.go
+++ b/internal/bundle/spark_jar_test.go
@@ -31,7 +31,7 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion strin
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		destroyBundle(t, ctx, bundleRoot)
+		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "jar_job")

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -176,7 +176,10 @@ func (t *cobraTestRunner) SendText(text string) {
 	if t.stdinW == nil {
 		panic("no standard input configured")
 	}
-	t.stdinW.Write([]byte(text + "\n"))
+	_, err := t.stdinW.Write([]byte(text + "\n"))
+	if err != nil {
+		panic("Failed to to write to t.stdinW")
+	}
 }
 
 func (t *cobraTestRunner) RunBackground() {
@@ -496,9 +499,10 @@ func TemporaryUcVolume(t *testing.T, w *databricks.WorkspaceClient) string {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		w.Schemas.Delete(ctx, catalog.DeleteSchemaRequest{
+		err := w.Schemas.Delete(ctx, catalog.DeleteSchemaRequest{
 			FullName: schema.FullName,
 		})
+		require.NoError(t, err)
 	})
 
 	// Create a volume
@@ -510,9 +514,10 @@ func TemporaryUcVolume(t *testing.T, w *databricks.WorkspaceClient) string {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		w.Volumes.Delete(ctx, catalog.DeleteVolumeRequest{
+		err := w.Volumes.Delete(ctx, catalog.DeleteVolumeRequest{
 			Name: volume.FullName,
 		})
+		require.NoError(t, err)
 	})
 
 	return path.Join("/Volumes", "main", schema.Name, volume.Name)

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -59,7 +59,8 @@ func TestAccBundleInitOnMlopsStacks(t *testing.T) {
 	}
 	b, err := json.Marshal(initConfig)
 	require.NoError(t, err)
-	os.WriteFile(filepath.Join(tmpDir1, "config.json"), b, 0644)
+	err = os.WriteFile(filepath.Join(tmpDir1, "config.json"), b, 0644)
+	require.NoError(t, err)
 
 	// Run bundle init
 	assert.NoFileExists(t, filepath.Join(tmpDir2, "repo_name", projectName, "README.md"))

--- a/internal/locker_test.go
+++ b/internal/locker_test.go
@@ -133,7 +133,8 @@ func TestAccLock(t *testing.T) {
 
 	// assert on active locker content
 	var res map[string]string
-	json.Unmarshal(b, &res)
+	err = json.Unmarshal(b, &res)
+	require.NoError(t, err)
 	assert.NoError(t, err)
 	assert.Equal(t, "Khan", res["surname"])
 	assert.Equal(t, "Shah Rukh", res["name"])

--- a/internal/tags_test.go
+++ b/internal/tags_test.go
@@ -47,7 +47,8 @@ func testTags(t *testing.T, tags map[string]string) error {
 
 	if resp != nil {
 		t.Cleanup(func() {
-			w.Jobs.DeleteByJobId(ctx, resp.JobId)
+			err := w.Jobs.DeleteByJobId(ctx, resp.JobId)
+			require.NoError(t, err)
 		})
 	}
 

--- a/libs/cmdgroup/command_test.go
+++ b/libs/cmdgroup/command_test.go
@@ -42,7 +42,8 @@ func TestCommandFlagGrouping(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	cmd.SetOutput(buf)
-	cmd.Usage()
+	err := cmd.Usage()
+	require.NoError(t, err)
 
 	expected := `Usage:
   parent test [flags]

--- a/libs/dyn/jsonsaver/marshal_test.go
+++ b/libs/dyn/jsonsaver/marshal_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/databricks/cli/libs/dyn"
 	assert "github.com/databricks/cli/libs/dyn/dynassert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshal_String(t *testing.T) {
@@ -44,8 +45,8 @@ func TestMarshal_Time(t *testing.T) {
 
 func TestMarshal_Map(t *testing.T) {
 	m := dyn.NewMapping()
-	m.Set(dyn.V("key1"), dyn.V("value1"))
-	m.Set(dyn.V("key2"), dyn.V("value2"))
+	require.NoError(t, m.Set(dyn.V("key1"), dyn.V("value1")))
+	require.NoError(t, m.Set(dyn.V("key2"), dyn.V("value2")))
 
 	b, err := Marshal(dyn.V(m))
 	if assert.NoError(t, err) {
@@ -66,16 +67,16 @@ func TestMarshal_Sequence(t *testing.T) {
 
 func TestMarshal_Complex(t *testing.T) {
 	map1 := dyn.NewMapping()
-	map1.Set(dyn.V("str1"), dyn.V("value1"))
-	map1.Set(dyn.V("str2"), dyn.V("value2"))
+	require.NoError(t, map1.Set(dyn.V("str1"), dyn.V("value1")))
+	require.NoError(t, map1.Set(dyn.V("str2"), dyn.V("value2")))
 
 	seq1 := []dyn.Value{}
 	seq1 = append(seq1, dyn.V("value1"))
 	seq1 = append(seq1, dyn.V("value2"))
 
 	root := dyn.NewMapping()
-	root.Set(dyn.V("map1"), dyn.V(map1))
-	root.Set(dyn.V("seq1"), dyn.V(seq1))
+	require.NoError(t, root.Set(dyn.V("map1"), dyn.V(map1)))
+	require.NoError(t, root.Set(dyn.V("seq1"), dyn.V(seq1)))
 
 	// Marshal without indent.
 	b, err := Marshal(dyn.V(root))

--- a/libs/dyn/merge/override_test.go
+++ b/libs/dyn/merge/override_test.go
@@ -432,10 +432,12 @@ func TestOverride_PreserveMappingKeys(t *testing.T) {
 	rightValueLocation := dyn.Location{File: "right.yml", Line: 3, Column: 1}
 
 	left := dyn.NewMapping()
-	left.Set(dyn.NewValue("a", []dyn.Location{leftKeyLocation}), dyn.NewValue(42, []dyn.Location{leftValueLocation}))
+	err := left.Set(dyn.NewValue("a", []dyn.Location{leftKeyLocation}), dyn.NewValue(42, []dyn.Location{leftValueLocation}))
+	require.NoError(t, err)
 
 	right := dyn.NewMapping()
-	right.Set(dyn.NewValue("a", []dyn.Location{rightKeyLocation}), dyn.NewValue(7, []dyn.Location{rightValueLocation}))
+	err = right.Set(dyn.NewValue("a", []dyn.Location{rightKeyLocation}), dyn.NewValue(7, []dyn.Location{rightValueLocation}))
+	require.NoError(t, err)
 
 	state, visitor := createVisitor(visitorOpts{})
 

--- a/libs/exec/exec_test.go
+++ b/libs/exec/exec_test.go
@@ -86,9 +86,15 @@ func testExecutorWithShell(t *testing.T, shell string) {
 	tmpDir := t.TempDir()
 	t.Setenv("PATH", tmpDir)
 	if runtime.GOOS == "windows" {
-		os.Symlink(p, fmt.Sprintf("%s/%s.exe", tmpDir, shell))
+		err = os.Symlink(p, fmt.Sprintf("%s/%s.exe", tmpDir, shell))
+		if err != nil {
+			t.Fatal(err)
+		}
 	} else {
-		os.Symlink(p, fmt.Sprintf("%s/%s", tmpDir, shell))
+		err = os.Symlink(p, fmt.Sprintf("%s/%s", tmpDir, shell))
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	executor, err := NewCommandExecutor(".")

--- a/libs/flags/json_flag_test.go
+++ b/libs/flags/json_flag_test.go
@@ -62,7 +62,9 @@ func TestJsonFlagFile(t *testing.T) {
 	{
 		f, err := os.Create(path.Join(t.TempDir(), "file"))
 		require.NoError(t, err)
-		f.Write(payload)
+		n, err := f.Write(payload)
+		require.NoError(t, err)
+		require.Greater(t, n, 0)
 		f.Close()
 		fpath = f.Name()
 	}

--- a/libs/git/fileset_test.go
+++ b/libs/git/fileset_test.go
@@ -56,7 +56,8 @@ func TestFileSetAddsCacheDirToGitIgnore(t *testing.T) {
 	projectDir := t.TempDir()
 	fileSet, err := NewFileSetAtRoot(vfs.MustNew(projectDir))
 	require.NoError(t, err)
-	fileSet.EnsureValidGitIgnoreExists()
+	err = fileSet.EnsureValidGitIgnoreExists()
+	require.NoError(t, err)
 
 	gitIgnorePath := filepath.Join(projectDir, ".gitignore")
 	assert.FileExists(t, gitIgnorePath)
@@ -74,7 +75,8 @@ func TestFileSetDoesNotCacheDirToGitIgnoreIfAlreadyPresent(t *testing.T) {
 	err = os.WriteFile(gitIgnorePath, []byte(".databricks"), 0o644)
 	require.NoError(t, err)
 
-	fileSet.EnsureValidGitIgnoreExists()
+	err = fileSet.EnsureValidGitIgnoreExists()
+	require.NoError(t, err)
 
 	b, err := os.ReadFile(gitIgnorePath)
 	require.NoError(t, err)

--- a/libs/git/reference_test.go
+++ b/libs/git/reference_test.go
@@ -54,7 +54,8 @@ func TestReferenceLoadingForObjectID(t *testing.T) {
 	f, err := os.Create(filepath.Join(tmp, "HEAD"))
 	require.NoError(t, err)
 	defer f.Close()
-	f.WriteString(strings.Repeat("e", 40) + "\r\n")
+	_, err = f.WriteString(strings.Repeat("e", 40) + "\r\n")
+	require.NoError(t, err)
 
 	ref, err := LoadReferenceFile(vfs.MustNew(tmp), "HEAD")
 	assert.NoError(t, err)
@@ -67,7 +68,8 @@ func TestReferenceLoadingForReference(t *testing.T) {
 	f, err := os.OpenFile(filepath.Join(tmp, "HEAD"), os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	require.NoError(t, err)
 	defer f.Close()
-	f.WriteString("ref: refs/heads/foo\n")
+	_, err = f.WriteString("ref: refs/heads/foo\n")
+	require.NoError(t, err)
 
 	ref, err := LoadReferenceFile(vfs.MustNew(tmp), "HEAD")
 	assert.NoError(t, err)
@@ -80,7 +82,8 @@ func TestReferenceLoadingFailsForInvalidContent(t *testing.T) {
 	f, err := os.OpenFile(filepath.Join(tmp, "HEAD"), os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	require.NoError(t, err)
 	defer f.Close()
-	f.WriteString("abc")
+	_, err = f.WriteString("abc")
+	require.NoError(t, err)
 
 	_, err = LoadReferenceFile(vfs.MustNew(tmp), "HEAD")
 	assert.ErrorContains(t, err, "unknown format for git HEAD")

--- a/libs/git/repository_test.go
+++ b/libs/git/repository_test.go
@@ -27,7 +27,7 @@ func newTestRepository(t *testing.T) *testRepository {
 	require.NoError(t, err)
 	defer f1.Close()
 
-	f1.WriteString(
+	_, err = f1.WriteString(
 		`[core]
 	repositoryformatversion = 0
 	filemode = true
@@ -36,6 +36,7 @@ func newTestRepository(t *testing.T) *testRepository {
 	ignorecase = true
 	precomposeunicode = true
 `)
+	require.NoError(t, err)
 
 	f2, err := os.Create(filepath.Join(tmp, ".git", "HEAD"))
 	require.NoError(t, err)

--- a/libs/jsonschema/from_type_test.go
+++ b/libs/jsonschema/from_type_test.go
@@ -403,7 +403,8 @@ func TestFromTypeError(t *testing.T) {
 	// Maps with non-string keys should panic.
 	type mapOfInts map[int]int
 	assert.PanicsWithValue(t, "found map with non-string key: int", func() {
-		FromType(reflect.TypeOf(mapOfInts{}), nil)
+		_, err := FromType(reflect.TypeOf(mapOfInts{}), nil)
+		require.NoError(t, err)
 	})
 
 	// Unsupported types should return an error.

--- a/libs/process/stub_test.go
+++ b/libs/process/stub_test.go
@@ -43,8 +43,12 @@ func TestStubCallback(t *testing.T) {
 	ctx := context.Background()
 	ctx, stub := process.WithStub(ctx)
 	stub.WithCallback(func(cmd *exec.Cmd) error {
-		cmd.Stderr.Write([]byte("something..."))
-		cmd.Stdout.Write([]byte("else..."))
+		if _, err := cmd.Stderr.Write([]byte("something...")); err != nil {
+			return err
+		}
+		if _, err := cmd.Stdout.Write([]byte("else...")); err != nil {
+			return err
+		}
 		return fmt.Errorf("yep")
 	})
 

--- a/libs/python/interpreters_unix_test.go
+++ b/libs/python/interpreters_unix_test.go
@@ -34,7 +34,8 @@ func TestFilteringInterpreters(t *testing.T) {
 	rogueBin := filepath.Join(t.TempDir(), "rogue-bin")
 	err := os.Mkdir(rogueBin, 0o777)
 	assert.NoError(t, err)
-	os.Chmod(rogueBin, 0o777)
+	err = os.Chmod(rogueBin, 0o777)
+	assert.NoError(t, err)
 
 	raw, err := os.ReadFile("testdata/world-writeable/python8.4")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Changes
Fix err check issues in all _test.go files: handle the error (mostly by adding require.NoError(t, err), sometime panic() where t object is not available).

## Tests
Existing tests.

