### PR TITLE
Define and use `testutil.TestingT` interface

### DIFF
--- a/internal/acc/debug.go
+++ b/internal/acc/debug.go
@@ -6,7 +6,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"testing"
+
+	"github.com/databricks/cli/internal/testutil"
 )
 
 // Detects if test is run from "debug test" feature in VS Code.
@@ -16,7 +17,7 @@ func isInDebug() bool {
 }
 
 // Loads debug environment from ~/.databricks/debug-env.json.
-func loadDebugEnvIfRunFromIDE(t *testing.T, key string) {
+func loadDebugEnvIfRunFromIDE(t testutil.TestingT, key string) {
 	if !isInDebug() {
 		return
 	}

--- a/internal/acc/workspace.go
+++ b/internal/acc/workspace.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/databricks-sdk-go"
@@ -15,7 +14,7 @@ import (
 )
 
 type WorkspaceT struct {
-	*testing.T
+	testutil.TestingT
 
 	W *databricks.WorkspaceClient
 
@@ -24,7 +23,7 @@ type WorkspaceT struct {
 	exec *compute.CommandExecutorV2
 }
 
-func WorkspaceTest(t *testing.T) (context.Context, *WorkspaceT) {
+func WorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 	loadDebugEnvIfRunFromIDE(t, "workspace")
 
 	t.Log(testutil.GetEnvOrSkipTest(t, "CLOUD_ENV"))
@@ -33,7 +32,7 @@ func WorkspaceTest(t *testing.T) (context.Context, *WorkspaceT) {
 	require.NoError(t, err)
 
 	wt := &WorkspaceT{
-		T: t,
+		TestingT: t,
 
 		W: w,
 
@@ -44,7 +43,7 @@ func WorkspaceTest(t *testing.T) (context.Context, *WorkspaceT) {
 }
 
 // Run the workspace test only on UC workspaces.
-func UcWorkspaceTest(t *testing.T) (context.Context, *WorkspaceT) {
+func UcWorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 	loadDebugEnvIfRunFromIDE(t, "workspace")
 
 	t.Log(testutil.GetEnvOrSkipTest(t, "CLOUD_ENV"))
@@ -60,7 +59,7 @@ func UcWorkspaceTest(t *testing.T) (context.Context, *WorkspaceT) {
 	require.NoError(t, err)
 
 	wt := &WorkspaceT{
-		T: t,
+		TestingT: t,
 
 		W: w,
 
@@ -71,7 +70,7 @@ func UcWorkspaceTest(t *testing.T) (context.Context, *WorkspaceT) {
 }
 
 func (t *WorkspaceT) TestClusterID() string {
-	clusterID := testutil.GetEnvOrSkipTest(t.T, "TEST_BRICKS_CLUSTER_ID")
+	clusterID := testutil.GetEnvOrSkipTest(t, "TEST_BRICKS_CLUSTER_ID")
 	err := t.W.Clusters.EnsureClusterIsRunning(t.ctx, clusterID)
 	require.NoError(t, err)
 	return clusterID

--- a/internal/bundle/clusters_test.go
+++ b/internal/bundle/clusters_test.go
@@ -16,7 +16,7 @@ import (
 func TestAccDeployBundleWithCluster(t *testing.T) {
 	ctx, wt := acc.WorkspaceTest(t)
 
-	if testutil.IsAWSCloud(wt.T) {
+	if testutil.IsAWSCloud(wt) {
 		t.Skip("Skipping test for AWS cloud because it is not permitted to create clusters")
 	}
 

--- a/internal/bundle/deploy_to_shared_test.go
+++ b/internal/bundle/deploy_to_shared_test.go
@@ -29,10 +29,10 @@ func TestAccDeployBasicToSharedWorkspacePath(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = destroyBundle(wt.T, ctx, bundleRoot)
-		require.NoError(wt.T, err)
+		err = destroyBundle(wt, ctx, bundleRoot)
+		require.NoError(wt, err)
 	})
 
-	err = deployBundle(wt.T, ctx, bundleRoot)
-	require.NoError(wt.T, err)
+	err = deployBundle(wt, ctx, bundleRoot)
+	require.NoError(wt, err)
 }

--- a/internal/bundle/python_wheel_test.go
+++ b/internal/bundle/python_wheel_test.go
@@ -57,7 +57,7 @@ func TestAccPythonWheelTaskDeployAndRunWithWrapper(t *testing.T) {
 func TestAccPythonWheelTaskDeployAndRunOnInteractiveCluster(t *testing.T) {
 	_, wt := acc.WorkspaceTest(t)
 
-	if testutil.IsAWSCloud(wt.T) {
+	if testutil.IsAWSCloud(wt) {
 		t.Skip("Skipping test for AWS cloud because it is not permitted to create clusters")
 	}
 

--- a/internal/filer_test.go
+++ b/internal/filer_test.go
@@ -122,7 +122,7 @@ func TestAccFilerRecursiveDelete(t *testing.T) {
 
 	for _, testCase := range []struct {
 		name string
-		f    func(t *testing.T) (filer.Filer, string)
+		f    func(t testutil.TestingT) (filer.Filer, string)
 	}{
 		{"local", setupLocalFiler},
 		{"workspace files", setupWsfsFiler},
@@ -233,7 +233,7 @@ func TestAccFilerReadWrite(t *testing.T) {
 
 	for _, testCase := range []struct {
 		name string
-		f    func(t *testing.T) (filer.Filer, string)
+		f    func(t testutil.TestingT) (filer.Filer, string)
 	}{
 		{"local", setupLocalFiler},
 		{"workspace files", setupWsfsFiler},
@@ -342,7 +342,7 @@ func TestAccFilerReadDir(t *testing.T) {
 
 	for _, testCase := range []struct {
 		name string
-		f    func(t *testing.T) (filer.Filer, string)
+		f    func(t testutil.TestingT) (filer.Filer, string)
 	}{
 		{"local", setupLocalFiler},
 		{"workspace files", setupWsfsFiler},

--- a/internal/fs_cp_test.go
+++ b/internal/fs_cp_test.go
@@ -62,8 +62,8 @@ func assertTargetDir(t *testing.T, ctx context.Context, f filer.Filer) {
 
 type cpTest struct {
 	name        string
-	setupSource func(*testing.T) (filer.Filer, string)
-	setupTarget func(*testing.T) (filer.Filer, string)
+	setupSource func(testutil.TestingT) (filer.Filer, string)
+	setupTarget func(testutil.TestingT) (filer.Filer, string)
 }
 
 func copyTests() []cpTest {

--- a/internal/fs_ls_test.go
+++ b/internal/fs_ls_test.go
@@ -18,7 +18,7 @@ import (
 
 type fsTest struct {
 	name       string
-	setupFiler func(t *testing.T) (filer.Filer, string)
+	setupFiler func(t testutil.TestingT) (filer.Filer, string)
 }
 
 var fsTests = []fsTest{

--- a/internal/secrets_test.go
+++ b/internal/secrets_test.go
@@ -68,7 +68,7 @@ func TestAccSecretsPutSecretStringValue(tt *testing.T) {
 	key := "test-key"
 	value := "test-value\nwith-newlines\n"
 
-	stdout, stderr := RequireSuccessfulRun(t.T, "secrets", "put-secret", scope, key, "--string-value", value)
+	stdout, stderr := RequireSuccessfulRun(t, "secrets", "put-secret", scope, key, "--string-value", value)
 	assert.Empty(t, stdout)
 	assert.Empty(t, stderr)
 
@@ -82,7 +82,7 @@ func TestAccSecretsPutSecretBytesValue(tt *testing.T) {
 	key := "test-key"
 	value := []byte{0x00, 0x01, 0x02, 0x03}
 
-	stdout, stderr := RequireSuccessfulRun(t.T, "secrets", "put-secret", scope, key, "--bytes-value", string(value))
+	stdout, stderr := RequireSuccessfulRun(t, "secrets", "put-secret", scope, key, "--bytes-value", string(value))
 	assert.Empty(t, stdout)
 	assert.Empty(t, stderr)
 

--- a/internal/testutil/cloud.go
+++ b/internal/testutil/cloud.go
@@ -1,9 +1,5 @@
 package testutil
 
-import (
-	"testing"
-)
-
 type Cloud int
 
 const (
@@ -13,7 +9,7 @@ const (
 )
 
 // Implement [Requirement].
-func (c Cloud) Verify(t *testing.T) {
+func (c Cloud) Verify(t TestingT) {
 	if c != GetCloud(t) {
 		t.Skipf("Skipping %s-specific test", c)
 	}
@@ -32,7 +28,7 @@ func (c Cloud) String() string {
 	}
 }
 
-func GetCloud(t *testing.T) Cloud {
+func GetCloud(t TestingT) Cloud {
 	env := GetEnvOrSkipTest(t, "CLOUD_ENV")
 	switch env {
 	case "aws":
@@ -50,6 +46,6 @@ func GetCloud(t *testing.T) Cloud {
 	return -1
 }
 
-func IsAWSCloud(t *testing.T) bool {
+func IsAWSCloud(t TestingT) bool {
 	return GetCloud(t) == AWS
 }

--- a/internal/testutil/copy.go
+++ b/internal/testutil/copy.go
@@ -5,14 +5,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 // CopyDirectory copies the contents of a directory to another directory.
 // The destination directory is created if it does not exist.
-func CopyDirectory(t *testing.T, src, dst string) {
+func CopyDirectory(t TestingT, src, dst string) {
 	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/internal/testutil/env.go
+++ b/internal/testutil/env.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +12,7 @@ import (
 // CleanupEnvironment sets up a pristine environment containing only $PATH and $HOME.
 // The original environment is restored upon test completion.
 // Note: use of this function is incompatible with parallel execution.
-func CleanupEnvironment(t *testing.T) {
+func CleanupEnvironment(t TestingT) {
 	// Restore environment when test finishes.
 	environ := os.Environ()
 	t.Cleanup(func() {
@@ -41,7 +40,7 @@ func CleanupEnvironment(t *testing.T) {
 
 // Changes into specified directory for the duration of the test.
 // Returns the current working directory.
-func Chdir(t *testing.T, dir string) string {
+func Chdir(t TestingT, dir string) string {
 	// Prevent parallel execution when changing the working directory.
 	// t.Setenv automatically fails if t.Parallel is set.
 	t.Setenv("DO_NOT_RUN_IN_PARALLEL", "true")

--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -3,12 +3,11 @@ package testutil
 import (
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TouchNotebook(t *testing.T, elems ...string) string {
+func TouchNotebook(t TestingT, elems ...string) string {
 	path := filepath.Join(elems...)
 	err := os.MkdirAll(filepath.Dir(path), 0o755)
 	require.NoError(t, err)
@@ -18,7 +17,7 @@ func TouchNotebook(t *testing.T, elems ...string) string {
 	return path
 }
 
-func Touch(t *testing.T, elems ...string) string {
+func Touch(t TestingT, elems ...string) string {
 	path := filepath.Join(elems...)
 	err := os.MkdirAll(filepath.Dir(path), 0o755)
 	require.NoError(t, err)
@@ -32,7 +31,7 @@ func Touch(t *testing.T, elems ...string) string {
 }
 
 // WriteFile writes content to a file.
-func WriteFile(t *testing.T, path, content string) {
+func WriteFile(t TestingT, path, content string) {
 	err := os.MkdirAll(filepath.Dir(path), 0o755)
 	require.NoError(t, err)
 
@@ -47,7 +46,7 @@ func WriteFile(t *testing.T, path, content string) {
 }
 
 // ReadFile reads a file and returns its content as a string.
-func ReadFile(t require.TestingT, path string) string {
+func ReadFile(t TestingT, path string) string {
 	b, err := os.ReadFile(path)
 	require.NoError(t, err)
 

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -5,11 +5,10 @@ import (
 	"math/rand"
 	"os"
 	"strings"
-	"testing"
 )
 
 // GetEnvOrSkipTest proceeds with test only with that env variable.
-func GetEnvOrSkipTest(t *testing.T, name string) string {
+func GetEnvOrSkipTest(t TestingT, name string) string {
 	value := os.Getenv(name)
 	if value == "" {
 		t.Skipf("Environment variable %s is missing", name)

--- a/internal/testutil/interface.go
+++ b/internal/testutil/interface.go
@@ -1,0 +1,27 @@
+package testutil
+
+// TestingT is an interface wrapper around *testing.T that provides the methods
+// that are used by the test package to convey information about test failures.
+//
+// We use an interface so we can wrap *testing.T and provide additional functionality.
+type TestingT interface {
+	Log(args ...any)
+	Logf(format string, args ...any)
+
+	Error(args ...any)
+	Errorf(format string, args ...any)
+
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+
+	Skip(args ...any)
+	Skipf(format string, args ...any)
+
+	FailNow()
+
+	Cleanup(func())
+
+	Setenv(key, value string)
+
+	TempDir() string
+}

--- a/internal/testutil/jdk.go
+++ b/internal/testutil/jdk.go
@@ -5,12 +5,11 @@ import (
 	"context"
 	"os/exec"
 	"strings"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func RequireJDK(t *testing.T, ctx context.Context, version string) {
+func RequireJDK(t TestingT, ctx context.Context, version string) {
 	var stderr bytes.Buffer
 
 	cmd := exec.Command("javac", "-version")

--- a/internal/testutil/requirement.go
+++ b/internal/testutil/requirement.go
@@ -1,18 +1,14 @@
 package testutil
 
-import (
-	"testing"
-)
-
 // Requirement is the interface for test requirements.
 type Requirement interface {
-	Verify(t *testing.T)
+	Verify(t TestingT)
 }
 
 // Require should be called at the beginning of a test to ensure that all
 // requirements are met before running the test.
 // If any requirement is not met, the test will be skipped.
-func Require(t *testing.T, requirements ...Requirement) {
+func Require(t TestingT, requirements ...Requirement) {
 	for _, r := range requirements {
 		r.Verify(t)
 	}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,36 @@
+package testutil_test
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoTestingImport checks that no file in the package imports the testing package.
+// All exported functions must use the TestingT interface instead of *testing.T.
+func TestNoTestingImport(t *testing.T) {
+	// Parse the package
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, parser.AllErrors)
+	require.NoError(t, err)
+
+	// Iterate through the files in the package
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			// Skip test files
+			if strings.HasSuffix(fset.Position(file.Pos()).Filename, "_test.go") {
+				continue
+			}
+			// Check the imports of each file
+			for _, imp := range file.Imports {
+				if imp.Path.Value == `"testing"` {
+					assert.Fail(t, "File imports the testing package", "File %s imports the testing package", fset.Position(file.Pos()).Filename)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Changes

Using an interface instead of a concrete type means we can pass `*testing.T` directly or any wrapper type that implements a superset of this interface. It prepares for more broad use of `acc.WorkspaceT`, which enhances the testing object with helper functions for using a Databricks workspace.

This eliminates the need to dereference a `*testing.T` field on a wrapper type.

## Tests

n/a