### PR TITLE
Cleanup SIGPIPE comment in acceptance test

### DIFF
--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -2,8 +2,6 @@ trace $CLI bundle deploy
 
 trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems.
 cmd_exec_id=$(extract_command_exec_id.py)
 
 update_file.py output.txt $cmd_exec_id  '[CMD-EXEC-ID]'


### PR DESCRIPTION
## Why
We no longer needed to disable pipefail following https://github.com/databricks/cli/pull/2602 but I missed removing this comment. Just a minor cleanup.