### PR TITLE
Support all version identifiers as per PEP440 in environment deps

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,9 +6,9 @@
 * Fixed "can't evaluate field Name in type interface{}" for "databricks queries list" command ([#2451](https://github.com/databricks/cli/pull/2451))
 * Fixed `query-history list` command failing with 'executing "command" at <.>: range cant iterate over' ([#2506](https://github.com/databricks/cli/pull/2506))
 * Include tarballs in releases ([#2515](https://github.com/databricks/cli/pull/2515))
-* Support all version identifiers as per PEP440 in environment deps ([#2522](https://github.com/databricks/cli/pull/2522))
 
 ### Bundles
+* Support all version identifiers as per PEP440 in environment deps ([#2522](https://github.com/databricks/cli/pull/2522))
 
 ### API Changes
 * Added `databricks genie execute-message-attachment-query` command.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed "can't evaluate field Name in type interface{}" for "databricks queries list" command ([#2451](https://github.com/databricks/cli/pull/2451))
 * Fixed `query-history list` command failing with 'executing "command" at <.>: range cant iterate over' ([#2506](https://github.com/databricks/cli/pull/2506))
 * Include tarballs in releases ([#2515](https://github.com/databricks/cli/pull/2515))
+* Support all version identifiers as per PEP440 in environment deps ([#2522](https://github.com/databricks/cli/pull/2522))
 
 ### Bundles
 

--- a/bundle/libraries/local_path.go
+++ b/bundle/libraries/local_path.go
@@ -1,6 +1,7 @@
 package libraries
 
 import (
+	"fmt"
 	"net/url"
 	"path"
 	"regexp"
@@ -81,13 +82,17 @@ func containsPipFlag(input string) bool {
 	return re.MatchString(input)
 }
 
+// pep440Regex is a regular expression that matches PEP 440 version specifiers.
+// https://peps.python.org/pep-0440/#public-version-identifiers
+const pep440Regex = `(?P<epoch>\d+!)?(?P<release>\d+(\.\d+)*)(?P<pre>[-_.]?(a|b|rc)\d+)?(?P<post>[-_.]?post\d+)?(?P<dev>[-_.]?dev\d+)?(?P<local>\+[a-zA-Z0-9]+([-_.][a-zA-Z0-9]+)*)?`
+
 // ^[a-zA-Z0-9\-_]+: Matches the package name, allowing alphanumeric characters, dashes (-), and underscores (_).
 // \[.*\])?: Optionally matches any extras specified in square brackets, e.g., [security].
-// ((==|!=|<=|>=|~=|>|<)\d+(\.\d+){0,2}(\.\*)?): Optionally matches version specifiers, supporting various operators (==, !=, etc.) followed by a version number (e.g., 2.25.1).
+// ((==|!=|<=|>=|~=|>|<)\s?pep440Regex): Optionally matches version specifiers, supporting various operators (==, !=, etc.) followed by a version number as per PEP440 spec.
 // ,?: Optionally matches a comma (,) at the end of the specifier which is used to separate multiple specifiers.
 // There can be multiple version specifiers separated by commas or no specifiers.
 // Spec for package name and version specifier: https://pip.pypa.io/en/stable/reference/requirement-specifiers/
-var packageRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?\d+(\.\d+){0,2}(\.\*)?,?)*$`)
+var packageRegex = regexp.MustCompile(fmt.Sprintf(`^[a-zA-Z0-9\-_]+\s?(\[.*\])?\s?((==|!=|<=|>=|~=|==|>|<)\s?%s,?)*$`, pep440Regex))
 
 func isPackage(name string) bool {
 	if packageRegex.MatchString(name) {

--- a/bundle/libraries/local_path_test.go
+++ b/bundle/libraries/local_path_test.go
@@ -56,7 +56,19 @@ func TestIsLibraryLocal(t *testing.T) {
 		{path: "s3://mybucket/path/to/package", expected: false},
 		{path: "dbfs:/mnt/path/to/package", expected: false},
 		{path: "beautifulsoup4", expected: false},
+
+		// Check the possible version specifiers as in PEP 440
+		// https://peps.python.org/pep-0440/#public-version-identifiers
+		{path: "beautifulsoup4==4", expected: false},
+		{path: "beautifulsoup4==4.12", expected: false},
 		{path: "beautifulsoup4==4.12.3", expected: false},
+		{path: "beautifulsoup4==4.12.3.dev1", expected: false},
+		{path: "beautifulsoup4==4.12.3.a1", expected: false},
+		{path: "beautifulsoup4==4.12.3.rc2", expected: false},
+		{path: "beautifulsoup4==4.12.3.rc2.dev1", expected: false},
+		{path: "beautifulsoup4==4.12.3+abc.5", expected: false},
+		{path: "beautifulsoup4==1!4.12.3", expected: false},
+
 		{path: "beautifulsoup4 >= 4.12.3", expected: false},
 		{path: "beautifulsoup4 < 4.12.3", expected: false},
 		{path: "beautifulsoup4 ~= 4.12.3", expected: false},
@@ -64,6 +76,7 @@ func TestIsLibraryLocal(t *testing.T) {
 		{path: "beautifulsoup4[security, tests] ~= 4.12.3", expected: false},
 		{path: "beautifulsoup4>=1.0.0,<2.0.0", expected: false},
 		{path: "beautifulsoup4>=1.0.0,~=1.2.0,<2.0.0", expected: false},
+		{path: "beautifulsoup4>=1.0.0+abc.5,~=1.2.0.rc2.dev1,<2.0.0.a1", expected: false},
 		{path: "https://github.com/pypa/pip/archive/22.0.2.zip", expected: false},
 		{path: "pip @ https://github.com/pypa/pip/archive/22.0.2.zip", expected: false},
 		{path: "requests [security] @ https://github.com/psf/requests/archive/refs/heads/main.zip", expected: false},


### PR DESCRIPTION
## Changes
Support all version identifiers as per PEP440 in environment deps

## Why
Some customers define their libraries dependencies like below and this should be supported by DABs

```
 dependencies:
     - my_package==1.2.3.dev1
 ```

## Tests
Added unit test to cover all the cases

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
