### PR TITLE
Add acceptance for test for sync.paths equal to two dots

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -137,6 +137,9 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 		tmpDir = t.TempDir()
 	}
 
+	repls.Set("/private"+tmpDir, "$TMPDIR")
+	repls.Set("/private"+filepath.Dir(tmpDir), "$TMPPARENT")
+	repls.Set("/private"+filepath.Dir(filepath.Dir(tmpDir)), "$TMPGPARENT")
 	repls.Set(tmpDir, "$TMPDIR")
 	repls.Set(filepath.Dir(tmpDir), "$TMPPARENT")
 	repls.Set(filepath.Dir(filepath.Dir(tmpDir)), "$TMPGPARENT")

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -137,6 +137,10 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 		tmpDir = t.TempDir()
 	}
 
+	repls.Set(tmpDir, "$TMPDIR")
+	repls.Set(filepath.Dir(tmpDir), "$TMPPARENT")
+	repls.Set(filepath.Dir(filepath.Dir(tmpDir)), "$TMPGPARENT")
+
 	scriptContents := readMergedScriptContents(t, dir)
 	testutil.WriteFile(t, filepath.Join(tmpDir, EntryPointScript), scriptContents)
 

--- a/acceptance/bundle/sync-paths-dotdot/databricks.yml
+++ b/acceptance/bundle/sync-paths-dotdot/databricks.yml
@@ -1,0 +1,5 @@
+bundle:
+  name: test-bundle
+sync:
+  paths:
+    - ..

--- a/acceptance/bundle/sync-paths-dotdot/output.txt
+++ b/acceptance/bundle/sync-paths-dotdot/output.txt
@@ -1,0 +1,11 @@
+Error: path "$TMPPARENT" is not within repository root "$TMPDIR"
+
+Name: test-bundle
+Target: default
+Workspace:
+  User: $USERNAME
+  Path: /Workspace/Users/$USERNAME/.bundle/test-bundle/default
+
+Found 1 error
+
+Exit code: 1

--- a/acceptance/bundle/sync-paths-dotdot/script
+++ b/acceptance/bundle/sync-paths-dotdot/script
@@ -1,0 +1,1 @@
+$CLI bundle validate


### PR DESCRIPTION
Based on integration test from @andrewnester in #2194

Manually checked that this databricks.yml passes validation on v0.235.0 but fails on v0.236.0, very like it was broken in https://github.com/databricks/cli/pull/1945

This also adds replacements for tmpdir, it's parent and (just in case) grand parent.