### PR TITLE
acc: only print non-zero exit codes in errcode function

### DIFF
--- a/acceptance/bundle/paths/fallback/output.txt
+++ b/acceptance/bundle/paths/fallback/output.txt
@@ -1,8 +1,6 @@
 
 >>> $CLI bundle validate -t development -o json
 
-Exit code: 0
-
 >>> $CLI bundle validate -t error
 Error: notebook this value is overridden not found. Local notebook references are expected
 to contain one of the following file extensions: [.py, .r, .scala, .sql, .ipynb]

--- a/acceptance/bundle/paths/nominal/output.txt
+++ b/acceptance/bundle/paths/nominal/output.txt
@@ -1,8 +1,6 @@
 
 >>> $CLI bundle validate -t development -o json
 
-Exit code: 0
-
 >>> $CLI bundle validate -t error
 Error: notebook this value is overridden not found. Local notebook references are expected
 to contain one of the following file extensions: [.py, .r, .scala, .sql, .ipynb]

--- a/acceptance/bundle/variables/arg-repeat/output.txt
+++ b/acceptance/bundle/variables/arg-repeat/output.txt
@@ -1,7 +1,5 @@
 
 >>> errcode $CLI bundle validate --var a=one -o json
-
-Exit code: 0
 {
   "a": {
     "default": "hello",

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -6,7 +6,9 @@ errcode() {
     local exit_code=$?
     # Re-enable 'set -e' if it was previously set
     set -e
-    >&2 printf "\nExit code: $exit_code\n"
+    if [ $exit_code -ne 0 ]; then
+        >&2 printf "\nExit code: $exit_code\n"
+    fi
 }
 
 trace() {


### PR DESCRIPTION
Reduce noise in the output and matches how "Exit code" is handled for the whole script.