### PR TITLE
Speed up best case for "make test" 12x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,7 +55,7 @@ jobs:
           pip3 install wheel
 
       - name: Run tests
-        run: make testonly
+        run: make test
 
   golangci:
     name: lint

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,24 @@
 default: build
 
-lint: vendor
+PACKAGES=./libs/... ./internal/... ./cmd/... ./bundle/... .
+
+lint:
 	@echo "✓ Linting source code with https://golangci-lint.run/ (with --fix)..."
 	@./lint.sh ./...
 
-lintcheck: vendor
+lintcheck:
 	@echo "✓ Linting source code with https://golangci-lint.run/ ..."
 	@golangci-lint run ./...
 
-test: lint testonly
-
-testonly:
+test:
 	@echo "✓ Running tests ..."
-	@gotestsum --format pkgname-and-test-fails --no-summary=skipped --raw-command go test -v -json -short -coverprofile=coverage.txt ./...
+	@gotestsum --format pkgname-and-test-fails --no-summary=skipped -- ${PACKAGES}
 
-coverage: test
+cover:
+	@echo "✓ Running tests with coverage..."
+	@gotestsum --format pkgname-and-test-fails --no-summary=skipped -- -coverprofile=coverage.txt ${PACKAGES}
+
+showcover:
 	@echo "✓ Opening coverage for unit tests ..."
 	@go tool cover -html=coverage.txt
 
@@ -42,4 +46,4 @@ integration:
 integration-short:
 	$(INTEGRATION) -short
 
-.PHONY: lint lintcheck test testonly coverage build snapshot vendor schema integration integration-short
+.PHONY: lint lintcheck test cover showcover build snapshot vendor schema integration integration-short


### PR DESCRIPTION
On main branch: ‘make test’ takes about 33s
On this branch: ‘make test’ takes about 2.7s

(all measurements are for hot cache)

What’s done (from highest impact to lowest):
 - Remove -coverprofile= option - this option was disabling "go test"'s built-in cache and also it took extra time to calculate the coverage (extra 21s).
 - Exclude ./integration/ folder, there are no unit tests there, but having it included adds significant time. "go test"'s caching also does not work there for me, due to TestMain() presence (extra 7.2s).
 - Remove dependency on "make lint" - nice to have, but slow to re-check the whole repo and should already be done by IDE (extra 2.5s).
 - Remove dependency on "make vendor" — rarely needed; on CI it is already executed separately (extra 1.1s).

The coverage option is still available under "make cover". Use "make showcover" to show it.

I’ve also removed separate "make testonly". If you only want tests, run "make test". If you want lint+test run "make lint test" etc.

I've also modified the test command, removed unnecessary -short, -v, --raw-command.
