### PR TITLE
Remove "Publish test coverage" step on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Run tests
         run: make testonly
 
-      - name: Publish test coverage
-        uses: codecov/codecov-action@v4
-
   golangci:
     name: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is not token for codecov and no plans on getting one.
