### PR TITLE
Remove ctx argument to PatchWheel

### DIFF
--- a/cmd/selftest/patchwhl.go
+++ b/cmd/selftest/patchwhl.go
@@ -12,11 +12,13 @@ func newPatchWhl() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := cmd.Context()
 			for _, arg := range args {
-				out, err := patchwheel.PatchWheel(ctx, arg, ".")
+				out, isBuilt, err := patchwheel.PatchWheel(arg, ".")
 				if err != nil {
 					log.Warnf(ctx, "Failed to patch whl: %s: %s", arg, err)
-				} else {
+				} else if isBuilt {
 					log.Warnf(ctx, "Patched whl: %s -> %s", arg, out)
+				} else {
+					log.Warnf(ctx, "Patched whl (cache): %s -> %s", arg, out)
 				}
 			}
 		},


### PR DESCRIPTION
## Changes
- Do not pass ctx parameter to PatchWheel; it no longer does any logs
- Return isBuilt flag from PatchWheel

## Why
While working on #2520 I realized that it's better to have logging in one place & style,
thus caller should control how the log message looks like.
