### PR TITLE
Add support for registered models in deployment bind/unbind commands

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,5 +10,6 @@
 * Added support for clusters in deployment bind/unbind commands ([#2536](https://github.com/databricks/cli/pull/2536))
 * Added support for volumes in deployment bind/unbind commands ([#2527](https://github.com/databricks/cli/pull/2527))
 * Added support for dashboards in deployment bind/unbind commands ([#2516](https://github.com/databricks/cli/pull/2516))
+* Added support for registered models in deployment bind/unbind commands ([#2556](https://github.com/databricks/cli/pull/2556))
 
 ### API Changes

--- a/acceptance/bundle/deployment/bind/registered-model/databricks.yml.tmpl
+++ b/acceptance/bundle/deployment/bind/registered-model/databricks.yml.tmpl
@@ -1,0 +1,10 @@
+bundle:
+  name: bind-registered-model-test-$UNIQUE_NAME
+
+resources:
+  registered_models:
+    model1:
+      name: $MODEL_NAME
+      catalog_name: $CATALOG_NAME
+      schema_name: $SCHEMA_NAME
+

--- a/acceptance/bundle/deployment/bind/registered-model/output.txt
+++ b/acceptance/bundle/deployment/bind/registered-model/output.txt
@@ -1,0 +1,53 @@
+bundle:
+  name: bind-registered-model-test-[UNIQUE_NAME]
+
+resources:
+  registered_models:
+    model1:
+      name: test-registered-model-[UUID]
+      catalog_name: main
+      schema_name: test-schema-rmodel-[UUID]
+
+
+>>> [CLI] schemas create test-schema-rmodel-[UUID] main
+{
+  "full_name": "main.test-schema-rmodel-[UUID]",
+  "catalog_name": "main"
+}
+
+>>> [CLI] bundle deployment bind model1 main.test-schema-rmodel-[UUID].test-registered-model-[UUID]
+Updating deployment state...
+Successfully bound databricks_registered_model with an id 'main.test-schema-rmodel-[UUID].test-registered-model-[UUID]'. Run 'bundle deploy' to deploy changes to your workspace
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/bind-registered-model-test-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] registered-models get main.test-schema-rmodel-[UUID].test-registered-model-[UUID]
+{
+  "full_name": "main.test-schema-rmodel-[UUID].test-registered-model-[UUID]",
+  "schema_name": "test-schema-rmodel-[UUID]",
+  "name": "test-registered-model-[UUID]"
+}
+
+>>> [CLI] bundle deployment unbind model1
+Updating deployment state...
+
+>>> [CLI] bundle destroy --auto-approve
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/bind-registered-model-test-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!
+
+>>> [CLI] registered-models get main.test-schema-rmodel-[UUID].test-registered-model-[UUID]
+{
+  "full_name": "main.test-schema-rmodel-[UUID].test-registered-model-[UUID]",
+  "schema_name": "test-schema-rmodel-[UUID]",
+  "name": "test-registered-model-[UUID]"
+}
+
+>>> [CLI] registered-models delete main.test-schema-rmodel-[UUID].test-registered-model-[UUID]
+
+>>> [CLI] schemas delete main.test-schema-rmodel-[UUID]

--- a/acceptance/bundle/deployment/bind/registered-model/script
+++ b/acceptance/bundle/deployment/bind/registered-model/script
@@ -1,0 +1,36 @@
+SCHEMA_NAME="test-schema-rmodel-$(uuid)"
+MODEL_NAME="test-registered-model-$(uuid)"
+if [ -z "$CLOUD_ENV" ]; then
+    SCHEMA_NAME="test-schema-rmodel-6260d50f-e8ff-4905-8f28-812345678903"   # use hard-coded uuid when running locally
+    MODEL_NAME="test-registered-model-6260d50f-e8ff-4905-8f28-812345678903"
+fi
+CATALOG_NAME=main
+export SCHEMA_NAME MODEL_NAME CATALOG_NAME
+envsubst < databricks.yml.tmpl > databricks.yml
+cat databricks.yml
+
+# Create a pre-defined schema:
+trace $CLI schemas create ${SCHEMA_NAME} ${CATALOG_NAME} | jq '{full_name, catalog_name}'
+
+# Create a pre-defined registered model:
+MODEL_FULL_NAME=$($CLI registered-models create "${CATALOG_NAME}" "${SCHEMA_NAME}" "${MODEL_NAME}" | jq -r '.full_name')
+
+cleanup() {
+    trace $CLI registered-models delete "${MODEL_FULL_NAME}"
+    trace $CLI schemas delete ${CATALOG_NAME}.${SCHEMA_NAME}
+}
+trap cleanup EXIT
+
+trace $CLI bundle deployment bind model1 "${MODEL_FULL_NAME}"
+
+trace $CLI bundle deploy
+
+trace $CLI registered-models get "${MODEL_FULL_NAME}" | jq '{full_name, schema_name, name}'
+
+trace $CLI bundle deployment unbind model1
+
+trace $CLI bundle destroy --auto-approve
+
+# Read the pre-defined model again (expecting it still exists and is not deleted):
+trace $CLI registered-models get "${MODEL_FULL_NAME}" | jq '{full_name, schema_name, name}'
+

--- a/acceptance/bundle/deployment/bind/registered-model/test.toml
+++ b/acceptance/bundle/deployment/bind/registered-model/test.toml
@@ -1,0 +1,43 @@
+Local = true
+Cloud = true
+RequiresUnityCatalog = true
+
+Ignore = [
+    "databricks.yml",
+]
+
+[[Server]]
+Pattern = "POST /api/2.1/unity-catalog/schemas"
+Response.Body = '''
+{
+    "catalog_name":"main",
+    "full_name":"main.test-schema-rmodel-6260d50f-e8ff-4905-8f28-812345678903"
+}
+'''
+
+[[Server]]
+Pattern = "POST /api/2.1/unity-catalog/models"
+Response.Body = '''
+{
+  "full_name": "main.test-schema-rmodel-6260d50f-e8ff-4905-8f28-812345678903.test-registered-model-6260d50f-e8ff-4905-8f28-812345678903",
+  "schema_name": "test-schema-rmodel-6260d50f-e8ff-4905-8f28-812345678903",
+  "name": "test-registered-model-6260d50f-e8ff-4905-8f28-812345678903"
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/models/{model_full_name}"
+Response.Body = '''
+{
+  "catalog_name": "main",
+  "full_name": "main.test-schema-rmodel-6260d50f-e8ff-4905-8f28-812345678903.test-registered-model-6260d50f-e8ff-4905-8f28-812345678903",
+  "schema_name": "test-schema-rmodel-6260d50f-e8ff-4905-8f28-812345678903",
+  "name": "test-registered-model-6260d50f-e8ff-4905-8f28-812345678903"
+}
+'''
+
+[[Server]]
+Pattern = "DELETE /api/2.1/unity-catalog/models/{model_full_name}"
+
+[[Server]]
+Pattern = "DELETE /api/2.1/unity-catalog/schemas/{schema_full_name}"

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -142,6 +142,12 @@ func (r *Resources) FindResourceByConfigKey(key string) (ConfigResource, error) 
 		}
 	}
 
+	for k := range r.RegisteredModels {
+		if k == key {
+			found = append(found, r.RegisteredModels[k])
+		}
+	}
+
 	if len(found) == 0 {
 		return nil, fmt.Errorf("no such resource: %s", key)
 	}


### PR DESCRIPTION
## Changes
1. Changed `FindResourceByConfigKey` to return registered models resources

## Why
This PR adds support for registered models in deployment operations, enabling users to:
- Bind experiments using `databricks bundle deployment bind <mymodel_key> <mymodel_full_name>`
- Unbind experiments using `databricks bundle deployment unbind <mymodel_key>`

Where:
- `mymodel_key` is a resource key defined in the bundle's .yml file
- `mymodel_full_name` references an existing model in the Unity Catalog using its fully qualified (3-level) name

These capabilities allow for more flexible resource management of registered models within bundles.

## Tests
Added a new acceptance test that tests bind and unbind methods together with bundle deployment and destruction.
