### PR TITLE
Set the write bit for files written during template initialization

### DIFF
--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,4 +52,32 @@ func ReadFile(t TestingT, path string) string {
 	require.NoError(t, err)
 
 	return string(b)
+}
+
+// StatFile returns the file info for a file.
+func StatFile(t TestingT, path string) os.FileInfo {
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+
+	return fi
+}
+
+// AssertFileContents asserts that the file at path has the expected content.
+func AssertFileContents(t TestingT, path, expected string) bool {
+	actual := ReadFile(t, path)
+	return assert.Equal(t, expected, actual)
+}
+
+// AssertFilePermissions asserts that the file at path has the expected permissions.
+func AssertFilePermissions(t TestingT, path string, expected os.FileMode) bool {
+	fi := StatFile(t, path)
+	assert.False(t, fi.Mode().IsDir(), "expected a file, got a directory")
+	return assert.Equal(t, expected, fi.Mode().Perm(), "expected 0%o, got 0%o", expected, fi.Mode().Perm())
+}
+
+// AssertDirPermissions asserts that the file at path has the expected permissions.
+func AssertDirPermissions(t TestingT, path string, expected os.FileMode) bool {
+	fi := StatFile(t, path)
+	assert.True(t, fi.Mode().IsDir(), "expected a directory, got a file")
+	return assert.Equal(t, expected, fi.Mode().Perm(), "expected 0%o, got 0%o", expected, fi.Mode().Perm())
 }

--- a/libs/template/file_test.go
+++ b/libs/template/file_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/filer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,8 +28,8 @@ func testInMemoryFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
 	err = f.Write(ctx, out)
 	assert.NoError(t, err)
 
-	assertFileContent(t, filepath.Join(tmpDir, "a/b/c"), "123")
-	assertFilePermissions(t, filepath.Join(tmpDir, "a/b/c"), perm)
+	testutil.AssertFileContents(t, filepath.Join(tmpDir, "a/b/c"), "123")
+	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "a/b/c"), perm)
 }
 
 func testCopyFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
@@ -48,8 +49,8 @@ func testCopyFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
 	err = f.Write(ctx, out)
 	assert.NoError(t, err)
 
-	assertFileContent(t, filepath.Join(tmpDir, "a/b/c"), "qwerty")
-	assertFilePermissions(t, filepath.Join(tmpDir, "a/b/c"), perm)
+	testutil.AssertFileContents(t, filepath.Join(tmpDir, "source"), "qwerty")
+	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "source"), perm)
 }
 
 func TestTemplateInMemoryFilePersistToDisk(t *testing.T) {

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -150,6 +150,10 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	}
 	perm := info.Mode().Perm()
 
+	// Always include the write bit for the owner of the file.
+	// It does not make sense to have a file that is not writable by the owner.
+	perm |= 0o200
+
 	// Execute relative path template to get destination path for the file
 	relPath, err := r.executeTemplate(relPathTemplate)
 	if err != nil {


### PR DESCRIPTION
## Changes

This used to work because the permission bits for built-in templates were hardcoded to 0644 for files and 0755 for directories.

As of #1912 (and the PRs it depends on), built-in templates are no longer pre-materialized to a temporary directory and read directly from the embedded filesystem. This built-in filesystem returns 0444 as the permission bits for the files it contains. These bits are carried over to the destination filesystem.

This change updates template materialization to always set the owner's write bit. It doesn't really make sense to write read-only files and expect users to work with these files in a VCS (note: Git only stores the executable bit).

The regression shipped as part of v0.235.0 and will be fixed as of v0.238.0.

## Tests

Unit tests.