### PR TITLE
Makefile: run 'go mod tidy' before 'go mod vendor'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: vendor fmt lint tidy ws
+default: tidy vendor fmt lint ws
 
 PACKAGES=./acceptance/... ./libs/... ./internal/... ./cmd/... ./bundle/... .
 
@@ -40,7 +40,7 @@ showcover:
 acc-showcover:
 	go tool cover -html=coverage-acceptance.txt
 
-build: vendor
+build: tidy vendor
 	go build -mod vendor
 
 snapshot:


### PR DESCRIPTION
## Changes
- Default 'make' will first run 'go mod tidy', then 'go mod vendor'
- 'make build' will also run 'go mod tidy' before 'go mod vendor'

## Why
It's a better sequence: 'go mod tidy' cleans up go.mod and go.sum and 'go mod vendor' populates vendor/ based on those.