### PR TITLE
Update VSCode settings to resolve files named `script` as shell scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
     "python.envFile": "${workspaceRoot}/.env",
     "python.analysis.stubPath": ".vscode",
     "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
-    "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------"
+    "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------",
+    "files.associations": {
+        "script": "shellscript"
+    }
 }


### PR DESCRIPTION
## Why
VSCode for me resolves `script` as YAML files showing incorrect syntax coloring. This setting forces VSCode to treat all files named `script` as shell scripts leading to better syntax highlighting. 

These files are common place in our acceptance tests.

## Tests
Manually.
