### PR TITLE
Enable gofumpt in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,10 @@
     "go.lintFlags": [
         "--fast"
     ],
+    "go.useLanguageServer": true,
+    "gopls": {
+         "formatting.gofumpt": true
+    },
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,


### PR DESCRIPTION
## Tests
Verified that with this setting, VSCode reformats code on Save according to gofumpt rules.

