### PR TITLE
default-python: Swap order of yes/no in serverless template

### DIFF
--- a/libs/template/templates/default-python/databricks_template_schema.json
+++ b/libs/template/templates/default-python/databricks_template_schema.json
@@ -33,7 +33,7 @@
         "serverless": {
             "type": "string",
             "default": "no",
-            "enum": ["yes", "no"],
+            "enum": ["no", "yes"],
             "description": "Use serverless compute",
             "order": 5
         }


### PR DESCRIPTION
## Changes
Since at this moment we set default to 'no', interactively it should also default to 'no'. However, it just uses the first option.

## Tests
Manually running `cli bundle init default-python`

