### PR TITLE
acc: Do not show all replacements on every failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 
 cover:
 	rm -fr ./acceptance/build/cover/
-	CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES}
+	CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES} -verbosetest
 	rm -fr ./acceptance/build/cover-merged/
 	mkdir -p acceptance/build/cover-merged/
 	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/
@@ -55,7 +55,7 @@ schema:
 docs:
 	go run ./bundle/docsgen ./bundle/internal/schema ./bundle/docsgen
 
-INTEGRATION = gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./acceptance ./integration/..." -- -parallel 4 -timeout=2h
+INTEGRATION = gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./acceptance ./integration/..." -- -parallel 4 -timeout=2h -verbosetest
 
 integration: vendor
 	$(INTEGRATION)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 
 cover:
 	rm -fr ./acceptance/build/cover/
-	CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES} -verbosetest
+	VERBOSE_TEST=1 CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES}
 	rm -fr ./acceptance/build/cover-merged/
 	mkdir -p acceptance/build/cover-merged/
 	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/
@@ -55,12 +55,12 @@ schema:
 docs:
 	go run ./bundle/docsgen ./bundle/internal/schema ./bundle/docsgen
 
-INTEGRATION = gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./acceptance ./integration/..." -- -parallel 4 -timeout=2h -verbosetest
+INTEGRATION = gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./acceptance ./integration/..." -- -parallel 4 -timeout=2h
 
 integration: vendor
 	$(INTEGRATION)
 
 integration-short: vendor
-	$(INTEGRATION) -short
+	VERBOSE_TEST=1 $(INTEGRATION) -short
 
 .PHONY: lint tidy lintcheck fmt test cover showcover build snapshot vendor schema integration integration-short acc-cover acc-showcover docs

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -32,7 +32,7 @@ import (
 var (
 	KeepTmp     bool
 	NoRepl      bool
-	VerboseTest bool
+	VerboseTest bool = os.Getenv("VERBOSE_TEST") != ""
 )
 
 // In order to debug CLI running under acceptance test, set this to full subtest name, e.g. "bundle/variables/empty"
@@ -49,7 +49,6 @@ func init() {
 	flag.BoolVar(&InprocessMode, "inprocess", SingleTest != "", "Run CLI in the same process as test (for debugging)")
 	flag.BoolVar(&KeepTmp, "keeptmp", false, "Do not delete TMP directory after run")
 	flag.BoolVar(&NoRepl, "norepl", false, "Do not apply any replacements (for debugging)")
-	flag.BoolVar(&VerboseTest, "verbosetest", false, "Print available replacements in case of failure")
 }
 
 const (

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -30,8 +30,9 @@ import (
 )
 
 var (
-	KeepTmp bool
-	NoRepl  bool
+	KeepTmp     bool
+	NoRepl      bool
+	VerboseTest bool
 )
 
 // In order to debug CLI running under acceptance test, set this to full subtest name, e.g. "bundle/variables/empty"
@@ -48,6 +49,7 @@ func init() {
 	flag.BoolVar(&InprocessMode, "inprocess", SingleTest != "", "Run CLI in the same process as test (for debugging)")
 	flag.BoolVar(&KeepTmp, "keeptmp", false, "Do not delete TMP directory after run")
 	flag.BoolVar(&NoRepl, "norepl", false, "Do not apply any replacements (for debugging)")
+	flag.BoolVar(&VerboseTest, "verbosetest", false, "Print available replacements in case of failure")
 }
 
 const (
@@ -412,7 +414,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		testutil.WriteFile(t, pathRef, valueNew)
 	}
 
-	if !equal && printedRepls != nil && !*printedRepls {
+	if VerboseTest && !equal && printedRepls != nil && !*printedRepls {
 		*printedRepls = true
 		var items []string
 		for _, item := range repls.Repls {


### PR DESCRIPTION
## Changes
- Only print replacements if VERBOSE_TEST flag is set.
- This is set on CI but not when you do "go test" or "make test".

Note, env var is used, so that it can be set in Makefile.

## Tests
Manually.

