### PR TITLE
Point to correct tagging.py in tagging.yml

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -48,4 +48,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          python tagging.py
+          python internal/genkit/tagging.py


### PR DESCRIPTION
## Changes
Point to correct tagging.py in tagging.yml

## Why
This file is updated on every genkit update-sdk run and points to tagging.py in root but since we moved it to internal folder we need to keep as is
