### PR TITLE
Enable TestBundleInitOnMlopsStacks

### DIFF
--- a/integration/bundle/init_test.go
+++ b/integration/bundle/init_test.go
@@ -39,8 +39,6 @@ func TestBundleInitErrorOnUnknownFields(t *testing.T) {
 //     make changes that can break the MLOps Stacks DAB. In which case we should
 //     skip this test until the MLOps Stacks DAB is updated to work again.
 func TestBundleInitOnMlopsStacks(t *testing.T) {
-	testutil.SkipUntil(t, "2025-01-09")
-
 	ctx, wt := acc.WorkspaceTest(t)
 	w := wt.W
 


### PR DESCRIPTION
## Changes
This test was broken due to upstream change: https://github.com/databricks/mlops-stacks/pull/187

Fixed in upstream change: https://github.com/databricks/mlops-stacks/pull/188

## Tests
Test passes now
