### PR TITLE
Remove include/exclude flags support from bundle sync command

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,5 +10,6 @@
 
 ### Bundles
 * Do not exit early when checking incompatible tasks for specified DBR ([#2692](https://github.com/databricks/cli/pull/2692))
+* Removed include/exclude flags support from bundle sync command ([#2718](https://github.com/databricks/cli/pull/2718))
 
 ### API Changes

--- a/acceptance/bundle/help/bundle-sync/output.txt
+++ b/acceptance/bundle/help/bundle-sync/output.txt
@@ -6,10 +6,8 @@ Usage:
   databricks bundle sync [flags]
 
 Flags:
-      --exclude strings     patterns to exclude from sync (can be specified multiple times)
       --full                perform full synchronization (default is incremental)
   -h, --help                help for sync
-      --include strings     patterns to include in sync (can be specified multiple times)
       --interval duration   file system polling interval (for --watch) (default 1s)
       --output type         type of the output format
       --watch               watch local file system for changes

--- a/acceptance/bundle/sync/databricks.yml
+++ b/acceptance/bundle/sync/databricks.yml
@@ -5,3 +5,10 @@ resources:
   dashboards:
     dashboard1:
       display_name: My dashboard
+
+sync:
+  exclude:
+    - 'project-folder/app.*'
+    - 'project-folder/query.sql'
+  include:
+    - 'ignored-folder/**/*.py'

--- a/acceptance/bundle/sync/output.txt
+++ b/acceptance/bundle/sync/output.txt
@@ -3,38 +3,6 @@
 Initial Sync Complete
 Uploaded .gitignore
 Uploaded databricks.yml
-Uploaded project-folder
-Uploaded project-folder/app.py
-Uploaded project-folder/app.yaml
-Uploaded project-folder/query.sql
-
->>> [CLI] bundle sync --exclude project-folder/app.* --output text
-Deleted project-folder/app.py
-Deleted project-folder/app.yaml
-Initial Sync Complete
-
->>> [CLI] bundle sync --exclude project-folder/app.* --exclude project-folder/query.sql --output text
-Deleted project-folder
-Deleted project-folder/query.sql
-Initial Sync Complete
-
->>> [CLI] bundle sync --exclude project-folder/app.* --exclude project-folder/query.sql --include ignored-folder/*.py --output text
-Initial Sync Complete
-Uploaded ignored-folder
-Uploaded ignored-folder/script.py
-
->>> [CLI] bundle sync --exclude project-folder/app.* --exclude project-folder/query.sql --include ignored-folder/**/*.py --output text
-Initial Sync Complete
 Uploaded ignored-folder/folder1
 Uploaded ignored-folder/folder1/script.py
-
->>> [CLI] bundle sync --output text
-Deleted ignored-folder
-Deleted ignored-folder/folder1
-Deleted ignored-folder/folder1/script.py
-Deleted ignored-folder/script.py
-Initial Sync Complete
-Uploaded project-folder
-Uploaded project-folder/app.py
-Uploaded project-folder/app.yaml
-Uploaded project-folder/query.sql
+Uploaded ignored-folder/script.py

--- a/acceptance/bundle/sync/script
+++ b/acceptance/bundle/sync/script
@@ -9,14 +9,9 @@ repls.json
 EOF
 
 cleanup() {
-  rm -rf project-folder ignored-folder .git
+  rm -rf project-folder ignored-folder .git .gitignore
 }
 trap cleanup EXIT
 
 # Note: output line starting with "Action: " lists files in non-deterministic order so we filter it out
-trace $CLI bundle sync --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'project-folder/app.*' --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/*.py' --output text | grep -v "^Action: " | sort
-trace $CLI bundle sync --exclude 'project-folder/app.*' --exclude 'project-folder/query.sql' --include 'ignored-folder/**/*.py' --output text | grep -v "^Action: " | sort
 trace $CLI bundle sync --output text | grep -v "^Action: " | sort

--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -22,8 +22,6 @@ type syncFlags struct {
 	full     bool
 	watch    bool
 	output   flags.Output
-	exclude  []string
-	include  []string
 }
 
 func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) (*sync.SyncOptions, error) {
@@ -49,8 +47,6 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) 
 
 	opts.Full = f.full
 	opts.PollInterval = f.interval
-	opts.Exclude = append(opts.Exclude, f.exclude...)
-	opts.Include = append(opts.Include, f.include...)
 	return opts, nil
 }
 
@@ -66,8 +62,6 @@ func newSyncCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&f.full, "full", false, "perform full synchronization (default is incremental)")
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
 	cmd.Flags().Var(&f.output, "output", "type of the output format")
-	cmd.Flags().StringSliceVar(&f.exclude, "exclude", nil, "patterns to exclude from sync (can be specified multiple times)")
-	cmd.Flags().StringSliceVar(&f.include, "include", nil, "patterns to include in sync (can be specified multiple times)")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
Recently introduced (#2650) `--include` and `--exclude` flag in `bundle sync` command duplicate the existing functionality of files inclusion and exclusion [via settings in .yml file](https://docs.databricks.com/aws/en/dev-tools/bundles/settings#include-and-exclude). This change removes the ability to supply include/exclude patterns via CLI flags which removes the confusion before the two methods

## Tests
<!-- How have you tested the changes? -->
Updated existing tests

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
