### PR TITLE
Fixed `query-history list` command

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### CLI
 * Fixed "can't evaluate field Name in type interface{}" for "databricks queries list" command ([#2451](https://github.com/databricks/cli/pull/2451))
+* Fixed `query-history list` command failing with 'executing "command" at <.>: range cant iterate over' ([#2506](https://github.com/databricks/cli/pull/2506))
 
 ### Bundles
 

--- a/acceptance/cmd/workspace/query-history/output.txt
+++ b/acceptance/cmd/workspace/query-history/output.txt
@@ -1,0 +1,3 @@
+
+>>> errcode [CLI] query-history list
+user_name  ENUM  query_text

--- a/acceptance/cmd/workspace/query-history/script
+++ b/acceptance/cmd/workspace/query-history/script
@@ -1,0 +1,1 @@
+trace errcode $CLI query-history list

--- a/acceptance/cmd/workspace/query-history/test.toml
+++ b/acceptance/cmd/workspace/query-history/test.toml
@@ -1,14 +1,3 @@
-Local = true
-Cloud = false
-
-[[Repls]]
-Old="Date: .*"
-New="Date: (redacted)"
-
-[[Repls]]
-Old="Traceparent: .*"
-New="Traceparent: (redacted)"
-
 [[Server]]
 Pattern = "GET /api/2.0/sql/history/queries"
 Response.Body = '''

--- a/acceptance/cmd/workspace/query-history/test.toml
+++ b/acceptance/cmd/workspace/query-history/test.toml
@@ -1,0 +1,71 @@
+Local = true
+Cloud = false
+
+[[Repls]]
+Old="Date: .*"
+New="Date: (redacted)"
+
+[[Repls]]
+Old="Traceparent: .*"
+New="Traceparent: (redacted)"
+
+[[Server]]
+Pattern = "GET /api/2.0/sql/history/queries"
+Response.Body = '''
+{
+    "has_next_page": false,
+    "next_page_token": "",
+    "res": [
+        {
+            "channel_used": {
+                "dbsql_version": "dbsql_version",
+                "name": "ENUM"
+            },
+            "duration": 42,
+            "endpoint_id": "endpoint_id",
+            "error_message": "error_message",
+            "executed_as_user_id": 42,
+            "executed_as_user_name": "executed_as_user_name",
+            "execution_end_time_ms": 42,
+            "is_final": false,
+            "lookup_key": "lookup_key",
+            "metrics": {
+                "compilation_time_ms": 42,
+                "execution_time_ms": 42,
+                "network_sent_bytes": 42,
+                "overloading_queue_start_timestamp": 42,
+                "photon_total_time_ms": 42,
+                "provisioning_queue_start_timestamp": 42,
+                "pruned_bytes": 42,
+                "pruned_files_count": 42,
+                "query_compilation_start_timestamp": 42,
+                "read_bytes": 42,
+                "read_cache_bytes": 42,
+                "read_files_count": 42,
+                "read_partitions_count": 42,
+                "read_remote_bytes": 42,
+                "result_fetch_time_ms": 42,
+                "result_from_cache": false,
+                "rows_produced_count": 42,
+                "rows_read_count": 42,
+                "spill_to_disk_bytes": 42,
+                "task_total_time_ms": 42,
+                "total_time_ms": 42,
+                "write_remote_bytes": 42
+            },
+            "plans_state": "ENUM",
+            "query_end_time_ms": 42,
+            "query_id": "query_id",
+            "query_start_time_ms": 42,
+            "query_text": "query_text",
+            "rows_produced": 42,
+            "spark_ui_url": "spark_ui_url",
+            "statement_type": "ENUM",
+            "status": "ENUM",
+            "user_id": 42,
+            "user_name": "user_name",
+            "warehouse_id": "warehouse_id"
+        }
+    ]
+}
+'''

--- a/acceptance/cmd/workspace/test.toml
+++ b/acceptance/cmd/workspace/test.toml
@@ -1,0 +1,7 @@
+[[Repls]]
+Old="Date: .*"
+New="Date: (redacted)"
+
+[[Repls]]
+Old="Traceparent: .*"
+New="Traceparent: (redacted)"

--- a/cmd/workspace/query-history/overrides.go
+++ b/cmd/workspace/query-history/overrides.go
@@ -9,7 +9,7 @@ import (
 func listOverride(listCmd *cobra.Command, listReq *sql.ListQueryHistoryRequest) {
 	// TODO: figure out the right format
 	listCmd.Annotations["template"] = cmdio.Heredoc(`
-	{{range .}}{{.UserName}}	{{cyan "%s" .Status}}	{{.QueryText}}
+	{{range .Res}}{{.UserName}}	{{cyan "%s" .Status}}	{{.QueryText}}
 	{{end}}`)
 }
 


### PR DESCRIPTION
## Changes
Fixed `Error: template: command:1:8: executing "command" at <.>: range can't iterate over` for query-history list command

## Why
`query-history list` command has an override to use a different output template for list command. This template got outdated comparing to underlying API response structure and hence led to the error above.

it was found by automatically generated tests here: https://github.com/databricks/cli/pull/2501

## Tests
Added acceptance test
