### PR TITLE
Show an error when non-yaml files used in include section

### DIFF
--- a/acceptance/bundle/includes/non_yaml_in_include/databricks.yml
+++ b/acceptance/bundle/includes/non_yaml_in_include/databricks.yml
@@ -1,0 +1,6 @@
+bundle:
+  name: non_yaml_in_includes
+
+include:
+ - resources/*.yml
+ - test.py

--- a/acceptance/bundle/includes/non_yaml_in_include/databricks.yml
+++ b/acceptance/bundle/includes/non_yaml_in_include/databricks.yml
@@ -2,5 +2,5 @@ bundle:
   name: non_yaml_in_includes
 
 include:
- - resources/*.yml
  - test.py
+ - resources/*.yml

--- a/acceptance/bundle/includes/non_yaml_in_include/output.txt
+++ b/acceptance/bundle/includes/non_yaml_in_include/output.txt
@@ -1,5 +1,5 @@
 Error: non-yaml file in 'include' section
-  in databricks.yml:5:2
+  in databricks.yml:5:4
 
 file test.py included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section
 

--- a/acceptance/bundle/includes/non_yaml_in_include/output.txt
+++ b/acceptance/bundle/includes/non_yaml_in_include/output.txt
@@ -1,4 +1,7 @@
-Error: file test.py included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section
+Error: non-yaml file in 'include' section
+  in databricks.yml:5:2
+
+file test.py included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section
 
 Name: non_yaml_in_includes
 

--- a/acceptance/bundle/includes/non_yaml_in_include/output.txt
+++ b/acceptance/bundle/includes/non_yaml_in_include/output.txt
@@ -1,7 +1,7 @@
-Error: non-yaml file in 'include' section
+Error: Files in the 'include' configuration section must be YAML files.
   in databricks.yml:5:4
 
-file test.py included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section
+The file test.py in the 'include' configuration section is not a YAML file, and only YAML files are supported. To include files to sync, specify them in the 'sync.include' configuration section instead.
 
 Name: non_yaml_in_includes
 

--- a/acceptance/bundle/includes/non_yaml_in_include/output.txt
+++ b/acceptance/bundle/includes/non_yaml_in_include/output.txt
@@ -1,0 +1,7 @@
+Error: file test.py included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section
+
+Name: non_yaml_in_includes
+
+Found 1 error
+
+Exit code: 1

--- a/acceptance/bundle/includes/non_yaml_in_include/script
+++ b/acceptance/bundle/includes/non_yaml_in_include/script
@@ -1,0 +1,1 @@
+$CLI bundle validate

--- a/acceptance/bundle/includes/non_yaml_in_include/test.py
+++ b/acceptance/bundle/includes/non_yaml_in_include/test.py
@@ -1,0 +1,1 @@
+print("Hello world")

--- a/bundle/config/loader/process_root_includes.go
+++ b/bundle/config/loader/process_root_includes.go
@@ -75,7 +75,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Error,
 					Summary:   "Files in the 'include' configuration section must be YAML files.",
-					Detail:    fmt.Sprintf("file %s included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section", rel),
+					Detail:    fmt.Sprintf("The file %s in the 'include' configuration section is not a YAML file, and only YAML files are supported. To include files to sync, specify them in the 'sync.include' configuration section instead.", rel),
 					Locations: b.Config.GetLocations(fmt.Sprintf("include[%d]", i)),
 				})
 				continue

--- a/bundle/config/loader/process_root_includes.go
+++ b/bundle/config/loader/process_root_includes.go
@@ -62,7 +62,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 
 		// Filter matches to ones we haven't seen yet.
 		var includes []string
-		for _, match := range matches {
+		for i, match := range matches {
 			rel, err := filepath.Rel(b.BundleRootPath, match)
 			if err != nil {
 				return diag.FromErr(err)
@@ -76,7 +76,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 					Severity:  diag.Error,
 					Summary:   "non-yaml file in 'include' section",
 					Detail:    fmt.Sprintf("file %s included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section", rel),
-					Locations: b.Config.GetLocations("include"),
+					Locations: b.Config.GetLocations(fmt.Sprintf("include[%d]", i)),
 				})
 				continue
 			}

--- a/bundle/config/loader/process_root_includes.go
+++ b/bundle/config/loader/process_root_includes.go
@@ -69,6 +69,9 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 				continue
 			}
 			seen[rel] = true
+			if filepath.Ext(rel) != ".yaml" && filepath.Ext(rel) != ".yml" {
+				return diag.Errorf("file %s included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section", rel)
+			}
 			includes = append(includes, rel)
 		}
 

--- a/bundle/config/loader/process_root_includes.go
+++ b/bundle/config/loader/process_root_includes.go
@@ -74,7 +74,7 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 			if filepath.Ext(rel) != ".yaml" && filepath.Ext(rel) != ".yml" {
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Error,
-					Summary:   "non-yaml file in 'include' section",
+					Summary:   "Files in the 'include' configuration section must be YAML files.",
 					Detail:    fmt.Sprintf("file %s included in 'include' section but only YAML files are supported. If you want to explicitly include files to sync, use 'sync.include' configuration section", rel),
 					Locations: b.Config.GetLocations(fmt.Sprintf("include[%d]", i)),
 				})


### PR DESCRIPTION
## Changes
`include` section is used only to include other bundle configuration YAML files. If any other file type is used, raise an error and guide users to use `sync.include` instead

## Tests
Added acceptance test

