### PR TITLE
Unset existing auth env vars in acceptance tests

### DIFF
--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,6 +12,9 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	sdkconfig "github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/iam"
 
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/testserver"
@@ -35,16 +39,19 @@ func isTruePtr(value *bool) bool {
 	return value != nil && *value
 }
 
-func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, outputDir string) *databricks.WorkspaceClient {
+func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, outputDir string) (*sdkconfig.Config, iam.User) {
 	cloudEnv := os.Getenv("CLOUD_ENV")
 
 	// If we are running on a cloud environment, use the host configured in the
 	// environment.
 	if cloudEnv != "" {
-		w, err := databricks.NewWorkspaceClient(&databricks.Config{})
+		w, err := databricks.NewWorkspaceClient()
 		require.NoError(t, err)
 
-		return w
+		user, err := w.CurrentUser.Me(context.Background())
+		require.NoError(t, err, "Failed to get current user")
+
+		return w.Config, *user
 	}
 
 	recordRequests := isTruePtr(config.RecordRequests)
@@ -55,23 +62,18 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 	// If we are not recording requests, and no custom server server stubs are configured,
 	// use the default shared server.
 	if len(config.Server) == 0 && !recordRequests {
-		w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		return &sdkconfig.Config{
 			Host:  os.Getenv("DATABRICKS_DEFAULT_HOST"),
 			Token: token,
-		})
-		require.NoError(t, err)
-
-		return w
+		}, TestUser
 	}
 
 	host := startDedicatedServer(t, config.Server, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
 
-	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+	return &sdkconfig.Config{
 		Host:  host,
 		Token: token,
-	})
-	require.NoError(t, err)
-	return w
+	}, TestUser
 }
 
 func startDedicatedServer(t *testing.T,

--- a/integration/bundle/apps_test.go
+++ b/integration/bundle/apps_test.go
@@ -52,7 +52,7 @@ func TestDeployBundleWithApp(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, user)
 	testdiff.PrepareReplacementsUser(t, replacements, *user)
-	testdiff.PrepareReplacementsWorkspaceClient(t, replacements, wt.W)
+	testdiff.PrepareReplacementsWorkspaceConfig(t, replacements, wt.W.Config)
 	testdiff.PrepareReplacementsUUID(t, replacements)
 	testdiff.PrepareReplacementsNumber(t, replacements)
 	testdiff.PrepareReplacementsTemporaryDirectory(t, replacements)

--- a/libs/testdiff/replacement.go
+++ b/libs/testdiff/replacement.go
@@ -136,29 +136,27 @@ func (r *ReplacementsContext) SetPathWithParents(old, new string) {
 	r.SetPath(filepath.Dir(filepath.Dir(old)), new+"_GPARENT")
 }
 
-func PrepareReplacementsWorkspaceClient(t testutil.TestingT, r *ReplacementsContext, w *databricks.WorkspaceClient) {
+func PrepareReplacementsWorkspaceConfig(t testutil.TestingT, r *ReplacementsContext, cfg *config.Config) {
 	t.Helper()
 	// in some clouds (gcp) w.Config.Host includes "https://" prefix in others it's really just a host (azure)
-	host := strings.TrimPrefix(strings.TrimPrefix(w.Config.Host, "http://"), "https://")
+	host := strings.TrimPrefix(strings.TrimPrefix(cfg.Host, "http://"), "https://")
 	r.Set("https://"+host, "[DATABRICKS_URL]")
 	r.Set("http://"+host, "[DATABRICKS_URL]")
 	r.Set(host, "[DATABRICKS_HOST]")
-	r.Set(w.Config.ClusterID, "[DATABRICKS_CLUSTER_ID]")
-	r.Set(w.Config.WarehouseID, "[DATABRICKS_WAREHOUSE_ID]")
-	r.Set(w.Config.ServerlessComputeID, "[DATABRICKS_SERVERLESS_COMPUTE_ID]")
-	r.Set(w.Config.AccountID, "[DATABRICKS_ACCOUNT_ID]")
-	r.Set(w.Config.Username, "[DATABRICKS_USERNAME]")
-	r.SetPath(w.Config.Profile, "[DATABRICKS_CONFIG_PROFILE]")
-	r.Set(w.Config.ConfigFile, "[DATABRICKS_CONFIG_FILE]")
-	r.Set(w.Config.GoogleServiceAccount, "[DATABRICKS_GOOGLE_SERVICE_ACCOUNT]")
-	r.Set(w.Config.AzureResourceID, "[DATABRICKS_AZURE_RESOURCE_ID]")
-	r.Set(w.Config.AzureClientID, testerName)
-	r.Set(w.Config.AzureTenantID, "[ARM_TENANT_ID]")
-	r.Set(w.Config.AzureEnvironment, "[ARM_ENVIRONMENT]")
-	r.Set(w.Config.ClientID, "[DATABRICKS_CLIENT_ID]")
-	r.SetPath(w.Config.DatabricksCliPath, "[DATABRICKS_CLI_PATH]")
-	// This is set to words like "path" that happen too frequently
-	// r.Set(w.Config.AuthType, "[DATABRICKS_AUTH_TYPE]")
+	r.Set(cfg.ClusterID, "[DATABRICKS_CLUSTER_ID]")
+	r.Set(cfg.WarehouseID, "[DATABRICKS_WAREHOUSE_ID]")
+	r.Set(cfg.ServerlessComputeID, "[DATABRICKS_SERVERLESS_COMPUTE_ID]")
+	r.Set(cfg.AccountID, "[DATABRICKS_ACCOUNT_ID]")
+	r.Set(cfg.Username, "[DATABRICKS_USERNAME]")
+	r.SetPath(cfg.Profile, "[DATABRICKS_CONFIG_PROFILE]")
+	r.Set(cfg.ConfigFile, "[DATABRICKS_CONFIG_FILE]")
+	r.Set(cfg.GoogleServiceAccount, "[DATABRICKS_GOOGLE_SERVICE_ACCOUNT]")
+	r.Set(cfg.AzureResourceID, "[DATABRICKS_AZURE_RESOURCE_ID]")
+	r.Set(cfg.AzureClientID, testerName)
+	r.Set(cfg.AzureTenantID, "[ARM_TENANT_ID]")
+	r.Set(cfg.AzureEnvironment, "[ARM_ENVIRONMENT]")
+	r.Set(cfg.ClientID, "[DATABRICKS_CLIENT_ID]")
+	r.SetPath(cfg.DatabricksCliPath, "[DATABRICKS_CLI_PATH]")
 }
 
 func PrepareReplacementsUser(t testutil.TestingT, r *ReplacementsContext, u iam.User) {

--- a/libs/testdiff/replacement.go
+++ b/libs/testdiff/replacement.go
@@ -11,6 +11,7 @@ import (
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/iamutil"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"golang.org/x/mod/semver"
 )


### PR DESCRIPTION
## Changes
This PR modified the test runner to use the `auth.ProcessEnv` function to compute the environment variables to pass to the test run instead of inheriting all environment variables by default.

## Why
Before acceptance, test runs would fail if an authentication method was configured in your environment. Now, they will pass.

## Tests
Existing tests.