### PR TITLE
acc: Add CloudEnvs setting

### DIFF
--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -27,6 +27,11 @@ type TestConfig struct {
 	// If absent, default to true.
 	GOOS map[string]bool
 
+	// Which Clouds the test is enabled on. Allowed values: "aws", "azure", "gcp".
+	// If absent, default to true.
+	// Only checked if CLOUD_ENV is not empty.
+	CloudEnvs map[string]bool
+
 	// If true, run this test when running locally with a testserver
 	Local *bool
 


### PR DESCRIPTION
## Why

Disable/enable tests based for specific clouds. Sometimes we need to break tests by cloud due to difference in the output, like we have in https://github.com/databricks/cli/pull/2532 with GCP/servicePrincipal issue.