### PR TITLE
Add a unique schema for recreate pipeline test

### DIFF
--- a/integration/bundle/bundles/recreate_pipeline/template/databricks.yml.tmpl
+++ b/integration/bundle/bundles/recreate_pipeline/template/databricks.yml.tmpl
@@ -9,7 +9,6 @@ variables:
     description: The catalog the DLT pipeline should use.
     default: main
 
-
 resources:
   pipelines:
     foo:
@@ -19,6 +18,13 @@ resources:
             path: ./nb.sql
       development: true
       catalog: ${var.catalog}
+      target: ${resources.schemas.bar.id}
+
+  schemas:
+    bar:
+      name: test-schema-{{.unique_id}}
+      catalog_name: ${var.catalog}
+      comment: This schema was created from DABs
 
 include:
   - "*.yml"


### PR DESCRIPTION
## Changes
Pipeline backend requires `target` to be always specified.

In order to do this we will create an unique schema as part of `TestBundlePipelineRecreateWithoutAutoApprove` test which will be used in pipelines

## Tests
```
    helpers_test.go:148: stderr: Destroy complete!
--- PASS: TestBundlePipelineRecreateWithoutAutoApprove (415.39s)
PASS
coverage: [no statements]
ok      github.com/databricks/cli/integration/bundle    416.141s        coverage: [no statements]
```

