### PR TITLE
Use tar.gz for Mac and Linux

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -96,3 +96,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             dist/databricks_cli_*.zip
+            dist/databricks_cli_*.tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,7 +41,10 @@ builds:
   binary: databricks
 
 archives:
-- format: zip
+- format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
 
   # Include version in archive only for release builds and not for snapshot builds.
   # Snapshot archives must have a stable file name such that the artifacts in the nightly


### PR DESCRIPTION
Changes
-------

Changes GitHub releases to handle Mac and Linux binaries slightly differently than Windows.

| Operating System | Archive Format |
| ---------------- | -------------- |
| Mac OS           | `tar.gz`       |
| Linux            | `tar.gz`       |
| Windows          | `zip`          |

Tests
-----

I tested with the following commands.

```bash
$ goreleaser release --snapshot

$ ls -1 dist/*.{zip,tar.gz}
dist/databricks_cli_darwin_amd64.tar.gz
dist/databricks_cli_darwin_arm64.tar.gz
dist/databricks_cli_linux_amd64.tar.gz
dist/databricks_cli_linux_arm64.tar.gz
dist/databricks_cli_windows_amd64.zip
dist/databricks_cli_windows_arm64.zip
```

Related issues
--------------

Closes #1296
