### PR TITLE
Require authentication when a user runs `bundle init`

### DIFF
--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -109,15 +109,15 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 			}
 			return w.Config.Host, nil
 		},
-		"user_name": func() (string, error) {
+		"user_name": func() string {
 			result := cachedUser.UserName
 			if result == "" {
 				result = cachedUser.Id
 			}
-			return result, nil
+			return result
 		},
-		"short_name": func() (string, error) {
-			return iamutil.GetShortUserName(cachedUser), nil
+		"short_name": func() string {
+			return iamutil.GetShortUserName(cachedUser)
 		},
 		// Get the default workspace catalog. If there is no default, or if
 		// Unity Catalog is not enabled, return an empty string.
@@ -138,13 +138,13 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 			}
 			return *cachedCatalog, nil
 		},
-		"is_service_principal": func() (bool, error) {
+		"is_service_principal": func() bool {
 			if cachedIsServicePrincipal != nil {
-				return *cachedIsServicePrincipal, nil
+				return *cachedIsServicePrincipal
 			}
 			result := iamutil.IsServicePrincipal(cachedUser)
 			cachedIsServicePrincipal = &result
-			return result, nil
+			return result
 		},
 	}
 }

--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -110,13 +110,6 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 			return w.Config.Host, nil
 		},
 		"user_name": func() (string, error) {
-			if cachedUser == nil {
-				var err error
-				cachedUser, err = w.CurrentUser.Me(ctx)
-				if err != nil {
-					return "", err
-				}
-			}
 			result := cachedUser.UserName
 			if result == "" {
 				result = cachedUser.Id
@@ -124,13 +117,6 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 			return result, nil
 		},
 		"short_name": func() (string, error) {
-			if cachedUser == nil {
-				var err error
-				cachedUser, err = w.CurrentUser.Me(ctx)
-				if err != nil {
-					return "", err
-				}
-			}
 			return iamutil.GetShortUserName(cachedUser), nil
 		},
 		// Get the default workspace catalog. If there is no default, or if
@@ -155,13 +141,6 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		"is_service_principal": func() (bool, error) {
 			if cachedIsServicePrincipal != nil {
 				return *cachedIsServicePrincipal, nil
-			}
-			if cachedUser == nil {
-				var err error
-				cachedUser, err = w.CurrentUser.Me(ctx)
-				if err != nil {
-					return false, err
-				}
 			}
 			result := iamutil.IsServicePrincipal(cachedUser)
 			cachedIsServicePrincipal = &result

--- a/libs/template/materialize.go
+++ b/libs/template/materialize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 
+	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/filer"
 )
@@ -40,6 +41,15 @@ func Materialize(ctx context.Context, configFilePath string, templateFS fs.FS, o
 		if err != nil {
 			return err
 		}
+	}
+
+	// Assert that the user is authenticated when materializing a template. We restrict
+	// usage of templates to authenticated users to log telemetry, even if the template
+	// does not require any authenticated functionality.
+	w := root.WorkspaceClient(ctx)
+	cachedUser, err = w.CurrentUser.Me(ctx)
+	if err != nil {
+		return fmt.Errorf("could not fetch information about the current user: %w", err)
 	}
 
 	helpers := loadHelpers(ctx)


### PR DESCRIPTION
## Changes
This will allow us to collect authenticated telemetry on `bundle init`

## Tests
Manually.

Existing templates like default-python are successfully created. 

When invalid credentials are present, bundle init exists early (before prompting):
```
go-playground-easy cli bundle init -p invalid
Error: could not fetch information about the current user: Invalid access token. [TraceId: 00-4ef3cd42fe0a88a2476674e8b38ddc74-1889b28d6c55778f-01]
```
