### PR TITLE
acc: Clean up redundant log message

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -233,7 +233,9 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 
 			if len(expanded) == 1 {
 				// env vars aren't part of the test case name, so log them for debugging
-				t.Logf("Running test with env %v", expanded[0])
+				if len(expanded[0]) > 0 {
+					t.Logf("Running test with env %v", expanded[0])
+				}
 				runTest(t, dir, coverDir, repls.Clone(), config, configPath, expanded[0])
 			} else {
 				for _, envset := range expanded {


### PR DESCRIPTION
Currently all tests log a message about running with empty env, this PR removes that:

```
=== NAME  TestAccept/workspace/jobs/create
    acceptance_test.go:236: Running test with env []
=== CONT  TestAccept/bundle/telemetry/deploy-mode
    acceptance_test.go:236: Running test with env []
=== CONT  TestAccept/bundle/help/bundle-schema
    acceptance_test.go:236: Running test with env []
```