### PR TITLE
acc: add Ignore setting to config

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -390,6 +390,9 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 		if _, ok := Ignored[relPath]; ok {
 			continue
 		}
+		if config.CompiledIgnoreObject.MatchesPath(relPath) {
+			continue
+		}
 		unexpected = append(unexpected, relPath)
 		if strings.HasPrefix(relPath, "out") {
 			// We have a new file starting with "out"

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/databricks/cli/libs/testdiff"
 	"github.com/databricks/cli/libs/testserver"
+	ignore "github.com/sabhiram/go-gitignore"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,6 +52,11 @@ type TestConfig struct {
 
 	// List of request headers to include when recording requests.
 	IncludeRequestHeaders []string
+
+	// List of gitignore patterns to ignore when checking output files
+	Ignore []string
+
+	CompiledIgnoreObject *ignore.GitIgnore
 }
 
 type ServerStub struct {
@@ -110,6 +116,8 @@ func LoadConfig(t *testing.T, dir string) (TestConfig, string) {
 			t.Fatalf("Error during config merge: %s: %s", cfgName, err)
 		}
 	}
+
+	result.CompiledIgnoreObject = ignore.CompileIgnoreLines(result.Ignore...)
 
 	return result, strings.Join(configs, ", ")
 }

--- a/acceptance/selftest/basic/script
+++ b/acceptance/selftest/basic/script
@@ -27,3 +27,7 @@ echo 123456
 
 printf "\n=== Testing --version"
 trace $CLI --version
+
+touch ignored_file.txt
+mkdir ignored_dir
+touch ignored_dir/hello.txt

--- a/acceptance/selftest/basic/test.toml
+++ b/acceptance/selftest/basic/test.toml
@@ -1,5 +1,8 @@
 # Badness = "Brief description of what's wrong with the test output, if anything"
 
+Ignore = ['ignore*']
+
+
 #[GOOS]
 # Disable on Windows
 #windows = false


### PR DESCRIPTION
Ignore output files using gitignore syntax.

## Changes
New Ignore setting in test.toml that will ignore specified files (syntax is gitignore).

## Why

I'm using it in #2396 to ignore virtual env. It includes a lot of files. The regular 'rm -fr .venv' approach only works if script get to that point, but due to errors it might abort early. In that cases test runner prints all unexpected files, polluting output. Ignoring those files at test runner level ensure you never see them.

## Tests
Updated selftest/basic.

