### PR TITLE
Disable ruff cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lintcheck:
 # formatting/goimports will not be applied by 'make lint'. However, it will be applied by 'make fmt'.
 # If you need to ensure that formatting & imports are always fixed, do "make fmt lint"
 fmt:
-	ruff format -q
+	ruff format -qn
 	golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix ./...
 
 test:


### PR DESCRIPTION
There is no perf difference, it's fast in both cases:

```
~/work/cli % hyperfine 'ruff format -qn'
Benchmark 1: ruff format -qn
  Time (mean ± σ):      22.5 ms ±   4.1 ms    [User: 23.6 ms, System: 106.7 ms]
  Range (min … max):    17.3 ms …  50.2 ms    52 runs
```

but it no longer produces .ruff_cache which can confuse acceptance test runner

```
~/work/cli % find . -type d | grep ruff
./.ruff_cache
./.ruff_cache/0.8.3
./libs/notebook/testdata/.ruff_cache
./libs/notebook/testdata/.ruff_cache/0.8.3
./libs/sync/testdata/.ruff_cache
./libs/sync/testdata/.ruff_cache/0.8.3
./acceptance/bundle/templates/default-sql/.ruff_cache
./acceptance/bundle/templates/default-sql/.ruff_cache/0.8.3
```
