### PR TITLE
Fix env variable for AzureCli local config

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -101,9 +101,9 @@ var envCopy = []string{
 	// same auxiliary programs (e.g. `az`, or `gcloud`) as the CLI.
 	"PATH",
 
-	// Include $AZURE_CONFIG_FILE in set of environment variables to pass along.
+	// Include $AZURE_CONFIG_DIR in set of environment variables to pass along.
 	// This is set in Azure DevOps by the AzureCLI@2 task.
-	"AZURE_CONFIG_FILE",
+	"AZURE_CONFIG_DIR",
 
 	// Include $TF_CLI_CONFIG_FILE to override terraform provider in development.
 	// See: https://developer.hashicorp.com/terraform/cli/config/config-file#explicit-installation-method-configuration

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -292,7 +292,7 @@ func TestInheritEnvVars(t *testing.T) {
 	t.Setenv("HOME", "/home/testuser")
 	t.Setenv("PATH", "/foo:/bar")
 	t.Setenv("TF_CLI_CONFIG_FILE", "/tmp/config.tfrc")
-	t.Setenv("AZURE_CONFIG_FILE", "/tmp/foo/bar")
+	t.Setenv("AZURE_CONFIG_DIR", "/tmp/foo/bar")
 
 	ctx := context.Background()
 	env := map[string]string{}
@@ -301,7 +301,7 @@ func TestInheritEnvVars(t *testing.T) {
 		assert.Equal(t, "/home/testuser", env["HOME"])
 		assert.Equal(t, "/foo:/bar", env["PATH"])
 		assert.Equal(t, "/tmp/config.tfrc", env["TF_CLI_CONFIG_FILE"])
-		assert.Equal(t, "/tmp/foo/bar", env["AZURE_CONFIG_FILE"])
+		assert.Equal(t, "/tmp/foo/bar", env["AZURE_CONFIG_DIR"])
 	}
 }
 


### PR DESCRIPTION
## Changes

Solves #1722 (current solution passes wrong variable)

## Tests

None, this is a simple find-and-replace on a previous PR.
Proof that this is the correct [variable](https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration#cli-configuration-file).
This just passes the variable along to the Terraform environment, which [should](https://github.com/hashicorp/terraform/issues/25416) be picked up by Terraform.

