### PR TITLE
Make apply_presets.go more resilient and consistent

### DIFF
--- a/acceptance/bundle/validate/empty_resources/empty_dict/output.txt
+++ b/acceptance/bundle/validate/empty_resources/empty_dict/output.txt
@@ -1,43 +1,51 @@
 
 === resources.jobs.rname ===
-Error: job rname is not defined
-
 {
   "jobs": {
-    "rname": {}
+    "rname": {
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "permissions": [],
+      "queue": {
+        "enabled": true
+      }
+    }
   }
 }
 
 === resources.pipelines.rname ===
-Error: pipeline rname is not defined
-
 {
   "pipelines": {
-    "rname": {}
+    "rname": {
+      "permissions": []
+    }
   }
 }
 
 === resources.models.rname ===
-Error: model rname is not defined
-
 {
   "models": {
-    "rname": {}
+    "rname": {
+      "permissions": []
+    }
   }
 }
 
 === resources.experiments.rname ===
-Error: experiment rname is not defined
-
 {
   "experiments": {
-    "rname": {}
+    "rname": {
+      "name": ".",
+      "permissions": []
+    }
   }
 }
 
 === resources.registered_models.rname ===
-Error: registered model rname is not defined
-
 {
   "registered_models": {
     "rname": {}
@@ -52,8 +60,6 @@ Error: registered model rname is not defined
 }
 
 === resources.schemas.rname ===
-Error: schema rname is not defined
-
 {
   "schemas": {
     "rname": {}
@@ -70,11 +76,11 @@ Error: schema rname is not defined
 }
 
 === resources.clusters.rname ===
-Error: cluster rname is not defined
-
 {
   "clusters": {
-    "rname": {}
+    "rname": {
+      "custom_tags": {}
+    }
   }
 }
 

--- a/acceptance/bundle/validate/empty_resources/with_grants/output.txt
+++ b/acceptance/bundle/validate/empty_resources/with_grants/output.txt
@@ -4,11 +4,20 @@ Warning: unknown field: grants
   at resources.jobs.rname
   in databricks.yml:7:7
 
-Error: job rname is not defined
-
 {
   "jobs": {
-    "rname": {}
+    "rname": {
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "permissions": [],
+      "queue": {
+        "enabled": true
+      }
+    }
   }
 }
 
@@ -17,11 +26,11 @@ Warning: unknown field: grants
   at resources.pipelines.rname
   in databricks.yml:7:7
 
-Error: pipeline rname is not defined
-
 {
   "pipelines": {
-    "rname": {}
+    "rname": {
+      "permissions": []
+    }
   }
 }
 
@@ -30,11 +39,11 @@ Warning: unknown field: grants
   at resources.models.rname
   in databricks.yml:7:7
 
-Error: model rname is not defined
-
 {
   "models": {
-    "rname": {}
+    "rname": {
+      "permissions": []
+    }
   }
 }
 
@@ -43,17 +52,16 @@ Warning: unknown field: grants
   at resources.experiments.rname
   in databricks.yml:7:7
 
-Error: experiment rname is not defined
-
 {
   "experiments": {
-    "rname": {}
+    "rname": {
+      "name": ".",
+      "permissions": []
+    }
   }
 }
 
 === resources.registered_models.rname ===
-Error: registered model rname is not defined
-
 {
   "registered_models": {
     "rname": {
@@ -74,8 +82,6 @@ Warning: unknown field: grants
 }
 
 === resources.schemas.rname ===
-Error: schema rname is not defined
-
 {
   "schemas": {
     "rname": {
@@ -99,11 +105,11 @@ Warning: unknown field: grants
   at resources.clusters.rname
   in databricks.yml:7:7
 
-Error: cluster rname is not defined
-
 {
   "clusters": {
-    "rname": {}
+    "rname": {
+      "custom_tags": {}
+    }
   }
 }
 

--- a/acceptance/bundle/validate/empty_resources/with_permissions/output.txt
+++ b/acceptance/bundle/validate/empty_resources/with_permissions/output.txt
@@ -1,18 +1,23 @@
 
 === resources.jobs.rname ===
-Error: job rname is not defined
-
 {
   "jobs": {
     "rname": {
-      "permissions": []
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "permissions": [],
+      "queue": {
+        "enabled": true
+      }
     }
   }
 }
 
 === resources.pipelines.rname ===
-Error: pipeline rname is not defined
-
 {
   "pipelines": {
     "rname": {
@@ -22,8 +27,6 @@ Error: pipeline rname is not defined
 }
 
 === resources.models.rname ===
-Error: model rname is not defined
-
 {
   "models": {
     "rname": {
@@ -33,11 +36,10 @@ Error: model rname is not defined
 }
 
 === resources.experiments.rname ===
-Error: experiment rname is not defined
-
 {
   "experiments": {
     "rname": {
+      "name": ".",
       "permissions": []
     }
   }
@@ -47,8 +49,6 @@ Error: experiment rname is not defined
 Warning: unknown field: permissions
   at resources.registered_models.rname
   in databricks.yml:7:7
-
-Error: registered model rname is not defined
 
 {
   "registered_models": {
@@ -72,8 +72,6 @@ Warning: unknown field: permissions
   at resources.schemas.rname
   in databricks.yml:7:7
 
-Error: schema rname is not defined
-
 {
   "schemas": {
     "rname": {}
@@ -94,11 +92,10 @@ Warning: unknown field: permissions
 }
 
 === resources.clusters.rname ===
-Error: cluster rname is not defined
-
 {
   "clusters": {
     "rname": {
+      "custom_tags": {},
       "permissions": []
     }
   }


### PR DESCRIPTION
## Changes
Modify ApplyPresets to never return errors and instead create necessary inner struct (unless full resource is declared as null).

## Why
The errors that it returned were not very helpful:

```
Error: dashboard set_to_true s is not defined
```
(If there are some required fields missing, we should have validators specifically for that).

Besides bad error message other issues were:
- Checking embedded pointer is not helpful, that could be empty if only fields on the outside struct are set.
- Checking outer pointer was often omitted, giving a possibility of a crash.

This made ApplyPresets behave different for different resources depending on whether those resources have default. If they have a default (e.g. dashboards), then those defaults would initialize embedded struct and ApplyPresets would work. Otherwise it would complain. This inconsistency would prevent moving ApplyPresets to run before defaults, see https://github.com/databricks/cli/pull/2778.

## Tests
Tests added previously in https://github.com/databricks/cli/pull/2771 and https://github.com/databricks/cli/pull/2774
