### PR TITLE
Fix incorrect TestingT.Errorf usage and enable linting for this

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,13 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+    settings:
+      printf:
+        funcs:
+          - (github.com/databricks/cli/internal/testutil.TestingT).Infof
+          - (github.com/databricks/cli/internal/testutil.TestingT).Errorf
+          - (github.com/databricks/cli/internal/testutil.TestingT).Fatalf
+          - (github.com/databricks/cli/internal/testutil.TestingT).Skipf
   gofmt:
     rewrite-rules:
       - pattern: 'a[b:len(a)]'

--- a/libs/testdiff/testdiff.go
+++ b/libs/testdiff/testdiff.go
@@ -26,7 +26,7 @@ func AssertEqualTexts(t testutil.TestingT, filename1, filename2, expected, out s
 		// only show diff for large texts
 		diff := UnifiedDiff(filename1, filename2, expected, out)
 		if diff != "" {
-			t.Errorf("Diff:\n" + diff)
+			t.Error("Diff:\n" + diff)
 			return false
 		}
 	}


### PR DESCRIPTION
## Changes
- Fix incorrect use Errorf on literal string. This resulted in garbage output in tests diagnostics where % was replaced by "(MISSING)".
- Enable linter on testingT.Errorf.

Note, the autofix by the linter is wrong, it proposes `t.Errorf("%s", string)` but it should be `t.Error(string)`. That can corrected manually though.

## Tests
Linter was tested manually by reverting the fix on Errorf.
