### PR TITLE
Use local git config in tests

### DIFF
--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -34,7 +34,7 @@ trace() {
 
 git-repo-init() {
     git init -qb main
-    git config --global core.autocrlf false
+    git config core.autocrlf false
     git config user.name "Tester"
     git config user.email "tester@databricks.com"
     git add databricks.yml


### PR DESCRIPTION
I've seen this error: could not lock config file $TMPDIR_GPARENT/TestAccept3968313522/002/.gitconfig: File exists

This is likely the cause.

