### PR TITLE
Skip serverless prompt in default-python (default is no)

### DIFF
--- a/libs/template/templates/default-python/databricks_template_schema.json
+++ b/libs/template/templates/default-python/databricks_template_schema.json
@@ -35,6 +35,7 @@
             "default": "no",
             "enum": ["no", "yes"],
             "description": "Use serverless compute",
+            "skip_prompt_if": {},
             "order": 5
         }
     },


### PR DESCRIPTION
## Tests
Manually running 'bundle init default-python' - no question about serverless.
