### PR TITLE
Simplify config-file telemetry acceptance test

### DIFF
--- a/acceptance/bundle/telemetry/deploy-config-file-count/output.txt
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/output.txt
@@ -6,40 +6,25 @@ Deployment complete!
 
 >>> cat out.requests.txt
 {
-  "frontend_log_event_id": "[UUID]",
-  "entry": {
-    "databricks_cli_log": {
-      "execution_context": {
-        "cmd_exec_id": "[CMD-EXEC-ID]",
-        "version": "[DEV_VERSION]",
-        "command": "bundle_deploy",
-        "operating_system": "[OS]",
-        "execution_time_ms": SMALL_INT,
-        "exit_code": 0
-      },
-      "bundle_deploy_event": {
-        "bundle_uuid": "[UUID]",
-        "resource_count": 0,
-        "resource_job_count": 0,
-        "resource_pipeline_count": 0,
-        "resource_model_count": 0,
-        "resource_experiment_count": 0,
-        "resource_model_serving_endpoint_count": 0,
-        "resource_registered_model_count": 0,
-        "resource_quality_monitor_count": 0,
-        "resource_schema_count": 0,
-        "resource_volume_count": 0,
-        "resource_cluster_count": 0,
-        "resource_dashboard_count": 0,
-        "resource_app_count": 0,
-        "experimental": {
-          "configuration_file_count": 4,
-          "variable_count": 0,
-          "complex_variable_count": 0,
-          "lookup_variable_count": 0,
-          "target_count": 0
-        }
-      }
-    }
+  "bundle_uuid": "[UUID]",
+  "resource_count": 0,
+  "resource_job_count": 0,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "experimental": {
+    "configuration_file_count": 4,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 0
   }
 }

--- a/acceptance/bundle/telemetry/deploy-config-file-count/script
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/script
@@ -1,9 +1,5 @@
 trace $CLI bundle deploy
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
-
-cmd_exec_id=$(extract_command_exec_id.py)
-
-update_file.py output.txt $cmd_exec_id  '[CMD-EXEC-ID]'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
 
 rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-config-file-count/script
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/script
@@ -2,9 +2,6 @@ trace $CLI bundle deploy
 
 trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
 
-# Disable pipefail. head will skip reading all input once it encounters a newline. Not disabling pipefail will trigger
-# a SIGPIPE in linux based systems.
-set +o pipefail
 cmd_exec_id=$(extract_command_exec_id.py)
 
 update_file.py output.txt $cmd_exec_id  '[CMD-EXEC-ID]'


### PR DESCRIPTION
## Changes
This PR:
1. Modifies config-file telemetry acceptance test to assert only on the entry. Other tests already assert on the entire payload.
2. Removes `set +o pipeline` which I forgot to remove from https://github.com/databricks/cli/pull/2589 before merging.

## Why
Simpler test that's easier to maintain.