### PR TITLE
Timeout for acceptance tests

### DIFF
--- a/acceptance/bundle/variables/empty/script
+++ b/acceptance/bundle/variables/empty/script
@@ -1,1 +1,2 @@
+sleep 12
 $CLI bundle validate


### PR DESCRIPTION
## Changes
- Kill the process group after 10s (plan to make it configurable later).

## Tests
Added sleep to one of the tests: https://github.com/databricks/cli/commit/023ac9a9df7c31189bacdbd85ddc2e36099ab502

