### PR TITLE
Clean up unnecessary cleanup of inferred flag

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -388,14 +388,6 @@ func (r *Root) MergeTargetOverrides(name string) error {
 			return err
 		}
 
-		// If the branch was overridden, we need to clear the inferred flag.
-		if branch := v.Get("branch"); branch.Kind() != dyn.KindInvalid {
-			out, err = dyn.SetByPath(out, dyn.NewPath(dyn.Key("inferred")), dyn.V(false))
-			if err != nil {
-				return err
-			}
-		}
-
 		// Set the merged value.
 		root, err = dyn.SetByPath(root, dyn.NewPath(dyn.Key("bundle"), dyn.Key("git")), out)
 		if err != nil {


### PR DESCRIPTION
## Changes
The SelectTarget mutator (part of Load phase) clears bundle.git.inferred flag but it is not set until later - Initialize phase / LoadGitDetails mutator.

## Tests
Existing tests.

