### PR TITLE
Pretty print telemetry payload in acceptance tests

### DIFF
--- a/acceptance/bundle/templates/telemetry/custom-template/output.txt
+++ b/acceptance/bundle/templates/telemetry/custom-template/output.txt
@@ -1,3 +1,24 @@
 
 >>> [CLI] bundle init . --config-file input.json --output-dir output
 ✨ Successfully initialized template
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[CMD-EXEC-ID]",
+        "version": "[DEV_VERSION]",
+        "command": "bundle_init",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "bundle_init_event": {
+        "bundle_uuid": "[BUNDLE-UUID]",
+        "template_name": "custom"
+      }
+    }
+  }
+}

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -12,3 +12,6 @@ bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'
 update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/dbt-sql/output.txt
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/output.txt
@@ -8,3 +8,30 @@ workspace_host: [DATABRICKS_URL]
 If you already have dbt installed, just type 'cd my_dbt_sql; dbt init' to get started.
 Refer to the README.md file for full "getting started" guide and production setup instructions.
 
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[CMD-EXEC-ID]",
+        "version": "[DEV_VERSION]",
+        "command": "bundle_init",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "bundle_init_event": {
+        "bundle_uuid": "[BUNDLE-UUID]",
+        "template_name": "dbt-sql",
+        "template_enum_args": [
+          {
+            "key": "personal_schemas",
+            "value": "yes, use a schema based on the current user name during development"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -12,3 +12,6 @@ bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'
 update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/default-python/output.txt
+++ b/acceptance/bundle/templates/telemetry/default-python/output.txt
@@ -6,3 +6,42 @@ Workspace to use (auto-detected, edit in 'my_default_python/databricks.yml'): [D
 
 Please refer to the README.md file for "getting started" instructions.
 See also the documentation at https://docs.databricks.com/dev-tools/bundles/index.html.
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[CMD-EXEC-ID]",
+        "version": "[DEV_VERSION]",
+        "command": "bundle_init",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "bundle_init_event": {
+        "bundle_uuid": "[BUNDLE-UUID]",
+        "template_name": "default-python",
+        "template_enum_args": [
+          {
+            "key": "include_dlt",
+            "value": "no"
+          },
+          {
+            "key": "include_notebook",
+            "value": "yes"
+          },
+          {
+            "key": "include_python",
+            "value": "yes"
+          },
+          {
+            "key": "serverless",
+            "value": "no"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -12,3 +12,6 @@ bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'
 update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/default-sql/output.txt
+++ b/acceptance/bundle/templates/telemetry/default-sql/output.txt
@@ -8,3 +8,30 @@ workspace_host: [DATABRICKS_URL]
 
 Please refer to the README.md file for "getting started" instructions.
 See also the documentation at https://docs.databricks.com/dev-tools/bundles/index.html.
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[CMD-EXEC-ID]",
+        "version": "[DEV_VERSION]",
+        "command": "bundle_init",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "bundle_init_event": {
+        "bundle_uuid": "[BUNDLE-UUID]",
+        "template_name": "default-sql",
+        "template_enum_args": [
+          {
+            "key": "personal_schemas",
+            "value": "yes, automatically use a schema based on the current user name during development"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -12,3 +12,6 @@ bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'
 update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/test.toml
+++ b/acceptance/bundle/templates/telemetry/test.toml
@@ -14,6 +14,10 @@ Old = 'execution_time_ms\\\":\d{1,5},'
 New = 'execution_time_ms\":\"SMALL_INT\",'
 
 [[Repls]]
+Old = '"execution_time_ms": \d{1,5},'
+New = '"execution_time_ms": SMALL_INT,'
+
+[[Repls]]
 Old = " upstream/[A-Za-z0-9.-]+"
 New = ""
 

--- a/acceptance/telemetry/failure/output.txt
+++ b/acceptance/telemetry/failure/output.txt
@@ -51,3 +51,113 @@ HH:MM:SS Debug: POST /telemetry-ext
 HH:MM:SS Debug: non-retriable error: Endpoint not implemented. pid=PID sdk=true
 HH:MM:SS Info: Attempt 3 failed due to a server side error. Retrying status code: 501 pid=PID
 HH:MM:SS Info: telemetry upload failed: failed to upload telemetry logs after three attempts pid=PID
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}

--- a/acceptance/telemetry/failure/script
+++ b/acceptance/telemetry/failure/script
@@ -1,1 +1,4 @@
 trace $CLI selftest send-telemetry --debug
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/telemetry/partial-success/output.txt
+++ b/acceptance/telemetry/partial-success/output.txt
@@ -48,3 +48,113 @@ HH:MM:SS Debug: POST /telemetry-ext
 < } pid=PID sdk=true
 HH:MM:SS Debug: Attempt 3 was a partial success. Number of logs uploaded: 1 out of 2 pid=PID
 HH:MM:SS Info: telemetry upload failed: failed to upload telemetry logs after three attempts pid=PID
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}

--- a/acceptance/telemetry/partial-success/script
+++ b/acceptance/telemetry/partial-success/script
@@ -1,1 +1,4 @@
 trace $CLI selftest send-telemetry --debug
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/telemetry/success/output.txt
+++ b/acceptance/telemetry/success/output.txt
@@ -17,3 +17,41 @@ HH:MM:SS Debug: POST /telemetry-ext
 <   "numProtoSuccess": 2
 < } pid=PID sdk=true
 HH:MM:SS Debug: All 2 logs uploaded successfully pid=PID
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[CMD-EXEC-ID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[CMD-EXEC-ID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}

--- a/acceptance/telemetry/success/script
+++ b/acceptance/telemetry/success/script
@@ -3,3 +3,6 @@ trace $CLI selftest send-telemetry --debug
 update_file.py out.requests.txt \
  $(cat out.requests.txt | jq '.headers."User-Agent".[0]'| grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2) \
  '[CMD-EXEC-ID]'
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'

--- a/acceptance/telemetry/test.toml
+++ b/acceptance/telemetry/test.toml
@@ -16,6 +16,10 @@ New = '[OS]'
 Old = 'execution_time_ms\\\":\d{1,5},'
 New = 'execution_time_ms\":\"SMALL_INT\",'
 
+[[Repls]]
+Old = '"execution_time_ms": \d{1,5},'
+New = '"execution_time_ms": SMALL_INT,'
+
 [[Server]]
 Pattern = "POST /telemetry-ext"
 Response.Body = '''

--- a/acceptance/telemetry/timeout/output.txt
+++ b/acceptance/telemetry/timeout/output.txt
@@ -15,3 +15,41 @@ HH:MM:SS Debug: POST /telemetry-ext
 HH:MM:SS Debug: non-retriable error: Post "[DATABRICKS_URL]/telemetry-ext": context deadline exceeded pid=PID sdk=true
 HH:MM:SS Debug: Attempt 1 failed due to a timeout. Will not retry pid=PID
 HH:MM:SS Info: telemetry upload failed: uploading telemetry logs timed out: Post "[DATABRICKS_URL]/telemetry-ext": context deadline exceeded pid=PID
+
+>>> cat out.requests.txt
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE1"
+      }
+    }
+  }
+}
+{
+  "frontend_log_event_id": "[UUID]",
+  "entry": {
+    "databricks_cli_log": {
+      "execution_context": {
+        "cmd_exec_id": "[UUID]",
+        "version": "[DEV_VERSION]",
+        "command": "selftest_send-telemetry",
+        "operating_system": "[OS]",
+        "execution_time_ms": SMALL_INT,
+        "exit_code": 0
+      },
+      "cli_test_event": {
+        "name": "VALUE2"
+      }
+    }
+  }
+}

--- a/acceptance/telemetry/timeout/script
+++ b/acceptance/telemetry/timeout/script
@@ -2,3 +2,6 @@
 export DATABRICKS_CLI_TELEMETRY_TIMEOUT=0.1
 
 trace $CLI selftest send-telemetry --debug
+
+# pretty print the telemetry payload.
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'


### PR DESCRIPTION
## Why
Before the telemetry payload was a single line of encoded JSON in `out.requests.txt.  This can be hard to review and catch regressions in.

After, the JSON payload is filtered and pretty printed in `output.txt` which will be a lot easier to review.

## Tests
N/A