### PR TITLE
Add support for debugging integration acceptance tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -78,6 +78,7 @@ var Ignored = map[string]bool{
 }
 
 func TestAccept(t *testing.T) {
+	testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
 	testAccept(t, InprocessMode, "")
 }
 

--- a/integration/internal/acc/workspace.go
+++ b/integration/internal/acc/workspace.go
@@ -22,7 +22,7 @@ type WorkspaceT struct {
 
 func WorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 	t.Helper()
-	loadDebugEnvIfRunFromIDE(t, "workspace")
+	testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
 
 	t.Logf("CLOUD_ENV=%s", testutil.GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
@@ -43,7 +43,7 @@ func WorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 // Run the workspace test only on UC workspaces.
 func UcWorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 	t.Helper()
-	loadDebugEnvIfRunFromIDE(t, "workspace")
+	testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
 
 	t.Logf("CLOUD_ENV=%s", testutil.GetEnvOrSkipTest(t, "CLOUD_ENV"))
 

--- a/internal/testutil/debug.go
+++ b/internal/testutil/debug.go
@@ -1,4 +1,4 @@
-package acc
+package testutil
 
 import (
 	"encoding/json"
@@ -6,19 +6,17 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-
-	"github.com/databricks/cli/internal/testutil"
 )
 
 // Detects if test is run from "debug test" feature in VS Code.
-func IsInDebug() bool {
+func isInDebug() bool {
 	ex, _ := os.Executable()
 	return strings.HasPrefix(path.Base(ex), "__debug_bin")
 }
 
 // Loads debug environment from ~/.databricks/debug-env.json.
-func loadDebugEnvIfRunFromIDE(t testutil.TestingT, key string) {
-	if !IsInDebug() {
+func LoadDebugEnvIfRunFromIDE(t TestingT, key string) {
+	if !isInDebug() {
 		return
 	}
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
## Changes
Now Deco devs can:
1. Run `deco env flip workspace` to choose a test environment.
2. Choose a single test to run
3. Directly click on "debug test" in their IDE to debug an acceptance test directly from the IDE.

## Why
Makes it simple to debug integration tests. 

## Tests
Manually.