### PR TITLE
acc: Set X-Databricks-Org-Id on scim/v2/Me endpoint

### DIFF
--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -63,7 +63,10 @@ func AddHandlers(server *testserver.Server) {
 	})
 
 	server.Handle("GET", "/api/2.0/preview/scim/v2/Me", func(req testserver.Request) any {
-		return testUser
+		return testserver.Response{
+			Headers: map[string][]string{"X-Databricks-Org-Id": {"900800700600"}},
+			Body:    testUser,
+		}
 	})
 
 	server.Handle("GET", "/api/2.0/workspace/get-status", func(req testserver.Request) any {


### PR DESCRIPTION
This is needed for b.WorkspaceClient().CurrentWorkspaceID(ctx) which is used by initialize_urls.go mutator ("bundle summary") #2316

It also also needed for to call serverless detection endpoint #2348

Builds on top of #2338

