### PR TITLE
Add support for dashboards in deployment bind/unbind commands

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,7 +5,7 @@
 ### CLI
 
 ### Bundles
-* Add support for dashboards in deployment bind/unbind commands
+* Add support for dashboards in deployment bind/unbind commands ([#2516](https://github.com/databricks/cli/pull/2516))
 
 * Processing 'artifacts' section is now done in "bundle validate" (adding defaults, inferring "build", asserting required fields) ([#2526])(https://github.com/databricks/cli/pull/2526))
 * When uploading artifacts, include relative path in log message ([#2539])(https://github.com/databricks/cli/pull/2539))

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,11 +5,10 @@
 ### CLI
 
 ### Bundles
-* Add support for dashboards in deployment bind/unbind commands ([#2516](https://github.com/databricks/cli/pull/2516))
-
 * Processing 'artifacts' section is now done in "bundle validate" (adding defaults, inferring "build", asserting required fields) ([#2526])(https://github.com/databricks/cli/pull/2526))
 * When uploading artifacts, include relative path in log message ([#2539])(https://github.com/databricks/cli/pull/2539))
 * Added support for clusters in deployment bind/unbind commands ([#2536](https://github.com/databricks/cli/pull/2536))
 * Added support for volumes in deployment bind/unbind commands ([#2527](https://github.com/databricks/cli/pull/2527))
+* Added support for dashboards in deployment bind/unbind commands ([#2516](https://github.com/databricks/cli/pull/2516))
 
 ### API Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### CLI
 
 ### Bundles
+* Add support for dashboards in deployment bind/unbind commands
 
 * Processing 'artifacts' section is now done in "bundle validate" (adding defaults, inferring "build", asserting required fields) ([#2526])(https://github.com/databricks/cli/pull/2526))
 * When uploading artifacts, include relative path in log message ([#2539])(https://github.com/databricks/cli/pull/2539))

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -80,7 +80,11 @@ var Ignored = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
-	testAccept(t, InprocessMode, "")
+	testAccept(t, InprocessMode, "bundle/deployment/bind/dashboard")
+}
+
+func TestAcceptLocal(t *testing.T) {
+	testAccept(t, InprocessMode, "bundle/deployment/bind/dashboard")
 }
 
 func TestInprocessMode(t *testing.T) {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -80,11 +80,7 @@ var Ignored = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
-	testAccept(t, InprocessMode, "bundle/deployment/bind/dashboard")
-}
-
-func TestAcceptLocal(t *testing.T) {
-	testAccept(t, InprocessMode, "bundle/deployment/bind/dashboard")
+	testAccept(t, InprocessMode, "")
 }
 
 func TestInprocessMode(t *testing.T) {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -290,6 +290,10 @@ func getSkipReason(config *internal.TestConfig, configPath string) string {
 			return fmt.Sprintf("Disabled via RequiresUnityCatalog setting in %s (TEST_METASTORE_ID=%s)", configPath, os.Getenv("TEST_METASTORE_ID"))
 		}
 
+		if isTruePtr(config.RequiresWarehouse) && os.Getenv("TEST_DEFAULT_WAREHOUSE_ID") == "" {
+			return fmt.Sprintf("Disabled via RequiresWarehouse setting in %s (TEST_DEFAULT_WAREHOUSE_ID=%s)", configPath, os.Getenv("TEST_DEFAULT_WAREHOUSE_ID"))
+		}
+
 		if isTruePtr(config.RequiresCluster) && os.Getenv("TEST_DEFAULT_CLUSTER_ID") == "" {
 			return fmt.Sprintf("Disabled via RequiresCluster setting in %s (TEST_DEFAULT_CLUSTER_ID=%s)", configPath, os.Getenv("TEST_DEFAULT_CLUSTER_ID"))
 		}

--- a/acceptance/bundle/deployment/bind/dashboard/databricks.yml
+++ b/acceptance/bundle/deployment/bind/dashboard/databricks.yml
@@ -7,6 +7,6 @@ resources:
       display_name: $DASHBOARD_DISPLAY_NAME
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
       embed_credentials: true
-      serialized_dashboard: '{"pages":[{"name":"02724bf2","displayName":"Page 1"}]}'
+      file_path: "sample-dashboard.lvdash.json"
       parent_path: /Users/$CURRENT_USER_NAME
 

--- a/acceptance/bundle/deployment/bind/dashboard/databricks.yml
+++ b/acceptance/bundle/deployment/bind/dashboard/databricks.yml
@@ -1,0 +1,12 @@
+bundle:
+  name: bind-dashboard-test-$BUNDLE_NAME_SUFFIX
+
+resources:
+  dashboards:
+    dashboard1:
+      display_name: $DASHBOARD_DISPLAY_NAME
+      warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
+      embed_credentials: true
+      serialized_dashboard: '{"pages":[{"name":"02724bf2","displayName":"Page 1"}]}'
+      parent_path: /Users/$CURRENT_USER_NAME
+

--- a/acceptance/bundle/deployment/bind/dashboard/databricks.yml.tmpl
+++ b/acceptance/bundle/deployment/bind/dashboard/databricks.yml.tmpl
@@ -1,5 +1,5 @@
 bundle:
-  name: bind-dashboard-test-$BUNDLE_NAME_SUFFIX
+  name: bind-dashboard-test-$UNIQUE_NAME
 
 resources:
   dashboards:

--- a/acceptance/bundle/deployment/bind/dashboard/output.txt
+++ b/acceptance/bundle/deployment/bind/dashboard/output.txt
@@ -1,5 +1,4 @@
 
-=== Create a pre-defined dashboard: 
 >>> [CLI] bundle deployment bind dashboard1 [DASHBOARD_ID] --auto-approve
 Updating deployment state...
 Successfully bound databricks_dashboard with an id '[DASHBOARD_ID]'. Run 'bundle deploy' to deploy changes to your workspace

--- a/acceptance/bundle/deployment/bind/dashboard/output.txt
+++ b/acceptance/bundle/deployment/bind/dashboard/output.txt
@@ -1,16 +1,17 @@
 
-=== Bind dashboard test: 
-=== Substitute variables in the template: 
 === Create a pre-defined dashboard: 
-=== Bind dashboard: Updating deployment state...
+>>> [CLI] bundle deployment bind dashboard1 [DASHBOARD_ID] --auto-approve
+Updating deployment state...
 Successfully bound databricks_dashboard with an id '[DASHBOARD_ID]'. Run 'bundle deploy' to deploy changes to your workspace
 
-=== Deploy bundle: Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-test-[UUID]/default/files...
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-test-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
 
-=== Read the pre-defined dashboard: {
+>>> [CLI] lakeview get [DASHBOARD_ID]
+{
   "display_name": "test dashboard [UUID]",
   "lifecycle_state": "ACTIVE",
   "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
@@ -18,20 +19,20 @@ Deployment complete!
   "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page One\"}]}"
 }
 
-=== Unbind the dashboard: Updating deployment state...
+>>> [CLI] bundle deployment unbind dashboard1
+Updating deployment state...
 
-=== Destroy the bundle: All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-test-[UUID]/default
+>>> [CLI] bundle destroy --auto-approve
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-test-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!
 
-=== Read the pre-defined dashboard again (expecting it still exists and is not deleted): {
+>>> [CLI] lakeview get [DASHBOARD_ID]
+{
   "display_name": "test dashboard [UUID]",
   "lifecycle_state": "ACTIVE",
   "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
   "parent_path": "/Users/[USERNAME]",
   "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page One\"}]}"
 }
-
-=== Test cleanup: 
-=== Delete the pre-defined dashboard [DASHBOARD_ID]: 0

--- a/acceptance/bundle/deployment/bind/dashboard/output.txt
+++ b/acceptance/bundle/deployment/bind/dashboard/output.txt
@@ -15,7 +15,7 @@ Deployment complete!
   "lifecycle_state": "ACTIVE",
   "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
   "parent_path": "/Users/[USERNAME]",
-  "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page 1\"}]}"
+  "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page One\"}]}"
 }
 
 === Unbind the dashboard: Updating deployment state...
@@ -30,7 +30,7 @@ Destroy complete!
   "lifecycle_state": "ACTIVE",
   "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
   "parent_path": "/Users/[USERNAME]",
-  "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page 1\"}]}"
+  "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page One\"}]}"
 }
 
 === Test cleanup: 

--- a/acceptance/bundle/deployment/bind/dashboard/output.txt
+++ b/acceptance/bundle/deployment/bind/dashboard/output.txt
@@ -1,0 +1,37 @@
+
+=== Bind dashboard test: 
+=== Substitute variables in the template: 
+=== Create a pre-defined dashboard: 
+=== Bind dashboard: Updating deployment state...
+Successfully bound databricks_dashboard with an id '[DASHBOARD_ID]'. Run 'bundle deploy' to deploy changes to your workspace
+
+=== Deploy bundle: Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-test-[UUID]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Read the pre-defined dashboard: {
+  "display_name": "test dashboard [UUID]",
+  "lifecycle_state": "ACTIVE",
+  "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
+  "parent_path": "/Users/[USERNAME]",
+  "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page 1\"}]}"
+}
+
+=== Unbind the dashboard: Updating deployment state...
+
+=== Destroy the bundle: All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-test-[UUID]/default
+
+Deleting files...
+Destroy complete!
+
+=== Read the pre-defined dashboard again (expecting it still exists and is not deleted): {
+  "display_name": "test dashboard [UUID]",
+  "lifecycle_state": "ACTIVE",
+  "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
+  "parent_path": "/Users/[USERNAME]",
+  "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page 1\"}]}"
+}
+
+=== Test cleanup: 
+=== Delete the pre-defined dashboard [DASHBOARD_ID]: 0

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/databricks.yml.tmpl
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/databricks.yml.tmpl
@@ -1,0 +1,11 @@
+bundle:
+  name: bind-dashboard-recreation-test-$UNIQUE_NAME
+
+resources:
+  dashboards:
+    dashboard1:
+      display_name: $DASHBOARD_DISPLAY_NAME
+      warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
+      embed_credentials: true
+      file_path: "sample-dashboard.lvdash.json"
+

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/output.txt
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/output.txt
@@ -1,0 +1,30 @@
+
+>>> [CLI] bundle deployment bind dashboard1 [DASHBOARD_ID] --auto-approve
+Updating deployment state...
+Successfully bound databricks_dashboard with an id '[DASHBOARD_ID]'. Run 'bundle deploy' to deploy changes to your workspace
+
+>>> errcode [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-recreation-test-[UNIQUE_NAME]/default/files...
+
+This action will result in the deletion or recreation of the following dashboards.
+This will result in changed IDs and permanent URLs of the dashboards that will be recreated:
+  recreate dashboard dashboard1
+Error: the deployment requires destructive actions, but current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed
+
+
+Exit code: 1
+
+>>> [CLI] bundle deployment unbind dashboard1
+Updating deployment state...
+
+>>> [CLI] bundle deploy --auto-approve
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/bind-dashboard-recreation-test-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] lakeview get [DASHBOARD_ID]
+{
+  "display_name": "test dashboard [UUID]",
+  "lifecycle_state": "ACTIVE"
+}

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/sample-dashboard.lvdash.json
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/sample-dashboard.lvdash.json
@@ -1,0 +1,1 @@
+{"pages":[{"name":"02724bf2","displayName":"Page One"}]}

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/script
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/script
@@ -17,13 +17,13 @@ trap cleanupRemoveDashboard EXIT
 
 trace $CLI bundle deployment bind dashboard1 "${DASHBOARD_ID}" --auto-approve
 
-trace $CLI bundle deploy
-
-trace $CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'
+trace errcode $CLI bundle deploy
 
 trace $CLI bundle deployment unbind dashboard1
 
-trace $CLI bundle destroy --auto-approve
+trace $CLI bundle deploy --auto-approve
 
-# Read the pre-defined dashboard again (expecting it still exists and is not deleted):
-trace $CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'
+trace $CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state}'
+
+
+

--- a/acceptance/bundle/deployment/bind/dashboard/sample-dashboard.lvdash.json
+++ b/acceptance/bundle/deployment/bind/dashboard/sample-dashboard.lvdash.json
@@ -1,0 +1,1 @@
+{"pages":[{"name":"02724bf2","displayName":"Page One"}]}

--- a/acceptance/bundle/deployment/bind/dashboard/script
+++ b/acceptance/bundle/deployment/bind/dashboard/script
@@ -1,9 +1,3 @@
-title "Bind dashboard test: "
-
-title "Substitute variables in the template: "
-BUNDLE_NAME_SUFFIX=$(uuid)
-export BUNDLE_NAME_SUFFIX
-
 DASHBOARD_DISPLAY_NAME="test dashboard $(uuid)"
 if [ -z "$CLOUD_ENV" ]; then
     DASHBOARD_DISPLAY_NAME="test dashboard 6260d50f-e8ff-4905-8f28-812345678903"   # use hard-coded uuid when running locally
@@ -11,33 +5,25 @@ if [ -z "$CLOUD_ENV" ]; then
 fi
 
 export DASHBOARD_DISPLAY_NAME
-envsubst < databricks.yml > out.yml && mv out.yml databricks.yml
+envsubst < databricks.yml.tmpl > databricks.yml
 
 title "Create a pre-defined dashboard: "
 DASHBOARD_ID=$($CLI lakeview create --display-name "${DASHBOARD_DISPLAY_NAME}" --warehouse-id "${TEST_DEFAULT_WAREHOUSE_ID}" --serialized-dashboard '{"pages":[{"name":"02724bf2","displayName":"Untitled page"}]}' | jq -r '.dashboard_id')
 
 cleanupRemoveDashboard() {
-    title "Test cleanup: "
-    title "Delete the pre-defined dashboard ${DASHBOARD_ID}: "
     $CLI lakeview trash "${DASHBOARD_ID}"
-    echo $?
 }
 trap cleanupRemoveDashboard EXIT
 
-title "Bind dashboard: "
-$CLI bundle deployment bind dashboard1 "${DASHBOARD_ID}" --auto-approve
+trace $CLI bundle deployment bind dashboard1 "${DASHBOARD_ID}" --auto-approve
 
-title "Deploy bundle: "
-$CLI bundle deploy
+trace $CLI bundle deploy
 
-title "Read the pre-defined dashboard: "
-$CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'
+trace $CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'
 
-title "Unbind the dashboard: "
-$CLI bundle deployment unbind dashboard1
+trace $CLI bundle deployment unbind dashboard1
 
-title "Destroy the bundle: "
-$CLI bundle destroy --auto-approve
+trace $CLI bundle destroy --auto-approve
 
-title "Read the pre-defined dashboard again (expecting it still exists and is not deleted): "
-$CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'
+# Read the pre-defined dashboard again (expecting it still exists and is not deleted):
+trace $CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'

--- a/acceptance/bundle/deployment/bind/dashboard/script
+++ b/acceptance/bundle/deployment/bind/dashboard/script
@@ -1,0 +1,43 @@
+title "Bind dashboard test: "
+
+title "Substitute variables in the template: "
+BUNDLE_NAME_SUFFIX=$(uuid)
+export BUNDLE_NAME_SUFFIX
+
+DASHBOARD_DISPLAY_NAME="test dashboard $(uuid)"
+if [ -z "$CLOUD_ENV" ]; then
+    DASHBOARD_DISPLAY_NAME="test dashboard 6260d50f-e8ff-4905-8f28-812345678903"   # use hard-coded uuid when running locally
+    export TEST_DEFAULT_WAREHOUSE_ID="warehouse-1234"
+fi
+
+export DASHBOARD_DISPLAY_NAME
+envsubst < databricks.yml > out.yml && mv out.yml databricks.yml
+
+title "Create a pre-defined dashboard: "
+DASHBOARD_ID=$($CLI lakeview create --display-name "${DASHBOARD_DISPLAY_NAME}" --warehouse-id "${TEST_DEFAULT_WAREHOUSE_ID}" --serialized-dashboard '{"pages":[{"name":"02724bf2","displayName":"Untitled page"}]}' | jq -r '.dashboard_id')
+
+cleanupRemoveDashboard() {
+    title "Test cleanup: "
+    title "Delete the pre-defined dashboard ${DASHBOARD_ID}: "
+    $CLI lakeview trash "${DASHBOARD_ID}"
+    echo $?
+}
+trap cleanupRemoveDashboard EXIT
+
+title "Bind dashboard: "
+$CLI bundle deployment bind dashboard1 "${DASHBOARD_ID}" --auto-approve
+
+title "Deploy bundle: "
+$CLI bundle deploy
+
+title "Read the pre-defined dashboard: "
+$CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'
+
+title "Unbind the dashboard: "
+$CLI bundle deployment unbind dashboard1
+
+title "Destroy the bundle: "
+$CLI bundle destroy --auto-approve
+
+title "Read the pre-defined dashboard again (expecting it still exists and is not deleted): "
+$CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name, lifecycle_state, path, parent_path, serialized_dashboard}'

--- a/acceptance/bundle/deployment/bind/dashboard/test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+Ignore = [
+    "databricks.yml",
+]
+
 [[Repls]]
 Old = "[0-9a-f]{32}"
 New = "[DASHBOARD_ID]"

--- a/acceptance/bundle/deployment/bind/dashboard/test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/test.toml
@@ -26,7 +26,7 @@ Response.Body = '''
     "lifecycle_state": "ACTIVE",
     "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
     "parent_path": "/Users/[USERNAME]",
-    "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page 1\"}]}"
+    "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page One\"}]}"
 }
 '''
 

--- a/acceptance/bundle/deployment/bind/dashboard/test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/test.toml
@@ -22,6 +22,9 @@ Response.Body = '''
 Pattern = "POST /api/2.0/lakeview/dashboards/{dashboard_id}/published"
 
 [[Server]]
+Pattern = "PATCH /api/2.0/lakeview/dashboards/{dashboard_id}"
+
+[[Server]]
 Pattern = "GET /api/2.0/lakeview/dashboards/{dashboard_id}"
 Response.Body = '''
 {
@@ -29,7 +32,7 @@ Response.Body = '''
     "display_name": "test dashboard 6260d50f-e8ff-4905-8f28-812345678903",
     "lifecycle_state": "ACTIVE",
     "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
-    "parent_path": "/Users/[USERNAME]",
+    "parent_path": "/Users/tester@databricks.com",
     "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page One\"}]}"
 }
 '''

--- a/acceptance/bundle/deployment/bind/dashboard/test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/test.toml
@@ -1,0 +1,34 @@
+Local = true
+Cloud = true
+RequiresWarehouse = true
+
+[[Repls]]
+Old = "[0-9a-f]{32}"
+New = "[DASHBOARD_ID]"
+
+[[Server]]
+Pattern = "POST /api/2.0/lakeview/dashboards"
+Response.Body = '''
+{
+    "dashboard_id":"1234567890abcdef1234567890abcdef"
+}
+'''
+
+[[Server]]
+Pattern = "POST /api/2.0/lakeview/dashboards/{dashboard_id}/published"
+
+[[Server]]
+Pattern = "GET /api/2.0/lakeview/dashboards/{dashboard_id}"
+Response.Body = '''
+{
+    "dashboard_id":"1234567890abcdef1234567890abcdef",
+    "display_name": "test dashboard 6260d50f-e8ff-4905-8f28-812345678903",
+    "lifecycle_state": "ACTIVE",
+    "path": "/Users/[USERNAME]/test dashboard [UUID].lvdash.json",
+    "parent_path": "/Users/[USERNAME]",
+    "serialized_dashboard": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Page 1\"}]}"
+}
+'''
+
+[[Server]]
+Pattern = "DELETE /api/2.0/lakeview/dashboards/{dashboard_id}"

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -42,6 +42,9 @@ type TestConfig struct {
 	// If true and Cloud=true, run this test only if a default test cluster is available in the cloud environment
 	RequiresCluster *bool
 
+	// If true and Cloud=true, run this test only if a default warehouse is available in the cloud environment
+	RequiresWarehouse *bool
+
 	// List of additional replacements to apply on this test.
 	// Old is a regexp, New is a replacement expression.
 	Repls []testdiff.Replacement

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -136,6 +136,12 @@ func (r *Resources) FindResourceByConfigKey(key string) (ConfigResource, error) 
 		}
 	}
 
+	for k := range r.Dashboards {
+		if k == key {
+			found = append(found, r.Dashboards[k])
+		}
+	}
+
 	if len(found) == 0 {
 		return nil, fmt.Errorf("no such resource: %s", key)
 	}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -69,9 +69,10 @@ func approvalForDeploy(ctx context.Context, b *bundle.Bundle) (bool, error) {
 	schemaActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_schema")
 	dltActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_pipeline")
 	volumeActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_volume")
+	dashboardActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_dashboard")
 
 	// We don't need to display any prompts in this case.
-	if len(schemaActions) == 0 && len(dltActions) == 0 && len(volumeActions) == 0 {
+	if len(schemaActions) == 0 && len(dltActions) == 0 && len(volumeActions) == 0 && len(dashboardActions) == 0 {
 		return true, nil
 	}
 
@@ -105,6 +106,17 @@ cloud tenant within 30 days. For external volumes, the metadata about the volume
 is removed from the catalog, but the underlying files are not deleted:`
 		cmdio.LogString(ctx, msg)
 		for _, action := range volumeActions {
+			cmdio.Log(ctx, action)
+		}
+	}
+
+	// One or more dashboards is being recreated.
+	if len(dashboardActions) != 0 {
+		msg := `
+This action will result in the deletion or recreation of the following dashboards.
+This will result in changed IDs and permanent URLs of the dashboards that will be recreated:`
+		cmdio.LogString(ctx, msg)
+		for _, action := range dashboardActions {
 			cmdio.Log(ctx, action)
 		}
 	}


### PR DESCRIPTION
## Changes
1. Changed `FindResourceByConfigKey` to return dashboard resources
2. Changed deploy phase to detect dashboard recreation and request user's approval before deploying

## Why
This PR adds support for dashboard resources in deployment operations, enabling users to:
- Bind experiments using `databricks bundle deployment bind <mydashboard_key> <mydashboard_id>`
- Unbind experiments using `databricks bundle deployment unbind <mydashboard_key>`

Where:
- `mydashboard_key` is a resource key defined in the bundle's .yml file
- `mydashboard_id` references an existing dashboard in the Databricks workspace

These capabilities allow for more flexible resource management of dashboards within bundles.

## Tests
Added two new acceptance tests that tests bind and unbind methods together with bundle deployment and destruction, including a case of dashboard recreation
