### PR TITLE
[DO NOT MERGE]readd parent path

### DIFF
--- a/cmd/workspace/lakeview/lakeview.go
+++ b/cmd/workspace/lakeview/lakeview.go
@@ -76,6 +76,7 @@ func newCreate() *cobra.Command {
 	// TODO: short flags
 	cmd.Flags().Var(&createJson, "json", `either inline JSON string or @path/to/file.json with request body`)
 
+	cmd.Flags().StringVar(&createReq.Dashboard.ParentPath, "parent-path", createReq.Dashboard.ParentPath, `The workspace path of the folder containing the dashboard.`)
 	cmd.Flags().StringVar(&createReq.Dashboard.DisplayName, "display-name", createReq.Dashboard.DisplayName, `The display name of the dashboard.`)
 	cmd.Flags().StringVar(&createReq.Dashboard.SerializedDashboard, "serialized-dashboard", createReq.Dashboard.SerializedDashboard, `The contents of the dashboard in serialized string form.`)
 	cmd.Flags().StringVar(&createReq.Dashboard.WarehouseId, "warehouse-id", createReq.Dashboard.WarehouseId, `The warehouse ID used to run the dashboard.`)
@@ -83,7 +84,7 @@ func newCreate() *cobra.Command {
 	cmd.Use = "create"
 	cmd.Short = `Create dashboard.`
 	cmd.Long = `Create dashboard.
-  
+
   Create a draft dashboard.`
 
 	cmd.Annotations = make(map[string]string)
@@ -441,7 +442,7 @@ func newGet() *cobra.Command {
 	cmd.Use = "get DASHBOARD_ID"
 	cmd.Short = `Get dashboard.`
 	cmd.Long = `Get dashboard.
-  
+
   Get a draft dashboard.
 
   Arguments:
@@ -499,7 +500,7 @@ func newGetPublished() *cobra.Command {
 	cmd.Use = "get-published DASHBOARD_ID"
 	cmd.Short = `Get published dashboard.`
 	cmd.Long = `Get published dashboard.
-  
+
   Get the current published dashboard.
 
   Arguments:
@@ -856,7 +857,7 @@ func newMigrate() *cobra.Command {
 	cmd.Use = "migrate SOURCE_DASHBOARD_ID"
 	cmd.Short = `Migrate dashboard.`
 	cmd.Long = `Migrate dashboard.
-  
+
   Migrates a classic SQL dashboard to Lakeview.
 
   Arguments:
@@ -940,7 +941,7 @@ func newPublish() *cobra.Command {
 	cmd.Use = "publish DASHBOARD_ID"
 	cmd.Short = `Publish dashboard.`
 	cmd.Long = `Publish dashboard.
-  
+
   Publish the current draft dashboard.
 
   Arguments:
@@ -1010,7 +1011,7 @@ func newTrash() *cobra.Command {
 	cmd.Use = "trash DASHBOARD_ID"
 	cmd.Short = `Trash dashboard.`
 	cmd.Long = `Trash dashboard.
-  
+
   Trash a dashboard.
 
   Arguments:
@@ -1068,7 +1069,7 @@ func newUnpublish() *cobra.Command {
 	cmd.Use = "unpublish DASHBOARD_ID"
 	cmd.Short = `Unpublish dashboard.`
 	cmd.Long = `Unpublish dashboard.
-  
+
   Unpublish the dashboard.
 
   Arguments:
@@ -1133,7 +1134,7 @@ func newUpdate() *cobra.Command {
 	cmd.Use = "update DASHBOARD_ID"
 	cmd.Short = `Update dashboard.`
 	cmd.Long = `Update dashboard.
-  
+
   Update a draft dashboard.
 
   Arguments:


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
The parent path flag to the lakeview create command has been removed in some recent cli version. 

```
> databricks --version
Databricks CLI v0.236.0
> databricks lakeview create --help
Create dashboard.
  
  Create a draft dashboard.

Usage:
  databricks lakeview create [flags]

Flags:
      --display-name string           The display name of the dashboard.
  -h, --help                          help for create
      --json JSON                     either inline JSON string or @path/to/file.json with request body (default JSON (0 bytes))
      --serialized-dashboard string   The contents of the dashboard in serialized string form.
      --warehouse-id string           The warehouse ID used to run the dashboard.

Global Flags:
      --debug            enable debug logging
  -o, --output type      output type: text or json (default text)
  -p, --profile string   ~/.databrickscfg profile
  -t, --target string    bundle target to use (if applicable)
```

But it is a valid flag in e.g. v0.232.0.

It should probably still be part of the cli as it is a valid bundle argument, and it still exist in the REST API under /api/2.0/lakeview/dashboards

As this file is automatically generated this should not be merged, but created the PR for reference.

## Tests
<!-- How is this tested? -->

