### PR TITLE
acc: fix find.py not to lose '.' at the beginning of the path

### DIFF
--- a/acceptance/bin/find.py
+++ b/acceptance/bin/find.py
@@ -22,7 +22,8 @@ result = []
 
 for root, dirs, files in os.walk("."):
     for filename in files:
-        path = os.path.join(root, filename).lstrip("./\\").replace("\\", "/")
+        path = os.path.join(root, filename).replace("\\", "/")
+        path = path.removeprefix("./")
         if regex.search(path):
             result.append(path)
 


### PR DESCRIPTION
Noticed that it currently turns ".databricks" in "databricks".