### PR TITLE
acc: lower case UNIQUE_NAME

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -311,7 +311,7 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 	}
 
 	id := uuid.New()
-	uniqueName := strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "=")
+	uniqueName := strings.ToLower(strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "="))
 	repls.Set(uniqueName, "[UNIQUE_NAME]")
 
 	var tmpDir string


### PR DESCRIPTION
Same reason as for https://github.com/databricks/cli/pull/2380

This makes $UNIQUE_NAME usable in PyPI distribution names, which are lowercased: https://github.com/pypa/setuptools/pull/4766
