### PR TITLE
acc: Use time.Duration to configure testserver delay

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -384,10 +384,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 				items := strings.Split(stub.Pattern, " ")
 				require.Len(t, items, 2)
 				server.Handle(items[0], items[1], func(req testserver.Request) any {
-					if stub.DelaySeconds != nil {
-						time.Sleep(time.Duration((*stub.DelaySeconds) * float64(time.Second)))
-					}
-
+					time.Sleep(stub.Delay)
 					return stub.Response
 				})
 			}

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"dario.cat/mergo"
 	"github.com/BurntSushi/toml"
@@ -85,8 +86,10 @@ type ServerStub struct {
 	// The response body to return.
 	Response testserver.Response
 
-	// Artificial delay in seconds to simulate slow responses.
-	DelaySeconds *float64
+	// Artificial delay to simulate slow responses.
+	// Configure as "1ms", "2s", "3m", etc.
+	// See [time.ParseDuration] for details.
+	Delay time.Duration
 }
 
 // FindConfigs finds all the config relevant for this test,

--- a/acceptance/telemetry/timeout/test.toml
+++ b/acceptance/telemetry/timeout/test.toml
@@ -6,4 +6,4 @@ Response.Body = '''
     "numProtoSuccess": 2
 }
 '''
-DelaySeconds = 5
+Delay = "5s"


### PR DESCRIPTION
## Changes

Use `time.Duration` for the testserver delay. It conveniently zero-initializes, so by default, there is no delay.

## Why

The TOML library natively supports `time.Duration`, so we should use it. 