### PR TITLE
Pass along $AZURE_CONFIG_DIR  to Terraform process

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -105,6 +105,13 @@ var envCopy = []string{
 	// This is set in Azure DevOps by the AzureCLI@2 task.
 	"AZURE_CONFIG_FILE",
 
+	// Include $AZURE_CONFIG_DIR in set of environment variables to pass along.
+	// This is set by Azure CLI as per https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file
+	azureConfigDir, ok := env.Lookup(ctx, "AZURE_CONFIG_DIR")
+	if ok {
+		environ["AZURE_CONFIG_DIR"] = azureConfigDir
+	}
+
 	// Include $TF_CLI_CONFIG_FILE to override terraform provider in development.
 	// See: https://developer.hashicorp.com/terraform/cli/config/config-file#explicit-installation-method-configuration
 	"TF_CLI_CONFIG_FILE",

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -293,6 +293,7 @@ func TestInheritEnvVars(t *testing.T) {
 	t.Setenv("PATH", "/foo:/bar")
 	t.Setenv("TF_CLI_CONFIG_FILE", "/tmp/config.tfrc")
 	t.Setenv("AZURE_CONFIG_FILE", "/tmp/foo/bar")
+	t.Setenv("AZURE_CONFIG_DIR", "/tmp/foo")
 
 	ctx := context.Background()
 	env := map[string]string{}
@@ -302,6 +303,7 @@ func TestInheritEnvVars(t *testing.T) {
 		assert.Equal(t, "/foo:/bar", env["PATH"])
 		assert.Equal(t, "/tmp/config.tfrc", env["TF_CLI_CONFIG_FILE"])
 		assert.Equal(t, "/tmp/foo/bar", env["AZURE_CONFIG_FILE"])
+		assert.Equal(t, "/tmp/foo", env["AZURE_CONFIG_DIR"])
 	}
 }
 


### PR DESCRIPTION
## Changes
`$AZURE_CONFIG_DIR` is used by Azure CLI to find the CLI config as per docs https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file

Fixes #1722 

