### PR TITLE
Limit comment about integration tests to PRs from forks

### DIFF
--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -19,7 +19,7 @@ jobs:
 
     # Only run this job for PRs from forks.
     # Integration tests are not run automatically for PRs from forks.
-    if: github.event.pull_request.head.repo.fork
+    if: "${{ github.event.pull_request.head.repo.fork }}"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -17,6 +17,10 @@ jobs:
     permissions:
       pull-requests: write
 
+    # Only run this job for PRs from forks.
+    # Integration tests are not run automatically for PRs from forks.
+    if: github.event.pull_request.head.repo.fork
+
     steps:
       - uses: actions/checkout@v4
 
@@ -43,7 +47,7 @@ jobs:
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body \
           "<!-- INTEGRATION_TESTS_MANUAL -->
-          If integration tests don't run automatically, an authorized user can run them manually by following the instructions below:
+          An authorized user can trigger integration tests manually by following the instructions below:
 
           Trigger:
           [go/deco-tests-run/cli](https://go/deco-tests-run/cli)

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -15,7 +15,7 @@ jobs:
 
     # Only run this job for PRs from branches on the main repository and not from forks.
     # Workflows triggered by PRs from forks don't have access to the "test-trigger-is" environment.
-    if: ! github.event.pull_request.head.repo.fork
+    if: "${{ !github.event.pull_request.head.repo.fork }}"
 
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -5,36 +5,17 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  check-token:
-    runs-on: ubuntu-latest
-    environment: "test-trigger-is"
-
-    outputs:
-      has_token: ${{ steps.set-token-status.outputs.has_token }}
-
-    steps:
-      - name: Check if DECO_WORKFLOW_TRIGGER_APP_ID is set
-        id: set-token-status
-        run: |
-          if [ -z "${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}" ]; then
-            echo "DECO_WORKFLOW_TRIGGER_APP_ID is empty. User has no access to secrets."
-            echo "::set-output name=has_token::false"
-          else
-            echo "DECO_WORKFLOW_TRIGGER_APP_ID is set. User has access to secrets."
-            echo "::set-output name=has_token::true"
-          fi
-
   # Trigger for pull requests.
   #
   # This workflow triggers the integration test workflow in a different repository.
   # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
-  # It depends on the "check-token" workflow to confirm access to this environment to avoid failures.
   trigger:
     runs-on: ubuntu-latest
     environment: "test-trigger-is"
 
-    if: needs.check-token.outputs.has_token == 'true'
-    needs: check-token
+    # Only run this job for PRs from branches on the main repository and not from forks.
+    # Workflows triggered by PRs from forks don't have access to the "test-trigger-is" environment.
+    if: ! github.event.pull_request.head.repo.fork
 
     steps:
       - name: Generate GitHub App Token


### PR DESCRIPTION
## Changes

The comment block appears on all PRs, even if the integration tests are automatically triggered. This is quite noisy. This change limits those comments to PRs from forks.

## Tests

Have to try by merging...

