### PR TITLE
Move merge fix-ups after variable resolution

### DIFF
--- a/acceptance/bundle/override/job_cluster_var/databricks.yml
+++ b/acceptance/bundle/override/job_cluster_var/databricks.yml
@@ -20,7 +20,6 @@ targets:
       jobs:
         foo:
           job_clusters:
-            # This does not work because merging is done before resolution
             - job_cluster_key: "${var.mykey}"
               new_cluster:
                 node_type_id: i3.xlarge

--- a/acceptance/bundle/override/job_cluster_var/output.txt
+++ b/acceptance/bundle/override/job_cluster_var/output.txt
@@ -12,14 +12,9 @@
       {
         "job_cluster_key": "key",
         "new_cluster": {
-          "spark_version": "13.3.x-scala2.12"
-        }
-      },
-      {
-        "job_cluster_key": "key",
-        "new_cluster": {
           "node_type_id": "i3.xlarge",
-          "num_workers": 1
+          "num_workers": 1,
+          "spark_version": "13.3.x-scala2.12"
         }
       }
     ],
@@ -54,14 +49,9 @@ Validation OK!
       {
         "job_cluster_key": "key",
         "new_cluster": {
-          "spark_version": "13.3.x-scala2.12"
-        }
-      },
-      {
-        "job_cluster_key": "key",
-        "new_cluster": {
           "node_type_id": "i3.2xlarge",
-          "num_workers": 4
+          "num_workers": 4,
+          "spark_version": "13.3.x-scala2.12"
         }
       }
     ],

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -33,10 +33,6 @@ func Initialize() bundle.Mutator {
 			// If it is an ancestor, this updates all paths to be relative to the sync root path.
 			mutator.SyncInferRoot(),
 
-			mutator.MergeJobClusters(),
-			mutator.MergeJobParameters(),
-			mutator.MergeJobTasks(),
-			mutator.MergePipelineClusters(),
 			mutator.InitializeWorkspaceClient(),
 			mutator.PopulateCurrentUser(),
 			mutator.LoadGitDetails(),
@@ -70,6 +66,12 @@ func Initialize() bundle.Mutator {
 				"workspace",
 				"variables",
 			),
+
+			mutator.MergeJobClusters(),
+			mutator.MergeJobParameters(),
+			mutator.MergeJobTasks(),
+			mutator.MergePipelineClusters(),
+
 			// Provide permission config errors & warnings after initializing all variables
 			permissions.PermissionDiagnostics(),
 			mutator.SetRunAs(),


### PR DESCRIPTION
## Changes
Move mutator.Merge{JobClusters,JobParameters,JobTasks,PipelineClusters} after variable resolution. This helps with the case when key contains a variable.

@pietern mentioned here https://github.com/databricks/cli/pull/2101#pullrequestreview-2539168762 it should be safe.

## Tests
Existing acceptance that was capturing the bug is updated with corrected output.

