### PR TITLE
acc: Remove initial '$CLI --version' call

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -448,7 +448,6 @@ func BuildCLI(t *testing.T, buildDir, coverDir string) string {
 	}
 
 	RunCommand(t, args, "..")
-	RunCommand(t, []string{execPath, "--version"}, ".")
 	return execPath
 }
 


### PR DESCRIPTION
It is proven to be not necessary.

```
~/work/cli/acceptance % hyperfine -w 2 'go test'  # with change:
Benchmark 1: go test
  Time (mean ± σ):      4.983 s ±  0.209 s    [User: 6.073 s, System: 9.869 s]
  Range (min … max):    4.792 s …  5.483 s    10 runs

~/work/cli/acceptance % git stash  # without change:
~/work/cli/acceptance % hyperfine -w 2 'go test'
Benchmark 1: go test
  Time (mean ± σ):      5.018 s ±  0.100 s    [User: 6.142 s, System: 10.234 s]
  Range (min … max):    4.899 s …  5.182 s    10 runs
```

