### PR TITLE
Pass tag to release as input to publish-winget workflow

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -2,6 +2,10 @@ name: publish-winget
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish'
+        default: ''
 
 jobs:
   publish-to-winget-pkgs:
@@ -18,3 +22,7 @@ jobs:
           installers-regex: 'windows_.*-signed\.zip$' # Only signed Windows releases
           token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
           fork-user: eng-dev-ecosystem-bot
+
+          # Use the tag from the input, or the ref name if the input is not provided.
+          # The ref name is equal to the tag name when this workflow is triggered by the "sign-cli" command.
+          release-tag: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
## Changes

This workflow only worked if it was triggered on the tag to publish itself. This means it is not possible to release a version if the workflow configuration at that tag is broken (as is the case for v0.238.0 because of #2105).

This change adds a "tag" input that can be set when manually triggering the workflow.

## Tests

* Succesful run with this change: https://github.com/databricks/cli/actions/runs/12689281843
* Pull request that the run created: https://github.com/microsoft/winget-pkgs/pull/209220