### PR TITLE
Run 'ruff format' in quiet mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lintcheck:
 # formatting/goimports will not be applied by 'make lint'. However, it will be applied by 'make fmt'.
 # If you need to ensure that formatting & imports are always fixed, do "make fmt lint"
 fmt:
-	ruff format
+	ruff format -q
 	golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix ./...
 
 test:


### PR DESCRIPTION
Otherwise it prints "83 files left unchanged".
