### PR TITLE
Added a warning when `config` section is used in apps

### DIFF
--- a/acceptance/bundle/apps/app_yaml/app/app.yml
+++ b/acceptance/bundle/apps/app_yaml/app/app.yml
@@ -1,0 +1,3 @@
+command:
+  - python
+  - app.py

--- a/acceptance/bundle/apps/app_yaml/databricks.yml
+++ b/acceptance/bundle/apps/app_yaml/databricks.yml
@@ -1,0 +1,8 @@
+bundle:
+  name: apps_yaml
+
+resources:
+  apps:
+    myapp:
+      name: myapp
+      source_code_path: ./app

--- a/acceptance/bundle/apps/app_yaml/out.app.yml.txt
+++ b/acceptance/bundle/apps/app_yaml/out.app.yml.txt
@@ -1,0 +1,5 @@
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/apps_yaml/default/files/app/app.yml",
+  "raw_body": "command:\n  - python\n  - app.py\n"
+}

--- a/acceptance/bundle/apps/app_yaml/output.txt
+++ b/acceptance/bundle/apps/app_yaml/output.txt
@@ -1,0 +1,15 @@
+
+>>> [CLI] bundle validate
+Name: apps_yaml
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/apps_yaml/default
+
+Validation OK!
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/apps_yaml/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!

--- a/acceptance/bundle/apps/app_yaml/script
+++ b/acceptance/bundle/apps/app_yaml/script
@@ -1,0 +1,4 @@
+trace $CLI bundle validate
+trace $CLI bundle deploy
+cat out.requests.txt | jq 'select(.path == "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/apps_yaml/default/files/app/app.yml")'  > out.app.yml.txt
+rm out.requests.txt

--- a/acceptance/bundle/apps/config_section/app/app.py
+++ b/acceptance/bundle/apps/config_section/app/app.py
@@ -1,0 +1,1 @@
+print("Hello world!")

--- a/acceptance/bundle/apps/config_section/databricks.yml
+++ b/acceptance/bundle/apps/config_section/databricks.yml
@@ -1,0 +1,12 @@
+bundle:
+  name: apps_config_section
+
+resources:
+  apps:
+    myapp:
+      name: myapp
+      source_code_path: ./app
+      config:
+        command:
+          - python
+          - app.py

--- a/acceptance/bundle/apps/config_section/out.app.yml.txt
+++ b/acceptance/bundle/apps/config_section/out.app.yml.txt
@@ -1,0 +1,5 @@
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/apps_config_section/default/files/app/app.yml",
+  "raw_body": "command:\n  - python\n  - app.py\n"
+}

--- a/acceptance/bundle/apps/config_section/output.txt
+++ b/acceptance/bundle/apps/config_section/output.txt
@@ -1,0 +1,23 @@
+
+>>> [CLI] bundle validate
+Warning: App config section detected
+
+remove 'config' from app resource 'myapp' section and use app.yml file in the root of this app instead
+
+Name: apps_config_section
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/apps_config_section/default
+
+Found 1 warning
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/apps_config_section/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+Warning: App config section detected
+
+remove 'config' from app resource 'myapp' section and use app.yml file in the root of this app instead
+

--- a/acceptance/bundle/apps/config_section/script
+++ b/acceptance/bundle/apps/config_section/script
@@ -1,0 +1,4 @@
+trace $CLI bundle validate
+trace $CLI bundle deploy
+cat out.requests.txt | jq 'select(.path == "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/apps_config_section/default/files/app/app.yml")'  > out.app.yml.txt
+rm out.requests.txt

--- a/acceptance/bundle/apps/test.toml
+++ b/acceptance/bundle/apps/test.toml
@@ -1,0 +1,26 @@
+Cloud = false
+RecordRequests = true
+
+Ignore = [
+    '.databricks',
+]
+
+[[Server]]
+Pattern = "POST /api/2.0/apps"
+
+[[Server]]
+Pattern = "GET /api/2.0/apps/myapp"
+Response.Body = '''
+{
+  "name": "myapp",
+  "description": "",
+  "compute_status": {
+    "state": "ACTIVE",
+    "message": "App compute is active."
+  },
+  "app_status": {
+    "state": "RUNNING",
+    "message": "Application is running."
+  }
+}
+'''

--- a/bundle/apps/validate.go
+++ b/bundle/apps/validate.go
@@ -3,8 +3,6 @@ package apps
 import (
 	"context"
 	"fmt"
-	"path"
-	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
@@ -14,7 +12,6 @@ type validate struct{}
 
 func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	var diags diag.Diagnostics
-	possibleConfigFiles := []string{"app.yml", "app.yaml"}
 	usedSourceCodePaths := make(map[string]string)
 
 	for key, app := range b.Config.Resources.Apps {
@@ -28,16 +25,12 @@ func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics
 		}
 		usedSourceCodePaths[app.SourceCodePath] = key
 
-		for _, configFile := range possibleConfigFiles {
-			appPath := strings.TrimPrefix(app.SourceCodePath, b.Config.Workspace.FilePath)
-			cf := path.Join(appPath, configFile)
-			if _, err := b.SyncRoot.Stat(cf); err == nil {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Error,
-					Summary:  configFile + " detected",
-					Detail:   fmt.Sprintf("remove %s and use 'config' property for app resource '%s' instead", cf, app.Name),
-				})
-			}
+		if app.Config != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  "App config section detected",
+				Detail:   fmt.Sprintf("remove 'config' from app resource '%s' section and use app.yml file in the root of this app instead", app.Name),
+			})
 		}
 	}
 

--- a/bundle/apps/validate_test.go
+++ b/bundle/apps/validate_test.go
@@ -11,47 +11,11 @@ import (
 	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/bundle/internal/bundletest"
 	"github.com/databricks/cli/internal/testutil"
-	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/vfs"
 	"github.com/databricks/databricks-sdk-go/service/apps"
 	"github.com/stretchr/testify/require"
 )
-
-func TestAppsValidate(t *testing.T) {
-	tmpDir := t.TempDir()
-	testutil.Touch(t, tmpDir, "app1", "app.py")
-
-	b := &bundle.Bundle{
-		BundleRootPath: tmpDir,
-		SyncRootPath:   tmpDir,
-		SyncRoot:       vfs.MustNew(tmpDir),
-		Config: config.Root{
-			Workspace: config.Workspace{
-				FilePath: "/foo/bar/",
-			},
-			Resources: config.Resources{
-				Apps: map[string]*resources.App{
-					"app1": {
-						App: &apps.App{
-							Name: "app1",
-						},
-						SourceCodePath: "./app1",
-						Config:         map[string]any{},
-					},
-				},
-			},
-		},
-	}
-
-	bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(tmpDir, "databricks.yml")}})
-
-	diags := bundle.ApplySeq(context.Background(), b, mutator.TranslatePaths(), Validate())
-	require.Len(t, diags, 1)
-	require.Equal(t, diag.Warning, diags[0].Severity)
-	require.Equal(t, "App config section detected", diags[0].Summary)
-	require.Contains(t, diags[0].Detail, "remove 'config' from app resource 'app1' section and use app.yml file in the root of this app instead")
-}
 
 func TestAppsValidateSameSourcePath(t *testing.T) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Changes
Added a warning when `config` section is used in apps

## Why
To avoid the confusion between using apps in DABs and outside of DABs, we want to provide only one way of configuring apps runtime configuration - by using `app.yml` file in the root of the app.

## Tests
Added acceptance tests
