### PR TITLE
Fix env_overrides not to use variables in workspace.profile

### DIFF
--- a/acceptance/bundle/variables/env_overrides/databricks.yml
+++ b/acceptance/bundle/variables/env_overrides/databricks.yml
@@ -18,11 +18,12 @@ variables:
     description: variable with lookup
     lookup:
       cluster_policy: wrong-cluster-policy
+
+  result:
+    default: ${var.a} ${var.b}
+
 bundle:
   name: test bundle
-
-workspace:
-  profile: ${var.a} ${var.b}
 
 targets:
   env-with-single-variable-override:

--- a/acceptance/bundle/variables/env_overrides/output.txt
+++ b/acceptance/bundle/variables/env_overrides/output.txt
@@ -36,5 +36,6 @@ Exit code: 1
   "b": "prod-b",
   "d": "4321",
   "e": "1234",
-  "f": "9876"
+  "f": "9876",
+  "result": "default-a prod-b"
 }

--- a/acceptance/bundle/variables/env_overrides/script
+++ b/acceptance/bundle/variables/env_overrides/script
@@ -1,6 +1,6 @@
-trace $CLI bundle validate -t env-with-single-variable-override -o json | jq .workspace.profile
-trace $CLI bundle validate -t env-with-two-variable-overrides -o json | jq .workspace.profile
-trace BUNDLE_VAR_b=env-var-b $CLI bundle validate -t env-with-two-variable-overrides -o json | jq .workspace.profile
+trace $CLI bundle validate -t env-with-single-variable-override -o json | jq .variables.result.value
+trace $CLI bundle validate -t env-with-two-variable-overrides -o json | jq .variables.result.value
+trace BUNDLE_VAR_b=env-var-b $CLI bundle validate -t env-with-two-variable-overrides -o json | jq .variables.result.value
 trace errcode $CLI bundle validate -t env-missing-a-required-variable-assignment
 trace errcode $CLI bundle validate -t env-using-an-undefined-variable
 trace $CLI bundle validate -t env-overrides-lookup -o json | jq '.variables | map_values(.value)'


### PR DESCRIPTION
This does not work when this test is run against cloud.

Needed for https://github.com/databricks/cli/pull/2242

