### PR TITLE
Fix "generate app" to interpret args relative to cwd

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,5 +14,6 @@
 * Added include/exclude flags support to bundle sync command ([#2650](https://github.com/databricks/cli/pull/2650))
 * Removed pipeline 'deployment' field from jsonschema ([#2653](https://github.com/databricks/cli/pull/2653))
 * Updated JSON schema for deprecated pipeline fields ([#2646](https://github.com/databricks/cli/pull/2646))
+* The --config-dir and --source-dir flags for "bundle generate app" are now relative to CWD, not bundle root ([#2683](https://github.com/databricks/cli/pull/2683))
 
 ### API Changes

--- a/cmd/bundle/generate/app.go
+++ b/cmd/bundle/generate/app.go
@@ -54,15 +54,6 @@ func NewGenerateAppCommand() *cobra.Command {
 			return err
 		}
 
-		// Making sure the config directory and source directory are absolute paths.
-		if !filepath.IsAbs(configDir) {
-			configDir = filepath.Join(b.BundleRootPath, configDir)
-		}
-
-		if !filepath.IsAbs(sourceDir) {
-			sourceDir = filepath.Join(b.BundleRootPath, sourceDir)
-		}
-
 		downloader := newDownloader(w, sourceDir, configDir)
 
 		sourceCodePath := app.DefaultSourceCodePath


### PR DESCRIPTION
## Changes
The --config-dir and --source-dir for "bundle generate app" no longer join value with bundle root. 

Related: #1928

## Why
This arguments should be interpreted relative to CWD, as is the case for all other generate commands.

## Tests
Existing tests.
