### PR TITLE
Print slowest tests on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -79,6 +79,9 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' }}
         run: make cover
 
+      - name: Analyze slow tests
+        run: go tool gotestsum tool slowest --jsonfile test-output.json --threshold 10s
+
   linters:
     needs: cleanups
     name: lint

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__
 .vscode/tasks.json
 
 .ruff_cache
+
+# Test results from 'make test'
+test-output.json

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ default: tidy vendor fmt lint ws
 PACKAGES=./acceptance/... ./libs/... ./internal/... ./cmd/... ./bundle/... .
 
 GOTESTSUM_FORMAT ?= pkgname-and-test-fails
-GOTESTSUM_CMD ?= go tool gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped
+GOTESTSUM_CMD ?= go tool gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped --jsonfile test-output.json
 
 
 lint:


### PR DESCRIPTION
## Changes
Similar to what we do for integration tests, print slowest unit tests.

## Why
Some tests are surprisingly slow, as discovered in https://github.com/databricks/cli/pull/2793
It would be good to know which ones are slow for the purposes of optimizing them and/or setting timeout.
