### PR TITLE
Stop start-integration-tests and revert runner change

### DIFF
--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -1,8 +1,8 @@
 name: start-integration-tests
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'
+  #schedule:
+  #  - cron: '*/10 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -12,8 +12,8 @@ jobs:
   # It requires secrets from the "test-trigger-is" environment, which are only available to authorized users.
   trigger:
     runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     environment: "test-trigger-is"
 


### PR DESCRIPTION
Partially reverts #2688

With those settings at least getting the token worked.

The job current fails at Generate GitHub App Token stage with:

https://github.com/databricks/cli/actions/runs/14375161919/job/40305746689

```
      message: 'Although you appear to have the correct authorization credentials, the `***` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.',
      documentation_url: 'https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app',
      status: '403'
```

The previous settings that this PR restores it was able to generate the token and failed when running the script:

https://github.com/databricks/cli/actions/runs/14356228123/job/40246162712

```
Run python3 ./start_integration_tests.py -R ***/*** --yes
+ gh pr -R databricks/cli list --limit 300 --json number,author,reviews,headRefOid,headRepository,headRepositoryOwner
GraphQL: Although you appear to have the correct authorization credentials, the `databricks` organization has an IP allow list enabled, and your IP address is not permitted to access this resource. (repository)
```