### PR TITLE
Add -inprocess mode for acceptance tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Verify -inprocess feature of acceptance test by running one test
         # QQQ this will succeed if test was not found, unfortunately
-        run: go test ./acceptance -v -inprocess -run TestAccept/bundle/variables/empty
+        run: go test ./acceptance -v -inprocess -run TestAccept/bundle/variables/^empty$
 
   golangci:
     needs: cleanups

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -80,6 +80,10 @@ jobs:
       - name: Run tests with coverage
         run: make cover
 
+      - name: Verify -inprocess feature of acceptance test by running one test
+        # QQQ this will succeed if test was not found, unfortunately
+        run: go test ./acceptance -v -inprocess -run TestAccept/bundle/variables/empty
+
   golangci:
     needs: cleanups
     name: lint

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -80,10 +80,6 @@ jobs:
       - name: Run tests with coverage
         run: make cover
 
-      - name: Verify -inprocess feature of acceptance test by running one test
-        # QQQ this will succeed if test was not found, unfortunately
-        run: go test ./acceptance -v -inprocess -run TestAccept/bundle/variables/^empty$
-
   golangci:
     needs: cleanups
     name: lint

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -143,8 +143,8 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 				t.Parallel()
 			}
 
-			if debugSubTest != "" && debugSubTest != testName {
-				t.Skip("Skipping due to debugSubTest")
+			if singleTest != "" && singleTest != testName {
+				t.Skip("Skipping due to singleTest")
 				return
 			}
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -54,6 +54,17 @@ var Scripts = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
+	testAccept(t, InprocessMode, "")
+}
+
+func TestInprocessMode(t *testing.T) {
+	if InprocessMode {
+		t.Skip("Already tested by TestAccept")
+	}
+	require.NotEmpty(t, testAccept(t, true, "help"))
+}
+
+func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 	repls := testdiff.ReplacementsContext{}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -140,6 +151,8 @@ func TestAccept(t *testing.T) {
 			runTest(t, dir, coverDir, repls.Clone())
 		})
 	}
+
+	return len(testDirs)
 }
 
 func getTests(t *testing.T) []string {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -32,7 +32,7 @@ var KeepTmp bool
 var singleTest = ""
 
 // If enabled, instead of compiling and running CLI externally, we'll start in-process server that accepts and runs
-// CLI commands. The $CLI in test scripts is a helper that just forwards command-line arguments to this server (see tools/callserver.py).
+// CLI commands. The $CLI in test scripts is a helper that just forwards command-line arguments to this server (see bin/callserver.py).
 // Also disables parallelism in tests.
 var InprocessMode bool
 
@@ -72,7 +72,7 @@ func TestAccept(t *testing.T) {
 	if InprocessMode {
 		cmdServer := StartCmdServer(t)
 		t.Setenv("CMD_SERVER_URL", cmdServer.URL)
-		execPath = "callserver.py"
+		execPath = filepath.Join(cwd, "bin", "callserver.py")
 	} else {
 		execPath = BuildCLI(t, cwd, coverDir)
 	}

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -61,7 +61,11 @@ func TestInprocessMode(t *testing.T) {
 	if InprocessMode {
 		t.Skip("Already tested by TestAccept")
 	}
-	t.Setenv("TERM", "dumb")
+	if runtime.GOOS == "windows" {
+		// -  catalogs                               A catalog is the first layer of Unity Catalog’s three-level namespace.
+		// +  catalogs                               A catalog is the first layer of Unity Catalog�s three-level namespace.
+		t.Skip("Fails on CI on unicode characters")
+	}
 	require.NotZero(t, testAccept(t, true, "help"))
 }
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -144,11 +144,6 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 				t.Parallel()
 			}
 
-			if singleTest != "" && singleTest != testName {
-				t.Skip("Skipping due to singleTest")
-				return
-			}
-
 			runTest(t, dir, coverDir, repls.Clone())
 		})
 	}

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -62,7 +62,7 @@ func TestInprocessMode(t *testing.T) {
 		t.Skip("Already tested by TestAccept")
 	}
 	t.Setenv("NO_COLOR", "1")
-	require.NotEmpty(t, testAccept(t, true, "help"))
+	require.NotZero(t, testAccept(t, true, "help"))
 }
 
 func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -61,7 +61,7 @@ func TestInprocessMode(t *testing.T) {
 	if InprocessMode {
 		t.Skip("Already tested by TestAccept")
 	}
-	t.Setenv("NO_COLOR", "1")
+	t.Setenv("TERM", "dumb")
 	require.NotZero(t, testAccept(t, true, "help"))
 }
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -61,6 +61,7 @@ func TestInprocessMode(t *testing.T) {
 	if InprocessMode {
 		t.Skip("Already tested by TestAccept")
 	}
+	t.Setenv("NO_COLOR", "1")
 	require.NotEmpty(t, testAccept(t, true, "help"))
 }
 

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -3,20 +3,25 @@ import sys
 import os
 import json
 import subprocess
-from urllib.parse import quote_plus
+from urllib.parse import urlencode
 
 env = {}
 for key, value in os.environ.items():
-    if "BUNDLE_VAR" in key or "DATABRICKS" in key:
-        env[key] = value
+    if len(value) > 1000:
+        sys.stderr.write(f"Dropping key={key} value len={len(value)}")
+        continue
+    env[key] = value
 
-q = [
-    "args=" + quote_plus(" ".join(sys.argv[1:])),
-    "cwd=" + quote_plus(os.getcwd()),
-    "env=" + quote_plus(json.dumps(env)),
-]
+q = {
+    "args": " ".join(sys.argv[1:]),
+    "cwd": os.getcwd(),
+    "env": json.dumps(env),
+}
 
-url = os.environ["CMD_SERVER_URL"] + "/?" + "&".join(q)
+url = os.environ["CMD_SERVER_URL"] + "/?" + urlencode(q)
+if len(url) > 100_000:
+    sys.exit("url too large")
+
 out = subprocess.run(["curl", "-s", url], stdout=subprocess.PIPE, check=True)
 result = json.loads(out.stdout)
 sys.stderr.write(result["stderr"])

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 env = {}
 for key, value in os.environ.items():
     if len(value) > 1000:
-        sys.stderr.write(f"Dropping key={key} value len={len(value)}")
+        sys.stderr.write(f"Dropping key={key} value len={len(value)}\n")
         continue
     env[key] = value
 

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -2,7 +2,7 @@
 import sys
 import os
 import json
-import subprocess
+import urllib.request
 from urllib.parse import urlencode
 
 env = {}
@@ -22,8 +22,9 @@ url = os.environ["CMD_SERVER_URL"] + "/?" + urlencode(q)
 if len(url) > 100_000:
     sys.exit("url too large")
 
-out = subprocess.run(["curl", "-s", url], stdout=subprocess.PIPE, check=True)
-result = json.loads(out.stdout)
+resp = urllib.request.urlopen(url)
+assert resp.status == 200, (resp.status, resp.url, resp.headers)
+result = json.load(resp)
 sys.stderr.write(result["stderr"])
 sys.stdout.write(result["stdout"])
 exitcode = int(result["exitcode"])

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -3,14 +3,20 @@ import sys
 import os
 import json
 import subprocess
-import urllib.parse
+from urllib.parse import quote_plus
 
+env = {}
+for key, value in os.environ.items():
+    if "BUNDLE_VAR" in key or "DATABRICKS" in key:
+        env[key] = value
 
-args = " ".join(sys.argv[1:])
-args = urllib.parse.quote_plus(args)
-cwd = urllib.parse.quote_plus(os.getcwd())
+q = [
+    "args=" + quote_plus(" ".join(sys.argv[1:])),
+    "cwd=" + quote_plus(os.getcwd()),
+    "env=" + quote_plus(json.dumps(env)),
+]
 
-url = os.environ["CMD_SERVER_URL"] + "/?args=" + args + "&cwd=" + cwd
+url = os.environ["CMD_SERVER_URL"] + "/?" + "&".join(q)
 out = subprocess.run(["curl", "-s", url], stdout=subprocess.PIPE, check=True)
 result = json.loads(out.stdout)
 sys.stderr.write(result["stderr"])

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 env = {}
 for key, value in os.environ.items():
-    if len(value) > 1000:
+    if len(value) > 10_000:
         sys.stderr.write(f"Dropping key={key} value len={len(value)}\n")
         continue
     env[key] = value

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import sys
+import os
+import urllib.parse
+
+
+
+args = "/".join(sys.argv[1:])
+args = urllib.parse.quote_plus(args)
+
+url = os.environ["CMD_SERVER_URL"] + "/?args=" + args
+os.execvp("curl", ["curl", "-s", url])

--- a/acceptance/bin/callserver.py
+++ b/acceptance/bin/callserver.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 import sys
 import os
+import json
+import subprocess
 import urllib.parse
 
 
-
-args = "/".join(sys.argv[1:])
+args = " ".join(sys.argv[1:])
 args = urllib.parse.quote_plus(args)
+cwd = urllib.parse.quote_plus(os.getcwd())
 
-url = os.environ["CMD_SERVER_URL"] + "/?args=" + args
-os.execvp("curl", ["curl", "-s", url])
+url = os.environ["CMD_SERVER_URL"] + "/?args=" + args + "&cwd=" + cwd
+out = subprocess.run(["curl", "-s", url], stdout=subprocess.PIPE, check=True)
+result = json.loads(out.stdout)
+sys.stderr.write(result["stderr"])
+sys.stdout.write(result["stdout"])
+exitcode = int(result["exitcode"])
+sys.exit(exitcode)

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -1,10 +1,17 @@
 package acceptance_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
+
+type Response struct {
+	Message string         `json:"message"`
+	Args    url.Values     `json:"args"`
+}
 
 type CmdServer struct {
 	*httptest.Server
@@ -44,7 +51,16 @@ func StartCmdServer(t *testing.T) *CmdServer {
 		server.Close()
 	})
 	server.Handle("/", func(r *http.Request) (string, error) {
-		return "hello, from server", nil
+		args := r.URL.Query()
+		resp := Response{
+			Message: "hello, from server",
+			Args:    args,
+		}
+		jsonResp, err := json.Marshal(resp)
+		if err != nil {
+			return "", err
+		}
+		return string(jsonResp), nil
 	})
 	return server
 }

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func StartCmdServer(t *testing.T) *TestServer {
-	server := NewTestServer()
-	t.Cleanup(func() {
-		server.Close()
-	})
+	server := StartServer(t)
 	server.Handle("/", func(r *http.Request) (any, error) {
 		q := r.URL.Query()
 		args := strings.Split(q.Get("args"), " ")

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -52,12 +52,10 @@ func StartCmdServer(t *testing.T) *CmdServer {
 		server.Close()
 	})
 	server.Handle("/", func(r *http.Request) (string, error) {
-		args := r.URL.Query()
-		resp := "hello, from server\n"
-		for key, values := range args {
-			for _, value := range values {
-				resp += key + ": " + value + "\n"
-			}
+		args := r.URL.Query().Get("args")
+		resp := "hello, from server"
+		if args != "" {
+			resp += "\nargs: " + args
 		}
 		return resp, nil
 	})

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -1,9 +1,16 @@
 package acceptance_test
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/databricks/cli/internal/testcli"
+	"github.com/stretchr/testify/require"
 )
 
 type CmdServer struct {
@@ -11,8 +18,7 @@ type CmdServer struct {
 	Mux *http.ServeMux
 }
 
-type StringHandlerFunc func(r *http.Request) (string, error)
-
+// type StringHandlerFunc func(r *http.Request) (string, error)
 func NewCmdServer() *CmdServer {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -23,16 +29,32 @@ func NewCmdServer() *CmdServer {
 	}
 }
 
-func (s *CmdServer) Handle(pattern string, handler StringHandlerFunc) {
+func (s *CmdServer) Handle(pattern string, handler HandlerFunc) {
 	s.Mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
 		resp, err := handler(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		// XXX helper function to share with server_test.go
+		// XXX actually share the whole server, it's the handler that's different?
 
-		w.Header().Set("Content-Type", "text/plain")
-		if _, err := w.Write([]byte(resp)); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+
+		var respBytes []byte
+
+		respString, ok := resp.(string)
+		if ok {
+			respBytes = []byte(respString)
+		} else {
+			respBytes, err = json.MarshalIndent(resp, "", "    ")
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		if _, err := w.Write(respBytes); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -44,13 +66,30 @@ func StartCmdServer(t *testing.T) *CmdServer {
 	t.Cleanup(func() {
 		server.Close()
 	})
-	server.Handle("/", func(r *http.Request) (string, error) {
+	server.Handle("/", func(r *http.Request) (any, error) {
 		args := r.URL.Query().Get("args")
-		resp := "hello, from server"
-		if args != "" {
-			resp += "\nargs: " + args
+		argsSlice := strings.Split(args, " ")
+		cwd := r.URL.Query().Get("cwd")
+
+		prevDir, err := os.Getwd()
+		require.NoError(t, err)
+		err = os.Chdir(cwd)
+		require.NoError(t, err)
+		defer os.Chdir(prevDir) // nolint:errcheck
+
+		c := testcli.NewRunner(t, context.Background(), argsSlice...)
+		c.NoLog = true
+		stdout, stderr, err := c.Run()
+		result := map[string]any{
+			"stdout": stdout.String(),
+			"stderr": stderr.String(),
 		}
-		return resp, nil
+		exitcode := 0
+		if err != nil {
+			exitcode = 1
+		}
+		result["exitcode"] = exitcode
+		return result, nil
 	})
 	return server
 }

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -13,56 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type CmdServer struct {
-	*httptest.Server
-	Mux *http.ServeMux
-}
-
-// type StringHandlerFunc func(r *http.Request) (string, error)
-func NewCmdServer() *CmdServer {
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-
-	return &CmdServer{
-		Server: server,
-		Mux:    mux,
-	}
-}
-
-func (s *CmdServer) Handle(pattern string, handler HandlerFunc) {
-	s.Mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
-		resp, err := handler(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		// XXX helper function to share with server_test.go
-		// XXX actually share the whole server, it's the handler that's different?
-
-		w.Header().Set("Content-Type", "application/json")
-
-		var respBytes []byte
-
-		respString, ok := resp.(string)
-		if ok {
-			respBytes = []byte(respString)
-		} else {
-			respBytes, err = json.MarshalIndent(resp, "", "    ")
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		}
-
-		if _, err := w.Write(respBytes); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
-}
-
-func StartCmdServer(t *testing.T) *CmdServer {
-	server := NewCmdServer()
+func StartCmdServer(t *testing.T) *TestServer {
+	server := NewTestServer()
 	t.Cleanup(func() {
 		server.Close()
 	})

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -38,6 +38,7 @@ func (s *CmdServer) Handle(pattern string, handler StringHandlerFunc) {
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/json")
 		if _, err := w.Write([]byte(resp)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -53,15 +53,13 @@ func StartCmdServer(t *testing.T) *CmdServer {
 	})
 	server.Handle("/", func(r *http.Request) (string, error) {
 		args := r.URL.Query()
-		resp := Response{
-			Message: "hello, from server",
-			Args:    args,
+		resp := "hello, from server\n"
+		for key, values := range args {
+			for _, value := range values {
+				resp += key + ": " + value + "\n"
+			}
 		}
-		jsonResp, err := json.Marshal(resp)
-		if err != nil {
-			return "", err
-		}
-		return string(jsonResp), nil
+		return resp, nil
 	})
 	return server
 }

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -31,7 +31,7 @@ func StartCmdServer(t *testing.T) *TestServer {
 		defer Chdir(t, q.Get("cwd"))()
 
 		c := testcli.NewRunner(t, context.Background(), args...)
-		c.NoLog = true
+		c.Verbose = false
 		stdout, stderr, err := c.Run()
 		result := map[string]any{
 			"stdout": stdout.String(),

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -1,7 +1,6 @@
 package acceptance_test
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -27,7 +26,7 @@ func StartCmdServer(t *testing.T) *TestServer {
 
 		defer Chdir(t, q.Get("cwd"))()
 
-		c := testcli.NewRunner(t, context.Background(), args...)
+		c := testcli.NewRunner(t, r.Context(), args...)
 		c.Verbose = false
 		stdout, stderr, err := c.Run()
 		result := map[string]any{

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -1,7 +1,6 @@
 package acceptance_test
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,8 +8,8 @@ import (
 )
 
 type Response struct {
-	Message string         `json:"message"`
-	Args    url.Values     `json:"args"`
+	Message string     `json:"message"`
+	Args    url.Values `json:"args"`
 }
 
 type CmdServer struct {

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -3,14 +3,8 @@ package acceptance_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 )
-
-type Response struct {
-	Message string     `json:"message"`
-	Args    url.Values `json:"args"`
-}
 
 type CmdServer struct {
 	*httptest.Server
@@ -37,7 +31,7 @@ func (s *CmdServer) Handle(pattern string, handler StringHandlerFunc) {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "text/plain")
 		if _, err := w.Write([]byte(resp)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Changes
- If you pass -inprocess flag to acceptance tests, they will run in the same process as test itself. This enables debugging.
- If you set singleTest variable on top of acceptance_test.go, you'll only run that test and with inprocess mode. This is intended for debugging in VSCode.
- (minor) Converted KeepTmp to flag -keeptmp from env var KEEP_TMP for consistency with other flags.

## Tests
- I verified that acceptance tests pass with -inprocess mode: `go test -inprocess < /dev/null | cat`
- I verified that debugging in VSCode works: set a test name in singleTest variable, set breakpoints inside CLI and click "debug test" in VSCode.

