### PR TITLE
Lock wheel version in GitHub actions to 0.45.1

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Pull external libraries
         run: |
           make vendor
-          pip3 install wheel
+          pip3 install wheel=0.45.1
 
       - name: Run tests with coverage
         run: make cover


### PR DESCRIPTION
## Changes
Lock wheel version in GitHub actions to 0.45.1

## Why
To avoid disruption because of broken wheel versions https://pypi.org/project/wheel/0.46.0/
