### PR TITLE
Upgrade Go to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/databricks/cli
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.2
 
 require (
 	dario.cat/mergo v1.0.1 // BSD 3-Clause


### PR DESCRIPTION
## Changes
- Bump to to 1.24.2

## Why
https://go.dev/doc/go1.24

Potentially relevant features:
 - tool section in go.mod
 - Directory limited file-system access: https://go.dev/doc/go1.24#directory-limited-filesystem-access
 - new omitzero tag in encoding/json: https://go.dev/doc/go1.24#encodingjsonpkgencodingjson

Related:
Terraform provider upgrade to 1.24 in February (https://github.com/databricks/terraform-provider-databricks/pull/4508) and made use of new "tool" functionality (https://github.com/databricks/terraform-provider-databricks/pull/4577).


## Tests
Existing tests.