### PR TITLE
Enable TestAuthDescribeSuccess integration test

### DIFF
--- a/integration/cmd/auth/describe_test.go
+++ b/integration/cmd/auth/describe_test.go
@@ -39,7 +39,7 @@ func TestAuthDescribeFailure(t *testing.T) {
 	ctx := context.Background()
 	profileSuffix := strings.ReplaceAll(uuid.NewString(), "-", "")
 	profileName := "nonexistent-TestAuthDescribeFailure-" + profileSuffix
-	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", profileName)
+	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", profileName, "--host", "https://test@non-existing-subdomain.databricks.com")
 	outStr := stdout.String()
 
 	require.NotEmpty(t, outStr)

--- a/integration/cmd/auth/describe_test.go
+++ b/integration/cmd/auth/describe_test.go
@@ -2,12 +2,9 @@ package auth_test
 
 import (
 	"context"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/google/uuid"
 
 	"github.com/databricks/cli/internal/testcli"
 	"github.com/databricks/databricks-sdk-go"
@@ -37,35 +34,20 @@ func TestAuthDescribeSuccess(t *testing.T) {
 }
 
 func TestAuthDescribeFailure(t *testing.T) {
-	// Store the original value of env variable
-	originalProfileValue, envProfileExists := os.LookupEnv("DATABRICKS_CONFIG_PROFILE")
-
-	// restore env variable after the test:
-	if envProfileExists {
-		// Unset the env variable for this test
-		err := os.Unsetenv("DATABRICKS_CONFIG_PROFILE")
-		require.NoError(t, err)
-
-		t.Cleanup(func() {
-			err := os.Setenv("DATABRICKS_CONFIG_PROFILE", originalProfileValue)
-			require.NoError(t, err)
-		})
-	}
+	t.Skipf("Skipping because of https://github.com/databricks/cli/issues/2010")
 
 	ctx := context.Background()
-	profileSuffix := strings.ReplaceAll(uuid.NewString(), "-", "")
-	profileName := "nonexistent-TestAuthDescribeFailure-" + profileSuffix
-	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", profileName)
+	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", "nonexistent")
 	outStr := stdout.String()
 
 	require.NotEmpty(t, outStr)
 	require.Contains(t, outStr, "Unable to authenticate: resolve")
-	require.Contains(t, outStr, "has no "+profileName+" profile configured")
+	require.Contains(t, outStr, "has no nonexistent profile configured")
 	require.Contains(t, outStr, "Current configuration:")
 
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{})
 	require.NoError(t, err)
 
 	require.Contains(t, outStr, "✓ host: "+w.Config.Host)
-	require.Contains(t, outStr, "✓ profile: "+profileName+" (from --profile flag)")
+	require.Contains(t, outStr, "✓ profile: nonexistent (from --profile flag)")
 }

--- a/integration/cmd/auth/describe_test.go
+++ b/integration/cmd/auth/describe_test.go
@@ -39,7 +39,7 @@ func TestAuthDescribeFailure(t *testing.T) {
 	ctx := context.Background()
 	profileSuffix := strings.ReplaceAll(uuid.NewString(), "-", "")
 	profileName := "nonexistent-TestAuthDescribeFailure-" + profileSuffix
-	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", profileName, "--host", "https://test@non-existing-subdomain.databricks.com")
+	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "clusters", "list", "--profile", profileName)
 	outStr := stdout.String()
 
 	require.NotEmpty(t, outStr)

--- a/integration/cmd/auth/describe_test.go
+++ b/integration/cmd/auth/describe_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestAuthDescribeSuccess(t *testing.T) {
-	t.Skipf("Skipping because of https://github.com/databricks/cli/issues/2010")
-
 	ctx := context.Background()
 	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe")
 	outStr := stdout.String()
@@ -20,7 +18,7 @@ func TestAuthDescribeSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEmpty(t, outStr)
-	require.Contains(t, outStr, "Host: "+w.Config.Host)
+	require.Contains(t, outStr, "Host: https://"+w.Config.Host)
 
 	me, err := w.CurrentUser.Me(context.Background())
 	require.NoError(t, err)
@@ -32,8 +30,6 @@ func TestAuthDescribeSuccess(t *testing.T) {
 }
 
 func TestAuthDescribeFailure(t *testing.T) {
-	t.Skipf("Skipping because of https://github.com/databricks/cli/issues/2010")
-
 	ctx := context.Background()
 	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", "nonexistent")
 	outStr := stdout.String()


### PR DESCRIPTION
## Changes
1. remove t.Skip directive from TestAuthDescribeSuccess integration test
2. change the test code to account for environments where host value can be prefixed  with the https protocol part

## Why
This enables integration test that exercises `databricks auth describe` command, which was previously throwing errors in the CI/CD pipeline

## Tests
Integration test is passing

