### PR TITLE
Include help output for bundle commands in acceptance tests

### DIFF
--- a/acceptance/bundle/help/bundle-deploy/output.txt
+++ b/acceptance/bundle/help/bundle-deploy/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle deploy --help
+>>> $CLI bundle deploy --help
 Deploy bundle
 
 Usage:

--- a/acceptance/bundle/help/bundle-deploy/output.txt
+++ b/acceptance/bundle/help/bundle-deploy/output.txt
@@ -1,0 +1,21 @@
+
+>>> databricks bundle deploy --help
+Deploy bundle
+
+Usage:
+  databricks bundle deploy [flags]
+
+Flags:
+      --auto-approve          Skip interactive approvals that might be required for deployment.
+  -c, --cluster-id string     Override cluster in the deployment with the given cluster ID.
+      --fail-on-active-runs   Fail if there are running jobs or pipelines in the deployment.
+      --force                 Force-override Git branch validation.
+      --force-lock            Force acquisition of deployment lock.
+  -h, --help                  help for deploy
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-deploy/script
+++ b/acceptance/bundle/help/bundle-deploy/script
@@ -1,1 +1,1 @@
-trace databricks bundle deploy --help
+trace $CLI bundle deploy --help

--- a/acceptance/bundle/help/bundle-deploy/script
+++ b/acceptance/bundle/help/bundle-deploy/script
@@ -1,0 +1,1 @@
+trace databricks bundle deploy --help

--- a/acceptance/bundle/help/bundle-deployment/output.txt
+++ b/acceptance/bundle/help/bundle-deployment/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle deployment --help
+>>> $CLI bundle deployment --help
 Deployment related commands
 
 Usage:

--- a/acceptance/bundle/help/bundle-deployment/output.txt
+++ b/acceptance/bundle/help/bundle-deployment/output.txt
@@ -1,0 +1,22 @@
+
+>>> databricks bundle deployment --help
+Deployment related commands
+
+Usage:
+  databricks bundle deployment [command]
+
+Available Commands:
+  bind        Bind bundle-defined resources to existing resources
+  unbind      Unbind bundle-defined resources from its managed remote resource
+
+Flags:
+  -h, --help   help for deployment
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"
+
+Use "databricks bundle deployment [command] --help" for more information about a command.

--- a/acceptance/bundle/help/bundle-deployment/script
+++ b/acceptance/bundle/help/bundle-deployment/script
@@ -1,0 +1,1 @@
+trace databricks bundle deployment --help

--- a/acceptance/bundle/help/bundle-deployment/script
+++ b/acceptance/bundle/help/bundle-deployment/script
@@ -1,1 +1,1 @@
-trace databricks bundle deployment --help
+trace $CLI bundle deployment --help

--- a/acceptance/bundle/help/bundle-destroy/output.txt
+++ b/acceptance/bundle/help/bundle-destroy/output.txt
@@ -1,0 +1,18 @@
+
+>>> databricks bundle destroy --help
+Destroy deployed bundle resources
+
+Usage:
+  databricks bundle destroy [flags]
+
+Flags:
+      --auto-approve   Skip interactive approvals for deleting resources and files
+      --force-lock     Force acquisition of deployment lock.
+  -h, --help           help for destroy
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-destroy/output.txt
+++ b/acceptance/bundle/help/bundle-destroy/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle destroy --help
+>>> $CLI bundle destroy --help
 Destroy deployed bundle resources
 
 Usage:

--- a/acceptance/bundle/help/bundle-destroy/script
+++ b/acceptance/bundle/help/bundle-destroy/script
@@ -1,0 +1,1 @@
+trace databricks bundle destroy --help

--- a/acceptance/bundle/help/bundle-destroy/script
+++ b/acceptance/bundle/help/bundle-destroy/script
@@ -1,1 +1,1 @@
-trace databricks bundle destroy --help
+trace $CLI bundle destroy --help

--- a/acceptance/bundle/help/bundle-generate-dashboard/output.txt
+++ b/acceptance/bundle/help/bundle-generate-dashboard/output.txt
@@ -6,13 +6,13 @@ Usage:
   databricks bundle generate dashboard [flags]
 
 Flags:
-  -s, --dashboard-dir string   directory to write the dashboard representation to (default "./src")
+  -s, --dashboard-dir string   directory to write the dashboard representation to (default "src")
       --existing-id string     ID of the dashboard to generate configuration for
       --existing-path string   workspace path of the dashboard to generate configuration for
   -f, --force                  force overwrite existing files in the output directory
   -h, --help                   help for dashboard
       --resource string        resource key of dashboard to watch for changes
-  -d, --resource-dir string    directory to write the configuration to (default "./resources")
+  -d, --resource-dir string    directory to write the configuration to (default "resources")
       --watch                  watch for changes to the dashboard and update the configuration
 
 Global Flags:

--- a/acceptance/bundle/help/bundle-generate-dashboard/output.txt
+++ b/acceptance/bundle/help/bundle-generate-dashboard/output.txt
@@ -1,0 +1,24 @@
+
+>>> databricks bundle generate dashboard --help
+Generate configuration for a dashboard
+
+Usage:
+  databricks bundle generate dashboard [flags]
+
+Flags:
+  -s, --dashboard-dir string   directory to write the dashboard representation to (default "./src")
+      --existing-id string     ID of the dashboard to generate configuration for
+      --existing-path string   workspace path of the dashboard to generate configuration for
+  -f, --force                  force overwrite existing files in the output directory
+  -h, --help                   help for dashboard
+      --resource string        resource key of dashboard to watch for changes
+  -d, --resource-dir string    directory to write the configuration to (default "./resources")
+      --watch                  watch for changes to the dashboard and update the configuration
+
+Global Flags:
+      --debug            enable debug logging
+      --key string       resource key to use for the generated configuration
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-generate-dashboard/output.txt
+++ b/acceptance/bundle/help/bundle-generate-dashboard/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle generate dashboard --help
+>>> $CLI bundle generate dashboard --help
 Generate configuration for a dashboard
 
 Usage:

--- a/acceptance/bundle/help/bundle-generate-dashboard/script
+++ b/acceptance/bundle/help/bundle-generate-dashboard/script
@@ -1,1 +1,1 @@
-trace databricks bundle generate dashboard --help
+trace $CLI bundle generate dashboard --help

--- a/acceptance/bundle/help/bundle-generate-dashboard/script
+++ b/acceptance/bundle/help/bundle-generate-dashboard/script
@@ -1,0 +1,1 @@
+trace databricks bundle generate dashboard --help

--- a/acceptance/bundle/help/bundle-generate-job/output.txt
+++ b/acceptance/bundle/help/bundle-generate-job/output.txt
@@ -1,0 +1,21 @@
+
+>>> databricks bundle generate job --help
+Generate bundle configuration for a job
+
+Usage:
+  databricks bundle generate job [flags]
+
+Flags:
+  -d, --config-dir string     Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job554412773/001/resources")
+      --existing-job-id int   Job ID of the job to generate config for
+  -f, --force                 Force overwrite existing files in the output directory
+  -h, --help                  help for job
+  -s, --source-dir string     Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job554412773/001/src")
+
+Global Flags:
+      --debug            enable debug logging
+      --key string       resource key to use for the generated configuration
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-generate-job/output.txt
+++ b/acceptance/bundle/help/bundle-generate-job/output.txt
@@ -6,11 +6,11 @@ Usage:
   databricks bundle generate job [flags]
 
 Flags:
-  -d, --config-dir string     Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job1271644346/001/resources")
+  -d, --config-dir string     Dir path where the output config will be stored (default "resources")
       --existing-job-id int   Job ID of the job to generate config for
   -f, --force                 Force overwrite existing files in the output directory
   -h, --help                  help for job
-  -s, --source-dir string     Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job1271644346/001/src")
+  -s, --source-dir string     Dir path where the downloaded files will be stored (default "src")
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/bundle/help/bundle-generate-job/output.txt
+++ b/acceptance/bundle/help/bundle-generate-job/output.txt
@@ -1,16 +1,16 @@
 
->>> databricks bundle generate job --help
+>>> $CLI bundle generate job --help
 Generate bundle configuration for a job
 
 Usage:
   databricks bundle generate job [flags]
 
 Flags:
-  -d, --config-dir string     Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job554412773/001/resources")
+  -d, --config-dir string     Dir path where the output config will be stored (default "resources")
       --existing-job-id int   Job ID of the job to generate config for
   -f, --force                 Force overwrite existing files in the output directory
   -h, --help                  help for job
-  -s, --source-dir string     Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job554412773/001/src")
+  -s, --source-dir string     Dir path where the downloaded files will be stored (default "src")
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/bundle/help/bundle-generate-job/output.txt
+++ b/acceptance/bundle/help/bundle-generate-job/output.txt
@@ -6,11 +6,11 @@ Usage:
   databricks bundle generate job [flags]
 
 Flags:
-  -d, --config-dir string     Dir path where the output config will be stored (default "resources")
+  -d, --config-dir string     Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job1271644346/001/resources")
       --existing-job-id int   Job ID of the job to generate config for
   -f, --force                 Force overwrite existing files in the output directory
   -h, --help                  help for job
-  -s, --source-dir string     Dir path where the downloaded files will be stored (default "src")
+  -s, --source-dir string     Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-job1271644346/001/src")
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/bundle/help/bundle-generate-job/script
+++ b/acceptance/bundle/help/bundle-generate-job/script
@@ -1,1 +1,1 @@
-trace databricks bundle generate job --help
+trace $CLI bundle generate job --help

--- a/acceptance/bundle/help/bundle-generate-job/script
+++ b/acceptance/bundle/help/bundle-generate-job/script
@@ -1,0 +1,1 @@
+trace databricks bundle generate job --help

--- a/acceptance/bundle/help/bundle-generate-pipeline/output.txt
+++ b/acceptance/bundle/help/bundle-generate-pipeline/output.txt
@@ -6,11 +6,11 @@ Usage:
   databricks bundle generate pipeline [flags]
 
 Flags:
-  -d, --config-dir string             Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline2765444723/001/resources")
+  -d, --config-dir string             Dir path where the output config will be stored (default "resources")
       --existing-pipeline-id string   ID of the pipeline to generate config for
   -f, --force                         Force overwrite existing files in the output directory
   -h, --help                          help for pipeline
-  -s, --source-dir string             Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline2765444723/001/src")
+  -s, --source-dir string             Dir path where the downloaded files will be stored (default "src")
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/bundle/help/bundle-generate-pipeline/output.txt
+++ b/acceptance/bundle/help/bundle-generate-pipeline/output.txt
@@ -6,11 +6,11 @@ Usage:
   databricks bundle generate pipeline [flags]
 
 Flags:
-  -d, --config-dir string             Dir path where the output config will be stored (default "resources")
+  -d, --config-dir string             Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline2765444723/001/resources")
       --existing-pipeline-id string   ID of the pipeline to generate config for
   -f, --force                         Force overwrite existing files in the output directory
   -h, --help                          help for pipeline
-  -s, --source-dir string             Dir path where the downloaded files will be stored (default "src")
+  -s, --source-dir string             Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline2765444723/001/src")
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/bundle/help/bundle-generate-pipeline/output.txt
+++ b/acceptance/bundle/help/bundle-generate-pipeline/output.txt
@@ -1,16 +1,16 @@
 
->>> databricks bundle generate pipeline --help
+>>> $CLI bundle generate pipeline --help
 Generate bundle configuration for a pipeline
 
 Usage:
   databricks bundle generate pipeline [flags]
 
 Flags:
-  -d, --config-dir string             Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline1587490482/001/resources")
+  -d, --config-dir string             Dir path where the output config will be stored (default "resources")
       --existing-pipeline-id string   ID of the pipeline to generate config for
   -f, --force                         Force overwrite existing files in the output directory
   -h, --help                          help for pipeline
-  -s, --source-dir string             Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline1587490482/001/src")
+  -s, --source-dir string             Dir path where the downloaded files will be stored (default "src")
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/bundle/help/bundle-generate-pipeline/output.txt
+++ b/acceptance/bundle/help/bundle-generate-pipeline/output.txt
@@ -1,0 +1,21 @@
+
+>>> databricks bundle generate pipeline --help
+Generate bundle configuration for a pipeline
+
+Usage:
+  databricks bundle generate pipeline [flags]
+
+Flags:
+  -d, --config-dir string             Dir path where the output config will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline1587490482/001/resources")
+      --existing-pipeline-id string   ID of the pipeline to generate config for
+  -f, --force                         Force overwrite existing files in the output directory
+  -h, --help                          help for pipeline
+  -s, --source-dir string             Dir path where the downloaded files will be stored (default "/var/folders/2g/pchp9w5x31ddddwv_9w6m9z00000gp/T/TestAcceptbundlehelpbundle-generate-pipeline1587490482/001/src")
+
+Global Flags:
+      --debug            enable debug logging
+      --key string       resource key to use for the generated configuration
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-generate-pipeline/script
+++ b/acceptance/bundle/help/bundle-generate-pipeline/script
@@ -1,1 +1,1 @@
-trace databricks bundle generate pipeline --help
+trace $CLI bundle generate pipeline --help

--- a/acceptance/bundle/help/bundle-generate-pipeline/script
+++ b/acceptance/bundle/help/bundle-generate-pipeline/script
@@ -1,0 +1,1 @@
+trace databricks bundle generate pipeline --help

--- a/acceptance/bundle/help/bundle-generate/output.txt
+++ b/acceptance/bundle/help/bundle-generate/output.txt
@@ -1,11 +1,12 @@
 
->>> databricks bundle generate --help
+>>> $CLI bundle generate --help
 Generate bundle configuration
 
 Usage:
   databricks bundle generate [command]
 
 Available Commands:
+  app         Generate bundle configuration for a Databricks app
   dashboard   Generate configuration for a dashboard
   job         Generate bundle configuration for a job
   pipeline    Generate bundle configuration for a pipeline

--- a/acceptance/bundle/help/bundle-generate/output.txt
+++ b/acceptance/bundle/help/bundle-generate/output.txt
@@ -1,0 +1,24 @@
+
+>>> databricks bundle generate --help
+Generate bundle configuration
+
+Usage:
+  databricks bundle generate [command]
+
+Available Commands:
+  dashboard   Generate configuration for a dashboard
+  job         Generate bundle configuration for a job
+  pipeline    Generate bundle configuration for a pipeline
+
+Flags:
+  -h, --help         help for generate
+      --key string   resource key to use for the generated configuration
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"
+
+Use "databricks bundle generate [command] --help" for more information about a command.

--- a/acceptance/bundle/help/bundle-generate/script
+++ b/acceptance/bundle/help/bundle-generate/script
@@ -1,1 +1,1 @@
-trace databricks bundle generate --help
+trace $CLI bundle generate --help

--- a/acceptance/bundle/help/bundle-generate/script
+++ b/acceptance/bundle/help/bundle-generate/script
@@ -1,0 +1,1 @@
+trace databricks bundle generate --help

--- a/acceptance/bundle/help/bundle-init/output.txt
+++ b/acceptance/bundle/help/bundle-init/output.txt
@@ -1,0 +1,31 @@
+
+>>> databricks bundle init --help
+Initialize using a bundle template.
+
+TEMPLATE_PATH optionally specifies which template to use. It can be one of the following:
+- default-python: The default Python template for Notebooks / Delta Live Tables / Workflows
+- default-sql: The default SQL template for .sql files that run with Databricks SQL
+- dbt-sql: The dbt SQL template (databricks.com/blog/delivering-cost-effective-data-real-time-dbt-and-databricks)
+- mlops-stacks: The Databricks MLOps Stacks template (github.com/databricks/mlops-stacks)
+- a local file system path with a template directory
+- a Git repository URL, e.g. https://github.com/my/repository
+
+See https://docs.databricks.com/en/dev-tools/bundles/templates.html for more information on templates.
+
+Usage:
+  databricks bundle init [TEMPLATE_PATH] [flags]
+
+Flags:
+      --branch string         Git branch to use for template initialization
+      --config-file string    JSON file containing key value pairs of input parameters required for template initialization.
+  -h, --help                  help for init
+      --output-dir string     Directory to write the initialized template to.
+      --tag string            Git tag to use for template initialization
+      --template-dir string   Directory path within a Git repository containing the template.
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-init/output.txt
+++ b/acceptance/bundle/help/bundle-init/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle init --help
+>>> $CLI bundle init --help
 Initialize using a bundle template.
 
 TEMPLATE_PATH optionally specifies which template to use. It can be one of the following:

--- a/acceptance/bundle/help/bundle-init/script
+++ b/acceptance/bundle/help/bundle-init/script
@@ -1,1 +1,1 @@
-trace databricks bundle init --help
+trace $CLI bundle init --help

--- a/acceptance/bundle/help/bundle-init/script
+++ b/acceptance/bundle/help/bundle-init/script
@@ -1,0 +1,1 @@
+trace databricks bundle init --help

--- a/acceptance/bundle/help/bundle-open/output.txt
+++ b/acceptance/bundle/help/bundle-open/output.txt
@@ -1,0 +1,17 @@
+
+>>> databricks bundle open --help
+Open a resource in the browser
+
+Usage:
+  databricks bundle open [flags]
+
+Flags:
+      --force-pull   Skip local cache and load the state from the remote workspace
+  -h, --help         help for open
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-open/output.txt
+++ b/acceptance/bundle/help/bundle-open/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle open --help
+>>> $CLI bundle open --help
 Open a resource in the browser
 
 Usage:

--- a/acceptance/bundle/help/bundle-open/script
+++ b/acceptance/bundle/help/bundle-open/script
@@ -1,1 +1,1 @@
-trace databricks bundle open --help
+trace $CLI bundle open --help

--- a/acceptance/bundle/help/bundle-open/script
+++ b/acceptance/bundle/help/bundle-open/script
@@ -1,0 +1,1 @@
+trace databricks bundle open --help

--- a/acceptance/bundle/help/bundle-run/output.txt
+++ b/acceptance/bundle/help/bundle-run/output.txt
@@ -1,0 +1,57 @@
+
+>>> databricks bundle run --help
+Run the job or pipeline identified by KEY.
+
+The KEY is the unique identifier of the resource to run. In addition to
+customizing the run using any of the available flags, you can also specify
+keyword or positional arguments as shown in these examples:
+
+   databricks bundle run my_job -- --key1 value1 --key2 value2
+
+Or:
+
+   databricks bundle run my_job -- value1 value2 value3
+
+If the specified job uses job parameters or the job has a notebook task with
+parameters, the first example applies and flag names are mapped to the
+parameter names.
+
+If the specified job does not use job parameters and the job has a Python file
+task or a Python wheel task, the second example applies.
+
+Usage:
+  databricks bundle run [flags] KEY
+
+Job Flags:
+      --params stringToString   comma separated k=v pairs for job parameters (default [])
+
+Job Task Flags:
+  Note: please prefer use of job-level parameters (--param) over task-level parameters.
+  For more information, see https://docs.databricks.com/en/workflows/jobs/create-run-jobs.html#pass-parameters-to-a-databricks-job-task
+      --dbt-commands strings                 A list of commands to execute for jobs with DBT tasks.
+      --jar-params strings                   A list of parameters for jobs with Spark JAR tasks.
+      --notebook-params stringToString       A map from keys to values for jobs with notebook tasks. (default [])
+      --pipeline-params stringToString       A map from keys to values for jobs with pipeline tasks. (default [])
+      --python-named-params stringToString   A map from keys to values for jobs with Python wheel tasks. (default [])
+      --python-params strings                A list of parameters for jobs with Python tasks.
+      --spark-submit-params strings          A list of parameters for jobs with Spark submit tasks.
+      --sql-params stringToString            A map from keys to values for jobs with SQL tasks. (default [])
+
+Pipeline Flags:
+      --full-refresh strings   List of tables to reset and recompute.
+      --full-refresh-all       Perform a full graph reset and recompute.
+      --refresh strings        List of tables to update.
+      --refresh-all            Perform a full graph update.
+      --validate-only          Perform an update to validate graph correctness.
+
+Flags:
+  -h, --help      help for run
+      --no-wait   Don't wait for the run to complete.
+      --restart   Restart the run if it is already running.
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-run/output.txt
+++ b/acceptance/bundle/help/bundle-run/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle run --help
+>>> $CLI bundle run --help
 Run the job or pipeline identified by KEY.
 
 The KEY is the unique identifier of the resource to run. In addition to

--- a/acceptance/bundle/help/bundle-run/script
+++ b/acceptance/bundle/help/bundle-run/script
@@ -1,1 +1,1 @@
-trace databricks bundle run --help
+trace $CLI bundle run --help

--- a/acceptance/bundle/help/bundle-run/script
+++ b/acceptance/bundle/help/bundle-run/script
@@ -1,0 +1,1 @@
+trace databricks bundle run --help

--- a/acceptance/bundle/help/bundle-schema/output.txt
+++ b/acceptance/bundle/help/bundle-schema/output.txt
@@ -1,0 +1,16 @@
+
+>>> databricks bundle schema --help
+Generate JSON Schema for bundle configuration
+
+Usage:
+  databricks bundle schema [flags]
+
+Flags:
+  -h, --help   help for schema
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-schema/output.txt
+++ b/acceptance/bundle/help/bundle-schema/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle schema --help
+>>> $CLI bundle schema --help
 Generate JSON Schema for bundle configuration
 
 Usage:

--- a/acceptance/bundle/help/bundle-schema/script
+++ b/acceptance/bundle/help/bundle-schema/script
@@ -1,0 +1,1 @@
+trace databricks bundle schema --help

--- a/acceptance/bundle/help/bundle-schema/script
+++ b/acceptance/bundle/help/bundle-schema/script
@@ -1,1 +1,1 @@
-trace databricks bundle schema --help
+trace $CLI bundle schema --help

--- a/acceptance/bundle/help/bundle-summary/output.txt
+++ b/acceptance/bundle/help/bundle-summary/output.txt
@@ -1,0 +1,17 @@
+
+>>> databricks bundle summary --help
+Summarize resources deployed by this bundle
+
+Usage:
+  databricks bundle summary [flags]
+
+Flags:
+      --force-pull   Skip local cache and load the state from the remote workspace
+  -h, --help         help for summary
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-summary/output.txt
+++ b/acceptance/bundle/help/bundle-summary/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle summary --help
+>>> $CLI bundle summary --help
 Summarize resources deployed by this bundle
 
 Usage:

--- a/acceptance/bundle/help/bundle-summary/script
+++ b/acceptance/bundle/help/bundle-summary/script
@@ -1,0 +1,1 @@
+trace databricks bundle summary --help

--- a/acceptance/bundle/help/bundle-summary/script
+++ b/acceptance/bundle/help/bundle-summary/script
@@ -1,1 +1,1 @@
-trace databricks bundle summary --help
+trace $CLI bundle summary --help

--- a/acceptance/bundle/help/bundle-sync/output.txt
+++ b/acceptance/bundle/help/bundle-sync/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle sync --help
+>>> $CLI bundle sync --help
 Synchronize bundle tree to the workspace
 
 Usage:

--- a/acceptance/bundle/help/bundle-sync/output.txt
+++ b/acceptance/bundle/help/bundle-sync/output.txt
@@ -1,0 +1,19 @@
+
+>>> databricks bundle sync --help
+Synchronize bundle tree to the workspace
+
+Usage:
+  databricks bundle sync [flags]
+
+Flags:
+      --full                perform full synchronization (default is incremental)
+  -h, --help                help for sync
+      --interval duration   file system polling interval (for --watch) (default 1s)
+      --output type         type of the output format
+      --watch               watch local file system for changes
+
+Global Flags:
+      --debug            enable debug logging
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-sync/script
+++ b/acceptance/bundle/help/bundle-sync/script
@@ -1,1 +1,1 @@
-trace databricks bundle sync --help
+trace $CLI bundle sync --help

--- a/acceptance/bundle/help/bundle-sync/script
+++ b/acceptance/bundle/help/bundle-sync/script
@@ -1,0 +1,1 @@
+trace databricks bundle sync --help

--- a/acceptance/bundle/help/bundle-validate/output.txt
+++ b/acceptance/bundle/help/bundle-validate/output.txt
@@ -1,0 +1,16 @@
+
+>>> databricks bundle validate --help
+Validate configuration
+
+Usage:
+  databricks bundle validate [flags]
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/bundle/help/bundle-validate/output.txt
+++ b/acceptance/bundle/help/bundle-validate/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle validate --help
+>>> $CLI bundle validate --help
 Validate configuration
 
 Usage:

--- a/acceptance/bundle/help/bundle-validate/script
+++ b/acceptance/bundle/help/bundle-validate/script
@@ -1,1 +1,1 @@
-trace databricks bundle validate --help
+trace $CLI bundle validate --help

--- a/acceptance/bundle/help/bundle-validate/script
+++ b/acceptance/bundle/help/bundle-validate/script
@@ -1,0 +1,1 @@
+trace databricks bundle validate --help

--- a/acceptance/bundle/help/bundle/output.txt
+++ b/acceptance/bundle/help/bundle/output.txt
@@ -1,5 +1,5 @@
 
->>> databricks bundle --help
+>>> $CLI bundle --help
 Databricks Asset Bundles let you express data/AI/analytics projects as code.
 
 Online documentation: https://docs.databricks.com/en/dev-tools/bundles/index.html

--- a/acceptance/bundle/help/bundle/output.txt
+++ b/acceptance/bundle/help/bundle/output.txt
@@ -1,0 +1,33 @@
+
+>>> databricks bundle --help
+Databricks Asset Bundles let you express data/AI/analytics projects as code.
+
+Online documentation: https://docs.databricks.com/en/dev-tools/bundles/index.html
+
+Usage:
+  databricks bundle [command]
+
+Available Commands:
+  deploy      Deploy bundle
+  deployment  Deployment related commands
+  destroy     Destroy deployed bundle resources
+  generate    Generate bundle configuration
+  init        Initialize using a bundle template
+  open        Open a resource in the browser
+  run         Run a job or pipeline update
+  schema      Generate JSON Schema for bundle configuration
+  summary     Summarize resources deployed by this bundle
+  sync        Synchronize bundle tree to the workspace
+  validate    Validate configuration
+
+Flags:
+  -h, --help          help for bundle
+      --var strings   set values for variables defined in bundle config. Example: --var="foo=bar"
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+
+Use "databricks bundle [command] --help" for more information about a command.

--- a/acceptance/bundle/help/bundle/script
+++ b/acceptance/bundle/help/bundle/script
@@ -1,0 +1,1 @@
+trace databricks bundle --help

--- a/acceptance/bundle/help/bundle/script
+++ b/acceptance/bundle/help/bundle/script
@@ -1,1 +1,1 @@
-trace databricks bundle --help
+trace $CLI bundle --help

--- a/cmd/bundle/generate/app.go
+++ b/cmd/bundle/generate/app.go
@@ -22,11 +22,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	appDefaultConfigDir = "resources"
-	appDefaultSourceDir = "src/app"
-)
-
 func NewGenerateAppCommand() *cobra.Command {
 	var configDir string
 	var sourceDir string
@@ -41,8 +36,8 @@ func NewGenerateAppCommand() *cobra.Command {
 	cmd.Flags().StringVar(&appName, "existing-app-name", "", `App name to generate config for`)
 	cmd.MarkFlagRequired("existing-app-name")
 
-	cmd.Flags().StringVarP(&configDir, "config-dir", "d", appDefaultConfigDir, `Directory path where the output bundle config will be stored`)
-	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", appDefaultSourceDir, `Directory path where the app files will be stored`)
+	cmd.Flags().StringVarP(&configDir, "config-dir", "d", "resources", `Directory path where the output bundle config will be stored`)
+	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", "src/app", `Directory path where the app files will be stored`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `Force overwrite existing files in the output directory`)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle/generate/app.go
+++ b/cmd/bundle/generate/app.go
@@ -22,6 +22,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	appDefaultConfigDir = "resources"
+	appDefaultSourceDir = "src/app"
+)
+
 func NewGenerateAppCommand() *cobra.Command {
 	var configDir string
 	var sourceDir string
@@ -36,8 +41,8 @@ func NewGenerateAppCommand() *cobra.Command {
 	cmd.Flags().StringVar(&appName, "existing-app-name", "", `App name to generate config for`)
 	cmd.MarkFlagRequired("existing-app-name")
 
-	cmd.Flags().StringVarP(&configDir, "config-dir", "d", filepath.Join("resources"), `Directory path where the output bundle config will be stored`)
-	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", filepath.Join("src", "app"), `Directory path where the app files will be stored`)
+	cmd.Flags().StringVarP(&configDir, "config-dir", "d", appDefaultConfigDir, `Directory path where the output bundle config will be stored`)
+	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", appDefaultSourceDir, `Directory path where the app files will be stored`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `Force overwrite existing files in the output directory`)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -32,6 +32,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	dashboardDefaultConfigDir = "resources"
+	dashboardDefaultSourceDir = "src"
+)
+
 type dashboard struct {
 	// Lookup flags for one-time generate.
 	existingPath string
@@ -441,8 +446,8 @@ func NewGenerateDashboardCommand() *cobra.Command {
 	cmd.Flags().MarkHidden("existing-dashboard-id")
 
 	// Output flags.
-	cmd.Flags().StringVarP(&d.resourceDir, "resource-dir", "d", "./resources", `directory to write the configuration to`)
-	cmd.Flags().StringVarP(&d.dashboardDir, "dashboard-dir", "s", "./src", `directory to write the dashboard representation to`)
+	cmd.Flags().StringVarP(&d.resourceDir, "resource-dir", "d", dashboardDefaultConfigDir, `directory to write the configuration to`)
+	cmd.Flags().StringVarP(&d.dashboardDir, "dashboard-dir", "s", dashboardDefaultSourceDir, `directory to write the dashboard representation to`)
 	cmd.Flags().BoolVarP(&d.force, "force", "f", false, `force overwrite existing files in the output directory`)
 
 	// Exactly one of the lookup flags must be provided.

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -32,11 +32,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	dashboardDefaultConfigDir = "resources"
-	dashboardDefaultSourceDir = "src"
-)
-
 type dashboard struct {
 	// Lookup flags for one-time generate.
 	existingPath string
@@ -446,8 +441,8 @@ func NewGenerateDashboardCommand() *cobra.Command {
 	cmd.Flags().MarkHidden("existing-dashboard-id")
 
 	// Output flags.
-	cmd.Flags().StringVarP(&d.resourceDir, "resource-dir", "d", dashboardDefaultConfigDir, `directory to write the configuration to`)
-	cmd.Flags().StringVarP(&d.dashboardDir, "dashboard-dir", "s", dashboardDefaultSourceDir, `directory to write the dashboard representation to`)
+	cmd.Flags().StringVarP(&d.resourceDir, "resource-dir", "d", "resources", `directory to write the configuration to`)
+	cmd.Flags().StringVarP(&d.dashboardDir, "dashboard-dir", "s", "src", `directory to write the dashboard representation to`)
 	cmd.Flags().BoolVarP(&d.force, "force", "f", false, `force overwrite existing files in the output directory`)
 
 	// Exactly one of the lookup flags must be provided.

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -18,6 +18,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	jobDefaultConfigDir = "resources"
+	jobDefaultSourceDir = "src"
+)
+
 func NewGenerateJobCommand() *cobra.Command {
 	var configDir string
 	var sourceDir string
@@ -32,13 +37,8 @@ func NewGenerateJobCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&jobId, "existing-job-id", 0, `Job ID of the job to generate config for`)
 	cmd.MarkFlagRequired("existing-job-id")
 
-	wd, err := os.Getwd()
-	if err != nil {
-		wd = "."
-	}
-
-	cmd.Flags().StringVarP(&configDir, "config-dir", "d", filepath.Join(wd, "resources"), `Dir path where the output config will be stored`)
-	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", filepath.Join(wd, "src"), `Dir path where the downloaded files will be stored`)
+	cmd.Flags().StringVarP(&configDir, "config-dir", "d", jobDefaultConfigDir, `Dir path where the output config will be stored`)
+	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", jobDefaultSourceDir, `Dir path where the downloaded files will be stored`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `Force overwrite existing files in the output directory`)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -18,11 +18,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	jobDefaultConfigDir = "resources"
-	jobDefaultSourceDir = "src"
-)
-
 func NewGenerateJobCommand() *cobra.Command {
 	var configDir string
 	var sourceDir string
@@ -37,8 +32,8 @@ func NewGenerateJobCommand() *cobra.Command {
 	cmd.Flags().Int64Var(&jobId, "existing-job-id", 0, `Job ID of the job to generate config for`)
 	cmd.MarkFlagRequired("existing-job-id")
 
-	cmd.Flags().StringVarP(&configDir, "config-dir", "d", jobDefaultConfigDir, `Dir path where the output config will be stored`)
-	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", jobDefaultSourceDir, `Dir path where the downloaded files will be stored`)
+	cmd.Flags().StringVarP(&configDir, "config-dir", "d", "resources", `Dir path where the output config will be stored`)
+	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", "src", `Dir path where the downloaded files will be stored`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `Force overwrite existing files in the output directory`)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -18,6 +18,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	pipelineDefaultConfigDir = "resources"
+	pipelineDefaultSourceDir = "src"
+)
+
 func NewGeneratePipelineCommand() *cobra.Command {
 	var configDir string
 	var sourceDir string
@@ -32,13 +37,8 @@ func NewGeneratePipelineCommand() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineId, "existing-pipeline-id", "", `ID of the pipeline to generate config for`)
 	cmd.MarkFlagRequired("existing-pipeline-id")
 
-	wd, err := os.Getwd()
-	if err != nil {
-		wd = "."
-	}
-
-	cmd.Flags().StringVarP(&configDir, "config-dir", "d", filepath.Join(wd, "resources"), `Dir path where the output config will be stored`)
-	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", filepath.Join(wd, "src"), `Dir path where the downloaded files will be stored`)
+	cmd.Flags().StringVarP(&configDir, "config-dir", "d", pipelineDefaultConfigDir, `Dir path where the output config will be stored`)
+	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", pipelineDefaultSourceDir, `Dir path where the downloaded files will be stored`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `Force overwrite existing files in the output directory`)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -18,11 +18,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	pipelineDefaultConfigDir = "resources"
-	pipelineDefaultSourceDir = "src"
-)
-
 func NewGeneratePipelineCommand() *cobra.Command {
 	var configDir string
 	var sourceDir string
@@ -37,8 +32,8 @@ func NewGeneratePipelineCommand() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineId, "existing-pipeline-id", "", `ID of the pipeline to generate config for`)
 	cmd.MarkFlagRequired("existing-pipeline-id")
 
-	cmd.Flags().StringVarP(&configDir, "config-dir", "d", pipelineDefaultConfigDir, `Dir path where the output config will be stored`)
-	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", pipelineDefaultSourceDir, `Dir path where the downloaded files will be stored`)
+	cmd.Flags().StringVarP(&configDir, "config-dir", "d", "resources", `Dir path where the output config will be stored`)
+	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", "src", `Dir path where the downloaded files will be stored`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `Force overwrite existing files in the output directory`)
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Changes

This includes a change to the defaults for the output directory flags of the "generate" commands. These defaults included the expanded working directory. This can be omitted because it is implied.