### PR TITLE
Update homebrew tap step to distinguish hashes for zip and tar.gz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
             artifacts = artifacts.filter(a => a.type == "Archive")
             artifacts = new Map(
               artifacts.map(a => [
-                a.goos + "_" + a.goarch,
+                a.goos + "_" + a.goarch + "_" + a.extra.Format,
                 a.extra.Checksum.replace("sha256:", "")
               ])
             )
@@ -119,10 +119,10 @@ jobs:
               ref: 'main',
               inputs: {
                 version: "${{ env.VERSION }}",
-                darwin_amd64_sha: artifacts.get('darwin_amd64'),
-                darwin_arm64_sha: artifacts.get('darwin_arm64'),
-                linux_amd64_sha: artifacts.get('linux_amd64'),
-                linux_arm64_sha: artifacts.get('linux_arm64')
+                darwin_amd64_sha: artifacts.get('darwin_amd64_zip'),
+                darwin_arm64_sha: artifacts.get('darwin_arm64_zip'),
+                linux_amd64_sha: artifacts.get('linux_amd64_zip'),
+                linux_arm64_sha: artifacts.get('linux_arm64_zip')
               }
             });
 


### PR DESCRIPTION
## Changes
Update homebrew tap step to distinguish hashes for zip and tar.gz

## Why
Homebrew tap release PRs are currently failing because they incorrectly use checksum hashes for tar.gz archives instead of zip
