### PR TITLE
Remove unused vscode settings in the templates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,6 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "python.envFile": "${workspaceRoot}/.env",
-    "databricks.python.envFile": "${workspaceFolder}/.env",
     "python.analysis.stubPath": ".vscode",
     "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
     "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------"

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/.vscode/settings.json.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/.vscode/settings.json.tmpl
@@ -1,6 +1,5 @@
 {
     "python.analysis.stubPath": ".vscode",
-    "databricks.python.envFile": "${workspaceFolder}/.env",
     "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
     "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------",
     "python.testing.pytestArgs": [

--- a/libs/template/templates/default-python/template/{{.project_name}}/.vscode/settings.json
+++ b/libs/template/templates/default-python/template/{{.project_name}}/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "python.analysis.stubPath": ".vscode",
-    "databricks.python.envFile": "${workspaceFolder}/.env",
     "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
     "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------",
     "python.testing.pytestArgs": [

--- a/libs/template/templates/default-sql/template/{{.project_name}}/.vscode/settings.json.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/.vscode/settings.json.tmpl
@@ -1,6 +1,5 @@
 {
     "python.analysis.stubPath": ".vscode",
-    "databricks.python.envFile": "${workspaceFolder}/.env",
     "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
     "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------",
     "python.testing.pytestArgs": [


### PR DESCRIPTION
## Changes
VSCode extension no longer uses `databricks.python.envFile ` setting. And older extension versions will use the same default value anyway.

## Tests
None

