### PR TITLE
Replace setup-go with manual go download script

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,8 +13,6 @@ on:
     # seed the build cache.
     branches:
       - main
-  schedule:
-    - cron: '0 0,12 * * *'  # Runs at 00:00 and 12:00 UTC daily
 
 env:
   GOTESTSUM_FORMAT: github-actions
@@ -48,9 +46,18 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
-        with:
-          go-version-file: go.mod
+        shell: bash
+        run: |
+          python3 tools/get_go.py
+          echo "GOROOT=${{ github.workspace }}/_go_binary/go" >> $GITHUB_ENV
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "${{ github.workspace }}/_go_binary/go/bin" >> $GITHUB_PATH
+          else
+            echo "PATH=${{ github.workspace }}/_go_binary/go/bin:$PATH" >> $GITHUB_ENV
+          fi
+
+      - name: Print Go version
+        run: go version
 
       - name: Setup Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,3 +1,4 @@
+
 Acceptance tests are blackbox tests that are run against compiled binary.
 
 Currently these tests are run against "fake" HTTP server pretending to be Databricks API. However, they will be extended to run against real environment as regular integration tests.

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,4 +1,3 @@
-
 Acceptance tests are blackbox tests that are run against compiled binary.
 
 Currently these tests are run against "fake" HTTP server pretending to be Databricks API. However, they will be extended to run against real environment as regular integration tests.

--- a/tools/get_go.py
+++ b/tools/get_go.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import platform
+import os
+import time
+import re
+import shutil
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from urllib.request import urlretrieve
+
+
+def get_go_version_from_mod(file_path):
+    with open(file_path) as f:
+        content = f.read()
+    match = re.search(r"^toolchain\s+go(\d+\.\d+(\.\d+)?)", content, re.MULTILINE)
+    if match:
+        return match.group(1)
+
+
+def detect_os_arch():
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    arch = {"x86_64": "amd64", "amd64": "amd64", "aarch64": "arm64", "arm64": "arm64"}.get(machine, machine)
+    print(f"Platform: {system=} {arch=} {machine=}")
+    return system, arch
+
+
+def download_and_extract(go_version, os_name, arch):
+    ext = "zip" if os_name == "windows" else "tar.gz"
+    filename = f"go{go_version}.{os_name}-{arch}.{ext}"
+    url = f"https://go.dev/dl/{filename}"
+
+    print(f"Downloading {url} to {filename}")
+    start = time.time()
+    urlretrieve(url, filename)
+    took = time.time() - start
+    size = os.stat(filename).st_size
+    print(f"Downloaded {size / 1024.0 / 1024.0:.1f}MB in {took:.1f}s")
+
+    try:
+        os.mkdir("_go_binary")
+    except FileExistsError:
+        pass
+
+    if ext == "zip":
+        with zipfile.ZipFile(filename, "r") as zip_ref:
+            zip_ref.extractall("_go_binary")
+    else:
+        with tarfile.open(filename, "r:gz") as tar_ref:
+            tar_ref.extractall("_go_binary")
+
+
+def main():
+    go_version = get_go_version_from_mod("go.mod")
+    assert go_version
+    os_name, arch = detect_os_arch()
+    download_and_extract(go_version, os_name, arch)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes
- Replace github action setup-go with manual downloading of Go binary.
- Remove scheduled job to populate cache.

## Why
- Unlike setup-go, it downloads it only once.
- There is no cache, which is really slow to fetch on Windows.