### PR TITLE
Add ruff.toml with increased line-length

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 150


### PR DESCRIPTION
The default is 88 which reformats too much.

This has no effect on templates but affects Python script in this PR https://github.com/databricks/cli/pull/2267

For context, we do not set any line length for golang and have 177 .go files with max line length 150 or more.

