### PR TITLE
Disable build in TestBuiltinPythonTemplateIsValid

### DIFF
--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -140,7 +140,7 @@ func TestBuiltinPythonTemplateValid(t *testing.T) {
 		"serverless":       "yes",
 	}
 	isServicePrincipal = false
-	build = true
+	// build = true
 
 	// On Windows, we can't always remove the resulting temp dir since background
 	// processes might have it open, so we use 'defer' for a best-effort cleanup


### PR DESCRIPTION
Fails on CI with:

```
Building python_artifact...
    renderer_test.go:103:
        	Error Trace:	D:/a/cli/cli/libs/template/renderer_test.go:103
        	            				D:/a/cli/cli/libs/template/renderer_test.go:151
        	Error:      	Received unexpected error:
        	            	build failed python_artifact, error: exit status 1, output: C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\setuptools\dist.py:487: UserWarning: Normalizing '0.0.1+20250403.095813' to '0.0.1+20250403.95813'
        	            	  warnings.warn(tmpl.format(**locals()))
        	            	usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
        	            	   or: setup.py --help [cmd1 cmd2 ...]
        	            	   or: setup.py --help-commands
        	            	   or: setup.py cmd --help

        	            	error: invalid command 'bdist_wheel'
        	Test:       	TestBuiltinPythonTemplateValid
```
