### PR TITLE
Remove 'make fmt' and 'fmt' workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,38 +57,6 @@ jobs:
       - name: Publish test coverage
         uses: codecov/codecov-action@v4
 
-  fmt:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.2
-
-          # No need to download cached dependencies when running gofmt.
-          cache: false
-
-      - name: Install goimports
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-
-      - name: Run make fmt
-        run: |
-          make fmt
-
-      - name: Run go mod tidy
-        run: |
-          go mod tidy
-
-      - name: Fail on differences
-        run: |
-          # Exit with status code 1 if there are differences (i.e. unformatted files)
-          git diff --exit-code
-
   golangci:
     name: lint
     runs-on: ubuntu-latest
@@ -97,6 +65,13 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23.2
+      - name: Run go mod tidy
+        run: |
+          go mod tidy
+      - name: Fail on differences
+        run: |
+          # Exit with status code 1 if there are differences (i.e. unformatted files)
+          git diff --exit-code
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,5 @@
 default: build
 
-fmt:
-	@echo "✓ Formatting source code with goimports ..."
-	@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
-	@echo "✓ Formatting source code with gofmt ..."
-	@gofmt -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
-
 lint: vendor
 	@echo "✓ Linting source code with https://golangci-lint.run/ (with --fix)..."
 	@golangci-lint run --fix ./...
@@ -39,4 +33,4 @@ vendor:
 integration:
 	gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./integration/..." -- -parallel 4 -timeout=2h
 
-.PHONY: fmt lint lintcheck test testonly coverage build snapshot vendor integration
+.PHONY: lint lintcheck test testonly coverage build snapshot vendor integration


### PR DESCRIPTION
Remove unnecessary make command and github workflow - it's a subset of "lint" now. However, keep "mod tidy" separately, don't think the linter does that.

