### PR TITLE
acc: Add example on how to do trap

### DIFF
--- a/acceptance/selftest/trap/output.txt
+++ b/acceptance/selftest/trap/output.txt
@@ -1,0 +1,6 @@
+run first
+
+>>> [CLI] missing-command
+Error: unknown command "missing-command" for "databricks"
+
+Exit code: 1

--- a/acceptance/selftest/trap/script
+++ b/acceptance/selftest/trap/script
@@ -1,0 +1,7 @@
+# This does not work on Windows, somehow all the slashes are lost:
+# command: trap "$CLI missing-command" EXIT
+# output: script: line 1: Y:cliacceptancebuildwindows_amd64databricks.exe: command not found
+
+# Adding single quotes around $CLI helps:
+trap "errcode trace '$CLI' missing-command" EXIT
+echo "run first"


### PR DESCRIPTION
Discovered that 'trap' does not work with $CLI on Windows when working #2471

This example shows a workaround.