### PR TITLE
Fix patchwheel.ParseWheelFilename to extract basename

### DIFF
--- a/libs/patchwheel/parse.go
+++ b/libs/patchwheel/parse.go
@@ -2,7 +2,7 @@ package patchwheel
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -40,7 +40,7 @@ func calculateNewVersion(info WheelInfo, mtime time.Time) (newVersion, newFilena
 // The function does not try hard to validate if the format is correct, it tries to parse whatever is available.
 // However, it does require 5 or 6 components in the filename.
 func ParseWheelFilename(filename string) (WheelInfo, error) {
-	filename = path.Base(filename)
+	filename = filepath.Base(filename)
 	parts := strings.Split(filename, "-")
 	if len(parts) < 5 {
 		return WheelInfo{}, fmt.Errorf("invalid wheel filename format: not enough parts in %s", filename)

--- a/libs/patchwheel/parse.go
+++ b/libs/patchwheel/parse.go
@@ -2,6 +2,7 @@ package patchwheel
 
 import (
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,7 @@ func calculateNewVersion(info WheelInfo, mtime time.Time) (newVersion, newFilena
 // The function does not try hard to validate if the format is correct, it tries to parse whatever is available.
 // However, it does require 5 or 6 components in the filename.
 func ParseWheelFilename(filename string) (WheelInfo, error) {
+	filename = path.Base(filename)
 	parts := strings.Split(filename, "-")
 	if len(parts) < 5 {
 		return WheelInfo{}, fmt.Errorf("invalid wheel filename format: not enough parts in %s", filename)

--- a/libs/patchwheel/parse_test.go
+++ b/libs/patchwheel/parse_test.go
@@ -265,18 +265,26 @@ func TestParseWheelFilename(t *testing.T) {
 		},
 	}
 
+	prefixes := []string{
+		"",
+		"./",
+		"hello/world/",
+	}
+
 	for _, tt := range tests {
-		t.Run(tt.filename, func(t *testing.T) {
-			info, err := ParseWheelFilename(tt.filename)
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.wantDistribution, info.Distribution, "distribution mismatch")
-				require.Equal(t, tt.wantVersion, info.Version, "version mismatch")
-				require.Equal(t, tt.wantTags, info.Tags, "tags mismatch")
-			}
-		})
+		for _, prefix := range prefixes {
+			t.Run(prefix+tt.filename, func(t *testing.T) {
+				info, err := ParseWheelFilename(tt.filename)
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.wantDistribution, info.Distribution, "distribution mismatch")
+					require.Equal(t, tt.wantVersion, info.Version, "version mismatch")
+					require.Equal(t, tt.wantTags, info.Tags, "tags mismatch")
+				}
+			})
+		}
 	}
 }
 

--- a/libs/patchwheel/parse_test.go
+++ b/libs/patchwheel/parse_test.go
@@ -79,6 +79,13 @@ func TestParseWheelFilename(t *testing.T) {
 			wantErr:          false,
 		},
 		{
+			filename:         "./myproj-0.1.0-py3-none-any.whl",
+			wantDistribution: "myproj",
+			wantVersion:      "0.1.0",
+			wantTags:         []string{"py3", "none", "any"},
+			wantErr:          false,
+		},
+		{
 			filename:         "myproj-0.1.0+20240303123456-py3-none-any.whl",
 			wantDistribution: "myproj",
 			wantVersion:      "0.1.0+20240303123456",
@@ -89,6 +96,13 @@ func TestParseWheelFilename(t *testing.T) {
 			filename:         "my_proj_with_parts-0.1.0-py3-none-any.whl",
 			wantDistribution: "my_proj_with_parts",
 			wantVersion:      "0.1.0",
+			wantTags:         []string{"py3", "none", "any"},
+			wantErr:          false,
+		},
+		{
+			filename:         "subdir/myproj-0.1.0+20240303123456-py3-none-any.whl",
+			wantDistribution: "myproj",
+			wantVersion:      "0.1.0+20240303123456",
 			wantTags:         []string{"py3", "none", "any"},
 			wantErr:          false,
 		},
@@ -265,26 +279,18 @@ func TestParseWheelFilename(t *testing.T) {
 		},
 	}
 
-	prefixes := []string{
-		"",
-		"./",
-		"hello/world/",
-	}
-
 	for _, tt := range tests {
-		for _, prefix := range prefixes {
-			t.Run(prefix+tt.filename, func(t *testing.T) {
-				info, err := ParseWheelFilename(tt.filename)
-				if tt.wantErr {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-					require.Equal(t, tt.wantDistribution, info.Distribution, "distribution mismatch")
-					require.Equal(t, tt.wantVersion, info.Version, "version mismatch")
-					require.Equal(t, tt.wantTags, info.Tags, "tags mismatch")
-				}
-			})
-		}
+		t.Run(tt.filename, func(t *testing.T) {
+			info, err := ParseWheelFilename(tt.filename)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantDistribution, info.Distribution, "distribution mismatch")
+				require.Equal(t, tt.wantVersion, info.Version, "version mismatch")
+				require.Equal(t, tt.wantTags, info.Tags, "tags mismatch")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why
This is a minor change but makes it easier to use, no need to remember doing this on the caller side.
Relying on this in #2520
Follow up to #2427

## Tests
New unit tests.