### PR TITLE
acc: Support per-test configuration; GOOS option to disable OS

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -105,3 +105,7 @@ License - https://github.com/wI2L/jsondiff/blob/master/LICENSE
 https://github.com/hexops/gotextdiff
 Copyright (c) 2009 The Go Authors. All rights reserved.
 License - https://github.com/hexops/gotextdiff/blob/main/LICENSE
+
+https://github.com/BurntSushi/toml
+Copyright (c) 2013 TOML authors
+https://github.com/BurntSushi/toml/blob/master/COPYING

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -175,6 +175,13 @@ func getTests(t *testing.T) []string {
 }
 
 func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsContext) {
+	config, configPath := LoadConfig(t, dir)
+
+	isEnabled, isPresent := config.GOOS[runtime.GOOS]
+	if isPresent && !isEnabled {
+		t.Skipf("Disabled via GOOS.%s setting in %s", runtime.GOOS, configPath)
+	}
+
 	var tmpDir string
 	var err error
 	if KeepTmp {

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -1,0 +1,98 @@
+package acceptance_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
+)
+
+const configFilename = "test.toml"
+
+var (
+	configCache map[string]TestConfig
+	configMutex sync.Mutex
+)
+
+type TestConfig struct {
+	// Place to describe what's wrong with this test. Does not affect how the test is run.
+	Badness string
+
+	// Which OSes the test is enabled on. Each string is compared against runtime.GOOS.
+	// If absent, default to true.
+	GOOS map[string]bool
+}
+
+// Find config finds the closest config file.
+func FindConfig(t *testing.T, dir string) (string, bool) {
+	shared := false
+	for {
+		path := filepath.Join(dir, configFilename)
+		_, err := os.Stat(path)
+
+		if err == nil {
+			return path, shared
+		}
+
+		shared = true
+
+		if dir == "" || dir == "." {
+			break
+		}
+
+		if os.IsNotExist(err) {
+			dir = filepath.Dir(dir)
+			continue
+		}
+
+		t.Fatalf("Error while reading %s: %s", path, err)
+	}
+
+	t.Fatal("Config not found: " + configFilename)
+	return "", shared
+}
+
+func LoadConfig(t *testing.T, dir string) (TestConfig, string) {
+	path, leafConfig := FindConfig(t, dir)
+
+	if leafConfig {
+		return DoLoadConfig(t, path), path
+	}
+
+	configMutex.Lock()
+	defer configMutex.Unlock()
+
+	if configCache == nil {
+		configCache = make(map[string]TestConfig)
+	}
+
+	result, ok := configCache[path]
+	if ok {
+		return result, path
+	}
+
+	result = DoLoadConfig(t, path)
+	configCache[path] = result
+	return result, path
+}
+
+func DoLoadConfig(t *testing.T, path string) TestConfig {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read config: %s", err)
+	}
+
+	var config TestConfig
+	meta, err := toml.Decode(string(bytes), &config)
+	require.NoError(t, err)
+
+	keys := meta.Undecoded()
+	if len(keys) > 0 {
+		t.Fatalf("Undecoded keys in %s: %#v", path, keys)
+	}
+
+	return config
+}

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -26,7 +26,7 @@ type TestConfig struct {
 	GOOS map[string]bool
 }
 
-// Find config finds the closest config file.
+// FindConfig finds the closest config file.
 func FindConfig(t *testing.T, dir string) (string, bool) {
 	shared := false
 	for {
@@ -55,6 +55,7 @@ func FindConfig(t *testing.T, dir string) (string, bool) {
 	return "", shared
 }
 
+// LoadConfig loads the config file. Non-leaf configs are cached.
 func LoadConfig(t *testing.T, dir string) (TestConfig, string) {
 	path, leafConfig := FindConfig(t, dir)
 

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -1,0 +1,1 @@
+# root configuration applicable to all tests

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -1,1 +1,2 @@
-# root configuration applicable to all tests
+# If test directory nor any of its parents do not have test.toml then this file serves as fallback configuration.
+# The configurations are not merged across parents; the closest one is used fully.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 toolchain go1.23.4
 
 require (
+	github.com/BurntSushi/toml v1.4.0 // MIT
 	github.com/Masterminds/semver/v3 v3.3.1 // MIT
 	github.com/briandowns/spinner v1.23.1 // Apache 2.0
 	github.com/databricks/databricks-sdk-go v0.55.0 // Apache 2.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1h
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=


### PR DESCRIPTION
## Changes
- Acceptance tests load test.toml to configure test behaviour.
- If file is not found in the test directory, parents are searched, until the test root.
- Currently there is one option: runtime.GOOS to switch off tests per OS.

## Tests
Using it in https://github.com/databricks/cli/pull/2223 to disable test on Windows that cannot be run there.
