### PR TITLE
acc: Fix RecordRequests to support requests without body

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -262,7 +262,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	// 2. The test is configured to record requests and assert on them. We need
 	//    a duplicate of the default server to record requests because the default
 	//    server otherwise is a shared resource.
-	if len(config.Server) > 0 || config.RecordRequests {
+	if cloudEnv == "" && (len(config.Server) > 0 || config.RecordRequests) {
 		server = testserver.New(t)
 		server.RecordRequests = config.RecordRequests
 		server.IncludeRequestHeaders = config.IncludeRequestHeaders


### PR DESCRIPTION
## Changes
Do not paste request body into output if it's not a valid JSON.

## Tests
While working on #2334 I found that if I try to record a test that calls /api/2.0/preview/scim/v2/Me which has no request body, it crashes.
