### PR TITLE
Enable linter 'copyloopvar' and fix the issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,6 +42,8 @@ linters-settings:
     disable:
       # good check, but we have too many assert.(No)?Errorf? so excluding for now
       - require-error
+  copyloopvar:
+    check-alias: true
 issues:
   exclude-dirs-use-default: false  # recommended by docs https://golangci-lint.run/usage/false-positives/
   max-issues-per-linter: 1000

--- a/bundle/config/validate/validate_sync_patterns.go
+++ b/bundle/config/validate/validate_sync_patterns.go
@@ -48,6 +48,11 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 	var diags diag.Diagnostics
 
 	for index, pattern := range patterns {
+		// If the pattern is negated, strip the negation prefix
+		// and check if the pattern matches any files.
+		// Negation in gitignore syntax means "don't look at this path'
+		// So if p matches nothing it's useless negation, but if there are matches,
+		// it means: do not include these files into result set
 		p := strings.TrimPrefix(pattern, "!")
 		errs.Go(func() error {
 			fs, err := fileset.NewGlobSet(rb.BundleRoot(), []string{p})

--- a/bundle/config/validate/validate_sync_patterns.go
+++ b/bundle/config/validate/validate_sync_patterns.go
@@ -48,8 +48,7 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 	var diags diag.Diagnostics
 
 	for i, pattern := range patterns {
-		index := i
-		fullPattern := pattern
+		p := strings.TrimPrefix(pattern, "!")
 		// If the pattern is negated, strip the negation prefix
 		// and check if the pattern matches any files.
 		// Negation in gitignore syntax means "don't look at this path'

--- a/bundle/config/validate/validate_sync_patterns.go
+++ b/bundle/config/validate/validate_sync_patterns.go
@@ -49,12 +49,6 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 
 	for i, pattern := range patterns {
 		p := strings.TrimPrefix(pattern, "!")
-		// If the pattern is negated, strip the negation prefix
-		// and check if the pattern matches any files.
-		// Negation in gitignore syntax means "don't look at this path'
-		// So if p matches nothing it's useless negation, but if there are matches,
-		// it means: do not include these files into result set
-		p := strings.TrimPrefix(fullPattern, "!")
 		errs.Go(func() error {
 			fs, err := fileset.NewGlobSet(rb.BundleRoot(), []string{p})
 			if err != nil {

--- a/bundle/config/validate/validate_sync_patterns.go
+++ b/bundle/config/validate/validate_sync_patterns.go
@@ -47,7 +47,7 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 	var errs errgroup.Group
 	var diags diag.Diagnostics
 
-	for i, pattern := range patterns {
+	for index, pattern := range patterns {
 		p := strings.TrimPrefix(pattern, "!")
 		errs.Go(func() error {
 			fs, err := fileset.NewGlobSet(rb.BundleRoot(), []string{p})
@@ -65,7 +65,7 @@ func checkPatterns(patterns []string, path string, rb bundle.ReadOnlyBundle) (di
 				mu.Lock()
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Warning,
-					Summary:   fmt.Sprintf("Pattern %s does not match any files", fullPattern),
+					Summary:   fmt.Sprintf("Pattern %s does not match any files", pattern),
 					Locations: []dyn.Location{loc.Location()},
 					Paths:     []dyn.Path{loc.Path()},
 				})

--- a/cmd/bundle/generate/utils.go
+++ b/cmd/bundle/generate/utils.go
@@ -139,8 +139,6 @@ func (n *downloader) FlushToDisk(ctx context.Context, force bool) error {
 
 	errs, errCtx := errgroup.WithContext(ctx)
 	for k, v := range n.files {
-		targetPath := k
-		filePath := v
 		errs.Go(func() error {
 			reader, err := n.w.Workspace.Download(errCtx, filePath)
 			if err != nil {

--- a/cmd/bundle/generate/utils.go
+++ b/cmd/bundle/generate/utils.go
@@ -140,12 +140,12 @@ func (n *downloader) FlushToDisk(ctx context.Context, force bool) error {
 	errs, errCtx := errgroup.WithContext(ctx)
 	for k, v := range n.files {
 		errs.Go(func() error {
-			reader, err := n.w.Workspace.Download(errCtx, filePath)
+			reader, err := n.w.Workspace.Download(errCtx, v)
 			if err != nil {
 				return err
 			}
 
-			file, err := os.Create(targetPath)
+			file, err := os.Create(k)
 			if err != nil {
 				return err
 			}

--- a/cmd/bundle/generate/utils.go
+++ b/cmd/bundle/generate/utils.go
@@ -138,14 +138,14 @@ func (n *downloader) FlushToDisk(ctx context.Context, force bool) error {
 	}
 
 	errs, errCtx := errgroup.WithContext(ctx)
-	for k, v := range n.files {
+	for targetPath, filePath := range n.files {
 		errs.Go(func() error {
-			reader, err := n.w.Workspace.Download(errCtx, v)
+			reader, err := n.w.Workspace.Download(errCtx, filePath)
 			if err != nil {
 				return err
 			}
 
-			file, err := os.Create(k)
+			file, err := os.Create(targetPath)
 			if err != nil {
 				return err
 			}
@@ -156,7 +156,7 @@ func (n *downloader) FlushToDisk(ctx context.Context, force bool) error {
 				return err
 			}
 
-			cmdio.LogString(errCtx, "File successfully saved to "+k)
+			cmdio.LogString(errCtx, "File successfully saved to "+targetPath)
 			return reader.Close()
 		})
 	}

--- a/cmd/bundle/generate/utils.go
+++ b/cmd/bundle/generate/utils.go
@@ -156,7 +156,7 @@ func (n *downloader) FlushToDisk(ctx context.Context, force bool) error {
 				return err
 			}
 
-			cmdio.LogString(errCtx, "File successfully saved to "+targetPath)
+			cmdio.LogString(errCtx, "File successfully saved to "+k)
 			return reader.Close()
 		})
 	}

--- a/integration/cmd/fs/cat_test.go
+++ b/integration/cmd/fs/cat_test.go
@@ -42,7 +42,7 @@ func TestFsCatOnADir(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 
 			err := f.Mkdir(context.Background(), "dir1")
 			require.NoError(t, err)

--- a/integration/cmd/fs/cat_test.go
+++ b/integration/cmd/fs/cat_test.go
@@ -38,9 +38,7 @@ func TestFsCatOnADir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cat_test.go
+++ b/integration/cmd/fs/cat_test.go
@@ -22,7 +22,7 @@ func TestFsCat(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 
 			err := f.Write(context.Background(), "hello.txt", strings.NewReader("abcd"), filer.CreateParentDirectories)
 			require.NoError(t, err)

--- a/integration/cmd/fs/cat_test.go
+++ b/integration/cmd/fs/cat_test.go
@@ -18,9 +18,7 @@ func TestFsCat(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cat_test.go
+++ b/integration/cmd/fs/cat_test.go
@@ -57,9 +57,7 @@ func TestFsCatOnNonExistentFile(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cat_test.go
+++ b/integration/cmd/fs/cat_test.go
@@ -61,7 +61,7 @@ func TestFsCatOnNonExistentFile(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			_, tmpDir := tc.setupFiler(t)
+			_, tmpDir := testCase.setupFiler(t)
 
 			_, _, err := testcli.RequireErrorRun(t, ctx, "fs", "cat", path.Join(tmpDir, "non-existent-file"))
 			assert.ErrorIs(t, err, fs.ErrNotExist)

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -203,8 +203,8 @@ func TestFsCpDirToDirFileNotOverwritten(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target
@@ -227,8 +227,8 @@ func TestFsCpFileToDirFileNotOverwritten(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target
@@ -251,8 +251,8 @@ func TestFsCpFileToFileFileNotOverwritten(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target
@@ -275,8 +275,8 @@ func TestFsCpDirToDirWithOverwriteFlag(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target
@@ -299,8 +299,8 @@ func TestFsCpFileToFileWithOverwriteFlag(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target
@@ -323,8 +323,8 @@ func TestFsCpFileToDirWithOverwriteFlag(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -245,9 +245,7 @@ func TestFsCpFileToFileFileNotOverwritten(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -372,8 +370,8 @@ func TestFsCpSourceIsDirectoryButTargetIsFile(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			// Write a conflicting file to target

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -267,9 +267,7 @@ func TestFsCpDirToDirWithOverwriteFlag(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -289,9 +289,7 @@ func TestFsCpFileToFileWithOverwriteFlag(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -313,9 +311,7 @@ func TestFsCpFileToDirWithOverwriteFlag(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -337,9 +333,7 @@ func TestFsCpErrorsWhenSourceIsDirWithoutRecursiveFlag(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -362,9 +356,7 @@ func TestFsCpSourceIsDirectoryButTargetIsFile(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -130,8 +130,8 @@ func TestFsCpDir(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceDir(t, context.Background(), sourceFiler)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", sourceDir, targetDir, "--recursive")

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -126,9 +126,7 @@ func TestFsCpDir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -168,8 +168,8 @@ func TestFsCpFileToDir(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceFile(t, context.Background(), sourceFiler)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "foo.txt"), targetDir)
@@ -347,7 +347,7 @@ func TestFsCpErrorsWhenSourceIsDirWithoutRecursiveFlag(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			_, tmpDir := tc.setupFiler(t)
+			_, tmpDir := testCase.setupFiler(t)
 
 			_, _, err := testcli.RequireErrorRun(t, ctx, "fs", "cp", path.Join(tmpDir), path.Join(tmpDir, "foobar"))
 			r := regexp.MustCompile("source path .* is a directory. Please specify the --recursive flag")

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -149,8 +149,8 @@ func TestFsCpFileToFile(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			sourceFiler, sourceDir := tc.setupSource(t)
-			targetFiler, targetDir := tc.setupTarget(t)
+			sourceFiler, sourceDir := testCase.setupSource(t)
+			targetFiler, targetDir := testCase.setupTarget(t)
 			setupSourceFile(t, context.Background(), sourceFiler)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "foo.txt"), path.Join(targetDir, "bar.txt"))

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -145,9 +145,7 @@ func TestFsCpFileToFile(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -164,9 +164,7 @@ func TestFsCpFileToDir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -201,9 +199,7 @@ func TestFsCpDirToDirFileNotOverwritten(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -227,9 +223,7 @@ func TestFsCpFileToDirFileNotOverwritten(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range copyTests() {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -79,7 +79,7 @@ func TestFsLsWithAbsolutePaths(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 			setupLsFiles(t, f)
 
 			stdout, stderr := testcli.RequireSuccessfulRun(t, ctx, "fs", "ls", tmpDir, "--output=json", "--absolute")

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -125,9 +125,7 @@ func TestFsLsOnEmptyDir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -149,9 +147,7 @@ func TestFsLsForNonexistingDir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -111,7 +111,7 @@ func TestFsLsOnFile(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 			setupLsFiles(t, f)
 
 			_, _, err := testcli.RequireErrorRun(t, ctx, "fs", "ls", path.Join(tmpDir, "a", "hello.txt"), "--output=json")
@@ -131,7 +131,7 @@ func TestFsLsOnEmptyDir(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			_, tmpDir := tc.setupFiler(t)
+			_, tmpDir := testCase.setupFiler(t)
 
 			stdout, stderr := testcli.RequireSuccessfulRun(t, ctx, "fs", "ls", tmpDir, "--output=json")
 			assert.Equal(t, "", stderr.String())

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -47,7 +47,7 @@ func TestFsLs(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 			setupLsFiles(t, f)
 
 			stdout, stderr := testcli.RequireSuccessfulRun(t, ctx, "fs", "ls", tmpDir, "--output=json")

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -107,9 +107,7 @@ func TestFsLsOnFile(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -75,9 +75,7 @@ func TestFsLsWithAbsolutePaths(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -151,7 +151,7 @@ func TestFsLsForNonexistingDir(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			_, tmpDir := tc.setupFiler(t)
+			_, tmpDir := testCase.setupFiler(t)
 
 			_, _, err := testcli.RequireErrorRun(t, ctx, "fs", "ls", path.Join(tmpDir, "nonexistent"), "--output=json")
 			assert.ErrorIs(t, err, fs.ErrNotExist)

--- a/integration/cmd/fs/ls_test.go
+++ b/integration/cmd/fs/ls_test.go
@@ -43,9 +43,7 @@ func TestFsLs(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/mkdir_test.go
+++ b/integration/cmd/fs/mkdir_test.go
@@ -45,7 +45,7 @@ func TestFsMkdirCreatesIntermediateDirectories(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 
 			// create directory "a/b/c"
 			stdout, stderr := testcli.RequireSuccessfulRun(t, ctx, "fs", "mkdir", path.Join(tmpDir, "a", "b", "c"))

--- a/integration/cmd/fs/mkdir_test.go
+++ b/integration/cmd/fs/mkdir_test.go
@@ -77,9 +77,7 @@ func TestFsMkdirWhenDirectoryAlreadyExists(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/mkdir_test.go
+++ b/integration/cmd/fs/mkdir_test.go
@@ -81,7 +81,7 @@ func TestFsMkdirWhenDirectoryAlreadyExists(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 
 			// create directory "a"
 			err := f.Mkdir(context.Background(), "a")

--- a/integration/cmd/fs/mkdir_test.go
+++ b/integration/cmd/fs/mkdir_test.go
@@ -21,7 +21,7 @@ func TestFsMkdir(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 
 			// create directory "a"
 			stdout, stderr := testcli.RequireSuccessfulRun(t, ctx, "fs", "mkdir", path.Join(tmpDir, "a"))

--- a/integration/cmd/fs/mkdir_test.go
+++ b/integration/cmd/fs/mkdir_test.go
@@ -17,9 +17,7 @@ func TestFsMkdir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/mkdir_test.go
+++ b/integration/cmd/fs/mkdir_test.go
@@ -41,9 +41,7 @@ func TestFsMkdirCreatesIntermediateDirectories(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/rm_test.go
+++ b/integration/cmd/fs/rm_test.go
@@ -22,7 +22,7 @@ func TestFsRmFile(t *testing.T) {
 
 			// Create a file
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 			err := f.Write(context.Background(), "hello.txt", strings.NewReader("abcd"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 

--- a/integration/cmd/fs/rm_test.go
+++ b/integration/cmd/fs/rm_test.go
@@ -104,9 +104,7 @@ func TestFsRmForNonExistentFile(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
@@ -123,9 +121,7 @@ func TestFsRmDirRecursively(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()

--- a/integration/cmd/fs/rm_test.go
+++ b/integration/cmd/fs/rm_test.go
@@ -108,7 +108,7 @@ func TestFsRmForNonExistentFile(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			_, tmpDir := tc.setupFiler(t)
+			_, tmpDir := testCase.setupFiler(t)
 
 			// Expect error if file does not exist
 			_, _, err := testcli.RequireErrorRun(t, ctx, "fs", "rm", path.Join(tmpDir, "does-not-exist"))
@@ -125,7 +125,7 @@ func TestFsRmDirRecursively(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 
 			// Create a directory
 			err := f.Mkdir(context.Background(), "a")

--- a/integration/cmd/fs/rm_test.go
+++ b/integration/cmd/fs/rm_test.go
@@ -80,7 +80,7 @@ func TestFsRmNonEmptyDirectory(t *testing.T) {
 
 			// Create a directory
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 			err := f.Mkdir(context.Background(), "a")
 			require.NoError(t, err)
 

--- a/integration/cmd/fs/rm_test.go
+++ b/integration/cmd/fs/rm_test.go
@@ -51,7 +51,7 @@ func TestFsRmEmptyDir(t *testing.T) {
 
 			// Create a directory
 			ctx := context.Background()
-			f, tmpDir := tc.setupFiler(t)
+			f, tmpDir := testCase.setupFiler(t)
 			err := f.Mkdir(context.Background(), "a")
 			require.NoError(t, err)
 
@@ -75,9 +75,7 @@ func TestFsRmNonEmptyDirectory(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			// Create a directory

--- a/integration/cmd/fs/rm_test.go
+++ b/integration/cmd/fs/rm_test.go
@@ -17,9 +17,7 @@ func TestFsRmFile(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			// Create a file
@@ -48,9 +46,7 @@ func TestFsRmEmptyDir(t *testing.T) {
 	t.Parallel()
 
 	for _, testCase := range fsTests {
-		tc := testCase
-
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			// Create a directory

--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -128,7 +128,6 @@ func TestFilerRecursiveDelete(t *testing.T) {
 		{"files", setupUcVolumesFiler},
 		{"workspace files extensions", setupWsfsExtensionsFiler},
 	} {
-		tc := testCase
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()

--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -132,7 +132,7 @@ func TestFilerRecursiveDelete(t *testing.T) {
 
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			f, _ := tc.f(t)
+			f, _ := testCase.f(t)
 			ctx := context.Background()
 
 			// Common tests we run across all filers to ensure consistent behavior.

--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -237,8 +237,6 @@ func TestFilerReadWrite(t *testing.T) {
 		{"files", setupUcVolumesFiler},
 		{"workspace files extensions", setupWsfsExtensionsFiler},
 	} {
-		tc := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			f, _ := tc.f(t)
@@ -346,8 +344,6 @@ func TestFilerReadDir(t *testing.T) {
 		{"files", setupUcVolumesFiler},
 		{"workspace files extensions", setupWsfsExtensionsFiler},
 	} {
-		tc := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			f, _ := tc.f(t)

--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -239,7 +239,7 @@ func TestFilerReadWrite(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			f, _ := tc.f(t)
+			f, _ := testCase.f(t)
 			ctx := context.Background()
 
 			// Common tests we run across all filers to ensure consistent behavior.
@@ -346,7 +346,7 @@ func TestFilerReadDir(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			f, _ := tc.f(t)
+			f, _ := testCase.f(t)
 			ctx := context.Background()
 
 			commonFilerReadDirTest(t, ctx, f)

--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -128,7 +128,6 @@ func TestFilerRecursiveDelete(t *testing.T) {
 		{"files", setupUcVolumesFiler},
 		{"workspace files extensions", setupWsfsExtensionsFiler},
 	} {
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			f, _ := testCase.f(t)

--- a/integration/libs/locker/locker_test.go
+++ b/integration/libs/locker/locker_test.go
@@ -68,10 +68,10 @@ func TestLock(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := range numConcurrentLocks {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
-			lockerErrs[currentIndex] = lockers[currentIndex].Lock(ctx, false)
+			lockerErrs[i] = lockers[i].Lock(ctx, false)
 		}()
 	}
 	wg.Wait()

--- a/integration/libs/locker/locker_test.go
+++ b/integration/libs/locker/locker_test.go
@@ -66,13 +66,13 @@ func TestLock(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := range numConcurrentLocks {
+	for currentIndex := range numConcurrentLocks {
 		wg.Add(1)
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
-			lockerErrs[i] = lockers[i].Lock(ctx, false)
-		}(i)
+			lockerErrs[currentIndex] = lockers[currentIndex].Lock(ctx, false)
+		}()
 	}
 	wg.Wait()
 

--- a/integration/libs/locker/locker_test.go
+++ b/integration/libs/locker/locker_test.go
@@ -68,7 +68,6 @@ func TestLock(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := range numConcurrentLocks {
 		wg.Add(1)
-		currentIndex := i
 		go func() {
 			defer wg.Done()
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)

--- a/integration/libs/locker/locker_test.go
+++ b/integration/libs/locker/locker_test.go
@@ -72,7 +72,7 @@ func TestLock(t *testing.T) {
 			defer wg.Done()
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
 			lockerErrs[i] = lockers[i].Lock(ctx, false)
-		}()
+		}(i)
 	}
 	wg.Wait()
 

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -303,8 +303,6 @@ func (w *FilesClient) recursiveDelete(ctx context.Context, name string) error {
 	group.SetLimit(maxFilesRequestsInFlight)
 
 	for _, file := range filesToDelete {
-		file := file
-
 		// Skip the file if the context has already been cancelled.
 		select {
 		case <-groupCtx.Done():


### PR DESCRIPTION
## Changes
- Remove all unnecessary copies of the loop variable, it is not necessary since Go 1.22 https://go.dev/blog/loopvar-preview
- Enable the linter that catches this issue https://github.com/karamaru-alpha/copyloopvar

## Tests
Existing tests.

