### PR TITLE
Added output message to warn about slower deployments with apps

### DIFF
--- a/bundle/apps/slow_deploy_message.go
+++ b/bundle/apps/slow_deploy_message.go
@@ -1,0 +1,29 @@
+package apps
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/diag"
+)
+
+type slowDeployMessage struct{}
+
+// TODO: needs to be removed when when no_compute option becomes available in TF provider and used in DABs
+// See https://github.com/databricks/cli/pull/2144
+func (v *slowDeployMessage) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	if len(b.Config.Resources.Apps) > 0 {
+		cmdio.LogString(ctx, "Databricks apps in your bundle can slow initial deployment as they wait for compute provisioning.")
+	}
+
+	return nil
+}
+
+func (v *slowDeployMessage) Name() string {
+	return "apps.SlowDeployMessage"
+}
+
+func SlowDeployMessage() bundle.Mutator {
+	return &slowDeployMessage{}
+}

--- a/bundle/apps/validate.go
+++ b/bundle/apps/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
 )
 
@@ -16,6 +17,10 @@ func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics
 	var diags diag.Diagnostics
 	possibleConfigFiles := []string{"app.yml", "app.yaml"}
 	usedSourceCodePaths := make(map[string]string)
+
+	if len(b.Config.Resources.Apps) > 0 {
+		cmdio.LogString(ctx, "Databricks apps in your bundle can slow initial deployment as they wait for compute provisioning.")
+	}
 
 	for key, app := range b.Config.Resources.Apps {
 		if _, ok := usedSourceCodePaths[app.SourceCodePath]; ok {

--- a/bundle/apps/validate.go
+++ b/bundle/apps/validate.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
 )
 
@@ -17,10 +16,6 @@ func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics
 	var diags diag.Diagnostics
 	possibleConfigFiles := []string{"app.yml", "app.yaml"}
 	usedSourceCodePaths := make(map[string]string)
-
-	if len(b.Config.Resources.Apps) > 0 {
-		cmdio.LogString(ctx, "Databricks apps in your bundle can slow initial deployment as they wait for compute provisioning.")
-	}
 
 	for key, app := range b.Config.Resources.Apps {
 		if _, ok := usedSourceCodePaths[app.SourceCodePath]; ok {

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -136,6 +136,7 @@ func Deploy(outputHandler sync.OutputHandler) bundle.Mutator {
 		bundle.Seq(
 			terraform.StatePush(),
 			terraform.Load(),
+			apps.SlowDeployMessage(),
 			apps.InterpolateVariables(),
 			apps.UploadConfig(),
 			metadata.Compute(),


### PR DESCRIPTION
## Changes
When users create one or more Databricks apps in their bundle it can lead to initial bundle deployment being slower because apps need to wait until their compute is fully provisioned and started.

This PR adds a message to warn about it. This message will be removed when `no_compute` option becomes available in TF provider and used in DABs (https://github.com/databricks/cli/pull/2144)

