### PR TITLE
acc: add -tail option to see output.txt in real time

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -742,6 +742,8 @@ func runWithTail(t *testing.T, cmd *exec.Cmd, filename string) error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	start := time.Now()
+
 	// Tail goroutine: open the file and read new lines as they are written.
 	go func() {
 		defer wg.Done()
@@ -771,13 +773,13 @@ func runWithTail(t *testing.T, cmd *exec.Cmd, filename string) error {
 			line, err := reader.ReadString('\n')
 			msg := strings.TrimRight(line, "\n")
 			if len(msg) > 0 {
-				t.Log(msg)
+				d := time.Since(start)
+				t.Logf("%2d.%03d %s", d/time.Second, (d%time.Second)/time.Millisecond, msg)
 			}
 
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					// Sleep briefly if no complete line is available.
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(50 * time.Millisecond)
 					continue
 				}
 				t.Logf("error reading file: %v", err)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -748,7 +748,7 @@ func runWithTail(t *testing.T, cmd *exec.Cmd, filename string) error {
 	go func() {
 		defer wg.Done()
 
-		f, err := openWait(filename)
+		f, err := os.Open(filename)
 		assert.NoError(t, err)
 		defer f.Close()
 
@@ -797,17 +797,4 @@ func runWithTail(t *testing.T, cmd *exec.Cmd, filename string) error {
 
 	wg.Wait()
 	return err
-}
-
-func openWait(path string) (*os.File, error) {
-	deadline := time.Now().Add(1 * time.Second)
-	for {
-		f, err := os.Open(path)
-		if err == nil {
-			return f, err
-		}
-		if time.Now().After(deadline) {
-			return nil, err
-		}
-	}
 }


### PR DESCRIPTION
## Changes
Add new option -tail to acceptance test runner. This logs output.txt in real time with relative timestamp prefix.
 
## Why
When working on long running integration tests, it's useful to see what stage they are at.

## Tests
Manually

```
~/work/cli/acceptance/selftest % testme -v -tail
+ go test .. -run ^TestAccept$/^selftest$ -v -tail
...
=== CONT  TestAccept/selftest/diff
    acceptance_test.go:774:  0.051 >>> diff.py out_dir_a out_dir_b
=== NAME  TestAccept/selftest/basic
    acceptance_test.go:774:  0.051 === Capturing STDERR
    acceptance_test.go:774:  0.051 >>> python3 -c import sys; sys.stderr.write("STDERR\n")
=== NAME  TestAccept/selftest/server
    acceptance_test.go:774:  0.050 >>> curl -s http://127.0.0.1:55850/api/2.0/preview/scim/v2/Me
...
    acceptance_test.go:774:  0.204 >>> /Users/denis.bilenko/work/cli/acceptance/build/darwin_arm64/databricks --version
=== NAME  TestAccept/selftest/server
    acceptance_test.go:774:  0.510 Error: Workspace path not found
...
```
