### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pietern @andrewnester @shreyas-goenka @denik


### PR DESCRIPTION
Goal is to have DABs core team automatically added as reviewers so that you don't have to click manually.

Based on this example: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file