### PR TITLE
Use the same test names on Win as on other OSes

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -87,7 +87,8 @@ func TestAccept(t *testing.T) {
 	require.NotEmpty(t, testDirs)
 
 	for _, dir := range testDirs {
-		t.Run(dir, func(t *testing.T) {
+		testName := strings.ReplaceAll(dir, "\\", "/")
+		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 			runTest(t, dir, coverDir, repls)
 		})


### PR DESCRIPTION
## Changes
Use name format "TestAccept/bundle/variables/host" (previously slashes were reversed on Windows).

## Tests
Manually run "go test ./acceptance -v -run TestAccept/bundle/variables/host" in Windows VM.

