### PR TITLE
Fix testutil.RandomName to use the full character set

### DIFF
--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -23,7 +23,7 @@ func RandomName(prefix ...string) string {
 	randLen := 12
 	b := make([]byte, randLen)
 	for i := range b {
-		b[i] = charset[rand.Intn(randLen)]
+		b[i] = charset[rand.Intn(len(charset))]
 	}
 	if len(prefix) > 0 {
 		return fmt.Sprintf("%s%s", strings.Join(prefix, ""), b)


### PR DESCRIPTION
## Changes
It was using first 12 chars, that does not seem intended.

## Tests
Existing tests.
