### PR TITLE
Increase close-after-stale from 7 to 30 days

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -31,7 +31,7 @@ jobs:
           exempt-pr-labels: No Autoclose
 
           # Issue timing
-          days-before-stale: 30
+          days-before-stale: 60
           days-before-close: 30
 
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -32,9 +32,7 @@ jobs:
 
           # Issue timing
           days-before-stale: 30
-          days-before-close: 7
+          days-before-close: 30
 
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           loglevel: DEBUG
-          # TODO: Remove dry-run after merge when confirmed it works correctly
-          dry-run: true


### PR DESCRIPTION
Giving 7 days to react before closing is too aggressive, IMO. Changed it to 30.

Also changed 'stale' label from 30d to 60d.

Also removed dry-run setting, it does not appear to do anything.

