### PR TITLE
Fix GoReleaser deprecation warning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,13 +41,13 @@ builds:
   binary: databricks
 
 archives:
-- format: zip
+  - formats: ["zip"]
 
-  # Include version in archive only for release builds and not for snapshot builds.
-  # Snapshot archives must have a stable file name such that the artifacts in the nightly
-  # release are automatically overwritten. If the snapshot version is included in the
-  # file name then additional logic to clean up older builds would be needed.
-  name_template: 'databricks_cli_{{ if not .IsSnapshot }}{{ .Version }}_{{ end }}{{ .Os }}_{{ .Arch }}'
+    # Include version in archive only for release builds and not for snapshot builds.
+    # Snapshot archives must have a stable file name such that the artifacts in the nightly
+    # release are automatically overwritten. If the snapshot version is included in the
+    # file name then additional logic to clean up older builds would be needed.
+    name_template: 'databricks_cli_{{ if not .IsSnapshot }}{{ .Version }}_{{ end }}{{ .Os }}_{{ .Arch }}'
 
 dockers:
   - id: arm64


### PR DESCRIPTION
## Changes

This warning surfaced in recent builds where GoReleaser >= v2.6 was used.

https://goreleaser.com/deprecations/#archivesformat

## Why

See the "Run GoReleaser" step in this job: https://github.com/databricks/cli/actions/runs/13680013259/job/38249650135

## Tests

Local run of GoReleaser no longer emits the warning.