### PR TITLE
acc: Use uv in deploy-whl-artifacts test

### DIFF
--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/script
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/script
@@ -1,3 +1,7 @@
+uv venv -q .venv
+venv_activate
+uv pip install -q setuptools
+
 trace $CLI bundle deploy -t one
 
 trace $CLI bundle deploy -t two


### PR DESCRIPTION
## Why
Otherwise it requires system Python to have setuptools.
