### PR TITLE
Clone ReplacementContext before passing into test

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -99,7 +99,7 @@ func TestAccept(t *testing.T) {
 		testName := strings.ReplaceAll(dir, "\\", "/")
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
-			runTest(t, dir, coverDir, repls)
+			runTest(t, dir, coverDir, repls.Clone())
 		})
 	}
 }

--- a/libs/testdiff/replacement.go
+++ b/libs/testdiff/replacement.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/internal/testutil"
@@ -29,6 +30,10 @@ type Replacement struct {
 
 type ReplacementsContext struct {
 	Repls []Replacement
+}
+
+func (r *ReplacementsContext) Clone() ReplacementsContext {
+	return ReplacementsContext{Repls: slices.Clone(r.Repls)}
 }
 
 func (r *ReplacementsContext) Replace(s string) string {


### PR DESCRIPTION
## Changes
- Add a new method Clone() on ReplacementContext
- Use it when passing common replacements to test cases.

## Tests
Manually. I have a different branch where this bug manifested and this change helped.
