### PR TITLE
Make fake_workspace create all parent folders exist when importing a file

### DIFF
--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -81,6 +81,19 @@ func (s *FakeWorkspace) WorkspaceFilesImportFile(path string, body []byte) {
 		path = "/" + path
 	}
 	s.files[path] = body
+
+	// Add all directories in the path to the directories map
+	parts := strings.Split(path, "/")
+	currentPath := ""
+	for i, part := range parts {
+		// Skip empty parts and the last part (which is the file itself)
+		if part == "" || i == len(parts)-1 {
+			continue
+		}
+
+		currentPath = currentPath + "/" + part
+		s.directories[currentPath] = true
+	}
 }
 
 func (s *FakeWorkspace) WorkspaceFilesExportFile(path string) []byte {


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
When a file is imported, FakeWorkspace now automatically identifies and records all parent directories in the directories map, ensuring the directory structure is properly maintained without requiring explicit directory creation.

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
During an acceptance test, production code might want to check a root folder for existence, this change makes sure that root folder is marked as existing when at least one file is imported into the workspace

## Tests
<!-- How have you tested the changes? -->
Tests for another change using this improvement are green: https://github.com/databricks/cli/pull/2463 

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
