### PR TITLE
Fixed downloading arm64 binaries

### DIFF
--- a/internal/bugbash/exec.sh
+++ b/internal/bugbash/exec.sh
@@ -31,7 +31,7 @@ function cli_snapshot_directory() {
         dir="${dir}_386"
         ;;
     arm64|aarch64)
-        dir="${dir}_arm64"
+        dir="${dir}_arm64_v8.0"
         ;;
     armv7l|armv8l)
         dir="${dir}_arm_6"


### PR DESCRIPTION
## Changes
Fixed downloading arm64 binaries

Go 1.23 changed the way built binaries are prefixed on amd64, more details here: https://tip.golang.org/doc/go1.23#arm64
