### PR TITLE
Assert command exec id is correctly set

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -80,7 +80,7 @@ var Ignored = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
-	testAccept(t, InprocessMode, "telemetry/success")
+	testAccept(t, InprocessMode, "")
 }
 
 func TestInprocessMode(t *testing.T) {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -80,7 +80,7 @@ var Ignored = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
-	testAccept(t, InprocessMode, "")
+	testAccept(t, InprocessMode, "telemetry/success")
 }
 
 func TestInprocessMode(t *testing.T) {
@@ -366,13 +366,11 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 					reqJson, err := json.MarshalIndent(req, "", "  ")
 					assert.NoErrorf(t, err, "Failed to indent: %#v", req)
 
-					reqJsonWithRepls := repls.Replace(string(reqJson))
-
 					f, err := os.OpenFile(requestsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 					assert.NoError(t, err)
 					defer f.Close()
 
-					_, err = f.WriteString(reqJsonWithRepls + "\n")
+					_, err = f.WriteString(string(reqJson) + "\n")
 					assert.NoError(t, err)
 				}
 			}

--- a/acceptance/bundle/apps/app_yaml/script
+++ b/acceptance/bundle/apps/app_yaml/script
@@ -1,4 +1,4 @@
 trace $CLI bundle validate
 trace $CLI bundle deploy
-jq 'select(.path == "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/apps_yaml/default/files/app/app.yml")' out.requests.txt | sed 's/\\r//g'  > out.app.yml.txt
+jq 'select(.path | test("/api/2.0/workspace-files/import-file/Workspace/Users/.*/.bundle/apps_yaml/default/files/app/app.yml"))' out.requests.txt | sed 's/\\r//g'  > out.app.yml.txt
 rm out.requests.txt

--- a/acceptance/bundle/apps/config_section/script
+++ b/acceptance/bundle/apps/config_section/script
@@ -1,4 +1,4 @@
 trace $CLI bundle validate
 trace $CLI bundle deploy
-jq 'select(.path == "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/apps_config_section/default/files/app/app.yml")' out.requests.txt  > out.app.yml.txt
+jq 'select(.path | test("/api/2.0/workspace-files/import-file/Workspace/Users/.*/.bundle/apps_config_section/default/files/app/app.yml"))' out.requests.txt  > out.app.yml.txt
 rm out.requests.txt

--- a/acceptance/bundle/state/script
+++ b/acceptance/bundle/state/script
@@ -1,4 +1,4 @@
 trace $CLI bundle deploy
 trace $CLI bundle deploy # We do 2 deploys because only 2nd deploy will pull state from remote after 1st created it
-jq 'select(.path == "/api/2.0/workspace-files/Workspace/Users/[USERNAME]/.bundle/state/default/state/terraform.tfstate")' out.requests.txt > out.state.txt
+jq 'select(.path | test("/api/2.0/workspace-files/Workspace/Users/.*/.bundle/state/default/state/terraform.tfstate"))' out.requests.txt > out.state.txt
 rm out.requests.txt

--- a/acceptance/telemetry/success/out.requests.txt
+++ b/acceptance/telemetry/success/out.requests.txt
@@ -18,15 +18,3 @@
     ]
   }
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ],
-    "User-Agent": [
-      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/current-user_me cmd-exec-id/[CMD-EXEC-ID] auth/pat"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/preview/scim/v2/Me"
-}

--- a/acceptance/telemetry/success/out.requests.txt
+++ b/acceptance/telemetry/success/out.requests.txt
@@ -18,3 +18,15 @@
     ]
   }
 }
+{
+  "headers": {
+    "Authorization": [
+      "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "User-Agent": [
+      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/current-user_me cmd-exec-id/[CMD-EXEC-ID] auth/pat"
+    ]
+  },
+  "method": "GET",
+  "path": "/api/2.0/preview/scim/v2/Me"
+}

--- a/acceptance/telemetry/success/out.requests.txt
+++ b/acceptance/telemetry/success/out.requests.txt
@@ -2,6 +2,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "User-Agent": [
+      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/selftest_send-telemetry cmd-exec-id/[CMD-EXEC-ID] auth/pat"
     ]
   },
   "method": "POST",
@@ -10,8 +13,8 @@
     "uploadTime": "UNIX_TIME_MILLIS",
     "items": [],
     "protoLogs": [
-      "{\"frontend_log_event_id\":\"[UUID]\",\"entry\":{\"databricks_cli_log\":{\"execution_context\":{\"cmd_exec_id\":\"[UUID]\",\"version\":\"[DEV_VERSION]\",\"command\":\"selftest_send-telemetry\",\"operating_system\":\"[OS]\",\"execution_time_ms\":\"SMALL_INT\",\"exit_code\":0},\"cli_test_event\":{\"name\":\"VALUE1\"}}}}",
-      "{\"frontend_log_event_id\":\"[UUID]\",\"entry\":{\"databricks_cli_log\":{\"execution_context\":{\"cmd_exec_id\":\"[UUID]\",\"version\":\"[DEV_VERSION]\",\"command\":\"selftest_send-telemetry\",\"operating_system\":\"[OS]\",\"execution_time_ms\":\"SMALL_INT\",\"exit_code\":0},\"cli_test_event\":{\"name\":\"VALUE2\"}}}}"
+      "{\"frontend_log_event_id\":\"[UUID]\",\"entry\":{\"databricks_cli_log\":{\"execution_context\":{\"cmd_exec_id\":\"[CMD-EXEC-ID]\",\"version\":\"[DEV_VERSION]\",\"command\":\"selftest_send-telemetry\",\"operating_system\":\"[OS]\",\"execution_time_ms\":\"SMALL_INT\",\"exit_code\":0},\"cli_test_event\":{\"name\":\"VALUE1\"}}}}",
+      "{\"frontend_log_event_id\":\"[UUID]\",\"entry\":{\"databricks_cli_log\":{\"execution_context\":{\"cmd_exec_id\":\"[CMD-EXEC-ID]\",\"version\":\"[DEV_VERSION]\",\"command\":\"selftest_send-telemetry\",\"operating_system\":\"[OS]\",\"execution_time_ms\":\"SMALL_INT\",\"exit_code\":0},\"cli_test_event\":{\"name\":\"VALUE2\"}}}}"
     ]
   }
 }

--- a/acceptance/telemetry/success/output.txt
+++ b/acceptance/telemetry/success/output.txt
@@ -17,3 +17,9 @@ HH:MM:SS Debug: POST /telemetry-ext
 <   "numProtoSuccess": 2
 < } pid=PID sdk=true
 HH:MM:SS Debug: All 2 logs uploaded successfully pid=PID
+
+>>> [CLI] current-user me
+{
+  "id":"[USERID]",
+  "userName":"[USERNAME]"
+}

--- a/acceptance/telemetry/success/output.txt
+++ b/acceptance/telemetry/success/output.txt
@@ -17,9 +17,3 @@ HH:MM:SS Debug: POST /telemetry-ext
 <   "numProtoSuccess": 2
 < } pid=PID sdk=true
 HH:MM:SS Debug: All 2 logs uploaded successfully pid=PID
-
->>> [CLI] current-user me
-{
-  "id":"[USERID]",
-  "userName":"[USERNAME]"
-}

--- a/acceptance/telemetry/success/script
+++ b/acceptance/telemetry/success/script
@@ -1,5 +1,8 @@
 trace $CLI selftest send-telemetry --debug
 
+# Make another API call to assert that the same cmd-exec-id is used in all API calls.
+trace $CLI current-user me
+
 # Extract the cmd-exec-id from the request user agent and replace all occurrences
 # in the output request log.
 cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' \

--- a/acceptance/telemetry/success/script
+++ b/acceptance/telemetry/success/script
@@ -6,4 +6,4 @@ trace $CLI current-user me
 # Extract the cmd-exec-id from the request user agent and replace all occurrences
 # in the output request log.
 cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' \
- | cut -d '/' -f2 | xargs -I {} sed -i '' 's|{}|[CMD-EXEC-ID]|g' out.requests.txt
+ | cut -d '/' -f2 | xargs -I {} sed -i '' 's/{}/[CMD-EXEC-ID]/g' out.requests.txt

--- a/acceptance/telemetry/success/script
+++ b/acceptance/telemetry/success/script
@@ -1,1 +1,6 @@
 trace $CLI selftest send-telemetry --debug
+
+# Extract the cmd-exec-id from the request user agent and replace all occurrences
+# in the output request log.
+cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' \
+ | cut -d '/' -f2 | xargs -I {} sed -i '' 's|{}|[CMD-EXEC-ID]|g' out.requests.txt

--- a/acceptance/telemetry/success/script
+++ b/acceptance/telemetry/success/script
@@ -1,9 +1,5 @@
 trace $CLI selftest send-telemetry --debug
 
-# Make another API call to assert that the same cmd-exec-id is used in all API calls.
-trace $CLI current-user me
-
-# Extract the cmd-exec-id from the request user agent and replace all occurrences
-# in the output request log.
-cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' \
- | cut -d '/' -f2 | xargs -I {} sed -i '' 's/{}/[CMD-EXEC-ID]/g' out.requests.txt
+update_file.py out.requests.txt \
+ $(cat out.requests.txt | jq '.headers."User-Agent".[0]'| grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2) \
+ '[CMD-EXEC-ID]'

--- a/acceptance/telemetry/success/test.toml
+++ b/acceptance/telemetry/success/test.toml
@@ -1,0 +1,13 @@
+IncludeRequestHeaders = ["User-Agent"]
+
+[[Repls]]
+Old = " upstream/[A-Za-z0-9.-]+"
+New = ""
+
+[[Repls]]
+Old = " upstream-version/[A-Za-z0-9.-]+"
+New = ""
+
+[[Repls]]
+Old = " cicd/[A-Za-z0-9.-]+"
+New = ""


### PR DESCRIPTION
## Changes
Modifies the telemetry acceptance test to assert that the same value of `cmd-exec-id` is used in both the user agent and the telemetry payload.

To facilitate this, this PR also requires the acceptance testing framework to write the request logs to disk without applying the replacements.

## Why
Asserting a consistent value of `cmd-exec-id` is an important correctness check because this is what we will use to get a completeness signal for our telemetry tables.

## Tests
N/A

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
