### PR TITLE
Fixed a typo in TestDeployBundleWithApp test

### DIFF
--- a/integration/bundle/apps_test.go
+++ b/integration/bundle/apps_test.go
@@ -27,7 +27,7 @@ func TestDeployBundleWithApp(t *testing.T) {
 	}
 
 	uniqueId := uuid.New().String()
-	appId := "app-%s" + uuid.New().String()[0:8]
+	appId := "app-" + uuid.New().String()[0:8]
 	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
 	instancePoolId := env.Get(ctx, "TEST_INSTANCE_POOL_ID")
 


### PR DESCRIPTION
## Changes
Fixed a typo in TestDeployBundleWithApp test

## Tests
```
   helpers_test.go:148: stderr: Destroy complete!
--- PASS: TestDeployBundleWithApp (647.51s)
PASS
coverage: [no statements]
ok      github.com/databricks/cli/integration/bundle    647.985s        coverage: [no statements]
```

