### PR TITLE
Fix start-integration-tests to start script without +x permissions

### DIFF
--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -37,4 +37,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          ./start_integration_tests.py -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} --yes
+          python3 ./start_integration_tests.py -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} --yes


### PR DESCRIPTION
Follow up to #2675
