### PR TITLE
exec(test): Do not clear PATH; this breaks coverage on Windows

### DIFF
--- a/libs/exec/exec_test.go
+++ b/libs/exec/exec_test.go
@@ -85,7 +85,7 @@ func testExecutorWithShell(t *testing.T, shell string) {
 
 	// Create temporary directory with only the shell executable in the PATH.
 	tmpDir := t.TempDir()
-	t.Setenv("PATH", tmpDir)
+	t.Setenv("PATH", fmt.Sprintf("%s%c%s", tmpDir, os.PathListSeparator, os.Getenv("PATH")))
 	if runtime.GOOS == "windows" {
 		err = os.Symlink(p, fmt.Sprintf("%s/%s.exe", tmpDir, shell))
 		require.NoError(t, err)


### PR DESCRIPTION
## Changes
When setting up PATH in tests, put desired entry first but keep the rest as well. Otherwise it fails on Windows

```
D:/a/cli/cli/libs/exec/exec_test.go:108
Error: Received unexpected error:
exit status 0xc0000135
```

Explanation from Claude:
> The error code 0xc0000135 is a Windows error indicating "Unable to locate DLL"
> When code coverage is enabled, Go instruments the binary with coverage tracking code, which requires additional DLL dependencies on Windows.

## Tests
Separate draft PR with coverage enabled on CI: https://github.com/databricks/cli/pull/2141

