### PR TITLE
acc: Create acceptance/internal package

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/databricks/cli/acceptance/internal"
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/testdiff"
@@ -112,7 +113,7 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 	execPath := ""
 
 	if InprocessMode {
-		cmdServer := StartCmdServer(t)
+		cmdServer := internal.StartCmdServer(t)
 		t.Setenv("CMD_SERVER_URL", cmdServer.URL)
 		execPath = filepath.Join(cwd, "bin", "callserver.py")
 	} else {
@@ -137,7 +138,7 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 
 	if cloudEnv == "" {
 		defaultServer := testserver.New(t)
-		AddHandlers(defaultServer)
+		internal.AddHandlers(defaultServer)
 		t.Setenv("DATABRICKS_DEFAULT_HOST", defaultServer.URL)
 
 		homeDir := t.TempDir()
@@ -198,7 +199,7 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 		t.Run(dir, func(t *testing.T) {
 			selectedDirs += 1
 
-			config, configPath := LoadConfig(t, dir)
+			config, configPath := internal.LoadConfig(t, dir)
 			skipReason := getSkipReason(&config, configPath)
 
 			if skipReason != "" {
@@ -241,7 +242,7 @@ func getTests(t *testing.T) []string {
 }
 
 // Return a reason to skip the test. Empty string means "don't skip".
-func getSkipReason(config *TestConfig, configPath string) string {
+func getSkipReason(config *internal.TestConfig, configPath string) string {
 	if Forcerun {
 		return ""
 	}
@@ -285,7 +286,7 @@ func getSkipReason(config *TestConfig, configPath string) string {
 	return ""
 }
 
-func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsContext, config TestConfig, configPath string) {
+func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsContext, config internal.TestConfig, configPath string) {
 	tailOutput := Tail
 	cloudEnv := os.Getenv("CLOUD_ENV")
 	isRunningOnCloud := cloudEnv != ""
@@ -380,7 +381,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 			}
 
 			// The earliest handlers take precedence, add default handlers last
-			AddHandlers(server)
+			internal.AddHandlers(server)
 			databricksLocalHost = server.URL
 		}
 
@@ -399,7 +400,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 
 		// For the purposes of replacements, use testUser.
 		// Note, users might have overriden /api/2.0/preview/scim/v2/Me but that should not affect the replacement:
-		user = testUser
+		user = internal.TestUser
 	} else {
 		// Use whatever authentication mechanism is configured by the test runner.
 		workspaceClient, err = databricks.NewWorkspaceClient(&databricks.Config{})

--- a/acceptance/internal/cmd_server.go
+++ b/acceptance/internal/cmd_server.go
@@ -1,4 +1,4 @@
-package acceptance_test
+package internal
 
 import (
 	"context"

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -1,4 +1,4 @@
-package acceptance_test
+package internal
 
 import (
 	"os"

--- a/acceptance/internal/server.go
+++ b/acceptance/internal/server.go
@@ -1,4 +1,4 @@
-package acceptance_test
+package internal
 
 import (
 	"encoding/json"
@@ -15,12 +15,12 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 )
 
-var testUser = iam.User{
+var TestUser = iam.User{
 	Id:       "1000012345",
 	UserName: "tester@databricks.com",
 }
 
-var testMetastore = catalog.MetastoreAssignment{
+var TestMetastore = catalog.MetastoreAssignment{
 	DefaultCatalogName: "hive_metastore",
 	MetastoreId:        "120efa64-9b68-46ba-be38-f319458430d2",
 	WorkspaceId:        470123456789500,
@@ -71,7 +71,7 @@ func AddHandlers(server *testserver.Server) {
 	server.Handle("GET", "/api/2.0/preview/scim/v2/Me", func(req testserver.Request) any {
 		return testserver.Response{
 			Headers: map[string][]string{"X-Databricks-Org-Id": {"900800700600"}},
-			Body:    testUser,
+			Body:    TestUser,
 		}
 	})
 
@@ -117,7 +117,7 @@ func AddHandlers(server *testserver.Server) {
 	})
 
 	server.Handle("GET", "/api/2.1/unity-catalog/current-metastore-assignment", func(req testserver.Request) any {
-		return testMetastore
+		return TestMetastore
 	})
 
 	server.Handle("GET", "/api/2.0/permissions/directories/{objectId}", func(req testserver.Request) any {


### PR DESCRIPTION
## Changes
Move acceptance/*_test.go to acceptance/internal (except for acceptance_test.go).

## Why
 Some of this code needs its own tests, having it in package supports the separation between "acceptance tests" and "acceptance test runner tests".
