### PR TITLE
Refactor initTestTemplate/deployBundle/destroyBundle to not return errors

### DIFF
--- a/integration/bundle/artifacts_test.go
+++ b/integration/bundle/artifacts_test.go
@@ -283,12 +283,11 @@ func TestUploadArtifactToVolumeNotYetDeployed(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	bundleRoot, err := initTestTemplate(t, ctx, "artifact_path_with_volume", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "artifact_path_with_volume", map[string]any{
 		"unique_id":   uuid.New().String(),
 		"schema_name": schemaName,
 		"volume_name": "my_volume",
 	})
-	require.NoError(t, err)
 
 	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
 	stdout, stderr, err := testcli.RequireErrorRun(t, ctx, "bundle", "deploy")

--- a/integration/bundle/artifacts_test.go
+++ b/integration/bundle/artifacts_test.go
@@ -247,12 +247,11 @@ func TestUploadArtifactFileToVolumeThatDoesNotExist(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	bundleRoot, err := initTestTemplate(t, ctx, "artifact_path_with_volume", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "artifact_path_with_volume", map[string]any{
 		"unique_id":   uuid.New().String(),
 		"schema_name": schemaName,
 		"volume_name": "doesnotexist",
 	})
-	require.NoError(t, err)
 
 	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
 	stdout, stderr, err := testcli.RequireErrorRun(t, ctx, "bundle", "deploy")

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -28,14 +28,12 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	// deploy empty bundle
-	err := deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
-	require.NoError(t, err)
+	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 
 	// Remove .databricks directory to simulate a fresh deployment
 	err = os.RemoveAll(filepath.Join(root, ".databricks"))
 	require.NoError(t, err)
 
 	// deploy empty bundle again
-	err = deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
-	require.NoError(t, err)
+	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 }

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -28,7 +28,7 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	// deploy empty bundle
-	err = deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	err := deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 	require.NoError(t, err)
 
 	// Remove .databricks directory to simulate a fresh deployment

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -23,7 +23,7 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		require.NoError(t, destroyBundle(t, ctx, root))
+		destroyBundle(t, ctx, root)
 	})
 
 	// deploy empty bundle

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -30,9 +30,8 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 
 	// Remove .databricks directory to simulate a fresh deployment
-	err = os.RemoveAll(filepath.Join(root, ".databricks"))
-	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(filepath.Join(root, ".databricks")))
 
 	// deploy empty bundle again
-	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	require.NoError(t, deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"}))
 }

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -16,12 +16,11 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	root, err := initTestTemplate(t, ctx, "basic", map[string]any{
+	root := initTestTemplate(t, ctx, "basic", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		err = destroyBundle(t, ctx, root)

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -23,8 +23,7 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, root)
-		require.NoError(t, err)
+		require.NoError(t, destroyBundle(t, ctx, root))
 	})
 
 	// deploy empty bundle

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -27,7 +27,7 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	// deploy empty bundle
-	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	require.NoError(t, deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"}))
 
 	// Remove .databricks directory to simulate a fresh deployment
 	require.NoError(t, os.RemoveAll(filepath.Join(root, ".databricks")))

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -27,11 +27,11 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	// deploy empty bundle
-	require.NoError(t, deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"}))
+	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 
 	// Remove .databricks directory to simulate a fresh deployment
 	require.NoError(t, os.RemoveAll(filepath.Join(root, ".databricks")))
 
 	// deploy empty bundle again
-	require.NoError(t, deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"}))
+	deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 }

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -23,16 +23,16 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, root)
+		err := destroyBundle(t, ctx, root)
 		require.NoError(t, err)
 	})
 
 	// deploy empty bundle
-	err = deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	err := deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 	require.NoError(t, err)
 
 	// Remove .databricks directory to simulate a fresh deployment
-	err = os.RemoveAll(filepath.Join(root, ".databricks"))
+	err := os.RemoveAll(filepath.Join(root, ".databricks"))
 	require.NoError(t, err)
 
 	// deploy empty bundle again

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -23,12 +23,12 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, root)
+		err := destroyBundle(t, ctx, root)
 		require.NoError(t, err)
 	})
 
 	// deploy empty bundle
-	err := deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
+	err = deployBundleWithFlags(t, ctx, root, []string{"--fail-on-active-runs"})
 	require.NoError(t, err)
 
 	// Remove .databricks directory to simulate a fresh deployment

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -32,7 +32,7 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove .databricks directory to simulate a fresh deployment
-	err := os.RemoveAll(filepath.Join(root, ".databricks"))
+	err = os.RemoveAll(filepath.Join(root, ".databricks"))
 	require.NoError(t, err)
 
 	// deploy empty bundle again

--- a/integration/bundle/basic_test.go
+++ b/integration/bundle/basic_test.go
@@ -23,7 +23,7 @@ func TestBasicBundleDeployWithFailOnActiveRuns(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, root)
+		err = destroyBundle(t, ctx, root)
 		require.NoError(t, err)
 	})
 

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -106,7 +106,7 @@ func TestAbortBind(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to bind the resource")
 	assert.ErrorContains(t, err, "This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed")
 
-	deployBundle(t, ctx, bundleRoot)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -84,12 +84,11 @@ func TestAbortBind(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "basic", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "basic", map[string]any{
 		"unique_id":     uniqueId,
 		"spark_version": "13.3.x-scala2.12",
 		"node_type_id":  nodeTypeId,
 	})
-	require.NoError(t, err)
 
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -64,8 +64,7 @@ func TestBindJobToExistingJob(t *testing.T) {
 	err = os.RemoveAll(filepath.Join(bundleRoot, ".databricks"))
 	require.NoError(t, err)
 
-	err = destroyBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	destroyBundle(t, ctx, bundleRoot)
 
 	// Check that job is unbound and exists after bundle is destroyed
 	job, err = w.Jobs.Get(ctx, jobs.GetJobRequest{
@@ -91,9 +90,7 @@ func TestAbortBind(t *testing.T) {
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {
 		gt.destroyJob(ctx, jobId)
-		if err := destroyBundle(t, ctx, bundleRoot); err != nil {
-			t.Error(err)
-		}
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	// Bind should fail because prompting is not possible.

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -43,8 +43,7 @@ func TestBindJobToExistingJob(t *testing.T) {
 	err = os.RemoveAll(filepath.Join(bundleRoot, ".databricks"))
 	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -163,8 +163,7 @@ func TestGenerateAndBind(t *testing.T) {
 
 	deployBundle(t, ctx, bundleRoot)
 
-	err = destroyBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	destroyBundle(t, ctx, bundleRoot)
 
 	// Check that job is bound and does not extsts after bundle is destroyed
 	_, err = w.Jobs.Get(ctx, jobs.GetJobRequest{

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -43,7 +43,7 @@ func TestBindJobToExistingJob(t *testing.T) {
 	err = os.RemoveAll(filepath.Join(bundleRoot, ".databricks"))
 	require.NoError(t, err)
 
-	deployBundle(t, ctx, bundleRoot)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -23,12 +23,11 @@ func TestBindJobToExistingJob(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "basic", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "basic", map[string]any{
 		"unique_id":     uniqueId,
 		"spark_version": "13.3.x-scala2.12",
 		"node_type_id":  nodeTypeId,
 	})
-	require.NoError(t, err)
 
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {
@@ -130,10 +129,9 @@ func TestGenerateAndBind(t *testing.T) {
 	gt := &generateJobTest{T: wt, w: wt.W}
 
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "with_includes", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "with_includes", map[string]any{
 		"unique_id": uniqueId,
 	})
-	require.NoError(t, err)
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -43,7 +43,7 @@ func TestBindJobToExistingJob(t *testing.T) {
 	err = os.RemoveAll(filepath.Join(bundleRoot, ".databricks"))
 	require.NoError(t, err)
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestAbortBind(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to bind the resource")
 	assert.ErrorContains(t, err, "This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed")
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)
@@ -164,8 +164,7 @@ func TestGenerateAndBind(t *testing.T) {
 	_, _, err = c.Run()
 	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	err = destroyBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -36,7 +36,7 @@ func TestBindJobToExistingJob(t *testing.T) {
 
 	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
 	c := testcli.NewRunner(t, ctx, "bundle", "deployment", "bind", "foo", fmt.Sprint(jobId), "--auto-approve")
-	_, _, err = c.Run()
+	_, _, err := c.Run()
 	require.NoError(t, err)
 
 	// Remove .databricks directory to simulate a fresh deployment

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -32,7 +32,6 @@ func TestBindJobToExistingJob(t *testing.T) {
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {
 		gt.destroyJob(ctx, jobId)
-		require.NoError(t, err)
 	})
 
 	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
@@ -93,8 +92,9 @@ func TestAbortBind(t *testing.T) {
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {
 		gt.destroyJob(ctx, jobId)
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		if err := destroyBundle(t, ctx, bundleRoot); err != nil {
+			t.Error(err)
+		}
 	})
 
 	// Bind should fail because prompting is not possible.

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -103,7 +103,7 @@ func TestAbortBind(t *testing.T) {
 	c := testcli.NewRunner(t, ctx, "bundle", "deployment", "bind", "foo", fmt.Sprint(jobId))
 
 	// Expect error suggesting to use --auto-approve
-	_, _, err = c.Run()
+	_, _, err := c.Run()
 	assert.ErrorContains(t, err, "failed to bind the resource")
 	assert.ErrorContains(t, err, "This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed")
 

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -106,8 +106,7 @@ func TestAbortBind(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to bind the resource")
 	assert.ErrorContains(t, err, "This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed")
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	w, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)

--- a/integration/bundle/clusters_test.go
+++ b/integration/bundle/clusters_test.go
@@ -27,8 +27,7 @@ func TestDeployBundleWithCluster(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, root)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, root)
 
 		cluster, err := wt.W.Clusters.GetByClusterName(ctx, fmt.Sprintf("test-cluster-%s", uniqueId))
 		if err != nil {

--- a/integration/bundle/clusters_test.go
+++ b/integration/bundle/clusters_test.go
@@ -38,8 +38,7 @@ func TestDeployBundleWithCluster(t *testing.T) {
 		}
 	})
 
-	err := deployBundle(t, ctx, root)
-	require.NoError(t, err)
+	deployBundle(t, ctx, root)
 
 	// Cluster should exists after bundle deployment
 	cluster, err := wt.W.Clusters.GetByClusterName(ctx, fmt.Sprintf("test-cluster-%s", uniqueId))

--- a/integration/bundle/clusters_test.go
+++ b/integration/bundle/clusters_test.go
@@ -20,7 +20,7 @@ func TestDeployBundleWithCluster(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	root, err := initTestTemplate(t, ctx, "clusters", map[string]any{
+	root := initTestTemplate(t, ctx, "clusters", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,

--- a/integration/bundle/clusters_test.go
+++ b/integration/bundle/clusters_test.go
@@ -25,10 +25,9 @@ func TestDeployBundleWithCluster(t *testing.T) {
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, root)
+		err := destroyBundle(t, ctx, root)
 		require.NoError(t, err)
 
 		cluster, err := wt.W.Clusters.GetByClusterName(ctx, fmt.Sprintf("test-cluster-%s", uniqueId))
@@ -39,7 +38,7 @@ func TestDeployBundleWithCluster(t *testing.T) {
 		}
 	})
 
-	err = deployBundle(t, ctx, root)
+	err := deployBundle(t, ctx, root)
 	require.NoError(t, err)
 
 	// Cluster should exists after bundle deployment

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -57,6 +57,6 @@ func TestDashboards(t *testing.T) {
 	assert.Contains(t, stdout, `Error: dashboard "file_reference" has been modified remotely`+"\n")
 
 	// Redeploy the bundle with the --force flag and confirm that the out of band modification is ignored.
-	_, stderr = deployBundleWithArgs(t, ctx, root, "--force")
+	_, stderr := deployBundleWithArgs(t, ctx, root, "--force")
 	assert.Contains(t, stderr, `Deployment complete!`+"\n")
 }

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -53,12 +53,10 @@ func TestDashboards(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to redeploy the bundle and confirm that the out of band modification is detected.
-	stdout, _, err := deployBundleWithArgs(t, ctx, root)
-	require.Error(t, err)
+	stdout, _ := deployBundleWithArgs(t, ctx, root)
 	assert.Contains(t, stdout, `Error: dashboard "file_reference" has been modified remotely`+"\n")
 
 	// Redeploy the bundle with the --force flag and confirm that the out of band modification is ignored.
-	_, stderr, err := deployBundleWithArgs(t, ctx, root, "--force")
-	require.NoError(t, err)
+	_, stderr = deployBundleWithArgs(t, ctx, root, "--force")
 	assert.Contains(t, stderr, `Deployment complete!`+"\n")
 }

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -28,8 +28,7 @@ func TestDashboards(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	err := deployBundle(t, ctx, root)
-	require.NoError(t, err)
+	deployBundle(t, ctx, root)
 
 	// Load bundle configuration by running the validate command.
 	b := unmarshalConfig(t, mustValidateBundle(t, ctx, root))

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -24,8 +24,7 @@ func TestDashboards(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, root)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, root)
 	})
 
 	deployBundle(t, ctx, root)

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -18,7 +18,7 @@ func TestDashboards(t *testing.T) {
 
 	warehouseID := testutil.GetEnvOrSkipTest(t, "TEST_DEFAULT_WAREHOUSE_ID")
 	uniqueID := uuid.New().String()
-	root, err := initTestTemplate(t, ctx, "dashboards", map[string]any{
+	root := initTestTemplate(t, ctx, "dashboards", map[string]any{
 		"unique_id":    uniqueID,
 		"warehouse_id": warehouseID,
 	})

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -22,14 +22,13 @@ func TestDashboards(t *testing.T) {
 		"unique_id":    uniqueID,
 		"warehouse_id": warehouseID,
 	})
-	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, root)
+		err := destroyBundle(t, ctx, root)
 		require.NoError(t, err)
 	})
 
-	err = deployBundle(t, ctx, root)
+	err := deployBundle(t, ctx, root)
 	require.NoError(t, err)
 
 	// Load bundle configuration by running the validate command.

--- a/integration/bundle/dashboards_test.go
+++ b/integration/bundle/dashboards_test.go
@@ -52,7 +52,8 @@ func TestDashboards(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to redeploy the bundle and confirm that the out of band modification is detected.
-	stdout, _ := deployBundleWithArgs(t, ctx, root)
+	stdout, _, err := deployBundleWithArgsErr(t, ctx, root)
+	require.Error(t, err)
 	assert.Contains(t, stdout, `Error: dashboard "file_reference" has been modified remotely`+"\n")
 
 	// Redeploy the bundle with the --force flag and confirm that the out of band modification is ignored.

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -29,7 +29,7 @@ func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.Worksp
 		"unique_id": uniqueId,
 	})
 
-	deployBundle(t, ctx, bundleRoot)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -181,7 +181,7 @@ func TestBundlePipelineRecreateWithoutAutoApprove(t *testing.T) {
 		"unique_id": uniqueId,
 	})
 
-	err := deployBundle(t, ctx, bundleRoot)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -183,8 +183,7 @@ func TestBundlePipelineRecreateWithoutAutoApprove(t *testing.T) {
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	// Assert the pipeline is created
@@ -220,8 +219,7 @@ func TestDeployBasicBundleLogs(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, root)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, root)
 	})
 
 	currentUser, err := wt.W.CurrentUser.Me(ctx)

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.WorkspaceClient, uniqueId string) string {
-	bundleRoot, err := initTestTemplate(t, ctx, "uc_schema", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "uc_schema", map[string]any{
 		"unique_id": uniqueId,
 	})
 	require.NoError(t, err)

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -28,9 +28,8 @@ func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.Worksp
 	bundleRoot := initTestTemplate(t, ctx, "uc_schema", map[string]any{
 		"unique_id": uniqueId,
 	})
-	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -135,7 +134,7 @@ func TestBundlePipelineDeleteWithoutAutoApprove(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "deploy_then_remove_resources", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "deploy_then_remove_resources", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
@@ -182,7 +181,7 @@ func TestBundlePipelineRecreateWithoutAutoApprove(t *testing.T) {
 	w := wt.W
 	uniqueId := uuid.New().String()
 
-	bundleRoot, err := initTestTemplate(t, ctx, "recreate_pipeline", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "recreate_pipeline", map[string]any{
 		"unique_id": uniqueId,
 	})
 	require.NoError(t, err)
@@ -221,7 +220,7 @@ func TestDeployBasicBundleLogs(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	root, err := initTestTemplate(t, ctx, "basic", map[string]any{
+	root := initTestTemplate(t, ctx, "basic", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -32,8 +32,7 @@ func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.Worksp
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	// Assert the schema is created

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -29,8 +29,7 @@ func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.Worksp
 		"unique_id": uniqueId,
 	})
 
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)
@@ -96,8 +95,7 @@ func TestBundleDeployUcSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	// Redeploy the bundle
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	// Assert the schema is deleted
 	_, err = w.Schemas.GetByFullName(ctx, strings.Join([]string{catalogName, schemaName}, "."))

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -247,12 +247,11 @@ func TestDeployUcVolume(t *testing.T) {
 	w := wt.W
 
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "volume", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "volume", map[string]any{
 		"unique_id": uniqueId,
 	})
-	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -29,7 +29,7 @@ func setupUcSchemaBundle(t *testing.T, ctx context.Context, w *databricks.Worksp
 		"unique_id": uniqueId,
 	})
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)
@@ -181,8 +181,7 @@ func TestBundlePipelineRecreateWithoutAutoApprove(t *testing.T) {
 		"unique_id": uniqueId,
 	})
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)
@@ -248,7 +247,7 @@ func TestDeployUcVolume(t *testing.T) {
 		"unique_id": uniqueId,
 	})
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -248,8 +248,7 @@ func TestDeployUcVolume(t *testing.T) {
 		"unique_id": uniqueId,
 	})
 
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -139,8 +139,7 @@ func TestBundlePipelineDeleteWithoutAutoApprove(t *testing.T) {
 	})
 
 	// deploy pipeline
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	// assert pipeline is created
 	pipelineName := "test-bundle-pipeline-" + uniqueId

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -139,10 +139,9 @@ func TestBundlePipelineDeleteWithoutAutoApprove(t *testing.T) {
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	// deploy pipeline
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	// assert pipeline is created
@@ -184,9 +183,8 @@ func TestBundlePipelineRecreateWithoutAutoApprove(t *testing.T) {
 	bundleRoot := initTestTemplate(t, ctx, "recreate_pipeline", map[string]any{
 		"unique_id": uniqueId,
 	})
-	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -225,10 +223,9 @@ func TestDeployBasicBundleLogs(t *testing.T) {
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, root)
+		err := destroyBundle(t, ctx, root)
 		require.NoError(t, err)
 	})
 

--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -247,8 +247,7 @@ func TestDeployUcVolume(t *testing.T) {
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	// Assert the volume is created successfully

--- a/integration/bundle/deploy_then_remove_resources_test.go
+++ b/integration/bundle/deploy_then_remove_resources_test.go
@@ -18,7 +18,7 @@ func TestBundleDeployThenRemoveResources(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "deploy_then_remove_resources", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "deploy_then_remove_resources", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,

--- a/integration/bundle/deploy_then_remove_resources_test.go
+++ b/integration/bundle/deploy_then_remove_resources_test.go
@@ -23,10 +23,9 @@ func TestBundleDeployThenRemoveResources(t *testing.T) {
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	// deploy pipeline
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	// assert pipeline is created

--- a/integration/bundle/deploy_then_remove_resources_test.go
+++ b/integration/bundle/deploy_then_remove_resources_test.go
@@ -25,8 +25,7 @@ func TestBundleDeployThenRemoveResources(t *testing.T) {
 	})
 
 	// deploy pipeline
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	// assert pipeline is created
 	pipelineName := "test-bundle-pipeline-" + uniqueId
@@ -45,8 +44,7 @@ func TestBundleDeployThenRemoveResources(t *testing.T) {
 	require.NoError(t, err)
 
 	// deploy again
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	// assert pipeline is deleted
 	_, err = w.Pipelines.GetByName(ctx, pipelineName)

--- a/integration/bundle/deploy_then_remove_resources_test.go
+++ b/integration/bundle/deploy_then_remove_resources_test.go
@@ -55,7 +55,6 @@ func TestBundleDeployThenRemoveResources(t *testing.T) {
 	assert.ErrorContains(t, err, "does not exist")
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 }

--- a/integration/bundle/deploy_to_shared_test.go
+++ b/integration/bundle/deploy_to_shared_test.go
@@ -32,6 +32,5 @@ func TestDeployBasicToSharedWorkspacePath(t *testing.T) {
 		require.NoError(wt, err)
 	})
 
-	err = deployBundle(wt, ctx, bundleRoot)
-	require.NoError(wt, err)
+	deployBundle(wt, ctx, bundleRoot)
 }

--- a/integration/bundle/deploy_to_shared_test.go
+++ b/integration/bundle/deploy_to_shared_test.go
@@ -19,7 +19,7 @@ func TestDeployBasicToSharedWorkspacePath(t *testing.T) {
 	currentUser, err := wt.W.CurrentUser.Me(ctx)
 	require.NoError(t, err)
 
-	bundleRoot, err := initTestTemplate(t, ctx, "basic", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "basic", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,

--- a/integration/bundle/deploy_to_shared_test.go
+++ b/integration/bundle/deploy_to_shared_test.go
@@ -28,8 +28,7 @@ func TestDeployBasicToSharedWorkspacePath(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		err = destroyBundle(wt, ctx, bundleRoot)
-		require.NoError(wt, err)
+		destroyBundle(wt, ctx, bundleRoot)
 	})
 
 	deployBundle(wt, ctx, bundleRoot)

--- a/integration/bundle/deploy_to_shared_test.go
+++ b/integration/bundle/deploy_to_shared_test.go
@@ -25,7 +25,6 @@ func TestDeployBasicToSharedWorkspacePath(t *testing.T) {
 		"spark_version": defaultSparkVersion,
 		"root_path":     fmt.Sprintf("/Shared/%s", currentUser.UserName),
 	})
-	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		destroyBundle(wt, ctx, bundleRoot)

--- a/integration/bundle/deployment_state_test.go
+++ b/integration/bundle/deployment_state_test.go
@@ -39,7 +39,7 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	err = os.WriteFile(filepath.Join(bundleRoot, "notebook.py"), []byte("# Databricks notebook source\nHello, World!"), 0o644)
 	require.NoError(t, err)
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
@@ -78,7 +78,7 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	err = os.WriteFile(filepath.Join(bundleRoot, "test_to_modify.py"), []byte("print('Modified!')"), 0o644)
 	require.NoError(t, err)
 
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	// Check that removed file is not in workspace anymore
 	_, err = w.Workspace.GetStatusByPath(ctx, path.Join(remoteRoot, "files", "test.py"))

--- a/integration/bundle/deployment_state_test.go
+++ b/integration/bundle/deployment_state_test.go
@@ -39,7 +39,7 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	err = os.WriteFile(filepath.Join(bundleRoot, "notebook.py"), []byte("# Databricks notebook source\nHello, World!"), 0o644)
 	require.NoError(t, err)
 
-	deployBundle(t, ctx, bundleRoot)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	t.Cleanup(func() {
 		require.NoError(t, destroyBundle(t, ctx, bundleRoot))

--- a/integration/bundle/deployment_state_test.go
+++ b/integration/bundle/deployment_state_test.go
@@ -20,17 +20,16 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "basic", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "basic", map[string]any{
 		"unique_id":     uniqueId,
 		"spark_version": "13.3.x-scala2.12",
 		"node_type_id":  nodeTypeId,
 	})
-	require.NoError(t, err)
 
 	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
 
 	// Add some test file to the bundle
-	err = os.WriteFile(filepath.Join(bundleRoot, "test.py"), []byte("print('Hello, World!')"), 0o644)
+	err := os.WriteFile(filepath.Join(bundleRoot, "test.py"), []byte("print('Hello, World!')"), 0o644)
 	require.NoError(t, err)
 
 	err = os.WriteFile(filepath.Join(bundleRoot, "test_to_modify.py"), []byte("print('Hello, World!')"), 0o644)

--- a/integration/bundle/deployment_state_test.go
+++ b/integration/bundle/deployment_state_test.go
@@ -42,7 +42,7 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	remoteRoot := getBundleRemoteRootPath(w, t, uniqueId)

--- a/integration/bundle/deployment_state_test.go
+++ b/integration/bundle/deployment_state_test.go
@@ -39,8 +39,7 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	err = os.WriteFile(filepath.Join(bundleRoot, "notebook.py"), []byte("# Databricks notebook source\nHello, World!"), 0o644)
 	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		require.NoError(t, destroyBundle(t, ctx, bundleRoot))

--- a/integration/bundle/deployment_state_test.go
+++ b/integration/bundle/deployment_state_test.go
@@ -78,8 +78,7 @@ func TestFilesAreSyncedCorrectlyWhenNoSnapshot(t *testing.T) {
 	err = os.WriteFile(filepath.Join(bundleRoot, "test_to_modify.py"), []byte("print('Modified!')"), 0o644)
 	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	// Check that removed file is not in workspace anymore
 	_, err = w.Workspace.GetStatusByPath(ctx, path.Join(remoteRoot, "files", "test.py"))

--- a/integration/bundle/destroy_test.go
+++ b/integration/bundle/destroy_test.go
@@ -33,8 +33,7 @@ func TestBundleDestroy(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	// deploy resources
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	// Assert the snapshot file exists
 	entries, err := os.ReadDir(snapshotsDir)

--- a/integration/bundle/destroy_test.go
+++ b/integration/bundle/destroy_test.go
@@ -58,8 +58,7 @@ func TestBundleDestroy(t *testing.T) {
 	assert.Equal(t, job.Settings.Name, jobName)
 
 	// destroy bundle
-	err = destroyBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	destroyBundle(t, ctx, bundleRoot)
 
 	// assert pipeline is deleted
 	_, err = w.Pipelines.GetByName(ctx, pipelineName)

--- a/integration/bundle/destroy_test.go
+++ b/integration/bundle/destroy_test.go
@@ -20,17 +20,16 @@ func TestBundleDestroy(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "deploy_then_remove_resources", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "deploy_then_remove_resources", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	snapshotsDir := filepath.Join(bundleRoot, ".databricks", "bundle", "default", "sync-snapshots")
 
 	// Assert the snapshot file does not exist
-	_, err = os.ReadDir(snapshotsDir)
+	_, err := os.ReadDir(snapshotsDir)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	// deploy resources

--- a/integration/bundle/empty_bundle_test.go
+++ b/integration/bundle/empty_bundle_test.go
@@ -26,8 +26,7 @@ func TestEmptyBundleDeploy(t *testing.T) {
 	f.Close()
 
 	// deploy empty bundle
-	err = deployBundle(t, ctx, tmpDir)
-	require.NoError(t, err)
+	deployBundle(t, ctx, tmpDir)
 
 	t.Cleanup(func() {
 		err = destroyBundle(t, ctx, tmpDir)

--- a/integration/bundle/empty_bundle_test.go
+++ b/integration/bundle/empty_bundle_test.go
@@ -29,7 +29,6 @@ func TestEmptyBundleDeploy(t *testing.T) {
 	deployBundle(t, ctx, tmpDir)
 
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, tmpDir)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, tmpDir)
 	})
 }

--- a/integration/bundle/environments_test.go
+++ b/integration/bundle/environments_test.go
@@ -17,8 +17,7 @@ func TestPythonWheelTaskWithEnvironmentsDeployAndRun(t *testing.T) {
 		"unique_id": uuid.New().String(),
 	})
 
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)

--- a/integration/bundle/environments_test.go
+++ b/integration/bundle/environments_test.go
@@ -13,12 +13,11 @@ func TestPythonWheelTaskWithEnvironmentsDeployAndRun(t *testing.T) {
 
 	ctx, _ := acc.WorkspaceTest(t)
 
-	bundleRoot, err := initTestTemplate(t, ctx, "python_wheel_task_with_environments", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "python_wheel_task_with_environments", map[string]any{
 		"unique_id": uuid.New().String(),
 	})
-	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/integration/bundle/environments_test.go
+++ b/integration/bundle/environments_test.go
@@ -20,8 +20,7 @@ func TestPythonWheelTaskWithEnvironmentsDeployAndRun(t *testing.T) {
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "some_other_job")

--- a/integration/bundle/generate_job_test.go
+++ b/integration/bundle/generate_job_test.go
@@ -61,8 +61,7 @@ func TestGenerateFromExistingJobAndDeploy(t *testing.T) {
 	require.Contains(t, generatedYaml, "spark_version: 13.3.x-scala2.12")
 	require.Contains(t, generatedYaml, "num_workers: 1")
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	err = destroyBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)

--- a/integration/bundle/generate_job_test.go
+++ b/integration/bundle/generate_job_test.go
@@ -63,8 +63,7 @@ func TestGenerateFromExistingJobAndDeploy(t *testing.T) {
 
 	deployBundle(t, ctx, bundleRoot)
 
-	err = destroyBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	destroyBundle(t, ctx, bundleRoot)
 }
 
 type generateJobTest struct {

--- a/integration/bundle/generate_job_test.go
+++ b/integration/bundle/generate_job_test.go
@@ -26,10 +26,9 @@ func TestGenerateFromExistingJobAndDeploy(t *testing.T) {
 	gt := &generateJobTest{T: wt, w: wt.W}
 
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "with_includes", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "with_includes", map[string]any{
 		"unique_id": uniqueId,
 	})
-	require.NoError(t, err)
 
 	jobId := gt.createTestJob(ctx)
 	t.Cleanup(func() {
@@ -41,7 +40,7 @@ func TestGenerateFromExistingJobAndDeploy(t *testing.T) {
 		"--existing-job-id", fmt.Sprint(jobId),
 		"--config-dir", filepath.Join(bundleRoot, "resources"),
 		"--source-dir", filepath.Join(bundleRoot, "src"))
-	_, _, err = c.Run()
+	_, _, err := c.Run()
 	require.NoError(t, err)
 
 	_, err = os.Stat(filepath.Join(bundleRoot, "src", "test.py"))

--- a/integration/bundle/generate_pipeline_test.go
+++ b/integration/bundle/generate_pipeline_test.go
@@ -25,10 +25,9 @@ func TestGenerateFromExistingPipelineAndDeploy(t *testing.T) {
 	gt := &generatePipelineTest{T: wt, w: wt.W}
 
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "with_includes", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "with_includes", map[string]any{
 		"unique_id": uniqueId,
 	})
-	require.NoError(t, err)
 
 	pipelineId, name := gt.createTestPipeline(ctx)
 	t.Cleanup(func() {
@@ -40,7 +39,7 @@ func TestGenerateFromExistingPipelineAndDeploy(t *testing.T) {
 		"--existing-pipeline-id", fmt.Sprint(pipelineId),
 		"--config-dir", filepath.Join(bundleRoot, "resources"),
 		"--source-dir", filepath.Join(bundleRoot, "src"))
-	_, _, err = c.Run()
+	_, _, err := c.Run()
 	require.NoError(t, err)
 
 	_, err = os.Stat(filepath.Join(bundleRoot, "src", "notebook.py"))

--- a/integration/bundle/generate_pipeline_test.go
+++ b/integration/bundle/generate_pipeline_test.go
@@ -69,8 +69,7 @@ func TestGenerateFromExistingPipelineAndDeploy(t *testing.T) {
 	require.Contains(t, generatedYaml, "- file:")
 	require.Contains(t, generatedYaml, fmt.Sprintf("path: %s", filepath.Join("..", "src", "test.py")))
 
-	err = deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	err = destroyBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)

--- a/integration/bundle/generate_pipeline_test.go
+++ b/integration/bundle/generate_pipeline_test.go
@@ -71,8 +71,7 @@ func TestGenerateFromExistingPipelineAndDeploy(t *testing.T) {
 
 	deployBundle(t, ctx, bundleRoot)
 
-	err = destroyBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	destroyBundle(t, ctx, bundleRoot)
 }
 
 type generatePipelineTest struct {

--- a/integration/bundle/helpers_test.go
+++ b/integration/bundle/helpers_test.go
@@ -80,28 +80,35 @@ func unmarshalConfig(t testutil.TestingT, data []byte) *bundle.Bundle {
 	return bundle
 }
 
-func deployBundle(t testutil.TestingT, ctx context.Context, path string) error {
+func deployBundle(t testutil.TestingT, ctx context.Context, path string) {
 	ctx = env.Set(ctx, "BUNDLE_ROOT", path)
 	c := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve")
 	_, _, err := c.Run()
-	return err
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
-func deployBundleWithArgs(t testutil.TestingT, ctx context.Context, path string, args ...string) (string, string, error) {
+func deployBundleWithArgs(t testutil.TestingT, ctx context.Context, path string, args ...string) (string, string) {
 	ctx = env.Set(ctx, "BUNDLE_ROOT", path)
 	args = append([]string{"bundle", "deploy"}, args...)
 	c := testcli.NewRunner(t, ctx, args...)
 	stdout, stderr, err := c.Run()
-	return stdout.String(), stderr.String(), err
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stdout.String(), stderr.String()
 }
 
-func deployBundleWithFlags(t testutil.TestingT, ctx context.Context, path string, flags []string) error {
+func deployBundleWithFlags(t testutil.TestingT, ctx context.Context, path string, flags []string) {
 	ctx = env.Set(ctx, "BUNDLE_ROOT", path)
 	args := []string{"bundle", "deploy", "--force-lock"}
 	args = append(args, flags...)
 	c := testcli.NewRunner(t, ctx, args...)
 	_, _, err := c.Run()
-	return err
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func runResource(t testutil.TestingT, ctx context.Context, path, key string) (string, error) {

--- a/integration/bundle/helpers_test.go
+++ b/integration/bundle/helpers_test.go
@@ -132,11 +132,11 @@ func runResourceWithParams(t testutil.TestingT, ctx context.Context, path, key s
 	return stdout.String(), err
 }
 
-func destroyBundle(t testutil.TestingT, ctx context.Context, path string) error {
+func destroyBundle(t testutil.TestingT, ctx context.Context, path string) {
 	ctx = env.Set(ctx, "BUNDLE_ROOT", path)
 	c := testcli.NewRunner(t, ctx, "bundle", "destroy", "--auto-approve")
 	_, _, err := c.Run()
-	return err
+	require.NoError(t, err)
 }
 
 func getBundleRemoteRootPath(w *databricks.WorkspaceClient, t testutil.TestingT, uniqueId string) string {

--- a/integration/bundle/helpers_test.go
+++ b/integration/bundle/helpers_test.go
@@ -84,9 +84,7 @@ func deployBundle(t testutil.TestingT, ctx context.Context, path string) {
 	ctx = env.Set(ctx, "BUNDLE_ROOT", path)
 	c := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve")
 	_, _, err := c.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func deployBundleWithArgs(t testutil.TestingT, ctx context.Context, path string, args ...string) (string, string) {
@@ -94,9 +92,7 @@ func deployBundleWithArgs(t testutil.TestingT, ctx context.Context, path string,
 	args = append([]string{"bundle", "deploy"}, args...)
 	c := testcli.NewRunner(t, ctx, args...)
 	stdout, stderr, err := c.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	return stdout.String(), stderr.String()
 }
 
@@ -106,9 +102,7 @@ func deployBundleWithFlags(t testutil.TestingT, ctx context.Context, path string
 	args = append(args, flags...)
 	c := testcli.NewRunner(t, ctx, args...)
 	_, _, err := c.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func runResource(t testutil.TestingT, ctx context.Context, path, key string) (string, error) {

--- a/integration/bundle/helpers_test.go
+++ b/integration/bundle/helpers_test.go
@@ -87,13 +87,18 @@ func deployBundle(t testutil.TestingT, ctx context.Context, path string) {
 	require.NoError(t, err)
 }
 
-func deployBundleWithArgs(t testutil.TestingT, ctx context.Context, path string, args ...string) (string, string) {
+func deployBundleWithArgsErr(t testutil.TestingT, ctx context.Context, path string, args ...string) (string, string, error) {
 	ctx = env.Set(ctx, "BUNDLE_ROOT", path)
 	args = append([]string{"bundle", "deploy"}, args...)
 	c := testcli.NewRunner(t, ctx, args...)
 	stdout, stderr, err := c.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func deployBundleWithArgs(t testutil.TestingT, ctx context.Context, path string, args ...string) (string, string) {
+	stdout, stderr, err := deployBundleWithArgsErr(t, ctx, path, args...)
 	require.NoError(t, err)
-	return stdout.String(), stderr.String()
+	return stdout, stderr
 }
 
 func deployBundleWithFlags(t testutil.TestingT, ctx context.Context, path string, flags []string) {

--- a/integration/bundle/job_metadata_test.go
+++ b/integration/bundle/job_metadata_test.go
@@ -31,8 +31,7 @@ func TestJobsMetadataFile(t *testing.T) {
 	})
 
 	// deploy bundle
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	// Cleanup the deployed bundle
 	t.Cleanup(func() {

--- a/integration/bundle/job_metadata_test.go
+++ b/integration/bundle/job_metadata_test.go
@@ -31,12 +31,11 @@ func TestJobsMetadataFile(t *testing.T) {
 	})
 
 	// deploy bundle
-	deployBundle(t, ctx, bundleRoot)
+	require.NoError(t, deployBundle(t, ctx, bundleRoot))
 
 	// Cleanup the deployed bundle
 	t.Cleanup(func() {
-		err = destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
 	})
 
 	// assert job 1 is created

--- a/integration/bundle/job_metadata_test.go
+++ b/integration/bundle/job_metadata_test.go
@@ -24,15 +24,14 @@ func TestJobsMetadataFile(t *testing.T) {
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
-	bundleRoot, err := initTestTemplate(t, ctx, "job_metadata", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "job_metadata", map[string]any{
 		"unique_id":     uniqueId,
 		"node_type_id":  nodeTypeId,
 		"spark_version": defaultSparkVersion,
 	})
-	require.NoError(t, err)
 
 	// deploy bundle
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	// Cleanup the deployed bundle

--- a/integration/bundle/job_metadata_test.go
+++ b/integration/bundle/job_metadata_test.go
@@ -31,7 +31,7 @@ func TestJobsMetadataFile(t *testing.T) {
 	})
 
 	// deploy bundle
-	require.NoError(t, deployBundle(t, ctx, bundleRoot))
+	deployBundle(t, ctx, bundleRoot)
 
 	// Cleanup the deployed bundle
 	t.Cleanup(func() {

--- a/integration/bundle/job_metadata_test.go
+++ b/integration/bundle/job_metadata_test.go
@@ -35,7 +35,7 @@ func TestJobsMetadataFile(t *testing.T) {
 
 	// Cleanup the deployed bundle
 	t.Cleanup(func() {
-		require.NoError(t, destroyBundle(t, ctx, bundleRoot))
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	// assert job 1 is created

--- a/integration/bundle/local_state_staleness_test.go
+++ b/integration/bundle/local_state_staleness_test.go
@@ -47,16 +47,13 @@ func TestLocalStateStaleness(t *testing.T) {
 	bundleB := initialize()
 
 	// 1) Deploy bundle A
-	err = deployBundle(t, ctx, bundleA)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleA)
 
 	// 2) Deploy bundle B
-	err = deployBundle(t, ctx, bundleB)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleB)
 
 	// 3) Deploy bundle A again
-	err = deployBundle(t, ctx, bundleA)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleA)
 
 	// Assert that there is only a single job in the workspace corresponding to this bundle.
 	iter := w.Jobs.List(context.Background(), jobs.ListJobsRequest{

--- a/integration/bundle/local_state_staleness_test.go
+++ b/integration/bundle/local_state_staleness_test.go
@@ -27,15 +27,14 @@ func TestLocalStateStaleness(t *testing.T) {
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()
 	initialize := func() string {
-		root, err := initTestTemplate(t, ctx, "basic", map[string]any{
+		root := initTestTemplate(t, ctx, "basic", map[string]any{
 			"unique_id":     uniqueId,
 			"node_type_id":  nodeTypeId,
 			"spark_version": defaultSparkVersion,
 		})
-		require.NoError(t, err)
 
 		t.Cleanup(func() {
-			err = destroyBundle(t, ctx, root)
+			err := destroyBundle(t, ctx, root)
 			require.NoError(t, err)
 		})
 

--- a/integration/bundle/local_state_staleness_test.go
+++ b/integration/bundle/local_state_staleness_test.go
@@ -34,8 +34,7 @@ func TestLocalStateStaleness(t *testing.T) {
 		})
 
 		t.Cleanup(func() {
-			err := destroyBundle(t, ctx, root)
-			require.NoError(t, err)
+			destroyBundle(t, ctx, root)
 		})
 
 		return root

--- a/integration/bundle/python_wheel_test.go
+++ b/integration/bundle/python_wheel_test.go
@@ -26,8 +26,7 @@ func runPythonWheelTest(t *testing.T, templateName, sparkVersion string, pythonW
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "some_other_job")

--- a/integration/bundle/python_wheel_test.go
+++ b/integration/bundle/python_wheel_test.go
@@ -15,16 +15,15 @@ func runPythonWheelTest(t *testing.T, templateName, sparkVersion string, pythonW
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	instancePoolId := env.Get(ctx, "TEST_INSTANCE_POOL_ID")
-	bundleRoot, err := initTestTemplate(t, ctx, templateName, map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, templateName, map[string]any{
 		"node_type_id":         nodeTypeId,
 		"unique_id":            uuid.New().String(),
 		"spark_version":        sparkVersion,
 		"python_wheel_wrapper": pythonWheelWrapper,
 		"instance_pool_id":     instancePoolId,
 	})
-	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/integration/bundle/python_wheel_test.go
+++ b/integration/bundle/python_wheel_test.go
@@ -23,8 +23,7 @@ func runPythonWheelTest(t *testing.T, templateName, sparkVersion string, pythonW
 		"instance_pool_id":     instancePoolId,
 	})
 
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)

--- a/integration/bundle/spark_jar_test.go
+++ b/integration/bundle/spark_jar_test.go
@@ -24,8 +24,7 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion, arti
 		"instance_pool_id": instancePoolId,
 	}, tmpDir)
 
-	err := deployBundle(t, ctx, bundleRoot)
-	require.NoError(t, err)
+	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
 		err := destroyBundle(t, ctx, bundleRoot)

--- a/integration/bundle/spark_jar_test.go
+++ b/integration/bundle/spark_jar_test.go
@@ -27,8 +27,7 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion, arti
 	deployBundle(t, ctx, bundleRoot)
 
 	t.Cleanup(func() {
-		err := destroyBundle(t, ctx, bundleRoot)
-		require.NoError(t, err)
+		destroyBundle(t, ctx, bundleRoot)
 	})
 
 	out, err := runResource(t, ctx, bundleRoot, "jar_job")

--- a/integration/bundle/spark_jar_test.go
+++ b/integration/bundle/spark_jar_test.go
@@ -15,7 +15,7 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion, arti
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	tmpDir := t.TempDir()
 	instancePoolId := env.Get(ctx, "TEST_INSTANCE_POOL_ID")
-	bundleRoot, err := initTestTemplateWithBundleRoot(t, ctx, "spark_jar_task", map[string]any{
+	bundleRoot := initTestTemplateWithBundleRoot(t, ctx, "spark_jar_task", map[string]any{
 		"node_type_id":     nodeTypeId,
 		"unique_id":        uuid.New().String(),
 		"spark_version":    sparkVersion,
@@ -23,9 +23,8 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion, arti
 		"artifact_path":    artifactPath,
 		"instance_pool_id": instancePoolId,
 	}, tmpDir)
-	require.NoError(t, err)
 
-	err = deployBundle(t, ctx, bundleRoot)
+	err := deployBundle(t, ctx, bundleRoot)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Changes
These test helpers were updated to handle the error internally and not return it. Since they have testing.T object, they can do so directly. On the caller side, this functions were always followed by require.NoError(t, err), that was cleaned up.

This approach helps reduce the setup/teardown boilerplate in the test cases.

## Tests
Existing tests.

