### PR TITLE
Add support for schemas in deployment bind/unbind commands

### DIFF
--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -112,6 +112,12 @@ func (r *Resources) FindResourceByConfigKey(key string) (ConfigResource, error) 
 		}
 	}
 
+	for k := range r.Schemas {
+		if k == key {
+			found = append(found, r.Schemas[k])
+		}
+	}
+
 	if len(found) == 0 {
 		return nil, fmt.Errorf("no such resource: %s", key)
 	}

--- a/bundle/config/resources/schema.go
+++ b/bundle/config/resources/schema.go
@@ -2,9 +2,10 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strings"
+
+	"github.com/databricks/cli/libs/log"
 
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/marshal"
@@ -25,8 +26,15 @@ type Schema struct {
 	URL            string         `json:"url,omitempty" bundle:"internal"`
 }
 
-func (s *Schema) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {
-	return false, errors.New("schema.Exists() is not supported")
+func (s *Schema) Exists(ctx context.Context, w *databricks.WorkspaceClient, fullName string) (bool, error) {
+	log.Tracef(ctx, "Checking if schema with fullName=%s exists", fullName)
+
+	_, err := w.Schemas.GetByFullName(ctx, fullName)
+	if err != nil {
+		log.Debugf(ctx, "schema with full name %s does not exist", fullName)
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *Schema) TerraformResourceName() string {

--- a/bundle/config/resources/schema_test.go
+++ b/bundle/config/resources/schema_test.go
@@ -1,0 +1,26 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockSchemasAPI().On("GetByFullName", mock.Anything, "non-existent-schema").Return(nil, &apierr.APIError{
+		StatusCode: 404,
+	})
+
+	s := &Schema{}
+	exists, err := s.Exists(ctx, m.WorkspaceClient, "non-existent-schema")
+
+	require.Falsef(t, exists, "Exists should return false when getting a 404 response from Workspace")
+	require.NoErrorf(t, err, "Exists should not return an error when getting a 404 response from Workspace")
+}

--- a/integration/bundle/bind_resource_test.go
+++ b/integration/bundle/bind_resource_test.go
@@ -35,13 +35,13 @@ func TestBindSchemaToExistingSchema(t *testing.T) {
 	})
 
 	// setup the bundle:
-	bundleRoot := initTestTemplate(t, ctx, "uc_schema", map[string]any{
+	bundleRoot := initTestTemplate(t, ctx, "uc_schema_only", map[string]any{
 		"unique_id": uniqueId,
 	})
 	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
 
 	// run the bind command:
-	c := testcli.NewRunner(t, ctx, "bundle", "deployment", "bind", "bar", predefinedSchema.FullName, "--auto-approve")
+	c := testcli.NewRunner(t, ctx, "bundle", "deployment", "bind", "schema1", predefinedSchema.FullName, "--auto-approve")
 	_, _, err = c.Run()
 	require.NoError(t, err)
 
@@ -58,7 +58,7 @@ func TestBindSchemaToExistingSchema(t *testing.T) {
 	require.Equal(t, "This schema was created from DABs", updatedSchema.Comment)
 
 	// unbind the schema:
-	c = testcli.NewRunner(t, ctx, "bundle", "deployment", "unbind", "bar")
+	c = testcli.NewRunner(t, ctx, "bundle", "deployment", "unbind", "schema1")
 	_, _, err = c.Run()
 	require.NoError(t, err)
 

--- a/integration/bundle/bundles/uc_schema_only/databricks_template_schema.json
+++ b/integration/bundle/bundles/uc_schema_only/databricks_template_schema.json
@@ -1,0 +1,8 @@
+{
+    "properties": {
+        "unique_id": {
+            "type": "string",
+            "description": "Unique ID for the schema name"
+        }
+    }
+}

--- a/integration/bundle/bundles/uc_schema_only/template/databricks.yml.tmpl
+++ b/integration/bundle/bundles/uc_schema_only/template/databricks.yml.tmpl
@@ -1,0 +1,13 @@
+bundle:
+  name: uc-schema-only
+
+workspace:
+  root_path: "~/.bundle/{{.unique_id}}"
+
+resources:
+  schemas:
+    schema1:
+      name: test-schema-{{.unique_id}}
+      catalog_name: main
+      comment: This schema was created from DABs
+


### PR DESCRIPTION
## Changes
1. Changed `FindResourceByConfigKey` to return schema resources
2. Implemented the `Exists` method for schema resources

## Why
This PR adds support for schema resources in deployment operations, enabling users to:
- Bind schemas using `databricks bundle deployment bind <myschema_key> <schema_full_name>`
- Unbind schemas using `databricks bundle deployment unbind <myschema_key>`

Where:
- `myschema_key` is a resource key defined in the bundle's .yml file
- `schema_full_name` references an existing schema in the Databricks workspace

These capabilities allow for more flexible resource management of schemas within bundles.

## Tests

Added a new integration test that tests bind and unbind methods together with bundle deployment and destruction.
