### PR TITLE
Fixed accessing required path parameters in CLI generation when --json flag

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -133,11 +133,11 @@ func new{{.PascalName}}() *cobra.Command {
 	cmd.Flags().BoolVar(&{{.CamelName}}SkipWait, "no-wait", {{.CamelName}}SkipWait, `do not wait to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state`)
 	cmd.Flags().DurationVar(&{{.CamelName}}Timeout, "timeout", {{.Wait.Timeout}}*time.Minute, `maximum amount of time to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state`)
 	{{end -}}
-	{{- $requestEntity := .Request -}}
+	{{- $request := .Request -}}
 	{{- if .RequestBodyField -}}
-	{{- $requestEntity = .RequestBodyField.Entity -}}
+	{{- $request = .RequestBodyField.Entity -}}
 	{{- end -}}
-    {{if $requestEntity }}// TODO: short flags
+    {{if $request }}// TODO: short flags
 	{{- if $canUseJson}}
 	cmd.Flags().Var(&{{.CamelName}}Json, "json", `either inline JSON string or @path/to/file.json with request body`)
 	{{- end}}
@@ -173,14 +173,14 @@ func new{{.PascalName}}() *cobra.Command {
 	{{- $noPrompt := or .IsCrudCreate (in $excludeFromPrompts $fullCommandName) }}
 
 	{{- $hasPosArgs := .HasRequiredPositionalArguments -}}
-	{{- $hasSinglePosArg := and $hasPosArgs (eq 1 (len $requestEntity.RequiredFields)) -}}
+	{{- $hasSinglePosArg := and $hasPosArgs (eq 1 (len $request.RequiredFields)) -}}
 	{{- $serviceHasNamedIdMap := and (and .Service.List .Service.List.NamedIdMap) (not (eq .PascalName "List")) -}}
 	{{- $hasIdPrompt := and (not $noPrompt) (and $hasSinglePosArg $serviceHasNamedIdMap) -}}
 	{{- $wait := and .Wait (and (not .IsCrudRead) (not (eq .SnakeName "get_run"))) -}}
 	{{- $hasRequiredArgs :=  and (not $hasIdPrompt) $hasPosArgs -}}
-	{{- $hasSingleRequiredRequestBodyFieldWithPrompt := and (and $hasIdPrompt $requestEntity) (eq 1 (len $requestEntity.RequiredRequestBodyFields))  -}}
+	{{- $hasSingleRequiredRequestBodyFieldWithPrompt := and (and $hasIdPrompt $request) (eq 1 (len $request.RequiredRequestBodyFields))  -}}
 	{{- $onlyPathArgsRequiredAsPositionalArguments := and .Request (eq (len .RequiredPositionalArguments) (len .Request.RequiredPathFields)) -}}
-	{{- $hasDifferentArgsWithJsonFlag := and (not $onlyPathArgsRequiredAsPositionalArguments) (and $canUseJson (or $requestEntity.HasRequiredRequestBodyFields )) -}}
+	{{- $hasDifferentArgsWithJsonFlag := and (not $onlyPathArgsRequiredAsPositionalArguments) (and $canUseJson (or $request.HasRequiredRequestBodyFields )) -}}
 	{{- $hasCustomArgHandler := or $hasRequiredArgs $hasDifferentArgsWithJsonFlag -}}
 
 	{{- $atleastOneArgumentWithDescription := false -}}
@@ -221,9 +221,9 @@ func new{{.PascalName}}() *cobra.Command {
 			err := root.ExactArgs({{len .Request.RequiredPathFields}})(cmd, args)
 			if err != nil {
 			{{- if eq 0 (len .Request.RequiredPathFields) }}
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide{{- range $index, $field := $requestEntity.RequiredFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
+				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide{{- range $index, $field := $request.RequiredFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
 			{{- else }}
-				return fmt.Errorf("when --json flag is specified, provide only{{- range $index, $field := .Request.RequiredPathFields}}{{if $index}},{{end}} {{$field.ConstantName}}{{end}} as positional arguments. Provide{{- range $index, $field := $requestEntity.RequiredRequestBodyFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
+				return fmt.Errorf("when --json flag is specified, provide only{{- range $index, $field := .Request.RequiredPathFields}}{{if $index}},{{end}} {{$field.ConstantName}}{{end}} as positional arguments. Provide{{- range $index, $field := $request.RequiredRequestBodyFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
 			{{- end }}
 			}
 			return nil
@@ -263,20 +263,20 @@ func new{{.PascalName}}() *cobra.Command {
 			{{- if $hasIdPrompt}}
 				if len(args) == 0 {
 					promptSpinner := cmdio.Spinner(ctx)
-					promptSpinner <- "No{{range $requestEntity.RequiredFields}} {{.ConstantName}}{{end}} argument specified. Loading names for {{.Service.TitleName}} drop-down."
+					promptSpinner <- "No{{range $request.RequiredFields}} {{.ConstantName}}{{end}} argument specified. Loading names for {{.Service.TitleName}} drop-down."
 					names, err := {{if .Service.IsAccounts}}a{{else}}w{{end}}.{{(.Service.TrimPrefix "account").PascalName}}.{{.Service.List.NamedIdMap.PascalName}}(ctx{{if .Service.List.Request}}, {{.Service.Package.Name}}.{{.Service.List.Request.PascalName}}{}{{end}})
 					close(promptSpinner)
 					if err != nil {
 						return fmt.Errorf("failed to load names for {{.Service.TitleName}} drop-down. Please manually specify required arguments. Original error: %w", err)
 					}
-					id, err := cmdio.Select(ctx, names, "{{range $requestEntity.RequiredFields}}{{.Summary | trimSuffix "."}}{{end}}")
+					id, err := cmdio.Select(ctx, names, "{{range $request.RequiredFields}}{{.Summary | trimSuffix "."}}{{end}}")
 					if err != nil {
 						return err
 					}
 					args = append(args, id)
 				}
 				if len(args) != 1 {
-					return fmt.Errorf("expected to have {{range $requestEntity.RequiredFields}}{{.Summary | trimSuffix "." | lower}}{{end}}")
+					return fmt.Errorf("expected to have {{range $request.RequiredFields}}{{.Summary | trimSuffix "." | lower}}{{end}}")
 				}
 			{{- end -}}
 

--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -133,11 +133,11 @@ func new{{.PascalName}}() *cobra.Command {
 	cmd.Flags().BoolVar(&{{.CamelName}}SkipWait, "no-wait", {{.CamelName}}SkipWait, `do not wait to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state`)
 	cmd.Flags().DurationVar(&{{.CamelName}}Timeout, "timeout", {{.Wait.Timeout}}*time.Minute, `maximum amount of time to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state`)
 	{{end -}}
-	{{- $request := .Request -}}
+	{{- $requestEntity := .Request -}}
 	{{- if .RequestBodyField -}}
-	{{- $request = .RequestBodyField.Entity -}}
+	{{- $requestEntity = .RequestBodyField.Entity -}}
 	{{- end -}}
-    {{if $request }}// TODO: short flags
+    {{if $requestEntity }}// TODO: short flags
 	{{- if $canUseJson}}
 	cmd.Flags().Var(&{{.CamelName}}Json, "json", `either inline JSON string or @path/to/file.json with request body`)
 	{{- end}}
@@ -173,14 +173,14 @@ func new{{.PascalName}}() *cobra.Command {
 	{{- $noPrompt := or .IsCrudCreate (in $excludeFromPrompts $fullCommandName) }}
 
 	{{- $hasPosArgs := .HasRequiredPositionalArguments -}}
-	{{- $hasSinglePosArg := and $hasPosArgs (eq 1 (len $request.RequiredFields)) -}}
+	{{- $hasSinglePosArg := and $hasPosArgs (eq 1 (len $requestEntity.RequiredFields)) -}}
 	{{- $serviceHasNamedIdMap := and (and .Service.List .Service.List.NamedIdMap) (not (eq .PascalName "List")) -}}
 	{{- $hasIdPrompt := and (not $noPrompt) (and $hasSinglePosArg $serviceHasNamedIdMap) -}}
 	{{- $wait := and .Wait (and (not .IsCrudRead) (not (eq .SnakeName "get_run"))) -}}
 	{{- $hasRequiredArgs :=  and (not $hasIdPrompt) $hasPosArgs -}}
-	{{- $hasSingleRequiredRequestBodyFieldWithPrompt := and (and $hasIdPrompt $request) (eq 1 (len $request.RequiredRequestBodyFields))  -}}
-	{{- $onlyPathArgsRequiredAsPositionalArguments := and $request (eq (len .RequiredPositionalArguments) (len $request.RequiredPathFields)) -}}
-	{{- $hasDifferentArgsWithJsonFlag := and (not $onlyPathArgsRequiredAsPositionalArguments) (and $canUseJson (or $request.HasRequiredRequestBodyFields )) -}}
+	{{- $hasSingleRequiredRequestBodyFieldWithPrompt := and (and $hasIdPrompt $requestEntity) (eq 1 (len $requestEntity.RequiredRequestBodyFields))  -}}
+	{{- $onlyPathArgsRequiredAsPositionalArguments := and .Request (eq (len .RequiredPositionalArguments) (len .Request.RequiredPathFields)) -}}
+	{{- $hasDifferentArgsWithJsonFlag := and (not $onlyPathArgsRequiredAsPositionalArguments) (and $canUseJson (or $requestEntity.HasRequiredRequestBodyFields )) -}}
 	{{- $hasCustomArgHandler := or $hasRequiredArgs $hasDifferentArgsWithJsonFlag -}}
 
 	{{- $atleastOneArgumentWithDescription := false -}}
@@ -218,12 +218,12 @@ func new{{.PascalName}}() *cobra.Command {
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
 		{{- if $hasDifferentArgsWithJsonFlag }}
 		if cmd.Flags().Changed("json") {
-			err := root.ExactArgs({{len $request.RequiredPathFields}})(cmd, args)
+			err := root.ExactArgs({{len .Request.RequiredPathFields}})(cmd, args)
 			if err != nil {
-			{{- if eq 0 (len $request.RequiredPathFields) }}
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide{{- range $index, $field := $request.RequiredFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
+			{{- if eq 0 (len .Request.RequiredPathFields) }}
+				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide{{- range $index, $field := $requestEntity.RequiredFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
 			{{- else }}
-				return fmt.Errorf("when --json flag is specified, provide only{{- range $index, $field := $request.RequiredPathFields}}{{if $index}},{{end}} {{$field.ConstantName}}{{end}} as positional arguments. Provide{{- range $index, $field := $request.RequiredRequestBodyFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
+				return fmt.Errorf("when --json flag is specified, provide only{{- range $index, $field := .Request.RequiredPathFields}}{{if $index}},{{end}} {{$field.ConstantName}}{{end}} as positional arguments. Provide{{- range $index, $field := $requestEntity.RequiredRequestBodyFields}}{{if $index}},{{end}} '{{$field.Name}}'{{end}} in your JSON input")
 			{{- end }}
 			}
 			return nil
@@ -263,20 +263,20 @@ func new{{.PascalName}}() *cobra.Command {
 			{{- if $hasIdPrompt}}
 				if len(args) == 0 {
 					promptSpinner := cmdio.Spinner(ctx)
-					promptSpinner <- "No{{range $request.RequiredFields}} {{.ConstantName}}{{end}} argument specified. Loading names for {{.Service.TitleName}} drop-down."
+					promptSpinner <- "No{{range $requestEntity.RequiredFields}} {{.ConstantName}}{{end}} argument specified. Loading names for {{.Service.TitleName}} drop-down."
 					names, err := {{if .Service.IsAccounts}}a{{else}}w{{end}}.{{(.Service.TrimPrefix "account").PascalName}}.{{.Service.List.NamedIdMap.PascalName}}(ctx{{if .Service.List.Request}}, {{.Service.Package.Name}}.{{.Service.List.Request.PascalName}}{}{{end}})
 					close(promptSpinner)
 					if err != nil {
 						return fmt.Errorf("failed to load names for {{.Service.TitleName}} drop-down. Please manually specify required arguments. Original error: %w", err)
 					}
-					id, err := cmdio.Select(ctx, names, "{{range $request.RequiredFields}}{{.Summary | trimSuffix "."}}{{end}}")
+					id, err := cmdio.Select(ctx, names, "{{range $requestEntity.RequiredFields}}{{.Summary | trimSuffix "."}}{{end}}")
 					if err != nil {
 						return err
 					}
 					args = append(args, id)
 				}
 				if len(args) != 1 {
-					return fmt.Errorf("expected to have {{range $request.RequiredFields}}{{.Summary | trimSuffix "." | lower}}{{end}}")
+					return fmt.Errorf("expected to have {{range $requestEntity.RequiredFields}}{{.Summary | trimSuffix "." | lower}}{{end}}")
 				}
 			{{- end -}}
 

--- a/acceptance/cmd/workspace/apps/input.json
+++ b/acceptance/cmd/workspace/apps/input.json
@@ -1,0 +1,14 @@
+{
+    "description": "My app description.",
+    "resources": [
+        {
+            "name": "api-key",
+            "description": "API key for external service.",
+            "secret": {
+                "scope": "my-scope",
+                "key": "my-key",
+                "permission": "READ"
+            }
+        }
+    ]
+}

--- a/acceptance/cmd/workspace/apps/out.requests.txt
+++ b/acceptance/cmd/workspace/apps/out.requests.txt
@@ -1,0 +1,19 @@
+{
+  "method": "PATCH",
+  "path": "/api/2.0/apps/test-name",
+  "body": {
+    "description": "My app description.",
+    "name": "",
+    "resources": [
+      {
+        "description": "API key for external service.",
+        "name": "api-key",
+        "secret": {
+          "key": "my-key",
+          "permission": "READ",
+          "scope": "my-scope"
+        }
+      }
+    ]
+  }
+}

--- a/acceptance/cmd/workspace/apps/output.txt
+++ b/acceptance/cmd/workspace/apps/output.txt
@@ -11,6 +11,7 @@
     "state":"ERROR"
   },
   "description":"My app description.",
+  "id":"12345",
   "name":"test-name",
   "resources": [
     {

--- a/acceptance/cmd/workspace/apps/output.txt
+++ b/acceptance/cmd/workspace/apps/output.txt
@@ -1,0 +1,48 @@
+
+=== Apps update with correct input
+>>> [CLI] apps update test-name --json @input.json
+{
+  "app_status": {
+    "message":"Application is running.",
+    "state":"DEPLOYING"
+  },
+  "compute_status": {
+    "message":"App compute is active.",
+    "state":"ERROR"
+  },
+  "description":"My app description.",
+  "name":"test-name",
+  "resources": [
+    {
+      "description":"API key for external service.",
+      "name":"api-key",
+      "secret": {
+        "key":"my-key",
+        "permission":"READ",
+        "scope":"my-scope"
+      }
+    }
+  ],
+  "url":"test-name-123.cloud.databricksapps.com"
+}
+
+=== Apps update with missing parameter
+>>> [CLI] apps update --json @input.json
+Error: accepts 1 arg(s), received 0
+
+Usage:
+  databricks apps update NAME [flags]
+
+Flags:
+      --description string   The description of the app.
+  -h, --help                 help for update
+      --json JSON            either inline JSON string or @path/to/file.json with request body (default JSON (0 bytes))
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+
+
+Exit code: 1

--- a/acceptance/cmd/workspace/apps/script
+++ b/acceptance/cmd/workspace/apps/script
@@ -1,0 +1,5 @@
+title "Apps update with correct input"
+trace $CLI apps update test-name --json @input.json
+
+title "Apps update with missing parameter"
+trace $CLI apps update --json @input.json

--- a/acceptance/cmd/workspace/apps/test.toml
+++ b/acceptance/cmd/workspace/apps/test.toml
@@ -1,0 +1,31 @@
+LocalOnly = true
+RecordRequests = true
+
+[[Server]]
+Pattern = "PATCH /api/2.0/apps/test-name"
+Response.Body = '''
+{
+  "name": "test-name",
+  "description": "My app description.",
+  "compute_status": {
+    "state": "ERROR",
+    "message": "App compute is active."
+  },
+  "app_status": {
+    "state": "DEPLOYING",
+    "message": "Application is running."
+  },
+  "url": "test-name-123.cloud.databricksapps.com",
+  "resources": [
+    {
+      "name": "api-key",
+      "description": "API key for external service.",
+      "secret": {
+        "scope": "my-scope",
+        "key": "my-key",
+        "permission": "READ"
+      }
+    }
+  ],
+  "id": "12345"
+}'''

--- a/cmd/account/budget-policy/budget-policy.go
+++ b/cmd/account/budget-policy/budget-policy.go
@@ -3,8 +3,6 @@
 package budget_policy
 
 import (
-	"fmt"
-
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
@@ -323,13 +321,6 @@ func newUpdate() *cobra.Command {
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("json") {
-			err := root.ExactArgs(0)(cmd, args)
-			if err != nil {
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'policy_id' in your JSON input")
-			}
-			return nil
-		}
 		check := root.ExactArgs(1)
 		return check(cmd, args)
 	}

--- a/cmd/workspace/apps/apps.go
+++ b/cmd/workspace/apps/apps.go
@@ -956,13 +956,6 @@ func newUpdate() *cobra.Command {
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("json") {
-			err := root.ExactArgs(0)(cmd, args)
-			if err != nil {
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'name' in your JSON input")
-			}
-			return nil
-		}
 		check := root.ExactArgs(1)
 		return check(cmd, args)
 	}

--- a/cmd/workspace/lakeview/lakeview.go
+++ b/cmd/workspace/lakeview/lakeview.go
@@ -163,13 +163,6 @@ func newCreateSchedule() *cobra.Command {
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("json") {
-			err := root.ExactArgs(0)(cmd, args)
-			if err != nil {
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'cron_schedule' in your JSON input")
-			}
-			return nil
-		}
 		check := root.ExactArgs(1)
 		return check(cmd, args)
 	}
@@ -242,13 +235,6 @@ func newCreateSubscription() *cobra.Command {
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("json") {
-			err := root.ExactArgs(0)(cmd, args)
-			if err != nil {
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'subscriber' in your JSON input")
-			}
-			return nil
-		}
 		check := root.ExactArgs(2)
 		return check(cmd, args)
 	}
@@ -1195,13 +1181,6 @@ func newUpdateSchedule() *cobra.Command {
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flags().Changed("json") {
-			err := root.ExactArgs(0)(cmd, args)
-			if err != nil {
-				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'cron_schedule' in your JSON input")
-			}
-			return nil
-		}
 		check := root.ExactArgs(2)
 		return check(cmd, args)
 	}


### PR DESCRIPTION
## Changes
CLI generation template was using RequiredPathField from incorrect request entity (body field from request and not request itself). Thus for some of the commands required path parameters were not required when --json was specified.

## Tests
Regenerated commands work correctly

