### PR TITLE
Migrate workflows that need write access to use hosted runners

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -7,12 +7,16 @@ on:
 
 jobs:
   cleanup:
+    name: Stale issue job
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
     permissions:
       issues: write
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
-    name: Stale issue job
+
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -9,8 +9,8 @@ jobs:
   cleanup:
     name: Stale issue job
     runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     permissions:
       issues: write

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   comment-on-pr:
     runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     permissions:
       pull-requests: write

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
     permissions:
       pull-requests: write
 

--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -18,8 +18,8 @@ jobs:
   #
   trigger:
     runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     steps:
       - name: Auto-approve squashed commit

--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -17,7 +17,9 @@ jobs:
   #   * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
   #
   trigger:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     steps:
       - name: Auto-approve squashed commit

--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -12,8 +12,8 @@ jobs:
   # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
   trigger:
     runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     environment: "test-trigger-is"
 

--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -11,7 +11,10 @@ jobs:
   # This workflow triggers the integration test workflow in a different repository.
   # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
   trigger:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
     environment: "test-trigger-is"
 
     steps:

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -10,7 +10,10 @@ jobs:
   # This workflow triggers the integration test workflow in a different repository.
   # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
   trigger:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
     environment: "test-trigger-is"
 
     # Only run this job for PRs from branches on the main repository and not from forks.

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -11,8 +11,8 @@ jobs:
   # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
   trigger:
     runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     environment: "test-trigger-is"
 

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -20,7 +20,10 @@ on:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,13 @@ on:
 
 jobs:
   goreleaser:
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     outputs:
       artifacts: ${{ steps.releaser.outputs.artifacts }}
-    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4


### PR DESCRIPTION
## Changes

Migrate workflows to Databricks-hosted GitHub Actions runners.

The GitHub-hosted runners can no longer be used because of security hardening.