### PR TITLE
acc: Fix default Cloud setting in bundle/

### DIFF
--- a/acceptance/bundle/apps/test.toml
+++ b/acceptance/bundle/apps/test.toml
@@ -1,4 +1,3 @@
-Cloud = false
 RecordRequests = true
 
 Ignore = [

--- a/acceptance/bundle/artifacts/test.toml
+++ b/acceptance/bundle/artifacts/test.toml
@@ -1,4 +1,3 @@
-Cloud = false
 RecordRequests = true
 Ignore = [
     '.venv',

--- a/acceptance/bundle/debug/test.toml
+++ b/acceptance/bundle/debug/test.toml
@@ -1,5 +1,3 @@
-Cloud = false
-
 [[Repls]]
 # The keys are unsorted and also vary per OS
 Old = 'Environment variables for Terraform: ([A-Z_ ,]+) '

--- a/acceptance/bundle/deploy/experimental-python/test.toml
+++ b/acceptance/bundle/deploy/experimental-python/test.toml
@@ -1,2 +1,1 @@
-Local = true
-Cloud = false # need deterministic ids and clean workspace
+# need deterministic ids and clean workspace

--- a/acceptance/bundle/deploy/python-notebook/test.toml
+++ b/acceptance/bundle/deploy/python-notebook/test.toml
@@ -1,2 +1,1 @@
-Local = true
-Cloud = false # need deterministic ids and clean workspace
+# need deterministic ids and clean workspace

--- a/acceptance/bundle/generate/git_job/test.toml
+++ b/acceptance/bundle/generate/git_job/test.toml
@@ -1,5 +1,3 @@
-Cloud = false  # This test needs to run against stubbed Databricks API
-
 [[Server]]
 Pattern = "GET /api/2.2/jobs/get"
 Response.Body = '''

--- a/acceptance/bundle/help/test.toml
+++ b/acceptance/bundle/help/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/override/test.toml
+++ b/acceptance/bundle/override/test.toml
@@ -1,1 +1,0 @@
-Cloud = false

--- a/acceptance/bundle/python/test.toml
+++ b/acceptance/bundle/python/test.toml
@@ -1,5 +1,4 @@
-Local = true
-Cloud = false # tests don't interact with APIs
+# Tests don't interact with APIs
 
 [EnvMatrix]
 UV_ARGS = [

--- a/acceptance/bundle/state/test.toml
+++ b/acceptance/bundle/state/test.toml
@@ -1,2 +1,1 @@
-Cloud = false
 RecordRequests = true

--- a/acceptance/bundle/telemetry/test.toml
+++ b/acceptance/bundle/telemetry/test.toml
@@ -1,6 +1,4 @@
 RecordRequests = true
-Cloud = false
-Local = true
 IncludeRequestHeaders = ["User-Agent"]
 
 [[Repls]]

--- a/acceptance/bundle/templates-machinery/test.toml
+++ b/acceptance/bundle/templates-machinery/test.toml
@@ -1,5 +1,3 @@
-Cloud = false
-
 [[Server]]
 Pattern = "POST /telemetry-ext"
 Response.Body = '''

--- a/acceptance/bundle/templates/test.toml
+++ b/acceptance/bundle/templates/test.toml
@@ -1,5 +1,4 @@
-# At the moment, there are many differences across different envs w.r.t to catalog use, node type and so on.
-Cloud = false
+# Local-only: At the moment, there are many differences across different envs w.r.t to catalog use, node type and so on.
 
 [[Server]]
 Pattern = "POST /telemetry-ext"

--- a/acceptance/bundle/test.toml
+++ b/acceptance/bundle/test.toml
@@ -1,6 +1,3 @@
-Local = true
-Cloud = true
-
 [EnvMatrix]
 # The lowest Python version we support. Alternative to "uv run --python 3.10"
 UV_PYTHON = ["3.10"]

--- a/acceptance/bundle/trampoline/warning_message_with_new_spark/test.toml
+++ b/acceptance/bundle/trampoline/warning_message_with_new_spark/test.toml
@@ -1,7 +1,5 @@
 # Since we use existing cluster id value which is not available in cloud envs, we need to stub the request
 # and run this test only locally
-Cloud = false
-
 [[Server]]
 Pattern = "GET /api/2.1/clusters/get"
 Response.Body = '''

--- a/acceptance/bundle/trampoline/warning_message_with_old_spark/test.toml
+++ b/acceptance/bundle/trampoline/warning_message_with_old_spark/test.toml
@@ -1,7 +1,5 @@
 # Since we use existing cluster id value which is not available in cloud envs, we need to stub the request
 # and run this test only locally
-Cloud = false
-
 [[Server]]
 Pattern = "GET /api/2.1/clusters/get"
 Response.Body = '''

--- a/acceptance/bundle/validate/sync_patterns/test.toml
+++ b/acceptance/bundle/validate/sync_patterns/test.toml
@@ -1,2 +1,1 @@
-Cloud = false
 RecordRequests = true

--- a/acceptance/bundle/variables/test.toml
+++ b/acceptance/bundle/variables/test.toml
@@ -1,3 +1,2 @@
 # The tests here intend to test variable interpolation via "bundle validate".
 # Even though "bundle validate" does a few API calls, that's not the focus there.
-Cloud = false


### PR DESCRIPTION
Setting to true by default goes against regular default and is not what most subdirectories need.

This makes bundle tests similar to other acceptance tests wrt to Cloud setting: if you want to run on cloud, you set it to true explicitly.

