### PR TITLE
[Python] Fix "Bundle resource explorer" in VSCode

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,5 +9,6 @@
 ### CLI
 
 ### Bundles
+* Fixed issue with jobs and pipelines declared in Python not showing in "Bundle resource explorer" in VSCode ([#2764](https://github.com/databricks/cli/pull/2764))
 
 ### API Changes

--- a/experimental/python/databricks/bundles/core/_load.py
+++ b/experimental/python/databricks/bundles/core/_load.py
@@ -161,7 +161,7 @@ def _parse_locations(module: ModuleType) -> dict[str, Location]:
 
             locations[var_name] = Location(
                 line=stmt.lineno,
-                column=stmt.col_offset,
+                column=stmt.col_offset + 1,
                 file=file,
             )
 

--- a/experimental/python/databricks/bundles/core/_load.py
+++ b/experimental/python/databricks/bundles/core/_load.py
@@ -161,6 +161,7 @@ def _parse_locations(module: ModuleType) -> dict[str, Location]:
 
             locations[var_name] = Location(
                 line=stmt.lineno,
+                # do conversion: col_offset is 0-based, and column is 1-based
                 column=stmt.col_offset + 1,
                 file=file,
             )

--- a/experimental/python/databricks/bundles/core/_location.py
+++ b/experimental/python/databricks/bundles/core/_location.py
@@ -11,8 +11,23 @@ __all__ = [
 @dataclass(kw_only=True, frozen=True)
 class Location:
     file: str
+
     line: Optional[int] = None
+    """
+    Line number in the file. Line numbers are 1-based and should be greater than 0.
+    """
+
     column: Optional[int] = None
+    """
+    Column number in the line. Column numbers are 1-based and should be greater than 0.
+    """
+
+    def __post_init__(self):
+        if self.line is not None and self.line < 1:
+            raise ValueError(f"Line number must be greater than 0, got {self.line}")
+
+        if self.column is not None and self.column < 1:
+            raise ValueError(f"Column number must be greater than 0, got {self.column}")
 
     @staticmethod
     def from_callable(fn: Callable) -> Optional["Location"]:

--- a/experimental/python/databricks_tests/core/test_load.py
+++ b/experimental/python/databricks_tests/core/test_load.py
@@ -66,7 +66,7 @@ def test_parse_locations():
     assert locations == {
         "my_job": Location(
             line=3,
-            column=0,
+            column=1,
             file="databricks_tests/fixtures/dummy_module.py",
         ),
     }

--- a/experimental/python/databricks_tests/core/test_location.py
+++ b/experimental/python/databricks_tests/core/test_location.py
@@ -1,0 +1,19 @@
+import pytest
+
+from databricks.bundles.core._location import Location
+
+
+def test_line_number_positive():
+    """
+    Line numbers are 1-based and should be greater than 0.
+    """
+    with pytest.raises(ValueError, match="Line number must be greater than 0"):
+        Location(file="test.py", line=0)
+
+
+def test_column_number_positive():
+    """
+    Column numbers are 1-based and should be greater than 0.
+    """
+    with pytest.raises(ValueError, match="Column number must be greater than 0"):
+        Location(file="test.py", line=1, column=0)


### PR DESCRIPTION
## Changes
Fix `load_resources_from_current_package_module` to produce 1-based column offsets instead of 0-based.

Enforce that all locations have 1-based column and line numbers, and clearly document their semantics.

## Why
VSCode fails to display resources declared in Python code:

> Illegal argument: character must be non-negative

The problem didn't affect resources added through `Resources.add_job` and `Resources.add_pipeline` because these methods implement 1-based indexing.

## Tests
Unit tests