### PR TITLE
acc: Unset all env vars in inprocess mode

### DIFF
--- a/acceptance/internal/cmd_server.go
+++ b/acceptance/internal/cmd_server.go
@@ -14,7 +14,6 @@ import (
 
 func StartCmdServer(t *testing.T) *testserver.Server {
 	server := testserver.New(t)
-
 	server.Handle("GET", "/", func(r testserver.Request) any {
 		q := r.URL.Query()
 		args := strings.Split(q.Get("args"), " ")

--- a/acceptance/internal/cmd_server.go
+++ b/acceptance/internal/cmd_server.go
@@ -8,12 +8,19 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/internal/testcli"
+	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/stretchr/testify/require"
 )
 
 func StartCmdServer(t *testing.T) *testserver.Server {
 	server := testserver.New(t)
+
+	// Unset all environment variables when executing CLI commands in process.
+	// All required environment variables will be provided as the `env` query parameter
+	// in the request.
+	testutil.NullEnvironment(t)
+
 	server.Handle("GET", "/", func(r testserver.Request) any {
 		q := r.URL.Query()
 		args := strings.Split(q.Get("args"), " ")

--- a/acceptance/internal/cmd_server.go
+++ b/acceptance/internal/cmd_server.go
@@ -8,18 +8,12 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/internal/testcli"
-	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/stretchr/testify/require"
 )
 
 func StartCmdServer(t *testing.T) *testserver.Server {
 	server := testserver.New(t)
-
-	// Unset all environment variables when executing CLI commands in process.
-	// All required environment variables will be provided as the `env` query parameter
-	// in the request.
-	testutil.NullEnvironment(t)
 
 	server.Handle("GET", "/", func(r testserver.Request) any {
 		q := r.URL.Query()
@@ -28,11 +22,11 @@ func StartCmdServer(t *testing.T) *testserver.Server {
 		var env map[string]string
 		require.NoError(t, json.Unmarshal([]byte(q.Get("env")), &env))
 
-		for key, val := range env {
-			defer Setenv(t, key, val)()
-		}
+		// Change current process's environment to match the callsite.
+		defer configureEnv(t, env)()
 
-		defer Chdir(t, q.Get("cwd"))()
+		// Change current working directory to match the callsite.
+		defer chdir(t, q.Get("cwd"))()
 
 		c := testcli.NewRunner(t, context.Background(), args...)
 		c.Verbose = false
@@ -51,9 +45,9 @@ func StartCmdServer(t *testing.T) *testserver.Server {
 	return server
 }
 
-// Chdir variant that is intended to be used with defer so that it can switch back before function ends.
+// chdir variant that is intended to be used with defer so that it can switch back before function ends.
 // This is unlike testutil.Chdir which switches back only when tests end.
-func Chdir(t *testing.T, cwd string) func() {
+func chdir(t *testing.T, cwd string) func() {
 	require.NotEmpty(t, cwd)
 	prevDir, err := os.Getwd()
 	require.NoError(t, err)
@@ -64,18 +58,21 @@ func Chdir(t *testing.T, cwd string) func() {
 	}
 }
 
-// Setenv variant that is intended to be used with defer so that it can switch back before function ends.
-// This is unlike t.Setenv which switches back only when tests end.
-func Setenv(t *testing.T, key, value string) func() {
-	prevVal, exists := os.LookupEnv(key)
+func configureEnv(t *testing.T, env map[string]string) func() {
+	oldEnv := os.Environ()
 
-	require.NoError(t, os.Setenv(key, value))
+	// Set current process's environment to match the input.
+	os.Clearenv()
+	for key, val := range env {
+		os.Setenv(key, val)
+	}
 
+	// Function callback to use with defer to restore original environment.
 	return func() {
-		if exists {
-			_ = os.Setenv(key, prevVal)
-		} else {
-			_ = os.Unsetenv(key)
+		os.Clearenv()
+		for _, kv := range oldEnv {
+			kvs := strings.SplitN(kv, "=", 2)
+			os.Setenv(kvs[0], kvs[1])
 		}
 	}
 }


### PR DESCRIPTION
## Why
We need to cleanup existing env vars in the parent CLI process in inprocess mode. Just setting new environment variables is not enough. This was noticed in https://github.com/databricks/cli/pull/2720 and is necessarily for it to work since otherwise we end up with conflicting auth.

## Tests
Manually, before local tests would fail when non PAT auth was configured in terminal, for example `selftest/server` fails with when OAuth is configured:
```
Error: inner token: Post "[UUID]/oauth2/token": Post "[UUID]/oauth2/token": unsupported protocol scheme ""
```

Now these local tests pass.
