### PR TITLE
Fix 'make fmt' after upgrading golangci-lint to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lintcheck:
 # If you need to ensure that formatting & imports are always fixed, do "make fmt lint"
 fmt:
 	ruff format -qn
-	golangci-lint run --enable-only="gofmt,gofumpt,goimports" --fix ./...
+	golangci-lint fmt
 
 test:
 	${GOTESTSUM_CMD} -- ${PACKAGES}


### PR DESCRIPTION
Follow up to #2586