### PR TITLE
Added telemetry for artifact deployment properties

### DIFF
--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/output.txt
@@ -32,6 +32,12 @@ Deployment complete!
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 2,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      }
+    ],
     "bundle_mode": "TYPE_UNSPECIFIED",
     "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
   }
@@ -58,6 +64,12 @@ Deployment complete!
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 2,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      }
+    ],
     "bundle_mode": "TYPE_UNSPECIFIED",
     "workspace_artifact_path_type": "UC_VOLUME"
   }

--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/script
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/script
@@ -2,6 +2,6 @@ trace $CLI bundle deploy -t one
 
 trace $CLI bundle deploy -t two
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
 
 rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-config-file-count/output.txt
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/output.txt
@@ -39,6 +39,12 @@ Deployment complete!
           "complex_variable_count": 0,
           "lookup_variable_count": 0,
           "target_count": 1,
+          "bool_values": [
+            {
+              "key": "python_wheel_wrapper_is_set",
+              "value": false
+            }
+          ],
           "bundle_mode": "TYPE_UNSPECIFIED",
           "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
         }

--- a/acceptance/bundle/telemetry/deploy-config-file-count/script
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/script
@@ -1,6 +1,6 @@
 trace $CLI bundle deploy
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'
 
 cmd_exec_id=$(extract_command_exec_id.py)
 

--- a/acceptance/bundle/telemetry/deploy-mode/output.txt
+++ b/acceptance/bundle/telemetry/deploy-mode/output.txt
@@ -38,6 +38,12 @@ A common practice is to use a username or principal name in this path, i.e. use
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 2,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      }
+    ],
     "bundle_mode": "DEVELOPMENT",
     "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
   }
@@ -64,6 +70,12 @@ A common practice is to use a username or principal name in this path, i.e. use
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 2,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      }
+    ],
     "bundle_mode": "PRODUCTION",
     "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
   }

--- a/acceptance/bundle/telemetry/deploy-mode/script
+++ b/acceptance/bundle/telemetry/deploy-mode/script
@@ -2,6 +2,6 @@ trace $CLI bundle deploy -t dev
 
 trace $CLI bundle deploy -t prod
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
 
 rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-no-uuid/output.txt
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/output.txt
@@ -43,6 +43,12 @@ Deployment complete!
           "complex_variable_count": 0,
           "lookup_variable_count": 0,
           "target_count": 1,
+          "bool_values": [
+            {
+              "key": "python_wheel_wrapper_is_set",
+              "value": false
+            }
+          ],
           "bundle_mode": "TYPE_UNSPECIFIED",
           "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
         }

--- a/acceptance/bundle/telemetry/deploy-no-uuid/script
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/script
@@ -1,6 +1,6 @@
 trace $CLI bundle deploy
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'
 
 cmd_exec_id=$(extract_command_exec_id.py)
 

--- a/acceptance/bundle/telemetry/deploy-target-count/output.txt
+++ b/acceptance/bundle/telemetry/deploy-target-count/output.txt
@@ -27,6 +27,12 @@ Deployment complete!
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 3,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      }
+    ],
     "bundle_mode": "TYPE_UNSPECIFIED",
     "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
   }

--- a/acceptance/bundle/telemetry/deploy-target-count/script
+++ b/acceptance/bundle/telemetry/deploy-target-count/script
@@ -1,5 +1,5 @@
 trace $CLI bundle deploy -t one
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
 
 rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/.gitignore
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/.gitignore
@@ -1,0 +1,3 @@
+build/
+*.egg-info
+.databricks

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/databricks.yml
@@ -1,0 +1,19 @@
+bundle:
+  name: deploy-artifacts
+
+targets:
+  one:
+    artifacts:
+      test:
+        type: whl
+        path: ./my_test_code
+
+  two:
+    artifacts:
+      test:
+        type: whl
+        path: ./my_test_code
+        dynamic_version: true
+        build: "python3 setup.py bdist_wheel"
+        files:
+          - source: "./my_test_code/dist/*.whl"

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/databricks.yml
@@ -1,6 +1,13 @@
 bundle:
   name: deploy-artifacts
 
+variables:
+  wrapper:
+    default: false
+
+experimental:
+  python_wheel_wrapper: ${var.wrapper}
+
 targets:
   one:
     artifacts:
@@ -9,6 +16,8 @@ targets:
         path: ./my_test_code
 
   two:
+    variables:
+      wrapper: true
     artifacts:
       test:
         type: whl

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/my_test_code/setup.py
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/my_test_code/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+import src
+
+setup(
+    name="my_test_code",
+    version=src.__version__,
+    author=src.__author__,
+    url="https://databricks.com",
+    author_email="john.doe@databricks.com",
+    description="my test wheel",
+    packages=find_packages(include=["src"]),
+    entry_points={"group_1": "run=src.__main__:main"},
+    install_requires=["setuptools"],
+)

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/my_test_code/src/__init__.py
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/my_test_code/src/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "0.0.1"
+__author__ = "Databricks"

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/my_test_code/src/__main__.py
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/my_test_code/src/__main__.py
@@ -1,0 +1,16 @@
+"""
+The entry point of the Python Wheel
+"""
+
+import sys
+
+
+def main():
+    # This method will print the provided arguments
+    print("Hello from my func")
+    print("Got arguments:")
+    print(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -64,19 +64,19 @@ Deployment complete!
     "target_count": 2,
     "set_fields": [
       {
-        "key": "artifact.build",
+        "key": "artifact_build_command_is_set",
         "value": true
       },
       {
-        "key": "artifact.files",
+        "key": "artifact_files_is_set",
         "value": true
       },
       {
-        "key": "artifact.dynamic_version",
+        "key": "dynamic_version_is_set",
         "value": true
       },
       {
-        "key": "experimental.python_wheel_wrapper",
+        "key": "python_wheel_wrapper_is_set",
         "value": true
       }
     ],

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -16,6 +16,7 @@ Deployment complete!
 >>> cat out.requests.txt
 {
   "bundle_uuid": "[UUID]",
+  "deployment_id": "[UUID]",
   "resource_count": 0,
   "resource_job_count": 0,
   "resource_pipeline_count": 0,
@@ -41,6 +42,7 @@ Deployment complete!
 }
 {
   "bundle_uuid": "[UUID]",
+  "deployment_id": "[UUID]",
   "resource_count": 0,
   "resource_job_count": 0,
   "resource_pipeline_count": 0,

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -1,0 +1,80 @@
+
+>>> [CLI] bundle deploy -t one
+Building test...
+Uploading my_test_code/dist/my_test_code-0.0.1-py3-none-any.whl...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-artifacts/one/files...
+Deploying resources...
+Deployment complete!
+
+>>> [CLI] bundle deploy -t two
+Building test...
+Uploading .databricks/bundle/two/patched_wheels/test_my_test_code/my_test_code-0.0.1+[TIMESTAMP_NS]-py3-none-any.whl...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-artifacts/two/files...
+Deploying resources...
+Deployment complete!
+
+>>> cat out.requests.txt
+{
+  "bundle_uuid": "[UUID]",
+  "resource_count": 0,
+  "resource_job_count": 0,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "experimental": {
+    "configuration_file_count": 1,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 2,
+    "bundle_mode": "TYPE_UNSPECIFIED",
+    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+  }
+}
+{
+  "bundle_uuid": "[UUID]",
+  "resource_count": 0,
+  "resource_job_count": 0,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "experimental": {
+    "configuration_file_count": 1,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 2,
+    "set_fields": [
+      {
+        "key": "artifact.build",
+        "value": true
+      },
+      {
+        "key": "artifact.files",
+        "value": true
+      },
+      {
+        "key": "artifact.dynamic_version",
+        "value": true
+      }
+    ],
+    "bundle_mode": "TYPE_UNSPECIFIED",
+    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+  }
+}

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -86,7 +86,7 @@ Deployment complete!
         "value": true
       },
       {
-        "key": "dynamic_version_is_set",
+        "key": "artifact_dynamic_version_is_set",
         "value": true
       },
       {

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -74,6 +74,10 @@ Deployment complete!
       {
         "key": "artifact.dynamic_version",
         "value": true
+      },
+      {
+        "key": "experimental.python_wheel_wrapper",
+        "value": true
       }
     ],
     "bundle_mode": "TYPE_UNSPECIFIED",

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -36,6 +36,20 @@ Deployment complete!
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 2,
+    "bool_values": [
+      {
+        "key": "artifact_build_command_is_set",
+        "value": false
+      },
+      {
+        "key": "artifact_files_is_set",
+        "value": false
+      },
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      }
+    ],
     "bundle_mode": "TYPE_UNSPECIFIED",
     "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
   }
@@ -62,7 +76,7 @@ Deployment complete!
     "complex_variable_count": 0,
     "lookup_variable_count": 0,
     "target_count": 2,
-    "set_fields": [
+    "bool_values": [
       {
         "key": "artifact_build_command_is_set",
         "value": true

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/script
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/script
@@ -1,0 +1,7 @@
+trace $CLI bundle deploy -t one
+
+trace $CLI bundle deploy -t two
+
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
+
+rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/test.toml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/test.toml
@@ -1,0 +1,8 @@
+Ignore = [
+    '.venv',
+    'dist',
+    'build',
+    '*egg-info',
+    '.databricks',
+    "__pycache__",
+]

--- a/acceptance/bundle/telemetry/deploy/output.txt
+++ b/acceptance/bundle/telemetry/deploy/output.txt
@@ -49,6 +49,12 @@ Deployment complete!
           "complex_variable_count": 0,
           "lookup_variable_count": 0,
           "target_count": 1,
+          "bool_values": [
+            {
+              "key": "python_wheel_wrapper_is_set",
+              "value": false
+            }
+          ],
           "bundle_mode": "TYPE_UNSPECIFIED",
           "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
         }

--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -1,6 +1,6 @@
 trace $CLI bundle deploy
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'
 
 cmd_exec_id=$(extract_command_exec_id.py)
 deployment_id=$(cat .databricks/bundle/default/deployment.json | jq -r .id)

--- a/acceptance/bundle/templates/telemetry/custom-template/script
+++ b/acceptance/bundle/templates/telemetry/custom-template/script
@@ -13,4 +13,4 @@ update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/dbt-sql/script
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/script
@@ -13,4 +13,4 @@ update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/default-python/script
+++ b/acceptance/bundle/templates/telemetry/default-python/script
@@ -13,4 +13,4 @@ update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/bundle/templates/telemetry/default-sql/script
+++ b/acceptance/bundle/templates/telemetry/default-sql/script
@@ -13,4 +13,4 @@ update_file.py out.requests.txt $bundle_uuid '[BUNDLE-UUID]'
 update_file.py out.databricks.yml $bundle_uuid '[BUNDLE-UUID]'
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/telemetry/failure/script
+++ b/acceptance/telemetry/failure/script
@@ -1,4 +1,4 @@
 trace $CLI selftest send-telemetry --debug
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/telemetry/partial-success/script
+++ b/acceptance/telemetry/partial-success/script
@@ -1,4 +1,4 @@
 trace $CLI selftest send-telemetry --debug
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/telemetry/success/script
+++ b/acceptance/telemetry/success/script
@@ -5,4 +5,4 @@ update_file.py out.requests.txt \
  '[CMD-EXEC-ID]'
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/acceptance/telemetry/timeout/script
+++ b/acceptance/telemetry/timeout/script
@@ -4,4 +4,4 @@ export DATABRICKS_CLI_TELEMETRY_TIMEOUT=0.1
 trace $CLI selftest send-telemetry --debug
 
 # pretty print the telemetry payload.
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs.[] | fromjson'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson'

--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -80,6 +80,7 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		}
 
 		if a.Type == "whl" && a.DynamicVersion && cacheDir != "" {
+			b.Metrics.AddSetField("artifact.dynamic_version")
 			for ind, artifactFile := range a.Files {
 				patchedWheel, extraDiags := makePatchedWheel(ctx, cacheDir, artifactName, artifactFile.Source)
 				log.Debugf(ctx, "Patching ind=%d artifactName=%s Source=%s patchedWheel=%s", ind, artifactName, artifactFile.Source, patchedWheel)

--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/patchwheel"
 	"github.com/databricks/cli/libs/python"
+	"github.com/databricks/cli/libs/telemetry/protos"
 )
 
 func Build() bundle.Mutator {
@@ -80,7 +81,7 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		}
 
 		if a.Type == "whl" && a.DynamicVersion && cacheDir != "" {
-			b.Metrics.AddSetField("artifact.dynamic_version")
+			b.Metrics.AddSetField(protos.DynamicVersionIsSet)
 			for ind, artifactFile := range a.Files {
 				patchedWheel, extraDiags := makePatchedWheel(ctx, cacheDir, artifactName, artifactFile.Source)
 				log.Debugf(ctx, "Patching ind=%d artifactName=%s Source=%s patchedWheel=%s", ind, artifactName, artifactFile.Source, patchedWheel)

--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -81,7 +81,7 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		}
 
 		if a.Type == "whl" && a.DynamicVersion && cacheDir != "" {
-			b.Metrics.AddSetField(protos.DynamicVersionIsSet)
+			b.Metrics.AddBoolValue(protos.DynamicVersionIsSet, true)
 			for ind, artifactFile := range a.Files {
 				patchedWheel, extraDiags := makePatchedWheel(ctx, cacheDir, artifactName, artifactFile.Source)
 				log.Debugf(ctx, "Patching ind=%d artifactName=%s Source=%s patchedWheel=%s", ind, artifactName, artifactFile.Source, patchedWheel)

--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/exec"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/patchwheel"
 	"github.com/databricks/cli/libs/python"
-	"github.com/databricks/cli/libs/telemetry/protos"
 )
 
 func Build() bundle.Mutator {
@@ -81,7 +81,7 @@ func (m *build) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		}
 
 		if a.Type == "whl" && a.DynamicVersion && cacheDir != "" {
-			b.Metrics.AddBoolValue(protos.DynamicVersionIsSet, true)
+			b.Metrics.AddBoolValue(metrics.ArtifactDynamicVersionIsSet, true)
 			for ind, artifactFile := range a.Files {
 				patchedWheel, extraDiags := makePatchedWheel(ctx, cacheDir, artifactName, artifactFile.Source)
 				log.Debugf(ctx, "Patching ind=%d artifactName=%s Source=%s patchedWheel=%s", ind, artifactName, artifactFile.Source, patchedWheel)

--- a/bundle/artifacts/prepare.go
+++ b/bundle/artifacts/prepare.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/python"
+	"github.com/databricks/cli/libs/telemetry/protos"
 )
 
 func Prepare() bundle.Mutator {
@@ -38,10 +39,10 @@ func (m *prepare) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 	for _, artifactName := range sortedKeys(b.Config.Artifacts) {
 		artifact := b.Config.Artifacts[artifactName]
 		if artifact.BuildCommand != "" {
-			b.Metrics.AddSetField("artifact.build")
+			b.Metrics.AddSetField(protos.ArtifactBuildCommandIsSet)
 		}
 		if len(artifact.Files) != 0 {
-			b.Metrics.AddSetField("artifact.files")
+			b.Metrics.AddSetField(protos.ArtifactFilesIsSet)
 		}
 
 		if artifact.Type == "whl" {

--- a/bundle/artifacts/prepare.go
+++ b/bundle/artifacts/prepare.go
@@ -9,10 +9,10 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/libraries"
+	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/python"
-	"github.com/databricks/cli/libs/telemetry/protos"
 )
 
 func Prepare() bundle.Mutator {
@@ -38,8 +38,8 @@ func (m *prepare) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 
 	for _, artifactName := range sortedKeys(b.Config.Artifacts) {
 		artifact := b.Config.Artifacts[artifactName]
-		b.Metrics.AddBoolValue(protos.ArtifactBuildCommandIsSet, artifact.BuildCommand != "")
-		b.Metrics.AddBoolValue(protos.ArtifactFilesIsSet, len(artifact.Files) != 0)
+		b.Metrics.AddBoolValue(metrics.ArtifactBuildCommandIsSet, artifact.BuildCommand != "")
+		b.Metrics.AddBoolValue(metrics.ArtifactFilesIsSet, len(artifact.Files) != 0)
 
 		if artifact.Type == "whl" {
 			if artifact.BuildCommand == "" && len(artifact.Files) == 0 {

--- a/bundle/artifacts/prepare.go
+++ b/bundle/artifacts/prepare.go
@@ -38,12 +38,8 @@ func (m *prepare) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 
 	for _, artifactName := range sortedKeys(b.Config.Artifacts) {
 		artifact := b.Config.Artifacts[artifactName]
-		if artifact.BuildCommand != "" {
-			b.Metrics.AddSetField(protos.ArtifactBuildCommandIsSet)
-		}
-		if len(artifact.Files) != 0 {
-			b.Metrics.AddSetField(protos.ArtifactFilesIsSet)
-		}
+		b.Metrics.AddBoolValue(protos.ArtifactBuildCommandIsSet, artifact.BuildCommand != "")
+		b.Metrics.AddBoolValue(protos.ArtifactFilesIsSet, len(artifact.Files) != 0)
 
 		if artifact.Type == "whl" {
 			if artifact.BuildCommand == "" && len(artifact.Files) == 0 {

--- a/bundle/artifacts/prepare.go
+++ b/bundle/artifacts/prepare.go
@@ -37,6 +37,12 @@ func (m *prepare) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 
 	for _, artifactName := range sortedKeys(b.Config.Artifacts) {
 		artifact := b.Config.Artifacts[artifactName]
+		if artifact.BuildCommand != "" {
+			b.Metrics.AddSetField("artifact.build")
+		}
+		if len(artifact.Files) != 0 {
+			b.Metrics.AddSetField("artifact.files")
+		}
 
 		if artifact.Type == "whl" {
 			if artifact.BuildCommand == "" && len(artifact.Files) == 0 {

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -39,11 +39,11 @@ type Metrics struct {
 	ConfigurationFileCount int64
 	TargetCount            int64
 	DeploymentId           uuid.UUID
-	SetFields              []protos.BoolMapEntry
+	BoolValues             []protos.BoolMapEntry
 }
 
-func (m *Metrics) AddSetField(key string) {
-	m.SetFields = append(m.SetFields, protos.BoolMapEntry{Key: key, Value: true})
+func (m *Metrics) AddBoolValue(key string, value bool) {
+	m.BoolValues = append(m.BoolValues, protos.BoolMapEntry{Key: key, Value: value})
 }
 
 type Bundle struct {

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -23,6 +23,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	libsync "github.com/databricks/cli/libs/sync"
 	"github.com/databricks/cli/libs/tags"
+	"github.com/databricks/cli/libs/telemetry/protos"
 	"github.com/databricks/cli/libs/terraform"
 	"github.com/databricks/cli/libs/vfs"
 	"github.com/databricks/databricks-sdk-go"
@@ -38,6 +39,11 @@ type Metrics struct {
 	ConfigurationFileCount int64
 	TargetCount            int64
 	DeploymentId           uuid.UUID
+	SetFields              []protos.BoolMapEntry
+}
+
+func (m *Metrics) AddSetField(key string) {
+	m.SetFields = append(m.SetFields, protos.BoolMapEntry{Key: key, Value: true})
 }
 
 type Bundle struct {

--- a/bundle/metrics/metrics.go
+++ b/bundle/metrics/metrics.go
@@ -1,0 +1,8 @@
+package metrics
+
+const (
+	ExperimentalPythonWheelWrapperIsSet = "python_wheel_wrapper_is_set"
+	ArtifactDynamicVersionIsSet         = "artifact_dynamic_version_is_set"
+	ArtifactBuildCommandIsSet           = "artifact_build_command_is_set"
+	ArtifactFilesIsSet                  = "artifact_files_is_set"
+)

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -362,6 +362,7 @@ func logTelemetry(ctx context.Context, b *bundle.Bundle) {
 				ConfigurationFileCount:    b.Metrics.ConfigurationFileCount,
 				TargetCount:               b.Metrics.TargetCount,
 				WorkspaceArtifactPathType: artifactPathType,
+				SetFields:                 b.Metrics.SetFields,
 			},
 		},
 	})

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -362,7 +362,7 @@ func logTelemetry(ctx context.Context, b *bundle.Bundle) {
 				ConfigurationFileCount:    b.Metrics.ConfigurationFileCount,
 				TargetCount:               b.Metrics.TargetCount,
 				WorkspaceArtifactPathType: artifactPathType,
-				SetFields:                 b.Metrics.SetFields,
+				BoolValues:                b.Metrics.BoolValues,
 			},
 		},
 	})

--- a/bundle/trampoline/python_wheel.go
+++ b/bundle/trampoline/python_wheel.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/libraries"
+	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/libs/diag"
-	"github.com/databricks/cli/libs/telemetry/protos"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 )
@@ -77,7 +77,7 @@ func TransformWheelTask() bundle.Mutator {
 
 func (transformWheelTask) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	isEnabled := b.Config.Experimental != nil && b.Config.Experimental.PythonWheelWrapper
-	b.Metrics.AddBoolValue(protos.ExperimentalPythonWheelWrapperIsSet, isEnabled)
+	b.Metrics.AddBoolValue(metrics.ExperimentalPythonWheelWrapperIsSet, isEnabled)
 	if !isEnabled {
 		return nil
 	}

--- a/bundle/trampoline/python_wheel.go
+++ b/bundle/trampoline/python_wheel.go
@@ -80,6 +80,7 @@ func (transformWheelTask) Apply(ctx context.Context, b *bundle.Bundle) diag.Diag
 		return nil
 	}
 
+	b.Metrics.AddSetField("python_wheel_wrapper")
 	return bundle.Apply(ctx, b, NewTrampoline(
 		"python_wheel",
 		&pythonTrampoline{},

--- a/bundle/trampoline/python_wheel.go
+++ b/bundle/trampoline/python_wheel.go
@@ -10,6 +10,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/libraries"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/telemetry/protos"
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 )
@@ -80,7 +81,7 @@ func (transformWheelTask) Apply(ctx context.Context, b *bundle.Bundle) diag.Diag
 		return nil
 	}
 
-	b.Metrics.AddSetField("experimental.python_wheel_wrapper")
+	b.Metrics.AddSetField(protos.ExperimentalPythonWheelWrapperIsSet)
 	return bundle.Apply(ctx, b, NewTrampoline(
 		"python_wheel",
 		&pythonTrampoline{},

--- a/bundle/trampoline/python_wheel.go
+++ b/bundle/trampoline/python_wheel.go
@@ -77,11 +77,11 @@ func TransformWheelTask() bundle.Mutator {
 
 func (transformWheelTask) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	isEnabled := b.Config.Experimental != nil && b.Config.Experimental.PythonWheelWrapper
+	b.Metrics.AddBoolValue(protos.ExperimentalPythonWheelWrapperIsSet, isEnabled)
 	if !isEnabled {
 		return nil
 	}
 
-	b.Metrics.AddSetField(protos.ExperimentalPythonWheelWrapperIsSet)
 	return bundle.Apply(ctx, b, NewTrampoline(
 		"python_wheel",
 		&pythonTrampoline{},

--- a/bundle/trampoline/python_wheel.go
+++ b/bundle/trampoline/python_wheel.go
@@ -80,7 +80,7 @@ func (transformWheelTask) Apply(ctx context.Context, b *bundle.Bundle) diag.Diag
 		return nil
 	}
 
-	b.Metrics.AddSetField("python_wheel_wrapper")
+	b.Metrics.AddSetField("experimental.python_wheel_wrapper")
 	return bundle.Apply(ctx, b, NewTrampoline(
 		"python_wheel",
 		&pythonTrampoline{},

--- a/libs/telemetry/protos/bundle_deploy.go
+++ b/libs/telemetry/protos/bundle_deploy.go
@@ -56,7 +56,8 @@ type BundleDeployExperimental struct {
 	// Examples: "bundle.terraform.exec_path", "bundle.git.branch" etc.
 	SetFields []BoolMapEntry `json:"set_fields,omitempty"`
 
-	// Values for boolean configuration fields like `experimental.python_wheel_wrapper`
+	// Values for boolean configuration fields like `experimental.python_wheel_wrapper` or just any
+	// boolean values that we want to track.
 	// We don't need to define protos to track boolean values and can simply write those
 	// values to this map to track them.
 	BoolValues []BoolMapEntry `json:"bool_values,omitempty"`
@@ -71,7 +72,7 @@ type BundleDeployExperimental struct {
 
 type BoolMapEntry struct {
 	Key   string `json:"key,omitempty"`
-	Value bool   `json:"value,omitempty"`
+	Value bool   `json:"value"`
 }
 
 type IntMapEntry struct {

--- a/libs/telemetry/protos/enum.go
+++ b/libs/telemetry/protos/enum.go
@@ -24,10 +24,3 @@ const (
 	BundleDeployArtifactPathTypeWorkspace   BundleDeployArtifactPathType = "WORKSPACE_FILE_SYSTEM"
 	BundleDeployArtifactPathTypeVolume      BundleDeployArtifactPathType = "UC_VOLUME"
 )
-
-const (
-	ExperimentalPythonWheelWrapperIsSet = "python_wheel_wrapper_is_set"
-	DynamicVersionIsSet                 = "dynamic_version_is_set"
-	ArtifactBuildCommandIsSet           = "artifact_build_command_is_set"
-	ArtifactFilesIsSet                  = "artifact_files_is_set"
-)

--- a/libs/telemetry/protos/enum.go
+++ b/libs/telemetry/protos/enum.go
@@ -24,3 +24,10 @@ const (
 	BundleDeployArtifactPathTypeWorkspace   BundleDeployArtifactPathType = "WORKSPACE_FILE_SYSTEM"
 	BundleDeployArtifactPathTypeVolume      BundleDeployArtifactPathType = "UC_VOLUME"
 )
+
+const (
+	ExperimentalPythonWheelWrapperIsSet = "python_wheel_wrapper_is_set"
+	DynamicVersionIsSet                 = "dynamic_version_is_set"
+	ArtifactBuildCommandIsSet           = "artifact_build_command_is_set"
+	ArtifactFilesIsSet                  = "artifact_files_is_set"
+)


### PR DESCRIPTION
## Changes
Added telemetry for artifact deployment properties

## Why
This allows us to get insights into usage of 
- Wheel patching
- Python trampoline for an older DBRs
- Build command inferring vs. explicit command
- How often build files for artifacts are specified

## Tests
Added acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
