### PR TITLE
Run push.yml periodically with clean cache

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,12 +13,24 @@ on:
     # seed the build cache.
     branches:
       - main
+  schedule:
+    - cron: '0 0,12 * * *'  # Runs at 00:00 and 12:00 UTC daily
 
 env:
   GOTESTSUM_FORMAT: github-actions
 
 jobs:
+  cleanups:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up cache if running on schedule
+        if: ${{ github.event_name == 'schedule' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh cache delete --all
+
   tests:
+    needs: cleanups
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -61,6 +73,7 @@ jobs:
         run: make test
 
   golangci:
+    needs: cleanups
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -86,6 +99,7 @@ jobs:
           args: --timeout=15m
 
   validate-bundle-schema:
+    needs: cleanups
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This ensures that our build still works with clean cache and also populates build/test cache, speeding up test runs.

## Tests
After deployment. Once scheduled job is run, we should check if empty PRs opened shortly after reports most of the tests as "(cached)".

