### PR TITLE
Trigger integration tests on push to main

### DIFF
--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -25,8 +25,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-            gh api -X POST -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/statuses/${{ github.sha }} \
-              -f 'state=success' \
-              -f 'context=Integration Tests Check'
+          gh api -X POST -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -f 'state=success' \
+            -f 'context=Integration Tests Check'

--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Mark Check
+      - name: Auto-approve squashed commit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash

--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -1,0 +1,32 @@
+name: integration-approve
+
+on:
+  merge_group:
+
+jobs:
+  # Trigger for merge groups.
+  #
+  # Statuses and checks apply to specific commits (by hash).
+  # Enforcement of required checks is done both at the PR level and the merge queue level.
+  # In case of multiple commits in a single PR, the hash of the squashed commit
+  # will not match the one for the latest (approved) commit in the PR.
+  #
+  # We auto approve the check for the merge queue for two reasons:
+  #
+  #   * Queue times out due to duration of tests.
+  #   * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
+  #
+  trigger:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Mark Check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+            gh api -X POST -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/statuses/${{ github.sha }} \
+              -f 'state=success' \
+              -f 'context=Integration Tests Check'

--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -1,0 +1,35 @@
+name: integration-main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Trigger for pushes to the main branch.
+  #
+  # This workflow triggers the integration test workflow in a different repository.
+  # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
+  trigger:
+    runs-on: ubuntu-latest
+    environment: "test-trigger-is"
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate GitHub App Token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
+        private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+        owner: ${{ secrets.ORG_NAME }}
+        repositories: ${{secrets.REPO_NAME}}
+
+    - name: Trigger Workflow in Another Repo
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+      run: |
+        gh workflow run cli-isolated-nightly.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
+        --ref main \
+        -f commit_sha=${{ github.event.after }}

--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -15,21 +15,19 @@ jobs:
     environment: "test-trigger-is"
 
     steps:
-    - uses: actions/checkout@v4
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+          owner: ${{ secrets.ORG_NAME }}
+          repositories: ${{secrets.REPO_NAME}}
 
-    - name: Generate GitHub App Token
-      id: generate-token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
-        private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
-        owner: ${{ secrets.ORG_NAME }}
-        repositories: ${{secrets.REPO_NAME}}
-
-    - name: Trigger Workflow in Another Repo
-      env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-      run: |
-        gh workflow run cli-isolated-nightly.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
-        --ref main \
-        -f commit_sha=${{ github.event.after }}
+      - name: Trigger Workflow in Another Repo
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh workflow run cli-isolated-nightly.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
+          --ref main \
+          -f commit_sha=${{ github.event.after }}

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -37,22 +37,20 @@ jobs:
     needs: check-token
 
     steps:
-    - uses: actions/checkout@v4
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+          owner: ${{ secrets.ORG_NAME }}
+          repositories: ${{secrets.REPO_NAME}}
 
-    - name: Generate GitHub App Token
-      id: generate-token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
-        private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
-        owner: ${{ secrets.ORG_NAME }}
-        repositories: ${{secrets.REPO_NAME}}
-
-    - name: Trigger Workflow in Another Repo
-      env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-      run: |
-        gh workflow run cli-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
-        --ref main \
-        -f pull_request_number=${{ github.event.pull_request.number }} \
-        -f commit_sha=${{ github.event.pull_request.head.sha }}
+      - name: Trigger Workflow in Another Repo
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh workflow run cli-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
+          --ref main \
+          -f pull_request_number=${{ github.event.pull_request.number }} \
+          -f commit_sha=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -1,19 +1,17 @@
-name: integration
+name: integration-pr
 
 on:
-
   pull_request:
     types: [opened, synchronize]
-
-  merge_group:
-
 
 jobs:
   check-token:
     runs-on: ubuntu-latest
     environment: "test-trigger-is"
+
     outputs:
       has_token: ${{ steps.set-token-status.outputs.has_token }}
+
     steps:
       - name: Check if DECO_WORKFLOW_TRIGGER_APP_ID is set
         id: set-token-status
@@ -26,11 +24,17 @@ jobs:
             echo "::set-output name=has_token::true"
           fi
 
-  trigger-tests:
+  # Trigger for pull requests.
+  #
+  # This workflow triggers the integration test workflow in a different repository.
+  # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
+  # It depends on the "check-token" workflow to confirm access to this environment to avoid failures.
+  trigger:
     runs-on: ubuntu-latest
-    needs: check-token
-    if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
     environment: "test-trigger-is"
+
+    if: needs.check-token.outputs.has_token == 'true'
+    needs: check-token
 
     steps:
     - uses: actions/checkout@v4
@@ -52,27 +56,3 @@ jobs:
         --ref main \
         -f pull_request_number=${{ github.event.pull_request.number }} \
         -f commit_sha=${{ github.event.pull_request.head.sha }}
-
-
-
-  # Statuses and checks apply to specific commits (by hash).
-  # Enforcement of required checks is done both at the PR level and the merge queue level.
-  # In case of multiple commits in a single PR, the hash of the squashed commit
-  # will not match the one for the latest (approved) commit in the PR.
-  # We auto approve the check for the merge queue for two reasons:
-  # * Queue times out due to duration of tests.
-  # * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
-  auto-approve:
-    if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mark Check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-            gh api -X POST -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              /repos/${{ github.repository }}/statuses/${{ github.sha }} \
-              -f 'state=success' \
-              -f 'context=Integration Tests Check'


### PR DESCRIPTION
## Changes

The existing workflow already had 2 trigger conditions, so instead of adding a third (and seeing more "skipped" jobs), I split them up into dedicated workflow files, each with their own trigger condition.

The integration test status is reported back via commit status.

## Tests

We can confirm that everything works as expected as this PR moves from here to the merge group to main.