### PR TITLE
Implement `HasSuffix` for `dyn.Path`

### DIFF
--- a/libs/dyn/path.go
+++ b/libs/dyn/path.go
@@ -89,6 +89,22 @@ func (p Path) HasPrefix(q Path) bool {
 	return true
 }
 
+// HasSuffix returns true if the path has the specified suffix.
+// The empty path is a suffix of all paths.
+func (p Path) HasSuffix(q Path) bool {
+	pl := len(p)
+	ql := len(q)
+	if pl < ql {
+		return false
+	}
+	for i := range ql {
+		if p[pl-ql+i] != q[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // String returns a string representation of the path.
 func (p Path) String() string {
 	var buf bytes.Buffer

--- a/libs/dyn/path_test.go
+++ b/libs/dyn/path_test.go
@@ -58,8 +58,37 @@ func TestPathHasPrefix(t *testing.T) {
 	p2 := dyn.NewPath(dyn.Key("bar"), dyn.Index(2))
 	assert.False(t, p1.HasPrefix(p2), "expected %q to not have prefix %q", p1, p2)
 
-	p3 := dyn.NewPath(dyn.Key("foo"))
-	assert.True(t, p1.HasPrefix(p3), "expected %q to have prefix %q", p1, p3)
+	p3 := dyn.NewPath(dyn.Key("foo"), dyn.Index(1), dyn.Key("bar"))
+	assert.False(t, p1.HasPrefix(p3), "expected %q to not have prefix %q", p1, p3)
+
+	p4 := dyn.NewPath(dyn.Key("foo"), dyn.Index(1))
+	assert.True(t, p1.HasPrefix(p4), "expected %q to have prefix %q", p1, p4)
+
+	p5 := dyn.NewPath(dyn.Key("foo"))
+	assert.True(t, p1.HasPrefix(p5), "expected %q to have prefix %q", p1, p5)
+}
+
+func TestPathHasSuffixEmpty(t *testing.T) {
+	empty := dyn.EmptyPath
+	nonEmpty := dyn.NewPath(dyn.Key("foo"))
+	assert.True(t, empty.HasSuffix(empty))
+	assert.True(t, nonEmpty.HasSuffix(empty))
+	assert.False(t, empty.HasSuffix(nonEmpty))
+}
+
+func TestPathHasSuffix(t *testing.T) {
+	p1 := dyn.NewPath(dyn.Key("foo"), dyn.Index(1))
+	p2 := dyn.NewPath(dyn.Key("bar"), dyn.Index(2))
+	assert.False(t, p1.HasSuffix(p2), "expected %q to not have suffix %q", p1, p2)
+
+	p3 := dyn.NewPath(dyn.Index(1))
+	assert.True(t, p1.HasSuffix(p3), "expected %q to have suffix %q", p1, p3)
+
+	p4 := dyn.NewPath(dyn.Key("foo"), dyn.Index(1))
+	assert.True(t, p1.HasSuffix(p4), "expected %q to have suffix %q", p1, p4)
+
+	p5 := dyn.NewPath(dyn.Key("bar"), dyn.Index(2), dyn.Key("baz"))
+	assert.False(t, p1.HasSuffix(p5), "expected %q to not have suffix %q", p1, p5)
 }
 
 func TestPathString(t *testing.T) {


### PR DESCRIPTION
## Changes

This complements the existing `HasPrefix` function.

## Why

While reviewing #2541, I found we need `CutPrefix` and `CutSuffix`. This change prepares for adding those.