### PR TITLE
Regenerate schema using OpenAPI spec

### DIFF
--- a/bundle/internal/schema/annotations_openapi.yml
+++ b/bundle/internal/schema/annotations_openapi.yml
@@ -97,28 +97,7 @@ github.com/databricks/cli/bundle/config/resources.Cluster:
       - Currently, Databricks allows at most 45 custom tags
 
       - Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags
-  "data_security_mode":
-    "description": |-
-      Data security mode decides what data governance model to use when accessing data
-      from a cluster.
-
-      The following modes can only be used when `kind = CLASSIC_PREVIEW`.
-      * `DATA_SECURITY_MODE_AUTO`: Databricks will choose the most appropriate access mode depending on your compute configuration.
-      * `DATA_SECURITY_MODE_STANDARD`: Alias for `USER_ISOLATION`.
-      * `DATA_SECURITY_MODE_DEDICATED`: Alias for `SINGLE_USER`.
-
-      The following modes can be used regardless of `kind`.
-      * `NONE`: No security isolation for multiple users sharing the cluster. Data governance features are not available in this mode.
-      * `SINGLE_USER`: A secure cluster that can only be exclusively used by a single user specified in `single_user_name`. Most programming languages, cluster features and data governance features are available in this mode.
-      * `USER_ISOLATION`: A secure cluster that can be shared by multiple users. Cluster users are fully isolated so that they cannot see each other's data and credentials. Most data governance features are supported in this mode. But programming languages and cluster features might be limited.
-
-      The following modes are deprecated starting with Databricks Runtime 15.0 and
-      will be removed for future Databricks Runtime versions:
-
-      * `LEGACY_TABLE_ACL`: This mode is for users migrating from legacy Table ACL clusters.
-      * `LEGACY_PASSTHROUGH`: This mode is for users migrating from legacy Passthrough on high concurrency clusters.
-      * `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy Passthrough on standard clusters.
-      * `LEGACY_SINGLE_USER_STANDARD`: This mode provides a way that doesn’t have UC nor passthrough enabled.
+  "data_security_mode": {}
   "docker_image":
     "description": |-
       Custom docker image BYOC
@@ -160,18 +139,7 @@ github.com/databricks/cli/bundle/config/resources.Cluster:
       This field can only be used when `kind = CLASSIC_PREVIEW`.
 
       When set to true, Databricks will automatically set single node related `custom_tags`, `spark_conf`, and `num_workers`
-  "kind":
-    "description": |-
-      The kind of compute described by this compute specification.
-
-      Depending on `kind`, different validations and default values will be applied.
-
-      Clusters with `kind = CLASSIC_PREVIEW` support the following fields, whereas clusters with no specified `kind` do not.
-      * [is_single_node](/api/workspace/clusters/create#is_single_node)
-      * [use_ml_runtime](/api/workspace/clusters/create#use_ml_runtime)
-      * [data_security_mode](/api/workspace/clusters/create#data_security_mode) set to `DATA_SECURITY_MODE_AUTO`, `DATA_SECURITY_MODE_DEDICATED`, or `DATA_SECURITY_MODE_STANDARD`
-
-      By using the [simple form](https://docs.databricks.com/compute/simple-form.html), your clusters are automatically using `kind = CLASSIC_PREVIEW`.
+  "kind": {}
   "node_type_id":
     "description": |-
       This field encodes, through a single value, the resources available to each of
@@ -236,9 +204,7 @@ github.com/databricks/cli/bundle/config/resources.Cluster:
       This field can only be used when `kind = CLASSIC_PREVIEW`.
 
       `effective_spark_version` is determined by `spark_version` (DBR release), this field `use_ml_runtime`, and whether `node_type_id` is gpu node or not.
-  "workload_type":
-    "description": |-
-      Cluster Attributes showing for clusters workload types.
+  "workload_type": {}
 github.com/databricks/cli/bundle/config/resources.Dashboard:
   "create_time":
     "description": |-
@@ -322,9 +288,7 @@ github.com/databricks/cli/bundle/config/resources.Job:
       If `git_source` is set, these tasks retrieve the file from the remote repository by default. However, this behavior can be overridden by setting `source` to `WORKSPACE` on the task.
 
       Note: dbt and SQL File tasks support only version-controlled sources. If dbt or SQL File tasks are used, `git_source` must be defined on the job.
-  "health":
-    "description": |-
-      An optional set of health rules that can be defined for this job.
+  "health": {}
   "job_clusters":
     "description": |-
       A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.
@@ -354,11 +318,7 @@ github.com/databricks/cli/bundle/config/resources.Job:
   "queue":
     "description": |-
       The queue settings of the job.
-  "run_as":
-    "description": |-
-      Write-only setting. Specifies the user or service principal that the job runs as. If not specified, the job runs as the user who created the job.
-
-      Either `user_name` or `service_principal_name` should be specified. If not, an error is thrown.
+  "run_as": {}
   "schedule":
     "description": |-
       An optional periodic schedule for this job. The default behavior is that the job only runs when triggered by clicking “Run Now” in the Jobs UI or sending an API request to `runNow`.
@@ -513,11 +473,7 @@ github.com/databricks/cli/bundle/config/resources.Pipeline:
   "restart_window":
     "description": |-
       Restart window of this pipeline.
-  "run_as":
-    "description": |-
-      Write-only setting, available only in Create/Update calls. Specifies the user or service principal that the pipeline runs as. If not specified, the pipeline runs as the user who created the pipeline.
-
-      Only `user_name` or `service_principal_name` can be specified. If both are specified, an error is thrown.
+  "run_as": {}
   "schema":
     "description": |-
       The default schema (database) where tables are read from or published to.
@@ -606,9 +562,7 @@ github.com/databricks/cli/bundle/config/resources.Schema:
   "name":
     "description": |-
       Name of schema, relative to parent catalog.
-  "properties":
-    "description": |-
-      A map of key-value properties attached to the securable.
+  "properties": {}
   "storage_root":
     "description": |-
       Storage root URL for managed tables within schema.
@@ -628,9 +582,7 @@ github.com/databricks/cli/bundle/config/resources.Volume:
   "storage_location":
     "description": |-
       The storage location on the cloud
-  "volume_type":
-    "description": |-
-      The type of the volume. An external volume is located in the specified external location. A managed volume is located in the default location which is specified by the parent schema, or the parent catalog, or the Metastore. [Learn more](https://docs.databricks.com/aws/en/volumes/managed-vs-external)
+  "volume_type": {}
 github.com/databricks/databricks-sdk-go/service/apps.AppDeployment:
   "create_time":
     "description": |-
@@ -967,11 +919,7 @@ github.com/databricks/databricks-sdk-go/service/compute.AwsAttributes:
   "_":
     "description": |-
       Attributes set during cluster creation which are related to Amazon Web Services.
-  "availability":
-    "description": |-
-      Availability type used for all subsequent nodes past the `first_on_demand` ones.
-
-      Note: If `first_on_demand` is zero, this availability type will be used for the entire cluster.
+  "availability": {}
   "ebs_volume_count":
     "description": |-
       The number of volumes launched for each instance. Users can choose up to 10 volumes.
@@ -1165,28 +1113,7 @@ github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec:
       - Currently, Databricks allows at most 45 custom tags
 
       - Clusters can only reuse cloud resources if the resources' tags are a subset of the cluster tags
-  "data_security_mode":
-    "description": |-
-      Data security mode decides what data governance model to use when accessing data
-      from a cluster.
-
-      The following modes can only be used when `kind = CLASSIC_PREVIEW`.
-      * `DATA_SECURITY_MODE_AUTO`: Databricks will choose the most appropriate access mode depending on your compute configuration.
-      * `DATA_SECURITY_MODE_STANDARD`: Alias for `USER_ISOLATION`.
-      * `DATA_SECURITY_MODE_DEDICATED`: Alias for `SINGLE_USER`.
-
-      The following modes can be used regardless of `kind`.
-      * `NONE`: No security isolation for multiple users sharing the cluster. Data governance features are not available in this mode.
-      * `SINGLE_USER`: A secure cluster that can only be exclusively used by a single user specified in `single_user_name`. Most programming languages, cluster features and data governance features are available in this mode.
-      * `USER_ISOLATION`: A secure cluster that can be shared by multiple users. Cluster users are fully isolated so that they cannot see each other's data and credentials. Most data governance features are supported in this mode. But programming languages and cluster features might be limited.
-
-      The following modes are deprecated starting with Databricks Runtime 15.0 and
-      will be removed for future Databricks Runtime versions:
-
-      * `LEGACY_TABLE_ACL`: This mode is for users migrating from legacy Table ACL clusters.
-      * `LEGACY_PASSTHROUGH`: This mode is for users migrating from legacy Passthrough on high concurrency clusters.
-      * `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy Passthrough on standard clusters.
-      * `LEGACY_SINGLE_USER_STANDARD`: This mode provides a way that doesn’t have UC nor passthrough enabled.
+  "data_security_mode": {}
   "docker_image":
     "description": |-
       Custom docker image BYOC
@@ -1228,18 +1155,7 @@ github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec:
       This field can only be used when `kind = CLASSIC_PREVIEW`.
 
       When set to true, Databricks will automatically set single node related `custom_tags`, `spark_conf`, and `num_workers`
-  "kind":
-    "description": |-
-      The kind of compute described by this compute specification.
-
-      Depending on `kind`, different validations and default values will be applied.
-
-      Clusters with `kind = CLASSIC_PREVIEW` support the following fields, whereas clusters with no specified `kind` do not.
-      * [is_single_node](/api/workspace/clusters/create#is_single_node)
-      * [use_ml_runtime](/api/workspace/clusters/create#use_ml_runtime)
-      * [data_security_mode](/api/workspace/clusters/create#data_security_mode) set to `DATA_SECURITY_MODE_AUTO`, `DATA_SECURITY_MODE_DEDICATED`, or `DATA_SECURITY_MODE_STANDARD`
-
-      By using the [simple form](https://docs.databricks.com/compute/simple-form.html), your clusters are automatically using `kind = CLASSIC_PREVIEW`.
+  "kind": {}
   "node_type_id":
     "description": |-
       This field encodes, through a single value, the resources available to each of
@@ -1304,9 +1220,7 @@ github.com/databricks/databricks-sdk-go/service/compute.ClusterSpec:
       This field can only be used when `kind = CLASSIC_PREVIEW`.
 
       `effective_spark_version` is determined by `spark_version` (DBR release), this field `use_ml_runtime`, and whether `node_type_id` is gpu node or not.
-  "workload_type":
-    "description": |-
-      Cluster Attributes showing for clusters workload types.
+  "workload_type": {}
 github.com/databricks/databricks-sdk-go/service/compute.DataSecurityMode:
   "_":
     "description": |-
@@ -1861,9 +1775,7 @@ github.com/databricks/databricks-sdk-go/service/jobs.GitSource:
   "git_provider":
     "description": |-
       Unique identifier of the service used to host the Git repository. The value is case insensitive.
-  "git_snapshot":
-    "description": |-
-      Read-only state of the remote repository at the time the job was run. This field is only included on job runs.
+  "git_snapshot": {}
   "git_tag":
     "description": |-
       Name of the tag to be checked out and used by this job. This field cannot be specified in conjunction with git_branch or git_commit.
@@ -1935,10 +1847,7 @@ github.com/databricks/databricks-sdk-go/service/jobs.JobEnvironment:
   "environment_key":
     "description": |-
       The key of an environment. It has to be unique within a job.
-  "spec":
-    "description": |-
-      The environment entity used to preserve serverless environment side panel and jobs' environment for non-notebook task.
-      In this minimal environment spec, only pip dependencies are supported.
+  "spec": {}
 github.com/databricks/databricks-sdk-go/service/jobs.JobNotificationSettings:
   "no_alert_for_canceled_runs":
     "description": |-
@@ -2025,18 +1934,8 @@ github.com/databricks/databricks-sdk-go/service/jobs.JobsHealthOperator:
       - |-
         GREATER_THAN
 github.com/databricks/databricks-sdk-go/service/jobs.JobsHealthRule:
-  "metric":
-    "description": |-
-      Specifies the health metric that is being evaluated for a particular health rule.
-
-      * `RUN_DURATION_SECONDS`: Expected total time for a run in seconds.
-      * `STREAMING_BACKLOG_BYTES`: An estimate of the maximum bytes of data waiting to be consumed across all streams. This metric is in Public Preview.
-      * `STREAMING_BACKLOG_RECORDS`: An estimate of the maximum offset lag across all streams. This metric is in Public Preview.
-      * `STREAMING_BACKLOG_SECONDS`: An estimate of the maximum consumer delay across all streams. This metric is in Public Preview.
-      * `STREAMING_BACKLOG_FILES`: An estimate of the maximum number of outstanding files across all streams. This metric is in Public Preview.
-  "op":
-    "description": |-
-      Specifies the operator used to compare the health metric value with the specified threshold.
+  "metric": {}
+  "op": {}
   "value":
     "description": |-
       Specifies the threshold value that the health metric should obey to satisfy the health rule.
@@ -2468,9 +2367,7 @@ github.com/databricks/databricks-sdk-go/service/jobs.Task:
     "description": |-
       The task executes a nested task for every input provided when the `for_each_task` field is present.
   "gen_ai_compute_task": {}
-  "health":
-    "description": |-
-      An optional set of health rules that can be defined for this job.
+  "health": {}
   "job_cluster_key":
     "description": |-
       If job_cluster_key, this task is executed reusing the cluster specified in `job.settings.job_clusters`.


### PR DESCRIPTION
## Changes
Regenerate schema using OpenAPI spec from `.codegen/_openapi_sha` and the latest genkit.

There is a behavioral change for fields without a description. Previously, we copied the description from referenced schemas. Now, we keep them undocumented.

## Why
Having the schema up-to-date with the OpenAPI spec is a prerequisite for further changes to avoid unnecessary diffs.