### PR TITLE
Do not load host from bundle for CLI commands when profile flag is used

### DIFF
--- a/acceptance/auth/bundle_and_profile/output.txt
+++ b/acceptance/auth/bundle_and_profile/output.txt
@@ -23,6 +23,65 @@ Error: cannot resolve bundle auth configuration: config host mismatch: profile u
 
 Exit code: 1
 
+=== Bundle commands load bundle configuration when no flags, validation OK
+>>> errcode [CLI] bundle validate
+Name: test-auth
+Target: dev
+Workspace:
+  Host: [DATABRICKS_TARGET]
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-auth/dev
+
+Validation OK!
+
+=== Bundle commands load bundle configuration with -t flag, validation OK
+>>> errcode [CLI] bundle validate -t dev
+Name: test-auth
+Target: dev
+Workspace:
+  Host: [DATABRICKS_TARGET]
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-auth/dev
+
+Validation OK!
+
+=== Bundle commands load bundle configuration with -p flag, validation not OK (profile host don't match bundle host)
+>>> errcode [CLI] bundle validate -p profile_name
+Error: cannot resolve bundle auth configuration: config host mismatch: profile uses host https://non-existing-subdomain.databricks.com, but CLI configured to use [DATABRICKS_TARGET]
+
+Name: test-auth
+Target: dev
+Workspace:
+  Host: [DATABRICKS_TARGET]
+
+Found 1 error
+
+Exit code: 1
+
+=== Bundle commands load bundle configuration with -t and -p flag, validation OK (profile host match bundle host)
+>>> errcode [CLI] bundle validate -t dev -p DEFAULT
+Name: test-auth
+Target: dev
+Workspace:
+  Host: [DATABRICKS_TARGET]
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-auth/dev
+
+Validation OK!
+
+=== Bundle commands load bundle configuration with -t and -p flag, validation not OK (profile host don't match bundle host)
+>>> errcode [CLI] bundle validate -t prod -p DEFAULT
+Error: cannot resolve bundle auth configuration: config host mismatch: profile uses host [DATABRICKS_TARGET], but CLI configured to use https://bar.com
+
+Name: test-auth
+Target: prod
+Workspace:
+  Host: https://bar.com
+
+Found 1 error
+
+Exit code: 1
+
 === Outside the bundle, no flags
 >>> errcode [CLI] current-user me
 "[USERNAME]"

--- a/acceptance/auth/bundle_and_profile/output.txt
+++ b/acceptance/auth/bundle_and_profile/output.txt
@@ -13,11 +13,7 @@
 
 === Inside the bundle, profile flag not matching bundle host.
 >>> errcode [CLI] current-user me -p profile_name
-<<<<<<< HEAD
-Error: cannot resolve bundle auth configuration: config host mismatch: profile uses host https://non-existing-subdomain.databricks.com, but CLI configured to use [DATABRICKS_TARGET]
-=======
-Error: Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": dial tcp: lookup non-existing-subdomain.databricks.com: no such host
->>>>>>> eef83858 (Do not load host from bundle for CLI commands when profile flag is used)
+Error: Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": (redacted)
 
 Exit code: 1
 

--- a/acceptance/auth/bundle_and_profile/output.txt
+++ b/acceptance/auth/bundle_and_profile/output.txt
@@ -11,7 +11,7 @@
 >>> errcode [CLI] current-user me -t dev -p DEFAULT
 "[USERNAME]"
 
-=== Inside the bundle, profile flag not matching bundle host.
+=== Inside the bundle, profile flag not matching bundle host. Should use profile from the flag and not the bundle.
 >>> errcode [CLI] current-user me -p profile_name
 Error: Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": (redacted)
 

--- a/acceptance/auth/bundle_and_profile/output.txt
+++ b/acceptance/auth/bundle_and_profile/output.txt
@@ -11,9 +11,13 @@
 >>> errcode [CLI] current-user me -t dev -p DEFAULT
 "[USERNAME]"
 
-=== Inside the bundle, profile flag not matching bundle host. Badness: should use profile from flag instead and not fail
+=== Inside the bundle, profile flag not matching bundle host.
 >>> errcode [CLI] current-user me -p profile_name
+<<<<<<< HEAD
 Error: cannot resolve bundle auth configuration: config host mismatch: profile uses host https://non-existing-subdomain.databricks.com, but CLI configured to use [DATABRICKS_TARGET]
+=======
+Error: Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": dial tcp: lookup non-existing-subdomain.databricks.com: no such host
+>>>>>>> eef83858 (Do not load host from bundle for CLI commands when profile flag is used)
 
 Exit code: 1
 

--- a/acceptance/auth/bundle_and_profile/script
+++ b/acceptance/auth/bundle_and_profile/script
@@ -15,7 +15,7 @@ trace errcode $CLI current-user me -t dev | jq .userName
 title "Inside the bundle, target and matching profile"
 trace errcode $CLI current-user me -t dev -p DEFAULT | jq .userName
 
-title "Inside the bundle, profile flag not matching bundle host. Badness: should use profile from flag instead and not fail"
+title "Inside the bundle, profile flag not matching bundle host."
 trace errcode $CLI current-user me -p profile_name | jq .userName
 
 title "Inside the bundle, target and not matching profile"

--- a/acceptance/auth/bundle_and_profile/script
+++ b/acceptance/auth/bundle_and_profile/script
@@ -21,6 +21,21 @@ trace errcode $CLI current-user me -p profile_name | jq .userName
 title "Inside the bundle, target and not matching profile"
 trace errcode $CLI current-user me -t dev -p profile_name
 
+title "Bundle commands load bundle configuration when no flags, validation OK"
+trace errcode $CLI bundle validate
+
+title "Bundle commands load bundle configuration with -t flag, validation OK"
+trace errcode $CLI bundle validate -t dev
+
+title "Bundle commands load bundle configuration with -p flag, validation not OK (profile host don't match bundle host)"
+trace errcode $CLI bundle validate -p profile_name
+
+title "Bundle commands load bundle configuration with -t and -p flag, validation OK (profile host match bundle host)"
+trace errcode $CLI bundle validate -t dev -p DEFAULT
+
+title "Bundle commands load bundle configuration with -t and -p flag, validation not OK (profile host don't match bundle host)"
+trace errcode $CLI bundle validate -t prod -p DEFAULT
+
 cd ..
 export DATABRICKS_HOST=$host
 title "Outside the bundle, no flags"

--- a/acceptance/auth/bundle_and_profile/script
+++ b/acceptance/auth/bundle_and_profile/script
@@ -15,7 +15,7 @@ trace errcode $CLI current-user me -t dev | jq .userName
 title "Inside the bundle, target and matching profile"
 trace errcode $CLI current-user me -t dev -p DEFAULT | jq .userName
 
-title "Inside the bundle, profile flag not matching bundle host."
+title "Inside the bundle, profile flag not matching bundle host. Should use profile from the flag and not the bundle."
 trace errcode $CLI current-user me -p profile_name | jq .userName
 
 title "Inside the bundle, target and not matching profile"

--- a/acceptance/auth/bundle_and_profile/test.toml
+++ b/acceptance/auth/bundle_and_profile/test.toml
@@ -1,4 +1,4 @@
-Badness = "When -p flag is used inside the bundle folder for any CLI commands, CLI use bundle host anyway instead of profile one"
+LocalOnly=true
 
 # Some of the clouds have DATABRICKS_HOST variable setup without https:// prefix
 # In the result, output is replaced with DATABRICKS_URL variable instead of DATABRICKS_HOST

--- a/acceptance/auth/bundle_and_profile/test.toml
+++ b/acceptance/auth/bundle_and_profile/test.toml
@@ -10,3 +10,7 @@ New='DATABRICKS_TARGET'
 [[Repls]]
 Old='DATABRICKS_URL'
 New='DATABRICKS_TARGET'
+
+[[Repls]]
+Old='Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": .*'
+New='Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": (redacted)'

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -196,8 +196,8 @@ func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
 	}
 
 	_, isTargetFlagSet := targetFlagValue(cmd)
+	// If the profile flag is set but the target flag is not, we should skip loading the bundle configuration.
 	if !isTargetFlagSet && hasProfileFlag {
-		// If the profile flag is set but the target flag is not, we should skip loading the bundle configuration.
 		cmd.SetContext(SkipLoadBundle(cmd.Context()))
 	}
 

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -195,6 +195,12 @@ func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
 		cfg.Profile = profile
 	}
 
+	_, isTargetFlagSet := targetFlagValue(cmd)
+	if !isTargetFlagSet && hasProfileFlag {
+		// If the profile flag is set but the target flag is not, we should skip loading the bundle configuration.
+		cmd.SetContext(SkipLoadBundle(cmd.Context()))
+	}
+
 	ctx := cmd.Context()
 	ctx = context.WithValue(ctx, &configUsed, cfg)
 	cmd.SetContext(ctx)

--- a/cmd/root/bundle.go
+++ b/cmd/root/bundle.go
@@ -14,26 +14,35 @@ import (
 
 // getTarget returns the name of the target to operate in.
 func getTarget(cmd *cobra.Command) (value string) {
+	target, isFlagSet := targetFlagValue(cmd)
+	if isFlagSet {
+		return target
+	}
+
+	// If it's not set, use the environment variable.
+	target, _ = env.Target(cmd.Context())
+	return target
+}
+
+func targetFlagValue(cmd *cobra.Command) (string, bool) {
 	// The command line flag takes precedence.
 	flag := cmd.Flag("target")
 	if flag != nil {
-		value = flag.Value.String()
+		value := flag.Value.String()
 		if value != "" {
-			return
+			return value, true
 		}
 	}
 
 	oldFlag := cmd.Flag("environment")
 	if oldFlag != nil {
-		value = oldFlag.Value.String()
+		value := oldFlag.Value.String()
 		if value != "" {
-			return
+			return value, true
 		}
 	}
 
-	// If it's not set, use the environment variable.
-	target, _ := env.Target(cmd.Context())
-	return target
+	return "", false
 }
 
 func getProfile(cmd *cobra.Command) (value string) {


### PR DESCRIPTION
## Changes
Now when `profile` flag is used we won't pick up host from bundle anymore and use the one provided by -p flag

Previous behaviour in the context of bundle
```
databricks current-user me -p profile_name
Error: cannot resolve bundle auth configuration: config host mismatch: profile uses host https://non-existing-subdomain.databricks.com, but CLI configured to use https://foo.com
```

New behaviour (make an api call)
```
databricks current-user me -p profile_name
{
  email: "foo@bar.com"
  ...
}
```

We still load bundle configuration when `-t` flag provide because we want to load host information from the target.

Fixes #1358 

## Tests
Added acceptance test

