### PR TITLE
Show an error when using a cluster override with 'mode: production'

### DIFF
--- a/bundle/config/mutator/override_compute.go
+++ b/bundle/config/mutator/override_compute.go
@@ -45,8 +45,9 @@ func (m *overrideCompute) Apply(ctx context.Context, b *bundle.Bundle) diag.Diag
 		if b.Config.Bundle.ClusterId != "" {
 			// Overriding compute via a command-line flag for production works, but is not recommended.
 			diags = diags.Extend(diag.Diagnostics{{
-				Summary: "Setting a cluster override for a target that uses 'mode: production' is not recommended",
-				Detail:  "It is recommended to always use the same compute for production target for consistency.",
+				Summary:  "Setting a cluster override for a target that uses 'mode: production' is not recommended",
+				Detail:   "It is recommended to always use the same compute for production target for consistency.",
+				Severity: diag.Warning,
 			}})
 		}
 	}

--- a/bundle/config/mutator/override_compute_test.go
+++ b/bundle/config/mutator/override_compute_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/mutator"
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/assert"
@@ -173,6 +174,7 @@ func TestOverrideComputeModeProduction(t *testing.T) {
 	diags := bundle.Apply(context.Background(), b, m)
 	require.Len(t, diags, 1)
 	assert.Equal(t, "Setting a cluster override for a target that uses 'mode: production' is not recommended", diags[0].Summary)
+	assert.Equal(t, diag.Warning, diags[0].Severity)
 	assert.Equal(t, "newClusterID", b.Config.Resources.Jobs["job1"].Tasks[0].ExistingClusterId)
 }
 


### PR DESCRIPTION
## Changes

We should show a warning when using a cluster override with 'mode: production'. Right now, we inadvertently show an error for this state. This is a followup based on https://github.com/databricks/cli/pull/1899#discussion_r1877765148.
