### PR TITLE
Upgrade golangci-lint to v1.63.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -75,7 +75,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62.2
+          version: v1.63.1
           args: --timeout=15m
 
   validate-bundle-schema:


### PR DESCRIPTION
Upgrade your laptops with: brew install golangci-lint

This has a lot more autofixes, which makes it easier to adopt those linters.

https://golangci-lint.run/product/changelog/#v1630