### PR TITLE
acc: Disable integration_whl/serverless

### DIFF
--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -1,3 +1,7 @@
+# disable everywhere, because it does not show consistent behaviour
+Cloud = false
+Local = false
+
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true
 


### PR DESCRIPTION
It was passing for the whole week since it was added in https://github.com/databricks/cli/pull/2519 but started failing on the recent commits, so it does not exhibit consistent behaviour without wheel patching.

Note, that we do have integration_whl/serverless_dynamic_version which tests the same but with wheel patching #2520