### PR TITLE
Run tests with coverage on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -77,8 +77,8 @@ jobs:
           make vendor
           pip3 install wheel
 
-      - name: Run tests
-        run: make test
+      - name: Run tests with coverage
+        run: make cover
 
   golangci:
     needs: cleanups

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ default: vendor fmt lint
 PACKAGES=./acceptance/... ./libs/... ./internal/... ./cmd/... ./bundle/... .
 
 GOTESTSUM_FORMAT ?= pkgname-and-test-fails
+GOTESTSUM_CMD ?= gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped
+
 
 lint:
 	golangci-lint run --fix
@@ -18,21 +20,18 @@ fmt:
 	golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix ./...
 
 test:
-	gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped -- ${PACKAGES}
+	${GOTESTSUM_CMD} -- ${PACKAGES}
 
 cover:
-	gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped -- -coverprofile=coverage.txt ${PACKAGES}
-
-showcover:
-	go tool cover -html=coverage.txt
-
-acc-cover:
 	rm -fr ./acceptance/build/cover/
-	CLI_GOCOVERDIR=build/cover go test ./acceptance
+	CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES}
 	rm -fr ./acceptance/build/cover-merged/
 	mkdir -p acceptance/build/cover-merged/
 	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/
 	go tool covdata textfmt -i acceptance/build/cover-merged -o coverage-acceptance.txt
+
+showcover:
+	go tool cover -html=coverage.txt
 
 acc-showcover:
 	go tool cover -html=coverage-acceptance.txt


### PR DESCRIPTION
Combine 'make cover' and 'make acc-cover' into single command. They still write coverage into different files -- it would be useful to see separate coverage numbers.

Note, we're not making use of coverage information yet. However, running tests in CI with coverage will
- let us catch issues that only manifest when coverage is enabled, like https://github.com/databricks/cli/pull/2150
- will let us know if there are any issues with running coverage on CI before investing in additional coverage support

