### PR TITLE
Add tools/start_integration_tests.py + periodic workflow

### DIFF
--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -1,7 +1,8 @@
 name: integration-pr
 
 on:
-  # AI TODO: Modify this to run on schedule every 10 minutes
+  schedule:
+    - cron: '*/10 * * * *'
   pull_request:
     types: [opened, synchronize]
 

--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -3,8 +3,6 @@ name: start-integration-tests
 on:
   schedule:
     - cron: '*/10 * * * *'
-  pull_request:
-    types: [opened, synchronize]
 
 jobs:
   # Trigger for pull requests.

--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -1,4 +1,4 @@
-name: integration-pr
+name: start-integration-tests
 
 on:
   schedule:

--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -39,4 +39,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          ./start_integration_tests.py -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}}
+          ./start_integration_tests.py -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} --yes

--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -1,0 +1,41 @@
+name: integration-pr
+
+on:
+  # AI TODO: Modify this to run on schedule every 10 minutes
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  # Trigger for pull requests.
+  #
+  # This workflow triggers the integration test workflow in a different repository.
+  # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
+  trigger:
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
+    environment: "test-trigger-is"
+
+    # Only run this job for PRs from branches on the main repository and not from forks.
+    # Workflows triggered by PRs from forks don't have access to the "test-trigger-is" environment.
+    if: "${{ !github.event.pull_request.head.repo.fork }}"
+
+    steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@136412a57a7081aa63c935a2cc2918f76c34f514 # v1.11.2
+        with:
+          app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+          owner: ${{ secrets.ORG_NAME }}
+          repositories: ${{secrets.REPO_NAME}}
+
+      - name: Fetch start_integration_tests.py
+        run: wget https://raw.githubusercontent.com/databricks/cli/refs/heads/main/tools/start_integration_tests.py
+
+      - name: Run start_integration_tests.py
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          ./start_integration_tests.py -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}}

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -1,0 +1,10 @@
+"""
+AI TODO: implement script. Use Python 3.9. Use pathlib. Do not add type annotations or redundant comments. Avoid wrapping exceptions in "nicer" error messages.
+
+Find open PRs by non-team member (read first line in .github/CODEOWNERS) but approved by team member.
+  Read most recent commit of such PR.
+
+Find if there is cli-isolated-pr job running for this PR number & commit (Job URL: https://github.com/databricks-eng/eng-dev-ecosystem/actions/workflows/cli-isolated-pr.yml).
+If not running, start one. Ask before starting,
+
+"""

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -123,7 +123,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--yes", action="store_true", default=False)
     parser.add_argument("--workflow", default="cli-isolated-pr")
-    parser.add_argument("-R", "--repo", default="databricks-eng/eng-dev-ecosystem")
+    parser.add_argument("-R", "--repo")
 
     args = parser.parse_args()
 

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -13,6 +13,8 @@ import re
 
 CLI_REPO = "databricks/cli"
 CODE_OWNERS = "pietern andrewnester shreyas-goenka denik anton-107".split()
+ALLOWED_HEAD_REPOSITORY = {"id": "R_kgDOHVGMwQ", "name": "cli"}
+ALLOWED_HEAD_OWNER = {"id": "MDEyOk9yZ2FuaXphdGlvbjQ5OTgwNTI=", "login": "databricks"}
 
 
 def run(cmd):
@@ -32,7 +34,9 @@ def run_json(cmd):
 
 
 def get_approved_prs_by_non_team():
-    prs = run_json(["gh", "pr", "-R", CLI_REPO, "list", "--limit", "300", "--json", "number,author,reviews,headRefOid"])
+    prs = run_json(
+        ["gh", "pr", "-R", CLI_REPO, "list", "--limit", "300", "--json", "number,author,reviews,headRefOid,headRepository,headRepositoryOwner"]
+    )
     result = []
 
     for pr in prs:
@@ -40,6 +44,16 @@ def get_approved_prs_by_non_team():
         author = pr["author"]["login"]
 
         if author in CODE_OWNERS:
+            continue
+
+        head_repo = pr["headRepository"]
+        if head_repo != ALLOWED_HEAD_REPOSITORY:
+            print(f"#{pr_number} by {author} skipped due to headRepository: {head_repo}")
+            continue
+
+        head_owner = pr["headRepositoryOwner"]
+        if head_owner != ALLOWED_HEAD_OWNER:
+            print(f"#{pr_number} by {author} skipped due to headRepositoryOwner: {head_owner}")
             continue
 
         approved_by = []

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -98,6 +98,7 @@ def start_job(pr_number, commit_sha, author):
     
     if response.lower() == "y":
         # Use the commit SHA directly instead of the PR ref
+        # AI TODO: This failed with : Error starting workflow: could not create workflow dispatch event: HTTP 422: Unexpected inputs provided: ["pr_number", "sha"] (https://api.github.com/repos/databricks-eng/eng-dev-ecosystem/actions/workflows/122636273/dispatches)
         result = subprocess.run([
             "gh", "workflow", "run", "cli-isolated-pr.yml",
             "-R", "databricks-eng/eng-dev-ecosystem",

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -72,8 +72,19 @@ def check_if_job_running(pr_number, commit_sha):
     return False
 
 def start_job(pr_number, commit_sha, author):
-    # AI TODO: include commit title there and full link
-    print(f"PR #{pr_number} by {author} (commit {commit_sha[:7]}) is approved but has no running tests.")
+    # Get PR details including title
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "title,url"],
+        capture_output=True, text=True
+    )
+    pr_details = json.loads(result.stdout)
+    
+    pr_title = pr_details.get("title", "")
+    pr_url = pr_details.get("url", "")
+    
+    print(f"PR #{pr_number}: \"{pr_title}\" by {author} (commit {commit_sha[:7]})")
+    print(f"URL: {pr_url}")
+    print("This PR is approved but has no running tests.")
     response = input("Start integration tests? (y/n): ")
     
     if response.lower() == "y":

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -97,6 +97,14 @@ def start_job(pr_number, commit_sha, author):
     response = input("Start integration tests? (y/n): ")
     
     if response.lower() == "y":
+        # AI TODO: fix failure, output below:
+        """
+        PR #2668: "Bump golang.org/x/sys from 0.31.0 to 0.32.0" by app/dependabot (commit bf81055)
+        URL: https://github.com/databricks/cli/pull/2668
+        This PR is approved by denik but has no running tests.
+        Start integration tests? (y/n): y
+        could not create workflow dispatch event: HTTP 422: No ref found for: refs/pull/2668/head (https://api.github.com/repos/databricks-eng/eng-dev-ecosystem/actions/workflows/122636273/dispatches)0
+        """
         subprocess.run([
             "gh", "workflow", "run", "cli-isolated-pr.yml",
             "-R", "databricks-eng/eng-dev-ecosystem",

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -1,10 +1,101 @@
 """
-AI TODO: implement script. Use Python 3.9. Use pathlib. Do not add type annotations or redundant comments. Avoid wrapping exceptions in "nicer" error messages.
-
-Find open PRs by non-team member (read first line in .github/CODEOWNERS) but approved by team member.
-  Read most recent commit of such PR.
-
-Find if there is cli-isolated-pr job running for this PR number & commit (Job URL: https://github.com/databricks-eng/eng-dev-ecosystem/actions/workflows/cli-isolated-pr.yml).
-If not running, start one. Ask before starting,
-
+Script to find open PRs by non-team members that are approved by team members,
+and start integration tests for them if not already running.
 """
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+import requests
+import time
+import re
+
+def get_team_members():
+    codeowners_path = Path(".github/CODEOWNERS")
+    with open(codeowners_path, "r") as f:
+        first_line = f.readline().strip()
+    
+    # Extract GitHub usernames from the first line
+    team_members = re.findall(r'@([a-zA-Z0-9-]+)', first_line)
+    return team_members
+
+def get_approved_prs_by_non_team():
+    team_members = get_team_members()
+    
+    # Get open PRs
+    result = subprocess.run(
+        ["gh", "pr", "list", "--json", "number,author,reviews,headRefOid"],
+        capture_output=True, text=True
+    )
+    
+    prs = json.loads(result.stdout)
+    approved_prs = []
+    
+    for pr in prs:
+        # Skip PRs by team members
+        if pr["author"]["login"] in team_members:
+            continue
+        
+        # Check if approved by a team member
+        is_approved = False
+        for review in pr.get("reviews", []):
+            if review["state"] == "APPROVED" and review["author"]["login"] in team_members:
+                is_approved = True
+                break
+        
+        if is_approved:
+            approved_prs.append({
+                "number": pr["number"],
+                "commit": pr["headRefOid"],
+                "author": pr["author"]["login"]
+            })
+    
+    return approved_prs
+
+def check_if_job_running(pr_number, commit_sha):
+    # Check if job is already running for this PR and commit
+    url = f"https://github.com/databricks-eng/eng-dev-ecosystem/actions/workflows/cli-isolated-pr.yml"
+    
+    result = subprocess.run(
+        ["gh", "api", f"/repos/databricks-eng/eng-dev-ecosystem/actions/workflows/cli-isolated-pr.yml/runs?status=in_progress"],
+        capture_output=True, text=True
+    )
+    
+    runs = json.loads(result.stdout)
+    
+    for run in runs.get("workflow_runs", []):
+        if f"refs/pull/{pr_number}/head" == run["head_branch"] and commit_sha == run["head_sha"]:
+            return True
+    
+    return False
+
+def start_job(pr_number, commit_sha, author):
+    print(f"PR #{pr_number} by {author} (commit {commit_sha[:7]}) is approved but has no running tests.")
+    response = input("Start integration tests? (y/n): ")
+    
+    if response.lower() == "y":
+        subprocess.run([
+            "gh", "workflow", "run", "cli-isolated-pr.yml",
+            "-R", "databricks-eng/eng-dev-ecosystem",
+            "-r", f"refs/pull/{pr_number}/head"
+        ])
+        print(f"Started integration tests for PR #{pr_number}")
+    else:
+        print("Skipped starting tests")
+
+def main():
+    approved_prs = get_approved_prs_by_non_team()
+    
+    if not approved_prs:
+        print("No approved PRs from non-team members found.")
+        return
+    
+    for pr in approved_prs:
+        if not check_if_job_running(pr["number"], pr["commit"]):
+            start_job(pr["number"], pr["commit"], pr["author"])
+        else:
+            print(f"Tests already running for PR #{pr['number']} (commit {pr['commit'][:7]})")
+
+if __name__ == "__main__":
+    main()

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -97,19 +97,17 @@ def start_job(pr_number, commit_sha, author):
     response = input("Start integration tests? (y/n): ")
     
     if response.lower() == "y":
-        # AI TODO: fix failure, output below:
-        """
-        PR #2668: "Bump golang.org/x/sys from 0.31.0 to 0.32.0" by app/dependabot (commit bf81055)
-        URL: https://github.com/databricks/cli/pull/2668
-        This PR is approved by denik but has no running tests.
-        Start integration tests? (y/n): y
-        could not create workflow dispatch event: HTTP 422: No ref found for: refs/pull/2668/head (https://api.github.com/repos/databricks-eng/eng-dev-ecosystem/actions/workflows/122636273/dispatches)0
-        """
-        subprocess.run([
+        # Use the commit SHA directly instead of the PR ref
+        result = subprocess.run([
             "gh", "workflow", "run", "cli-isolated-pr.yml",
             "-R", "databricks-eng/eng-dev-ecosystem",
-            "-r", f"refs/pull/{pr_number}/head"
-        ])
+            "-f", f"pr_number={pr_number}",
+            "-f", f"sha={commit_sha}"
+        ], capture_output=True, text=True)
+        
+        if result.returncode != 0:
+            print(f"Error starting workflow: {result.stderr}")
+            return
         print(f"Started integration tests for PR #{pr_number}")
     else:
         print("Skipped starting tests")

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -1,154 +1,155 @@
 #!/usr/bin/env python3
 """
-Script to find open PRs by non-team members that are approved by team members,
-and start integration tests for them if not already running.
+Start integration test jobs for PRs by non-team members that are approved by team members.
 """
 
+import argparse
 import json
 import subprocess
 import sys
 from pathlib import Path
-#import requests
-import time
 import re
+
+
+def run(cmd):
+    sys.stderr.write("+ " + " ".join(cmd) + "\n")
+    return subprocess.run(cmd, check=True)
+
+
+def run_json(cmd):
+    sys.stderr.write("+ " + " ".join(cmd) + "\n")
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, encoding="utf-8", check=True)
+
+    try:
+        return json.loads(result.stdout)
+    except Exception:
+        sys.stderr.write(f"Failed to JSON parse:\n{result.stdout}\n")
+        raise
+
 
 def get_team_members():
     codeowners_path = Path(".github/CODEOWNERS")
     with open(codeowners_path, "r") as f:
         first_line = f.readline().strip()
-    
-    # Extract GitHub usernames from the first line
-    team_members = re.findall(r'@([a-zA-Z0-9-]+)', first_line)
+
+    team_members = re.findall(r"@([a-zA-Z0-9-.]+)", first_line)
+    print("Team members:", team_members)
     return team_members
+
 
 def get_approved_prs_by_non_team():
     team_members = get_team_members()
-    
-    # Get open PRs
-    result = subprocess.run(
-        ["gh", "pr", "list", "--json", "number,author,reviews,headRefOid"],
-        capture_output=True, text=True
-    )
-    
-    prs = json.loads(result.stdout)
-    approved_prs = []
-    
+
+    prs = run_json(["gh", "pr", "list", "--json", "number,author,reviews,headRefOid"])
+    result = []
+
     for pr in prs:
-        # Skip PRs by team members
-        if pr["author"]["login"] in team_members:
+        pr_number = pr["number"]
+        author = pr["author"]["login"]
+
+        if author in team_members:
+            # print(f"Skipping #{pr_number} by {author}")
             continue
-        
-        # Check if approved by a team member
+
         is_approved = False
         for review in pr.get("reviews", []):
             if review["state"] == "APPROVED" and review["author"]["login"] in team_members:
                 is_approved = True
                 break
-        
-        if is_approved:
-            approved_prs.append({
-                "number": pr["number"],
+
+        if not is_approved:
+            # print(f"Skipping #{pr_number} by {author} -- not approved yet.")
+            continue
+
+        print(f"Needs tests: #{pr_number} by {author}")
+
+        result.append(
+            {
+                "number": pr_number,
                 "commit": pr["headRefOid"],
-                "author": pr["author"]["login"]
-            })
-    
-    return approved_prs
+                "author": author,
+            }
+        )
 
-def check_if_job_running(pr_number, commit_sha):
-    # Check if job is already running for this PR and commit
-    url = f"https://github.com/databricks-eng/eng-dev-ecosystem/actions/workflows/cli-isolated-pr.yml"
-    
-    result = subprocess.run(
-        ["gh", "api", f"/repos/databricks-eng/eng-dev-ecosystem/actions/workflows/cli-isolated-pr.yml/runs?status=in_progress"],
-        capture_output=True, text=True
-    )
-    
-    runs = json.loads(result.stdout)
-    
-    for run in runs.get("workflow_runs", []):
-        if f"refs/pull/{pr_number}/head" == run["head_branch"] and commit_sha == run["head_sha"]:
-            return True
-    
-    return False
+    return result
 
-def start_job(pr_number, commit_sha, author):
-    # Get PR details including title
-    result = subprocess.run(
-        ["gh", "pr", "view", str(pr_number), "--json", "title,url"],
-        capture_output=True, text=True
-    )
-    pr_details = json.loads(result.stdout)
-    
+
+def start_job(pr_number, commit_sha, author, force=False):
+    pr_details = run_json(["gh", "pr", "view", str(pr_number), "--json", "title,url"])
     pr_title = pr_details.get("title", "")
     pr_url = pr_details.get("url", "")
-    
-    print(f"PR #{pr_number}: \"{pr_title}\" by {author} (commit {commit_sha[:7]})")
-    print(f"URL: {pr_url}")
-    
+
+    print(f"PR: {pr_url}")
+    print(f'PR: #{pr_number}: "{pr_title}" by {author} (commit {commit_sha[:7]})')
+
     # Get approver information
-    result = subprocess.run(
-        ["gh", "pr", "view", str(pr_number), "--json", "reviews"],
-        capture_output=True, text=True
-    )
-    reviews = json.loads(result.stdout).get("reviews", [])
+    pr_view = run_json(["gh", "pr", "view", str(pr_number), "--json", "reviews"])
+    reviews = pr_view.get("reviews", [])
     approvers = [review["author"]["login"] for review in reviews if review["state"] == "APPROVED"]
-    
-    print(f"This PR is approved by {', '.join(approvers)} but has no running tests.")
-    response = input("Start integration tests? (y/n): ")
-    
-    if response.lower() == "y":
-        # Use the commit SHA directly instead of the PR ref
-        # Check the workflow file to get the correct input parameters
-        result = subprocess.run([
-            "gh", "workflow", "view", "cli-isolated-pr.yml",
-            "-R", "databricks-eng/eng-dev-ecosystem",
-            "--json", "inputs"
-        ], capture_output=True, text=True)
-        
-        if result.returncode != 0:
-            print(f"Error getting workflow inputs: {result.stderr}")
-            return
-            
-        workflow_inputs = json.loads(result.stdout).get("inputs", {})
-        input_params = []
-        
-        # Only add parameters that are defined in the workflow
-        if "pr_number" in workflow_inputs:
-            input_params.extend(["-f", f"pr_number={pr_number}"])
-        if "sha" in workflow_inputs:
-            input_params.extend(["-f", f"sha={commit_sha}"])
-        if "ref" in workflow_inputs:
-            input_params.extend(["-f", f"ref=refs/pull/{pr_number}/head"])
-            
-        # If no valid inputs were found, use default behavior
-        if not input_params:
-            input_params = ["-r", f"refs/pull/{pr_number}/head"]
-            
-        result = subprocess.run([
-            "gh", "workflow", "run", "cli-isolated-pr.yml",
-            "-R", "databricks-eng/eng-dev-ecosystem",
-            *input_params
-        ], capture_output=True, text=True)
-        
-        if result.returncode != 0:
-            print(f"Error starting workflow: {result.stderr}")
-            return
-        print(f"Started integration tests for PR #{pr_number}")
+
+    commit_url = f"https://github.com/databricks/cli/pull/{pr_number}/commits/{commit_sha}"
+    print(f"This PR is approved by {', '.join(approvers)} but has no integration tests for {commit_url}")
+
+    if force:
+        response = "y"
+        print("Starting integration tests.")
     else:
-        print("Skipped starting tests")
+        response = input("Start integration tests? (y/n): ")
+
+    if response.lower() == "y":
+        result = run(
+            [
+                "gh",
+                "workflow",
+                "run",
+                "cli-isolated-pr",
+                "-R",
+                "databricks-eng/eng-dev-ecosystem",
+                "-F",
+                f"pull_request_number={pr_number}",
+                "-F",
+                f"commit_sha={commit_sha}",
+            ],
+            check=True,
+        )
+        print(f"Started integration tests for PR #{pr_number}")
+
+
+def get_status(commit_sha):
+    statuses = run_json(["gh", "api", f"repos/databricks/cli/commits/{commit_sha}/statuses"])
+    result = []
+    for st in statuses:
+        if st["context"] != "Integration Tests Check":
+            continue
+        result.append(f"{st['state']} {st['target_url']}")
+    return result
+
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--yes", action="store_true", default=False)
+    args = parser.parse_args()
+
     approved_prs = get_approved_prs_by_non_team()
-    
+
     if not approved_prs:
         print("No approved PRs from non-team members found.")
         return
-    
+
     for pr in approved_prs:
-        if not check_if_job_running(pr["number"], pr["commit"]):
-            start_job(pr["number"], pr["commit"], pr["author"])
+        pr_number = pr["number"]
+        commit_sha = pr["commit"]
+
+        status = get_status(commit_sha)
+
+        if not status:
+            start_job(pr_number, commit_sha, pr["author"], force=args.yes)
         else:
-            print(f"Tests already running for PR #{pr['number']} (commit {pr['commit'][:7]})")
+            commit_url = f"https://github.com/databricks/cli/pull/{pr_number}/commits/{commit_sha}"
+            print(f"Tests already running for PR #{pr_number} {commit_url}")
+            print("\n".join(status))
+        print()
+
 
 if __name__ == "__main__":
     main()

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -84,6 +84,7 @@ def start_job(pr_number, commit_sha, author):
     
     print(f"PR #{pr_number}: \"{pr_title}\" by {author} (commit {commit_sha[:7]})")
     print(f"URL: {pr_url}")
+    # AI TODO: include details below. approved by who?
     print("This PR is approved but has no running tests.")
     response = input("Start integration tests? (y/n): ")
     

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Script to find open PRs by non-team members that are approved by team members,
 and start integration tests for them if not already running.
@@ -7,7 +8,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-import requests
+#import requests
 import time
 import re
 
@@ -71,6 +72,7 @@ def check_if_job_running(pr_number, commit_sha):
     return False
 
 def start_job(pr_number, commit_sha, author):
+    # AI TODO: include commit title there and full link
     print(f"PR #{pr_number} by {author} (commit {commit_sha[:7]}) is approved but has no running tests.")
     response = input("Start integration tests? (y/n): ")
     

--- a/tools/start_integration_tests.py
+++ b/tools/start_integration_tests.py
@@ -84,8 +84,16 @@ def start_job(pr_number, commit_sha, author):
     
     print(f"PR #{pr_number}: \"{pr_title}\" by {author} (commit {commit_sha[:7]})")
     print(f"URL: {pr_url}")
-    # AI TODO: include details below. approved by who?
-    print("This PR is approved but has no running tests.")
+    
+    # Get approver information
+    result = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "reviews"],
+        capture_output=True, text=True
+    )
+    reviews = json.loads(result.stdout).get("reviews", [])
+    approvers = [review["author"]["login"] for review in reviews if review["state"] == "APPROVED"]
+    
+    print(f"This PR is approved by {', '.join(approvers)} but has no running tests.")
     response = input("Start integration tests? (y/n): ")
     
     if response.lower() == "y":


### PR DESCRIPTION
## Changes
- New script to start integration tests for PRs that were approved by team members.
- New workflow to run this script every 10 minutes.

## Why
When dependabot posts many PR you need to start the integration tests. If rebased, the results are lost and you need to do that again. This script automates starting these tests.

## Tests
Manually.
