### PR TITLE
Avoid panic if Config.Workspace.CurrentUser.User is not set

### DIFF
--- a/bundle/config/mutator/expand_workspace_root.go
+++ b/bundle/config/mutator/expand_workspace_root.go
@@ -28,7 +28,7 @@ func (m *expandWorkspaceRoot) Apply(ctx context.Context, b *bundle.Bundle) diag.
 	}
 
 	currentUser := b.Config.Workspace.CurrentUser
-	if currentUser == nil || currentUser.UserName == "" {
+	if currentUser == nil || currentUser.User == nil || currentUser.UserName == "" {
 		return diag.Errorf("unable to expand workspace root: current user not set")
 	}
 


### PR DESCRIPTION
## Changes
Extra check to avoid panic if /api/2.0/preview/scim/v2/Me returns `{}`

## Tests
Existing tests.

