### PR TITLE
Remove bundle.git.inferred

### DIFF
--- a/acceptance/bundle/git-permerror/output.txt
+++ b/acceptance/bundle/git-permerror/output.txt
@@ -21,8 +21,7 @@ Error: unable to load repository specific gitconfig: open config: permission den
 
 Exit code: 1
 {
-  "bundle_root_path": ".",
-  "inferred": true
+  "bundle_root_path": "."
 }
 
 >>> withdir subdir/a/b $CLI bundle validate -o json
@@ -31,8 +30,7 @@ Error: unable to load repository specific gitconfig: open config: permission den
 
 Exit code: 1
 {
-  "bundle_root_path": ".",
-  "inferred": true
+  "bundle_root_path": "."
 }
 
 
@@ -42,14 +40,12 @@ Exit code: 1
 
 >>> $CLI bundle validate -o json
 {
-  "bundle_root_path": ".",
-  "inferred": true
+  "bundle_root_path": "."
 }
 
 >>> withdir subdir/a/b $CLI bundle validate -o json
 {
-  "bundle_root_path": ".",
-  "inferred": true
+  "bundle_root_path": "."
 }
 
 
@@ -63,8 +59,7 @@ Error: unable to load repository specific gitconfig: open config: permission den
 
 Exit code: 1
 {
-  "bundle_root_path": ".",
-  "inferred": true
+  "bundle_root_path": "."
 }
 
 >>> withdir subdir/a/b $CLI bundle validate -o json
@@ -73,6 +68,5 @@ Error: unable to load repository specific gitconfig: open config: permission den
 
 Exit code: 1
 {
-  "bundle_root_path": ".",
-  "inferred": true
+  "bundle_root_path": "."
 }

--- a/acceptance/bundle/variables/prepend-workspace-var/output.txt
+++ b/acceptance/bundle/variables/prepend-workspace-var/output.txt
@@ -3,8 +3,7 @@
   "bundle": {
     "environment": "dev",
     "git": {
-      "bundle_root_path": ".",
-      "inferred": true
+      "bundle_root_path": "."
     },
     "target": "dev",
     "terraform": {

--- a/bundle/config/git.go
+++ b/bundle/config/git.go
@@ -8,9 +8,6 @@ type Git struct {
 	// Path to bundle root relative to the git repository root.
 	BundleRootPath string `json:"bundle_root_path,omitempty" bundle:"readonly"`
 
-	// Inferred is set to true if the Git details were inferred and weren't set explicitly
-	Inferred bool `json:"inferred,omitempty" bundle:"readonly"`
-
 	// The actual branch according to Git (may be different from the configured branch)
 	ActualBranch string `json:"actual_branch,omitempty" bundle:"readonly"`
 }

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -40,7 +40,6 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	b.Config.Bundle.Git.ActualBranch = info.CurrentBranch
 	if b.Config.Bundle.Git.Branch == "" {
 		// Only load branch if there's no user defined value
-		b.Config.Bundle.Git.Inferred = true
 		b.Config.Bundle.Git.Branch = info.CurrentBranch
 	}
 

--- a/bundle/config/mutator/process_target_mode.go
+++ b/bundle/config/mutator/process_target_mode.go
@@ -135,11 +135,6 @@ func findNonUserPath(b *bundle.Bundle) string {
 }
 
 func validateProductionMode(ctx context.Context, b *bundle.Bundle, isPrincipalUsed bool) diag.Diagnostics {
-	if b.Config.Bundle.Git.Inferred {
-		env := b.Config.Bundle.Target
-		log.Warnf(ctx, "target with 'mode: production' should specify an explicit 'targets.%s.git' configuration", env)
-	}
-
 	r := b.Config.Resources
 	for i := range r.Pipelines {
 		if r.Pipelines[i].Development {

--- a/bundle/deploy/metadata/compute_test.go
+++ b/bundle/deploy/metadata/compute_test.go
@@ -31,7 +31,6 @@ func TestComputeMetadataMutator(t *testing.T) {
 					OriginURL:      "www.host.com",
 					Commit:         "abcd",
 					BundleRootPath: "a/b/c/d",
-					Inferred:       true,
 				},
 			},
 			Resources: config.Resources{
@@ -72,9 +71,6 @@ func TestComputeMetadataMutator(t *testing.T) {
 					OriginURL:      "www.host.com",
 					Commit:         "abcd",
 					BundleRootPath: "a/b/c/d",
-
-					// Test that this field doesn't carry over into the metadata.
-					Inferred: false,
 				},
 			},
 			Resources: metadata.Resources{

--- a/bundle/tests/environment_git_test.go
+++ b/bundle/tests/environment_git_test.go
@@ -13,7 +13,6 @@ import (
 func TestGitAutoLoadWithEnvironment(t *testing.T) {
 	b := load(t, "./environments_autoload_git")
 	bundle.Apply(context.Background(), b, mutator.LoadGitDetails())
-	assert.True(t, b.Config.Bundle.Git.Inferred)
 	validUrl := strings.Contains(b.Config.Bundle.Git.OriginURL, "/cli") || strings.Contains(b.Config.Bundle.Git.OriginURL, "/bricks")
 	assert.True(t, validUrl, "Expected URL to contain '/cli' or '/bricks', got %s", b.Config.Bundle.Git.OriginURL)
 }
@@ -21,7 +20,6 @@ func TestGitAutoLoadWithEnvironment(t *testing.T) {
 func TestGitManuallySetBranchWithEnvironment(t *testing.T) {
 	b := loadTarget(t, "./environments_autoload_git", "production")
 	bundle.Apply(context.Background(), b, mutator.LoadGitDetails())
-	assert.False(t, b.Config.Bundle.Git.Inferred)
 	assert.Equal(t, "main", b.Config.Bundle.Git.Branch)
 	validUrl := strings.Contains(b.Config.Bundle.Git.OriginURL, "/cli") || strings.Contains(b.Config.Bundle.Git.OriginURL, "/bricks")
 	assert.True(t, validUrl, "Expected URL to contain '/cli' or '/bricks', got %s", b.Config.Bundle.Git.OriginURL)

--- a/bundle/tests/git_test.go
+++ b/bundle/tests/git_test.go
@@ -14,7 +14,6 @@ import (
 func TestGitAutoLoad(t *testing.T) {
 	b := load(t, "./autoload_git")
 	bundle.Apply(context.Background(), b, mutator.LoadGitDetails())
-	assert.True(t, b.Config.Bundle.Git.Inferred)
 	validUrl := strings.Contains(b.Config.Bundle.Git.OriginURL, "/cli") || strings.Contains(b.Config.Bundle.Git.OriginURL, "/bricks")
 	assert.True(t, validUrl, "Expected URL to contain '/cli' or '/bricks', got %s", b.Config.Bundle.Git.OriginURL)
 }
@@ -22,7 +21,6 @@ func TestGitAutoLoad(t *testing.T) {
 func TestGitManuallySetBranch(t *testing.T) {
 	b := loadTarget(t, "./autoload_git", "production")
 	bundle.Apply(context.Background(), b, mutator.LoadGitDetails())
-	assert.False(t, b.Config.Bundle.Git.Inferred)
 	assert.Equal(t, "main", b.Config.Bundle.Git.Branch)
 	validUrl := strings.Contains(b.Config.Bundle.Git.OriginURL, "/cli") || strings.Contains(b.Config.Bundle.Git.OriginURL, "/bricks")
 	assert.True(t, validUrl, "Expected URL to contain '/cli' or '/bricks', got %s", b.Config.Bundle.Git.OriginURL)
@@ -36,7 +34,6 @@ func TestGitBundleBranchValidation(t *testing.T) {
 
 	b := load(t, "./git_branch_validation")
 	bundle.Apply(context.Background(), b, mutator.LoadGitDetails())
-	assert.False(t, b.Config.Bundle.Git.Inferred)
 	assert.Equal(t, "feature-a", b.Config.Bundle.Git.Branch)
 	assert.Equal(t, "feature-b", b.Config.Bundle.Git.ActualBranch)
 

--- a/integration/bundle/testdata/default_python/bundle_summary.txt
+++ b/integration/bundle/testdata/default_python/bundle_summary.txt
@@ -7,8 +7,7 @@
       "exec_path": "/tmp/.../terraform"
     },
     "git": {
-      "bundle_root_path": ".",
-      "inferred": true
+      "bundle_root_path": "."
     },
     "mode": "development",
     "deployment": {


### PR DESCRIPTION
The only use case for it was to emit a warning and based on the discussion here https://github.com/databricks/cli/pull/2213/files#r1933558087 the warning it not useful and logging that with reduced severity is also not useful.
