### PR TITLE
acc: Raise timeout for jobs-as-code and ignore .venv

### DIFF
--- a/acceptance/bundle/templates/experimental-jobs-as-code/test.toml
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/test.toml
@@ -1,1 +1,6 @@
+Ignore = [
+    '.venv',
+]
+
+Timeout = '40s'
 TimeoutWindows = '120s'


### PR DESCRIPTION
## Why
I saw it failing with timeout a few times.