### PR TITLE
Include tarballs in releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,7 +41,7 @@ builds:
   binary: databricks
 
 archives:
-  - formats: ["zip"]
+  - formats: ["zip", "tar.gz"]
 
     # Include version in archive only for release builds and not for snapshot builds.
     # Snapshot archives must have a stable file name such that the artifacts in the nightly


### PR DESCRIPTION
## Changes

Builds on #2513 to support multiple archive formats.

## Why

See #2351 and #1296.

Instead of producing tarballs only for a subset of operating systems, I figured we should produce them for every operating system/architecture combination to avoid unnecessary conditionals when writing platform-independent installers (for example, the `setup-cli` installer scripts).

## Tests

I manually confirmed that GoReleaser now produces both ZIP files and tarballs:
```
% ls -1 dist/*.{zip,tar.gz}                      
dist/databricks_cli_darwin_amd64.tar.gz
dist/databricks_cli_darwin_amd64.zip
dist/databricks_cli_darwin_arm64.tar.gz
dist/databricks_cli_darwin_arm64.zip
dist/databricks_cli_linux_amd64.tar.gz
dist/databricks_cli_linux_amd64.zip
dist/databricks_cli_linux_arm64.tar.gz
dist/databricks_cli_linux_arm64.zip
dist/databricks_cli_windows_amd64.tar.gz
dist/databricks_cli_windows_amd64.zip
dist/databricks_cli_windows_arm64.tar.gz
dist/databricks_cli_windows_arm64.zip
```