### PR TITLE
Skip job runs during integration testing for PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,6 @@ vendor:
 	@go mod vendor
 
 integration:
-	gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./integration/..." -- -parallel 4 -timeout=2h
+	gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./integration/..." -- -parallel 4 -timeout=2h -short
 
 .PHONY: fmt lint lintcheck test testonly coverage build snapshot vendor integration

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,12 @@ vendor:
 	@echo "✓ Filling vendor folder with library code ..."
 	@go mod vendor
 
-integration:
-	gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./integration/..." -- -parallel 4 -timeout=2h -short
+INTEGRATION = gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./integration/..." -- -parallel 4 -timeout=2h
 
-.PHONY: fmt lint lintcheck test testonly coverage build snapshot vendor integration
+integration:
+	$(INTEGRATION)
+
+integration-short:
+	$(INTEGRATION) -short
+
+.PHONY: fmt lint lintcheck test testonly coverage build snapshot vendor integration integration-short

--- a/integration/bundle/clusters_test.go
+++ b/integration/bundle/clusters_test.go
@@ -44,6 +44,11 @@ func TestDeployBundleWithCluster(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cluster)
 
+	if testing.Short() {
+		t.Log("Skip the job run in short mode")
+		return
+	}
+
 	out, err := runResource(t, ctx, root, "foo")
 	require.NoError(t, err)
 	require.Contains(t, out, "Hello World!")

--- a/integration/bundle/python_wheel_test.go
+++ b/integration/bundle/python_wheel_test.go
@@ -29,6 +29,11 @@ func runPythonWheelTest(t *testing.T, templateName, sparkVersion string, pythonW
 		destroyBundle(t, ctx, bundleRoot)
 	})
 
+	if testing.Short() {
+		t.Log("Skip the job run in short mode")
+		return
+	}
+
 	out, err := runResource(t, ctx, bundleRoot, "some_other_job")
 	require.NoError(t, err)
 	require.Contains(t, out, "Hello from my func")

--- a/integration/bundle/spark_jar_test.go
+++ b/integration/bundle/spark_jar_test.go
@@ -30,6 +30,11 @@ func runSparkJarTestCommon(t *testing.T, ctx context.Context, sparkVersion, arti
 		destroyBundle(t, ctx, bundleRoot)
 	})
 
+	if testing.Short() {
+		t.Log("Skip the job run in short mode")
+		return
+	}
+
 	out, err := runResource(t, ctx, bundleRoot, "jar_job")
 	require.NoError(t, err)
 	require.Contains(t, out, "Hello from Jar!")


### PR DESCRIPTION
## Changes

A small subset of tests trigger cluster creation to run jobs. These tests comprise a substantial amount of the total integration test runtime. We can skip them on PRs and only run them on the main branch.

## Tests

Confirmed the short runtime is ~20 mins.

