### PR TITLE
Run tests without coverage on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,7 +67,16 @@ jobs:
           make vendor
           pip3 install wheel==0.45.1
 
+      - name: Run tests without coverage
+        # We run tests without coverage on PR because we don't make use of coverage information
+        # and would like to run the tests as fast as possible. We run it on schedule as well, because that is what
+        # populates the cache and cache may include test results.
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+        run: make test
+
       - name: Run tests with coverage
+        # Still run 'make cover' on push to main and merge checks to make sure it does not get broken.
+        if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' }}
         run: make cover
 
   linters:


### PR DESCRIPTION
## Why
- We don't use coverage info at the moment but we would like to speed up CI runs on PRs.
- Keep 'push' event unchanged, so that we validate that 'make cover' is still working, as it could get broken otherwise. Related: https://github.com/databricks/cli/pull/2141