### PR TITLE
Extract relative path visitors

### DIFF
--- a/bundle/config/mutator/paths/app_paths_visitor.go
+++ b/bundle/config/mutator/paths/app_paths_visitor.go
@@ -1,0 +1,18 @@
+package paths
+
+import (
+	"github.com/databricks/cli/libs/dyn"
+)
+
+func VisitAppPaths(value dyn.Value, fn VisitFunc) (dyn.Value, error) {
+	pattern := dyn.NewPattern(
+		dyn.Key("resources"),
+		dyn.Key("apps"),
+		dyn.AnyKey(),
+		dyn.Key("source_code_path"),
+	)
+
+	return dyn.MapByPattern(value, pattern, func(path dyn.Path, value dyn.Value) (dyn.Value, error) {
+		return fn(path, TranslateModeDirectory, value)
+	})
+}

--- a/bundle/config/mutator/paths/app_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/app_paths_visitor_test.go
@@ -1,0 +1,42 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/dyn"
+	assert "github.com/databricks/cli/libs/dyn/dynassert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppPathsVisitor(t *testing.T) {
+	root := config.Root{
+		Resources: config.Resources{
+			Apps: map[string]*resources.App{
+				"app0": {
+					SourceCodePath: "foo",
+				},
+			},
+		},
+	}
+
+	actual := visitAppPaths(t, root)
+	expected := []dyn.Path{
+		dyn.MustPathFromString("resources.apps.app0.source_code_path"),
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
+func visitAppPaths(t *testing.T, root config.Root) []dyn.Path {
+	var actual []dyn.Path
+	err := root.Mutate(func(value dyn.Value) (dyn.Value, error) {
+		return VisitAppPaths(value, func(p dyn.Path, mode TranslateMode, v dyn.Value) (dyn.Value, error) {
+			actual = append(actual, p)
+			return v, nil
+		})
+	})
+	require.NoError(t, err)
+	return actual
+}

--- a/bundle/config/mutator/paths/artifact_paths_visitor.go
+++ b/bundle/config/mutator/paths/artifact_paths_visitor.go
@@ -1,0 +1,42 @@
+package paths
+
+import (
+	"github.com/databricks/cli/libs/dyn"
+)
+
+type artifactRewritePattern struct {
+	pattern dyn.Pattern
+	mode    TranslateMode
+}
+
+func artifactRewritePatterns() []artifactRewritePattern {
+	// Base pattern to match all artifacts.
+	base := dyn.NewPattern(
+		dyn.Key("artifacts"),
+		dyn.AnyKey(),
+	)
+
+	// Compile list of configuration paths to rewrite.
+	return []artifactRewritePattern{
+		{
+			pattern: base.Append(dyn.Key("path")),
+			mode:    TranslateModeLocalAbsoluteDirectory,
+		},
+	}
+}
+
+func VisitArtifactPaths(value dyn.Value, fn VisitFunc) (dyn.Value, error) {
+	var err error
+	newValue := value
+
+	for _, rewritePattern := range artifactRewritePatterns() {
+		newValue, err = dyn.MapByPattern(newValue, rewritePattern.pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+			return fn(p, rewritePattern.mode, v)
+		})
+		if err != nil {
+			return dyn.InvalidValue, err
+		}
+	}
+
+	return newValue, nil
+}

--- a/bundle/config/mutator/paths/artifact_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/artifact_paths_visitor_test.go
@@ -1,0 +1,39 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactPathsVisitor(t *testing.T) {
+	root := config.Root{
+		Artifacts: config.Artifacts{
+			"artifact0": &config.Artifact{
+				Path: "foo.whl",
+			},
+		},
+	}
+
+	actual := visitArtifactPaths(t, root)
+	expected := []dyn.Path{
+		dyn.MustPathFromString("artifacts.artifact0.path"),
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
+func visitArtifactPaths(t *testing.T, root config.Root) []dyn.Path {
+	var actual []dyn.Path
+	err := root.Mutate(func(value dyn.Value) (dyn.Value, error) {
+		return VisitArtifactPaths(value, func(p dyn.Path, mode TranslateMode, v dyn.Value) (dyn.Value, error) {
+			actual = append(actual, p)
+			return v, nil
+		})
+	})
+	require.NoError(t, err)
+	return actual
+}

--- a/bundle/config/mutator/paths/dashboard_paths_visitor.go
+++ b/bundle/config/mutator/paths/dashboard_paths_visitor.go
@@ -1,0 +1,18 @@
+package paths
+
+import (
+	"github.com/databricks/cli/libs/dyn"
+)
+
+func VisitDashboardPaths(value dyn.Value, fn VisitFunc) (dyn.Value, error) {
+	pattern := dyn.NewPattern(
+		dyn.Key("resources"),
+		dyn.Key("dashboards"),
+		dyn.AnyKey(),
+		dyn.Key("file_path"),
+	)
+
+	return dyn.MapByPattern(value, pattern, func(path dyn.Path, value dyn.Value) (dyn.Value, error) {
+		return fn(path, TranslateModeLocalAbsoluteFile, value)
+	})
+}

--- a/bundle/config/mutator/paths/dashboard_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/dashboard_paths_visitor_test.go
@@ -1,0 +1,42 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/dyn"
+	assert "github.com/databricks/cli/libs/dyn/dynassert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisitDashboardPaths(t *testing.T) {
+	root := config.Root{
+		Resources: config.Resources{
+			Dashboards: map[string]*resources.Dashboard{
+				"dashboard0": {
+					FilePath: "foo.lvdash.json",
+				},
+			},
+		},
+	}
+
+	actual := visitDashboardPaths(t, root)
+	expected := []dyn.Path{
+		dyn.MustPathFromString("resources.dashboards.dashboard0.file_path"),
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
+func visitDashboardPaths(t *testing.T, root config.Root) []dyn.Path {
+	var actual []dyn.Path
+	err := root.Mutate(func(value dyn.Value) (dyn.Value, error) {
+		return VisitDashboardPaths(value, func(p dyn.Path, mode TranslateMode, v dyn.Value) (dyn.Value, error) {
+			actual = append(actual, p)
+			return v, nil
+		})
+	})
+	require.NoError(t, err)
+	return actual
+}

--- a/bundle/config/mutator/paths/job_paths_visitor.go
+++ b/bundle/config/mutator/paths/job_paths_visitor.go
@@ -7,7 +7,7 @@ import (
 
 type jobRewritePattern struct {
 	pattern     dyn.Pattern
-	kind        PathKind
+	mode        TranslateMode
 	skipRewrite func(string) bool
 }
 
@@ -19,37 +19,37 @@ func jobTaskRewritePatterns(base dyn.Pattern) []jobRewritePattern {
 	return []jobRewritePattern{
 		{
 			base.Append(dyn.Key("notebook_task"), dyn.Key("notebook_path")),
-			PathKindNotebook,
+			TranslateModeNotebook,
 			noSkipRewrite,
 		},
 		{
 			base.Append(dyn.Key("spark_python_task"), dyn.Key("python_file")),
-			PathKindWorkspaceFile,
+			TranslateModeFile,
 			noSkipRewrite,
 		},
 		{
 			base.Append(dyn.Key("dbt_task"), dyn.Key("project_directory")),
-			PathKindDirectory,
+			TranslateModeDirectory,
 			noSkipRewrite,
 		},
 		{
 			base.Append(dyn.Key("sql_task"), dyn.Key("file"), dyn.Key("path")),
-			PathKindWorkspaceFile,
+			TranslateModeFile,
 			noSkipRewrite,
 		},
 		{
 			base.Append(dyn.Key("libraries"), dyn.AnyIndex(), dyn.Key("whl")),
-			PathKindLibrary,
+			TranslateModeLocalRelative,
 			noSkipRewrite,
 		},
 		{
 			base.Append(dyn.Key("libraries"), dyn.AnyIndex(), dyn.Key("jar")),
-			PathKindLibrary,
+			TranslateModeLocalRelative,
 			noSkipRewrite,
 		},
 		{
 			base.Append(dyn.Key("libraries"), dyn.AnyIndex(), dyn.Key("requirements")),
-			PathKindWorkspaceFile,
+			TranslateModeFile,
 			noSkipRewrite,
 		},
 	}
@@ -78,7 +78,7 @@ func jobRewritePatterns() []jobRewritePattern {
 				dyn.Key("dependencies"),
 				dyn.AnyIndex(),
 			),
-			PathKindWithPrefix,
+			TranslateModeLocalRelativeWithPrefix,
 			func(s string) bool {
 				return !libraries.IsLibraryLocal(s)
 			},
@@ -103,7 +103,7 @@ func VisitJobPaths(value dyn.Value, fn VisitFunc) (dyn.Value, error) {
 				return v, nil
 			}
 
-			return fn(p, rewritePattern.kind, v)
+			return fn(p, rewritePattern.mode, v)
 		})
 		if err != nil {
 			return dyn.InvalidValue, err

--- a/bundle/config/mutator/paths/job_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/job_paths_visitor_test.go
@@ -158,7 +158,7 @@ func TestVisitJobPaths_foreach(t *testing.T) {
 func visitJobPaths(t *testing.T, root config.Root) []dyn.Path {
 	var actual []dyn.Path
 	err := root.Mutate(func(value dyn.Value) (dyn.Value, error) {
-		return VisitJobPaths(value, func(p dyn.Path, kind PathKind, v dyn.Value) (dyn.Value, error) {
+		return VisitJobPaths(value, func(p dyn.Path, mode TranslateMode, v dyn.Value) (dyn.Value, error) {
 			actual = append(actual, p)
 			return v, nil
 		})

--- a/bundle/config/mutator/paths/pipeline_paths_visitor.go
+++ b/bundle/config/mutator/paths/pipeline_paths_visitor.go
@@ -1,0 +1,49 @@
+package paths
+
+import (
+	"github.com/databricks/cli/libs/dyn"
+)
+
+type pipelineRewritePattern struct {
+	pattern dyn.Pattern
+	mode    TranslateMode
+}
+
+func pipelineRewritePatterns() []pipelineRewritePattern {
+	// Base pattern to match all libraries in all pipelines.
+	base := dyn.NewPattern(
+		dyn.Key("resources"),
+		dyn.Key("pipelines"),
+		dyn.AnyKey(),
+		dyn.Key("libraries"),
+		dyn.AnyIndex(),
+	)
+
+	// Compile list of configuration paths to rewrite.
+	return []pipelineRewritePattern{
+		{
+			pattern: base.Append(dyn.Key("notebook"), dyn.Key("path")),
+			mode:    TranslateModeNotebook,
+		},
+		{
+			pattern: base.Append(dyn.Key("file"), dyn.Key("path")),
+			mode:    TranslateModeFile,
+		},
+	}
+}
+
+func VisitPipelinePaths(value dyn.Value, fn VisitFunc) (dyn.Value, error) {
+	var err error
+	newValue := value
+
+	for _, rewritePattern := range pipelineRewritePatterns() {
+		newValue, err = dyn.MapByPattern(newValue, rewritePattern.pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+			return fn(p, rewritePattern.mode, v)
+		})
+		if err != nil {
+			return dyn.InvalidValue, err
+		}
+	}
+
+	return newValue, nil
+}

--- a/bundle/config/mutator/paths/pipeline_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/pipeline_paths_visitor_test.go
@@ -1,0 +1,57 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/dyn"
+	assert "github.com/databricks/cli/libs/dyn/dynassert"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisitPipelinePaths(t *testing.T) {
+	root := config.Root{
+		Resources: config.Resources{
+			Pipelines: map[string]*resources.Pipeline{
+				"pipeline0": {
+					CreatePipeline: &pipelines.CreatePipeline{
+						Libraries: []pipelines.PipelineLibrary{
+							{
+								File: &pipelines.FileLibrary{
+									Path: "dist/foo.whl",
+								},
+							},
+							{
+								Notebook: &pipelines.NotebookLibrary{
+									Path: "src/foo.py",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actual := visitPipelinePaths(t, root)
+	expected := []dyn.Path{
+		dyn.MustPathFromString("resources.pipelines.pipeline0.libraries[0].file.path"),
+		dyn.MustPathFromString("resources.pipelines.pipeline0.libraries[1].notebook.path"),
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
+
+func visitPipelinePaths(t *testing.T, root config.Root) []dyn.Path {
+	var actual []dyn.Path
+	err := root.Mutate(func(value dyn.Value) (dyn.Value, error) {
+		return VisitPipelinePaths(value, func(p dyn.Path, mode TranslateMode, v dyn.Value) (dyn.Value, error) {
+			actual = append(actual, p)
+			return v, nil
+		})
+	})
+	require.NoError(t, err)
+	return actual
+}

--- a/bundle/config/mutator/paths/translation_mode.go
+++ b/bundle/config/mutator/paths/translation_mode.go
@@ -1,0 +1,32 @@
+package paths
+
+// TranslateMode specifies how a path should be translated.
+type TranslateMode int
+
+const (
+	// TranslateModeNotebook translates a path to a remote notebook.
+	TranslateModeNotebook TranslateMode = iota
+
+	// TranslateModeFile translates a path to a remote regular file.
+	TranslateModeFile
+
+	// TranslateModeDirectory translates a path to a remote directory.
+	TranslateModeDirectory
+
+	// TranslateModeLocalAbsoluteFile translates a path to the local absolute file path.
+	// It returns an error if the path does not exist or is a directory.
+	TranslateModeLocalAbsoluteFile
+
+	// TranslateModeLocalAbsoluteDirectory translates a path to the local absolute directory path.
+	// It returns an error if the path does not exist or is not a directory.
+	TranslateModeLocalAbsoluteDirectory
+
+	// TranslateModeLocalRelative translates a path to be relative to the bundle sync root path.
+	// It does not check if the path exists, nor care if it is a file or directory.
+	TranslateModeLocalRelative
+
+	// TranslateModeLocalRelativeWithPrefix translates a path to be relative to the bundle sync root path.
+	// It a "./" prefix to the path if it does not already have one.
+	// This allows for disambiguating between paths and PyPI package names.
+	TranslateModeLocalRelativeWithPrefix
+)

--- a/bundle/config/mutator/paths/visitor.go
+++ b/bundle/config/mutator/paths/visitor.go
@@ -1,26 +1,7 @@
 package paths
 
-import "github.com/databricks/cli/libs/dyn"
-
-type PathKind int
-
-const (
-	// PathKindLibrary is a path to a library file
-	PathKindLibrary = iota
-
-	// PathKindNotebook is a path to a notebook file
-	PathKindNotebook
-
-	// PathKindWorkspaceFile is a path to a regular workspace file,
-	// notebooks are not allowed because they are uploaded a special
-	// kind of workspace object.
-	PathKindWorkspaceFile
-
-	// PathKindWithPrefix is a path that starts with './'
-	PathKindWithPrefix
-
-	// PathKindDirectory is a path to directory
-	PathKindDirectory
+import (
+	"github.com/databricks/cli/libs/dyn"
 )
 
-type VisitFunc func(path dyn.Path, kind PathKind, value dyn.Value) (dyn.Value, error)
+type VisitFunc func(path dyn.Path, mode TranslateMode, value dyn.Value) (dyn.Value, error)

--- a/bundle/config/mutator/python/python_mutator.go
+++ b/bundle/config/mutator/python/python_mutator.go
@@ -431,7 +431,7 @@ func loadOutput(rootPath string, outputFile io.Reader, locations *pythonLocation
 	// we can remove this once we:
 	// - add variable interpolation before and after PythonMutator
 	// - implement path normalization (aka path normal form)
-	_, err = paths.VisitJobPaths(generated, func(p dyn.Path, kind paths.PathKind, v dyn.Value) (dyn.Value, error) {
+	_, err = paths.VisitJobPaths(generated, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
 		putPythonLocation(locations, p, v.Location())
 		return v, nil
 	})

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/databricks/cli/bundle/config/mutator/paths"
+
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/libs/diag"
@@ -18,41 +20,10 @@ import (
 	"github.com/databricks/cli/libs/notebook"
 )
 
-// TranslateMode specifies how a path should be translated.
-type TranslateMode int
-
-const (
-	// TranslateModeNotebook translates a path to a remote notebook.
-	TranslateModeNotebook TranslateMode = iota
-
-	// TranslateModeFile translates a path to a remote regular file.
-	TranslateModeFile
-
-	// TranslateModeDirectory translates a path to a remote directory.
-	TranslateModeDirectory
-
-	// TranslateModeLocalAbsoluteFile translates a path to the local absolute file path.
-	// It returns an error if the path does not exist or is a directory.
-	TranslateModeLocalAbsoluteFile
-
-	// TranslateModeLocalAbsoluteDirectory translates a path to the local absolute directory path.
-	// It returns an error if the path does not exist or is not a directory.
-	TranslateModeLocalAbsoluteDirectory
-
-	// TranslateModeLocalRelative translates a path to be relative to the bundle sync root path.
-	// It does not check if the path exists, nor care if it is a file or directory.
-	TranslateModeLocalRelative
-
-	// TranslateModeLocalRelativeWithPrefix translates a path to be relative to the bundle sync root path.
-	// It a "./" prefix to the path if it does not already have one.
-	// This allows for disambiguating between paths and PyPI package names.
-	TranslateModeLocalRelativeWithPrefix
-)
-
 // translateOptions control path translation behavior.
 type translateOptions struct {
 	// Mode specifies how the path should be translated.
-	Mode TranslateMode
+	Mode paths.TranslateMode
 
 	// AllowPathOutsideSyncRoot can be set for paths that are not tied to the sync root path.
 	// This is the case for artifact paths, for example.
@@ -158,19 +129,19 @@ func (t *translateContext) rewritePath(
 	// Convert local path into workspace path via specified function.
 	var interp string
 	switch opts.Mode {
-	case TranslateModeNotebook:
+	case paths.TranslateModeNotebook:
 		interp, err = t.translateNotebookPath(ctx, input, localPath, localRelPath)
-	case TranslateModeFile:
+	case paths.TranslateModeFile:
 		interp, err = t.translateFilePath(ctx, input, localPath, localRelPath)
-	case TranslateModeDirectory:
+	case paths.TranslateModeDirectory:
 		interp, err = t.translateDirectoryPath(ctx, input, localPath, localRelPath)
-	case TranslateModeLocalAbsoluteFile:
+	case paths.TranslateModeLocalAbsoluteFile:
 		interp, err = t.translateLocalAbsoluteFilePath(ctx, input, localPath, localRelPath)
-	case TranslateModeLocalAbsoluteDirectory:
+	case paths.TranslateModeLocalAbsoluteDirectory:
 		interp, err = t.translateLocalAbsoluteDirectoryPath(ctx, input, localPath, localRelPath)
-	case TranslateModeLocalRelative:
+	case paths.TranslateModeLocalRelative:
 		interp, err = t.translateLocalRelativePath(ctx, input, localPath, localRelPath)
-	case TranslateModeLocalRelativeWithPrefix:
+	case paths.TranslateModeLocalRelativeWithPrefix:
 		interp, err = t.translateLocalRelativeWithPrefixPath(ctx, input, localPath, localRelPath)
 	default:
 		return "", fmt.Errorf("unsupported translate mode: %d", opts.Mode)

--- a/bundle/config/mutator/translate_paths_apps.go
+++ b/bundle/config/mutator/translate_paths_apps.go
@@ -4,24 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/databricks/cli/bundle/config/mutator/paths"
+
 	"github.com/databricks/cli/libs/dyn"
 )
 
 func (t *translateContext) applyAppsTranslations(ctx context.Context, v dyn.Value) (dyn.Value, error) {
 	// Convert the `source_code_path` field to a remote absolute path.
 	// We use this path for app deployment to point to the source code.
-	pattern := dyn.NewPattern(
-		dyn.Key("resources"),
-		dyn.Key("apps"),
-		dyn.AnyKey(),
-		dyn.Key("source_code_path"),
-	)
 
-	opts := translateOptions{
-		Mode: TranslateModeDirectory,
-	}
+	return paths.VisitAppPaths(v, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
+		opts := translateOptions{
+			Mode: mode,
+		}
 
-	return dyn.MapByPattern(v, pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 		key := p[2].Key()
 		dir, err := v.Location().Directory()
 		if err != nil {

--- a/bundle/config/mutator/translate_paths_artifacts.go
+++ b/bundle/config/mutator/translate_paths_artifacts.go
@@ -4,53 +4,27 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/databricks/cli/bundle/config/mutator/paths"
+
 	"github.com/databricks/cli/libs/dyn"
 )
 
-type artifactRewritePattern struct {
-	pattern dyn.Pattern
-	opts    translateOptions
-}
-
-func (t *translateContext) artifactRewritePatterns() []artifactRewritePattern {
-	// Base pattern to match all artifacts.
-	base := dyn.NewPattern(
-		dyn.Key("artifacts"),
-		dyn.AnyKey(),
-	)
-
-	// Compile list of configuration paths to rewrite.
-	return []artifactRewritePattern{
-		{
-			base.Append(dyn.Key("path")),
-			translateOptions{
-				Mode: TranslateModeLocalAbsoluteDirectory,
-
-				// Artifact paths may be outside the sync root.
-				// They are the working directory for artifact builds.
-				AllowPathOutsideSyncRoot: true,
-			},
-		},
-	}
-}
-
 func (t *translateContext) applyArtifactTranslations(ctx context.Context, v dyn.Value) (dyn.Value, error) {
-	var err error
+	return paths.VisitArtifactPaths(v, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
+		opts := translateOptions{
+			Mode: mode,
 
-	for _, rewritePattern := range t.artifactRewritePatterns() {
-		v, err = dyn.MapByPattern(v, rewritePattern.pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
-			key := p[1].Key()
-			dir, err := v.Location().Directory()
-			if err != nil {
-				return dyn.InvalidValue, fmt.Errorf("unable to determine directory for artifact %s: %w", key, err)
-			}
-
-			return t.rewriteValue(ctx, p, v, dir, rewritePattern.opts)
-		})
-		if err != nil {
-			return dyn.InvalidValue, err
+			// Artifact paths may be outside the sync root.
+			// They are the working directory for artifact builds.
+			AllowPathOutsideSyncRoot: true,
 		}
-	}
 
-	return v, nil
+		key := p[1].Key()
+		dir, err := v.Location().Directory()
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf("unable to determine directory for artifact %s: %w", key, err)
+		}
+
+		return t.rewriteValue(ctx, p, v, dir, opts)
+	})
 }

--- a/bundle/config/mutator/translate_paths_dashboards.go
+++ b/bundle/config/mutator/translate_paths_dashboards.go
@@ -4,28 +4,24 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/databricks/cli/bundle/config/mutator/paths"
+
 	"github.com/databricks/cli/libs/dyn"
 )
 
 func (t *translateContext) applyDashboardTranslations(ctx context.Context, v dyn.Value) (dyn.Value, error) {
 	// Convert the `file_path` field to a local absolute path.
 	// We load the file at this path and use its contents for the dashboard contents.
-	pattern := dyn.NewPattern(
-		dyn.Key("resources"),
-		dyn.Key("dashboards"),
-		dyn.AnyKey(),
-		dyn.Key("file_path"),
-	)
 
-	opts := translateOptions{
-		Mode: TranslateModeLocalAbsoluteFile,
-	}
-
-	return dyn.MapByPattern(v, pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+	return paths.VisitDashboardPaths(v, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
 		key := p[2].Key()
 		dir, err := v.Location().Directory()
 		if err != nil {
 			return dyn.InvalidValue, fmt.Errorf("unable to determine directory for dashboard %s: %w", key, err)
+		}
+
+		opts := translateOptions{
+			Mode: mode,
 		}
 
 		return t.rewriteValue(ctx, p, v, dir, opts)

--- a/bundle/config/mutator/translate_paths_jobs.go
+++ b/bundle/config/mutator/translate_paths_jobs.go
@@ -26,7 +26,7 @@ func (t *translateContext) applyJobTranslations(ctx context.Context, v dyn.Value
 		}
 	}
 
-	return paths.VisitJobPaths(v, func(p dyn.Path, kind paths.PathKind, v dyn.Value) (dyn.Value, error) {
+	return paths.VisitJobPaths(v, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
 		key := p[2].Key()
 
 		// Skip path translation if the job is using git source.
@@ -37,11 +37,6 @@ func (t *translateContext) applyJobTranslations(ctx context.Context, v dyn.Value
 		dir, err := v.Location().Directory()
 		if err != nil {
 			return dyn.InvalidValue, fmt.Errorf("unable to determine directory for job %s: %w", key, err)
-		}
-
-		mode, err := getJobTranslateMode(kind)
-		if err != nil {
-			return dyn.InvalidValue, err
 		}
 
 		opts := translateOptions{
@@ -66,21 +61,4 @@ func (t *translateContext) applyJobTranslations(ctx context.Context, v dyn.Value
 
 		return dyn.InvalidValue, err
 	})
-}
-
-func getJobTranslateMode(kind paths.PathKind) (TranslateMode, error) {
-	switch kind {
-	case paths.PathKindLibrary:
-		return TranslateModeLocalRelative, nil
-	case paths.PathKindNotebook:
-		return TranslateModeNotebook, nil
-	case paths.PathKindWorkspaceFile:
-		return TranslateModeFile, nil
-	case paths.PathKindDirectory:
-		return TranslateModeDirectory, nil
-	case paths.PathKindWithPrefix:
-		return TranslateModeLocalRelativeWithPrefix, nil
-	}
-
-	return TranslateMode(0), fmt.Errorf("unsupported path kind: %d", kind)
 }

--- a/bundle/config/mutator/translate_paths_pipelines.go
+++ b/bundle/config/mutator/translate_paths_pipelines.go
@@ -4,36 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/databricks/cli/bundle/config/mutator/paths"
+
 	"github.com/databricks/cli/libs/dyn"
 )
-
-type pipelineRewritePattern struct {
-	pattern dyn.Pattern
-	opts    translateOptions
-}
-
-func (t *translateContext) pipelineRewritePatterns() []pipelineRewritePattern {
-	// Base pattern to match all libraries in all pipelines.
-	base := dyn.NewPattern(
-		dyn.Key("resources"),
-		dyn.Key("pipelines"),
-		dyn.AnyKey(),
-		dyn.Key("libraries"),
-		dyn.AnyIndex(),
-	)
-
-	// Compile list of configuration paths to rewrite.
-	return []pipelineRewritePattern{
-		{
-			base.Append(dyn.Key("notebook"), dyn.Key("path")),
-			translateOptions{Mode: TranslateModeNotebook},
-		},
-		{
-			base.Append(dyn.Key("file"), dyn.Key("path")),
-			translateOptions{Mode: TranslateModeFile},
-		},
-	}
-}
 
 func (t *translateContext) applyPipelineTranslations(ctx context.Context, v dyn.Value) (dyn.Value, error) {
 	var err error
@@ -43,36 +17,33 @@ func (t *translateContext) applyPipelineTranslations(ctx context.Context, v dyn.
 		return dyn.InvalidValue, err
 	}
 
-	for _, rewritePattern := range t.pipelineRewritePatterns() {
-		v, err = dyn.MapByPattern(v, rewritePattern.pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
-			key := p[2].Key()
-			dir, err := v.Location().Directory()
-			if err != nil {
-				return dyn.InvalidValue, fmt.Errorf("unable to determine directory for pipeline %s: %w", key, err)
-			}
+	return paths.VisitPipelinePaths(v, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
+		key := p[2].Key()
+		dir, err := v.Location().Directory()
+		if err != nil {
+			return dyn.InvalidValue, fmt.Errorf("unable to determine directory for pipeline %s: %w", key, err)
+		}
 
-			// Try to rewrite the path relative to the directory of the configuration file where the value was defined.
-			nv, err := t.rewriteValue(ctx, p, v, dir, rewritePattern.opts)
-			if err == nil {
+		opts := translateOptions{
+			Mode: mode,
+		}
+
+		// Try to rewrite the path relative to the directory of the configuration file where the value was defined.
+		nv, err := t.rewriteValue(ctx, p, v, dir, opts)
+		if err == nil {
+			return nv, nil
+		}
+
+		// If we failed to rewrite the path, try to rewrite it relative to the fallback directory.
+		// We only do this for jobs and pipelines because of the comment in [gatherFallbackPaths].
+		if fallback[key] != "" {
+			nv, nerr := t.rewriteValue(ctx, p, v, fallback[key], opts)
+			if nerr == nil {
+				// TODO: Emit a warning that this path should be rewritten.
 				return nv, nil
 			}
-
-			// If we failed to rewrite the path, try to rewrite it relative to the fallback directory.
-			// We only do this for jobs and pipelines because of the comment in [gatherFallbackPaths].
-			if fallback[key] != "" {
-				nv, nerr := t.rewriteValue(ctx, p, v, fallback[key], rewritePattern.opts)
-				if nerr == nil {
-					// TODO: Emit a warning that this path should be rewritten.
-					return nv, nil
-				}
-			}
-
-			return dyn.InvalidValue, err
-		})
-		if err != nil {
-			return dyn.InvalidValue, err
 		}
-	}
 
-	return v, nil
+		return dyn.InvalidValue, err
+	})
 }


### PR DESCRIPTION
## Changes
Extract relative path visitors so we can implement path normalization using them.

Replace `PathKind` with `TranslateMode` because there is no difference in how we use them.

## Why
By splitting the logic that visits all fields that contain a path from the code that performs the path translation, it becomes possible to make this a 2-pass operation.

In the first pass, we make all paths relative to the bundle root (incorporating their location). This can happen as early as possible. Then, in the second pass, we know that all relative paths have already been normalized to be relative to the bundle root, and we can perform path translation without relying on the location information.

## Tests
Added unit tests in addition to the existing coverage