### PR TITLE
acc: Set LC_ALL=C for consistent locale

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -96,6 +96,9 @@ func testAccept(t *testing.T, InprocessMode bool, singleTest string) int {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
+	// Consistent behavior of locale-dependent tools, such as 'sort'
+	t.Setenv("LC_ALL", "C")
+
 	buildDir := filepath.Join(cwd, "build", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH))
 
 	// Download terraform and provider and create config; this also creates build directory.


### PR DESCRIPTION
## Why
After upgrading MacOSX on my laptop to 15.4.1 (from 15.3.*) I get these tests that use sort fail:

```
    --- FAIL: TestAccept/bundle/artifacts/whl_implicit_custom_path (2.33s)
        acceptance_test.go:224: Running test with env [UV_PYTHON=3.10]
        acceptance_test.go:525: Diff:
            --- bundle/artifacts/whl_implicit_custom_path/output.txt
            +++ /var/folders/5y/9kkdnjw91p11vsqwk0cvmk200000gp/T/TestAcceptbundleartifactswhl_implicit_custom_path1072264327/001/output.txt
            @@ -42,5 +42,5 @@

             === Expecting 1 wheel to be uploaded
             >>> jq .path
            -"/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel-local/default/files/package/my_test_code-0.0.1-py3-none-any.whl"
             "/api/2.0/workspace-files/import-file/Workspace/foo/bar/.internal/my_test_code-0.0.1-py3-none-any.whl"
            +"/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel-local/default/files/package/my_test_code-0.0.1-py3-none-any.whl"

    --- FAIL: TestAccept/bundle/artifacts/whl_multiple (3.38s)
        acceptance_test.go:224: Running test with env [UV_PYTHON=3.10]
        acceptance_test.go:525: Diff:
            --- bundle/artifacts/whl_multiple/output.txt
            +++ /var/folders/5y/9kkdnjw91p11vsqwk0cvmk200000gp/T/TestAcceptbundleartifactswhl_multiple1582749030/001/output.txt
            @@ -36,7 +36,7 @@

             === Expecting 2 wheels to be uploaded
             >>> jq .path
            -"/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel/default/artifacts/.internal/my_test_code-0.0.1-py3-none-any.whl"
             "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel/default/artifacts/.internal/my_test_code_2-0.0.1-py3-none-any.whl"
            -"/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel/default/files/my_test_code/dist/my_test_code-0.0.1-py3-none-any.whl"
            +"/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel/default/artifacts/.internal/my_test_code-0.0.1-py3-none-any.whl"
             "/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel/default/files/my_test_code/dist/my_test_code_2-0.0.1-py3-none-any.whl"
            +"/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/python-wheel/default/files/my_test_code/dist/my_test_code-0.0.1-py3-none-any.whl"

FAIL
FAIL    github.com/databricks/cli/acceptance    15.751s
```

## Tests
`go test ./acceptance` on my laptop is fixed with this patch.
