### PR TITLE
Add script to run uber-go/nilaway

### DIFF
--- a/.nilaway/.custom-gcl.yml
+++ b/.nilaway/.custom-gcl.yml
@@ -1,0 +1,6 @@
+## This has to be >= v1.57.0 for module plugin system support.
+version: v2.0.2
+plugins:
+  - module: "go.uber.org/nilaway"
+    import: "go.uber.org/nilaway/cmd/gclplugin"
+    version: latest # Or a fixed version for reproducible builds.

--- a/.nilaway/.golangci.yaml
+++ b/.nilaway/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - nilaway
+  settings:
+    custom:
+      nilaway:
+        type: module
+        description: Static analysis tool to detect potential nil panics in Go code.
+        settings:
+          # Settings must be a "map from string to string" to mimic command line flags: the keys are
+          # flag names and the values are the values to the particular flags.
+          include-pkgs: "github.com/databricks/cli"
+issues:
+  max-issues-per-linter: 1000
+  max-same-issues: 1000

--- a/.nilaway/Makefile
+++ b/.nilaway/Makefile
@@ -1,0 +1,2 @@
+custom-gcl: .custom-gcl.yml .golangci.yaml
+	golangci-lint custom

--- a/.nilaway/run_nilaway.py
+++ b/.nilaway/run_nilaway.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Build nilaway then run it and filter out diagnostics on test files.
+"""
+
+import os
+import sys
+import re
+import subprocess
+
+args = sys.argv[1:]
+directory = os.path.dirname(__file__)
+
+os.chdir(directory)
+if os.system("make"):
+    sys.exit(1)
+
+os.chdir("..")
+cmd = [directory + "/custom-gcl", "-c", directory + "/.golangci.yaml", *args]
+print("+ " + " ".join(cmd), flush=True)
+result = subprocess.run(cmd, stdout=subprocess.PIPE, encoding="utf-8")
+errors = 0
+skip_block = False
+
+for line in result.stdout.split("\n"):
+    m = re.match(r"^([^: ]+):\d+:\d+: ", line)
+    if m is not None:
+        path = m.group(1)
+        if path.endswith("_test.go"):
+            # print("SKIP", line)
+            skip_block = True
+        else:
+            skip_block = False
+            errors += 1
+    if skip_block:
+        continue
+    print(line)
+
+
+print(f"{errors} errors.")
+if errors:
+    sys.exit(1)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ fmt:
 ws:
 	./tools/validate_whitespace.py
 
+nilaway:
+	./.nilaway/run_nilaway.py run ./...
+
 test:
 	${GOTESTSUM_CMD} -- ${PACKAGES}
 


### PR DESCRIPTION
## Changes
- New 'make nilaway' command to run https://github.com/uber-go/nilaway on our codebase

## Why
I wanted to see if we can detect issues such as https://github.com/databricks/cli/pull/2776 However, it does not detect that one.


