### PR TITLE
Update publish-winget action to use Komac directly

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -53,6 +53,10 @@ jobs:
             grep -E '_windows_.*-signed\.zip$' | \
             tr '\n' ' '
           )
+          if [ -z "$urls" ]; then
+            echo "No signed Windows binaries found" >&2
+            exit 1
+          fi
           echo "urls=$urls" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -23,7 +23,7 @@ jobs:
         # Find both at https://github.com/russellbanks/Komac/releases.
       - name: Download komac binary
         run: |
-          curl -L -o $RUNNER_TEMP/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz https://github.com/russellbanks/Komac/releases/download/v2.9.0/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz
+          curl -s -L -o $RUNNER_TEMP/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz https://github.com/russellbanks/Komac/releases/download/v2.9.0/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Verify komac binary
         run: |
@@ -37,6 +37,9 @@ jobs:
       - name: Add komac to PATH
         run: echo "$RUNNER_TEMP/komac" >> $GITHUB_PATH
 
+      - name: Confirm komac version
+        run: komac --version
+
       - name: Strip "v" prefix from version
         id: strip_version
         run: echo "version=${{ inputs.tag || github.ref_name }}" | sed 's/^v//' >> "$GITHUB_OUTPUT"
@@ -47,7 +50,8 @@ jobs:
           urls=$(
             gh api https://api.github.com/repos/databricks/cli/releases/tags/${{ inputs.tag || github.ref_name }} | \
             jq -r .assets[].browser_download_url | \
-            grep -E '_windows_.*-signed\.zip$'
+            grep -E '_windows_.*-signed\.zip$' | \
+            tr '\n' ' '
           )
           echo "urls=$urls" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -60,9 +60,10 @@ jobs:
       - name: Publish to Winget
         run: |
           komac update Databricks.DatabricksCLI \
-            --version ${{ steps.strip_version.outputs.version }} \
-            --urls ${{ steps.get_windows_urls.outputs.urls }} \
             --dry-run
+            --version ${{ steps.strip_version.outputs.version }} \
+            --submit \
+            --urls ${{ steps.get_windows_urls.outputs.urls }} \
         env:
           KOMAC_FORK_OWNER: eng-dev-ecosystem-bot
           GITHUB_TOKEN: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Strip "v" prefix from version
         id: strip_version
-        run: echo "version=${{ inputs.tag || github.ref_name }}" | sed 's/^v//' >> "$GITHUB_OUTPUT"
+        run: echo "version=$(echo ${{ inputs.tag || github.ref_name }} | sed 's/^v//')" >> "$GITHUB_OUTPUT"
 
       - name: Get URLs of signed Windows binaries
         id: get_windows_urls

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Publish to Winget
         run: |
           komac update Databricks.DatabricksCLI \
-            --dry-run \
             --version ${{ steps.strip_version.outputs.version }} \
             --submit \
             --urls ${{ steps.get_windows_urls.outputs.urls }} \

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -10,19 +10,55 @@ on:
 jobs:
   publish-to-winget-pkgs:
     runs-on:
-      group: databricks-protected-runner-group
-      labels: windows-server-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     environment: release
 
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@93fd8b606a1672ec3e5c6c3bb19426be68d1a8b0 # v2
-        with:
-          identifier: Databricks.DatabricksCLI
-          installers-regex: 'windows_.*-signed\.zip$' # Only signed Windows releases
-          token: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}
-          fork-user: eng-dev-ecosystem-bot
+      - name: Checkout repository and submodules
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-          # Use the tag from the input, or the ref name if the input is not provided.
-          # The ref name is equal to the tag name when this workflow is triggered by the "sign-cli" command.
-          release-tag: ${{ inputs.tag || github.ref_name }}
+        # When updating the version of komac, make sure to update the checksum in the next step.
+        # Find both at https://github.com/russellbanks/Komac/releases.
+      - name: Download komac binary
+        run: |
+          curl -L -o $RUNNER_TEMP/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz https://github.com/russellbanks/Komac/releases/download/v2.9.0/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz
+
+      - name: Verify komac binary
+        run: |
+          echo "d07a12831ad5418fee715488542a98ce3c0e591d05c850dd149fe78432be8c4c  $RUNNER_TEMP/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c -
+
+      - name: Untar komac binary to temporary path
+        run: |
+          mkdir -p $RUNNER_TEMP/komac
+          tar -xzf $RUNNER_TEMP/komac-2.9.0-x86_64-unknown-linux-gnu.tar.gz -C $RUNNER_TEMP/komac
+
+      - name: Add komac to PATH
+        run: echo "$RUNNER_TEMP/komac" >> $GITHUB_PATH
+
+      - name: Strip "v" prefix from version
+        id: strip_version
+        run: echo "version=${{ inputs.tag || github.ref_name }}" | sed 's/^v//' >> "$GITHUB_OUTPUT"
+
+      - name: Get URLs of signed Windows binaries
+        id: get_windows_urls
+        run: |
+          urls=$(
+            gh api https://api.github.com/repos/databricks/cli/releases/tags/${{ inputs.tag || github.ref_name }} | \
+            jq -r .assets[].browser_download_url | \
+            grep -E '_windows_.*-signed\.zip$'
+          )
+          echo "urls=$urls" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Winget
+        run: |
+          komac update Databricks.DatabricksCLI \
+            --version ${{ steps.strip_version.outputs.version }} \
+            --urls ${{ steps.get_windows_urls.outputs.urls }} \
+            --dry-run
+        env:
+          KOMAC_FORK_OWNER: eng-dev-ecosystem-bot
+          GITHUB_TOKEN: ${{ secrets.ENG_DEV_ECOSYSTEM_BOT_TOKEN }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Publish to Winget
         run: |
           komac update Databricks.DatabricksCLI \
-            --dry-run
+            --dry-run \
             --version ${{ steps.strip_version.outputs.version }} \
             --submit \
             --urls ${{ steps.get_windows_urls.outputs.urls }} \

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Confirm komac version
         run: komac --version
 
+        # Use the tag from the input, or the ref name if the input is not provided.
+        # The ref name is equal to the tag name when this workflow is triggered by the "sign-cli" command.
       - name: Strip "v" prefix from version
         id: strip_version
         run: echo "version=$(echo ${{ inputs.tag || github.ref_name }} | sed 's/^v//')" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Changes

For the most recent release, I had to re-run the "publish-winget" action a couple of times before it passed. The underlying issue that causes the failure should be solved by the latest version of the action, but upon inspection of the latest version, I found that it always installs the latest version of [Komac](https://github.com/russellbanks/Komac). To both fix the issue and lock this down further, I updated our action to call Komac directly instead of relying on a separate action to do this for us.

## Tests

Successful run in https://github.com/databricks/cli/actions/runs/12951529979.

