### PR TITLE
Enable 'num_workers: 0' default on jobs

### DIFF
--- a/acceptance/bundle/debug/out.stderr.txt
+++ b/acceptance/bundle/debug/out.stderr.txt
@@ -70,7 +70,6 @@
 10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:validate_sync_patterns
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_cluster_key_defined
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_task_cluster_spec
-10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:SingleNodeCluster
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:artifact_paths
 10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/debug/default/files
 < HTTP/1.1 404 Not Found

--- a/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
@@ -54,6 +54,7 @@
               },
               "data_security_mode": "SINGLE_USER",
               "node_type_id": "[NODE_TYPE_ID]",
+              "num_workers": 0,
               "spark_version": "15.4.x-scala2.12"
             }
           }

--- a/acceptance/bundle/templates/default-python/integration_classic/output.txt
+++ b/acceptance/bundle/templates/default-python/integration_classic/output.txt
@@ -60,13 +60,19 @@ Resources:
 +        "id": "[NUMBER]",
          "job_clusters": [
            {
-@@ -61,5 +62,4 @@
+@@ -55,5 +56,4 @@
+               "data_security_mode": "SINGLE_USER",
+               "node_type_id": "[NODE_TYPE_ID]",
+-              "num_workers": 0,
+               "spark_version": "15.4.x-scala2.12"
+             }
+@@ -62,5 +62,4 @@
          "max_concurrent_runs": 4,
          "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_job",
 -        "permissions": [],
          "queue": {
            "enabled": true
-@@ -112,5 +112,6 @@
+@@ -113,5 +112,6 @@
              "unit": "DAYS"
            }
 -        }
@@ -74,13 +80,13 @@ Resources:
 +        "url": "[DATABRICKS_URL]/jobs/[NUMBER]"
        }
      },
-@@ -127,4 +128,5 @@
+@@ -128,4 +128,5 @@
          "development": true,
          "edition": "ADVANCED",
 +        "id": "[UUID]",
          "libraries": [
            {
-@@ -135,6 +137,6 @@
+@@ -136,6 +137,6 @@
          ],
          "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_pipeline",
 -        "permissions": [],
@@ -89,7 +95,7 @@ Resources:
 +        "url": "[DATABRICKS_URL]/pipelines/[UUID]"
        }
      }
-@@ -145,5 +147,4 @@
+@@ -146,5 +147,4 @@
      ]
    },
 -  "targets": null,
@@ -168,7 +174,7 @@ Validation OK!
 +          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/state/metadata.json"
          },
          "edit_mode": "UI_LOCKED",
-@@ -59,12 +51,9 @@
+@@ -60,12 +52,9 @@
            }
          ],
 -        "max_concurrent_runs": 4,
@@ -183,21 +189,21 @@ Validation OK!
 -          "dev": "[USERNAME]"
          },
          "tasks": [
-@@ -72,5 +61,5 @@
+@@ -73,5 +62,5 @@
              "job_cluster_key": "job_cluster",
              "notebook_task": {
 -              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook"
 +              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook"
              },
              "task_key": "notebook_task"
-@@ -107,5 +96,5 @@
+@@ -108,5 +97,5 @@
          ],
          "trigger": {
 -          "pause_status": "PAUSED",
 +          "pause_status": "UNPAUSED",
            "periodic": {
              "interval": 1,
-@@ -119,22 +108,21 @@
+@@ -120,22 +109,21 @@
          "channel": "CURRENT",
          "configuration": {
 -          "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src"
@@ -225,7 +231,7 @@ Validation OK!
 +        "schema": "project_name_[UNIQUE_NAME]_prod"
        }
      }
-@@ -147,10 +135,10 @@
+@@ -148,10 +136,10 @@
    "targets": null,
    "workspace": {
 -    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
@@ -31,6 +31,7 @@ Warning: Ignoring Databricks CLI version constraint for development build. Requi
             },
             "data_security_mode": "SINGLE_USER",
             "node_type_id": "i3.xlarge",
+            "num_workers": 0,
             "spark_version": "15.4.x-scala2.12"
           }
         }

--- a/acceptance/bundle/variables/resolve-field-within-complex/output.txt
+++ b/acceptance/bundle/variables/resolve-field-within-complex/output.txt
@@ -1,3 +1,4 @@
 {
-  "node_type_id": "Standard_DS3_v2"
+  "node_type_id": "Standard_DS3_v2",
+  "num_workers": 0
 }

--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions.go
@@ -61,7 +61,7 @@ func ApplyBundlePermissions() bundle.Mutator {
 }
 
 func (m *bundlePermissions) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	err := validate(b)
+	err := validatePermissions(b)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -119,7 +119,7 @@ func (m *bundlePermissions) Apply(ctx context.Context, b *bundle.Bundle) diag.Di
 	return nil
 }
 
-func validate(b *bundle.Bundle) error {
+func validatePermissions(b *bundle.Bundle) error {
 	for _, p := range b.Config.Permissions {
 		if !slices.Contains(allowedLevels, p.Level) {
 			return fmt.Errorf("invalid permission level: %s, allowed values: [%s]", p.Level, strings.Join(allowedLevels, ", "))

--- a/bundle/config/mutator/resourcemutator/resource_mutator.go
+++ b/bundle/config/mutator/resourcemutator/resource_mutator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/config/validate"
 
 	"github.com/databricks/cli/libs/dyn/merge"
 
@@ -38,6 +39,8 @@ func applyInitializeMutators(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 
 		// ApplyPresets should have more priority than defaults below, so it should be run first
 		ApplyPresets(),
+
+		validate.SingleNodeCluster(),
 	)
 
 	if diags.HasError() {
@@ -68,7 +71,7 @@ func applyInitializeMutators(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 
 		// https://github.com/databricks/terraform-provider-databricks/blob/v1.75.0/clusters/resource_cluster.go
 		// This triggers SingleNodeCluster() cluster validator. It needs to be run before applying defaults.
-		//{"resources.jobs.*.job_clusters[*].new_cluster.num_workers", 0},
+		{"resources.jobs.*.job_clusters[*].new_cluster.num_workers", 0},
 		{"resources.jobs.*.job_clusters[*].new_cluster.workload_type.clients.notebooks", true},
 		{"resources.jobs.*.job_clusters[*].new_cluster.workload_type.clients.jobs", true},
 

--- a/bundle/config/validate/fast_validate.go
+++ b/bundle/config/validate/fast_validate.go
@@ -29,7 +29,6 @@ func (f *fastValidate) Apply(ctx context.Context, rb *bundle.Bundle) diag.Diagno
 		// Fast mutators with only in-memory checks
 		JobClusterKeyDefined(),
 		JobTaskClusterSpec(),
-		SingleNodeCluster(),
 
 		// Blocking mutators. Deployments will fail if these checks fail.
 		ValidateArtifactPath(),


### PR DESCRIPTION
## Changes
- Set default num_workers=0 on jobs
- Move SingleNodeCluster() validator to run before applying defaults, otherwise it complains about num_workers being 0 even though users did not set it.
 
## Why
See https://github.com/databricks/cli/pull/2767 for justification.
Needed for https://github.com/databricks/cli/pull/2791

## Tests
Existing tests.
