### PR TITLE
Make bind/schema acceptance test run locally

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -223,7 +223,9 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 
 	if !isTruePtr(config.Cloud) && cloudEnv != "" {
 		t.Skipf("Disabled via Cloud setting in %s (CLOUD_ENV=%s)", configPath, cloudEnv)
-	} else {
+	}
+
+	if cloudEnv != "" {
 		if isTruePtr(config.RequiresUnityCatalog) && os.Getenv("TEST_METASTORE_ID") == "" {
 			t.Skipf("Skipping on non-UC workspaces")
 		}
@@ -361,6 +363,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	absDir, err := filepath.Abs(dir)
 	require.NoError(t, err)
 	cmd.Env = append(cmd.Env, "TESTDIR="+absDir)
+	cmd.Env = append(cmd.Env, "CLOUD_ENV="+cloudEnv)
 
 	// Write combined output to a file
 	out, err := os.Create(filepath.Join(tmpDir, "output.txt"))

--- a/acceptance/bundle/deployment/bind/schema/output.txt
+++ b/acceptance/bundle/deployment/bind/schema/output.txt
@@ -3,8 +3,7 @@
 === Substitute variables in the template: 
 === Create a pre-defined schema: {
   "full_name": "main.test-schema-[UUID]",
-  "catalog_name": "main",
-  "comment": null
+  "catalog_name": "main"
 }
 
 === Bind schema: Updating deployment state...

--- a/acceptance/bundle/deployment/bind/schema/script
+++ b/acceptance/bundle/deployment/bind/schema/script
@@ -2,12 +2,16 @@ title "Bind schema test: "
 
 title "Substitute variables in the template: "
 export BUNDLE_NAME_SUFFIX=$(uuid)
+
 export SCHEMA_NAME="test-schema-$(uuid)"
+if [ -z "$CLOUD_ENV" ]; then
+    export SCHEMA_NAME="test-schema-6260d50f-e8ff-4905-8f28-812345678903"   # use hard-coded uuid when running locally
+fi
 envsubst < databricks.yml > out.yml && mv out.yml databricks.yml
 
 title "Create a pre-defined schema: "
 CATALOG_NAME=main
-$CLI schemas create ${SCHEMA_NAME} ${CATALOG_NAME} | jq '{full_name, catalog_name, comment}'
+$CLI schemas create ${SCHEMA_NAME} ${CATALOG_NAME} | jq '{full_name, catalog_name}'
 
 cleanupRemoveSchema() {
     title "Test cleanup: "

--- a/acceptance/bundle/deployment/bind/schema/test.toml
+++ b/acceptance/bundle/deployment/bind/schema/test.toml
@@ -1,3 +1,30 @@
-Local = false
+Local = true
 Cloud = true
 RequiresUnityCatalog = true
+
+[[Server]]
+Pattern = "POST /api/2.1/unity-catalog/schemas"
+Response.Body = '''
+{
+    "name":"test-schema-6260d50f-e8ff-4905-8f28-812345678903",
+    "catalog_name":"main",
+    "full_name":"main.test-schema-6260d50f-e8ff-4905-8f28-812345678903"
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/schemas/{schema_fullname}"
+Response.Body = '''
+{
+    "name":"test-schema-6260d50f-e8ff-4905-8f28-812345678903",
+    "catalog_name":"main",
+    "full_name":"main.test-schema-6260d50f-e8ff-4905-8f28-812345678903",
+    "comment": "This schema was created from DABs"
+}
+'''
+
+[[Server]]
+Pattern = "PATCH /api/2.1/unity-catalog/schemas/{schema_fullname}"
+
+[[Server]]
+Pattern = "DELETE /api/2.1/unity-catalog/schemas/{schema_fullname}"

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -1,12 +1,9 @@
 package acceptance_test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/databricks/cli/libs/log"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -104,7 +101,6 @@ func AddHandlers(server *testserver.Server) {
 	server.Handle("POST", "/api/2.0/workspace/delete", func(req testserver.Request) any {
 		path := req.URL.Query().Get("path")
 		recursive := req.URL.Query().Get("recursive") == "true"
-		log.Debugf(context.Background(), "[workspace files] Delete file: %s, %v ", path, recursive)
 		req.Workspace.WorkspaceDelete(path, recursive)
 		return ""
 	})
@@ -112,15 +108,12 @@ func AddHandlers(server *testserver.Server) {
 	server.Handle("POST", "/api/2.0/workspace-files/import-file/{path:.*}", func(req testserver.Request) any {
 		path := req.Vars["path"]
 		req.Workspace.WorkspaceFilesImportFile(path, req.Body)
-		log.Debug(context.Background(), "[workspace files] Import file: "+path)
 		return ""
 	})
 
 	server.Handle("GET", "/api/2.0/workspace-files/{path:.*}", func(req testserver.Request) any {
 		path := req.Vars["path"]
-		file := req.Workspace.WorkspaceFilesExportFile(path)
-		log.Debugf(context.Background(), "[workspace files] Read file: %s, exists: %v", path, file != nil)
-		return file
+		return req.Workspace.WorkspaceFilesExportFile(path)
 	})
 
 	server.Handle("GET", "/api/2.1/unity-catalog/current-metastore-assignment", func(req testserver.Request) any {

--- a/acceptance/server_test.go
+++ b/acceptance/server_test.go
@@ -1,9 +1,12 @@
 package acceptance_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/databricks/cli/libs/log"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -101,6 +104,7 @@ func AddHandlers(server *testserver.Server) {
 	server.Handle("POST", "/api/2.0/workspace/delete", func(req testserver.Request) any {
 		path := req.URL.Query().Get("path")
 		recursive := req.URL.Query().Get("recursive") == "true"
+		log.Debugf(context.Background(), "[workspace files] Delete file: %s, %v ", path, recursive)
 		req.Workspace.WorkspaceDelete(path, recursive)
 		return ""
 	})
@@ -108,12 +112,15 @@ func AddHandlers(server *testserver.Server) {
 	server.Handle("POST", "/api/2.0/workspace-files/import-file/{path:.*}", func(req testserver.Request) any {
 		path := req.Vars["path"]
 		req.Workspace.WorkspaceFilesImportFile(path, req.Body)
+		log.Debug(context.Background(), "[workspace files] Import file: "+path)
 		return ""
 	})
 
 	server.Handle("GET", "/api/2.0/workspace-files/{path:.*}", func(req testserver.Request) any {
 		path := req.Vars["path"]
-		return req.Workspace.WorkspaceFilesExportFile(path)
+		file := req.Workspace.WorkspaceFilesExportFile(path)
+		log.Debugf(context.Background(), "[workspace files] Read file: %s, exists: %v", path, file != nil)
+		return file
 	})
 
 	server.Handle("GET", "/api/2.1/unity-catalog/current-metastore-assignment", func(req testserver.Request) any {


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
1. Change the cloud acceptance test for `bind/schema` to run locally
2. Add debug lines to the mock server
3. Change `fake_workspace` to create directories for imported files

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
1. Local version of the test run can indicate breaking changes faster than the cloud version and it can be run locally without any predefined environment variables 

## Tests
<!-- How have you tested the changes? -->
1. Ran both acloud and local versions of test, both succeeded

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
