### PR TITLE
Fixed TestProxyHandleWebSocket flakiness

### DIFF
--- a/libs/appproxy/appproxy_test.go
+++ b/libs/appproxy/appproxy_test.go
@@ -138,7 +138,7 @@ func TestProxyHandleWebSocket(t *testing.T) {
 		"websocket: close 1006 (abnormal closure)",
 		"An established connection was aborted by the software in your host machine",
 		"connection reset by peer",
-		"An existing connection was forcibly closed by the remote host"
+		"An existing connection was forcibly closed by the remote host",
 	}
 	for _, msg := range potentialErrMessages {
 		if strings.Contains(err.Error(), msg) {

--- a/libs/appproxy/appproxy_test.go
+++ b/libs/appproxy/appproxy_test.go
@@ -140,12 +140,16 @@ func TestProxyHandleWebSocket(t *testing.T) {
 		"connection reset by peer",
 		"An existing connection was forcibly closed by the remote host",
 	}
+	found := false
 	for _, msg := range potentialErrMessages {
 		if strings.Contains(err.Error(), msg) {
-			return
+			found = true
+			break
 		}
 	}
 
 	// If none of the expected error messages are found, fail the test
-	t.Errorf("Expected one of the expected errors, got %s", err)
+	if !found {
+		t.Errorf("Expected one of the expected errors, got %s", err)
+	}
 }

--- a/libs/appproxy/appproxy_test.go
+++ b/libs/appproxy/appproxy_test.go
@@ -134,9 +134,18 @@ func TestProxyHandleWebSocket(t *testing.T) {
 
 	_, _, err = conn.ReadMessage()
 	require.Error(t, err)
-	if !strings.Contains(err.Error(), "websocket: close 1006 (abnormal closure)") &&
-		!strings.Contains(err.Error(), "An established connection was aborted by the software in your host machine") &&
-		!strings.Contains(err.Error(), "connection reset by peer") {
-		t.Errorf("Expected abnormal closure, An established connection was aborted, or connection reset by peer, got %s", err)
+	potentialErrMessages := []string{
+		"websocket: close 1006 (abnormal closure)",
+		"An established connection was aborted by the software in your host machine",
+		"connection reset by peer",
+		"An existing connection was forcibly closed by the remote host"
 	}
+	for _, msg := range potentialErrMessages {
+		if strings.Contains(err.Error(), msg) {
+			return
+		}
+	}
+
+	// If none of the expected error messages are found, fail the test
+	t.Errorf("Expected one of the expected errors, got %s", err)
 }


### PR DESCRIPTION
## Changes
Fixed TestProxyHandleWebSocket flakiness

## Why
Websocket ReadMessage on a closed host might fail with different error messages depending on when host is closed. The actual message does not really matter as long as it's one of the expected error messages

## Tests
Existing test is not flaky anymore
