### PR TITLE
Set default data_security_mode to "SINGLE_USER" in bundle templates

### DIFF
--- a/acceptance/bundle/templates/default-python/output/my_default_python/resources/my_default_python.job.yml
+++ b/acceptance/bundle/templates/default-python/output/my_default_python/resources/my_default_python.job.yml
@@ -44,6 +44,7 @@ resources:
           new_cluster:
             spark_version: 15.4.x-scala2.12
             node_type_id: i3.xlarge
+            data_security_mode: SINGLE_USER
             autoscale:
                 min_workers: 1
                 max_workers: 4

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
@@ -34,6 +34,7 @@ Warning: Ignoring Databricks CLI version constraint for development build. Requi
               "max_workers": 4,
               "min_workers": 1
             },
+            "data_security_mode": "SINGLE_USER",
             "node_type_id": "i3.xlarge",
             "spark_version": "15.4.x-scala2.12"
           }

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/resources/my_jobs_as_code_job.py
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/resources/my_jobs_as_code_job.py
@@ -56,6 +56,7 @@ my_jobs_as_code_job = Job.from_dict(
                 "new_cluster": {
                     "spark_version": "15.4.x-scala2.12",
                     "node_type_id": "i3.xlarge",
+                    "data_security_mode": "SINGLE_USER",
                     "autoscale": {
                         "min_workers": 1,
                         "max_workers": 4,

--- a/integration/bundle/testdata/default_python/bundle_summary.txt
+++ b/integration/bundle/testdata/default_python/bundle_summary.txt
@@ -33,11 +33,10 @@
           "value": "[USERNAME]"
         }
       ],
-      "externalId": "[UUID]",
       "groups": [
         {
           "$ref": "Groups/[USERGROUP]",
-          "display": "admins",
+          "display": "team.engineering",
           "type": "direct",
           "value": "[USERGROUP]"
         }
@@ -68,6 +67,11 @@
           "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_$UNIQUE_PRJ/dev/state/metadata.json"
         },
         "edit_mode": "UI_LOCKED",
+        "email_notifications": {
+          "on_failure": [
+            "[USERNAME]"
+          ]
+        },
         "format": "MULTI_TASK",
         "id": "[NUMID]",
         "job_clusters": [
@@ -79,7 +83,7 @@
                 "min_workers": 1
               },
               "data_security_mode": "SINGLE_USER",
-              "node_type_id": "Standard_D3_v2",
+              "node_type_id": "i3.xlarge",
               "spark_version": "15.4.x-scala2.12"
             }
           }
@@ -142,6 +146,7 @@
     },
     "pipelines": {
       "project_name_$UNIQUE_PRJ_pipeline": {
+        "catalog": "main",
         "configuration": {
           "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_$UNIQUE_PRJ/dev/files/src"
         },
@@ -160,7 +165,7 @@
         ],
         "name": "[dev [USERNAME]] project_name_$UNIQUE_PRJ_pipeline",
         "target": "project_name_$UNIQUE_PRJ_dev",
-        "url": "[DATABRICKS_URL]/pipelines/[UUID]"
+        "url": "[DATABRICKS_URL]/pipelines/[UUID]?o=[NUMID]"
       }
     }
   },

--- a/integration/bundle/testdata/default_python/bundle_summary.txt
+++ b/integration/bundle/testdata/default_python/bundle_summary.txt
@@ -33,10 +33,11 @@
           "value": "[USERNAME]"
         }
       ],
+      "externalId": "[UUID]",
       "groups": [
         {
           "$ref": "Groups/[USERGROUP]",
-          "display": "team.engineering",
+          "display": "admins",
           "type": "direct",
           "value": "[USERGROUP]"
         }
@@ -67,11 +68,6 @@
           "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_$UNIQUE_PRJ/dev/state/metadata.json"
         },
         "edit_mode": "UI_LOCKED",
-        "email_notifications": {
-          "on_failure": [
-            "[USERNAME]"
-          ]
-        },
         "format": "MULTI_TASK",
         "id": "[NUMID]",
         "job_clusters": [
@@ -82,7 +78,8 @@
                 "max_workers": 4,
                 "min_workers": 1
               },
-              "node_type_id": "i3.xlarge",
+              "data_security_mode": "SINGLE_USER",
+              "node_type_id": "Standard_D3_v2",
               "spark_version": "15.4.x-scala2.12"
             }
           }
@@ -145,7 +142,6 @@
     },
     "pipelines": {
       "project_name_$UNIQUE_PRJ_pipeline": {
-        "catalog": "main",
         "configuration": {
           "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_$UNIQUE_PRJ/dev/files/src"
         },
@@ -164,7 +160,7 @@
         ],
         "name": "[dev [USERNAME]] project_name_$UNIQUE_PRJ_pipeline",
         "target": "project_name_$UNIQUE_PRJ_dev",
-        "url": "[DATABRICKS_URL]/pipelines/[UUID]?o=[NUMID]"
+        "url": "[DATABRICKS_URL]/pipelines/[UUID]"
       }
     }
   },

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -69,6 +69,7 @@ resources:
           new_cluster:
             spark_version: {{template "latest_lts_dbr_version"}}
             node_type_id: {{smallest_node_type}}
+            data_security_mode: SINGLE_USER
             autoscale:
                 min_workers: 1
                 max_workers: 4

--- a/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/resources/{{.project_name}}_job.py.tmpl
+++ b/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/resources/{{.project_name}}_job.py.tmpl
@@ -97,6 +97,7 @@ This job runs {{.project_name}}_pipeline on a schedule.
                 "new_cluster": {
                     "spark_version": "{{template "latest_lts_dbr_version"}}",
                     "node_type_id": "{{smallest_node_type}}",
+                    "data_security_mode": "SINGLE_USER",
                     "autoscale": {
                         "min_workers": 1,
                         "max_workers": 4,


### PR DESCRIPTION
## Changes
1. Change the **default-python** bundle template to set `data_security_mode` of a cluster to SINGLE_USER
2. Change the **experimental-jobs-as-code** bundle template to set `data_security_mode` of a cluster to SINGLE_USER

## Why
Explicitly adding this field saves experienced users from confusion onto what security mode is applied to the cluster

## Tests
Changed existing unit and integration tests to pass with this change

