### PR TITLE
[Python] Add acceptance tests for locations

### DIFF
--- a/acceptance/bundle/python/mutator-ordering/output.txt
+++ b/acceptance/bundle/python/mutator-ordering/output.txt
@@ -1,5 +1,5 @@
 
->>> uv run [UV_ARGS] -q [CLI] bundle validate --output json
+>>> uv run [UV_ARGS] -q [CLI] bundle validate --output json --include-locations
 {
   "experimental": {
     "python": {
@@ -32,6 +32,77 @@
           }
         ]
       }
+    }
+  },
+  "__locations": {
+    "files": [
+      "databricks.yml",
+      "mutators.py"
+    ],
+    "locations": {
+      "bundle": [
+        [
+          0,
+          2,
+          3
+        ]
+      ],
+      "experimental": [
+        [
+          0,
+          7,
+          3
+        ]
+      ],
+      "resources": [
+        [
+          0,
+          13,
+          3
+        ]
+      ],
+      "resources.jobs": [
+        [
+          0,
+          14,
+          5
+        ]
+      ],
+      "resources.jobs.my_job": [
+        [
+          0,
+          15,
+          7
+        ]
+      ],
+      "resources.jobs.my_job.tasks": [
+        [
+          0,
+          15,
+          14
+        ]
+      ],
+      "resources.jobs.my_job.tasks[0]": [
+        [
+          1,
+          8,
+          1
+        ]
+      ],
+      "resources.jobs.my_job.tasks[1]": [
+        [
+          1,
+          8,
+          1
+        ]
+      ],
+      "sync": [
+        [
+          0,
+          4,
+          7
+        ]
+      ]
     }
   }
 }

--- a/acceptance/bundle/python/mutator-ordering/script
+++ b/acceptance/bundle/python/mutator-ordering/script
@@ -1,6 +1,8 @@
 UV_ARGS="${UV_ARGS//\[\DATABRICKS_BUNDLES_WHEEL\]/$DATABRICKS_BUNDLES_WHEEL}"
 
-trace uv run $UV_ARGS -q $CLI bundle validate --output json | \
-  jq "pick(.experimental.python, .resources)"
+# after mutators are applied, we expect to record location of the last mutator that had any effect
+
+trace uv run $UV_ARGS -q $CLI bundle validate --output json --include-locations | \
+  jq "pick(.experimental.python, .resources, .__locations.files, .__locations.locations)"
 
 rm -fr .databricks __pycache__

--- a/acceptance/bundle/python/resource-loading/output.txt
+++ b/acceptance/bundle/python/resource-loading/output.txt
@@ -1,5 +1,5 @@
 
->>> uv run [UV_ARGS] -q [CLI] bundle validate --output json
+>>> uv run [UV_ARGS] -q [CLI] bundle validate --output json --include-locations
 {
   "experimental": {
     "python": {
@@ -53,6 +53,70 @@
         },
         "tags": {}
       }
+    }
+  },
+  "__locations": {
+    "files": [
+      "databricks.yml",
+      "resources.py"
+    ],
+    "locations": {
+      "bundle": [
+        [
+          0,
+          2,
+          3
+        ]
+      ],
+      "experimental": [
+        [
+          0,
+          7,
+          3
+        ]
+      ],
+      "resources": [
+        [
+          0,
+          13,
+          3
+        ]
+      ],
+      "resources.jobs": [
+        [
+          0,
+          14,
+          5
+        ]
+      ],
+      "resources.jobs.my_job_1": [
+        [
+          1,
+          16,
+          1
+        ]
+      ],
+      "resources.jobs.my_job_2": [
+        [
+          1,
+          6,
+          1
+        ]
+      ],
+      "resources.jobs.my_job_3": [
+        [
+          0,
+          15,
+          7
+        ]
+      ],
+      "sync": [
+        [
+          0,
+          4,
+          7
+        ]
+      ]
     }
   }
 }

--- a/acceptance/bundle/python/resource-loading/script
+++ b/acceptance/bundle/python/resource-loading/script
@@ -1,6 +1,8 @@
 UV_ARGS="${UV_ARGS//\[\DATABRICKS_BUNDLES_WHEEL\]/$DATABRICKS_BUNDLES_WHEEL}"
 
-trace uv run $UV_ARGS -q $CLI bundle validate --output json | \
-  jq "pick(.experimental.python, .resources)"
+# each job should record location where add_job function was called
+
+trace uv run $UV_ARGS -q $CLI bundle validate --output json --include-locations | \
+  jq "pick(.experimental.python, .resources, .__locations.files, .__locations.locations)"
 
 rm -fr .databricks __pycache__


### PR DESCRIPTION
## Changes
Add acceptance tests capturing how locations are recorded. 

Note that `--include-locations` doesn't include any location "deeper" than "tasks," so we can't use it to test locations for properties with "special" behavior like "notebook_path" that wouldn't have the same location as other properties. For "notebook_path", we keep the location of a virtual file in a bundle root.