### PR TITLE
Filter out system clusters in cluster picker

### DIFF
--- a/libs/databrickscfg/cfgpickers/clusters.go
+++ b/libs/databrickscfg/cfgpickers/clusters.go
@@ -136,7 +136,18 @@ func loadInteractiveClusters(ctx context.Context, w *databricks.WorkspaceClient,
 	promptSpinner := cmdio.Spinner(ctx)
 	promptSpinner <- "Loading list of clusters to select from"
 	defer close(promptSpinner)
-	all, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{})
+	all, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{
+		// Maximum page size to optimize for load time.
+		PageSize: 100,
+
+		// Filter out system clusters.
+		FilterBy: &compute.ListClustersFilterBy{
+			ClusterSources: []compute.ClusterSource{
+				compute.ClusterSourceApi,
+				compute.ClusterSourceUi,
+			},
+		},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list clusters: %w", err)
 	}

--- a/libs/databrickscfg/cfgpickers/clusters_test.go
+++ b/libs/databrickscfg/cfgpickers/clusters_test.go
@@ -70,7 +70,7 @@ func TestFirstCompatibleCluster(t *testing.T) {
 	cfg, server := qa.HTTPFixtures{
 		{
 			Method:   "GET",
-			Resource: "/api/2.1/clusters/list?",
+			Resource: "/api/2.1/clusters/list?filter_by.cluster_sources=API&filter_by.cluster_sources=UI&page_size=100",
 			Response: compute.ListClustersResponse{
 				Clusters: []compute.ClusterDetails{
 					{
@@ -125,7 +125,7 @@ func TestNoCompatibleClusters(t *testing.T) {
 	cfg, server := qa.HTTPFixtures{
 		{
 			Method:   "GET",
-			Resource: "/api/2.1/clusters/list?",
+			Resource: "/api/2.1/clusters/list?filter_by.cluster_sources=API&filter_by.cluster_sources=UI&page_size=100",
 			Response: compute.ListClustersResponse{
 				Clusters: []compute.ClusterDetails{
 					{


### PR DESCRIPTION
## Changes

As of the clusters API v2.1 the results include system clusters. On large workspaces this can lead to long load times and include many irrelevant results. The cluster picker should only show interactive clusters.

Also see #1754.

## Tests

Manually confirmed the picker runs fast on a large workspace.
