### PR TITLE
[Python] Move deprecated phase load into initialization

### DIFF
--- a/acceptance/bundle/debug/out.stderr.txt
+++ b/acceptance/bundle/debug/out.stderr.txt
@@ -10,7 +10,6 @@
 10:07:59 Debug: Apply pid=12345 mutator=ComputeIdToClusterId
 10:07:59 Debug: Apply pid=12345 mutator=InitializeVariables
 10:07:59 Debug: Apply pid=12345 mutator=DefineDefaultTarget(default)
-10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load)
 10:07:59 Debug: Apply pid=12345 mutator=validate:unique_resource_keys
 10:07:59 Debug: Apply pid=12345 mutator=SelectDefaultTarget
 10:07:59 Debug: Apply pid=12345 mutator=SelectDefaultTarget mutator=SelectTarget(default)
@@ -35,6 +34,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=PrependWorkspacePrefix
 10:07:59 Debug: Apply pid=12345 mutator=RewriteWorkspacePrefix
 10:07:59 Debug: Apply pid=12345 mutator=SetVariables
+10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load)
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(init)
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load_resources)
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(apply_mutators)

--- a/bundle/config/mutator/mutator.go
+++ b/bundle/config/mutator/mutator.go
@@ -6,7 +6,6 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/loader"
-	pythonmutator "github.com/databricks/cli/bundle/config/mutator/python"
 	"github.com/databricks/cli/bundle/config/validate"
 	"github.com/databricks/cli/bundle/scripts"
 	"github.com/databricks/cli/libs/diag"
@@ -29,7 +28,6 @@ func DefaultMutators(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		ComputeIdToClusterId(),
 		InitializeVariables(),
 		DefineDefaultTarget(),
-		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseLoad),
 
 		// Note: This mutator must run before the target overrides are merged.
 		// See the mutator for more details.

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -60,6 +60,7 @@ func Initialize(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		// Intentionally placed before ResolveVariableReferencesInLookup, ResolveResourceReferences,
 		// ResolveVariableReferencesInComplexVariables and ResolveVariableReferences.
 		// See what is expected in PythonMutatorPhaseInit doc
+		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseLoad),
 		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseInit),
 		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseLoadResources),
 		pythonmutator.PythonMutator(pythonmutator.PythonMutatorPhaseApplyMutators),


### PR DESCRIPTION
## Changes
Move `PythonMutatorPhaseLoad` from `DefaultMutators` into `Initialize`.

No changelog entry because the feature is deprecated and not documented.

## Why
DefaultMutators is used for auto-completion that is not needed.

By moving into `Initialize`, we make behavior more similar to how `load_resources/apply_mutators` are implemented.