### PR TITLE
Improve resolution of complex variables within complex variables

### DIFF
--- a/acceptance/bundle/variables/complex-transitive/output.txt
+++ b/acceptance/bundle/variables/complex-transitive/output.txt
@@ -1,3 +1,3 @@
 {
-  "spark.databricks.sql.initial.catalog.name": "${var.catalog}"
+  "spark.databricks.sql.initial.catalog.name": "hive_metastore"
 }

--- a/acceptance/bundle/variables/complex-with-var-reference/databricks.yml
+++ b/acceptance/bundle/variables/complex-with-var-reference/databricks.yml
@@ -1,0 +1,17 @@
+bundle:
+  name: TestResolveComplexVariableWithVarReference
+
+variables:
+  package_version:
+    default: "1.0.0"
+  cluster_libraries:
+    type: "complex"
+    default:
+      - pypi:
+          package: "cicd_template==${var.package_version}"
+
+resources:
+  jobs:
+    job1:
+      tasks:
+        - libraries: ${var.cluster_libraries}

--- a/acceptance/bundle/variables/complex-with-var-reference/output.txt
+++ b/acceptance/bundle/variables/complex-with-var-reference/output.txt
@@ -1,0 +1,12 @@
+[
+  {
+    "libraries": [
+      {
+        "pypi": {
+          "package": "cicd_template==1.0.0"
+        }
+      }
+    ],
+    "task_key": ""
+  }
+]

--- a/acceptance/bundle/variables/complex-with-var-reference/script
+++ b/acceptance/bundle/variables/complex-with-var-reference/script
@@ -1,0 +1,1 @@
+$CLI bundle validate -o json | jq .resources.jobs.job1.tasks

--- a/acceptance/bundle/variables/complex-within-complex/output.txt
+++ b/acceptance/bundle/variables/complex-within-complex/output.txt
@@ -2,17 +2,16 @@ Warning: unknown field: node_type_id
   at resources.jobs.job1.job_clusters[0]
   in databricks.yml:25:11
 
-Error: complex variables cannot contain references to another complex variables
-
 [
   {
     "job_cluster_key": "my_cluster",
-    "new_cluster": null
-  },
-  {
-    "job_cluster_key": "my_cluster",
-    "new_cluster": "${var.cluster}"
+    "new_cluster": {
+      "node_type_id": "Standard_DS3_v2",
+      "num_workers": 2,
+      "spark_conf": {
+        "spark.executor.cores": "2",
+        "spark.executor.memory": "4g"
+      }
+    }
   }
 ]
-
-Exit code: 1

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -61,7 +61,11 @@ func Initialize() bundle.Mutator {
 			pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseApplyMutators),
 			mutator.ResolveVariableReferencesInLookup(),
 			mutator.ResolveResourceReferences(),
-			mutator.ResolveVariableReferencesInComplexVariables(),
+			mutator.ResolveVariableReferences(
+				"bundle",
+				"workspace",
+				"variables",
+			),
 			mutator.ResolveVariableReferences(
 				"bundle",
 				"workspace",


### PR DESCRIPTION
## Changes
- Remove ResolveVariableReferencesInComplexVariables - it blocked complex-within-complex for no good reason.
- Repeat regular resolution twice, it helps with a couple test cases we have.

There may be a case for running it 3 times or more in a loop, but there is no test case for that, so this PR is simple incremental improvement.

## Tests
Existing acceptance tests. Previously all unit tests for complex variables were converted to acceptance tests, to capture this change and ensure nothing breaks.

