### PR TITLE
acc: set PYTHONDONTWRITEBYTECODE=1 in all tests

### DIFF
--- a/acceptance/bundle/artifacts/script.prepare
+++ b/acceptance/bundle/artifacts/script.prepare
@@ -1,5 +1,3 @@
-export PYTHONDONTWRITEBYTECODE=1
-
 uv venv -q .venv
 venv_activate
 uv pip install -q setuptools

--- a/acceptance/bundle/integration_whl/script.prepare
+++ b/acceptance/bundle/integration_whl/script.prepare
@@ -1,5 +1,3 @@
-export PYTHONDONTWRITEBYTECODE=1
-
 uv venv -q .venv
 venv_activate
 uv pip install -q setuptools

--- a/acceptance/bundle/templates/default-python/integration_classic/script
+++ b/acceptance/bundle/templates/default-python/integration_classic/script
@@ -1,5 +1,3 @@
-export PYTHONDONTWRITEBYTECODE=1
-
 uv venv -q .venv
 venv_activate
 trace python -c 'import sys; print("%s.%s" % sys.version_info[:2])'

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -3,3 +3,4 @@ Local = true
 Cloud = false
 
 Env.PYTHONDONTWRITEBYTECODE = "1"
+EnvRepl.PYTHONDONTWRITEBYTECODE = false

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -1,3 +1,5 @@
 # Default settings that apply to all tests unless overriden by test.toml files in inner directories.
 Local = true
 Cloud = false
+
+Env.PYTHONDONTWRITEBYTECODE = "1"


### PR DESCRIPTION
## Why
Tests are run in fresh directory, so don't benefit from caching. No need to filter out `__pycache__` manually everywhere.
