### PR TITLE
Set Go patch version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/databricks/cli
 
-go 1.23
+go 1.23.0
 
 toolchain go1.23.7
 


### PR DESCRIPTION
## Changes
Set Go patch version in go.mod

## Why

Our dependabot PRs failing with the following diff

```
Run # Exit with status code 1 if there are differences (i.e. unformatted files)
diff --git a/go.mod b/go.mod
index 5c1cb1d..493152a 100644
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,[7](https://github.com/databricks/cli/actions/runs/13768953030/job/38502532441?pr=2459#step:5:8) @@
 module github.com/databricks/cli
 
-go 1.23
+go 1.23.0
+
```

While I'm not 100% sure why it started to happen, setting the patch version at least should fix these PR.

This might be related to this change in Go https://github.com/golang/go/issues/69095 and the fact that the proposal is to enforce 1.(N-1).0 version in go.mod. 1.24 version of [released in mid of February](https://tip.golang.org/doc/devel/release#go1.24.0) so altogether this might be a reason why it started to fail


