### PR TITLE
Do not run mlops-stacks integration test in parallel

### DIFF
--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -39,7 +39,6 @@ func TestAccBundleInitErrorOnUnknownFields(t *testing.T) {
 //     make changes that can break the MLOps Stacks DAB. In which case we should
 //     skip this test until the MLOps Stacks DAB is updated to work again.
 func TestAccBundleInitOnMlopsStacks(t *testing.T) {
-	t.Parallel()
 	env := testutil.GetCloud(t).String()
 
 	tmpDir1 := t.TempDir()

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -52,6 +52,7 @@ func GetEnvOrSkipTest(t *testing.T, name string) string {
 // Returns the current working directory.
 func Chdir(t *testing.T, dir string) string {
 	// Prevent parallel execution when changing the working directory.
+	// t.Setenv automatically fails if t.Parallel is set.
 	t.Setenv("DO_NOT_RUN_IN_PARALLEL", "true")
 
 	wd, err := os.Getwd()

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -51,6 +51,9 @@ func GetEnvOrSkipTest(t *testing.T, name string) string {
 // Changes into specified directory for the duration of the test.
 // Returns the current working directory.
 func Chdir(t *testing.T, dir string) string {
+	// Prevent parallel execution when changing the working directory.
+	t.Setenv("DO_NOT_RUN_IN_PARALLEL", "true")
+
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes
This test changes the cwd using the `testutil.Chdir` function. This causes flakiness with other integration tests, like `TestAccWorkspaceFilesExtensionsNotebooksAreNotDeletedAsFiles`, which rely on the cwd being configured correctly to read test fixtures.

The `t.Setenv` call in `testutil.Chdir` ensures that it is not run from a test whose upstream is executing in parallel.