### PR TITLE
dyn: replace Mapping.Set with Mapping.SetLoc

### DIFF
--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -104,10 +104,12 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 	info := getStructInfo(src.Type())
 	for k, v := range info.FieldValues(src) {
 		pair, ok := refm.GetPairByString(k)
+		refloc := pair.Key.Locations()
 		refv := pair.Value
 
 		// Use nil reference if there is no reference for this key
 		if !ok {
+			refloc = nil
 			refv = dyn.NilValue
 		}
 
@@ -124,7 +126,7 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 
 		// Either if the key was set in the reference or the field is not zero-valued, we include it.
 		if ok || nv.Kind() != dyn.KindNil {
-			out.SetLoc(k, nil, nv)
+			out.SetLoc(k, refloc, nv)
 		}
 	}
 
@@ -165,10 +167,12 @@ func fromTypedMap(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 		k := iter.Key().String()
 		v := iter.Value()
 		pair, ok := refm.GetPairByString(k)
+		refloc := pair.Key.Locations()
 		refv := pair.Value
 
 		// Use nil reference if there is no reference for this key
 		if !ok {
+			refloc = nil
 			refv = dyn.NilValue
 		}
 
@@ -180,7 +184,7 @@ func fromTypedMap(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 
 		// Every entry is represented, even if it is a nil.
 		// Otherwise, a map with zero-valued structs would yield a nil as well.
-		out.SetLoc(k, nil, nv)
+		out.SetLoc(k, refloc, nv)
 	}
 
 	return dyn.V(out), nil

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -104,12 +104,10 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 	info := getStructInfo(src.Type())
 	for k, v := range info.FieldValues(src) {
 		pair, ok := refm.GetPairByString(k)
-		refk := pair.Key
 		refv := pair.Value
 
 		// Use nil reference if there is no reference for this key
 		if !ok {
-			refk = dyn.V(k)
 			refv = dyn.NilValue
 		}
 
@@ -126,7 +124,7 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 
 		// Either if the key was set in the reference or the field is not zero-valued, we include it.
 		if ok || nv.Kind() != dyn.KindNil {
-			out.Set(refk, nv) // nolint:errcheck
+			out.SetLoc(k, nil, nv)
 		}
 	}
 
@@ -167,12 +165,10 @@ func fromTypedMap(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 		k := iter.Key().String()
 		v := iter.Value()
 		pair, ok := refm.GetPairByString(k)
-		refk := pair.Key
 		refv := pair.Value
 
 		// Use nil reference if there is no reference for this key
 		if !ok {
-			refk = dyn.V(k)
 			refv = dyn.NilValue
 		}
 
@@ -184,7 +180,7 @@ func fromTypedMap(src reflect.Value, ref dyn.Value) (dyn.Value, error) {
 
 		// Every entry is represented, even if it is a nil.
 		// Otherwise, a map with zero-valued structs would yield a nil as well.
-		out.Set(refk, nv) //nolint:errcheck
+		out.SetLoc(k, nil, nv)
 	}
 
 	return dyn.V(out), nil

--- a/libs/dyn/convert/normalize.go
+++ b/libs/dyn/convert/normalize.go
@@ -116,7 +116,7 @@ func (n normalizeOptions) normalizeStruct(typ reflect.Type, src dyn.Value, seen 
 				}
 			}
 
-			out.Set(pk, nv) //nolint:errcheck
+			out.SetLoc(pk.MustString(), pk.Locations(), nv)
 		}
 
 		// Return the normalized value if missing fields are not included.
@@ -162,7 +162,7 @@ func (n normalizeOptions) normalizeStruct(typ reflect.Type, src dyn.Value, seen 
 				continue
 			}
 			if v.IsValid() {
-				out.Set(dyn.V(k), v) // nolint:errcheck
+				out.SetLoc(k, nil, v)
 			}
 		}
 
@@ -201,7 +201,7 @@ func (n normalizeOptions) normalizeMap(typ reflect.Type, src dyn.Value, seen []r
 				}
 			}
 
-			out.Set(pk, nv) //nolint:errcheck
+			out.SetLoc(pk.MustString(), pk.Locations(), nv)
 		}
 
 		return dyn.NewValue(out, src.Locations()), diags

--- a/libs/dyn/convert/normalize_test.go
+++ b/libs/dyn/convert/normalize_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
 	assert "github.com/databricks/cli/libs/dyn/dynassert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeStruct(t *testing.T) {
@@ -61,15 +60,13 @@ func TestNormalizeStructUnknownField(t *testing.T) {
 	var typ Tmp
 
 	m := dyn.NewMapping()
-	err := m.Set(dyn.V("foo"), dyn.V("val-foo"))
-	require.NoError(t, err)
+	m.SetLoc("foo", nil, dyn.V("val-foo"))
 
 	// Set the unknown field, with location information.
-	err = m.Set(dyn.NewValue("bar", []dyn.Location{
+	m.SetLoc("bar", []dyn.Location{
 		{File: "hello.yaml", Line: 1, Column: 1},
 		{File: "world.yaml", Line: 2, Column: 2},
-	}), dyn.V("var-bar"))
-	require.NoError(t, err)
+	}, dyn.V("var-bar"))
 
 	vin := dyn.V(m)
 

--- a/libs/dyn/jsonloader/json.go
+++ b/libs/dyn/jsonloader/json.go
@@ -63,7 +63,7 @@ func decodeValue(decoder *json.Decoder, o *Offset) (dyn.Value, error) {
 
 				// Get the offset of the key by subtracting the length of the key and the '"' character
 				keyOffset := decoder.InputOffset() - int64(len(key)+1)
-				keyVal := dyn.NewValue(key, []dyn.Location{o.GetPosition(keyOffset)})
+				loc := []dyn.Location{o.GetPosition(keyOffset)}
 
 				// Decode the value recursively
 				val, err := decodeValue(decoder, o)
@@ -71,7 +71,7 @@ func decodeValue(decoder *json.Decoder, o *Offset) (dyn.Value, error) {
 					return invalidValueWithLocation(decoder, o), err
 				}
 
-				obj.Set(keyVal, val) //nolint:errcheck
+				obj.SetLoc(key, loc, val)
 			}
 			// Consume the closing '}'
 			if _, err := decoder.Token(); err != nil {

--- a/libs/dyn/jsonsaver/marshal_test.go
+++ b/libs/dyn/jsonsaver/marshal_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/databricks/cli/libs/dyn"
 	assert "github.com/databricks/cli/libs/dyn/dynassert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMarshal_String(t *testing.T) {
@@ -45,8 +44,8 @@ func TestMarshal_Time(t *testing.T) {
 
 func TestMarshal_Map(t *testing.T) {
 	m := dyn.NewMapping()
-	require.NoError(t, m.Set(dyn.V("key1"), dyn.V("value1")))
-	require.NoError(t, m.Set(dyn.V("key2"), dyn.V("value2")))
+	m.SetLoc("key1", nil, dyn.V("value1"))
+	m.SetLoc("key2", nil, dyn.V("value2"))
 
 	b, err := Marshal(dyn.V(m))
 	if assert.NoError(t, err) {
@@ -67,16 +66,16 @@ func TestMarshal_Sequence(t *testing.T) {
 
 func TestMarshal_Complex(t *testing.T) {
 	map1 := dyn.NewMapping()
-	require.NoError(t, map1.Set(dyn.V("str1"), dyn.V("value1")))
-	require.NoError(t, map1.Set(dyn.V("str2"), dyn.V("value2")))
+	map1.SetLoc("str1", nil, dyn.V("value1"))
+	map1.SetLoc("str2", nil, dyn.V("value2"))
 
 	var seq1 []dyn.Value
 	seq1 = append(seq1, dyn.V("value1"))
 	seq1 = append(seq1, dyn.V("value2"))
 
 	root := dyn.NewMapping()
-	require.NoError(t, root.Set(dyn.V("map1"), dyn.V(map1)))
-	require.NoError(t, root.Set(dyn.V("seq1"), dyn.V(seq1)))
+	root.SetLoc("map1", nil, dyn.V(map1))
+	root.SetLoc("seq1", nil, dyn.V(seq1))
 
 	// Marshal without indent.
 	b, err := Marshal(dyn.V(root))

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -166,6 +166,7 @@ func (m Mapping) Clone() Mapping {
 // Merge merges the key-value pairs from another Mapping into the current Mapping.
 func (m *Mapping) Merge(n Mapping) {
 	for _, p := range n.pairs {
-		m.Set(p.Key, p.Value) //nolint:errcheck
+		// Following original Merge logic: do not take key locations from n
+		m.SetLoc(p.Key.MustString(), nil, p.Value)
 	}
 }

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -94,24 +94,15 @@ func (m *Mapping) GetByString(skey string) (Value, bool) {
 // If the key already exists, the value is updated.
 // If the key does not exist, a new key-value pair is added.
 // The key must be a string, otherwise an error is returned.
+//
+// Deprecated: Use SetLoc instead.
 func (m *Mapping) Set(key, value Value) error {
 	skey, ok := key.AsString()
 	if !ok {
 		return fmt.Errorf("key must be a string, got %s", key.Kind())
 	}
 
-	// If the key already exists, update the value.
-	if i, ok := m.index[skey]; ok {
-		m.pairs[i].Value = value
-		return nil
-	}
-
-	// Otherwise, add a new pair.
-	m.pairs = append(m.pairs, Pair{key, value})
-	if m.index == nil {
-		m.index = make(map[string]int)
-	}
-	m.index[skey] = len(m.pairs) - 1
+	m.SetLoc(skey, key.l, value)
 	return nil
 }
 

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -41,7 +41,7 @@ func newMappingWithSize(size int) Mapping {
 func newMappingFromGoMap(vin map[string]Value) Mapping {
 	m := newMappingWithSize(len(vin))
 	for k, v := range vin {
-		m.Set(V(k), v) //nolint:errcheck
+		m.SetLoc(k, nil, v)
 	}
 	return m
 }
@@ -113,6 +113,28 @@ func (m *Mapping) Set(key, value Value) error {
 	}
 	m.index[skey] = len(m.pairs) - 1
 	return nil
+}
+
+// Set sets the value for the given key in the mapping and optionally location of the key.
+// If the key already exists, the value is updated. The location is updated if loc != nil.
+// If the key does not exist, a new key-value pair is added.
+func (m *Mapping) SetLoc(skey string, loc []Location, value Value) {
+	// If the key already exists, update the value.
+	if i, ok := m.index[skey]; ok {
+		p := m.pairs[i]
+		p.Value = value
+		if loc != nil {
+			p.Key.l = loc
+		}
+		return
+	}
+
+	// Otherwise, add a new pair.
+	m.pairs = append(m.pairs, Pair{NewValue(skey, loc), value})
+	if m.index == nil {
+		m.index = make(map[string]int)
+	}
+	m.index[skey] = len(m.pairs) - 1
 }
 
 // Keys returns all the keys in the Mapping.

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -89,17 +89,14 @@ func (m *Mapping) GetByString(skey string) (Value, bool) {
 	return p.Value, ok
 }
 
-// Set sets the value for the given key in the mapping and optionally location of the key.
-// If the key already exists, the value is updated. The location is updated if loc != nil.
+// Set sets the value for the given key in the mapping.
+// If the key already exists, the value is updated. The location loc is ignored.
 // If the key does not exist, a new key-value pair is added.
 func (m *Mapping) SetLoc(skey string, loc []Location, value Value) {
 	// If the key already exists, update the value.
 	if i, ok := m.index[skey]; ok {
 		p := &m.pairs[i]
 		p.Value = value
-		if loc != nil {
-			p.Key.l = loc
-		}
 		return
 	}
 

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -1,7 +1,6 @@
 package dyn
 
 import (
-	"fmt"
 	"maps"
 	"slices"
 )
@@ -88,22 +87,6 @@ func (m Mapping) Get(key Value) (Value, bool) {
 func (m *Mapping) GetByString(skey string) (Value, bool) {
 	p, ok := m.GetPairByString(skey)
 	return p.Value, ok
-}
-
-// Set sets the value for the given key in the mapping.
-// If the key already exists, the value is updated.
-// If the key does not exist, a new key-value pair is added.
-// The key must be a string, otherwise an error is returned.
-//
-// Deprecated: Use SetLoc instead.
-func (m *Mapping) Set(key, value Value) error {
-	skey, ok := key.AsString()
-	if !ok {
-		return fmt.Errorf("key must be a string, got %s", key.Kind())
-	}
-
-	m.SetLoc(skey, key.l, value)
-	return nil
 }
 
 // Set sets the value for the given key in the mapping and optionally location of the key.

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -136,7 +136,6 @@ func (m Mapping) Clone() Mapping {
 // Merge merges the key-value pairs from another Mapping into the current Mapping.
 func (m *Mapping) Merge(n Mapping) {
 	for _, p := range n.pairs {
-		// Following original Merge logic: do not take key locations from n
-		m.SetLoc(p.Key.MustString(), nil, p.Value)
+		m.SetLoc(p.Key.MustString(), p.Key.Locations(), p.Value)
 	}
 }

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -95,8 +95,7 @@ func (m *Mapping) GetByString(skey string) (Value, bool) {
 func (m *Mapping) SetLoc(skey string, loc []Location, value Value) {
 	// If the key already exists, update the value.
 	if i, ok := m.index[skey]; ok {
-		p := &m.pairs[i]
-		p.Value = value
+		m.pairs[i].Value = value
 		return
 	}
 

--- a/libs/dyn/mapping.go
+++ b/libs/dyn/mapping.go
@@ -121,7 +121,7 @@ func (m *Mapping) Set(key, value Value) error {
 func (m *Mapping) SetLoc(skey string, loc []Location, value Value) {
 	// If the key already exists, update the value.
 	if i, ok := m.index[skey]; ok {
-		p := m.pairs[i]
+		p := &m.pairs[i]
 		p.Value = value
 		if loc != nil {
 			p.Key.l = loc

--- a/libs/dyn/mapping_test.go
+++ b/libs/dyn/mapping_test.go
@@ -27,8 +27,7 @@ func TestMappingZeroValue(t *testing.T) {
 
 func TestMappingGet(t *testing.T) {
 	var m dyn.Mapping
-	err := m.Set(dyn.V("key"), dyn.V("value"))
-	assert.NoError(t, err)
+	m.SetLoc("key", nil, dyn.V("value"))
 	assert.Equal(t, 1, m.Len())
 
 	// Call GetPair

--- a/libs/dyn/mapping_test.go
+++ b/libs/dyn/mapping_test.go
@@ -92,13 +92,11 @@ func TestMappingGet(t *testing.T) {
 	assert.Equal(t, dyn.InvalidValue, value)
 }
 
-func TestMappingSet(t *testing.T) {
-	var err error
+func TestMappingSetLoc(t *testing.T) {
 	var m dyn.Mapping
 
 	// Set a value
-	err = m.Set(dyn.V("key1"), dyn.V("foo"))
-	assert.NoError(t, err)
+	m.SetLoc("key1", nil, dyn.V("foo"))
 	assert.Equal(t, 1, m.Len())
 
 	// Confirm the value
@@ -107,8 +105,7 @@ func TestMappingSet(t *testing.T) {
 	assert.Equal(t, dyn.V("foo"), value)
 
 	// Set another value
-	err = m.Set(dyn.V("key2"), dyn.V("bar"))
-	assert.NoError(t, err)
+	m.SetLoc("key2", nil, dyn.V("bar"))
 	assert.Equal(t, 2, m.Len())
 
 	// Confirm the value
@@ -117,30 +114,20 @@ func TestMappingSet(t *testing.T) {
 	assert.Equal(t, dyn.V("bar"), value)
 
 	// Overwrite first value
-	err = m.Set(dyn.V("key1"), dyn.V("qux"))
-	assert.NoError(t, err)
+	m.SetLoc("key1", nil, dyn.V("qux"))
 	assert.Equal(t, 2, m.Len())
 
 	// Confirm the value
 	value, ok = m.Get(dyn.V("key1"))
 	assert.True(t, ok)
 	assert.Equal(t, dyn.V("qux"), value)
-
-	// Try to set non-string key
-	err = m.Set(dyn.V(1), dyn.V("qux"))
-	assert.Error(t, err)
-	assert.Equal(t, 2, m.Len())
 }
 
 func TestMappingKeysValues(t *testing.T) {
-	var err error
-
 	// Configure mapping
 	var m dyn.Mapping
-	err = m.Set(dyn.V("key1"), dyn.V("foo"))
-	assert.NoError(t, err)
-	err = m.Set(dyn.V("key2"), dyn.V("bar"))
-	assert.NoError(t, err)
+	m.SetLoc("key1", nil, dyn.V("foo"))
+	m.SetLoc("key2", nil, dyn.V("bar"))
 
 	// Confirm keys
 	keys := m.Keys()
@@ -156,22 +143,17 @@ func TestMappingKeysValues(t *testing.T) {
 }
 
 func TestMappingClone(t *testing.T) {
-	var err error
-
 	// Configure mapping
 	var m1 dyn.Mapping
-	err = m1.Set(dyn.V("key1"), dyn.V("foo"))
-	assert.NoError(t, err)
-	err = m1.Set(dyn.V("key2"), dyn.V("bar"))
-	assert.NoError(t, err)
+	m1.SetLoc("key1", nil, dyn.V("foo"))
+	m1.SetLoc("key2", nil, dyn.V("bar"))
 
 	// Clone mapping
 	m2 := m1.Clone()
 	assert.Equal(t, m1.Len(), m2.Len())
 
 	// Modify original mapping
-	err = m1.Set(dyn.V("key1"), dyn.V("qux"))
-	assert.NoError(t, err)
+	m1.SetLoc("key1", nil, dyn.V("qux"))
 
 	// Confirm values
 	value, ok := m1.Get(dyn.V("key1"))
@@ -185,14 +167,12 @@ func TestMappingClone(t *testing.T) {
 func TestMappingMerge(t *testing.T) {
 	var m1 dyn.Mapping
 	for i := range 10 {
-		err := m1.Set(dyn.V(strconv.Itoa(i)), dyn.V(i))
-		require.NoError(t, err)
+		m1.SetLoc(strconv.Itoa(i), nil, dyn.V(i))
 	}
 
 	var m2 dyn.Mapping
 	for i := 5; i < 15; i++ {
-		err := m2.Set(dyn.V(strconv.Itoa(i)), dyn.V(i))
-		require.NoError(t, err)
+		m2.SetLoc(strconv.Itoa(i), nil, dyn.V(i))
 	}
 
 	var out dyn.Mapping

--- a/libs/dyn/mapping_test.go
+++ b/libs/dyn/mapping_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/databricks/cli/libs/dyn"
 	assert "github.com/databricks/cli/libs/dyn/dynassert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewMapping(t *testing.T) {
@@ -126,8 +125,8 @@ func TestMappingSetLoc(t *testing.T) {
 func TestMappingKeysValues(t *testing.T) {
 	// Configure mapping
 	var m dyn.Mapping
-	m.SetLoc("key1", nil, dyn.V("foo"))
-	m.SetLoc("key2", nil, dyn.V("bar"))
+	m.SetLoc("key1", []dyn.Location{}, dyn.V("foo"))
+	m.SetLoc("key2", []dyn.Location{}, dyn.V("bar"))
 
 	// Confirm keys
 	keys := m.Keys()

--- a/libs/dyn/merge/merge.go
+++ b/libs/dyn/merge/merge.go
@@ -81,6 +81,7 @@ func mergeMap(a, b dyn.Value) (dyn.Value, error) {
 	// Merge the values from b into the output map.
 	for _, pair := range bm.Pairs() {
 		pk := pair.Key
+		key := pk.MustString()
 		pv := pair.Value
 		if ov, ok := out.Get(pk); ok {
 			// If the key already exists, merge the values.
@@ -88,10 +89,10 @@ func mergeMap(a, b dyn.Value) (dyn.Value, error) {
 			if err != nil {
 				return dyn.InvalidValue, err
 			}
-			out.Set(pk, merged) //nolint:errcheck
+			out.SetLoc(key, pair.Key.Locations(), merged)
 		} else {
 			// Otherwise, just set the value.
-			out.Set(pk, pv) //nolint:errcheck
+			out.SetLoc(key, pair.Key.Locations(), pv)
 		}
 	}
 

--- a/libs/dyn/merge/override.go
+++ b/libs/dyn/merge/override.go
@@ -112,13 +112,14 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 		// detect if key was removed
 		if _, ok := rightMapping.GetPair(leftPair.Key); !ok {
 			key := leftPair.Key.MustString()
+			keyLoc := leftPair.Key.Locations()
 			path := basePath.Append(dyn.Key(key))
 
 			err := visitor.VisitDelete(path, leftPair.Value)
 
 			// if 'delete' was undone, add it back
 			if errors.Is(err, ErrOverrideUndoDelete) {
-				out.SetLoc(key, leftPair.Key.Locations(), leftPair.Value)
+				out.SetLoc(key, keyLoc, leftPair.Value)
 			} else if err != nil {
 				return dyn.NewMapping(), err
 			}
@@ -130,6 +131,7 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 
 	for _, rightPair := range rightMapping.Pairs() {
 		key := rightPair.Key.MustString()
+		keyLoc := rightPair.Key.Locations()
 		if leftPair, ok := leftMapping.GetPair(rightPair.Key); ok {
 			path := basePath.Append(dyn.Key(key))
 			newValue, err := override(path, leftPair.Value, rightPair.Value, visitor)
@@ -138,7 +140,7 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 			}
 
 			// key was there before, so keep its location
-			out.SetLoc(key, rightPair.Key.Locations(), newValue)
+			out.SetLoc(key, keyLoc, newValue)
 		} else {
 			path := basePath.Append(dyn.Key(rightPair.Key.MustString()))
 
@@ -147,7 +149,7 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 				return dyn.NewMapping(), err
 			}
 
-			out.SetLoc(key, rightPair.Key.Locations(), newValue)
+			out.SetLoc(key, keyLoc, newValue)
 		}
 	}
 

--- a/libs/dyn/merge/override.go
+++ b/libs/dyn/merge/override.go
@@ -111,16 +111,14 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 	for _, leftPair := range leftMapping.Pairs() {
 		// detect if key was removed
 		if _, ok := rightMapping.GetPair(leftPair.Key); !ok {
-			path := basePath.Append(dyn.Key(leftPair.Key.MustString()))
+			key := leftPair.Key.MustString()
+			path := basePath.Append(dyn.Key(key))
 
 			err := visitor.VisitDelete(path, leftPair.Value)
 
 			// if 'delete' was undone, add it back
 			if errors.Is(err, ErrOverrideUndoDelete) {
-				err := out.Set(leftPair.Key, leftPair.Value)
-				if err != nil {
-					return dyn.NewMapping(), err
-				}
+				out.SetLoc(key, leftPair.Key.Locations(), leftPair.Value)
 			} else if err != nil {
 				return dyn.NewMapping(), err
 			}
@@ -131,18 +129,16 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 	// and insert new keys
 
 	for _, rightPair := range rightMapping.Pairs() {
+		key := rightPair.Key.MustString()
 		if leftPair, ok := leftMapping.GetPair(rightPair.Key); ok {
-			path := basePath.Append(dyn.Key(rightPair.Key.MustString()))
+			path := basePath.Append(dyn.Key(key))
 			newValue, err := override(path, leftPair.Value, rightPair.Value, visitor)
 			if err != nil {
 				return dyn.NewMapping(), err
 			}
 
 			// key was there before, so keep its location
-			err = out.Set(leftPair.Key, newValue)
-			if err != nil {
-				return dyn.NewMapping(), err
-			}
+			out.SetLoc(key, rightPair.Key.Locations(), newValue)
 		} else {
 			path := basePath.Append(dyn.Key(rightPair.Key.MustString()))
 
@@ -151,10 +147,7 @@ func overrideMapping(basePath dyn.Path, leftMapping, rightMapping dyn.Mapping, v
 				return dyn.NewMapping(), err
 			}
 
-			err = out.Set(rightPair.Key, newValue)
-			if err != nil {
-				return dyn.NewMapping(), err
-			}
+			out.SetLoc(key, rightPair.Key.Locations(), newValue)
 		}
 	}
 

--- a/libs/dyn/merge/override_test.go
+++ b/libs/dyn/merge/override_test.go
@@ -432,12 +432,10 @@ func TestOverride_PreserveMappingKeys(t *testing.T) {
 	rightValueLocation := dyn.Location{File: "right.yml", Line: 3, Column: 1}
 
 	left := dyn.NewMapping()
-	err := left.Set(dyn.NewValue("a", []dyn.Location{leftKeyLocation}), dyn.NewValue(42, []dyn.Location{leftValueLocation}))
-	require.NoError(t, err)
+	left.SetLoc("a", []dyn.Location{leftKeyLocation}, dyn.NewValue(42, []dyn.Location{leftValueLocation}))
 
 	right := dyn.NewMapping()
-	err = right.Set(dyn.NewValue("a", []dyn.Location{rightKeyLocation}), dyn.NewValue(7, []dyn.Location{rightValueLocation}))
-	require.NoError(t, err)
+	right.SetLoc("a", []dyn.Location{rightKeyLocation}, dyn.NewValue(7, []dyn.Location{rightValueLocation}))
 
 	state, visitor := createVisitor(visitorOpts{})
 

--- a/libs/dyn/merge/select.go
+++ b/libs/dyn/merge/select.go
@@ -18,10 +18,7 @@ func Select(value dyn.Value, included []string) (dyn.Value, error) {
 		pair, ok := mapping.GetPairByString(key)
 
 		if ok {
-			err := newMapping.Set(pair.Key, pair.Value)
-			if err != nil {
-				return dyn.InvalidValue, err
-			}
+			newMapping.SetLoc(key, pair.Key.Locations(), pair.Value)
 		}
 	}
 

--- a/libs/dyn/pattern.go
+++ b/libs/dyn/pattern.go
@@ -69,7 +69,7 @@ func (c anyKeyComponent) visit(v Value, prefix Path, suffix Pattern, opts visitO
 			return InvalidValue, err
 		}
 
-		m.SetLoc(pk.MustString(), nil, nv)
+		m.SetLoc(pk.MustString(), pk.Locations(), nv)
 	}
 
 	return NewValue(m, v.Locations()), nil

--- a/libs/dyn/pattern.go
+++ b/libs/dyn/pattern.go
@@ -69,7 +69,7 @@ func (c anyKeyComponent) visit(v Value, prefix Path, suffix Pattern, opts visitO
 			return InvalidValue, err
 		}
 
-		m.Set(pk, nv) //nolint:errcheck
+		m.SetLoc(pk.MustString(), nil, nv)
 	}
 
 	return NewValue(m, v.Locations()), nil

--- a/libs/dyn/visit.go
+++ b/libs/dyn/visit.go
@@ -122,7 +122,7 @@ func (component pathComponent) visit(v Value, prefix Path, suffix Pattern, opts 
 
 		// Return an updated map value.
 		m = m.Clone()
-		m.Set(V(component.key), nv) //nolint:errcheck
+		m.SetLoc(component.key, nil, nv)
 		return Value{
 			v: m,
 			k: KindMap,

--- a/libs/dyn/visit_map.go
+++ b/libs/dyn/visit_map.go
@@ -25,7 +25,7 @@ func Foreach(fn MapFunc) MapFunc {
 				if err != nil {
 					return InvalidValue, err
 				}
-				m.Set(pk, nv) //nolint:errcheck
+				m.SetLoc(pk.MustString(), nil, nv)
 			}
 			return NewValue(m, v.Locations()), nil
 		case KindSequence:

--- a/libs/dyn/visit_map.go
+++ b/libs/dyn/visit_map.go
@@ -25,7 +25,7 @@ func Foreach(fn MapFunc) MapFunc {
 				if err != nil {
 					return InvalidValue, err
 				}
-				m.SetLoc(pk.MustString(), nil, nv)
+				m.SetLoc(pk.MustString(), pk.Locations(), nv)
 			}
 			return NewValue(m, v.Locations()), nil
 		case KindSequence:

--- a/libs/dyn/visit_set.go
+++ b/libs/dyn/visit_set.go
@@ -41,7 +41,7 @@ func SetByPath(v Value, p Path, nv Value) (Value, error) {
 
 				// Return an updated map value.
 				m = m.Clone()
-				m.Set(V(component.key), nv) //nolint:errcheck
+				m.SetLoc(component.key, nil, nv)
 				return Value{
 					v: m,
 					k: KindMap,

--- a/libs/dyn/walk.go
+++ b/libs/dyn/walk.go
@@ -45,7 +45,7 @@ func walk(v Value, p Path, fn func(p Path, v Value) (Value, error)) (Value, erro
 			if err != nil {
 				return InvalidValue, err
 			}
-			out.Set(pk, nv) //nolint:errcheck
+			out.SetLoc(pk.MustString(), pk.Locations(), nv)
 		}
 		v.v = out
 	case KindSequence:

--- a/libs/dyn/yamlloader/loader.go
+++ b/libs/dyn/yamlloader/loader.go
@@ -118,18 +118,18 @@ func (d *loader) loadMapping(node *yaml.Node, loc dyn.Location) (dyn.Value, erro
 			return dyn.InvalidValue, errorf(loc, "invalid key tag: %v", st)
 		}
 
-		k := dyn.NewValue(key.Value, []dyn.Location{{
+		loc := []dyn.Location{{
 			File:   d.path,
 			Line:   key.Line,
 			Column: key.Column,
-		}})
+		}}
 
 		v, err := d.load(val)
 		if err != nil {
 			return dyn.InvalidValue, err
 		}
 
-		acc.Set(k, v) //nolint:errcheck
+		acc.SetLoc(key.Value, loc, v)
 	}
 
 	if merge == nil {

--- a/libs/dyn/yamlsaver/utils.go
+++ b/libs/dyn/yamlsaver/utils.go
@@ -57,10 +57,7 @@ func sortMapAlphabetically(mv dyn.Value) (dyn.Value, error) {
 				return dyn.InvalidValue, err
 			}
 		}
-		err = sortedMap.Set(key, value)
-		if err != nil {
-			return dyn.InvalidValue, err
-		}
+		sortedMap.SetLoc(key.MustString(), key.Locations(), value)
 	}
 
 	return dyn.V(sortedMap), nil


### PR DESCRIPTION
## Changes
- Add Mapping.SetLoc(string, []Location, Value), which is a replacement for Set() that does not return an error and only accepts string keys.
- Migrate all code to use this function.

## Why
The original function returned an error if key was holding value of wrong type but the error was never checked. The new function does not return an error.

This interface embraces string key rather than pretending that all types are supported. 

Note, in some cases this increases number of MustString() calls in the code, however, this 
- only happens where there already is MustString()
- is temporary - once we add a function to iterate over string keys rather than values or pairs, it won't be necessary.

## Tests
Existing tests.
