### PR TITLE
Format Python code with ruff

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,6 +64,7 @@ jobs:
         uses: astral-sh/ruff-action@31a518504640beb4897d0b9f9e50a2a9196e75ba # v3.0.1
         with:
           version: "0.9.1"
+          args: "format --check"
 
       - name: Set go env
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0
 
-      - name: Install ruff
+      - name: Run ruff
         uses: astral-sh/ruff-action@31a518504640beb4897d0b9f9e50a2a9196e75ba # v3.0.1
         with:
           version: "0.9.1"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0
 
+      - name: Install ruff
+        uses: astral-sh/ruff-action@31a518504640beb4897d0b9f9e50a2a9196e75ba # v3.0.1
+        with:
+          version: "0.9.1"
+
       - name: Set go env
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ __pycache__
 .vscode/tasks.json
 
 .databricks
+.ruff_cache

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ lintcheck:
 # formatting/goimports will not be applied by 'make lint'. However, it will be applied by 'make fmt'.
 # If you need to ensure that formatting & imports are always fixed, do "make fmt lint"
 fmt:
+	ruff format
 	golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix ./...
 
 test:
@@ -44,7 +45,7 @@ snapshot:
 
 vendor:
 	go mod vendor
-  
+
 schema:
 	go run ./bundle/internal/schema ./bundle/internal/schema ./bundle/schema/jsonschema.json
 

--- a/acceptance/bin/sort_blocks.py
+++ b/acceptance/bin/sort_blocks.py
@@ -4,6 +4,7 @@ Helper to sort blocks in text file. A block is a set of lines separated from oth
 
 This is to workaround non-determinism in the output.
 """
+
 import sys
 
 blocks = []
@@ -11,10 +12,10 @@ blocks = []
 for line in sys.stdin:
     if not line.strip():
         if blocks and blocks[-1]:
-            blocks.append('')
+            blocks.append("")
         continue
     if not blocks:
-        blocks.append('')
+        blocks.append("")
     blocks[-1] += line
 
 blocks.sort()

--- a/bundle/tests/python_wheel/environment_key/my_test_code/src/__main__.py
+++ b/bundle/tests/python_wheel/environment_key/my_test_code/src/__main__.py
@@ -7,10 +7,10 @@ import sys
 
 def main():
     # This method will print the provided arguments
-    print('Hello from my func')
-    print('Got arguments:')
+    print("Hello from my func")
+    print("Got arguments:")
     print(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bundle/tests/python_wheel/python_wheel/my_test_code/src/__main__.py
+++ b/bundle/tests/python_wheel/python_wheel/my_test_code/src/__main__.py
@@ -7,10 +7,10 @@ import sys
 
 def main():
     # This method will print the provided arguments
-    print('Hello from my func')
-    print('Got arguments:')
+    print("Hello from my func")
+    print("Got arguments:")
     print(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bundle/tests/python_wheel/python_wheel_multiple/my_test_code/src/__main__.py
+++ b/bundle/tests/python_wheel/python_wheel_multiple/my_test_code/src/__main__.py
@@ -7,10 +7,10 @@ import sys
 
 def main():
     # This method will print the provided arguments
-    print('Hello from my func')
-    print('Got arguments:')
+    print("Hello from my func")
+    print("Got arguments:")
     print(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bundle/tests/python_wheel/python_wheel_no_artifact/my_test_code/__main__.py
+++ b/bundle/tests/python_wheel/python_wheel_no_artifact/my_test_code/__main__.py
@@ -7,10 +7,10 @@ import sys
 
 def main():
     # This method will print the provided arguments
-    print('Hello from my func')
-    print('Got arguments:')
+    print("Hello from my func")
+    print("Got arguments:")
     print(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bundle/tests/python_wheel/python_wheel_no_artifact_notebook/my_test_code/__main__.py
+++ b/bundle/tests/python_wheel/python_wheel_no_artifact_notebook/my_test_code/__main__.py
@@ -7,10 +7,10 @@ import sys
 
 def main():
     # This method will print the provided arguments
-    print('Hello from my func')
-    print('Got arguments:')
+    print("Hello from my func")
+    print("Got arguments:")
     print(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/cmd/labs/project/testdata/installed-in-home/.databricks/labs/blueprint/lib/install.py
+++ b/cmd/labs/project/testdata/installed-in-home/.databricks/labs/blueprint/lib/install.py
@@ -1,1 +1,1 @@
-print(f'setting up important infrastructure')
+print(f"setting up important infrastructure")

--- a/cmd/labs/project/testdata/installed-in-home/.databricks/labs/blueprint/lib/main.py
+++ b/cmd/labs/project/testdata/installed-in-home/.databricks/labs/blueprint/lib/main.py
@@ -2,26 +2,34 @@ import os, sys, json
 
 payload = json.loads(sys.argv[1])
 
-if 'echo' == payload['command']:
-    json.dump({
-        'command': payload['command'],
-        'flags': payload['flags'],
-        'env': {k:v for k,v in os.environ.items()}
-    }, sys.stdout)
+if "echo" == payload["command"]:
+    json.dump(
+        {
+            "command": payload["command"],
+            "flags": payload["flags"],
+            "env": {k: v for k, v in os.environ.items()},
+        },
+        sys.stdout,
+    )
     sys.exit(0)
 
-if 'table' == payload['command']:
+if "table" == payload["command"]:
     sys.stderr.write("some intermediate info\n")
-    json.dump({'records': [
-        {'key': 'First', 'value': 'Second'},
-        {'key': 'Third', 'value': 'Fourth'},
-    ]}, sys.stdout)
+    json.dump(
+        {
+            "records": [
+                {"key": "First", "value": "Second"},
+                {"key": "Third", "value": "Fourth"},
+            ]
+        },
+        sys.stdout,
+    )
     sys.exit(0)
 
-print(f'host is {os.environ["DATABRICKS_HOST"]}')
+print(f"host is {os.environ['DATABRICKS_HOST']}")
 
-print(f'[{payload["command"]}] command flags are {payload["flags"]}')
+print(f"[{payload['command']}] command flags are {payload['flags']}")
 
-answer = input('What is your name? ')
+answer = input("What is your name? ")
 
-print(f'Hello, {answer}!')
+print(f"Hello, {answer}!")

--- a/libs/notebook/testdata/.ruff.toml
+++ b/libs/notebook/testdata/.ruff.toml
@@ -1,0 +1,2 @@
+[format]
+exclude = ["*.ipynb"]

--- a/libs/sync/testdata/.ruff.toml
+++ b/libs/sync/testdata/.ruff.toml
@@ -1,0 +1,2 @@
+[format]
+exclude = ["*.ipynb"]


### PR DESCRIPTION
## Changes

The materialized templates included in #2146 include Python code that we require to be formatted. Instead of running ruff as part of the testcase, we can enforce that all Python code in the repository is formatted. It won't be possible to have a passing acceptance test for template initialization with unformatted code.

