### PR TITLE
Add `uuid` to builtin templates

### DIFF
--- a/integration/bundle/testdata/default_python/bundle_summary.txt
+++ b/integration/bundle/testdata/default_python/bundle_summary.txt
@@ -15,7 +15,8 @@
       "lock": {
         "enabled": false
       }
-    }
+    },
+    "uuid": "<UUID>"
   },
   "include": [
     "resources/project_name_$UNIQUE_PRJ.job.yml",

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -3,6 +3,7 @@
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}
+  uuid: {{bundle_uuid}}
 
 include:
   - resources/*.yml

--- a/libs/template/templates/default-python/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/databricks.yml.tmpl
@@ -2,6 +2,7 @@
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}
+  uuid: {{bundle_uuid}}
 
 include:
   - resources/*.yml

--- a/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -2,6 +2,7 @@
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}
+  uuid: {{bundle_uuid}}
 
 include:
   - resources/*.yml


### PR DESCRIPTION
## Changes
This is useful to track telemetry associated with the templates and can later be useful for functional usecases as well.  Mlops stacks does the same here: https://github.com/databricks/mlops-stacks/pull/185

## Tests
Existing tests.
