### PR TITLE
Add default regex for DEV_VERSION

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -128,6 +128,7 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 	testdiff.PrepareReplacementsUser(t, &repls, *user)
 	testdiff.PrepareReplacementsWorkspaceClient(t, &repls, workspaceClient)
 	testdiff.PrepareReplacementsUUID(t, &repls)
+	testdiff.PrepareReplacementsDevVersion(t, &repls)
 
 	testDirs := getTests(t)
 	require.NotEmpty(t, testDirs)

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
@@ -10,6 +10,8 @@ Please refer to the README.md file for "getting started" instructions.
 See also the documentation at https://docs.databricks.com/dev-tools/bundles/index.html.
 
 >>> $CLI bundle validate -t dev --output json
+Warning: Ignoring Databricks CLI version constraint for development build. Required: >= 0.238.0, current: $DEV_VERSION
+
 {
   "jobs": {
     "my_jobs_as_code_job": {

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/databricks.yml
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/databricks.yml
@@ -3,6 +3,7 @@
 bundle:
   name: my_jobs_as_code
   uuid: <UUID>
+  databricks_cli_version: ">= 0.238.0"
 
 experimental:
   python:

--- a/acceptance/bundle/templates/experimental-jobs-as-code/script
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/script
@@ -5,10 +5,6 @@ cd output/my_jobs_as_code
 # silence uv output because it's non-deterministic
 uv sync -q
 
-# remove version constraint because it always creates a warning on dev builds
-cat databricks.yml | grep -v databricks_cli_version > databricks.yml.new
-mv databricks.yml.new databricks.yml
-
 trace $CLI bundle validate -t dev --output json | jq ".resources"
 
 rm -fr .venv resources/__pycache__ uv.lock my_jobs_as_code.egg-info

--- a/acceptance/selftest/output.txt
+++ b/acceptance/selftest/output.txt
@@ -33,3 +33,7 @@ $TMPDIR/subdir/a/b/c
 1234
 CUSTOM_NUMBER_REGEX
 123456
+
+=== Testing --version
+>>> $CLI --version
+Databricks CLI v$DEV_VERSION

--- a/acceptance/selftest/script
+++ b/acceptance/selftest/script
@@ -24,3 +24,6 @@ printf "\n=== Custom regex can be specified in [[Repl]] section\n"
 echo 1234
 echo 12345
 echo 123456
+
+printf "\n=== Testing --version"
+trace $CLI --version

--- a/libs/testdiff/replacement.go
+++ b/libs/testdiff/replacement.go
@@ -23,6 +23,8 @@ var (
 	uuidRegex        = regexp.MustCompile(`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`)
 	numIdRegex       = regexp.MustCompile(`[0-9]{3,}`)
 	privatePathRegex = regexp.MustCompile(`(/tmp|/private)(/.*)/([a-zA-Z0-9]+)`)
+	// Version could v0.0.0-dev+21e1aacf518a or just v0.0.0-dev (the latter is currently the case on Windows)
+	devVersionRegex = regexp.MustCompile(`0\.0\.0-dev(\+[a-f0-9]{10,16})?`)
 )
 
 type Replacement struct {
@@ -210,4 +212,9 @@ func PrepareReplacementsNumber(t testutil.TestingT, r *ReplacementsContext) {
 func PrepareReplacementsTemporaryDirectory(t testutil.TestingT, r *ReplacementsContext) {
 	t.Helper()
 	r.append(privatePathRegex, "/tmp/.../$3")
+}
+
+func PrepareReplacementsDevVersion(t testutil.TestingT, r *ReplacementsContext) {
+	t.Helper()
+	r.append(devVersionRegex, "$$DEV_VERSION")
 }


### PR DESCRIPTION
## Changes

- Replace development version with $DEV_VERSION
- Update experimental-jobs-as-code to make use of it.

## Tests
- Existing tests.
- Using this in https://github.com/databricks/cli/pull/2213
