### PR TITLE
Fix duplicate "apps" entry in help output

### DIFF
--- a/acceptance/help/output.txt
+++ b/acceptance/help/output.txt
@@ -115,7 +115,6 @@ Marketplace
 
 Apps
   apps                                   Apps run directly on a customer’s Databricks instance, integrate with their data, use and extend Databricks services, and enable users to interact through single sign-on.
-  apps                                   Apps run directly on a customer’s Databricks instance, integrate with their data, use and extend Databricks services, and enable users to interact through single sign-on.
 
 Clean Rooms
   clean-room-assets                      Clean room assets are data and code objects — Tables, volumes, and notebooks that are shared with the clean room.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,7 +15,6 @@ import (
 	"github.com/databricks/cli/cmd/sync"
 	"github.com/databricks/cli/cmd/version"
 	"github.com/databricks/cli/cmd/workspace"
-	"github.com/databricks/cli/cmd/workspace/apps"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +67,6 @@ func New(ctx context.Context) *cobra.Command {
 
 	// Add other subcommands.
 	cli.AddCommand(api.New())
-	cli.AddCommand(apps.New())
 	cli.AddCommand(auth.New())
 	cli.AddCommand(bundle.New())
 	cli.AddCommand(configure.New())


### PR DESCRIPTION
## Changes

This is not needed because the command group is already returned by `workspace.All()`.

The additional command registration was added in #1679.

## Tests

Acceptance test.
