### PR TITLE
Restrict same name libraries check for only whl and jar types

### DIFF
--- a/bundle/libraries/same_name_libraries.go
+++ b/bundle/libraries/same_name_libraries.go
@@ -13,8 +13,10 @@ import (
 type checkForSameNameLibraries struct{}
 
 var patterns = []dyn.Pattern{
-	taskLibrariesPattern.Append(dyn.AnyIndex(), dyn.AnyKey()),
-	forEachTaskLibrariesPattern.Append(dyn.AnyIndex(), dyn.AnyKey()),
+	taskLibrariesPattern.Append(dyn.AnyIndex(), dyn.Key("whl")),
+	taskLibrariesPattern.Append(dyn.AnyIndex(), dyn.Key("jar")),
+	forEachTaskLibrariesPattern.Append(dyn.AnyIndex(), dyn.Key("whl")),
+	forEachTaskLibrariesPattern.Append(dyn.AnyIndex(), dyn.Key("jar")),
 	envDepsPattern.Append(dyn.AnyIndex()),
 }
 


### PR DESCRIPTION
## Changes
Same name libraries check only valid for local libraries. Local libraries are only supported for Whl and Jar types. Hence we can restrict matching pattern only to these libraries.

## Tests
Existing acceptance tests pass

