### PR TITLE
Revert "Disable build in TestBuiltinPythonTemplateIsValid (#2641)"

### DIFF
--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -140,7 +140,7 @@ func TestBuiltinPythonTemplateValid(t *testing.T) {
 		"serverless":       "yes",
 	}
 	isServicePrincipal = false
-	// build = true
+	build = true
 
 	// On Windows, we can't always remove the resulting temp dir since background
 	// processes might have it open, so we use 'defer' for a best-effort cleanup


### PR DESCRIPTION
This reverts commit 9e43332079000b8b2bc20155b17874404b017cd1.

Broken version of `wheel` package was released which caused the initial problem, package is yanked so we can bring back the test

https://pypi.org/project/wheel/0.46.0/