### PR TITLE
Add lint.sh to run golanci-lint in 2 stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: build
 
 lint: vendor
 	@echo "✓ Linting source code with https://golangci-lint.run/ (with --fix)..."
-	@golangci-lint run --fix ./...
+	@./lint.sh ./...
 
 lintcheck: vendor
 	@echo "✓ Linting source code with https://golangci-lint.run/ ..."

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+# With golangci-lint, if there are any compliation issues, they formatters autofix won't be applied.
+# https://github.com/golangci/golangci-lint/issues/5257
+# However, running goimports first alone will actually fix some of the compilation issues.
+# For this reason, this script runs golangci-lint in two stages:
+golangci-lint run --fix --no-config --disable-all --enable gofumpt,goimports $@
+exec golangci-lint run --fix $@

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 # With golangci-lint, if there are any compliation issues, they formatters autofix won't be applied.
 # https://github.com/golangci/golangci-lint/issues/5257
 # However, running goimports first alone will actually fix some of the compilation issues.

--- a/lint.sh
+++ b/lint.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
-# With golangci-lint, if there are any compliation issues, they formatters autofix won't be applied.
+# With golangci-lint, if there are any compliation issues, then formatters' autofix won't be applied.
 # https://github.com/golangci/golangci-lint/issues/5257
 # However, running goimports first alone will actually fix some of the compilation issues.
+# Fixing formatting is also reasonable thing to do.
 # For this reason, this script runs golangci-lint in two stages:
 golangci-lint run --fix --no-config --disable-all --enable gofumpt,goimports $@
 exec golangci-lint run --fix $@


### PR DESCRIPTION
First stage is to run goimports and formatter, second is full suite.

This ensures that imports and formatting are fixed even in presence of other issues. Otherwise golanci-lint refuses to fix anything https://github.com/golangci/golangci-lint/issues/5257

This helpful when running aider with config like this - aider will use that to autofix what it can after every update:

```
% cat .aider.conf.yml
lint-cmd:
  - "go: ./lint.sh"
```

