### PR TITLE
acc: Add CloudSlow config setting

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -220,17 +220,39 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	}
 
 	cloudEnv := os.Getenv("CLOUD_ENV")
-	if !isTruePtr(config.Local) && cloudEnv == "" {
-		t.Skipf("Disabled via Local setting in %s (CLOUD_ENV=%s)", configPath, cloudEnv)
-	}
+	isRunningOnCloud := cloudEnv != ""
+	tailOutput := Tail
 
-	if !isTruePtr(config.Cloud) && cloudEnv != "" {
-		t.Skipf("Disabled via Cloud setting in %s (CLOUD_ENV=%s)", configPath, cloudEnv)
-	}
+	if isRunningOnCloud {
+		if isTruePtr(config.CloudLong) {
+			if testing.Short() {
+				t.Skipf("Disabled via CloudLong setting in %s (CLOUD_ENV=%s, Short=%v)", configPath, cloudEnv, testing.Short())
+			}
 
-	if cloudEnv != "" {
+			if testing.Verbose() {
+				// Combination of CloudLong and -v auto-enables -tail
+				tailOutput = true
+			}
+		}
+
+		isCloudEnabled := isTruePtr(config.Cloud) || isTruePtr(config.CloudLong)
+		if !isCloudEnabled {
+			t.Skipf("Disabled via Cloud/CloudLong setting in %s (CLOUD_ENV=%s, Cloud=%v, CloudLong=%v)",
+				configPath,
+				cloudEnv,
+				isTruePtr(config.Cloud),
+				isTruePtr(config.CloudLong),
+			)
+		}
+
 		if isTruePtr(config.RequiresUnityCatalog) && os.Getenv("TEST_METASTORE_ID") == "" {
-			t.Skipf("Skipping on non-UC workspaces")
+			t.Skipf("Disable via RequiresUnityCatalog setting in %s (TEST_METASTORE_ID=%s)", configPath, os.Getenv("TEST_METASTORE_ID"))
+		}
+
+	} else {
+		// Local run
+		if !isTruePtr(config.Local) {
+			t.Skipf("Disabled via Local setting in %s (CLOUD_ENV=%s)", configPath, cloudEnv)
 		}
 	}
 
@@ -267,7 +289,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	// specifies a custom server stubs.
 	var server *testserver.Server
 
-	if cloudEnv == "" {
+	if !isRunningOnCloud {
 		// Start a new server for this test if either:
 		// 1. A custom server spec is defined in the test configuration.
 		// 2. The test is configured to record requests and assert on them. We need
@@ -374,7 +396,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	require.NoError(t, err)
 	defer out.Close()
 
-	err = runWithLog(t, cmd, out)
+	err = runWithLog(t, cmd, out, tailOutput)
 
 	// Include exit code in output (if non-zero)
 	formatOutput(out, err)
@@ -725,7 +747,7 @@ func isTruePtr(value *bool) bool {
 	return value != nil && *value
 }
 
-func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File) error {
+func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File, tail bool) error {
 	r, w := io.Pipe()
 	cmd.Stdout = w
 	cmd.Stderr = w
@@ -743,7 +765,7 @@ func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File) error {
 	reader := bufio.NewReader(r)
 	for {
 		line, err := reader.ReadString('\n')
-		if Tail {
+		if tail {
 			msg := strings.TrimRight(line, "\n")
 			if len(msg) > 0 {
 				d := time.Since(start)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -224,24 +224,24 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	tailOutput := Tail
 
 	if isRunningOnCloud {
-		if isTruePtr(config.CloudLong) {
+		if isTruePtr(config.CloudSlow) {
 			if testing.Short() {
-				t.Skipf("Disabled via CloudLong setting in %s (CLOUD_ENV=%s, Short=%v)", configPath, cloudEnv, testing.Short())
+				t.Skipf("Disabled via CloudSlow setting in %s (CLOUD_ENV=%s, Short=%v)", configPath, cloudEnv, testing.Short())
 			}
 
 			if testing.Verbose() {
-				// Combination of CloudLong and -v auto-enables -tail
+				// Combination of CloudSlow and -v auto-enables -tail
 				tailOutput = true
 			}
 		}
 
-		isCloudEnabled := isTruePtr(config.Cloud) || isTruePtr(config.CloudLong)
+		isCloudEnabled := isTruePtr(config.Cloud) || isTruePtr(config.CloudSlow)
 		if !isCloudEnabled {
-			t.Skipf("Disabled via Cloud/CloudLong setting in %s (CLOUD_ENV=%s, Cloud=%v, CloudLong=%v)",
+			t.Skipf("Disabled via Cloud/CloudSlow setting in %s (CLOUD_ENV=%s, Cloud=%v, CloudSlow=%v)",
 				configPath,
 				cloudEnv,
 				isTruePtr(config.Cloud),
-				isTruePtr(config.CloudLong),
+				isTruePtr(config.CloudSlow),
 			)
 		}
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -246,7 +246,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 		}
 
 		if isTruePtr(config.RequiresUnityCatalog) && os.Getenv("TEST_METASTORE_ID") == "" {
-			t.Skipf("Disable via RequiresUnityCatalog setting in %s (TEST_METASTORE_ID=%s)", configPath, os.Getenv("TEST_METASTORE_ID"))
+			t.Skipf("Disabled via RequiresUnityCatalog setting in %s (TEST_METASTORE_ID=%s)", configPath, os.Getenv("TEST_METASTORE_ID"))
 		}
 
 	} else {

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -31,6 +31,10 @@ type TestConfig struct {
 	// If true, run this test when running with cloud env configured
 	Cloud *bool
 
+	// If true, this test is not run if -short is passed and cloud env is configured
+	// This implies Cloud = true.
+	CloudLong *bool
+
 	// If true and Cloud=true, run this test only if unity catalog is available in the cloud environment
 	RequiresUnityCatalog *bool
 

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -33,7 +33,7 @@ type TestConfig struct {
 
 	// If true, run this test when running with cloud env configured and -short is not passed
 	// This also sets -tail when -v is passed.
-	CloudLong *bool
+	CloudSlow *bool
 
 	// If true and Cloud=true, run this test only if unity catalog is available in the cloud environment
 	RequiresUnityCatalog *bool

--- a/acceptance/config_test.go
+++ b/acceptance/config_test.go
@@ -31,8 +31,8 @@ type TestConfig struct {
 	// If true, run this test when running with cloud env configured
 	Cloud *bool
 
-	// If true, this test is not run if -short is passed and cloud env is configured
-	// This implies Cloud = true.
+	// If true, run this test when running with cloud env configured and -short is not passed
+	// This also sets -tail when -v is passed.
 	CloudLong *bool
 
 	// If true and Cloud=true, run this test only if unity catalog is available in the cloud environment


### PR DESCRIPTION
## Changes
New bool config setting CloudSlow in acceptance tests. If set, it enables this test on Cloud but skips it in -short setting there. It does not affect local runs, "Slow" is only applied to Cloud. The reason is that we won't need to wait for cluster with mocked testserver.

Additionally, this setting enables -tail if -v is already enabled. 

## Why
Certain tests that use "bundle run" are too long due to starting a cluster.

## Tests
Using this option in #2471
