### PR TITLE
Fix for regression deploying resources with PyPi and Maven library types

### DIFF
--- a/acceptance/bundle/artifacts/same_name_libraries/databricks.yml
+++ b/acceptance/bundle/artifacts/same_name_libraries/databricks.yml
@@ -34,6 +34,8 @@ resources:
             package_name: my_default_python
           libraries:
             - whl: ./whl1/dist/*.whl
+            - pypi:
+                package: test_package
         - task_key: task2
           new_cluster: ${var.cluster}
           python_wheel_task:

--- a/acceptance/bundle/artifacts/same_name_libraries/output.txt
+++ b/acceptance/bundle/artifacts/same_name_libraries/output.txt
@@ -6,7 +6,7 @@ Error: Duplicate local library name my_default_python-0.0.1-py3-none-any.whl
   at resources.jobs.test.tasks[0].libraries[0].whl
      resources.jobs.test.tasks[1].libraries[0].whl
   in databricks.yml:36:15
-     databricks.yml:43:15
+     databricks.yml:45:15
 
 Local library names must be unique
 

--- a/bundle/libraries/same_name_libraries.go
+++ b/bundle/libraries/same_name_libraries.go
@@ -31,13 +31,18 @@ func (c checkForSameNameLibraries) Apply(ctx context.Context, b *bundle.Bundle) 
 		var err error
 		for _, pattern := range patterns {
 			v, err = dyn.MapByPattern(v, pattern, func(p dyn.Path, lv dyn.Value) (dyn.Value, error) {
-				libPath := lv.MustString()
+				libFullPath, ok := lv.AsString()
+				// If the value is not a string, skip the check because it's not whl or jar type which defines the library
+				// as a string versus PyPi or Maven which defines the library as a map.
+				if !ok {
+					return v, nil
+				}
+
 				// If not local library, skip the check
-				if !IsLibraryLocal(libPath) {
+				if !IsLibraryLocal(libFullPath) {
 					return lv, nil
 				}
 
-				libFullPath := lv.MustString()
 				lib := filepath.Base(libFullPath)
 				// If the same basename was seen already but full path is different
 				// then it's a duplicate. Add the location to the location list.


### PR DESCRIPTION
## Changes

The CheckForSameNameLibraries mutator incorrectly assumed all resource libraries define libraries as paths of the `string` type, but some libraries, such as PyPi and Maven, define them as objects.

This PR addresses this issue. It was introduced in #2297.

## Tests

Added regression test.