### PR TITLE
acc: Disable git hooks

### DIFF
--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -39,6 +39,7 @@ git-repo-init() {
     git config core.autocrlf false
     git config user.name "Tester"
     git config user.email "tester@databricks.com"
+    git config core.hooksPath no-hooks
     git add databricks.yml
     git commit -qm 'Add databricks.yml'
 }


### PR DESCRIPTION
Otherwise hooks from universe and custom hooks run in tests.

Needed for running acceptance tests as integration tests: https://github.com/databricks/cli/pull/2242