### PR TITLE
Alias 'make' to 'make vendor fmt lint'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: build
+default: vendor fmt lint
 
 PACKAGES=./acceptance/... ./libs/... ./internal/... ./cmd/... ./bundle/... .
 


### PR DESCRIPTION
The current default of building a binary is not frequently used.

The new default is useful after switching branches, stashing/unstashing, AI changes.

Note "fmt" and  "lint" are separate steps because "fmt" can fix formatting and imports in presence of compilation errors and "lint" cannot. Without compilation errors, "lint" also does formatting.

