### PR TITLE
acc: add -logrequests option

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -41,6 +41,7 @@ var (
 	VerboseTest bool = os.Getenv("VERBOSE_TEST") != ""
 	Tail        bool
 	Forcerun    bool
+	LogRequests bool
 )
 
 // In order to debug CLI running under acceptance test, search for TestInprocessMode and update
@@ -58,6 +59,7 @@ func init() {
 	flag.BoolVar(&NoRepl, "norepl", false, "Do not apply any replacements (for debugging)")
 	flag.BoolVar(&Tail, "tail", false, "Log output of script in real time. Use with -v to see the logs: -tail -v")
 	flag.BoolVar(&Forcerun, "forcerun", false, "Force running the specified tests, ignore all reasons to skip")
+	flag.BoolVar(&LogRequests, "logrequests", false, "Log request and responses from testserver")
 }
 
 const (
@@ -389,10 +391,10 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 			server = testserver.New(t)
 			if isTruePtr(config.RecordRequests) {
 				requestsPath := filepath.Join(tmpDir, "out.requests.txt")
-				server.RecordRequestsCallback = func(request *testserver.Request) {
+				server.RequestCallback = func(request *testserver.Request) {
 					req := getLoggedRequest(request, config.IncludeRequestHeaders)
 					reqJson, err := json.MarshalIndent(req, "", "  ")
-					assert.NoErrorf(t, err, "Failed to indent: %#v", req)
+					assert.NoErrorf(t, err, "Failed to json-encode: %#v", req)
 
 					f, err := os.OpenFile(requestsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 					assert.NoError(t, err)
@@ -400,6 +402,16 @@ func runTest(t *testing.T, dir, coverDir string, repls testdiff.ReplacementsCont
 
 					_, err = f.WriteString(string(reqJson) + "\n")
 					assert.NoError(t, err)
+				}
+			}
+
+			if LogRequests {
+				server.ResponseCallback = func(request *testserver.Request, response *testserver.EncodedResponse) {
+					t.Logf("%d %s %s\n%s\n%s",
+						response.StatusCode, request.Method, request.URL,
+						formatHeadersAndBody("> ", request.Headers, request.Body),
+						formatHeadersAndBody("# ", response.Headers, response.Body),
+					)
 				}
 			}
 
@@ -942,4 +954,26 @@ func buildDatabricksBundlesWheel(t *testing.T, buildDir string) (string, error) 
 	} else {
 		return "", fmt.Errorf("databricks-bundles wheel not found in %s", buildDir)
 	}
+}
+
+func formatHeadersAndBody(prefix string, headers http.Header, body []byte) string {
+	var result []string
+	for key, values := range headers {
+		if len(values) == 1 {
+			result = append(result, fmt.Sprintf("%s%s: %s", prefix, key, values[0]))
+		} else {
+			result = append(result, fmt.Sprintf("%s%s: %s", prefix, key, values))
+		}
+	}
+	if len(body) > 0 {
+		var s string
+		if utf8.Valid(body) {
+			s = string(body)
+		} else {
+			s = fmt.Sprintf("[Binary %d bytes]", len(body))
+		}
+		s = strings.ReplaceAll(s, "\n", "\n"+prefix)
+		result = append(result, prefix+s)
+	}
+	return strings.Join(result, "\n")
 }


### PR DESCRIPTION
## Changes
- New option to acceptance test runner: -logrequests. When specified request + responses from testserver are logged.

## Why
- Debugging the test server & CLI interaction.

## Tests
Manually: `go test .. -run ^TestAccept$/^selftest$ -v -logrequests`

```
    acceptance_test.go:409: 200 GET /api/2.0/preview/scim/v2/Me
        > User-Agent: curl/8.7.1
        > Accept: */*
        # X-Databricks-Org-Id: 900800700600
        # {
        #     "id": "1000012345",
        #     "userName": "tester@databricks.com"
        # }
```