### PR TITLE
Coverage for acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 
 *.log
 coverage.txt
+coverage-acceptance.txt
 
 __pycache__
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,17 @@ cover:
 showcover:
 	go tool cover -html=coverage.txt
 
+acc-cover:
+	rm -fr ./acceptance/build/cover/
+	CLI_GOCOVERDIR=build/cover go test ./acceptance
+	rm -fr ./acceptance/build/cover-merged/
+	mkdir -p acceptance/build/cover-merged/
+	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/
+	go tool covdata textfmt -i acceptance/build/cover-merged -o coverage-acceptance.txt
+
+acc-showcover:
+	go tool cover -html=coverage-acceptance.txt
+
 build: vendor
 	go build -mod vendor
 
@@ -45,4 +56,4 @@ integration:
 integration-short:
 	$(INTEGRATION) -short
 
-.PHONY: lint lintcheck fmt test cover showcover build snapshot vendor schema integration integration-short
+.PHONY: lint lintcheck fmt test cover showcover build snapshot vendor schema integration integration-short acc-cover acc-showcover


### PR DESCRIPTION
## Changes

Add two new make commands:
- make acc-cover: runs acceptance tests and outputs coverage-acceptance.txt
- make acc-showcover: show coverage-acceptance.txt locally in browser

Using the GOCOVERDIR functionality: https://go.dev/blog/integration-test-coverage

This works, but there are a couple of issues encountered:
- GOCOVERDIR does not play well with regular "go test -cover". Once this fixed, we can simplify the code and have 'make cover' output coverage for everything at once. We can also probably get rid of CLI_GOCOVERDIR. https://github.com/golang/go/issues/66225
- When running tests in parallel to the same directory there is rare conflict on writing covmeta file. For this reason each tests writes coverage to their own directory which is then merged together by 'make acc-cover'.

<!-- Summary of your changes that are easy to understand --


## Tests
Manually running the new make commands.

