### PR TITLE
[Python] Update README.md during tagging

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -12,6 +12,7 @@
     "version": {
       "experimental/python/databricks/bundles/version.py": "__version__ = \"$VERSION\"",
       "experimental/python/pyproject.toml": "version = \"$VERSION\"",
+      "experimental/python/README.md": "version $VERSION or above",
       "libs/template/templates/experimental-jobs-as-code/library/versions.tmpl": "{{define \"latest_databricks_bundles_version\" -}}$VERSION{{- end}}"
     },
     "toolchain": {


### PR DESCRIPTION
## Changes
Update `experimental/python/README.md` during tagging to reference the latest version of CLI.

## Why
README is used as the package description on PyPi. We highlight that versions of the CLI and PyPi package have to be in sync.

## Tests
Not tested