### PR TITLE
acc: Automatically rename .gitignore -> out.gitignore

### DIFF
--- a/acceptance/bundle/templates/dbt-sql/script
+++ b/acceptance/bundle/templates/dbt-sql/script
@@ -3,6 +3,3 @@ trace $CLI bundle init dbt-sql --config-file ./input.json --output-dir output
 cd output/my_dbt_sql
 trace $CLI bundle validate -t dev
 trace $CLI bundle validate -t prod
-
-# Do not affect this repository's git behaviour #2318
-mv .gitignore out.gitignore

--- a/acceptance/bundle/templates/default-python/serverless/script
+++ b/acceptance/bundle/templates/default-python/serverless/script
@@ -3,6 +3,3 @@ trace $CLI bundle init default-python --config-file ./input.json --output-dir ou
 cd output/my_default_python
 trace $CLI bundle validate -t dev
 trace $CLI bundle validate -t prod
-
-# Do not affect this repository's git behaviour #2318
-mv .gitignore out.gitignore

--- a/acceptance/bundle/templates/default-sql/script
+++ b/acceptance/bundle/templates/default-sql/script
@@ -3,6 +3,3 @@ trace $CLI bundle init default-sql --config-file ./input.json --output-dir outpu
 cd output/my_default_sql
 trace $CLI bundle validate -t dev
 trace $CLI bundle validate -t prod
-
-# Do not affect this repository's git behaviour #2318
-mv .gitignore out.gitignore

--- a/acceptance/bundle/templates/experimental-jobs-as-code/script
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/script
@@ -8,6 +8,3 @@ uv sync -q
 trace $CLI bundle validate -t dev --output json | jq ".resources"
 
 rm -fr .venv resources/__pycache__ uv.lock my_jobs_as_code.egg-info
-
-# Do not affect this repository's git behaviour #2318
-mv .gitignore out.gitignore


### PR DESCRIPTION
## Changes
Acceptance test runner will now automatically rename .gitignore to out.gitignore whenever it sees them. 

## Why
This to avoid manually renaming it in every test. We never want .gitignore in our tests that are related to tests and not cli repo itself.

Note, there is still a use case where renaming in 'script' is needed: when using diff.py to compare results with other pre-recorded output. In that case, local directory is not yet processed by test runner, so mv is still need.

## Tests
Using this in #2429