### PR TITLE
acc: Skip utf-8 check for main output file

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -705,7 +705,10 @@ func tryReading(t *testing.T, path string) (string, bool) {
 		return "", false
 	}
 
-	if !utf8.Valid(data) {
+	// Do not check output.txt for UTF8 validity, because 'deploy --debug' logs binary request/responses
+	doUTF8Check := filepath.Base(path) != "output.txt"
+
+	if doUTF8Check && !utf8.Valid(data) {
 		t.Errorf("%s: not valid utf-8", path)
 		return "", false
 	}


### PR DESCRIPTION
## Why
This check originally was added to prevent printing large binary files (e.g. zip files). However, "bundle deploy --debug" can output binary data as well (request and response bodies), causing test failure and not showing the contents, preventing debugging.