### PR TITLE
Improve error when target override fails

### DIFF
--- a/acceptance/bundle/variables/env_overrides/output.txt
+++ b/acceptance/bundle/variables/env_overrides/output.txt
@@ -22,7 +22,7 @@ Found 1 error
 Exit code: 1
 
 >>> errcode [CLI] bundle validate -t env-using-an-undefined-variable
-Error: variable c is not defined but is assigned a value
+Error: failed to perform target override for target=env-using-an-undefined-variable: variable c is not defined but is assigned a value
 
 Name: test bundle
 

--- a/bundle/config/mutator/select_target.go
+++ b/bundle/config/mutator/select_target.go
@@ -40,7 +40,7 @@ func (m *selectTarget) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnosti
 	// Merge specified target into root configuration structure.
 	err := b.Config.MergeTargetOverrides(m.name)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.FromErr(fmt.Errorf("failed to perform target override for target=%s: %w", m.name, err))
 	}
 
 	// Store specified target in configuration for reference.

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -320,7 +320,7 @@ func (r *Root) MergeTargetOverrides(name string) error {
 		"presets",
 	} {
 		if root, err = mergeField(root, target, f); err != nil {
-			return err
+			return fmt.Errorf("failed to merge target=%s field=%s: %w", name, f, err)
 		}
 	}
 


### PR DESCRIPTION
## Changes
Add prefixes with context for errors in target override.

## Why
Saw an error that looks like
```
Error: invalid path '.'
```
The error was caused by some other breaking changes, so I don't have a test, but still, if users ever see that it's not very helpful (e.g. path does not refer to file system but it is related to dyn.Value).

## Tests
Existing tests.