### PR TITLE
acc: Raise timeout for cloud tests

### DIFF
--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -1,4 +1,4 @@
-Cloud = true
+CloudSlow = true
 Local = false
 
 # serverless is only enabled if UC is enabled

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = true
+CloudSlow = true
 Ignore = [
     ".databricks",
     ".venv",


### PR DESCRIPTION
## Changes
Raise timeout for acceptance tests from 2m to 25m.

Follow up to https://github.com/databricks/cli/pull/2793

## Why
I forgot that we don't run the slowest tests on PR, they only run on push.
