### PR TITLE
Enable integration workflows

### DIFF
--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -6,14 +6,10 @@ name: PR Comment
 # DO NOT PULL THE PR OR EXECUTE ANY CODE FROM THE PR.
 
 on:
-  workflow_dispatch:
-
-  # Disable because of https://github.com/databricks/cli/issues/2084.
-  #
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
-  #   branches:
-  #     - main
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
 
 jobs:
   comment-on-pr:

--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -1,11 +1,7 @@
 name: integration-approve
 
 on:
-  workflow_dispatch:
-
-  # Disable because of https://github.com/databricks/cli/issues/2084.
-  #
-  # merge_group:
+  merge_group:
 
 jobs:
   # Trigger for merge groups.

--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -1,13 +1,9 @@
 name: integration-main
 
 on:
-  workflow_dispatch:
-
-  # Disable because of https://github.com/databricks/cli/issues/2084.
-  #
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
 jobs:
   # Trigger for pushes to the main branch.

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -1,12 +1,8 @@
 name: integration-pr
 
 on:
-  workflow_dispatch:
-
-  # Disable because of https://github.com/databricks/cli/issues/2084.
-  #
-  # pull_request:
-  #   types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   # Trigger for pull requests.


### PR DESCRIPTION
## Changes

This reverts commit 31552852ff6856a70f54454322d7407f6fdcfb06.

These workflows were disabled in #2085.

They should work again now that we're using self-hosted runners (see #2077).

## Tests

(inline)

