### PR TITLE
[Python] Reformat variable regex

### DIFF
--- a/experimental/python/databricks/bundles/core/_transform.py
+++ b/experimental/python/databricks/bundles/core/_transform.py
@@ -270,9 +270,10 @@ def _unwrap_variable(tpe: type) -> Optional[type]:
     return None
 
 
-# from cli/libs/dyn/dynvar/ref.go
+# from libs/dyn/dynvar/ref.go
+_base_var_def = r"[a-zA-Z]+([-_]*[a-zA-Z0-9]+)*"
 _variable_regex = re.compile(
-    r"\$\{([a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\[[0-9]+\])*)*(\[[0-9]+\])*)\}",
+    r"\$\{(%s(\.%s(\[[0-9]+\])*)*(\[[0-9]+\])*)\}" % (_base_var_def, _base_var_def)
 )
 
 

--- a/experimental/python/databricks/bundles/core/_transform.py
+++ b/experimental/python/databricks/bundles/core/_transform.py
@@ -270,7 +270,14 @@ def _unwrap_variable(tpe: type) -> Optional[type]:
     return None
 
 
-# from libs/dyn/dynvar/ref.go
+# Regex for string corresponding to variables.
+#
+# The source of truth is regex in libs/dyn/dynvar/ref.go
+#
+# Example:
+#   - "${a.b}"
+#   - "${a.b.c}"
+#   - "${a.b[0].c}"
 _base_var_def = r"[a-zA-Z]+([-_]*[a-zA-Z0-9]+)*"
 _variable_regex = re.compile(
     r"\$\{(%s(\.%s(\[[0-9]+\])*)*(\[[0-9]+\])*)\}" % (_base_var_def, _base_var_def)

--- a/libs/dyn/dynvar/ref.go
+++ b/libs/dyn/dynvar/ref.go
@@ -37,6 +37,7 @@ type ref struct {
 // Examples of a valid variable references:
 //   - "${a.b}"
 //   - "${a.b.c}"
+//   - "${a.b[0].c}"
 //   - "${a} ${b} ${c}"
 func newRef(v dyn.Value) (ref, bool) {
 	s, ok := v.AsString()

--- a/libs/dyn/dynvar/ref.go
+++ b/libs/dyn/dynvar/ref.go
@@ -8,12 +8,11 @@ import (
 )
 
 var (
-	// Regex should be in sync with _variable_regex in Python code.
-	//
-	// LINT.IfChange
+	// !!! Should be in sync with _variable_regex in Python code.
+	// !!!
+	// !!! See experimental/python/databricks/bundles/core/_transform.py
 	baseVarDef = `[a-zA-Z]+([-_]*[a-zA-Z0-9]+)*`
 	re         = regexp.MustCompile(fmt.Sprintf(`\$\{(%s(\.%s(\[[0-9]+\])*)*(\[[0-9]+\])*)\}`, baseVarDef, baseVarDef))
-	// LINT.ThenChange(experimental/python/databricks/bundles/core/_transform.py)
 )
 
 // ref represents a variable reference.

--- a/libs/dyn/dynvar/ref.go
+++ b/libs/dyn/dynvar/ref.go
@@ -8,8 +8,12 @@ import (
 )
 
 var (
+	// Regex should be in sync with _variable_regex in Python code.
+	//
+	// LINT.IfChange
 	baseVarDef = `[a-zA-Z]+([-_]*[a-zA-Z0-9]+)*`
 	re         = regexp.MustCompile(fmt.Sprintf(`\$\{(%s(\.%s(\[[0-9]+\])*)*(\[[0-9]+\])*)\}`, baseVarDef, baseVarDef))
+	// LINT.ThenChange(experimental/python/databricks/bundles/core/_transform.py)
 )
 
 // ref represents a variable reference.


### PR DESCRIPTION
## Changes
Reformat variable regex in Python code to follow Golang. The effective regex is not changed.

## Why
We need to keep both regexes in sync.

## Tests
Using existing tests and manually inspecting resulting regex.
