### PR TITLE
Disable integration_whl tests on PRs

### DIFF
--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,5 +1,5 @@
 Local = false
-#CloudSlow = true
+CloudSlow = true
 Ignore = [
     ".databricks",
     "build",


### PR DESCRIPTION
## Why
When this tests were integration tests, they did not do run() part in -short mode.

After converting them to acceptance I kept them on always in #2471

This PR disables them in short mode (they will still run on main) because it seems they do expand PR integration test time.