### PR TITLE
Update Go to 1.23.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli
 
 go 1.23
 
-toolchain go1.23.4
+toolchain go1.23.6
 
 require (
 	dario.cat/mergo v1.0.1 // BSD 3-Clause

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.7
 
 require (
 	dario.cat/mergo v1.0.1 // BSD 3-Clause


### PR DESCRIPTION
## Changes
Update Go to 1.23.7

From https://go.dev/doc/devel/release#go1.23.minor

> go1.23.5 (released 2025-01-16) includes security fixes to the crypto/x509 and net/http packages, as well as bug fixes to the compiler, the runtime, and the net package. See the [Go 1.23.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved) on our issue tracker for details.

> go1.23.6 (released 2025-02-04) includes security fixes to the crypto/elliptic package, as well as bug fixes to the compiler and the go command. See the [Go 1.23.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved) on our issue tracker for details.

> go1.23.7 (released 2025-03-04) includes security fixes to the net/http package, as well as bug fixes to cgo, the compiler, and the reflect, runtime, and syscall packages. See the [Go 1.23.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.7+label%3ACherryPickApproved) on our issue tracker for details.