### PR TITLE
Set WorktreeRoot to sync root outside git repo

### DIFF
--- a/acceptance/bundle/syncroot/dotdot-nogit/output.txt
+++ b/acceptance/bundle/syncroot/dotdot-nogit/output.txt
@@ -1,11 +1,7 @@
-Error: path "$TMPDIR_PARENT" is not within repository root "$TMPDIR"
-
 Name: test-bundle
 Target: default
 Workspace:
   User: $USERNAME
   Path: /Workspace/Users/$USERNAME/.bundle/test-bundle/default
 
-Found 1 error
-
-Exit code: 1
+Validation OK!

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -32,7 +32,7 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	}
 
 	if info.WorktreeRoot == "" {
-		b.WorktreeRoot = b.BundleRoot
+		b.WorktreeRoot = b.SyncRoot
 	} else {
 		b.WorktreeRoot = vfs.MustNew(info.WorktreeRoot)
 	}


### PR DESCRIPTION
## Changes
If git is not detected, set default worktree root to sync root. Otherwise NewFileSet/View raise an error about worktree root being outside view root in acceptance/bundle/sync-paths-dotdot.

This behavior is introduced in https://github.com/databricks/cli/pull/1945

Stacked on https://github.com/databricks/cli/pull/2202

## Tests
Existing tests.

