### PR TITLE
Fixed spark version check for clusters defined in the same bundle

### DIFF
--- a/acceptance/bundle/trampoline/warning_message/databricks.yml
+++ b/acceptance/bundle/trampoline/warning_message/databricks.yml
@@ -1,0 +1,37 @@
+bundle:
+  name: trampoline_warning_message
+
+targets:
+  dev:
+    mode: development
+    default: true
+
+  prod:
+    resources:
+      clusters:
+        development_cluster:
+          spark_version: 14.2.x-cpu-ml-scala2.12
+
+
+resources:
+  clusters:
+    development_cluster:
+      cluster_name: jobs-as-code-all-purpose-cluster
+      spark_version: 12.2.x-cpu-ml-scala2.12
+      node_type_id: r5d.8xlarge
+      autotermination_minutes: 30
+      autoscale:
+        min_workers: 1
+        max_workers: 1
+      driver_node_type_id: r5d.8xlarge
+  jobs:
+    whl:
+      name: "wheel-job"
+      tasks:
+        - task_key: test_task
+          python_wheel_task:
+            package_name: my_package
+            entry_point: my_module.my_function
+          existing_cluster_id: ${resources.clusters.development_cluster.id}
+          libraries:
+            - whl: ./dist/*.whl

--- a/acceptance/bundle/trampoline/warning_message/output.txt
+++ b/acceptance/bundle/trampoline/warning_message/output.txt
@@ -1,0 +1,18 @@
+Error: Python wheel tasks require compute with DBR 13.3+ to include local libraries. Please change your cluster configuration or use the experimental 'python_wheel_wrapper' setting. See https://docs.databricks.com/dev-tools/bundles/python-wheel.html for more information.
+
+Name: trampoline_warning_message
+Target: dev
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/trampoline_warning_message/dev
+
+Found 1 error
+
+Exit code: 1
+Name: trampoline_warning_message
+Target: prod
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/trampoline_warning_message/prod
+
+Validation OK!

--- a/acceptance/bundle/trampoline/warning_message/script
+++ b/acceptance/bundle/trampoline/warning_message/script
@@ -1,0 +1,2 @@
+errcode $CLI bundle validate -t dev
+errcode $CLI bundle validate -t prod


### PR DESCRIPTION
## Changes
Previously using python wheel tasks in the tasks with compute referering to interactive cluster defied in the same bundle would produce a warning like below

```
GET /api/2.1/clusters/get?cluster_id=${resources.clusters.development_cluster.id}
< HTTP/2.0 400 Bad Request
< {
<   "error_code": "INVALID_PARAMETER_VALUE",
<   "message": "Cluster ${resources.clusters.development_cluster.id} does not exist"
< } pid=14465 mutator=seq mutator=initialize mutator=seq mutator=PythonWrapperWarning sdk=true
```

This PR fixes it by making sure that we check spark version for such clusters based on its bundle configuration and don't make API calls

## Tests
Added acceptance test

