### PR TITLE
Simplify dynvar: replace variables in a single pass

### DIFF
--- a/libs/dyn/dynvar/resolve.go
+++ b/libs/dyn/dynvar/resolve.go
@@ -50,7 +50,7 @@ type resolver struct {
 }
 
 func (r resolver) run() (out dyn.Value, err error) {
-	r.lookups = make(map[string]lookupResult)
+	r.lookups = make(map[string]lookupResult, 8)
 
 	out, err = dyn.Walk(r.in, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 		ref, ok := newRef(v)


### PR DESCRIPTION
Not ready for merge -  due to another bug root dyn.Value is reordered randomly and this makes the loop cycle diagnostic message non-deterministic. 

## Changes
- Remove the three stages / 2 walk() calls in dynvar/resolve.go and replace it with a single one.
- Remove cached for resolved: we already cache lookups, caching strings referencing variables seems excessive (low hit ratio, fast computation).

This simplification might help adding cycle detection for complex variables into dynvar module as there is less state to worry about.

## Tests
Existing tests.
