### PR TITLE
Enable TestAuthDescribeFailure integration test

### DIFF
--- a/integration/cmd/auth/describe_test.go
+++ b/integration/cmd/auth/describe_test.go
@@ -51,8 +51,9 @@ func TestAuthDescribeFailure(t *testing.T) {
 	require.NoError(t, err)
 	t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
 
+	// run the command:
 	ctx := context.Background()
-	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", "nonexistent", "--log-level", "trace")
+	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "auth", "describe", "--profile", "nonexistent")
 	outStr := stdout.String()
 
 	require.NotEmpty(t, outStr)


### PR DESCRIPTION
## Changes
1. remove t.Skip directive from TestAuthDescribeFailure integration test
2. remove checking the host in the test

## Why
1. This enables integration test that exercises `databricks auth describe` command, which was previously throwing errors in the CI/CD pipeline. For the nonexistent profile check to fail, we need to create a new profile file for the CLI to check (otherwise the configuration skips checking of the provided profile actually exists). 
2. I removed the assertion for the host part because it is not relevant for the test, and setting that up just required more code in the test setup.

## Tests
The integration test is passing

