### PR TITLE
Generated new Python types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,6 @@ generate:
 	genkit update-sdk
 	[ ! -f tagging.py ] || mv tagging.py internal/genkit/tagging.py
 	[ ! -f .github/workflows/next-changelog.yml ] || rm .github/workflows/next-changelog.yml
+	pushd experimental/python && make codegen
 
 .PHONY: lint tidy lintcheck fmt test cover showcover build snapshot vendor schema integration integration-short acc-cover acc-showcover docs ws

--- a/experimental/python/databricks/bundles/jobs/_models/authentication_method.py
+++ b/experimental/python/databricks/bundles/jobs/_models/authentication_method.py
@@ -3,10 +3,6 @@ from typing import Literal
 
 
 class AuthenticationMethod(Enum):
-    """
-    :meta private: [EXPERIMENTAL]
-    """
-
     OAUTH = "OAUTH"
     PAT = "PAT"
 

--- a/experimental/python/databricks/bundles/jobs/_models/power_bi_model.py
+++ b/experimental/python/databricks/bundles/jobs/_models/power_bi_model.py
@@ -16,9 +16,7 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class PowerBiModel:
-    """
-    :meta private: [EXPERIMENTAL]
-    """
+    """"""
 
     authentication_method: VariableOrOptional[AuthenticationMethod] = None
     """

--- a/experimental/python/databricks/bundles/jobs/_models/power_bi_table.py
+++ b/experimental/python/databricks/bundles/jobs/_models/power_bi_table.py
@@ -12,9 +12,7 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class PowerBiTable:
-    """
-    :meta private: [EXPERIMENTAL]
-    """
+    """"""
 
     catalog: VariableOrOptional[str] = None
     """

--- a/experimental/python/databricks/bundles/jobs/_models/power_bi_task.py
+++ b/experimental/python/databricks/bundles/jobs/_models/power_bi_task.py
@@ -19,9 +19,7 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class PowerBiTask:
-    """
-    :meta private: [EXPERIMENTAL]
-    """
+    """"""
 
     connection_resource_name: VariableOrOptional[str] = None
     """

--- a/experimental/python/databricks/bundles/jobs/_models/storage_mode.py
+++ b/experimental/python/databricks/bundles/jobs/_models/storage_mode.py
@@ -3,10 +3,6 @@ from typing import Literal
 
 
 class StorageMode(Enum):
-    """
-    :meta private: [EXPERIMENTAL]
-    """
-
     DIRECT_QUERY = "DIRECT_QUERY"
     IMPORT = "IMPORT"
     DUAL = "DUAL"

--- a/experimental/python/databricks/bundles/jobs/_models/task.py
+++ b/experimental/python/databricks/bundles/jobs/_models/task.py
@@ -215,8 +215,6 @@ class Task:
 
     power_bi_task: VariableOrOptional[PowerBiTask] = None
     """
-    :meta private: [EXPERIMENTAL]
-    
     The task triggers a Power BI semantic model update when the `power_bi_task` field is present.
     """
 
@@ -415,8 +413,6 @@ class TaskDict(TypedDict, total=False):
 
     power_bi_task: VariableOrOptional[PowerBiTaskParam]
     """
-    :meta private: [EXPERIMENTAL]
-    
     The task triggers a Power BI semantic model update when the `power_bi_task` field is present.
     """
 


### PR DESCRIPTION
## Changes
Generated new Python types by running `pushd experimental/python && make codegen`

## Why
This PR https://github.com/databricks/cli/pull/2788 introduced new task types but Python types were not generated causing schema checks to fail.
