### PR TITLE
acc: Avoid printing too many unexpected files

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -547,7 +547,9 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 	// The test produced an unexpected output file.
 	if !okRef && okNew {
 		t.Errorf("Unexpected output file: %s\npathRef: %s\npathNew: %s", relPath, pathRef, pathNew)
-		testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
+		if shouldShowDiff(pathNew, valueNew) {
+			testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
+		}
 		if testdiff.OverwriteMode {
 			t.Logf("Writing output file: %s", relPath)
 			testutil.WriteFile(t, pathRef, valueNew)
@@ -570,6 +572,20 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		}
 		t.Log("Available replacements:\n" + strings.Join(items, "\n"))
 	}
+}
+
+func shouldShowDiff(pathNew, valueNew string) bool {
+	if strings.Contains(pathNew, "site-packages") {
+		return false
+	}
+	if strings.Contains(pathNew, ".venv") {
+		return false
+	}
+	if len(valueNew) > 10_000 {
+		return false
+	}
+	// if file itself starts with "out" then it's likely to be intended to be recorded
+	return strings.HasPrefix(filepath.Base(pathNew), "out")
 }
 
 // Returns combined script.prepare (root) + script.prepare (parent) + ... + script + ... + script.cleanup (parent) + ...


### PR DESCRIPTION
## Changes
If test detects an unexpected output file, use a heuristic on whether it's useful to print its contents. Note, you can always see the contents by running the test with -output setting, so it's okay to print less there.

## Why
In some tests (e.g. experimental-jobs-as-code), where .venv is not ignored but is located inside output folder, this prints a lot of contents, making it hard to read the output.

## Tests
Manually caused experimental-jobs-as-code to see the effect.