### PR TITLE
acc: Fix default-python integration test

### DIFF
--- a/acceptance/bundle/templates/default-python/integration_classic/output.txt
+++ b/acceptance/bundle/templates/default-python/integration_classic/output.txt
@@ -1,4 +1,7 @@
 
+>>> python3 -c import sys; print("%s.%s" % sys.version_info[:2])
+[UV_PYTHON]
+
 >>> [CLI] bundle init default-python --config-file ./input.json --output-dir .
 
 Welcome to the default Python template for Databricks Asset Bundles!

--- a/acceptance/bundle/templates/default-python/integration_classic/output.txt
+++ b/acceptance/bundle/templates/default-python/integration_classic/output.txt
@@ -1,5 +1,5 @@
 
->>> python3 -c import sys; print("%s.%s" % sys.version_info[:2])
+>>> python -c import sys; print("%s.%s" % sys.version_info[:2])
 [UV_PYTHON]
 
 >>> [CLI] bundle init default-python --config-file ./input.json --output-dir .

--- a/acceptance/bundle/templates/default-python/integration_classic/script
+++ b/acceptance/bundle/templates/default-python/integration_classic/script
@@ -2,6 +2,7 @@ export PYTHONDONTWRITEBYTECODE=1
 
 uv venv -q .venv
 venv_activate
+trace python3 -c 'import sys; print("%s.%s" % sys.version_info[:2])'
 uv pip install -q setuptools
 
 envsubst < input.json.tmpl > input.json

--- a/acceptance/bundle/templates/default-python/integration_classic/script
+++ b/acceptance/bundle/templates/default-python/integration_classic/script
@@ -2,7 +2,7 @@ export PYTHONDONTWRITEBYTECODE=1
 
 uv venv -q .venv
 venv_activate
-trace python3 -c 'import sys; print("%s.%s" % sys.version_info[:2])'
+trace python -c 'import sys; print("%s.%s" % sys.version_info[:2])'
 uv pip install -q setuptools
 
 envsubst < input.json.tmpl > input.json

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,5 +1,4 @@
 Cloud = true
-CloudSlow = false
 Local = false
 
 # Temporarily disabling due to IsServicePrincipal/email_notifications differences.

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,4 +1,5 @@
 Cloud = true
+CloudSlow = false
 Local = false
 
 # Temporarily disabling due to IsServicePrincipal/email_notifications differences.

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -10,7 +10,7 @@ Ignore = [
 ]
 
 [EnvMatrix]
-UV_VERSION = [
+UV_PYTHON = [
     "3.9",
     "3.10",
     "3.11",

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -19,7 +19,8 @@ UV_VERSION = [
 ]
 
 [[Repls]]
-Old = '\d{6,}'
+# for some reason leading number is lost converting "%H%M%S" 061234 to 61234
+Old = '\d{5,}'
 New = '[NUMBER]'
 
 [[Repls]]


### PR DESCRIPTION
This failure is caused by 6 digit timestamp being converted to 5 digit if there is a leading zero:
```
           >>> [CLI] bundle deploy -t dev
           Building python_artifact...
          -Uploading dist/project_name_[UNIQUE_NAME]-0.0.1+[NUMBER].[NUMBER]-py3-none-any.whl...
          +Uploading dist/project_name_[UNIQUE_NAME]-0.0.1+[NUMBER].63807-py3-none-any.whl...
           Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files...
           Deploying resources...
           Updating deployment state...
```

Also fix Python selection variable: it's not UV_VERSION, it's UV_PYTHON.