### PR TITLE
test: Lock setuptools version in TestDefaultPython test

### DIFF
--- a/integration/bundle/init_default_python_test.go
+++ b/integration/bundle/init_default_python_test.go
@@ -31,8 +31,8 @@ var pythonVersionsShort = []string{
 }
 
 var extraInstalls = map[string][]string{
-	"3.12": {"setuptools"},
-	"3.13": {"setuptools"},
+	"3.12": {"setuptools==75.8.2"},
+	"3.13": {"setuptools==75.8.2"},
 }
 
 func TestDefaultPython(t *testing.T) {


### PR DESCRIPTION
## Changes
Lock setuptools version to 75.8.2 (latest as of March 3, 2025)

## Why
As part of the tests `uv install` was installing latest version of setuptools which led to all tests started to fail on Feb 25 when 75.8.1 setuptools version was released and which changed the naming of the output built artifacts
https://setuptools.pypa.io/en/stable/history.html#v75-8-1

This change prevents us from breakages like this.

## Tests
Existing tests pass

