### PR TITLE
Append newline to "-o json" for validate/summary/run

### DIFF
--- a/acceptance/bundle/variables/host/output.txt
+++ b/acceptance/bundle/variables/host/output.txt
@@ -23,6 +23,7 @@ Error: failed during request visitor: parse "https://${var.host}": invalid chara
     "host": "${var.host}"
   }
 }
+
 Exit code: 1
 
 >>> errcode [CLI] bundle validate

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -173,6 +173,7 @@ task or a Python wheel task, the second example applies.
 				if err != nil {
 					return err
 				}
+				_, _ = cmd.OutOrStdout().Write([]byte{'\n'})
 			default:
 				return fmt.Errorf("unknown output type %s", root.OutputType(cmd))
 			}

--- a/cmd/bundle/summary.go
+++ b/cmd/bundle/summary.go
@@ -74,6 +74,7 @@ func newSummaryCommand() *cobra.Command {
 				return err
 			}
 			_, _ = cmd.OutOrStdout().Write(buf)
+			_, _ = cmd.OutOrStdout().Write([]byte{'\n'})
 		default:
 			return fmt.Errorf("unknown output type %s", root.OutputType(cmd))
 		}

--- a/cmd/bundle/validate.go
+++ b/cmd/bundle/validate.go
@@ -20,7 +20,9 @@ func renderJsonOutput(cmd *cobra.Command, b *bundle.Bundle) error {
 	if err != nil {
 		return err
 	}
-	_, _ = cmd.OutOrStdout().Write(buf)
+	out := cmd.OutOrStdout()
+	_, _ = out.Write(buf)
+	_, _ = out.Write([]byte{'\n'})
 	return nil
 }
 


### PR DESCRIPTION
## Changes
- Insert newline after rendering indented JSON in bundle validate/summary/run. 
- This prevents "No newline at end of file" message in various cases, for example when switching between recording raw output of the command to output processed by jq, since jq does add a newline or when running diff in acceptance tests.

## Tests
Manually running validate:

```
~/work/dabs_cuj_brickfood % ../cli/cli-main bundle validate -o json | tail -n 2  # without change
Error: root_path must start with '~/' or contain the current username to ensure uniqueness when using 'mode: development'

  }
}%
~/work/dabs_cuj_brickfood % ../cli/cli bundle validate -o json | tail -n 2  # with change
Error: root_path must start with '~/' or contain the current username to ensure uniqueness when using 'mode: development'

  }
}
~/work/dabs_cuj_brickfood %
```

Via #2316 -- see cleaner output there.