### PR TITLE
Extend testserver for deployment (2)

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -152,7 +152,6 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 	require.NoError(t, err)
 
 	user, err := workspaceClient.CurrentUser.Me(ctx)
-
 	require.NoError(t, err)
 	require.NotNil(t, user)
 	testdiff.PrepareReplacementsUser(t, &repls, *user)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -314,8 +314,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 			require.NoError(t, err)
 
 			reqJsonWithRepls := repls.Replace(string(reqJson))
-			line := fmt.Sprintf("%s\n", reqJsonWithRepls)
-			_, err = f.WriteString(line)
+			_, err = f.WriteString(reqJsonWithRepls + "\n")
 			require.NoError(t, err)
 		}
 

--- a/acceptance/bundle/scripts/output.txt
+++ b/acceptance/bundle/scripts/output.txt
@@ -42,11 +42,9 @@ from myscript.py 0 postbuild: hello stderr!
 Executing 'predeploy' script
 from myscript.py 0 predeploy: hello stdout!
 from myscript.py 0 predeploy: hello stderr!
-Error: unable to deploy to /Workspace/Users/[USERNAME]/.bundle/scripts/default/state as [USERNAME].
-Please make sure the current user or one of their groups is listed under the permissions of this bundle.
-For assistance, contact the owners of this project.
-They may need to redeploy the bundle to apply the new permissions.
-Please refer to https://docs.databricks.com/dev-tools/bundles/permissions.html for more on managing permissions.
-
-
-Exit code: 1
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/scripts/default/files...
+Deploying resources...
+Deployment complete!
+Executing 'postdeploy' script
+from myscript.py 0 postdeploy: hello stdout!
+from myscript.py 0 postdeploy: hello stderr!

--- a/acceptance/cmd_server_test.go
+++ b/acceptance/cmd_server_test.go
@@ -15,7 +15,7 @@ import (
 func StartCmdServer(t *testing.T) *testserver.Server {
 	server := testserver.New(t)
 
-	server.Handle("/", func(r *http.Request) (any, int) {
+	server.Handle("/", func(w *testserver.FakeWorkspace, r *http.Request) (any, int) {
 		q := r.URL.Query()
 		args := strings.Split(q.Get("args"), " ")
 

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"github.com/databricks/cli/libs/testserver"

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -1,97 +1,116 @@
 package acceptance_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"net/http"
 
 	"github.com/databricks/cli/libs/testserver"
-	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/databricks/databricks-sdk-go/service/compute"
-	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 )
 
 func AddHandlers(server *testserver.Server) {
-	server.Handle("GET /api/2.0/policies/clusters/list", func(r *http.Request) (any, int) {
-		return compute.ListPoliciesResponse{
-			Policies: []compute.Policy{
-				{
-					PolicyId: "5678",
-					Name:     "wrong-cluster-policy",
-				},
-				{
-					PolicyId: "9876",
-					Name:     "some-test-cluster-policy",
-				},
-			},
-		}, http.StatusOK
+	server.Handle("GET /api/2.0/policies/clusters/list", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return fakeWorkspace.PoliciesList()
 	})
 
-	server.Handle("GET /api/2.0/instance-pools/list", func(r *http.Request) (any, int) {
-		return compute.ListInstancePools{
-			InstancePools: []compute.InstancePoolAndStats{
-				{
-					InstancePoolName: "some-test-instance-pool",
-					InstancePoolId:   "1234",
-				},
-			},
-		}, http.StatusOK
+	server.Handle("GET /api/2.0/instance-pools/list", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return fakeWorkspace.InstancePoolsList()
 	})
 
-	server.Handle("GET /api/2.1/clusters/list", func(r *http.Request) (any, int) {
-		return compute.ListClustersResponse{
-			Clusters: []compute.ClusterDetails{
-				{
-					ClusterName: "some-test-cluster",
-					ClusterId:   "4321",
-				},
-				{
-					ClusterName: "some-other-cluster",
-					ClusterId:   "9876",
-				},
-			},
-		}, http.StatusOK
+	server.Handle("GET /api/2.1/clusters/list", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return fakeWorkspace.ClustersList()
 	})
 
-	server.Handle("GET /api/2.0/preview/scim/v2/Me", func(r *http.Request) (any, int) {
-		return iam.User{
-			Id:       "1000012345",
-			UserName: "tester@databricks.com",
-		}, http.StatusOK
+	server.Handle("GET /api/2.1/unity-catalog/current-metastore-assignment", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return fakeWorkspace.CurrentMetastoreAssignment()
 	})
 
-	server.Handle("GET /api/2.0/workspace/get-status", func(r *http.Request) (any, int) {
-		return workspace.ObjectInfo{
-			ObjectId:   1001,
-			ObjectType: "DIRECTORY",
-			Path:       "",
-			ResourceId: "1001",
-		}, http.StatusOK
+	server.Handle("GET /api/2.0/permissions/directories/{objectId}", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		objectId := r.PathValue("objectId")
+
+		return fakeWorkspace.DirectoryPermissions(objectId)
 	})
 
-	server.Handle("GET /api/2.1/unity-catalog/current-metastore-assignment", func(r *http.Request) (any, int) {
-		return catalog.MetastoreAssignment{
-			DefaultCatalogName: "main",
-		}, http.StatusOK
+	server.Handle("GET /api/2.0/preview/scim/v2/Me", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return fakeWorkspace.ScimMe()
 	})
 
-	server.Handle("GET /api/2.0/permissions/directories/1001", func(r *http.Request) (any, int) {
-		return workspace.WorkspaceObjectPermissions{
-			ObjectId:   "1001",
-			ObjectType: "DIRECTORY",
-			AccessControlList: []workspace.WorkspaceObjectAccessControlResponse{
-				{
-					UserName: "tester@databricks.com",
-					AllPermissions: []workspace.WorkspaceObjectPermission{
-						{
-							PermissionLevel: "CAN_MANAGE",
-						},
-					},
-				},
-			},
-		}, http.StatusOK
+	server.Handle("GET /api/2.0/workspace/get-status", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		path := r.URL.Query().Get("path")
+
+		return fakeWorkspace.WorkspaceGetStatus(path)
 	})
 
-	server.Handle("POST /api/2.0/workspace/mkdirs", func(r *http.Request) (any, int) {
-		return "{}", http.StatusOK
+	server.Handle("POST /api/2.0/workspace/mkdirs", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		request := workspace.Mkdirs{}
+		decoder := json.NewDecoder(r.Body)
+
+		err := decoder.Decode(&request)
+		if err != nil {
+			return internalError(err)
+		}
+
+		return fakeWorkspace.WorkspaceMkdirs(request)
 	})
+
+	server.Handle("GET /api/2.0/workspace/export", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		path := r.URL.Query().Get("path")
+
+		return fakeWorkspace.WorkspaceExport(path)
+	})
+
+	server.Handle("POST /api/2.0/workspace/delete", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		path := r.URL.Query().Get("path")
+		recursiveStr := r.URL.Query().Get("recursive")
+		var recursive bool
+
+		if recursiveStr == "true" {
+			recursive = true
+		} else {
+			recursive = false
+		}
+
+		return fakeWorkspace.WorkspaceDelete(path, recursive)
+	})
+
+	server.Handle("POST /api/2.0/workspace-files/import-file/{path}", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		path := r.PathValue("path")
+
+		body := new(bytes.Buffer)
+		_, err := body.ReadFrom(r.Body)
+		if err != nil {
+			return internalError(err)
+		}
+
+		return fakeWorkspace.WorkspaceFilesImportFile(path, body.Bytes())
+	})
+
+	server.Handle("POST /api/2.1/jobs/create", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		request := jobs.CreateJob{}
+		decoder := json.NewDecoder(r.Body)
+
+		err := decoder.Decode(&request)
+		if err != nil {
+			return internalError(err)
+		}
+
+		return fakeWorkspace.JobsCreate(request)
+	})
+
+	server.Handle("GET /api/2.1/jobs/get", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		jobId := r.URL.Query().Get("job_id")
+
+		return fakeWorkspace.JobsGet(jobId)
+	})
+
+	server.Handle("GET /api/2.1/jobs/list", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return fakeWorkspace.JobsList()
+	})
+}
+
+func internalError(err error) (any, int) {
+	return fmt.Errorf("internal error: %w", err), http.StatusInternalServerError
 }

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -4,10 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
-
 	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"net/http"
 
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/databricks/databricks-sdk-go/service/workspace"

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"github.com/databricks/cli/libs/testserver"

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"net/http"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/databricks/databricks-sdk-go/service/workspace"

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 
+	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"github.com/databricks/cli/libs/testserver"
@@ -52,29 +53,6 @@ func AddHandlers(server *testserver.Server) {
 				{
 					ClusterName: "some-other-cluster",
 					ClusterId:   "9876",
-				},
-			},
-		}, http.StatusOK
-	})
-
-	server.Handle("GET /api/2.1/unity-catalog/current-metastore-assignment", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
-		return fakeWorkspace.CurrentMetastoreAssignment()
-	})
-
-	server.Handle("GET /api/2.0/permissions/directories/{objectId}", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
-		objectId := r.PathValue("objectId")
-
-		return workspace.WorkspaceObjectPermissions{
-			ObjectId:   objectId,
-			ObjectType: "DIRECTORY",
-			AccessControlList: []workspace.WorkspaceObjectAccessControlResponse{
-				{
-					UserName: "tester@databricks.com",
-					AllPermissions: []workspace.WorkspaceObjectPermission{
-						{
-							PermissionLevel: "CAN_MANAGE",
-						},
-					},
 				},
 			},
 		}, http.StatusOK
@@ -135,6 +113,31 @@ func AddHandlers(server *testserver.Server) {
 		}
 
 		return fakeWorkspace.WorkspaceFilesImportFile(path, body.Bytes())
+	})
+
+	server.Handle("GET /api/2.1/unity-catalog/current-metastore-assignment", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		return catalog.MetastoreAssignment{
+			DefaultCatalogName: "main",
+		}, http.StatusOK
+	})
+
+	server.Handle("GET /api/2.0/permissions/directories/{objectId}", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {
+		objectId := r.PathValue("objectId")
+
+		return workspace.WorkspaceObjectPermissions{
+			ObjectId:   objectId,
+			ObjectType: "DIRECTORY",
+			AccessControlList: []workspace.WorkspaceObjectAccessControlResponse{
+				{
+					UserName: "tester@databricks.com",
+					AllPermissions: []workspace.WorkspaceObjectPermission{
+						{
+							PermissionLevel: "CAN_MANAGE",
+						},
+					},
+				},
+			},
+		}, http.StatusOK
 	})
 
 	server.Handle("POST /api/2.1/jobs/create", func(fakeWorkspace *testserver.FakeWorkspace, r *http.Request) (any, int) {

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"net/http"
+
+
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/databricks/databricks-sdk-go/service/workspace"

--- a/acceptance/workspace/jobs/create/out.requests.txt
+++ b/acceptance/workspace/jobs/create/out.requests.txt
@@ -1,1 +1,1 @@
-{"headers":{"Authorization":"Bearer dapi1234","User-Agent":"cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/jobs_create cmd-exec-id/[UUID] auth/pat"},"method":"POST","path":"/api/2.1/jobs/create","body":{"name":"abc"}}
+{"headers":{"Authorization":"Bearer [DATABRICKS_TOKEN]","User-Agent":"cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/jobs_create cmd-exec-id/[UUID] auth/pat"},"method":"POST","path":"/api/2.1/jobs/create","body":{"name":"abc"}}

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/databricks/databricks-sdk-go/service/compute"
-	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 )
@@ -35,33 +33,9 @@ func NewFakeWorkspace() *FakeWorkspace {
 	}
 }
 
-func (s *FakeWorkspace) ScimMe() (iam.User, int) {
-	return iam.User{
-		Id:       "1000012345",
-		UserName: "tester@databricks.com",
-	}, http.StatusOK
-}
-
 func (s *FakeWorkspace) CurrentMetastoreAssignment() (catalog.MetastoreAssignment, int) {
 	return catalog.MetastoreAssignment{
 		DefaultCatalogName: "main",
-	}, http.StatusOK
-}
-
-func (s *FakeWorkspace) DirectoryPermissions(objectId string) (workspace.WorkspaceObjectPermissions, int) {
-	return workspace.WorkspaceObjectPermissions{
-		ObjectId:   objectId,
-		ObjectType: "DIRECTORY",
-		AccessControlList: []workspace.WorkspaceObjectAccessControlResponse{
-			{
-				UserName: "tester@databricks.com",
-				AllPermissions: []workspace.WorkspaceObjectPermission{
-					{
-						PermissionLevel: "CAN_MANAGE",
-					},
-				},
-			},
-		},
 	}, http.StatusOK
 }
 
@@ -170,47 +144,6 @@ func (s *FakeWorkspace) JobsList() (any, int) {
 
 	return jobs.ListJobsResponse{
 		Jobs: list,
-	}, http.StatusOK
-}
-
-func (s *FakeWorkspace) InstancePoolsList() (compute.ListInstancePools, int) {
-	return compute.ListInstancePools{
-		InstancePools: []compute.InstancePoolAndStats{
-			{
-				InstancePoolName: "some-test-instance-pool",
-				InstancePoolId:   "1234",
-			},
-		},
-	}, http.StatusOK
-}
-
-func (s *FakeWorkspace) ClustersList() (compute.ListClustersResponse, int) {
-	return compute.ListClustersResponse{
-		Clusters: []compute.ClusterDetails{
-			{
-				ClusterName: "some-test-cluster",
-				ClusterId:   "4321",
-			},
-			{
-				ClusterName: "some-other-cluster",
-				ClusterId:   "9876",
-			},
-		},
-	}, http.StatusOK
-}
-
-func (s *FakeWorkspace) PoliciesList() (any, int) {
-	return compute.ListPoliciesResponse{
-		Policies: []compute.Policy{
-			{
-				PolicyId: "5678",
-				Name:     "wrong-cluster-policy",
-			},
-			{
-				PolicyId: "9876",
-				Name:     "some-test-cluster-policy",
-			},
-		},
 	}, http.StatusOK
 }
 

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 )
@@ -31,12 +31,6 @@ func NewFakeWorkspace() *FakeWorkspace {
 		jobs:      map[int64]jobs.Job{},
 		nextJobId: 1,
 	}
-}
-
-func (s *FakeWorkspace) CurrentMetastoreAssignment() (catalog.MetastoreAssignment, int) {
-	return catalog.MetastoreAssignment{
-		DefaultCatalogName: "main",
-	}, http.StatusOK
 }
 
 func (s *FakeWorkspace) WorkspaceGetStatus(path string) (workspace.ObjectInfo, int) {
@@ -141,6 +135,11 @@ func (s *FakeWorkspace) JobsList() (any, int) {
 
 		list = append(list, baseJob)
 	}
+
+	// sort to have less non-determinism in tests
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].JobId < list[j].JobId
+	})
 
 	return jobs.ListJobsResponse{
 		Jobs: list,

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -1,0 +1,237 @@
+package testserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+// FakeWorkspace holds a state of a workspace for acceptance tests.
+type FakeWorkspace struct {
+	directories map[string]bool
+	files       map[string][]byte
+	// normally, ids are not sequential, but we make them sequential for deterministic diff
+	nextJobId int64
+	jobs      map[int64]jobs.Job
+}
+
+func NewFakeWorkspace() *FakeWorkspace {
+	return &FakeWorkspace{
+		directories: map[string]bool{
+			"/Workspace": true,
+		},
+		files:     map[string][]byte{},
+		jobs:      map[int64]jobs.Job{},
+		nextJobId: 1,
+	}
+}
+
+func (s *FakeWorkspace) ScimMe() (iam.User, int) {
+	return iam.User{
+		Id:       "1000012345",
+		UserName: "tester@databricks.com",
+	}, http.StatusOK
+}
+
+func (s *FakeWorkspace) CurrentMetastoreAssignment() (catalog.MetastoreAssignment, int) {
+	return catalog.MetastoreAssignment{
+		DefaultCatalogName: "main",
+	}, http.StatusOK
+}
+
+func (s *FakeWorkspace) DirectoryPermissions(objectId string) (workspace.WorkspaceObjectPermissions, int) {
+	return workspace.WorkspaceObjectPermissions{
+		ObjectId:   objectId,
+		ObjectType: "DIRECTORY",
+		AccessControlList: []workspace.WorkspaceObjectAccessControlResponse{
+			{
+				UserName: "tester@databricks.com",
+				AllPermissions: []workspace.WorkspaceObjectPermission{
+					{
+						PermissionLevel: "CAN_MANAGE",
+					},
+				},
+			},
+		},
+	}, http.StatusOK
+}
+
+func (s *FakeWorkspace) WorkspaceGetStatus(path string) (workspace.ObjectInfo, int) {
+	if s.directories[path] {
+		return workspace.ObjectInfo{
+			ObjectType: "DIRECTORY",
+			Path:       path,
+		}, http.StatusOK
+	} else if _, ok := s.files[path]; ok {
+		return workspace.ObjectInfo{
+			ObjectType: "FILE",
+			Path:       path,
+			Language:   "SCALA",
+		}, http.StatusOK
+	} else {
+		return workspace.ObjectInfo{}, http.StatusNotFound
+	}
+}
+
+func (s *FakeWorkspace) WorkspaceMkdirs(request workspace.Mkdirs) (string, int) {
+	s.directories[request.Path] = true
+
+	return "{}", http.StatusOK
+}
+
+func (s *FakeWorkspace) WorkspaceExport(path string) ([]byte, int) {
+	file := s.files[path]
+
+	if file == nil {
+		return nil, http.StatusNotFound
+	}
+
+	return file, http.StatusOK
+}
+
+func (s *FakeWorkspace) WorkspaceDelete(path string, recursive bool) (string, int) {
+	if !recursive {
+		s.files[path] = nil
+	} else {
+		for key := range s.files {
+			if strings.HasPrefix(key, path) {
+				s.files[key] = nil
+			}
+		}
+	}
+
+	return "{}", http.StatusOK
+}
+
+func (s *FakeWorkspace) WorkspaceFilesImportFile(path string, body []byte) (any, int) {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	s.files[path] = body
+
+	return "{}", http.StatusOK
+}
+
+func (s *FakeWorkspace) JobsCreate(request jobs.CreateJob) (any, int) {
+	jobId := s.nextJobId
+	s.nextJobId++
+
+	jobSettings := jobs.JobSettings{}
+	err := jsonConvert(request, &jobSettings)
+	if err != nil {
+		return internalError(err)
+	}
+
+	s.jobs[jobId] = jobs.Job{
+		JobId:    jobId,
+		Settings: &jobSettings,
+	}
+
+	return jobs.CreateResponse{JobId: jobId}, http.StatusOK
+}
+
+func (s *FakeWorkspace) JobsGet(jobId string) (any, int) {
+	id := jobId
+
+	jobIdInt, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return internalError(fmt.Errorf("failed to parse job id: %s", err))
+	}
+
+	job, ok := s.jobs[jobIdInt]
+	if !ok {
+		return jobs.Job{}, http.StatusNotFound
+	}
+
+	return job, http.StatusOK
+}
+
+func (s *FakeWorkspace) JobsList() (any, int) {
+	list := make([]jobs.BaseJob, 0, len(s.jobs))
+	for _, job := range s.jobs {
+		baseJob := jobs.BaseJob{}
+		err := jsonConvert(job, &baseJob)
+		if err != nil {
+			return internalError(fmt.Errorf("failed to convert job to base job: %w", err))
+		}
+
+		list = append(list, baseJob)
+	}
+
+	return jobs.ListJobsResponse{
+		Jobs: list,
+	}, http.StatusOK
+}
+
+func (s *FakeWorkspace) InstancePoolsList() (compute.ListInstancePools, int) {
+	return compute.ListInstancePools{
+		InstancePools: []compute.InstancePoolAndStats{
+			{
+				InstancePoolName: "some-test-instance-pool",
+				InstancePoolId:   "1234",
+			},
+		},
+	}, http.StatusOK
+}
+
+func (s *FakeWorkspace) ClustersList() (compute.ListClustersResponse, int) {
+	return compute.ListClustersResponse{
+		Clusters: []compute.ClusterDetails{
+			{
+				ClusterName: "some-test-cluster",
+				ClusterId:   "4321",
+			},
+			{
+				ClusterName: "some-other-cluster",
+				ClusterId:   "9876",
+			},
+		},
+	}, http.StatusOK
+}
+
+func (s *FakeWorkspace) PoliciesList() (any, int) {
+	return compute.ListPoliciesResponse{
+		Policies: []compute.Policy{
+			{
+				PolicyId: "5678",
+				Name:     "wrong-cluster-policy",
+			},
+			{
+				PolicyId: "9876",
+				Name:     "some-test-cluster-policy",
+			},
+		},
+	}, http.StatusOK
+}
+
+// jsonConvert saves input to a value pointed by output
+func jsonConvert(input, output any) error {
+	writer := new(bytes.Buffer)
+	encoder := json.NewEncoder(writer)
+	err := encoder.Encode(input)
+	if err != nil {
+		return fmt.Errorf("failed to encode: %w", err)
+	}
+
+	decoder := json.NewDecoder(writer)
+	err = decoder.Decode(output)
+	if err != nil {
+		return fmt.Errorf("failed to decode: %w", err)
+	}
+
+	return nil
+}
+
+func internalError(err error) (string, int) {
+	return fmt.Sprintf("internal error: %s", err), http.StatusInternalServerError
+}


### PR DESCRIPTION
## Changes
Extend testserver for bundle deployment:

- Allocate a new workspace per test case to isolate test cases from each other
- Support jobs get/list/create
- Support creation and listing of workspace files

## Tests
Using existing acceptance tests

