### PR TITLE
Correctly handle required query params in CLI generation

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -411,5 +411,5 @@ func new{{.PascalName}}() *cobra.Command {
 {{- define "request-body-obj" -}}
 	{{- $method := .Method -}}
 	{{- $field := .Field -}}
-	{{$method.CamelName}}Req{{ if (and $method.RequestBodyField (not $field.IsPath)) }}.{{$method.RequestBodyField.PascalName}}{{end}}.{{$field.PascalName}}
+	{{$method.CamelName}}Req{{ if (and $method.RequestBodyField (and (not $field.IsPath) (not $field.IsQuery))) }}.{{$method.RequestBodyField.PascalName}}{{end}}.{{$field.PascalName}}
 {{- end -}}


### PR DESCRIPTION
## Changes
If there's required query params, it is a top-level field of request object and not a field of nested request body.

This is needed for upcoming changes from OpenAPI spec changes where such query parameters is introduced.

No changes after regenerating CLI with current spec and the fix (appears we haven't had such params before)


