### PR TITLE
acc: Print full URL and request body for missing handlers

### DIFF
--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -206,9 +206,7 @@ Body: %s
 For acceptance tests, add this to test.toml:
 [[Server]]
 Pattern = %q
-Response.Body = '''
-<response body here>
-'''
+Response.Body = '<response body here>'
 # Response.StatusCode = <response code if not 200>
 `, r.URL, body, pattern)
 

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -2,6 +2,7 @@ package testserver
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -191,24 +192,25 @@ func New(t testutil.TestingT) *Server {
 	// Set up the not found handler as fallback
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pattern := r.Method + " " + r.URL.Path
+		bodyBytes, err := io.ReadAll(r.Body)
+		var body string
+		if err != nil {
+			body = fmt.Sprintf("failed to read the body: %s", err)
+		} else {
+			body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
+		}
 
-		t.Errorf(`
+		t.Errorf(`No handler for URL: %s
+Body: %s
 
-----------------------------------------
-No stub found for pattern: %s
-
-To stub a response for this request, you can add
-the following to test.toml:
+For acceptance tests, add this to test.toml:
 [[Server]]
 Pattern = %q
 Response.Body = '''
 <response body here>
 '''
-Response.StatusCode = <response status-code here>
-----------------------------------------
-
-
-`, pattern, pattern)
+# Response.StatusCode = <response code if not 200>
+`, r.URL, body, pattern)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)


### PR DESCRIPTION
## Tests
Manually, I have a test that fails.

Before:

```
=== NAME  TestAccept
    server.go:195:

        ----------------------------------------
        No stub found for pattern: GET /api/2.1/clusters/get

        To stub a response for this request, you can add
        the following to test.toml:
        [[Server]]
        Pattern = "GET /api/2.1/clusters/get"
        Response.Body = '''
        <response body here>
        '''
        Response.StatusCode = <response status-code here>
        ----------------------------------------
```

After:
```
    server.go:203: No handler for URL: /api/2.1/clusters/get?cluster_id=0717-132531-5opeqon1
        Body: [0 bytes]

        For acceptance tests, add this to test.toml:
        [[Server]]
        Pattern = "GET /api/2.1/clusters/get"
        Response.Body = '<response body here>'
        # Response.StatusCode = <response code if not 200>
```
