### PR TITLE
acceptance: add -buildvcs=false when building on Windows

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -257,10 +257,23 @@ func BuildCLI(t *testing.T, cwd, coverDir string) string {
 	}
 
 	start := time.Now()
-	args := []string{"go", "build", "-mod", "vendor", "-o", execPath}
+	args := []string{
+		"go", "build",
+		"-mod", "vendor",
+		"-o", execPath,
+	}
+
 	if coverDir != "" {
 		args = append(args, "-cover")
 	}
+
+	if runtime.GOOS == "windows" {
+		// Get this error on my local Windows:
+		// error obtaining VCS status: exit status 128
+		// Use -buildvcs=false to disable VCS stamping.
+		args = append(args, "-buildvcs=false")
+	}
+
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Dir = ".."
 	out, err := cmd.CombinedOutput()
@@ -275,6 +288,7 @@ func BuildCLI(t *testing.T, cwd, coverDir string) string {
 	cmd = exec.Command(execPath, "--version")
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, "%s --version failed: %s\n%s", execPath, err, out)
+	t.Logf("%s --version: %s", execPath, out)
 	return execPath
 }
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -288,7 +288,6 @@ func BuildCLI(t *testing.T, cwd, coverDir string) string {
 	cmd = exec.Command(execPath, "--version")
 	out, err = cmd.CombinedOutput()
 	require.NoError(t, err, "%s --version failed: %s\n%s", execPath, err, out)
-	t.Logf("%s --version: %s", execPath, out)
 	return execPath
 }
 


### PR DESCRIPTION
I get an error on my local Windows otherwise: error obtaining VCS status: exit status 128

On CI this does not make a difference.

Also, log full path to binary and output of $CLI --version.