### PR TITLE
Make placeholder target name more unique

### DIFF
--- a/bundle/config/mutator/default_target.go
+++ b/bundle/config/mutator/default_target.go
@@ -13,16 +13,16 @@ type definePlaceholderTarget struct {
 	name string
 }
 
-const PlaceholderTargetName = "BUNDLE_PLACEHOLDER_TARGET"
+const PlaceholderTargetName = "PLACEHOLDER_TARGET"
 
-// DefinePlaceholderTarget adds a target named "BUNDLE_PLACEHOLDER_TARGET"
+// DefinePlaceholderTarget adds a target named "PLACEHOLDER_TARGET"
 // to the configuration if none have been defined.
 //
 // We do this because downstream mutators like [SelectDefaultTarget]
 // and [SelectTarget] expect at least one target to be defined.
 func DefinePlaceholderTarget() bundle.Mutator {
 	return &definePlaceholderTarget{
-		name: "PlaceholderTargetName",
+		name: PlaceholderTargetName,
 	}
 }
 

--- a/bundle/config/mutator/default_target.go
+++ b/bundle/config/mutator/default_target.go
@@ -13,9 +13,9 @@ type definePlaceholderTarget struct {
 	name string
 }
 
-const PlaceholderTargetName = "PLACEHOLDER_TARGET"
+const PlaceholderTargetName = "BUNDLE_PLACEHOLDER_TARGET"
 
-// DefinePlaceholderTarget adds a target named "PLACEHOLDER_TARGET"
+// DefinePlaceholderTarget adds a target named "BUNDLE_PLACEHOLDER_TARGET"
 // to the configuration if none have been defined.
 //
 // We do this because downstream mutators like [SelectDefaultTarget]

--- a/bundle/config/mutator/default_target.go
+++ b/bundle/config/mutator/default_target.go
@@ -9,23 +9,28 @@ import (
 	"github.com/databricks/cli/libs/diag"
 )
 
-type defineDefaultTarget struct {
+type definePlaceholderTarget struct {
 	name string
 }
 
-// DefineDefaultTarget adds a target named "default"
+const PlaceholderTargetName = "PLACEHOLDER_TARGET"
+
+// DefinePlaceholderTarget adds a target named "PLACEHOLDER_TARGET"
 // to the configuration if none have been defined.
-func DefineDefaultTarget() bundle.Mutator {
-	return &defineDefaultTarget{
-		name: "default",
+//
+// We do this because downstream mutators like [SelectDefaultTarget]
+// and [SelectTarget] expect at least one target to be defined.
+func DefinePlaceholderTarget() bundle.Mutator {
+	return &definePlaceholderTarget{
+		name: "PlaceholderTargetName",
 	}
 }
 
-func (m *defineDefaultTarget) Name() string {
+func (m *definePlaceholderTarget) Name() string {
 	return fmt.Sprintf("DefineDefaultTarget(%s)", m.name)
 }
 
-func (m *defineDefaultTarget) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
+func (m *definePlaceholderTarget) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 	// Nothing to do if the configuration has at least 1 target.
 	if len(b.Config.Targets) > 0 {
 		return nil

--- a/bundle/config/mutator/default_target_test.go
+++ b/bundle/config/mutator/default_target_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDefaultTarget(t *testing.T) {
 	b := &bundle.Bundle{}
-	diags := bundle.Apply(context.Background(), b, mutator.DefineDefaultTarget())
+	diags := bundle.Apply(context.Background(), b, mutator.DefinePlaceholderTarget())
 	require.NoError(t, diags.Error())
 
 	env, ok := b.Config.Targets["default"]
@@ -29,7 +29,7 @@ func TestDefaultTargetAlreadySpecified(t *testing.T) {
 			},
 		},
 	}
-	diags := bundle.Apply(context.Background(), b, mutator.DefineDefaultTarget())
+	diags := bundle.Apply(context.Background(), b, mutator.DefinePlaceholderTarget())
 	require.NoError(t, diags.Error())
 
 	_, ok := b.Config.Targets["default"]

--- a/bundle/config/mutator/mutator.go
+++ b/bundle/config/mutator/mutator.go
@@ -28,7 +28,7 @@ func DefaultMutators(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		EnvironmentsToTargets(),
 		ComputeIdToClusterId(),
 		InitializeVariables(),
-		DefineDefaultTarget(),
+		DefinePlaceholderTarget(),
 		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseLoad),
 
 		// Note: This mutator must run before the target overrides are merged.


### PR DESCRIPTION
## Why
Prompted by https://github.com/databricks/cli/pull/2413#discussion_r1987544286.

Making the default target's name more unique allows us to assert in the bundle exec command whether the user defined a target.

## Tests
Existing tests. This mutator is not functional beyond avoiding downstream "no target defined" error in SelectTarget or SelectDefaultTarget. Ideally, I'd consolidate the code and remove the mutator altogether, but the refactoring does not seem worth the ROI right now.