### PR TITLE
minor refactoring: use path.Dir when splitting a file path into parts in fake_workspace.go

### DIFF
--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -90,16 +90,8 @@ func (s *FakeWorkspace) WorkspaceFilesImportFile(filePath string, body []byte) {
 	s.files[filePath] = body
 
 	// Add all directories in the path to the directories map
-	parts := strings.Split(path.Dir(filePath), "/")
-	currentPath := ""
-	for _, part := range parts {
-		// Skip empty parts
-		if part == "" {
-			continue
-		}
-
-		currentPath = currentPath + "/" + part
-		s.directories[currentPath] = true
+	for dir := path.Dir(filePath); dir != "/"; dir = path.Dir(dir) {
+		s.directories[dir] = true
 	}
 }
 

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -82,18 +83,18 @@ func (s *FakeWorkspace) WorkspaceDelete(path string, recursive bool) {
 	}
 }
 
-func (s *FakeWorkspace) WorkspaceFilesImportFile(path string, body []byte) {
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+func (s *FakeWorkspace) WorkspaceFilesImportFile(filePath string, body []byte) {
+	if !strings.HasPrefix(filePath, "/") {
+		filePath = "/" + filePath
 	}
-	s.files[path] = body
+	s.files[filePath] = body
 
 	// Add all directories in the path to the directories map
-	parts := strings.Split(path, "/")
+	parts := strings.Split(path.Dir(filePath), "/")
 	currentPath := ""
-	for i, part := range parts {
-		// Skip empty parts and the last part (which is the file itself)
-		if part == "" || i == len(parts)-1 {
+	for _, part := range parts {
+		// Skip empty parts
+		if part == "" {
 			continue
 		}
 


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
Addresses a comment from #2465

## Tests
<!-- How have you tested the changes? -->
Existing tests

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
