### PR TITLE
Make lint.sh to run golangci-lint only once in the best case

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 # With golangci-lint, if there are any compliation issues, then formatters' autofix won't be applied.
 # https://github.com/golangci/golangci-lint/issues/5257
-# However, running goimports first alone will actually fix some of the compilation issues.
-# Fixing formatting is also reasonable thing to do.
-# For this reason, this script runs golangci-lint in two stages:
-golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix $@
-exec golangci-lint run --fix $@
+
+golangci-lint run --fix "$@"
+lint_exit_code=$?
+
+if [ $lint_exit_code -ne 0 ]; then
+    # These linters work in presence of compilation issues when run alone, so let's get these fixes at least.
+    golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix "$@"
+fi
+
+exit $lint_exit_code


### PR DESCRIPTION
Follow up to #2051 and #2056.

Running golangci-lint twice always is measurably slower (1.5s vs 2.5s), so only run it twice in case it is necessary.

