### PR TITLE
acc: Consistent & detailed output for file issues

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -335,7 +335,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 	bufRef, okRef := tryReading(t, pathRef)
 	bufNew, okNew := tryReading(t, pathNew)
 	if !okRef && !okNew {
-		t.Errorf("Both files are missing or have errors: %s\npathNew: %s\npathRef: %s", relPath, pathRef, pathNew)
+		t.Errorf("Both files are missing or have errors: %s\npathRef: %s\npathNew: %s", relPath, pathRef, pathNew)
 		return
 	}
 
@@ -350,7 +350,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 
 	// The test did not produce an expected output file.
 	if okRef && !okNew {
-		t.Errorf("Missing output file: %s\npathNew: %s\npathRef: %s", relPath, pathNew, pathRef)
+		t.Errorf("Missing output file: %s\npathRef: %s\npathNew: %s", relPath, pathRef, pathNew)
 		testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		if testdiff.OverwriteMode {
 			t.Logf("Removing output file: %s", relPath)
@@ -361,7 +361,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 
 	// The test produced an unexpected output file.
 	if !okRef && okNew {
-		t.Errorf("Unexpected output file: %s\npathNew: %s\npathRef: %s", relPath, pathNew, pathRef)
+		t.Errorf("Unexpected output file: %s\npathRef: %s\npathNew: %s", relPath, pathRef, pathNew)
 		testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		if testdiff.OverwriteMode {
 			t.Logf("Writing output file: %s", relPath)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -335,7 +335,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 	bufRef, okRef := tryReading(t, pathRef)
 	bufNew, okNew := tryReading(t, pathNew)
 	if !okRef && !okNew {
-		t.Errorf("Both files are missing or have errors: %s, %s", pathRef, pathNew)
+		t.Errorf("Both files are missing or have errors: %s\npathNew: %s\npathRef: %s", relPath, pathRef, pathNew)
 		return
 	}
 
@@ -350,7 +350,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 
 	// The test did not produce an expected output file.
 	if okRef && !okNew {
-		t.Errorf("Missing output file: %s", relPath)
+		t.Errorf("Missing output file: %s\npathNew: %s\npathRef: %s", relPath, pathNew, pathRef)
 		testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		if testdiff.OverwriteMode {
 			t.Logf("Removing output file: %s", relPath)
@@ -361,7 +361,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 
 	// The test produced an unexpected output file.
 	if !okRef && okNew {
-		t.Errorf("Unexpected output file: %s", relPath)
+		t.Errorf("Unexpected output file: %s\npathNew: %s\npathRef: %s", relPath, pathNew, pathRef)
 		testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		if testdiff.OverwriteMode {
 			t.Logf("Writing output file: %s", relPath)


### PR DESCRIPTION
## Changes
- Include compact relPath in the error message title. Include full paths in separate lines below.
- Previously sometimes full paths were printed, sometime only rel path.

## Tests
Manually trigger the errors.