### PR TITLE
[Python] Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,9 +161,13 @@ jobs:
 
     needs: goreleaser
 
+
+    # IMPORTANT: 
+    # - 'id-token: write' is mandatory for OIDC and trusted publishing to PyPi
+    # - 'environment: release' is checked by PyPi to protect from unwanted publishing
     environment: release
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write
 
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
     needs: goreleaser
 
 
-    # IMPORTANT: 
+    # IMPORTANT:
     # - 'id-token: write' is mandatory for OIDC and trusted publishing to PyPi
     # - 'environment: release' is a part of OIDC assertion done by PyPi
     #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,9 @@ jobs:
 
     # IMPORTANT: 
     # - 'id-token: write' is mandatory for OIDC and trusted publishing to PyPi
-    # - 'environment: release' is checked by PyPi to protect from unwanted publishing
+    # - 'environment: release' is a part of OIDC assertion done by PyPi
+    #
+    # See: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,35 @@ jobs:
                 version: "${{ env.VERSION }}",
               }
             });
+
+  pypi-publish:
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
+    needs: goreleaser
+
+    environment: release
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          version: "0.6.5"
+
+      - name: Build wheel
+        working-directory: experimental/python
+        run: make dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        with:
+          packages-dir: experimental/python/dist


### PR DESCRIPTION
## Changes
Add release workflow to publish `databricks-bundles` PyPi package

Should be merged after https://github.com/databricks/cli/pull/2676

## Why
It publishes PyPi package that is co-versioned with CLI