### PR TITLE
Remove redundant lines from PrepareReplacementsUser

### DIFF
--- a/libs/testdiff/golden.go
+++ b/libs/testdiff/golden.go
@@ -185,8 +185,6 @@ func PrepareReplacementsUser(t testutil.TestingT, r *ReplacementsContext, u iam.
 		u.DisplayName,
 		u.UserName,
 		iamutil.GetShortUserName(&u),
-		u.Name.FamilyName,
-		u.Name.GivenName,
 	}
 	if u.Name != nil {
 		names = append(names, u.Name.FamilyName)


### PR DESCRIPTION
They are not necessary because they are added below. Also, they will cause a crash if u.Name is nil.

