### PR TITLE
[Release] Release v0.241.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,17 +14,12 @@ API Changes:
  * Added `databricks account budget-policy` command group.
  * Added `databricks lakeview-embedded` command group.
  * Added `databricks query-execution` command group.
- * Changed `databricks serving-endpoints http-request` command to type `databricks serving-endpoints http-request` command.
  * Added `databricks account enable-ip-access-lists` command group.
  * Added `databricks redash-config` command group.
 
 OpenAPI commit c72c58f97b950fcb924a90ef164bcb10cfcd5ece (2025-02-03)
 Dependency updates:
  * Upgrade to TF provider 1.65.1 ([#2328](https://github.com/databricks/cli/pull/2328)).
- * Bump golangci/golangci-lint-action from 6.1.1 to 6.2.0 ([#2273](https://github.com/databricks/cli/pull/2273)).
- * Bump astral-sh/ruff-action from 3.0.1 to 3.1.0 ([#2274](https://github.com/databricks/cli/pull/2274)).
- * Bump actions/stale from 9.0.0 to 9.1.0 ([#2275](https://github.com/databricks/cli/pull/2275)).
- * Bump actions/create-github-app-token from 1.11.1 to 1.11.2 ([#2276](https://github.com/databricks/cli/pull/2276)).
  * Bump github.com/hashicorp/terraform-exec from 0.21.0 to 0.22.0 ([#2237](https://github.com/databricks/cli/pull/2237)).
  * Bump github.com/spf13/pflag from 1.0.5 to 1.0.6 ([#2281](https://github.com/databricks/cli/pull/2281)).
  * Bump github.com/databricks/databricks-sdk-go from 0.56.1 to 0.57.0 ([#2321](https://github.com/databricks/cli/pull/2321)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Version changelog
 
+## [Release] Release v0.241.0
+
+Bundles:
+ * Added support to generate Git based jobs ([#2304](https://github.com/databricks/cli/pull/2304)).
+ * Added support for run_as in pipelines ([#2287](https://github.com/databricks/cli/pull/2287)).
+ * Raise an error when there are multiple local libraries with the same basename used ([#2297](https://github.com/databricks/cli/pull/2297)).
+ * Fix env variable for AzureCli local config ([#2248](https://github.com/databricks/cli/pull/2248)).
+ * Accept JSON files in includes section ([#2265](https://github.com/databricks/cli/pull/2265)).
+ * Always print warnings and errors; clean up format ([#2213](https://github.com/databricks/cli/pull/2213))
+
+API Changes:
+ * Added `databricks account budget-policy` command group.
+ * Added `databricks lakeview-embedded` command group.
+ * Added `databricks query-execution` command group.
+ * Changed `databricks serving-endpoints http-request` command to type `databricks serving-endpoints http-request` command.
+ * Added `databricks account enable-ip-access-lists` command group.
+ * Added `databricks redash-config` command group.
+
+OpenAPI commit c72c58f97b950fcb924a90ef164bcb10cfcd5ece (2025-02-03)
+Dependency updates:
+ * Upgrade to TF provider 1.65.1 ([#2328](https://github.com/databricks/cli/pull/2328)).
+ * Bump golangci/golangci-lint-action from 6.1.1 to 6.2.0 ([#2273](https://github.com/databricks/cli/pull/2273)).
+ * Bump astral-sh/ruff-action from 3.0.1 to 3.1.0 ([#2274](https://github.com/databricks/cli/pull/2274)).
+ * Bump actions/stale from 9.0.0 to 9.1.0 ([#2275](https://github.com/databricks/cli/pull/2275)).
+ * Bump actions/create-github-app-token from 1.11.1 to 1.11.2 ([#2276](https://github.com/databricks/cli/pull/2276)).
+ * Bump github.com/hashicorp/terraform-exec from 0.21.0 to 0.22.0 ([#2237](https://github.com/databricks/cli/pull/2237)).
+ * Bump github.com/spf13/pflag from 1.0.5 to 1.0.6 ([#2281](https://github.com/databricks/cli/pull/2281)).
+ * Bump github.com/databricks/databricks-sdk-go from 0.56.1 to 0.57.0 ([#2321](https://github.com/databricks/cli/pull/2321)).
+ * Bump golang.org/x/oauth2 from 0.25.0 to 0.26.0 ([#2322](https://github.com/databricks/cli/pull/2322)).
+ * Bump golang.org/x/term from 0.28.0 to 0.29.0 ([#2325](https://github.com/databricks/cli/pull/2325)).
+ * Bump golang.org/x/text from 0.21.0 to 0.22.0 ([#2323](https://github.com/databricks/cli/pull/2323)).
+ * Bump golang.org/x/mod from 0.22.0 to 0.23.0 ([#2324](https://github.com/databricks/cli/pull/2324)).
+
 ## [Release] Release v0.240.0
 
 Bundles:


### PR DESCRIPTION
Bundles:
 * Added support to generate Git based jobs ([#2304](https://github.com/databricks/cli/pull/2304)).
 * Added support for run_as in pipelines ([#2287](https://github.com/databricks/cli/pull/2287)).
 * Raise an error when there are multiple local libraries with the same basename used ([#2297](https://github.com/databricks/cli/pull/2297)).
 * Fix env variable for AzureCli local config ([#2248](https://github.com/databricks/cli/pull/2248)).
 * Accept JSON files in includes section ([#2265](https://github.com/databricks/cli/pull/2265)).
 * Always print warnings and errors; clean up format ([#2213](https://github.com/databricks/cli/pull/2213))

API Changes:
 * Added `databricks account budget-policy` command group.
 * Added `databricks lakeview-embedded` command group.
 * Added `databricks query-execution` command group.
 * Added `databricks account enable-ip-access-lists` command group.
 * Added `databricks redash-config` command group.

OpenAPI commit c72c58f97b950fcb924a90ef164bcb10cfcd5ece (2025-02-03)
Dependency updates:
 * Upgrade to TF provider 1.65.1 ([#2328](https://github.com/databricks/cli/pull/2328)).
 * Bump github.com/hashicorp/terraform-exec from 0.21.0 to 0.22.0 ([#2237](https://github.com/databricks/cli/pull/2237)).
 * Bump github.com/spf13/pflag from 1.0.5 to 1.0.6 ([#2281](https://github.com/databricks/cli/pull/2281)).
 * Bump github.com/databricks/databricks-sdk-go from 0.56.1 to 0.57.0 ([#2321](https://github.com/databricks/cli/pull/2321)).
 * Bump golang.org/x/oauth2 from 0.25.0 to 0.26.0 ([#2322](https://github.com/databricks/cli/pull/2322)).
 * Bump golang.org/x/term from 0.28.0 to 0.29.0 ([#2325](https://github.com/databricks/cli/pull/2325)).
 * Bump golang.org/x/text from 0.21.0 to 0.22.0 ([#2323](https://github.com/databricks/cli/pull/2323)).
 * Bump golang.org/x/mod from 0.22.0 to 0.23.0 ([#2324](https://github.com/databricks/cli/pull/2324)).