### PR TITLE
lint: Raise max issues output

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,3 +40,5 @@ linters-settings:
       - require-error
 issues:
   exclude-dirs-use-default: false  # recommended by docs https://golangci-lint.run/usage/false-positives/
+  max-issues-per-linter: 1000
+  max-same-issues: 1000


### PR DESCRIPTION
By default it stops after 3 issues of a given type, which gives false impression and also unhelpful if you fixing it with aider.

1000 is almost like unlimited but not unlimited in case there is a bug in a linter.

