### PR TITLE
Use python script to extract command exec id

### DIFF
--- a/acceptance/bin/extract_command_exec_id.py
+++ b/acceptance/bin/extract_command_exec_id.py
@@ -8,7 +8,8 @@ from pathlib import Path
 def extract_cmd_exec_id():
     requests_file = Path("out.requests.txt")
 
-    # Read until we find a complete JSON object
+    # Read until we find a complete JSON object. This is required because we pretty
+    # print the JSON object (with new lines) in the out.requests.txt file.
     with requests_file.open("r") as f:
         json_str = ""
         while True:

--- a/acceptance/bin/extract_command_exec_id.py
+++ b/acceptance/bin/extract_command_exec_id.py
@@ -15,7 +15,7 @@ def extract_cmd_exec_id():
         while True:
             line = f.readline()
             if not line:
-                return "Requests file is empty"
+                raise SystemExit("Requests file is empty")
 
             json_str += line
             try:
@@ -29,18 +29,15 @@ def extract_cmd_exec_id():
         user_agent = data["headers"]["User-Agent"][0]
 
         if not user_agent:
-            return "User-Agent header is empty"
+            raise SystemExit("User-Agent header is empty")
 
         match = re.search(r"cmd-exec-id/([^\s]+)", user_agent)
         if match:
-            print(match.group(1))
-            return None
+            return match.group(1)
 
-        return f"No command execution ID found in User-Agent: {user_agent}"
+        raise SystemExit(f"No command execution ID found in User-Agent: {user_agent}")
 
 
 if __name__ == "__main__":
-    error = extract_cmd_exec_id()
-    if error:
-        print(f"Error: {error}", file=sys.stderr)
-        sys.exit(1)
+    exec_id = extract_cmd_exec_id()
+    print(exec_id)

--- a/acceptance/bin/extract_command_exec_id.py
+++ b/acceptance/bin/extract_command_exec_id.py
@@ -8,43 +8,34 @@ from pathlib import Path
 def extract_cmd_exec_id():
     requests_file = Path("out.requests.txt")
 
-    if not requests_file.exists():
-        return f"Requests file '{requests_file}' not found"
+    # Read until we find a complete JSON object
+    with requests_file.open("r") as f:
+        json_str = ""
+        while True:
+            line = f.readline()
+            if not line:
+                return "Requests file is empty"
 
-    try:
-        # Read until we find a complete JSON object
-        with requests_file.open("r") as f:
-            json_str = ""
-            while True:
-                line = f.readline()
-                if not line:
-                    return "Requests file is empty"
+            json_str += line
+            try:
+                # Try to parse the accumulated string as JSON
+                data = json.loads(json_str)
+                break
+            except json.JSONDecodeError:
+                # If incomplete, continue reading
+                continue
 
-                json_str += line
-                try:
-                    # Try to parse the accumulated string as JSON
-                    data = json.loads(json_str)
-                    break
-                except json.JSONDecodeError:
-                    # If incomplete, continue reading
-                    continue
+        user_agent = data["headers"]["User-Agent"][0]
 
-            user_agent = data["headers"]["User-Agent"][0]
+        if not user_agent:
+            return "User-Agent header is empty"
 
-            if not user_agent:
-                return "User-Agent header is empty"
+        match = re.search(r"cmd-exec-id/([^\s]+)", user_agent)
+        if match:
+            print(match.group(1))
+            return None
 
-            match = re.search(r"cmd-exec-id/([^\s]+)", user_agent)
-            if match:
-                print(match.group(1))
-                return None
-
-            return f"No command execution ID found in User-Agent: {user_agent}"
-
-    except KeyError as e:
-        return f"Missing required field in JSON: {e}"
-    except IndexError:
-        return "No User-Agent headers found in requests"
+        return f"No command execution ID found in User-Agent: {user_agent}"
 
 
 if __name__ == "__main__":

--- a/acceptance/bin/extract_command_exec_id.py
+++ b/acceptance/bin/extract_command_exec_id.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import sys
+from pathlib import Path
+
+def extract_cmd_exec_id():
+    requests_file = Path('out.requests.txt')
+
+    if not requests_file.exists():
+        return f"Requests file '{requests_file}' not found"
+
+    try:
+        # Read until we find a complete JSON object
+        with requests_file.open('r') as f:
+            json_str = ''
+            while True:
+                line = f.readline()
+                if not line:
+                    return "Requests file is empty"
+
+                json_str += line
+                try:
+                    # Try to parse the accumulated string as JSON
+                    data = json.loads(json_str)
+                    break
+                except json.JSONDecodeError:
+                    # If incomplete, continue reading
+                    continue
+
+            user_agent = data['headers']['User-Agent'][0]
+
+            if not user_agent:
+                return "User-Agent header is empty"
+
+            match = re.search(r'cmd-exec-id/([^\s]+)', user_agent)
+            if match:
+                print(match.group(1))
+                return None
+
+            return f"No command execution ID found in User-Agent: {user_agent}"
+
+    except KeyError as e:
+        return f"Missing required field in JSON: {e}"
+    except IndexError:
+        return "No User-Agent headers found in requests"
+
+if __name__ == '__main__':
+    error = extract_cmd_exec_id()
+    if error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/acceptance/bin/extract_command_exec_id.py
+++ b/acceptance/bin/extract_command_exec_id.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
-
 import json
 import re
 import sys
 from pathlib import Path
 
+
 def extract_cmd_exec_id():
-    requests_file = Path('out.requests.txt')
+    requests_file = Path("out.requests.txt")
 
     if not requests_file.exists():
         return f"Requests file '{requests_file}' not found"
 
     try:
         # Read until we find a complete JSON object
-        with requests_file.open('r') as f:
-            json_str = ''
+        with requests_file.open("r") as f:
+            json_str = ""
             while True:
                 line = f.readline()
                 if not line:
@@ -29,12 +29,12 @@ def extract_cmd_exec_id():
                     # If incomplete, continue reading
                     continue
 
-            user_agent = data['headers']['User-Agent'][0]
+            user_agent = data["headers"]["User-Agent"][0]
 
             if not user_agent:
                 return "User-Agent header is empty"
 
-            match = re.search(r'cmd-exec-id/([^\s]+)', user_agent)
+            match = re.search(r"cmd-exec-id/([^\s]+)", user_agent)
             if match:
                 print(match.group(1))
                 return None
@@ -46,7 +46,8 @@ def extract_cmd_exec_id():
     except IndexError:
         return "No User-Agent headers found in requests"
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     error = extract_cmd_exec_id()
     if error:
         print(f"Error: {error}", file=sys.stderr)

--- a/acceptance/bundle/telemetry/deploy-no-uuid/script
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/script
@@ -5,7 +5,7 @@ trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext
 # Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
 # a SIGPIPE in linux based systems.
 set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(extract_command_exec_id.py)
 
 update_file.py output.txt $cmd_exec_id  '[CMD-EXEC-ID]'
 update_file.py output.txt "00000000-0000-0000-0000-000000000000"  '[ZERO_UUID]'

--- a/acceptance/bundle/telemetry/deploy-no-uuid/script
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/script
@@ -2,9 +2,6 @@ trace $CLI bundle deploy
 
 trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems.
-set +o pipefail
 cmd_exec_id=$(extract_command_exec_id.py)
 
 update_file.py output.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -4,8 +4,7 @@ trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext
 
 # Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
 # a SIGPIPE in linux based systems.
-set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(extract_command_exec_id.py)
 
 update_file.py output.txt $cmd_exec_id  '[CMD-EXEC-ID]'
 update_file.py output.txt "11111111-2222-3333-4444-555555555555"  '[BUNDLE_UUID]'

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -8,7 +8,7 @@ rm -r output
 
 # Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -5,9 +5,6 @@ trace $CLI bundle init . --config-file input.json --output-dir output
 mv output/my_custom_template/databricks.yml out.databricks.yml
 rm -r output
 
-
-# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
-set +o pipefail
 cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -7,7 +7,7 @@ rm -r output
 
 # Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -5,8 +5,6 @@ $CLI bundle init dbt-sql --config-file input.json --output-dir output
 mv output/my_dbt_sql/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
-set +o pipefail
 cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -7,7 +7,7 @@ rm -r output
 
 # Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 # set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -5,8 +5,6 @@ $CLI bundle init default-python --config-file input.json --output-dir output
 mv output/my_default_python/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
-# set +o pipefail
 cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -7,7 +7,7 @@ rm -r output
 
 # Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
 set +o pipefail
-cmd_exec_id=$(cat out.requests.txt | jq '.headers."User-Agent".[0]'| head -n 1 | grep -o 'cmd-exec-id/[^ ]*' | cut -d '/' -f2)
+cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 
 update_file.py out.requests.txt $cmd_exec_id  '[CMD-EXEC-ID]'

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -5,8 +5,6 @@ $CLI bundle init default-sql --config-file input.json --output-dir output
 mv output/my_default_sql/databricks.yml out.databricks.yml
 rm -r output
 
-# Disable pipefail. head can exit early if it encounters a new line. That would cause a SIGPIPE in linux systems.
-set +o pipefail
 cmd_exec_id=$(extract_command_exec_id.py)
 bundle_uuid=$(cat out.databricks.yml | grep -o 'uuid: [^\n]*' | cut -d ' ' -f2)
 


### PR DESCRIPTION
## Why
The previous approach of using a pipeline was flaky on windows. Unix tools have slightly different semantics on different operating systems so it's hard to use and maintain them for acceptance tests.

That's why this PR switches to using a python script to extract the command exec id.

## Tests
Existing tests pass.
