### PR TITLE
Use -update instead of TESTS_OUTPUT=OVERWRITE

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -9,7 +9,7 @@ To author a test,
 
 The test runner will run script and capture output and compare it with `output.txt` file in the same directory.
 
-In order to write `output.txt` for the first time or overwrite it with the current output, set `TESTS_OUTPUT=OVERWRITE` env var.
+In order to write `output.txt` for the first time or overwrite it with the current output pass -update flag to go test.
 
 The scripts are run with `bash -e` so any errors will be propagated. They are captured in `output.txt` by appending `Exit code: N` line at the end.
 

--- a/libs/testdiff/golden.go
+++ b/libs/testdiff/golden.go
@@ -2,6 +2,7 @@ package testdiff
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -16,7 +17,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var OverwriteMode = os.Getenv("TESTS_OUTPUT") == "OVERWRITE"
+var OverwriteMode = false
+
+func init() {
+	flag.BoolVar(&OverwriteMode, "update", false, "Overwrite golden files")
+}
 
 func ReadFile(t testutil.TestingT, ctx context.Context, filename string) string {
 	t.Helper()


### PR DESCRIPTION
It's easier to remember and type and also validated and part of help:

```
  % go test ./acceptance -updat 2>&1 | grep updat
  flag provided but not defined: -updat
    -update
```
