### PR TITLE
[Python] Update uv.lock during tagging

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -24,7 +24,8 @@
             "make schema",
             "echo 'bundle/internal/tf/schema/\\*.go linguist-generated=true' >> ./.gitattributes",
             "echo 'go.sum linguist-generated=true' >> ./.gitattributes",
-            "echo 'bundle/schema/jsonschema.json linguist-generated=true' >> ./.gitattributes"
+            "echo 'bundle/schema/jsonschema.json linguist-generated=true' >> ./.gitattributes",
+            "pushd experimental/python && uv lock"
         ]
     }
 }

--- a/.codegen.json
+++ b/.codegen.json
@@ -10,9 +10,10 @@
         ".codegen/cmds-account.go.tmpl": "cmd/account/cmd.go"
     },
     "version": {
+      "experimental/python/README.md": "version $VERSION or above",
       "experimental/python/databricks/bundles/version.py": "__version__ = \"$VERSION\"",
       "experimental/python/pyproject.toml": "version = \"$VERSION\"",
-      "experimental/python/README.md": "version $VERSION or above",
+      "experimental/python/uv.lock": "name = \"databricks-bundles\"\nversion = \"$VERSION\"",
       "libs/template/templates/experimental-jobs-as-code/library/versions.tmpl": "{{define \"latest_databricks_bundles_version\" -}}$VERSION{{- end}}"
     },
     "toolchain": {
@@ -24,8 +25,7 @@
             "make schema",
             "echo 'bundle/internal/tf/schema/\\*.go linguist-generated=true' >> ./.gitattributes",
             "echo 'go.sum linguist-generated=true' >> ./.gitattributes",
-            "echo 'bundle/schema/jsonschema.json linguist-generated=true' >> ./.gitattributes",
-            "pushd experimental/python && uv lock"
+            "echo 'bundle/schema/jsonschema.json linguist-generated=true' >> ./.gitattributes"
         ]
     }
 }

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -43,11 +43,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install PyGithub
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
-        with:
-          version: "0.6.5"
-
       - name: Run script
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -43,6 +43,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install PyGithub
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          version: "0.6.5"
+
       - name: Run script
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/experimental/python/uv.lock
+++ b/experimental/python/uv.lock
@@ -166,7 +166,7 @@ toml = [
 
 [[package]]
 name = "databricks-bundles"
-version = "0.248.0"
+version = "0.249.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Changes
Update `uv.lock` during tagging and fix `uv.lock` broken during the previous release.

Previously, we used the genkit version substitution mechanism, which didn't work because it replaced all versions in the UV lock file, and we reverted it in https://github.com/databricks/cli/pull/2731

## Why
Having an outdated `uv.lock` breaks Python builds after release.

## Tests
Not tested