### PR TITLE
Add `template` field to `bundle` section of DABs configuration

### DIFF
--- a/bundle/config/bundle.go
+++ b/bundle/config/bundle.go
@@ -53,4 +53,8 @@ type Bundle struct {
 	// A stable generated UUID for the bundle. This is normally serialized by
 	// Databricks first party template when a user runs bundle init.
 	Uuid string `json:"uuid,omitempty"`
+
+	// The template used to generate this bundle. This allows us to attribute bundle
+	// deploy revenue to a template.
+	Template string `json:"template,omitempty"`
 }


### PR DESCRIPTION
## Changes
Templates can serialise this field to allow us to attribute revenue to templates during `bundle deploy`. Example for how mlops-stacks sets this: https://github.com/databricks/mlops-stacks/pull/185

## Tests
N/A
