### PR TITLE
Set gotestsum --format to github-actions when running on github

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+env:
+  GOTESTSUM_FORMAT: github-actions
+
 jobs:
   tests:
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ default: build
 
 PACKAGES=./libs/... ./internal/... ./cmd/... ./bundle/... .
 
+GOTESTSUM_FORMAT ?= pkgname-and-test-fails
+
 lint:
 	./lint.sh ./...
 
@@ -9,10 +11,10 @@ lintcheck:
 	golangci-lint run ./...
 
 test:
-	gotestsum --format pkgname-and-test-fails --no-summary=skipped -- ${PACKAGES}
+	gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped -- ${PACKAGES}
 
 cover:
-	gotestsum --format pkgname-and-test-fails --no-summary=skipped -- -coverprofile=coverage.txt ${PACKAGES}
+	gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped -- -coverprofile=coverage.txt ${PACKAGES}
 
 showcover:
 	go tool cover -html=coverage.txt


### PR DESCRIPTION
This gives grouping and ability to open individual test logs.

