### PR TITLE
Remove superfluous helper

### DIFF
--- a/integration/bundle/clusters_test.go
+++ b/integration/bundle/clusters_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestDeployBundleWithCluster(t *testing.T) {
-	ctx, wt := acc.WorkspaceTest(t)
-
-	if testutil.IsAWSCloud(wt) {
+	if testutil.GetCloud(t) == testutil.AWS {
 		t.Skip("Skipping test for AWS cloud because it is not permitted to create clusters")
 	}
+
+	ctx, wt := acc.WorkspaceTest(t)
 
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	uniqueId := uuid.New().String()

--- a/integration/bundle/python_wheel_test.go
+++ b/integration/bundle/python_wheel_test.go
@@ -51,9 +51,7 @@ func TestPythonWheelTaskDeployAndRunWithWrapper(t *testing.T) {
 }
 
 func TestPythonWheelTaskDeployAndRunOnInteractiveCluster(t *testing.T) {
-	_, wt := acc.WorkspaceTest(t)
-
-	if testutil.IsAWSCloud(wt) {
+	if testutil.GetCloud(t) == testutil.AWS {
 		t.Skip("Skipping test for AWS cloud because it is not permitted to create clusters")
 	}
 

--- a/internal/testutil/cloud.go
+++ b/internal/testutil/cloud.go
@@ -58,7 +58,3 @@ func GetCloud(t TestingT) Cloud {
 	}
 	return -1
 }
-
-func IsAWSCloud(t TestingT) bool {
-	return GetCloud(t) == AWS
-}


### PR DESCRIPTION
## Changes

There was only one helper for AWS and not the other clouds. Found this when looking through double calls to `acc.WorkspaceTest()` (see `TestPythonWheelTaskDeployAndRunOnInteractiveCluster`).

## Tests

n/a

