### PR TITLE
Silence a comment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	golangci-lint run --fix
 
 tidy:
-	# not part of golangci-lint, apparently
+	@# not part of golangci-lint, apparently
 	go mod tidy
 
 lintcheck:


### PR DESCRIPTION
It was not indended to be printed. Follow up to #2298