### PR TITLE
[Python] Fix issues with multiple resource loaders

### DIFF
--- a/experimental/python/databricks/bundles/build.py
+++ b/experimental/python/databricks/bundles/build.py
@@ -241,9 +241,11 @@ def _load_resources(
 
     for function in functions:
         try:
-            resources, diagnostics = diagnostics.extend_tuple(
+            function_resources, diagnostics = diagnostics.extend_tuple(
                 _load_resources_from_function(bundle, function)
             )
+
+            resources.add_resources(function_resources)
         except Exception as exc:
             diagnostics = diagnostics.extend(
                 Diagnostics.from_exception(
@@ -342,7 +344,7 @@ def _explain_common_import_error(exc: Exception) -> Diagnostics:
     # a common case when default name of the module is not found
     # we can give a hint to the user how to fix it
     explanation = """Make sure to create a new Python file at resources/__init__.py with contents:
-    
+
 from databricks.bundles.core import load_resources_from_current_package_module
 
 


### PR DESCRIPTION
## Changes
Fix issues with multiple resource loaders. 

Previously, we discarded outputs of all loaders except the last one. That worked well if there is only a single resource loader.

## Tests
- Unit tests
- Acceptance tests in https://github.com/databricks/cli/pull/2493