### PR TITLE
Ignore command -> cmdctx rename in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # Add error checking in tests and enable errcheck there (#1980)
 1b2be1b2cb4b7909df2a8ad4cb6a0f43e8fcf0c6
+
+# Rename the command package to cmdctx (#2462)
+899386eeda4cae0addf87a33bc9f23f859148a8a


### PR DESCRIPTION
## Why
To avoid polluting the git blame because of this package rename.

Prompted by: https://github.com/databricks/cli/pull/2462

## Tests
N/A
