### PR TITLE
acc: Restore unexpected output error

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -245,6 +245,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 		if _, ok := outputs[relPath]; ok {
 			continue
 		}
+		t.Errorf("Unexpected output: %s", relPath)
 		if strings.HasPrefix(relPath, "out") {
 			// We have a new file starting with "out"
 			// Show the contents & support overwrite mode for it:

--- a/acceptance/bundle/git-permerror/script
+++ b/acceptance/bundle/git-permerror/script
@@ -22,4 +22,5 @@ trace chmod 000 .git/config
 errcode trace $CLI bundle validate -o json | jq .bundle.git
 errcode trace withdir subdir/a/b $CLI bundle validate -o json | jq .bundle.git
 
-rm -fr .git
+cd ..
+rm -fr myrepo

--- a/acceptance/bundle/syncroot/dotdot-git/script
+++ b/acceptance/bundle/syncroot/dotdot-git/script
@@ -3,4 +3,6 @@ mkdir myrepo
 cd myrepo
 cp ../databricks.yml .
 git-repo-init
-$CLI bundle validate | sed 's/\\\\/\//g'
+errcode $CLI bundle validate
+cd ..
+rm -fr myrepo

--- a/acceptance/bundle/syncroot/dotdot-git/test.toml
+++ b/acceptance/bundle/syncroot/dotdot-git/test.toml
@@ -1,0 +1,3 @@
+[[Repls]]
+Old = '\\\\myrepo'
+New = '/myrepo'


### PR DESCRIPTION
## Changes
Restore original behaviour of acceptance tests: any unaccounted for files trigger an error (not just those that start with "out"). This got changed in https://github.com/databricks/cli/pull/2146/files#diff-2bb968d823f4afb825e1dcea2879bdbdedf2b7c15d4e77f47905691b14246a04L196 which started only checking out files.

## Tests
Existing tests.

