### PR TITLE
[Python] Fix JSON schema

### DIFF
--- a/bundle/config/experimental.go
+++ b/bundle/config/experimental.go
@@ -39,12 +39,12 @@ type Python struct {
 	// defined in Python code.
 	//
 	// Example: ["my_project.resources:load_resources"]
-	Resources []string `json:"resources"`
+	Resources []string `json:"resources,omitempty"`
 
 	// Mutators contains a list of fully qualified function paths to mutator functions.
 	//
 	// Example: ["my_project.mutators:add_default_cluster"]
-	Mutators []string `json:"mutators"`
+	Mutators []string `json:"mutators,omitempty"`
 
 	// VEnvPath is path to the virtual environment.
 	//

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1776,11 +1776,7 @@
                       "$ref": "#/$defs/string"
                     }
                   },
-                  "additionalProperties": false,
-                  "required": [
-                    "resources",
-                    "mutators"
-                  ]
+                  "additionalProperties": false
                 },
                 {
                   "type": "string",


### PR DESCRIPTION
## Changes
Make `experimental/python/mutators` and `experimental/python/resources` fields optional in the JSON schema.

## Why
The JSON schema wasn't correctly reflecting their optionality.
