### PR TITLE
Add test about using variable in bundle.git.branch

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -56,8 +56,12 @@ func TestAccept(t *testing.T) {
 	// Make helper scripts available
 	t.Setenv("PATH", fmt.Sprintf("%s%c%s", filepath.Join(cwd, "bin"), os.PathListSeparator, os.Getenv("PATH")))
 
+	repls := testdiff.ReplacementsContext{}
+	repls.Set(execPath, "$CLI")
+
 	tempHomeDir := t.TempDir()
-	t.Logf("tempHomeDir=%v", tempHomeDir)
+	repls.Set(tempHomeDir, "$TMPHOME")
+	t.Logf("$TMPHOME=%v", tempHomeDir)
 
 	// Prevent CLI from downloading terraform in each test:
 	t.Setenv("DATABRICKS_TF_EXEC_PATH", tempHomeDir)
@@ -76,10 +80,6 @@ func TestAccept(t *testing.T) {
 		// Do not read user's ~/.databrickscfg
 		t.Setenv(env.HomeEnvVar(), homeDir)
 	}
-
-	repls := testdiff.ReplacementsContext{}
-	repls.Set(execPath, "$CLI")
-	repls.Set(tempHomeDir, "$TMPHOME")
 
 	workspaceClient, err := databricks.NewWorkspaceClient()
 	require.NoError(t, err)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -57,6 +57,7 @@ func TestAccept(t *testing.T) {
 	t.Setenv("PATH", fmt.Sprintf("%s%c%s", filepath.Join(cwd, "bin"), os.PathListSeparator, os.Getenv("PATH")))
 
 	tempHomeDir := t.TempDir()
+	t.Logf("tempHomeDir=%v", tempHomeDir)
 
 	// Prevent CLI from downloading terraform in each test:
 	t.Setenv("DATABRICKS_TF_EXEC_PATH", tempHomeDir)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -265,22 +265,10 @@ func BuildCLI(t *testing.T, cwd, coverDir string) string {
 	}
 
 	start := time.Now()
-	args := []string{
-		"go", "build",
-		"-mod", "vendor",
-		"-o", execPath,
-	}
+	args := []string{"go", "build", "-mod", "vendor", "-o", execPath}
 	if coverDir != "" {
 		args = append(args, "-cover")
 	}
-
-	if runtime.GOOS == "windows" {
-		// Get this error on my local Windows:
-		// error obtaining VCS status: exit status 128
-		// Use -buildvcs=false to disable VCS stamping.
-		args = append(args, "-buildvcs=false")
-	}
-
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()
@@ -295,7 +283,6 @@ func BuildCLI(t *testing.T, cwd, coverDir string) string {
 	cmd = exec.Command(execPath, "--version")
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, "%s --version failed: %s\n%s", execPath, err, out)
-	t.Logf("%s --version: %s", execPath, out)
 	return execPath
 }
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2,7 +2,6 @@ package acceptance_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -79,7 +78,6 @@ func TestAccept(t *testing.T) {
 
 	repls := testdiff.ReplacementsContext{}
 	repls.Set(execPath, "$CLI")
-	repls.Set(toJson(t, tempHomeDir), "\"$TMPHOME\"")
 	repls.Set(tempHomeDir, "$TMPHOME")
 
 	workspaceClient, err := databricks.NewWorkspaceClient()
@@ -373,10 +371,4 @@ func CopyDir(src, dst string, inputs, outputs map[string]bool) error {
 
 		return copyFile(path, destPath)
 	})
-}
-
-func toJson(t *testing.T, value any) string {
-	encoded, err := json.Marshal(value)
-	require.NoError(t, err)
-	return string(encoded)
 }

--- a/acceptance/bundle/variables/git-branch/databricks.yml
+++ b/acceptance/bundle/variables/git-branch/databricks.yml
@@ -1,14 +1,12 @@
 bundle:
   name: git
+  git:
+    # This is currently not supported
+    branch: ${var.deployment_branch}
 
 variables:
   deployment_branch:
     default: ""  # read from git
-
-bundle:
-  git:
-    # This is currently not supported
-    branch: ${var.deployment_branch}
 
 targets:
   prod:

--- a/acceptance/bundle/variables/git-branch/databricks.yml
+++ b/acceptance/bundle/variables/git-branch/databricks.yml
@@ -6,7 +6,8 @@ bundle:
 
 variables:
   deployment_branch:
-    default: ""  # read from git
+    # read from git; inferred should be set to true; current it's not happening
+    default: ""
 
 targets:
   prod:

--- a/acceptance/bundle/variables/git-branch/databricks.yml
+++ b/acceptance/bundle/variables/git-branch/databricks.yml
@@ -1,0 +1,18 @@
+bundle:
+  name: git
+
+variables:
+  deployment_branch:
+    default: ""  # read from git
+
+bundle:
+  git:
+    # This is currently not supported
+    branch: ${var.deployment_branch}
+
+targets:
+  prod:
+    default: true
+  dev:
+    variables:
+      deployment_branch: dev-branch

--- a/acceptance/bundle/variables/git-branch/databricks.yml
+++ b/acceptance/bundle/variables/git-branch/databricks.yml
@@ -6,7 +6,9 @@ bundle:
 
 variables:
   deployment_branch:
-    # read from git; inferred should be set to true; current it's not happening
+    # By setting deployment_branch to "" we set bundle.git.branch to "" which is the same unsetting it.
+    # This this should make CLI read branch from git and update bundle.git.branch accordingly. It should
+    # Also set bundle.git.inferred to true.
     default: ""
 
 targets:

--- a/acceptance/bundle/variables/git-branch/output.txt
+++ b/acceptance/bundle/variables/git-branch/output.txt
@@ -1,0 +1,42 @@
+
+>>> errcode $CLI bundle validate -o json
+Error: unable to define default workspace root: bundle name not defined
+
+{
+  "bundle": {
+    "environment": "prod",
+    "git": {
+      "actual_branch": "main",
+      "branch": "${var.deployment_branch}",
+      "bundle_root_path": ".",
+      "commit": "005c1c6e1941df870c41d0541859f49ada648679"
+    },
+    "target": "prod"
+  },
+  "sync": {
+    "paths": [
+      "."
+    ]
+  },
+  "targets": null,
+  "variables": {
+    "deployment_branch": {
+      "default": ""
+    }
+  },
+  "workspace": {
+    "current_user": {
+      "short_name": "tester",
+      "userName": "tester@databricks.com"
+    }
+  }
+}
+Exit code: 1
+
+>>> errcode $CLI bundle validate
+Error: unable to define default workspace root: bundle name not defined
+
+
+Found 1 error
+
+Exit code: 1

--- a/acceptance/bundle/variables/git-branch/output.txt
+++ b/acceptance/bundle/variables/git-branch/output.txt
@@ -1,17 +1,18 @@
 
->>> errcode $CLI bundle validate -o json
-Error: unable to define default workspace root: bundle name not defined
-
+>>> $CLI bundle validate -o json
 {
   "bundle": {
     "environment": "prod",
     "git": {
       "actual_branch": "main",
-      "branch": "${var.deployment_branch}",
+      "branch": "",
       "bundle_root_path": ".",
-      "commit": "005c1c6e1941df870c41d0541859f49ada648679"
     },
-    "target": "prod"
+    "name": "git",
+    "target": "prod",
+    "terraform": {
+      "exec_path": "/tmp/"
+    }
   },
   "sync": {
     "paths": [
@@ -21,22 +22,77 @@ Error: unable to define default workspace root: bundle name not defined
   "targets": null,
   "variables": {
     "deployment_branch": {
-      "default": ""
+      "default": "",
+      "value": ""
     }
   },
   "workspace": {
+    "artifact_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/artifacts",
     "current_user": {
       "short_name": "tester",
       "userName": "tester@databricks.com"
-    }
+    },
+    "file_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/files",
+    "resource_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/resources",
+    "root_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod",
+    "state_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/state"
   }
 }
-Exit code: 1
 
->>> errcode $CLI bundle validate
-Error: unable to define default workspace root: bundle name not defined
+>>> $CLI bundle validate
+Name: git
+Target: prod
+Workspace:
+  User: tester@databricks.com
+  Path: /Workspace/Users/tester@databricks.com/.bundle/git/prod
 
+Validation OK!
 
-Found 1 error
+>>> $CLI bundle validate -o json -t dev
+{
+  "bundle": {
+    "environment": "dev",
+    "git": {
+      "actual_branch": "main",
+      "branch": "dev-branch",
+      "bundle_root_path": ".",
+    },
+    "name": "git",
+    "target": "dev",
+    "terraform": {
+      "exec_path": "/tmp/"
+    }
+  },
+  "sync": {
+    "paths": [
+      "."
+    ]
+  },
+  "targets": null,
+  "variables": {
+    "deployment_branch": {
+      "default": "dev-branch",
+      "value": "dev-branch"
+    }
+  },
+  "workspace": {
+    "artifact_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/artifacts",
+    "current_user": {
+      "short_name": "tester",
+      "userName": "tester@databricks.com"
+    },
+    "file_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/files",
+    "resource_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/resources",
+    "root_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev",
+    "state_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/state"
+  }
+}
 
-Exit code: 1
+>>> $CLI bundle validate -t dev
+Name: git
+Target: dev
+Workspace:
+  User: tester@databricks.com
+  Path: /Workspace/Users/tester@databricks.com/.bundle/git/dev
+
+Validation OK!

--- a/acceptance/bundle/variables/git-branch/output.txt
+++ b/acceptance/bundle/variables/git-branch/output.txt
@@ -11,7 +11,7 @@
     "name": "git",
     "target": "prod",
     "terraform": {
-      "exec_path": $TMPHOME
+      "exec_path": "$TMPHOME"
     }
   },
   "sync": {
@@ -27,15 +27,15 @@
     }
   },
   "workspace": {
-    "artifact_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/artifacts",
+    "artifact_path": "/Workspace/Users/$USERNAME/.bundle/git/prod/artifacts",
     "current_user": {
-      "short_name": "tester",
-      "userName": "tester@databricks.com"
+      "short_name": "$USERNAME",
+      "userName": "$USERNAME"
     },
-    "file_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/files",
-    "resource_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/resources",
-    "root_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod",
-    "state_path": "/Workspace/Users/tester@databricks.com/.bundle/git/prod/state"
+    "file_path": "/Workspace/Users/$USERNAME/.bundle/git/prod/files",
+    "resource_path": "/Workspace/Users/$USERNAME/.bundle/git/prod/resources",
+    "root_path": "/Workspace/Users/$USERNAME/.bundle/git/prod",
+    "state_path": "/Workspace/Users/$USERNAME/.bundle/git/prod/state"
   }
 }
 
@@ -43,8 +43,8 @@
 Name: git
 Target: prod
 Workspace:
-  User: tester@databricks.com
-  Path: /Workspace/Users/tester@databricks.com/.bundle/git/prod
+  User: $USERNAME
+  Path: /Workspace/Users/$USERNAME/.bundle/git/prod
 
 Validation OK!
 
@@ -60,7 +60,7 @@ Validation OK!
     "name": "git",
     "target": "dev",
     "terraform": {
-      "exec_path": $TMPHOME
+      "exec_path": "$TMPHOME"
     }
   },
   "sync": {
@@ -76,15 +76,15 @@ Validation OK!
     }
   },
   "workspace": {
-    "artifact_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/artifacts",
+    "artifact_path": "/Workspace/Users/$USERNAME/.bundle/git/dev/artifacts",
     "current_user": {
-      "short_name": "tester",
-      "userName": "tester@databricks.com"
+      "short_name": "$USERNAME",
+      "userName": "$USERNAME"
     },
-    "file_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/files",
-    "resource_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/resources",
-    "root_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev",
-    "state_path": "/Workspace/Users/tester@databricks.com/.bundle/git/dev/state"
+    "file_path": "/Workspace/Users/$USERNAME/.bundle/git/dev/files",
+    "resource_path": "/Workspace/Users/$USERNAME/.bundle/git/dev/resources",
+    "root_path": "/Workspace/Users/$USERNAME/.bundle/git/dev",
+    "state_path": "/Workspace/Users/$USERNAME/.bundle/git/dev/state"
   }
 }
 
@@ -92,7 +92,7 @@ Validation OK!
 Name: git
 Target: dev
 Workspace:
-  User: tester@databricks.com
-  Path: /Workspace/Users/tester@databricks.com/.bundle/git/dev
+  User: $USERNAME
+  Path: /Workspace/Users/$USERNAME/.bundle/git/dev
 
 Validation OK!

--- a/acceptance/bundle/variables/git-branch/output.txt
+++ b/acceptance/bundle/variables/git-branch/output.txt
@@ -11,7 +11,7 @@
     "name": "git",
     "target": "prod",
     "terraform": {
-      "exec_path": "/tmp/"
+      "exec_path": $TMPHOME
     }
   },
   "sync": {
@@ -60,7 +60,7 @@ Validation OK!
     "name": "git",
     "target": "dev",
     "terraform": {
-      "exec_path": "/tmp/"
+      "exec_path": $TMPHOME
     }
   },
   "sync": {

--- a/acceptance/bundle/variables/git-branch/script
+++ b/acceptance/bundle/variables/git-branch/script
@@ -1,0 +1,4 @@
+git-repo-init
+trace errcode $CLI bundle validate -o json
+trace errcode $CLI bundle validate
+rm -fr .git

--- a/acceptance/bundle/variables/git-branch/script
+++ b/acceptance/bundle/variables/git-branch/script
@@ -1,4 +1,6 @@
 git-repo-init
-trace errcode $CLI bundle validate -o json
-trace errcode $CLI bundle validate
+trace $CLI bundle validate -o json | grep -v '"commit"'
+trace $CLI bundle validate
+trace $CLI bundle validate -o json -t dev | grep -v '"commit"'
+trace $CLI bundle validate -t dev | grep -v '"commit"'
 rm -fr .git

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -36,7 +36,7 @@ trace() {
 }
 
 git-repo-init() {
-    git init -q
+    git init -qb main
     git config user.name "Tester"
     git config user.email "tester@databricks.com"
     git add databricks.yml

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -1,6 +1,3 @@
-# Prevent CLI from downloading terraform in each test:
-export DATABRICKS_TF_EXEC_PATH=/tmp/
-
 errcode() {
     # Temporarily disable 'set -e' to prevent the script from exiting on error
     set +e
@@ -37,6 +34,7 @@ trace() {
 
 git-repo-init() {
     git init -qb main
+    git config --global core.autocrlf false
     git config user.name "Tester"
     git config user.email "tester@databricks.com"
     git add databricks.yml

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -34,3 +34,11 @@ trace() {
 
     return $?
 }
+
+git-repo-init() {
+    git init -q
+    git config user.name "Tester"
+    git config user.email "tester@databricks.com"
+    git add databricks.yml
+    git commit -qm 'Add databricks.yml'
+}


### PR DESCRIPTION
This test checks load git details functionality + variable interpolation there.

The variables are not working there because LoadGitDetails mutator is running before variable interpolation.

This also includes a couple fixes for acceptance tests on Windows:
- Correctly replace tmp path that is used for DATABRICKS_TF_EXEC_PATH
- Pass -buildvcs=false to go build. It's not needed on CI but it is needed on my local windows VM.