### PR TITLE
Log warnings to stderr for "bundle validate -o json"

### DIFF
--- a/acceptance/bundle/override/job_tasks/out.development.stderr.txt
+++ b/acceptance/bundle/override/job_tasks/out.development.stderr.txt
@@ -1,5 +1,5 @@
 
->>> errcode /Users/denis.bilenko/work/cli/acceptance/build/databricks bundle validate -o json -t development
+>>> errcode $CLI bundle validate -o json -t development
 Error: file ./test1.py not found
 
 

--- a/acceptance/bundle/override/job_tasks/out.development.stderr.txt
+++ b/acceptance/bundle/override/job_tasks/out.development.stderr.txt
@@ -1,0 +1,6 @@
+
+>>> errcode /Users/denis.bilenko/work/cli/acceptance/build/databricks bundle validate -o json -t development
+Error: file ./test1.py not found
+
+
+Exit code: 1

--- a/acceptance/bundle/override/job_tasks/output.txt
+++ b/acceptance/bundle/override/job_tasks/output.txt
@@ -1,9 +1,3 @@
-
->>> errcode $CLI bundle validate -o json -t development
-Error: file ./test1.py not found
-
-
-Exit code: 1
 {
   "name": "job",
   "queue": {

--- a/acceptance/bundle/override/job_tasks/output.txt
+++ b/acceptance/bundle/override/job_tasks/output.txt
@@ -2,6 +2,7 @@
 >>> errcode $CLI bundle validate -o json -t development
 Error: file ./test1.py not found
 
+
 Exit code: 1
 {
   "name": "job",
@@ -36,6 +37,7 @@ Exit code: 1
 >>> errcode $CLI bundle validate -o json -t staging
 Error: file ./test1.py not found
 
+
 Exit code: 1
 {
   "name": "job",
@@ -66,3 +68,16 @@ Exit code: 1
     }
   ]
 }
+
+>>> errcode $CLI bundle validate -t staging
+Error: file ./test1.py not found
+
+Name: override_job_tasks
+Target: staging
+Workspace:
+  User: tester@databricks.com
+  Path: /Workspace/Users/tester@databricks.com/.bundle/override_job_tasks/staging
+
+Found 1 error
+
+Exit code: 1

--- a/acceptance/bundle/override/job_tasks/script
+++ b/acceptance/bundle/override/job_tasks/script
@@ -1,2 +1,3 @@
 trace errcode $CLI bundle validate -o json -t development | jq .resources.jobs.foo
 trace errcode $CLI bundle validate -o json -t staging | jq .resources.jobs.foo
+trace errcode $CLI bundle validate -t staging

--- a/acceptance/bundle/override/job_tasks/script
+++ b/acceptance/bundle/override/job_tasks/script
@@ -1,3 +1,3 @@
-trace errcode $CLI bundle validate -o json -t development | jq .resources.jobs.foo
+trace errcode $CLI bundle validate -o json -t development 2> out.development.stderr.txt | jq .resources.jobs.foo
 trace errcode $CLI bundle validate -o json -t staging | jq .resources.jobs.foo
 trace errcode $CLI bundle validate -t staging

--- a/acceptance/bundle/override/merge-string-map/output.txt
+++ b/acceptance/bundle/override/merge-string-map/output.txt
@@ -1,5 +1,9 @@
 
 >>> $CLI bundle validate -o json -t dev
+Warning: expected map, found string
+  at resources.clusters.my_cluster
+  in databricks.yml:6:17
+
 {
   "clusters": {
     "my_cluster": {

--- a/cmd/bundle/validate.go
+++ b/cmd/bundle/validate.go
@@ -66,7 +66,7 @@ func newValidateCommand() *cobra.Command {
 			return nil
 		case flags.OutputJSON:
 			renderOpts := render.RenderOptions{RenderSummaryTable: false}
-			err1 := render.RenderDiagnostics(cmd.OutOrStderr(), b, diags, renderOpts)
+			err1 := render.RenderDiagnostics(cmd.ErrOrStderr(), b, diags, renderOpts)
 			err2 := renderJsonOutput(cmd, b)
 
 			if err2 != nil {

--- a/cmd/bundle/validate.go
+++ b/cmd/bundle/validate.go
@@ -11,18 +11,17 @@ import (
 	"github.com/databricks/cli/bundle/render"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
-	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/spf13/cobra"
 )
 
-func renderJsonOutput(cmd *cobra.Command, b *bundle.Bundle, diags diag.Diagnostics) error {
+func renderJsonOutput(cmd *cobra.Command, b *bundle.Bundle) error {
 	buf, err := json.MarshalIndent(b.Config.Value().AsAny(), "", "  ")
 	if err != nil {
 		return err
 	}
 	_, _ = cmd.OutOrStdout().Write(buf)
-	return diags.Error()
+	return nil
 }
 
 func newValidateCommand() *cobra.Command {
@@ -66,7 +65,23 @@ func newValidateCommand() *cobra.Command {
 
 			return nil
 		case flags.OutputJSON:
-			return renderJsonOutput(cmd, b, diags)
+			renderOpts := render.RenderOptions{RenderSummaryTable: false}
+			err1 := render.RenderDiagnostics(cmd.OutOrStderr(), b, diags, renderOpts)
+			err2 := renderJsonOutput(cmd, b)
+
+			if err2 != nil {
+				return err2
+			}
+
+			if err1 != nil {
+				return err1
+			}
+
+			if diags.HasError() {
+				return root.ErrAlreadyPrinted
+			}
+
+			return nil
 		default:
 			return fmt.Errorf("unknown output type %s", root.OutputType(cmd))
 		}


### PR DESCRIPTION
## Changes
Previously diagnostics were not seen in JSON output mode. This change prints them to stderr.

This also fixes acceptance tests to preprocess all output with s/execPath/$CLI/  not just output.txt.

## Tests
Existing acceptance tests. In one case I've added non-json command to check that they match in output.
