### PR TITLE
Migrate TestResolveComplexVariableWithVarReference

### DIFF
--- a/acceptance/bundle/variables/complex-with-var-reference/databricks.yml
+++ b/acceptance/bundle/variables/complex-with-var-reference/databricks.yml
@@ -1,0 +1,17 @@
+bundle:
+  name: TestResolveComplexVariableWithVarReference
+
+variables:
+  package_version:
+    default: "1.0.0"
+  cluster_libraries:
+    type: "complex"
+    default:
+      - pypi:
+          package: "cicd_template==${var.package_version}"
+
+resources:
+  jobs:
+    job1:
+      tasks:
+        - libraries: ${var.cluster_libraries}

--- a/acceptance/bundle/variables/complex-with-var-reference/output.txt
+++ b/acceptance/bundle/variables/complex-with-var-reference/output.txt
@@ -1,0 +1,12 @@
+[
+  {
+    "libraries": [
+      {
+        "pypi": {
+          "package": "cicd_template==1.0.0"
+        }
+      }
+    ],
+    "task_key": ""
+  }
+]

--- a/acceptance/bundle/variables/complex-with-var-reference/script
+++ b/acceptance/bundle/variables/complex-with-var-reference/script
@@ -1,0 +1,1 @@
+$CLI bundle validate -o json | jq .resources.jobs.job1.tasks


### PR DESCRIPTION
This is the last test referencing ResolveVariableReferencesInComplexVariables, allowing removal of that mutator.

