### PR TITLE
Add acc test for case where both 'build' and 'files' are specified

### DIFF
--- a/acceptance/bundle/artifacts/build_and_files_whl/databricks.yml
+++ b/acceptance/bundle/artifacts/build_and_files_whl/databricks.yml
@@ -3,7 +3,8 @@ bundle:
 
 artifacts:
   artifact_with_custom_dist:
-    # commenting out 'type: whl' here actually makes 'bundle deploy' to work
+    # commenting out 'type: whl' here actually makes 'bundle deploy' to build and upload correct wheel,
+    # because for non-whl types it does respect 'files' section.
     type: whl
     build: python setup.py bdist_wheel --dist-dir mydist
     files:

--- a/acceptance/bundle/artifacts/build_and_files_whl/databricks.yml
+++ b/acceptance/bundle/artifacts/build_and_files_whl/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: build_and_files_whl
+
+artifacts:
+  artifact_with_custom_dist:
+    # commenting out 'type: whl' here actually makes 'bundle deploy' to work
+    type: whl
+    build: python setup.py bdist_wheel --dist-dir mydist
+    files:
+      - source: mydist/*.whl

--- a/acceptance/bundle/artifacts/build_and_files_whl/output.txt
+++ b/acceptance/bundle/artifacts/build_and_files_whl/output.txt
@@ -1,0 +1,16 @@
+
+>>> [CLI] bundle validate
+Name: build_and_files_whl
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/build_and_files_whl/default
+
+Validation OK!
+
+>>> errcode [CLI] bundle deploy
+Building artifact_with_custom_dist...
+Error: cannot find built wheel in [TMPDIR] for package artifact_with_custom_dist
+
+
+Exit code: 1

--- a/acceptance/bundle/artifacts/build_and_files_whl/script
+++ b/acceptance/bundle/artifacts/build_and_files_whl/script
@@ -1,0 +1,5 @@
+cp -r $TESTDIR/../whl_explicit/my_test_code/* .
+trace $CLI bundle validate
+# I expect this deploy to work because I explicitly told where to find the wheel, but it does not:
+trace errcode $CLI bundle deploy
+rm mydist/my_test_code-0.0.1-py3-none-any.whl setup.py src/*.py

--- a/acceptance/bundle/artifacts/build_and_files_whl/script
+++ b/acceptance/bundle/artifacts/build_and_files_whl/script
@@ -1,4 +1,4 @@
-cp -r $TESTDIR/../whl_explicit/my_test_code/* .
+cp -r $TESTDIR/../whl_explicit/my_test_code/{setup.py,src} .
 trace $CLI bundle validate
 # I expect this deploy to work because I explicitly told where to find the wheel, but it does not:
 trace errcode $CLI bundle deploy

--- a/acceptance/bundle/artifacts/build_and_files_whl/test.toml
+++ b/acceptance/bundle/artifacts/build_and_files_whl/test.toml
@@ -1,0 +1,2 @@
+Badness = "artifacts of type 'whl' hard-code dist directory even if explicit files section is present"
+RecordRequests = false


### PR DESCRIPTION
This test highlights inconsistency between type:whl and non-whl artifacts.

The test for non-whl artifacts exists [here](https://github.com/databricks/cli/tree/main/acceptance/bundle/artifacts/build_and_files) added in https://github.com/databricks/cli/pull/2526