### PR TITLE
accept JSON includes

### DIFF
--- a/bundle/config/loader/process_root_includes.go
+++ b/bundle/config/loader/process_root_includes.go
@@ -71,11 +71,11 @@ func (m *processRootIncludes) Apply(ctx context.Context, b *bundle.Bundle) diag.
 				continue
 			}
 			seen[rel] = true
-			if filepath.Ext(rel) != ".yaml" && filepath.Ext(rel) != ".yml" {
+			if filepath.Ext(rel) != ".yaml" && filepath.Ext(rel) != ".yml" && filepath.Ext(rel) != ".json" {
 				diags = diags.Append(diag.Diagnostic{
 					Severity:  diag.Error,
-					Summary:   "Files in the 'include' configuration section must be YAML files.",
-					Detail:    fmt.Sprintf("The file %s in the 'include' configuration section is not a YAML file, and only YAML files are supported. To include files to sync, specify them in the 'sync.include' configuration section instead.", rel),
+					Summary:   "Files in the 'include' configuration section must be YAML or JSON files.",
+					Detail:    fmt.Sprintf("The file %s in the 'include' configuration section is not a YAML or JSON file, and only such files are supported. To include files to sync, specify them in the 'sync.include' configuration section instead.", rel),
 					Locations: b.Config.GetLocations(fmt.Sprintf("include[%d]", i)),
 				})
 				continue


### PR DESCRIPTION
#2201 disabled using JSON as part of a bundle definition. I believe this was not intended.

## Changes
Accept json files as includes, just as YAML files.
## Tests
Covered by the tests in #2201 

