### PR TITLE
Include databricks api usage text fix in changelog

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@ Previously ".internal" folder under artifact_path was not cleaned up as expected
 ### CLI
 * Include supported values for enum positional args in docs ([#2557](https://github.com/databricks/cli/pull/2557))
 * Upgrade Go SDK to 0.61.0 ([#2575](https://github.com/databricks/cli/pull/2575))
+* Fix `databricks api` command usage string to include PATH positional argument ([#2591](https://github.com/databricks/cli/pull/2591))
 
 ### Bundles
 * Fixed cleaning up artifact path .internal folder ([#2572](https://github.com/databricks/cli/pull/2572))


### PR DESCRIPTION
## Why
Forgot to include this when merging https://github.com/databricks/cli/pull/2591. This change calls out the fix in the changelog.