### PR TITLE
Return 501 status code when API stub is not implemented

### DIFF
--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -76,7 +76,7 @@ Response.StatusCode = <response status-code here>
 
 		return apierr.APIError{
 			Message: "No stub found for pattern: " + pattern,
-		}, http.StatusNotFound
+		}, http.StatusNotImplemented
 	})
 
 	return s


### PR DESCRIPTION
## Changes
Addresses feedback from https://github.com/databricks/cli/pull/2292#discussion_r1946846865

## Tests
Manually, confirmed that unstubbed API calls still cause acceptance tests to fail.
