### PR TITLE
Disable pipefail in bundle init acceptance tests

### DIFF
--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -6,6 +6,9 @@ mv output/my_custom_template/databricks.yml out.databricks.yml
 rm -r output
 
 
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -5,7 +5,11 @@ trace $CLI bundle init . --config-file input.json --output-dir output
 mv output/my_custom_template/databricks.yml out.databricks.yml
 rm -r output
 
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -6,8 +6,7 @@ mv output/my_custom_template/databricks.yml out.databricks.yml
 rm -r output
 
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
+# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -5,11 +5,7 @@ trace $CLI bundle init . --config-file input.json --output-dir output
 mv output/my_custom_template/databricks.yml out.databricks.yml
 rm -r output
 
-
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
-set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -5,8 +5,7 @@ $CLI bundle init dbt-sql --config-file input.json --output-dir output
 mv output/my_dbt_sql/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
+# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -5,7 +5,10 @@ $CLI bundle init dbt-sql --config-file input.json --output-dir output
 mv output/my_dbt_sql/databricks.yml out.databricks.yml
 rm -r output
 
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -5,7 +5,9 @@ $CLI bundle init dbt-sql --config-file input.json --output-dir output
 mv output/my_dbt_sql/databricks.yml out.databricks.yml
 rm -r output
 
-
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -5,10 +5,7 @@ $CLI bundle init dbt-sql --config-file input.json --output-dir output
 mv output/my_dbt_sql/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
-set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -5,10 +5,7 @@ $CLI bundle init default-python --config-file input.json --output-dir output
 mv output/my_default_python/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
-set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -5,9 +5,8 @@ $CLI bundle init default-python --config-file input.json --output-dir output
 mv output/my_default_python/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
-set +o pipefail
+# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
+# set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -5,7 +5,9 @@ $CLI bundle init default-python --config-file input.json --output-dir output
 mv output/my_default_python/databricks.yml out.databricks.yml
 rm -r output
 
-
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -5,7 +5,10 @@ $CLI bundle init default-python --config-file input.json --output-dir output
 mv output/my_default_python/databricks.yml out.databricks.yml
 rm -r output
 
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -5,8 +5,7 @@ $CLI bundle init default-sql --config-file input.json --output-dir output
 mv output/my_default_sql/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
+# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -5,10 +5,7 @@ $CLI bundle init default-sql --config-file input.json --output-dir output
 mv output/my_default_sql/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems if jq outputs more than one line.
-set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -5,7 +5,9 @@ $CLI bundle init default-sql --config-file input.json --output-dir output
 mv output/my_default_sql/databricks.yml out.databricks.yml
 rm -r output
 
-
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
 cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -5,7 +5,10 @@ $CLI bundle init default-sql --config-file input.json --output-dir output
 mv output/my_default_sql/databricks.yml out.databricks.yml
 rm -r output
 
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]' | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
+# a SIGPIPE in linux based systems if jq outputs more than one line.
+set +o pipefail
+cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'


### PR DESCRIPTION
## Why
Caught in https://github.com/databricks/cli/pull/2554. When `-o pipefail` is set in bash, a SIGPIPE is triggered in linux systems if downstream applications exit while upstream applications in a pipeline are still outputting logs.

head can exit early if the command has determined that reading more from stdin will not change its output. Those cases will cause a SIGPIPE on linux systems. 

### Why don't we disable `-o pipefail` all together globally

Because by default bash returns the exit code of the last command in a pipeline. `pipefail` makes bash return the exit code of the first failing command instead. That's a nice global property to have.

For more details about the gotchas you can read: https://mywiki.wooledge.org/BashPitfalls#pipefail

## Tests
N/A