### PR TITLE
Introduce $DATABRICKS_URL replacement in tests

### DIFF
--- a/acceptance/bundle/init/dbt-sql/output.txt
+++ b/acceptance/bundle/init/dbt-sql/output.txt
@@ -4,7 +4,7 @@
 Welcome to the dbt template for Databricks Asset Bundles!
 
 A workspace was selected based on your current profile. For information about how to change this, see https://docs.databricks.com/dev-tools/cli/profiles.html.
-workspace_host: http://$DATABRICKS_HOST
+workspace_host: $DATABRICKS_URL
 
 📊 Your new project has been created in the 'my_dbt_sql' directory!
 If you already have dbt installed, just type 'cd my_dbt_sql; dbt init' to get started.
@@ -15,7 +15,7 @@ Refer to the README.md file for full "getting started" guide and production setu
 Name: my_dbt_sql
 Target: dev
 Workspace:
-  Host: http://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/my_dbt_sql/dev
 
@@ -25,7 +25,7 @@ Validation OK!
 Name: my_dbt_sql
 Target: prod
 Workspace:
-  Host: http://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/my_dbt_sql/prod
 

--- a/acceptance/bundle/init/default-python/output.txt
+++ b/acceptance/bundle/init/default-python/output.txt
@@ -2,7 +2,7 @@
 >>> $CLI bundle init default-python --config-file ./input.json
 
 Welcome to the default Python template for Databricks Asset Bundles!
-Workspace to use (auto-detected, edit in 'my_default_python/databricks.yml'): http://$DATABRICKS_HOST
+Workspace to use (auto-detected, edit in 'my_default_python/databricks.yml'): $DATABRICKS_URL
 
 ✨ Your new project has been created in the 'my_default_python' directory!
 
@@ -13,7 +13,7 @@ See also the documentation at https://docs.databricks.com/dev-tools/bundles/inde
 Name: my_default_python
 Target: dev
 Workspace:
-  Host: http://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/my_default_python/dev
 
@@ -23,7 +23,7 @@ Validation OK!
 Name: my_default_python
 Target: prod
 Workspace:
-  Host: http://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/my_default_python/prod
 

--- a/acceptance/bundle/init/default-sql/output.txt
+++ b/acceptance/bundle/init/default-sql/output.txt
@@ -4,7 +4,7 @@
 Welcome to the default SQL template for Databricks Asset Bundles!
 
 A workspace was selected based on your current profile. For information about how to change this, see https://docs.databricks.com/dev-tools/cli/profiles.html.
-workspace_host: http://$DATABRICKS_HOST
+workspace_host: $DATABRICKS_URL
 
 ✨ Your new project has been created in the 'my_default_sql' directory!
 
@@ -15,7 +15,7 @@ See also the documentation at https://docs.databricks.com/dev-tools/bundles/inde
 Name: my_default_sql
 Target: dev
 Workspace:
-  Host: http://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/my_default_sql/dev
 
@@ -25,7 +25,7 @@ Validation OK!
 Name: my_default_sql
 Target: prod
 Workspace:
-  Host: http://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/my_default_sql/prod
 

--- a/integration/bundle/testdata/default_python/bundle_init.txt
+++ b/integration/bundle/testdata/default_python/bundle_init.txt
@@ -1,6 +1,6 @@
 
 Welcome to the default Python template for Databricks Asset Bundles!
-Workspace to use (auto-detected, edit in 'project_name_$UNIQUE_PRJ/databricks.yml'): https://$DATABRICKS_HOST
+Workspace to use (auto-detected, edit in 'project_name_$UNIQUE_PRJ/databricks.yml'): $DATABRICKS_URL
 
 ✨ Your new project has been created in the 'project_name_$UNIQUE_PRJ' directory!
 

--- a/integration/bundle/testdata/default_python/bundle_summary.txt
+++ b/integration/bundle/testdata/default_python/bundle_summary.txt
@@ -23,7 +23,7 @@
     "resources/project_name_$UNIQUE_PRJ.pipeline.yml"
   ],
   "workspace": {
-    "host": "https://$DATABRICKS_HOST",
+    "host": "$DATABRICKS_URL",
     "current_user": {
       "active": true,
       "displayName": "$USERNAME",
@@ -141,7 +141,7 @@
             "unit": "DAYS"
           }
         },
-        "url": "https://$DATABRICKS_HOST/jobs/<NUMID>?o=<NUMID>"
+        "url": "$DATABRICKS_URL/jobs/<NUMID>?o=<NUMID>"
       }
     },
     "pipelines": {
@@ -165,7 +165,7 @@
         ],
         "name": "[dev $USERNAME] project_name_$UNIQUE_PRJ_pipeline",
         "target": "project_name_$UNIQUE_PRJ_dev",
-        "url": "https://$DATABRICKS_HOST/pipelines/<UUID>?o=<NUMID>"
+        "url": "$DATABRICKS_URL/pipelines/<UUID>?o=<NUMID>"
       }
     }
   },

--- a/integration/bundle/testdata/default_python/bundle_validate.txt
+++ b/integration/bundle/testdata/default_python/bundle_validate.txt
@@ -1,7 +1,7 @@
 Name: project_name_$UNIQUE_PRJ
 Target: dev
 Workspace:
-  Host: https://$DATABRICKS_HOST
+  Host: $DATABRICKS_URL
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/project_name_$UNIQUE_PRJ/dev
 

--- a/libs/testdiff/replacement.go
+++ b/libs/testdiff/replacement.go
@@ -80,6 +80,8 @@ func PrepareReplacementsWorkspaceClient(t testutil.TestingT, r *ReplacementsCont
 	t.Helper()
 	// in some clouds (gcp) w.Config.Host includes "https://" prefix in others it's really just a host (azure)
 	host := strings.TrimPrefix(strings.TrimPrefix(w.Config.Host, "http://"), "https://")
+	r.Set("https://"+host, "$DATABRICKS_URL")
+	r.Set("http://"+host, "$DATABRICKS_URL")
 	r.Set(host, "$DATABRICKS_HOST")
 	r.Set(w.Config.ClusterID, "$DATABRICKS_CLUSTER_ID")
 	r.Set(w.Config.WarehouseID, "$DATABRICKS_WAREHOUSE_ID")


### PR DESCRIPTION
## Changes
It covers both https://$DATABRICKS_HOST and http://$DATABRICKS_HOST so the test output does not change between local and the cloud.

## Tests
Existing tests using golden files (acceptance and integration) catch this and were updated.
