### PR TITLE
Specify schema for resource permissions

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bundles
 * Added support for model serving endpoints in deployment bind/unbind commands ([#2634](https://github.com/databricks/cli/pull/2634))
 * Added include/exclude flags support to bundle sync command ([#2650](https://github.com/databricks/cli/pull/2650))
+* Added JSON schema for resource permissions ([#2674](https://github.com/databricks/cli/pull/2674))
 * Removed pipeline 'deployment' field from jsonschema ([#2653](https://github.com/databricks/cli/pull/2653))
 * Updated JSON schema for deprecated pipeline fields ([#2646](https://github.com/databricks/cli/pull/2646))
 

--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
@@ -72,58 +72,58 @@ func TestApplyBundlePermissions(t *testing.T) {
 	require.NoError(t, diags.Error())
 
 	require.Len(t, b.Config.Resources.Jobs["job_1"].Permissions, 3)
-	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.Permission{Level: "CAN_MANAGE_RUN", ServicePrincipalName: "TestServicePrincipal"})
+	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.JobPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.JobPermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.JobPermission{Level: "CAN_MANAGE_RUN", ServicePrincipalName: "TestServicePrincipal"})
 
 	require.Len(t, b.Config.Resources.Jobs["job_2"].Permissions, 3)
-	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.Permission{Level: "CAN_MANAGE_RUN", ServicePrincipalName: "TestServicePrincipal"})
+	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.JobPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.JobPermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.JobPermission{Level: "CAN_MANAGE_RUN", ServicePrincipalName: "TestServicePrincipal"})
 
 	require.Len(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, 3)
-	require.Contains(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, resources.Permission{Level: "CAN_RUN", ServicePrincipalName: "TestServicePrincipal"})
+	require.Contains(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, resources.PipelinePermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, resources.PipelinePermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Pipelines["pipeline_1"].Permissions, resources.PipelinePermission{Level: "CAN_RUN", ServicePrincipalName: "TestServicePrincipal"})
 
 	require.Len(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, 3)
-	require.Contains(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, resources.Permission{Level: "CAN_RUN", ServicePrincipalName: "TestServicePrincipal"})
+	require.Contains(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, resources.PipelinePermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, resources.PipelinePermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Pipelines["pipeline_2"].Permissions, resources.PipelinePermission{Level: "CAN_RUN", ServicePrincipalName: "TestServicePrincipal"})
 
 	require.Len(t, b.Config.Resources.Models["model_1"].Permissions, 2)
-	require.Contains(t, b.Config.Resources.Models["model_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Models["model_1"].Permissions, resources.Permission{Level: "CAN_READ", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Models["model_1"].Permissions, resources.MlflowModelPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Models["model_1"].Permissions, resources.MlflowModelPermission{Level: "CAN_READ", GroupName: "TestGroup"})
 
 	require.Len(t, b.Config.Resources.Models["model_2"].Permissions, 2)
-	require.Contains(t, b.Config.Resources.Models["model_2"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Models["model_2"].Permissions, resources.Permission{Level: "CAN_READ", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Models["model_2"].Permissions, resources.MlflowModelPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Models["model_2"].Permissions, resources.MlflowModelPermission{Level: "CAN_READ", GroupName: "TestGroup"})
 
 	require.Len(t, b.Config.Resources.Experiments["experiment_1"].Permissions, 2)
-	require.Contains(t, b.Config.Resources.Experiments["experiment_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Experiments["experiment_1"].Permissions, resources.Permission{Level: "CAN_READ", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Experiments["experiment_1"].Permissions, resources.MlflowExperimentPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Experiments["experiment_1"].Permissions, resources.MlflowExperimentPermission{Level: "CAN_READ", GroupName: "TestGroup"})
 
 	require.Len(t, b.Config.Resources.Experiments["experiment_2"].Permissions, 2)
-	require.Contains(t, b.Config.Resources.Experiments["experiment_2"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Experiments["experiment_2"].Permissions, resources.Permission{Level: "CAN_READ", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Experiments["experiment_2"].Permissions, resources.MlflowExperimentPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Experiments["experiment_2"].Permissions, resources.MlflowExperimentPermission{Level: "CAN_READ", GroupName: "TestGroup"})
 
 	require.Len(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, 3)
-	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, resources.Permission{Level: "CAN_QUERY", ServicePrincipalName: "TestServicePrincipal"})
+	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, resources.ModelServingEndpointPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, resources.ModelServingEndpointPermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_1"].Permissions, resources.ModelServingEndpointPermission{Level: "CAN_QUERY", ServicePrincipalName: "TestServicePrincipal"})
 
 	require.Len(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, 3)
-	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, resources.Permission{Level: "CAN_QUERY", ServicePrincipalName: "TestServicePrincipal"})
+	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, resources.ModelServingEndpointPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, resources.ModelServingEndpointPermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint_2"].Permissions, resources.ModelServingEndpointPermission{Level: "CAN_QUERY", ServicePrincipalName: "TestServicePrincipal"})
 
 	require.Len(t, b.Config.Resources.Dashboards["dashboard_1"].Permissions, 2)
-	require.Contains(t, b.Config.Resources.Dashboards["dashboard_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Dashboards["dashboard_1"].Permissions, resources.Permission{Level: "CAN_READ", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Dashboards["dashboard_1"].Permissions, resources.DashboardPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Dashboards["dashboard_1"].Permissions, resources.DashboardPermission{Level: "CAN_READ", GroupName: "TestGroup"})
 
 	require.Len(t, b.Config.Resources.Apps["app_1"].Permissions, 2)
-	require.Contains(t, b.Config.Resources.Apps["app_1"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Apps["app_1"].Permissions, resources.Permission{Level: "CAN_USE", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Apps["app_1"].Permissions, resources.AppPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Apps["app_1"].Permissions, resources.AppPermission{Level: "CAN_USE", GroupName: "TestGroup"})
 }
 
 func TestWarningOnOverlapPermission(t *testing.T) {
@@ -142,16 +142,16 @@ func TestWarningOnOverlapPermission(t *testing.T) {
 						JobSettings: &jobs.JobSettings{
 							Name: "job_1",
 						},
-						Permissions: []resources.Permission{
-							{Level: permissions.CAN_VIEW, UserName: "TestUser"},
+						Permissions: []resources.JobPermission{
+							{Level: "CAN_VIEW", UserName: "TestUser"},
 						},
 					},
 					"job_2": {
 						JobSettings: &jobs.JobSettings{
 							Name: "job_2",
 						},
-						Permissions: []resources.Permission{
-							{Level: permissions.CAN_VIEW, UserName: "TestUser2"},
+						Permissions: []resources.JobPermission{
+							{Level: "CAN_VIEW", UserName: "TestUser2"},
 						},
 					},
 				},
@@ -162,11 +162,11 @@ func TestWarningOnOverlapPermission(t *testing.T) {
 	diags := bundle.Apply(context.Background(), b, ApplyBundlePermissions())
 	require.NoError(t, diags.Error())
 
-	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.Permission{Level: "CAN_VIEW", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
-	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.Permission{Level: "CAN_VIEW", UserName: "TestUser2"})
-	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.Permission{Level: "CAN_MANAGE", UserName: "TestUser"})
-	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.Permission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.JobPermission{Level: "CAN_VIEW", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Jobs["job_1"].Permissions, resources.JobPermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
+	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.JobPermission{Level: "CAN_VIEW", UserName: "TestUser2"})
+	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.JobPermission{Level: "CAN_MANAGE", UserName: "TestUser"})
+	require.Contains(t, b.Config.Resources.Jobs["job_2"].Permissions, resources.JobPermission{Level: "CAN_VIEW", GroupName: "TestGroup"})
 }
 
 func TestAllResourcesExplicitlyDefinedForPermissionsSupport(t *testing.T) {

--- a/bundle/config/mutator/resourcemutator/filter_current_user_test.go
+++ b/bundle/config/mutator/resourcemutator/filter_current_user_test.go
@@ -14,26 +14,110 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var alice = resources.Permission{
+var jobAlice = resources.JobPermission{
+	Level:    "CAN_MANAGE",
+	UserName: "alice@databricks.com",
+}
+
+var jobBob = resources.JobPermission{
+	Level:    "CAN_VIEW",
+	UserName: "bob@databricks.com",
+}
+
+var jobRobot = resources.JobPermission{
+	Level:                "CAN_MANAGE_RUN",
+	ServicePrincipalName: "i-Robot",
+}
+
+var pipelineAlice = resources.PipelinePermission{
 	Level:    permissions.CAN_MANAGE,
 	UserName: "alice@databricks.com",
 }
 
-var bob = resources.Permission{
+var pipelineBob = resources.PipelinePermission{
 	Level:    permissions.CAN_VIEW,
 	UserName: "bob@databricks.com",
 }
 
-var robot = resources.Permission{
+var pipelineRobot = resources.PipelinePermission{
+	Level:                permissions.CAN_RUN,
+	ServicePrincipalName: "i-Robot",
+}
+
+var experimentAlice = resources.MlflowExperimentPermission{
+	Level:    permissions.CAN_MANAGE,
+	UserName: "alice@databricks.com",
+}
+
+var experimentBob = resources.MlflowExperimentPermission{
+	Level:    permissions.CAN_VIEW,
+	UserName: "bob@databricks.com",
+}
+
+var experimentRobot = resources.MlflowExperimentPermission{
+	Level:                permissions.CAN_RUN,
+	ServicePrincipalName: "i-Robot",
+}
+
+var modelAlice = resources.MlflowModelPermission{
+	Level:    permissions.CAN_MANAGE,
+	UserName: "alice@databricks.com",
+}
+
+var modelBob = resources.MlflowModelPermission{
+	Level:    permissions.CAN_VIEW,
+	UserName: "bob@databricks.com",
+}
+
+var modelRobot = resources.MlflowModelPermission{
+	Level:                permissions.CAN_RUN,
+	ServicePrincipalName: "i-Robot",
+}
+
+var endpointAlice = resources.ModelServingEndpointPermission{
+	Level:    permissions.CAN_MANAGE,
+	UserName: "alice@databricks.com",
+}
+
+var endpointBob = resources.ModelServingEndpointPermission{
+	Level:    permissions.CAN_VIEW,
+	UserName: "bob@databricks.com",
+}
+
+var endpointRobot = resources.ModelServingEndpointPermission{
 	Level:                permissions.CAN_RUN,
 	ServicePrincipalName: "i-Robot",
 }
 
 func testFixture(userName string) *bundle.Bundle {
-	p := []resources.Permission{
-		alice,
-		bob,
-		robot,
+	jobPermissions := []resources.JobPermission{
+		jobAlice,
+		jobBob,
+		jobRobot,
+	}
+
+	pipelinePermissions := []resources.PipelinePermission{
+		pipelineAlice,
+		pipelineBob,
+		pipelineRobot,
+	}
+
+	experimentPermissions := []resources.MlflowExperimentPermission{
+		experimentAlice,
+		experimentBob,
+		experimentRobot,
+	}
+
+	modelPermissions := []resources.MlflowModelPermission{
+		modelAlice,
+		modelBob,
+		modelRobot,
+	}
+
+	endpointPermissions := []resources.ModelServingEndpointPermission{
+		endpointAlice,
+		endpointBob,
+		endpointRobot,
 	}
 
 	return &bundle.Bundle{
@@ -51,33 +135,33 @@ func testFixture(userName string) *bundle.Bundle {
 						JobSettings: &jobs.JobSettings{
 							Name: "job1",
 						},
-						Permissions: p,
+						Permissions: jobPermissions,
 					},
 					"job2": {
 						JobSettings: &jobs.JobSettings{
 							Name: "job2",
 						},
-						Permissions: p,
+						Permissions: jobPermissions,
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline1": {
-						Permissions: p,
+						Permissions: pipelinePermissions,
 					},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment1": {
-						Permissions: p,
+						Permissions: experimentPermissions,
 					},
 				},
 				Models: map[string]*resources.MlflowModel{
 					"model1": {
-						Permissions: p,
+						Permissions: modelPermissions,
 					},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint1": {
-						Permissions: p,
+						Permissions: endpointPermissions,
 					},
 				},
 				RegisteredModels: map[string]*resources.RegisteredModel{
@@ -102,28 +186,28 @@ func TestFilterCurrentUser(t *testing.T) {
 
 	// Assert current user is filtered out.
 	assert.Len(t, b.Config.Resources.Jobs["job1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, robot)
-	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, jobRobot)
+	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, jobBob)
 
 	assert.Len(t, b.Config.Resources.Jobs["job2"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, robot)
-	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, jobRobot)
+	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, jobBob)
 
 	assert.Len(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, robot)
-	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, pipelineRobot)
+	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, pipelineBob)
 
 	assert.Len(t, b.Config.Resources.Experiments["experiment1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, robot)
-	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, experimentRobot)
+	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, experimentBob)
 
 	assert.Len(t, b.Config.Resources.Models["model1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, robot)
-	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, modelRobot)
+	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, modelBob)
 
 	assert.Len(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, robot)
-	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, endpointRobot)
+	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, endpointBob)
 
 	// Assert there's no change to the grant.
 	assert.Len(t, b.Config.Resources.RegisteredModels["registered_model1"].Grants, 1)
@@ -137,28 +221,28 @@ func TestFilterCurrentServicePrincipal(t *testing.T) {
 
 	// Assert current user is filtered out.
 	assert.Len(t, b.Config.Resources.Jobs["job1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, alice)
-	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, jobAlice)
+	assert.Contains(t, b.Config.Resources.Jobs["job1"].Permissions, jobBob)
 
 	assert.Len(t, b.Config.Resources.Jobs["job2"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, alice)
-	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, jobAlice)
+	assert.Contains(t, b.Config.Resources.Jobs["job2"].Permissions, jobBob)
 
 	assert.Len(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, alice)
-	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, pipelineAlice)
+	assert.Contains(t, b.Config.Resources.Pipelines["pipeline1"].Permissions, pipelineBob)
 
 	assert.Len(t, b.Config.Resources.Experiments["experiment1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, alice)
-	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, experimentAlice)
+	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Permissions, experimentBob)
 
 	assert.Len(t, b.Config.Resources.Models["model1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, alice)
-	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, modelAlice)
+	assert.Contains(t, b.Config.Resources.Models["model1"].Permissions, modelBob)
 
 	assert.Len(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, 2)
-	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, alice)
-	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, bob)
+	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, endpointAlice)
+	assert.Contains(t, b.Config.Resources.ModelServingEndpoints["endpoint1"].Permissions, endpointBob)
 
 	// Assert there's no change to the grant.
 	assert.Len(t, b.Config.Resources.RegisteredModels["registered_model1"].Grants, 1)

--- a/bundle/config/mutator/resourcemutator/run_as.go
+++ b/bundle/config/mutator/resourcemutator/run_as.go
@@ -168,11 +168,11 @@ func setPipelineOwnersToRunAsIdentity(b *bundle.Bundle) {
 
 	for i := range b.Config.Resources.Pipelines {
 		pipeline := b.Config.Resources.Pipelines[i]
-		pipeline.Permissions = slices.DeleteFunc(pipeline.Permissions, func(p resources.Permission) bool {
+		pipeline.Permissions = slices.DeleteFunc(pipeline.Permissions, func(p resources.PipelinePermission) bool {
 			return (runAs.ServicePrincipalName != "" && p.ServicePrincipalName == runAs.ServicePrincipalName) ||
 				(runAs.UserName != "" && p.UserName == runAs.UserName)
 		})
-		pipeline.Permissions = append(pipeline.Permissions, resources.Permission{
+		pipeline.Permissions = append(pipeline.Permissions, resources.PipelinePermission{
 			Level:                "IS_OWNER",
 			ServicePrincipalName: runAs.ServicePrincipalName,
 			UserName:             runAs.UserName,

--- a/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
@@ -49,23 +49,53 @@ func TestProcessTargetModeProduction(t *testing.T) {
 	diags = validateProductionMode(b, false)
 	require.ErrorContains(t, diags.Error(), "A common practice is to use a username or principal name in this path, i.e. use\n\n  root_path: /Workspace/Users/lennart@company.com/.bundle/${bundle.name}/${bundle.target}")
 
-	permissions := []resources.Permission{
+	jobPermissions := []resources.JobPermission{
 		{
 			Level:    "CAN_MANAGE",
 			UserName: "user@company.com",
 		},
 	}
-	b.Config.Resources.Jobs["job1"].Permissions = permissions
+	pipelinePermissions := []resources.PipelinePermission{
+		{
+			Level:    "CAN_MANAGE",
+			UserName: "user@company.com",
+		},
+	}
+	experimentPermissions := []resources.MlflowExperimentPermission{
+		{
+			Level:    "CAN_MANAGE",
+			UserName: "user@company.com",
+		},
+	}
+	modelPermissions := []resources.MlflowModelPermission{
+		{
+			Level:    "CAN_MANAGE",
+			UserName: "user@company.com",
+		},
+	}
+	endpointPermissions := []resources.ModelServingEndpointPermission{
+		{
+			Level:    "CAN_MANAGE",
+			UserName: "user@company.com",
+		},
+	}
+	clusterPermissions := []resources.ClusterPermission{
+		{
+			Level:    "CAN_MANAGE",
+			UserName: "user@company.com",
+		},
+	}
+	b.Config.Resources.Jobs["job1"].Permissions = jobPermissions
 	b.Config.Resources.Jobs["job1"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
 	b.Config.Resources.Jobs["job2"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
 	b.Config.Resources.Jobs["job3"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
 	b.Config.Resources.Jobs["job4"].RunAs = &jobs.JobRunAs{UserName: "user@company.com"}
-	b.Config.Resources.Pipelines["pipeline1"].Permissions = permissions
-	b.Config.Resources.Experiments["experiment1"].Permissions = permissions
-	b.Config.Resources.Experiments["experiment2"].Permissions = permissions
-	b.Config.Resources.Models["model1"].Permissions = permissions
-	b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Permissions = permissions
-	b.Config.Resources.Clusters["cluster1"].Permissions = permissions
+	b.Config.Resources.Pipelines["pipeline1"].Permissions = pipelinePermissions
+	b.Config.Resources.Experiments["experiment1"].Permissions = experimentPermissions
+	b.Config.Resources.Experiments["experiment2"].Permissions = experimentPermissions
+	b.Config.Resources.Models["model1"].Permissions = modelPermissions
+	b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Permissions = endpointPermissions
+	b.Config.Resources.Clusters["cluster1"].Permissions = clusterPermissions
 
 	diags = validateProductionMode(b, false)
 	require.NoError(t, diags.Error())

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -10,6 +10,18 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/apps"
 )
 
+type AppPermissionLevel string
+
+// AppPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any app.
+type AppPermission struct {
+	Level AppPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type App struct {
 	// SourceCodePath is a required field used by DABs to point to Databricks app source code
 	// on local disk and to the corresponding workspace path during app deployment.
@@ -21,9 +33,9 @@ type App struct {
 	// If there’s app.yml defined locally, DABs will raise an error.
 	Config map[string]any `json:"config,omitempty"`
 
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	Permissions    []AppPermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string          `json:"url,omitempty" bundle:"internal"`
 
 	*apps.App
 }

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -10,11 +10,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/compute"
 )
 
+type ClusterPermissionLevel string
+
+// ClusterPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any cluster.
+type ClusterPermission struct {
+	Level ClusterPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type Cluster struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	ID             string              `json:"id,omitempty" bundle:"readonly"`
+	Permissions    []ClusterPermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus      `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string              `json:"url,omitempty" bundle:"internal"`
 
 	*compute.ClusterSpec
 }

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -11,11 +11,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 )
 
+type DashboardPermissionLevel string
+
+// DashboardPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any dashboard.
+type DashboardPermission struct {
+	Level DashboardPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type Dashboard struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	ID             string                `json:"id,omitempty" bundle:"readonly"`
+	Permissions    []DashboardPermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus        `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string                `json:"url,omitempty" bundle:"internal"`
 
 	*dashboards.Dashboard
 

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -11,11 +11,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 )
 
+type JobPermissionLevel string
+
+// JobPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any job.
+type JobPermission struct {
+	Level JobPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type Job struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	ID             string          `json:"id,omitempty" bundle:"readonly"`
+	Permissions    []JobPermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string          `json:"url,omitempty" bundle:"internal"`
 
 	*jobs.JobSettings
 }

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -10,11 +10,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
 
+type MlflowExperimentPermissionLevel string
+
+// MlflowExperimentPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any experiment.
+type MlflowExperimentPermission struct {
+	Level MlflowExperimentPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type MlflowExperiment struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	ID             string                       `json:"id,omitempty" bundle:"readonly"`
+	Permissions    []MlflowExperimentPermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus               `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string                       `json:"url,omitempty" bundle:"internal"`
 
 	*ml.Experiment
 }

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -10,11 +10,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
 
+type MlflowModelPermissionLevel string
+
+// MlflowModelPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any model.
+type MlflowModelPermission struct {
+	Level MlflowModelPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type MlflowModel struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	ID             string                  `json:"id,omitempty" bundle:"readonly"`
+	Permissions    []MlflowModelPermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus          `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string                  `json:"url,omitempty" bundle:"internal"`
 
 	*ml.Model
 }

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -10,6 +10,18 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/serving"
 )
 
+type ModelServingEndpointPermissionLevel string
+
+// ModelServingEndpointPermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any serving endpoint.
+type ModelServingEndpointPermission struct {
+	Level ModelServingEndpointPermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type ModelServingEndpoint struct {
 	// This represents the input args for terraform, and will get converted
 	// to a HCL representation for CRUD
@@ -21,7 +33,7 @@ type ModelServingEndpoint struct {
 
 	// This is a resource agnostic implementation of permissions for ACLs.
 	// Implementation could be different based on the resource type.
-	Permissions []Permission `json:"permissions,omitempty"`
+	Permissions []ModelServingEndpointPermission `json:"permissions,omitempty"`
 
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string         `json:"url,omitempty" bundle:"internal"`

--- a/bundle/config/resources/permission.go
+++ b/bundle/config/resources/permission.go
@@ -3,7 +3,6 @@ package resources
 import "fmt"
 
 // Permission holds the permission level setting for a single principal.
-// Multiple of these can be defined on any resource.
 type Permission struct {
 	Level string `json:"level"`
 

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -10,11 +10,23 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
 )
 
+type PipelinePermissionLevel string
+
+// PipelinePermission holds the permission level setting for a single principal.
+// Multiple of these can be defined on any pipeline.
+type PipelinePermission struct {
+	Level PipelinePermissionLevel `json:"level"`
+
+	UserName             string `json:"user_name,omitempty"`
+	ServicePrincipalName string `json:"service_principal_name,omitempty"`
+	GroupName            string `json:"group_name,omitempty"`
+}
+
 type Pipeline struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []Permission   `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	ID             string               `json:"id,omitempty" bundle:"readonly"`
+	Permissions    []PipelinePermission `json:"permissions,omitempty"`
+	ModifiedStatus ModifiedStatus       `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string               `json:"url,omitempty" bundle:"internal"`
 
 	*pipelines.CreatePipeline
 }

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -95,7 +95,7 @@ func TestBundleToTerraformJob(t *testing.T) {
 
 func TestBundleToTerraformJobPermissions(t *testing.T) {
 	src := resources.Job{
-		Permissions: []resources.Permission{
+		Permissions: []resources.JobPermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",
@@ -264,7 +264,7 @@ func TestBundleToTerraformPipeline(t *testing.T) {
 
 func TestBundleToTerraformPipelinePermissions(t *testing.T) {
 	src := resources.Pipeline{
-		Permissions: []resources.Permission{
+		Permissions: []resources.PipelinePermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",
@@ -335,7 +335,7 @@ func TestBundleToTerraformModelPermissions(t *testing.T) {
 		Model: &ml.Model{
 			Name: "name",
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.MlflowModelPermission{
 			{
 				Level:    "CAN_READ",
 				UserName: "jane@doe.com",
@@ -389,7 +389,7 @@ func TestBundleToTerraformExperimentPermissions(t *testing.T) {
 		Experiment: &ml.Experiment{
 			Name: "name",
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.MlflowExperimentPermission{
 			{
 				Level:    "CAN_READ",
 				UserName: "jane@doe.com",
@@ -485,7 +485,7 @@ func TestBundleToTerraformModelServingPermissions(t *testing.T) {
 				},
 			},
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.ModelServingEndpointPermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",

--- a/bundle/deploy/terraform/tfdyn/convert_app_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_app_test.go
@@ -39,7 +39,7 @@ func TestConvertApp(t *testing.T) {
 				},
 			},
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.AppPermission{
 			{
 				Level:    "CAN_RUN",
 				UserName: "jack@gmail.com",

--- a/bundle/deploy/terraform/tfdyn/convert_cluster_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_cluster_test.go
@@ -36,7 +36,7 @@ func TestConvertCluster(t *testing.T) {
 			},
 		},
 
-		Permissions: []resources.Permission{
+		Permissions: []resources.ClusterPermission{
 			{
 				Level:    "CAN_RUN",
 				UserName: "jack@gmail.com",

--- a/bundle/deploy/terraform/tfdyn/convert_dashboard_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_dashboard_test.go
@@ -23,7 +23,7 @@ func TestConvertDashboard(t *testing.T) {
 
 		EmbedCredentials: true,
 
-		Permissions: []resources.Permission{
+		Permissions: []resources.DashboardPermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",

--- a/bundle/deploy/terraform/tfdyn/convert_experiment_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_experiment_test.go
@@ -18,7 +18,7 @@ func TestConvertExperiment(t *testing.T) {
 		Experiment: &ml.Experiment{
 			Name: "name",
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.MlflowExperimentPermission{
 			{
 				Level:    "CAN_READ",
 				UserName: "jane@doe.com",

--- a/bundle/deploy/terraform/tfdyn/convert_job_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_job_test.go
@@ -68,7 +68,7 @@ func TestConvertJob(t *testing.T) {
 				},
 			},
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.JobPermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",

--- a/bundle/deploy/terraform/tfdyn/convert_model_serving_endpoint_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_model_serving_endpoint_test.go
@@ -36,7 +36,7 @@ func TestConvertModelServingEndpoint(t *testing.T) {
 				},
 			},
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.ModelServingEndpointPermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",

--- a/bundle/deploy/terraform/tfdyn/convert_model_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_model_test.go
@@ -29,7 +29,7 @@ func TestConvertModel(t *testing.T) {
 				},
 			},
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.MlflowModelPermission{
 			{
 				Level:    "CAN_READ",
 				UserName: "jane@doe.com",

--- a/bundle/deploy/terraform/tfdyn/convert_permissions_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_permissions_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestConvertPermissions(t *testing.T) {
 	src := resources.Job{
-		Permissions: []resources.Permission{
+		Permissions: []resources.JobPermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",
@@ -24,7 +24,7 @@ func TestConvertPermissions(t *testing.T) {
 				GroupName: "special admins",
 			},
 			{
-				Level:                "CAN_RUN",
+				Level:                "CAN_MANAGE_RUN",
 				ServicePrincipalName: "spn",
 			},
 		},
@@ -50,7 +50,7 @@ func TestConvertPermissions(t *testing.T) {
 			ServicePrincipalName: "",
 		},
 		{
-			PermissionLevel:      "CAN_RUN",
+			PermissionLevel:      "CAN_MANAGE_RUN",
 			UserName:             "",
 			GroupName:            "",
 			ServicePrincipalName: "spn",
@@ -73,7 +73,7 @@ func TestConvertPermissionsNil(t *testing.T) {
 
 func TestConvertPermissionsEmpty(t *testing.T) {
 	src := resources.Job{
-		Permissions: []resources.Permission{},
+		Permissions: []resources.JobPermission{},
 	}
 
 	vin, err := convert.FromTyped(src, dyn.NilValue)

--- a/bundle/deploy/terraform/tfdyn/convert_pipeline_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_pipeline_test.go
@@ -65,7 +65,7 @@ func TestConvertPipeline(t *testing.T) {
 				},
 			},
 		},
-		Permissions: []resources.Permission{
+		Permissions: []resources.PipelinePermission{
 			{
 				Level:    "CAN_VIEW",
 				UserName: "jane@doe.com",

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -403,6 +403,45 @@ github.com/databricks/cli/bundle/config.Workspace:
   "state_path":
     "description": |-
       The workspace state path
+github.com/databricks/cli/bundle/config/resources.AppPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.ClusterPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.DashboardPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
 github.com/databricks/cli/bundle/config/resources.Grant:
   "principal":
     "description": |-
@@ -410,6 +449,58 @@ github.com/databricks/cli/bundle/config/resources.Grant:
   "privileges":
     "description": |-
       The privileges to grant to the specified entity
+github.com/databricks/cli/bundle/config/resources.JobPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.MlflowModelPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
 github.com/databricks/cli/bundle/config/resources.Permission:
   "-":
     "description": |-
@@ -428,6 +519,19 @@ github.com/databricks/cli/bundle/config/resources.Permission:
   "user_name":
     "description": |-
       The name of the user that has the permission set in level.
+github.com/databricks/cli/bundle/config/resources.PipelinePermission:
+  "group_name":
+    "description": |-
+      PLACEHOLDER
+  "level":
+    "description": |-
+      PLACEHOLDER
+  "service_principal_name":
+    "description": |-
+      PLACEHOLDER
+  "user_name":
+    "description": |-
+      PLACEHOLDER
 github.com/databricks/cli/bundle/config/variable.Lookup:
   "alert":
     "description": |-

--- a/bundle/internal/schema/annotations_openapi_overrides.yml
+++ b/bundle/internal/schema/annotations_openapi_overrides.yml
@@ -38,6 +38,11 @@ github.com/databricks/cli/bundle/config/resources.App:
   "user_api_scopes":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.AppPermissionLevel:
+  "_":
+    "enum":
+      - CAN_MANAGE
+      - CAN_USE
 github.com/databricks/cli/bundle/config/resources.Cluster:
   "_":
     "markdown_description": |-
@@ -86,6 +91,12 @@ github.com/databricks/cli/bundle/config/resources.Cluster:
   "workload_type":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.ClusterPermissionLevel:
+  "_":
+    "enum":
+      - CAN_MANAGE
+      - CAN_RESTART
+      - CAN_ATTACH_TO
 github.com/databricks/cli/bundle/config/resources.Dashboard:
   "_":
     "markdown_description": |-
@@ -113,6 +124,13 @@ github.com/databricks/cli/bundle/config/resources.Dashboard:
   "permissions":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.DashboardPermissionLevel:
+  "_":
+    "enum":
+      - CAN_READ
+      - CAN_RUN
+      - CAN_EDIT
+      - CAN_MANAGE
 github.com/databricks/cli/bundle/config/resources.Job:
   "_":
     "markdown_description": |-
@@ -141,6 +159,13 @@ github.com/databricks/cli/bundle/config/resources.Job:
   "run_as":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.JobPermissionLevel:
+  "_":
+    "enum":
+      - CAN_MANAGE
+      - CAN_MANAGE_RUN
+      - CAN_VIEW
+      - IS_OWNER
 github.com/databricks/cli/bundle/config/resources.MlflowExperiment:
   "_":
     "markdown_description": |-
@@ -161,6 +186,12 @@ github.com/databricks/cli/bundle/config/resources.MlflowExperiment:
   "permissions":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermissionLevel:
+  "_":
+    "enum":
+      - CAN_MANAGE
+      - CAN_EDIT
+      - CAN_READ
 github.com/databricks/cli/bundle/config/resources.MlflowModel:
   "_":
     "markdown_description": |-
@@ -168,6 +199,14 @@ github.com/databricks/cli/bundle/config/resources.MlflowModel:
   "permissions":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.MlflowModelPermissionLevel:
+  "_":
+    "enum":
+      - CAN_EDIT
+      - CAN_MANAGE
+      - CAN_MANAGE_STAGING_VERSIONS
+      - CAN_MANAGE_PRODUCTION_VERSIONS
+      - CAN_READ
 github.com/databricks/cli/bundle/config/resources.ModelServingEndpoint:
   "_":
     "markdown_description": |-
@@ -197,6 +236,12 @@ github.com/databricks/cli/bundle/config/resources.ModelServingEndpoint:
   "permissions":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermissionLevel:
+  "_":
+    "enum":
+      - CAN_MANAGE
+      - CAN_QUERY
+      - CAN_VIEW
 github.com/databricks/cli/bundle/config/resources.Pipeline:
   "_":
     "markdown_description": |-
@@ -236,6 +281,13 @@ github.com/databricks/cli/bundle/config/resources.Pipeline:
     "deprecation_message": ""
   "trigger":
     "deprecation_message": Use continuous instead
+github.com/databricks/cli/bundle/config/resources.PipelinePermissionLevel:
+  "_":
+    "enum":
+      - CAN_MANAGE
+      - IS_OWNER
+      - CAN_RUN
+      - CAN_VIEW
 github.com/databricks/cli/bundle/config/resources.QualityMonitor:
   "_":
     "markdown_description": |-

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -122,7 +122,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppDeployment"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.AppPermission"
                       },
                       "resources": {
                         "description": "Resources for the app.",
@@ -160,6 +160,50 @@
                     "required": [
                       "source_code_path",
                       "name"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.AppPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.AppPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.AppPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_MANAGE",
+                      "CAN_USE"
                     ]
                   },
                   {
@@ -256,7 +300,7 @@
                         "$ref": "#/$defs/int"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ClusterPermission"
                       },
                       "policy_id": {
                         "description": "The ID of the cluster policy used to create the cluster if applicable.",
@@ -295,6 +339,51 @@
                     },
                     "additionalProperties": false,
                     "markdownDescription": "The cluster resource defines an [all-purpose cluster](https://docs.databricks.com/api/workspace/clusters/create)."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.ClusterPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.ClusterPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.ClusterPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_MANAGE",
+                      "CAN_RESTART",
+                      "CAN_ATTACH_TO"
+                    ]
                   },
                   {
                     "type": "string",
@@ -342,7 +431,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.DashboardPermission"
                       },
                       "serialized_dashboard": {
                         "description": "The contents of the dashboard in serialized string form.\nThis field is excluded in List Dashboards responses.\nUse the [get dashboard API](https://docs.databricks.com/api/workspace/lakeview/get)\nto retrieve an example response, which includes the `serialized_dashboard` field.\nThis field provides the structure of the JSON string that represents the dashboard's\nlayout and components.",
@@ -359,6 +448,52 @@
                     },
                     "additionalProperties": false,
                     "markdownDescription": "The dashboard resource allows you to manage [AI/BI dashboards](https://docs.databricks.com/api/workspace/lakeview/create) in a bundle. For information about AI/BI dashboards, see [link](https://docs.databricks.com/dashboards/index.html)."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.DashboardPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.DashboardPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.DashboardPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_READ",
+                      "CAN_RUN",
+                      "CAN_EDIT",
+                      "CAN_MANAGE"
+                    ]
                   },
                   {
                     "type": "string",
@@ -449,7 +584,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PerformanceTarget"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.JobPermission"
                       },
                       "queue": {
                         "description": "The queue settings of the job.",
@@ -492,6 +627,52 @@
                   }
                 ]
               },
+              "resources.JobPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.JobPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.JobPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_MANAGE",
+                      "CAN_MANAGE_RUN",
+                      "CAN_VIEW",
+                      "IS_OWNER"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
               "resources.MlflowExperiment": {
                 "oneOf": [
                   {
@@ -523,7 +704,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermission"
                       },
                       "tags": {
                         "description": "Tags: Additional metadata key-value pairs.",
@@ -532,6 +713,51 @@
                     },
                     "additionalProperties": false,
                     "markdownDescription": "The experiment resource allows you to define [MLflow experiments](https://docs.databricks.com/api/workspace/experiments/createexperiment) in a bundle. For information about MLflow experiments, see [link](https://docs.databricks.com/mlflow/experiments.html)."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.MlflowExperimentPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.MlflowExperimentPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_MANAGE",
+                      "CAN_EDIT",
+                      "CAN_READ"
+                    ]
                   },
                   {
                     "type": "string",
@@ -565,7 +791,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowModelPermission"
                       },
                       "tags": {
                         "description": "Tags: Additional metadata key-value pairs for this `registered_model`.",
@@ -578,6 +804,53 @@
                     },
                     "additionalProperties": false,
                     "markdownDescription": "The model resource allows you to define [legacy models](https://docs.databricks.com/api/workspace/modelregistry/createmodel) in bundles. Databricks recommends you use Unity Catalog [registered models](https://docs.databricks.com/dev-tools/bundles/reference.html#registered-model) instead."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.MlflowModelPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.MlflowModelPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.MlflowModelPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_EDIT",
+                      "CAN_MANAGE",
+                      "CAN_MANAGE_STAGING_VERSIONS",
+                      "CAN_MANAGE_PRODUCTION_VERSIONS",
+                      "CAN_READ"
+                    ]
                   },
                   {
                     "type": "string",
@@ -607,7 +880,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermission"
                       },
                       "rate_limits": {
                         "description": "Rate limits to be applied to the serving endpoint. NOTE: this field is deprecated, please use AI Gateway to manage rate limits.",
@@ -627,6 +900,51 @@
                       "name"
                     ],
                     "markdownDescription": "The model_serving_endpoint resource allows you to define [model serving endpoints](https://docs.databricks.com/api/workspace/servingendpoints/create). See [link](https://docs.databricks.com/machine-learning/model-serving/manage-serving-endpoints.html)."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.ModelServingEndpointPermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.ModelServingEndpointPermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_MANAGE",
+                      "CAN_QUERY",
+                      "CAN_VIEW"
+                    ]
                   },
                   {
                     "type": "string",
@@ -737,7 +1055,7 @@
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.Notifications"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.PipelinePermission"
                       },
                       "photon": {
                         "description": "Whether Photon is enabled for this pipeline.",
@@ -775,6 +1093,52 @@
                     },
                     "additionalProperties": false,
                     "markdownDescription": "The pipeline resource allows you to create Delta Live Tables [pipelines](https://docs.databricks.com/api/workspace/pipelines/create). For information about pipelines, see [link](https://docs.databricks.com/dlt/index.html). For a tutorial that uses the Databricks Asset Bundles template to create a pipeline, see [link](https://docs.databricks.com/dev-tools/bundles/pipelines-tutorial.html)."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.PipelinePermission": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "group_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "level": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.PipelinePermissionLevel"
+                      },
+                      "service_principal_name": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "user_name": {
+                        "$ref": "#/$defs/string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "level"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.PipelinePermissionLevel": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "CAN_MANAGE",
+                      "IS_OWNER",
+                      "CAN_RUN",
+                      "CAN_VIEW"
+                    ]
                   },
                   {
                     "type": "string",
@@ -7143,6 +7507,48 @@
           "cli": {
             "bundle": {
               "config": {
+                "resources.AppPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.AppPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.ClusterPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.ClusterPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.DashboardPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.DashboardPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
                 "resources.Grant": {
                   "oneOf": [
                     {
@@ -7157,12 +7563,82 @@
                     }
                   ]
                 },
+                "resources.JobPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.JobPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.MlflowExperimentPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.MlflowModelPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.MlflowModelPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.ModelServingEndpointPermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
                 "resources.Permission": {
                   "oneOf": [
                     {
                       "type": "array",
                       "items": {
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Permission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.PipelinePermission": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.PipelinePermission"
                       }
                     },
                     {

--- a/bundle/tests/bundle_permissions_test.go
+++ b/bundle/tests/bundle_permissions_test.go
@@ -23,16 +23,16 @@ func TestBundlePermissions(t *testing.T) {
 	require.NoError(t, diags.Error())
 
 	pipelinePermissions := b.Config.Resources.Pipelines["nyc_taxi_pipeline"].Permissions
-	assert.Contains(t, pipelinePermissions, resources.Permission{Level: "CAN_RUN", UserName: "test@company.com"})
-	assert.NotContains(t, pipelinePermissions, resources.Permission{Level: "CAN_MANAGE", GroupName: "devs"})
-	assert.NotContains(t, pipelinePermissions, resources.Permission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
-	assert.NotContains(t, pipelinePermissions, resources.Permission{Level: "CAN_RUN", UserName: "bot@company.com"})
+	assert.Contains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_RUN", UserName: "test@company.com"})
+	assert.NotContains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_MANAGE", GroupName: "devs"})
+	assert.NotContains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
+	assert.NotContains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_RUN", UserName: "bot@company.com"})
 
 	jobsPermissions := b.Config.Resources.Jobs["pipeline_schedule"].Permissions
-	assert.Contains(t, jobsPermissions, resources.Permission{Level: "CAN_MANAGE_RUN", UserName: "test@company.com"})
-	assert.NotContains(t, jobsPermissions, resources.Permission{Level: "CAN_MANAGE", GroupName: "devs"})
-	assert.NotContains(t, jobsPermissions, resources.Permission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
-	assert.NotContains(t, jobsPermissions, resources.Permission{Level: "CAN_RUN", UserName: "bot@company.com"})
+	assert.Contains(t, jobsPermissions, resources.JobPermission{Level: "CAN_MANAGE_RUN", UserName: "test@company.com"})
+	assert.NotContains(t, jobsPermissions, resources.JobPermission{Level: "CAN_MANAGE", GroupName: "devs"})
+	assert.NotContains(t, jobsPermissions, resources.JobPermission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
+	assert.NotContains(t, jobsPermissions, resources.JobPermission{Level: "CAN_MANAGE_RUN", UserName: "bot@company.com"})
 }
 
 func TestBundlePermissionsDevTarget(t *testing.T) {
@@ -46,14 +46,14 @@ func TestBundlePermissionsDevTarget(t *testing.T) {
 	require.NoError(t, diags.Error())
 
 	pipelinePermissions := b.Config.Resources.Pipelines["nyc_taxi_pipeline"].Permissions
-	assert.Contains(t, pipelinePermissions, resources.Permission{Level: "CAN_RUN", UserName: "test@company.com"})
-	assert.Contains(t, pipelinePermissions, resources.Permission{Level: "CAN_MANAGE", GroupName: "devs"})
-	assert.Contains(t, pipelinePermissions, resources.Permission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
-	assert.Contains(t, pipelinePermissions, resources.Permission{Level: "CAN_RUN", UserName: "bot@company.com"})
+	assert.Contains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_RUN", UserName: "test@company.com"})
+	assert.Contains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_MANAGE", GroupName: "devs"})
+	assert.Contains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
+	assert.Contains(t, pipelinePermissions, resources.PipelinePermission{Level: "CAN_RUN", UserName: "bot@company.com"})
 
 	jobsPermissions := b.Config.Resources.Jobs["pipeline_schedule"].Permissions
-	assert.Contains(t, jobsPermissions, resources.Permission{Level: "CAN_MANAGE_RUN", UserName: "test@company.com"})
-	assert.Contains(t, jobsPermissions, resources.Permission{Level: "CAN_MANAGE", GroupName: "devs"})
-	assert.Contains(t, jobsPermissions, resources.Permission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
-	assert.Contains(t, jobsPermissions, resources.Permission{Level: "CAN_MANAGE_RUN", UserName: "bot@company.com"})
+	assert.Contains(t, jobsPermissions, resources.JobPermission{Level: "CAN_MANAGE_RUN", UserName: "test@company.com"})
+	assert.Contains(t, jobsPermissions, resources.JobPermission{Level: "CAN_MANAGE", GroupName: "devs"})
+	assert.Contains(t, jobsPermissions, resources.JobPermission{Level: "CAN_VIEW", ServicePrincipalName: "1234-abcd"})
+	assert.Contains(t, jobsPermissions, resources.JobPermission{Level: "CAN_MANAGE_RUN", UserName: "bot@company.com"})
 }

--- a/bundle/tests/model_serving_endpoint_test.go
+++ b/bundle/tests/model_serving_endpoint_test.go
@@ -13,8 +13,10 @@ func assertExpected(t *testing.T, p *resources.ModelServingEndpoint) {
 	assert.Equal(t, "1", p.Config.ServedModels[0].ModelVersion)
 	assert.Equal(t, "model-name-1", p.Config.TrafficConfig.Routes[0].ServedModelName)
 	assert.Equal(t, 100, p.Config.TrafficConfig.Routes[0].TrafficPercentage)
-	assert.Equal(t, "users", p.Permissions[0].GroupName)
-	assert.Equal(t, "CAN_QUERY", p.Permissions[0].Level)
+	assert.Equal(t, resources.ModelServingEndpointPermission{
+		GroupName: "users",
+		Level:     "CAN_QUERY",
+	}, p.Permissions[0])
 }
 
 func TestModelServingEndpointDevelopment(t *testing.T) {

--- a/bundle/tests/run_as_test.go
+++ b/bundle/tests/run_as_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/databricks/cli/bundle/config/resources"
+
 	"github.com/databricks/cli/bundle/config/mutator/resourcemutator"
 
 	"github.com/databricks/cli/bundle"
@@ -295,11 +297,15 @@ func TestLegacyRunAs(t *testing.T) {
 	pipelines := b.Config.Resources.Pipelines
 	assert.Len(t, pipelines["nyc_taxi_pipeline"].Permissions, 2)
 
-	assert.Equal(t, "CAN_VIEW", pipelines["nyc_taxi_pipeline"].Permissions[0].Level)
-	assert.Equal(t, "my_user_name", pipelines["nyc_taxi_pipeline"].Permissions[0].UserName)
+	assert.Equal(t, resources.PipelinePermission{
+		Level:    "CAN_VIEW",
+		UserName: "my_user_name",
+	}, pipelines["nyc_taxi_pipeline"].Permissions[0])
 
-	assert.Equal(t, "IS_OWNER", pipelines["nyc_taxi_pipeline"].Permissions[1].Level)
-	assert.Equal(t, "my_service_principal", pipelines["nyc_taxi_pipeline"].Permissions[1].ServicePrincipalName)
+	assert.Equal(t, resources.PipelinePermission{
+		Level:                "IS_OWNER",
+		ServicePrincipalName: "my_service_principal",
+	}, pipelines["nyc_taxi_pipeline"].Permissions[1])
 
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, *b.Config.Resources.Models["model_one"].Model)


### PR DESCRIPTION
## Changes
Specify JSON schema for resource permissions.

We replace a string with an enum for the `level` field. Each resource supports different permission-level values and has its own enum.

Bundle root permissions remain as-is, and there is already a translation code that, for example, changes `CAN_RUN` into `CAN_MANAGE_RUN` for jobs. However, when `CAN_RUN` is specified directly on a job, it doesn't get translated, which makes sense. With the correct schema, we are going to avoid the mistake of accidentally specifying `CAN_RUN`, assuming that it works.

## Why
`resources.Permission` schema allows arbitrary strings while different resources support different permission levels.

## Tests
Manually by inspecting JSON schema