### PR TITLE
Fix failing integration test due to lowercased wheel file

### DIFF
--- a/integration/bundle/init_default_python_test.go
+++ b/integration/bundle/init_default_python_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/databricks/cli/integration/internal/acc"
@@ -53,6 +54,7 @@ func testDefaultPython(t *testing.T, pythonVersion string) {
 	uniqueProjectId := testutil.RandomName("")
 	ctx, replacements := testdiff.WithReplacementsMap(ctx)
 	replacements.Set(uniqueProjectId, "$UNIQUE_PRJ")
+	replacements.Set(strings.ToLower(uniqueProjectId), "$UNIQUE_PRJ")
 
 	user, err := wt.W.CurrentUser.Me(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes
I'm not completely sure what is lowercasing it, we can investigate this later. This unblocks tests on main.

> Name: project_name_kLvfBngEcUEI
> Uploading project_name_klvfbngecuei-0.0.1+[NUMID].[NUMID]-py3-none-any.whl...

## Tests
`CLOUD_ENV=aws go test --timeout 3h -v -run TestDefaultPython/3.9 ./integration/bundle`