### PR TITLE
Separate variable resolution for resources

### DIFF
--- a/acceptance/bundle/debug/out.stderr.txt
+++ b/acceptance/bundle/debug/out.stderr.txt
@@ -41,6 +41,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
 10:07:59 Debug: Apply pid=12345 mutator=ResolveResourceReferences
 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
+10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences(resources)
 10:07:59 Debug: Apply pid=12345 mutator=MergeJobClusters
 10:07:59 Debug: Apply pid=12345 mutator=MergeJobParameters
 10:07:59 Debug: Apply pid=12345 mutator=MergeJobTasks

--- a/bundle/config/mutator/resolve_variable_references.go
+++ b/bundle/config/mutator/resolve_variable_references.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/databricks/cli/libs/dyn/merge"
 
 	"github.com/databricks/cli/bundle"

--- a/bundle/config/mutator/resolve_variable_references_test.go
+++ b/bundle/config/mutator/resolve_variable_references_test.go
@@ -59,7 +59,7 @@ func TestResolveVariableReferencesWithSourceLinkedDeployment(t *testing.T) {
 			},
 		}
 
-		diags := bundle.Apply(context.Background(), b, ResolveVariableReferences("workspace"))
+		diags := bundle.Apply(context.Background(), b, ResolveVariableReferencesOnlyResources("workspace"))
 		require.NoError(t, diags.Error())
 		testCase.assert(t, b)
 	}

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -830,7 +830,7 @@ func TestTranslatePathWithComplexVariables(t *testing.T) {
 
 	diags = bundle.ApplySeq(ctx, b,
 		mutator.SetVariables(),
-		mutator.ResolveVariableReferences("variables"),
+		mutator.ResolveVariableReferencesOnlyResources("variables"),
 		mutator.TranslatePaths())
 	require.NoError(t, diags.Error())
 

--- a/bundle/phases/build.go
+++ b/bundle/phases/build.go
@@ -20,7 +20,10 @@ func Build(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		scripts.Execute(config.ScriptPreBuild),
 		artifacts.Build(),
 		scripts.Execute(config.ScriptPostBuild),
-		mutator.ResolveVariableReferences(
+		mutator.ResolveVariableReferencesWithoutResources(
+			"artifacts",
+		),
+		mutator.ResolveVariableReferencesOnlyResources(
 			"artifacts",
 		),
 	)

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -65,7 +65,12 @@ func Initialize(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseApplyMutators),
 		mutator.ResolveVariableReferencesInLookup(),
 		mutator.ResolveResourceReferences(),
-		mutator.ResolveVariableReferences(
+		mutator.ResolveVariableReferencesWithoutResources(
+			"bundle",
+			"workspace",
+			"variables",
+		),
+		mutator.ResolveVariableReferencesOnlyResources(
 			"bundle",
 			"workspace",
 			"variables",

--- a/bundle/tests/apps_test.go
+++ b/bundle/tests/apps_test.go
@@ -15,7 +15,7 @@ func TestApps(t *testing.T) {
 
 	diags := bundle.ApplySeq(context.Background(), b,
 		mutator.SetVariables(),
-		mutator.ResolveVariableReferences("variables"),
+		mutator.ResolveVariableReferencesOnlyResources("variables"),
 	)
 	assert.Empty(t, diags)
 
@@ -38,7 +38,7 @@ func TestAppsOverride(t *testing.T) {
 
 	diags := bundle.ApplySeq(context.Background(), b,
 		mutator.SetVariables(),
-		mutator.ResolveVariableReferences("variables"),
+		mutator.ResolveVariableReferencesOnlyResources("variables"),
 	)
 	assert.Empty(t, diags)
 	app := b.Config.Resources.Apps["my_app"]

--- a/bundle/tests/interpolation_test.go
+++ b/bundle/tests/interpolation_test.go
@@ -12,22 +12,41 @@ import (
 
 func TestInterpolation(t *testing.T) {
 	b := load(t, "./interpolation")
-	diags := bundle.Apply(context.Background(), b, mutator.ResolveVariableReferences(
-		"bundle",
-		"workspace",
-	))
+	diags := bundle.ApplySeq(
+		context.Background(),
+		b,
+		mutator.ResolveVariableReferencesOnlyResources(
+			"bundle",
+			"workspace",
+		),
+		mutator.ResolveVariableReferencesWithoutResources(
+			"bundle",
+			"workspace",
+		),
+	)
 	require.NoError(t, diags.Error())
 	assert.Equal(t, "foo bar", b.Config.Bundle.Name)
 	assert.Equal(t, "foo bar | bar", b.Config.Resources.Jobs["my_job"].Name)
 }
 
-func TestInterpolationWithTarget(t *testing.T) {
+func TestInterpolationWithTarget_withoutResources(t *testing.T) {
 	b := loadTarget(t, "./interpolation_target", "development")
-	diags := bundle.Apply(context.Background(), b, mutator.ResolveVariableReferences(
+	diags := bundle.Apply(context.Background(), b, mutator.ResolveVariableReferencesOnlyResources(
+		"bundle",
+		"workspace",
+	))
+	require.NoError(t, diags.Error())
+	assert.Equal(t, "foo ${workspace.profile}", b.Config.Bundle.Name)
+	assert.Equal(t, "foo bar | bar | development | development", b.Config.Resources.Jobs["my_job"].Name)
+}
+
+func TestInterpolationWithTarget_onlyResources(t *testing.T) {
+	b := loadTarget(t, "./interpolation_target", "development")
+	diags := bundle.Apply(context.Background(), b, mutator.ResolveVariableReferencesWithoutResources(
 		"bundle",
 		"workspace",
 	))
 	require.NoError(t, diags.Error())
 	assert.Equal(t, "foo bar", b.Config.Bundle.Name)
-	assert.Equal(t, "foo bar | bar | development | development", b.Config.Resources.Jobs["my_job"].Name)
+	assert.Equal(t, "${bundle.name} | ${workspace.profile} | ${bundle.environment} | ${bundle.target}", b.Config.Resources.Jobs["my_job"].Name)
 }

--- a/cmd/bundle/destroy.go
+++ b/cmd/bundle/destroy.go
@@ -70,7 +70,10 @@ func newDestroyCommand() *cobra.Command {
 			// We need to resolve artifact variable (how we do it in build phase)
 			// because some of the to-be-destroyed resource might use this variable.
 			// Not resolving might lead to terraform "Reference to undeclared resource" error
-			bundle.Apply(ctx, b, mutator.ResolveVariableReferences("artifacts")),
+			bundle.ApplySeq(ctx, b,
+				mutator.ResolveVariableReferencesWithoutResources("artifacts"),
+				mutator.ResolveVariableReferencesOnlyResources("artifacts"),
+			),
 		)
 
 		if err := diags.Error(); err != nil {

--- a/libs/dyn/merge/select.go
+++ b/libs/dyn/merge/select.go
@@ -2,6 +2,7 @@ package merge
 
 import (
 	"fmt"
+
 	"github.com/databricks/cli/libs/dyn"
 )
 

--- a/libs/dyn/merge/select.go
+++ b/libs/dyn/merge/select.go
@@ -1,0 +1,53 @@
+package merge
+
+import (
+	"fmt"
+	"github.com/databricks/cli/libs/dyn"
+)
+
+func Select(value dyn.Value, included []string) (dyn.Value, error) {
+	mapping, ok := value.AsMap()
+	if !ok {
+		return dyn.InvalidValue, fmt.Errorf("expected a map, but found %s", value.Kind())
+	}
+
+	newMapping := dyn.NewMapping()
+	for _, key := range included {
+		pair, ok := mapping.GetPairByString(key)
+
+		if ok {
+			err := newMapping.Set(pair.Key, pair.Value)
+			if err != nil {
+				return dyn.InvalidValue, err
+			}
+		}
+	}
+
+	return dyn.NewValue(newMapping, value.Locations()), nil
+}
+
+func AntiSelect(value dyn.Value, excluded []string) (dyn.Value, error) {
+	mapping, ok := value.AsMap()
+	if !ok {
+		return dyn.InvalidValue, fmt.Errorf("expected a map, but found %s", value.Kind())
+	}
+
+	excludedSet := make(map[string]struct{})
+	for _, key := range excluded {
+		excludedSet[key] = struct{}{}
+	}
+
+	included := make([]string, 0, len(mapping.Pairs()))
+	for _, pair := range mapping.Pairs() {
+		key, ok := pair.Key.AsString()
+		if !ok {
+			return dyn.InvalidValue, fmt.Errorf("expected a string key, but found %s", pair.Key.Kind())
+		}
+
+		if _, ok := excludedSet[key]; !ok {
+			included = append(included, pair.Key.MustString())
+		}
+	}
+
+	return Select(value, included)
+}

--- a/libs/dyn/merge/select.go
+++ b/libs/dyn/merge/select.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/cli/libs/dyn"
 )
 
+// Select returns a new map that contains only the keys specified in the included list.
 func Select(value dyn.Value, included []string) (dyn.Value, error) {
 	mapping, ok := value.AsMap()
 	if !ok {
@@ -27,6 +28,7 @@ func Select(value dyn.Value, included []string) (dyn.Value, error) {
 	return dyn.NewValue(newMapping, value.Locations()), nil
 }
 
+// AntiSelect returns a new map with all keys from the input map except for the ones in the excluded list.
 func AntiSelect(value dyn.Value, excluded []string) (dyn.Value, error) {
 	mapping, ok := value.AsMap()
 	if !ok {

--- a/libs/dyn/merge/select_test.go
+++ b/libs/dyn/merge/select_test.go
@@ -1,0 +1,53 @@
+package merge
+
+import (
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSelect(t *testing.T) {
+	locations := []dyn.Location{{File: "foo.yml", Line: 1, Column: 1}}
+	included := []string{"foo"}
+	input := dyn.NewValue(
+		map[string]dyn.Value{
+			"foo": dyn.V("bar"),
+			"baz": dyn.V("qux"),
+		},
+		locations,
+	)
+	expected := dyn.NewValue(
+		map[string]dyn.Value{
+			"foo": dyn.V("bar"),
+		},
+		locations,
+	)
+
+	actual, err := Select(input, included)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestAntiSelect(t *testing.T) {
+	locations := []dyn.Location{{File: "foo.yml", Line: 1, Column: 1}}
+	excluded := []string{"foo"}
+	input := dyn.NewValue(
+		map[string]dyn.Value{
+			"foo": dyn.V("bar"),
+			"baz": dyn.V("qux"),
+		},
+		locations,
+	)
+	expected := dyn.NewValue(
+		map[string]dyn.Value{
+			"baz": dyn.V("qux"),
+		},
+		locations,
+	)
+
+	actual, err := AntiSelect(input, excluded)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/libs/dyn/merge/select_test.go
+++ b/libs/dyn/merge/select_test.go
@@ -3,8 +3,9 @@ package merge
 import (
 	"testing"
 
+	assert "github.com/databricks/cli/libs/dyn/dynassert"
+
 	"github.com/databricks/cli/libs/dyn"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSelect(t *testing.T) {

--- a/libs/dyn/merge/select_test.go
+++ b/libs/dyn/merge/select_test.go
@@ -1,9 +1,10 @@
 package merge
 
 import (
+	"testing"
+
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSelect(t *testing.T) {


### PR DESCRIPTION
## Changes
Separate variable resolution for "resources" from the rest of the configuration.

## Why
It allows keeping a part of the bundle with unresolved variables and resolving them as a separate stage.

## Tests
Using existing tests