### PR TITLE
acc: Summarize unexpected files

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -343,6 +343,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 
 	// Make sure there are not unaccounted for new files
 	files := ListDir(t, tmpDir)
+	unexpected := []string{}
 	for _, relPath := range files {
 		if _, ok := inputs[relPath]; ok {
 			continue
@@ -350,12 +351,16 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 		if _, ok := outputs[relPath]; ok {
 			continue
 		}
-		t.Errorf("Unexpected output: %s", relPath)
+		unexpected = append(unexpected, relPath)
 		if strings.HasPrefix(relPath, "out") {
 			// We have a new file starting with "out"
 			// Show the contents & support overwrite mode for it:
 			doComparison(t, repls, dir, tmpDir, relPath, &printedRepls)
 		}
+	}
+
+	if len(unexpected) > 0 {
+		t.Error("Test produced unexpected files:\n" + strings.Join(unexpected, "\n"))
 	}
 }
 


### PR DESCRIPTION
## Changes
When there are many unexpected files, it's good to see them as a list rather than scattered throughout the output.

<!-- Summary of your changes that are easy to understand -->

## Tests
Manually, example output:
```
    acceptance_test.go:363: Test produced unexpected files:
        output/my_default_sql/.databricks/bundle/dev/sync-snapshots/71c79ded90615dc7.json
        output/my_default_sql/.databricks/bundle/dev/terraform/.terraform/providers/registry.terraform.io/databricks/databricks/1.64.1/darwin_arm64
        output/my_default_sql/.databricks/bundle/dev/terraform/plan
        output/my_default_sql/.databricks/bundle/prod/sync-snapshots/83e677e75259c93b.json
        output/my_default_sql/.databricks/bundle/prod/terraform/.terraform/providers/registry.terraform.io/databricks/databricks/1.64.1/darwin_arm64
```

