### PR TITLE
Add include/exclude flags to sync and bundle-sync commands

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,8 +7,10 @@
 ### Dependency updates
 
 ### CLI
+* Added include/exclude flags support to sync command ([#2650](https://github.com/databricks/cli/pull/2650))
 
 ### Bundles
 * Added support for model serving endpoints in deployment bind/unbind commands ([#2634](https://github.com/databricks/cli/pull/2634))
+* Added include/exclude flags support to bundle sync command ([#2650](https://github.com/databricks/cli/pull/2650))
 
 ### API Changes

--- a/acceptance/bundle/help/bundle-sync/output.txt
+++ b/acceptance/bundle/help/bundle-sync/output.txt
@@ -6,8 +6,10 @@ Usage:
   databricks bundle sync [flags]
 
 Flags:
+      --exclude strings     patterns to exclude from sync (can be specified multiple times)
       --full                perform full synchronization (default is incremental)
   -h, --help                help for sync
+      --include strings     patterns to include in sync (can be specified multiple times)
       --interval duration   file system polling interval (for --watch) (default 1s)
       --output type         type of the output format
       --watch               watch local file system for changes

--- a/acceptance/bundle/sync/databricks.yml
+++ b/acceptance/bundle/sync/databricks.yml
@@ -5,4 +5,3 @@ resources:
   dashboards:
     dashboard1:
       display_name: My dashboard
-      file_path: "sample-dashboard.lvdash.json"

--- a/acceptance/bundle/sync/databricks.yml
+++ b/acceptance/bundle/sync/databricks.yml
@@ -1,0 +1,8 @@
+bundle:
+  name: bundle-sync-test
+
+resources:
+  dashboards:
+    dashboard1:
+      display_name: My dashboard
+      file_path: "sample-dashboard.lvdash.json"

--- a/acceptance/bundle/sync/output.txt
+++ b/acceptance/bundle/sync/output.txt
@@ -7,7 +7,6 @@ Uploaded project-folder
 Uploaded project-folder/app.py
 Uploaded project-folder/app.yaml
 Uploaded project-folder/query.sql
-Uploaded sample-dashboard.lvdash.json
 
 >>> [CLI] bundle sync --exclude project-folder/app.* --output text
 Deleted project-folder/app.py

--- a/acceptance/bundle/sync/output.txt
+++ b/acceptance/bundle/sync/output.txt
@@ -1,0 +1,38 @@
+
+>>> [CLI] bundle sync --output text
+Initial Sync Complete
+Uploaded .gitignore
+Uploaded app.py
+Uploaded app.yaml
+Uploaded databricks.yml
+Uploaded query.sql
+Uploaded sample-dashboard.lvdash.json
+
+>>> [CLI] bundle sync --exclude app.* --output text
+Deleted app.py
+Deleted app.yaml
+Initial Sync Complete
+
+>>> [CLI] bundle sync --exclude app.* --exclude query.sql --output text
+Deleted query.sql
+Initial Sync Complete
+
+>>> [CLI] bundle sync --exclude app.* --exclude query.sql --include ignored-folder/*.py --output text
+Initial Sync Complete
+Uploaded ignored-folder
+Uploaded ignored-folder/script.py
+
+>>> [CLI] bundle sync --exclude app.* --exclude query.sql --include ignored-folder/**/*.py --output text
+Initial Sync Complete
+Uploaded ignored-folder/folder1
+Uploaded ignored-folder/folder1/script.py
+
+>>> [CLI] bundle sync --output text
+Deleted ignored-folder
+Deleted ignored-folder/folder1
+Deleted ignored-folder/folder1/script.py
+Deleted ignored-folder/script.py
+Initial Sync Complete
+Uploaded app.py
+Uploaded app.yaml
+Uploaded query.sql

--- a/acceptance/bundle/sync/output.txt
+++ b/acceptance/bundle/sync/output.txt
@@ -2,27 +2,29 @@
 >>> [CLI] bundle sync --output text
 Initial Sync Complete
 Uploaded .gitignore
-Uploaded app.py
-Uploaded app.yaml
 Uploaded databricks.yml
-Uploaded query.sql
+Uploaded project-folder
+Uploaded project-folder/app.py
+Uploaded project-folder/app.yaml
+Uploaded project-folder/query.sql
 Uploaded sample-dashboard.lvdash.json
 
->>> [CLI] bundle sync --exclude app.* --output text
-Deleted app.py
-Deleted app.yaml
+>>> [CLI] bundle sync --exclude project-folder/app.* --output text
+Deleted project-folder/app.py
+Deleted project-folder/app.yaml
 Initial Sync Complete
 
->>> [CLI] bundle sync --exclude app.* --exclude query.sql --output text
-Deleted query.sql
+>>> [CLI] bundle sync --exclude project-folder/app.* --exclude project-folder/query.sql --output text
+Deleted project-folder
+Deleted project-folder/query.sql
 Initial Sync Complete
 
->>> [CLI] bundle sync --exclude app.* --exclude query.sql --include ignored-folder/*.py --output text
+>>> [CLI] bundle sync --exclude project-folder/app.* --exclude project-folder/query.sql --include ignored-folder/*.py --output text
 Initial Sync Complete
 Uploaded ignored-folder
 Uploaded ignored-folder/script.py
 
->>> [CLI] bundle sync --exclude app.* --exclude query.sql --include ignored-folder/**/*.py --output text
+>>> [CLI] bundle sync --exclude project-folder/app.* --exclude project-folder/query.sql --include ignored-folder/**/*.py --output text
 Initial Sync Complete
 Uploaded ignored-folder/folder1
 Uploaded ignored-folder/folder1/script.py
@@ -33,6 +35,7 @@ Deleted ignored-folder/folder1
 Deleted ignored-folder/folder1/script.py
 Deleted ignored-folder/script.py
 Initial Sync Complete
-Uploaded app.py
-Uploaded app.yaml
-Uploaded query.sql
+Uploaded project-folder
+Uploaded project-folder/app.py
+Uploaded project-folder/app.yaml
+Uploaded project-folder/query.sql

--- a/acceptance/bundle/sync/sample-dashboard.lvdash.json
+++ b/acceptance/bundle/sync/sample-dashboard.lvdash.json
@@ -1,0 +1,1 @@
+{"pages":[{"name":"12724bf2","displayName":"Page One"}]}

--- a/acceptance/bundle/sync/sample-dashboard.lvdash.json
+++ b/acceptance/bundle/sync/sample-dashboard.lvdash.json
@@ -1,1 +1,0 @@
-{"pages":[{"name":"12724bf2","displayName":"Page One"}]}

--- a/acceptance/bundle/sync/script
+++ b/acceptance/bundle/sync/script
@@ -1,0 +1,24 @@
+touch "app.yaml"
+touch "app.py"
+touch "query.sql"
+mkdir "ignored-folder" "ignored-folder/folder1"
+touch "ignored-folder/script.py"
+touch "ignored-folder/folder1/script.py"
+echo "ignored-folder/" > .gitignore
+echo "script" >> .gitignore
+echo "output.txt" >> .gitignore
+echo "repls.json" >> .gitignore
+
+cleanup() {
+  rm app.yaml app.py .gitignore query.sql
+  rm -rf ignored-folder
+}
+trap cleanup EXIT
+
+# Note: output line starting with "Action: " lists files in non-deterministic order so we filter it out
+trace $CLI bundle sync --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'app.*' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'app.*' --exclude 'query.sql' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/*.py' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/**/*.py' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --output text | grep -v "^Action: " | sort

--- a/acceptance/bundle/sync/script
+++ b/acceptance/bundle/sync/script
@@ -1,24 +1,22 @@
-touch "app.yaml"
-touch "app.py"
-touch "query.sql"
-mkdir "ignored-folder" "ignored-folder/folder1"
-touch "ignored-folder/script.py"
-touch "ignored-folder/folder1/script.py"
-echo "ignored-folder/" > .gitignore
-echo "script" >> .gitignore
-echo "output.txt" >> .gitignore
-echo "repls.json" >> .gitignore
+mkdir "project-folder" "ignored-folder" "ignored-folder/folder1"
+touch "project-folder/app.yaml" "project-folder/app.py" "project-folder/query.sql"
+touch "ignored-folder/script.py" "ignored-folder/folder1/script.py"
+cat > .gitignore << EOF
+ignored-folder/
+script
+output.txt
+repls.json
+EOF
 
 cleanup() {
-  rm app.yaml app.py .gitignore query.sql
-  rm -rf ignored-folder
+  rm -rf project-folder ignored-folder .git
 }
 trap cleanup EXIT
 
 # Note: output line starting with "Action: " lists files in non-deterministic order so we filter it out
 trace $CLI bundle sync --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'app.*' --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'app.*' --exclude 'query.sql' --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/*.py' --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/**/*.py' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'project-folder/app.*' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/*.py' --output text | grep -v "^Action: " | sort
+trace $CLI bundle sync --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/**/*.py' --output text | grep -v "^Action: " | sort
 trace $CLI bundle sync --output text | grep -v "^Action: " | sort

--- a/acceptance/cmd/sync/output.txt
+++ b/acceptance/cmd/sync/output.txt
@@ -1,42 +1,39 @@
 
 >>> [CLI] sync . /Users/[USERNAME]
-Warn: Failed to read git info: stat /.git: no such file or directory
 Initial Sync Complete
 Uploaded .gitignore
-Uploaded app.py
-Uploaded app.yaml
-Uploaded query.sql
+Uploaded project-folder
+Uploaded project-folder/app.py
+Uploaded project-folder/app.yaml
+Uploaded project-folder/query.sql
 
->>> [CLI] sync . /Users/[USERNAME] --exclude app.*
-Warn: Failed to read git info: stat /.git: no such file or directory
-Deleted app.py
-Deleted app.yaml
+>>> [CLI] sync . /Users/[USERNAME] --exclude project-folder/app.*
+Deleted project-folder/app.py
+Deleted project-folder/app.yaml
 Initial Sync Complete
 
->>> [CLI] sync . /Users/[USERNAME] --exclude app.* --exclude query.sql
-Warn: Failed to read git info: stat /.git: no such file or directory
-Deleted query.sql
+>>> [CLI] sync . /Users/[USERNAME] --exclude project-folder/app.* --exclude project-folder/query.sql
+Deleted project-folder
+Deleted project-folder/query.sql
 Initial Sync Complete
 
->>> [CLI] sync . /Users/[USERNAME] --exclude app.* --exclude query.sql --include ignored-folder/*.py
-Warn: Failed to read git info: stat /.git: no such file or directory
+>>> [CLI] sync . /Users/[USERNAME] --exclude project-folder/app.* --exclude project-folder/query.sql --include ignored-folder/*.py
 Initial Sync Complete
 Uploaded ignored-folder
 Uploaded ignored-folder/script.py
 
->>> [CLI] sync . /Users/[USERNAME] --exclude app.* --exclude query.sql --include ignored-folder/**/*.py
-Warn: Failed to read git info: stat /.git: no such file or directory
+>>> [CLI] sync . /Users/[USERNAME] --exclude project-folder/app.* --exclude project-folder/query.sql --include ignored-folder/**/*.py
 Initial Sync Complete
 Uploaded ignored-folder/folder1
 Uploaded ignored-folder/folder1/script.py
 
 >>> [CLI] sync . /Users/[USERNAME]
-Warn: Failed to read git info: stat /.git: no such file or directory
 Deleted ignored-folder
 Deleted ignored-folder/folder1
 Deleted ignored-folder/folder1/script.py
 Deleted ignored-folder/script.py
 Initial Sync Complete
-Uploaded app.py
-Uploaded app.yaml
-Uploaded query.sql
+Uploaded project-folder
+Uploaded project-folder/app.py
+Uploaded project-folder/app.yaml
+Uploaded project-folder/query.sql

--- a/acceptance/cmd/sync/output.txt
+++ b/acceptance/cmd/sync/output.txt
@@ -27,13 +27,18 @@ Initial Sync Complete
 Uploaded ignored-folder/folder1
 Uploaded ignored-folder/folder1/script.py
 
->>> [CLI] sync . /Users/[USERNAME]
-Deleted ignored-folder
-Deleted ignored-folder/folder1
-Deleted ignored-folder/folder1/script.py
-Deleted ignored-folder/script.py
+>>> [CLI] sync . /Users/[USERNAME] --include ignored-folder/** --include !ignored-folder/folder1/big-blob
 Initial Sync Complete
+Uploaded ignored-folder/folder1/script.yaml
 Uploaded project-folder
 Uploaded project-folder/app.py
 Uploaded project-folder/app.yaml
 Uploaded project-folder/query.sql
+
+>>> [CLI] sync . /Users/[USERNAME]
+Deleted ignored-folder
+Deleted ignored-folder/folder1
+Deleted ignored-folder/folder1/script.py
+Deleted ignored-folder/folder1/script.yaml
+Deleted ignored-folder/script.py
+Initial Sync Complete

--- a/acceptance/cmd/sync/output.txt
+++ b/acceptance/cmd/sync/output.txt
@@ -1,0 +1,42 @@
+
+>>> [CLI] sync . /Users/[USERNAME]
+Warn: Failed to read git info: stat /.git: no such file or directory
+Initial Sync Complete
+Uploaded .gitignore
+Uploaded app.py
+Uploaded app.yaml
+Uploaded query.sql
+
+>>> [CLI] sync . /Users/[USERNAME] --exclude app.*
+Warn: Failed to read git info: stat /.git: no such file or directory
+Deleted app.py
+Deleted app.yaml
+Initial Sync Complete
+
+>>> [CLI] sync . /Users/[USERNAME] --exclude app.* --exclude query.sql
+Warn: Failed to read git info: stat /.git: no such file or directory
+Deleted query.sql
+Initial Sync Complete
+
+>>> [CLI] sync . /Users/[USERNAME] --exclude app.* --exclude query.sql --include ignored-folder/*.py
+Warn: Failed to read git info: stat /.git: no such file or directory
+Initial Sync Complete
+Uploaded ignored-folder
+Uploaded ignored-folder/script.py
+
+>>> [CLI] sync . /Users/[USERNAME] --exclude app.* --exclude query.sql --include ignored-folder/**/*.py
+Warn: Failed to read git info: stat /.git: no such file or directory
+Initial Sync Complete
+Uploaded ignored-folder/folder1
+Uploaded ignored-folder/folder1/script.py
+
+>>> [CLI] sync . /Users/[USERNAME]
+Warn: Failed to read git info: stat /.git: no such file or directory
+Deleted ignored-folder
+Deleted ignored-folder/folder1
+Deleted ignored-folder/folder1/script.py
+Deleted ignored-folder/script.py
+Initial Sync Complete
+Uploaded app.py
+Uploaded app.yaml
+Uploaded query.sql

--- a/acceptance/cmd/sync/script
+++ b/acceptance/cmd/sync/script
@@ -1,0 +1,24 @@
+touch "app.yaml"
+touch "app.py"
+touch "query.sql"
+mkdir "ignored-folder" "ignored-folder/folder1"
+touch "ignored-folder/script.py"
+touch "ignored-folder/folder1/script.py"
+echo "ignored-folder/" > .gitignore
+echo "script" >> .gitignore
+echo "output.txt" >> .gitignore
+echo "repls.json" >> .gitignore
+
+cleanup() {
+  rm app.yaml app.py .gitignore query.sql
+  rm -rf ignored-folder
+}
+trap cleanup EXIT
+
+# Note: output line starting with "Action: " lists files in non-deterministic order so we filter it out
+trace $CLI sync . /Users/$CURRENT_USER_NAME | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' --exclude 'query.sql' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/*.py' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/**/*.py' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME | grep -v "^Action: " | sort

--- a/acceptance/cmd/sync/script
+++ b/acceptance/cmd/sync/script
@@ -1,6 +1,6 @@
 mkdir "project-folder" "ignored-folder" "ignored-folder/folder1" ".git"
 touch "project-folder/app.yaml" "project-folder/app.py" "project-folder/query.sql"
-touch "ignored-folder/script.py" "ignored-folder/folder1/script.py"
+touch "ignored-folder/script.py" "ignored-folder/folder1/script.py" "ignored-folder/folder1/script.yaml" "ignored-folder/folder1/big-blob"
 cat > .gitignore << EOF
 ignored-folder/
 script
@@ -15,8 +15,21 @@ trap cleanup EXIT
 
 # Note: output line starting with "Action: " lists files in non-deterministic order so we filter it out
 trace $CLI sync . /Users/$CURRENT_USER_NAME | grep -v "^Action: " | sort
+
+# excluding by mask:
 trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' | grep -v "^Action: " | sort
+
+# combining excludes:
 trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' | grep -v "^Action: " | sort
+
+# combining excludes and includes:
 trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/*.py' | grep -v "^Action: " | sort
+
+# include sub-folders:
 trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/**/*.py' | grep -v "^Action: " | sort
+
+# use negated include to exclude files from syncing:
+trace $CLI sync . /Users/$CURRENT_USER_NAME --include 'ignored-folder/**' --include '!ignored-folder/folder1/big-blob' | grep -v "^Action: " | sort
+
+# subsequent call without include/exclude flag syncs files based on .gitignore:
 trace $CLI sync . /Users/$CURRENT_USER_NAME | grep -v "^Action: " | sort

--- a/acceptance/cmd/sync/script
+++ b/acceptance/cmd/sync/script
@@ -1,24 +1,22 @@
-touch "app.yaml"
-touch "app.py"
-touch "query.sql"
-mkdir "ignored-folder" "ignored-folder/folder1"
-touch "ignored-folder/script.py"
-touch "ignored-folder/folder1/script.py"
-echo "ignored-folder/" > .gitignore
-echo "script" >> .gitignore
-echo "output.txt" >> .gitignore
-echo "repls.json" >> .gitignore
+mkdir "project-folder" "ignored-folder" "ignored-folder/folder1" ".git"
+touch "project-folder/app.yaml" "project-folder/app.py" "project-folder/query.sql"
+touch "ignored-folder/script.py" "ignored-folder/folder1/script.py"
+cat > .gitignore << EOF
+ignored-folder/
+script
+output.txt
+repls.json
+EOF
 
 cleanup() {
-  rm app.yaml app.py .gitignore query.sql
-  rm -rf ignored-folder
+  rm -rf project-folder ignored-folder .git
 }
 trap cleanup EXIT
 
 # Note: output line starting with "Action: " lists files in non-deterministic order so we filter it out
 trace $CLI sync . /Users/$CURRENT_USER_NAME | grep -v "^Action: " | sort
-trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' | grep -v "^Action: " | sort
-trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' --exclude 'query.sql' | grep -v "^Action: " | sort
-trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/*.py' | grep -v "^Action: " | sort
-trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'app.*' --exclude 'query.sql' --include 'ignored-folder/**/*.py' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/*.py' | grep -v "^Action: " | sort
+trace $CLI sync . /Users/$CURRENT_USER_NAME --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/**/*.py' | grep -v "^Action: " | sort
 trace $CLI sync . /Users/$CURRENT_USER_NAME | grep -v "^Action: " | sort

--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -22,6 +22,8 @@ type syncFlags struct {
 	full     bool
 	watch    bool
 	output   flags.Output
+	exclude  []string
+	include  []string
 }
 
 func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) (*sync.SyncOptions, error) {
@@ -47,6 +49,8 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) 
 
 	opts.Full = f.full
 	opts.PollInterval = f.interval
+	opts.Exclude = append(opts.Exclude, f.exclude...)
+	opts.Include = append(opts.Include, f.include...)
 	return opts, nil
 }
 
@@ -62,6 +66,8 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&f.full, "full", false, "perform full synchronization (default is incremental)")
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
 	cmd.Flags().Var(&f.output, "output", "type of the output format")
+	cmd.Flags().StringSliceVar(&f.exclude, "exclude", nil, "patterns to exclude from sync (can be specified multiple times)")
+	cmd.Flags().StringSliceVar(&f.include, "include", nil, "patterns to include in sync (can be specified multiple times)")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -27,6 +27,8 @@ type syncFlags struct {
 	full     bool
 	watch    bool
 	output   flags.Output
+	exclude  []string
+	include  []string
 }
 
 func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *bundle.Bundle) (*sync.SyncOptions, error) {
@@ -42,6 +44,8 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 	opts.Full = f.full
 	opts.PollInterval = f.interval
 	opts.WorktreeRoot = b.WorktreeRoot
+	opts.Exclude = append(opts.Exclude, f.exclude...)
+	opts.Include = append(opts.Include, f.include...)
 	return opts, nil
 }
 
@@ -86,8 +90,8 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		WorktreeRoot: worktreeRoot,
 		LocalRoot:    localRoot,
 		Paths:        []string{"."},
-		Include:      nil,
-		Exclude:      nil,
+		Include:      f.include,
+		Exclude:      f.exclude,
 
 		RemotePath:   args[1],
 		Full:         f.full,
@@ -120,6 +124,8 @@ func New() *cobra.Command {
 	cmd.Flags().BoolVar(&f.full, "full", false, "perform full synchronization (default is incremental)")
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
 	cmd.Flags().Var(&f.output, "output", "type of output format")
+	cmd.Flags().StringSliceVar(&f.exclude, "exclude", nil, "patterns to exclude from sync (can be specified multiple times)")
+	cmd.Flags().StringSliceVar(&f.include, "include", nil, "patterns to include in sync (can be specified multiple times)")
 
 	// Wrapper for [root.MustWorkspaceClient] that disables loading authentication configuration from a bundle.
 	mustWorkspaceClient := func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
This allows users to specify file patterns to include / exclude from syncs using respective flags in sync and bundle sync commands:

* `$ databricks sync <SRC> <DEST> --exclude "*.bak" --include "node_modules/mylib"`
* `$ databricks bundle sync --exclude "*.bak" --include "node_modules/mylib"`

[gitignore syntax](https://git-scm.com/docs/gitignore) for advanced pattern matching is supported.

Note that in the current implementation excludes always takes higher priority over includes. The order in which the flags are provided in the prompt does not change this behavior. To overcome this behavior users can provide an `--include` flag with a negated pattern (prefixed by a `!`) instead of using an `--exclude` flag in the combinations of patterns.

## Tests
<!-- How have you tested the changes? -->
Manual testing + introduced new acceptance tests

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
