### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -99,7 +99,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.63.4
+          version: v2.0.2
           args: --timeout=15m
       - name: Run ruff
         uses: astral-sh/ruff-action@f14634c415d3e63ffd4d550a22f037df4c734a60 # v3.1.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -97,7 +97,7 @@ jobs:
           # Exit with status code 1 if there are differences (i.e. unformatted files)
           git diff --exit-code
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: v1.63.4
           args: --timeout=15m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,66 +1,76 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - errcheck
-    - gosimple
+    - gocritic
     - govet
     - ineffassign
-    - staticcheck
-    - unused
-    - gofmt
-    - gofumpt
-    - goimports
-    - testifylint
     - intrange
     - mirror
     - perfsprint
+    - staticcheck
+    - testifylint
     - unconvert
-    - gocritic
-linters-settings:
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-    settings:
-      printf:
-        funcs:
-          - (github.com/databricks/cli/internal/testutil.TestingT).Infof
-          - (github.com/databricks/cli/internal/testutil.TestingT).Errorf
-          - (github.com/databricks/cli/internal/testutil.TestingT).Fatalf
-          - (github.com/databricks/cli/internal/testutil.TestingT).Skipf
-  gofmt:
-    rewrite-rules:
-      - pattern: 'a[b:len(a)]'
-        replacement: 'a[b:]'
-      - pattern: 'interface{}'
-        replacement: 'any'
-  errcheck:
-    exclude-functions:
-      - (*github.com/spf13/cobra.Command).RegisterFlagCompletionFunc
-      - (*github.com/spf13/cobra.Command).MarkFlagRequired
-      - (*github.com/spf13/pflag.FlagSet).MarkDeprecated
-      - (*github.com/spf13/pflag.FlagSet).MarkHidden
-  gofumpt:
-    module-path: github.com/databricks/cli
-    extra-rules: true
-  testifylint:
-    enable-all: true
-    disable:
-      # good check, but we have too many assert.(No)?Errorf? so excluding for now
-      - require-error
-  copyloopvar:
-    check-alias: true
-  gocritic:
-    disable-all: true
-    enabled-checks:
-      - ruleguard
-    settings:
-      ruleguard:
-        rules: 'libs/gorules/rule_*.go'
-        failOn: all
+    - unused
+  settings:
+    copyloopvar:
+      check-alias: true
+    errcheck:
+      exclude-functions:
+        - (*github.com/spf13/cobra.Command).RegisterFlagCompletionFunc
+        - (*github.com/spf13/cobra.Command).MarkFlagRequired
+        - (*github.com/spf13/pflag.FlagSet).MarkDeprecated
+        - (*github.com/spf13/pflag.FlagSet).MarkHidden
+    gocritic:
+      disable-all: true
+      enabled-checks:
+        - ruleguard
+      settings:
+        ruleguard:
+          failOn: all
+          rules: libs/gorules/rule_*.go
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+      settings:
+        printf:
+          funcs:
+            - (github.com/databricks/cli/internal/testutil.TestingT).Infof
+            - (github.com/databricks/cli/internal/testutil.TestingT).Errorf
+            - (github.com/databricks/cli/internal/testutil.TestingT).Fatalf
+            - (github.com/databricks/cli/internal/testutil.TestingT).Skipf
+    testifylint:
+      enable-all: true
+      disable:
+        - require-error
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
 issues:
-  exclude-dirs-use-default: false  # recommended by docs https://golangci-lint.run/usage/false-positives/
   max-issues-per-linter: 1000
   max-same-issues: 1000
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: a[b:len(a)]
+          replacement: a[b:]
+        - pattern: interface{}
+          replacement: any
+    gofumpt:
+      module-path: github.com/databricks/cli
+      extra-rules: true
+  exclusions:
+    generated: lax

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,21 @@ linters:
             - (github.com/databricks/cli/internal/testutil.TestingT).Errorf
             - (github.com/databricks/cli/internal/testutil.TestingT).Fatalf
             - (github.com/databricks/cli/internal/testutil.TestingT).Skipf
+    staticcheck:
+      checks:
+        - all
+        # disabled checks:
+        - -ST1003
+        - -ST1016
+        - -ST1005
+        - -ST1023
+        - -QF1001
+        - -QF1003
+        - -QF1007
+        - -QF1008
+        - -QF1009
+        - -QF1011
+        - -QF1012
     testifylint:
       enable-all: true
       disable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,8 +61,10 @@ linters:
     testifylint:
       enable-all: true
       disable:
-        # good check, but we have too many assert.(No)?Errorf? so excluding for now
-        - require-error
+        - require-error # good check, but we have too many assert.(No)?Errorf? so excluding for now
+        - empty
+        - len
+        - equal-values
   exclusions:
     generated: lax
     presets:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,7 @@ linters:
     testifylint:
       enable-all: true
       disable:
+        # good check, but we have too many assert.(No)?Errorf? so excluding for now
         - require-error
   exclusions:
     generated: lax

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Notable Changes
 Previously ".internal" folder under artifact_path was not cleaned up as expected. In this release this behaviour is fixed and now DABs cleans up this folder before uploading artifacts to it.
 
+### Dependency updates
+* Bump golangci-lint version to v2.0.2 from v1.63.4 ([#2586](https://github.com/databricks/cli/pull/2586)).
+
 ### CLI
 * Upgrade Go SDK to 0.61.0 ([#2575](https://github.com/databricks/cli/pull/2575))
 


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
1. Bump golangci-lint version to v2.0.2 from v1.63.4
2. Migrate the configuration file to v2 format
3. Disable certain lint checks that were disabled in v1, but are enabled by default now

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

[golangci-lint v2](https://golangci-lint.run/product/changelog/#v200) is a major update that provides multiple enhancements, new linter and new features support  and bug fixes

## Tests
<!-- How have you tested the changes? -->
Existing `make lintcheck` is passing

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
