### PR TITLE
Fixed TestAccBundleDeployUcSchema test

### DIFF
--- a/internal/bundle/bundles/uc_schema/template/databricks.yml.tmpl
+++ b/internal/bundle/bundles/uc_schema/template/databricks.yml.tmpl
@@ -12,7 +12,6 @@ resources:
         - notebook:
             path: ./nb.sql
       development: true
-      catalog: main
 
 include:
   - "*.yml"

--- a/internal/bundle/bundles/uc_schema/template/schema.yml.tmpl
+++ b/internal/bundle/bundles/uc_schema/template/schema.yml.tmpl
@@ -11,3 +11,4 @@ targets:
       pipelines:
         foo:
           target: ${resources.schemas.bar.id}
+          catalog: main


### PR DESCRIPTION
## Changes
It was failing because when schema.yml was removed, `catalog: main` option left set in the base pipeline definition in databricks.yml which lead to incorrect config (empty target schema)

## Tests
```
--- PASS: TestAccBundleDeployUcSchema (41.75s)
PASS
coverage: 33.3% of statements in ./...
ok      github.com/databricks/cli/internal/bundle       42.210s coverage: 33.3% of statements in ./...
```

