### PR TITLE
Make NO_CHANGELOG=true a default in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,7 @@ For example, were there any decisions behind the change that are not reflected i
 ## Tests
 <!-- How have you tested the changes? -->
 
-If your PR needs to be included in the release notes for next release, add a separate entry in NEXT_CHANGELOG.md
+---
+<!-- If your PR needs to be included in the release notes for next release,
+remove the line below and add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
+NO_CHANGELOG=true


### PR DESCRIPTION
## Changes
Make NO_CHANGELOG=true a default in PR template

## Why
Quite large amount of our changes are internal and don't need call outs in CHANGELOG hence this is a good default for majority of our PRs. Without NO_CHANGELOG=true CI check expects to have an entry in NEXT_CHANGELOG file as part of same PR.

NO_CHANGELOG=true
