### PR TITLE
Upgrade databricks-bundles to 0.7.2

### DIFF
--- a/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/pyproject.toml
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/pyproject.toml
@@ -30,7 +30,7 @@ where = ["src"]
 [tool.uv]
 ## Dependencies for local development
 dev-dependencies = [
-    "databricks-bundles==0.7.0",
+    "databricks-bundles==0.7.2",
 
     ## Add code completion support for DLT
     # "databricks-dlt",

--- a/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/pyproject.toml.tmpl
+++ b/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/pyproject.toml.tmpl
@@ -39,7 +39,7 @@ py-modules = []
 [tool.uv]
 ## Dependencies for local development
 dev-dependencies = [
-    "databricks-bundles==0.7.0",
+    "databricks-bundles==0.7.2",
 
     ## Add code completion support for DLT
     # "databricks-dlt",


### PR DESCRIPTION
## Changes
Upgrade databricks-bundles to 0.7.2

It fixes problems with bundles using more than one resource loader or mutator.