### PR TITLE
Add doc string for the `auth token` command

### DIFF
--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -46,6 +46,7 @@ func newTokenCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "token [HOST]",
 		Short: "Get authentication token",
+		Hidden: true,
 	}
 
 	var tokenTimeout time.Duration

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -46,7 +46,10 @@ func newTokenCommand(persistentAuth *auth.PersistentAuth) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "token [HOST]",
 		Short: "Get authentication token",
-		Hidden: true,
+		Long: `Get authentication token from the local cache in ~/.databricks/token-cache.json.
+Refresh the access token if it is expired. Note: This command only works with
+U2M authentication (using the 'databricks auth login' command). M2M authentication
+using a client ID and secret is not supported.`,
 	}
 
 	var tokenTimeout time.Duration


### PR DESCRIPTION
## Changes
The intent of this PR is to clarify that the `databricks auth token` command is not supported for M2M auth. Fixes: https://github.com/databricks/cli/issues/1939

## Tests
Manually.

