### PR TITLE
Embed struct, not pointer in resources

### DIFF
--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -1,4 +1,4 @@
-Cloud = true
+CloudSlow = true
 Local = false
 
 # serverless is only enabled if UC is enabled

--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -1,4 +1,4 @@
-CloudSlow = true
+Cloud = true
 Local = false
 
 # serverless is only enabled if UC is enabled

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,5 +1,5 @@
 Local = false
-CloudSlow = true
+Cloud = true
 Ignore = [
     ".databricks",
     ".venv",

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = true
+CloudSlow = true
 Ignore = [
     ".databricks",
     ".venv",

--- a/bundle/apps/interpolate_variables_test.go
+++ b/bundle/apps/interpolate_variables_test.go
@@ -17,7 +17,7 @@ func TestAppInterpolateVariables(t *testing.T) {
 			Resources: config.Resources{
 				Apps: map[string]*resources.App{
 					"my_app_1": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "my_app_1",
 						},
 						Config: map[string]any{
@@ -28,7 +28,7 @@ func TestAppInterpolateVariables(t *testing.T) {
 						},
 					},
 					"my_app_2": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "my_app_2",
 						},
 					},

--- a/bundle/apps/upload_config_test.go
+++ b/bundle/apps/upload_config_test.go
@@ -37,7 +37,7 @@ func TestAppUploadConfig(t *testing.T) {
 			Resources: config.Resources{
 				Apps: map[string]*resources.App{
 					"my_app": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "my_app",
 						},
 						SourceCodePath: "./my_app",

--- a/bundle/apps/validate_test.go
+++ b/bundle/apps/validate_test.go
@@ -32,13 +32,13 @@ func TestAppsValidateSameSourcePath(t *testing.T) {
 			Resources: config.Resources{
 				Apps: map[string]*resources.App{
 					"app1": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "app1",
 						},
 						SourceCodePath: "./app1",
 					},
 					"app2": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "app2",
 						},
 						SourceCodePath: "./app1",

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -32,7 +32,7 @@ func TestInitializeURLs(t *testing.T) {
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline1": {
 						ID:             "3",
-						CreatePipeline: &pipelines.CreatePipeline{Name: "pipeline1"},
+						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1"},
 					},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -44,7 +44,7 @@ func TestInitializeURLs(t *testing.T) {
 				Models: map[string]*resources.MlflowModel{
 					"model1": {
 						ID:    "a model uses its name for identifier",
-						Model: &ml.Model{Name: "a model uses its name for identifier"},
+						Model: ml.Model{Name: "a model uses its name for identifier"},
 					},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -26,7 +26,7 @@ func TestInitializeURLs(t *testing.T) {
 				Jobs: map[string]*resources.Job{
 					"job1": {
 						ID:          "1",
-						JobSettings: &jobs.JobSettings{Name: "job1"},
+						JobSettings: jobs.JobSettings{Name: "job1"},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
@@ -127,7 +127,7 @@ func TestInitializeURLsWithoutOrgId(t *testing.T) {
 				Jobs: map[string]*resources.Job{
 					"job1": {
 						ID:          "1",
-						JobSettings: &jobs.JobSettings{Name: "job1"},
+						JobSettings: jobs.JobSettings{Name: "job1"},
 					},
 				},
 			},

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -80,7 +80,7 @@ func TestInitializeURLs(t *testing.T) {
 				Clusters: map[string]*resources.Cluster{
 					"cluster1": {
 						ID: "1017-103929-vlr7jzcf",
-						ClusterSpec: &compute.ClusterSpec{
+						ClusterSpec: compute.ClusterSpec{
 							ClusterName: "cluster1",
 						},
 					},

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -50,7 +50,7 @@ func TestInitializeURLs(t *testing.T) {
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"servingendpoint1": {
 						ID: "my_serving_endpoint",
-						CreateServingEndpoint: &serving.CreateServingEndpoint{
+						CreateServingEndpoint: serving.CreateServingEndpoint{
 							Name: "my_serving_endpoint",
 						},
 					},

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -38,7 +38,7 @@ func TestInitializeURLs(t *testing.T) {
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment1": {
 						ID:         "4",
-						Experiment: &ml.Experiment{Name: "experiment1"},
+						Experiment: ml.Experiment{Name: "experiment1"},
 					},
 				},
 				Models: map[string]*resources.MlflowModel{

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -58,7 +58,7 @@ func TestInitializeURLs(t *testing.T) {
 				RegisteredModels: map[string]*resources.RegisteredModel{
 					"registeredmodel1": {
 						ID: "8",
-						CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+						CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 							Name: "my_registered_model",
 						},
 					},
@@ -66,13 +66,13 @@ func TestInitializeURLs(t *testing.T) {
 				QualityMonitors: map[string]*resources.QualityMonitor{
 					"qualityMonitor1": {
 						TableName:     "catalog.schema.qualityMonitor1",
-						CreateMonitor: &catalog.CreateMonitor{},
+						CreateMonitor: catalog.CreateMonitor{},
 					},
 				},
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
 						ID: "catalog.schema",
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							Name: "schema",
 						},
 					},
@@ -88,7 +88,7 @@ func TestInitializeURLs(t *testing.T) {
 				Dashboards: map[string]*resources.Dashboard{
 					"dashboard1": {
 						ID: "01ef8d56871e1d50ae30ce7375e42478",
-						Dashboard: &dashboards.Dashboard{
+						Dashboard: dashboards.Dashboard{
 							DisplayName: "My special dashboard",
 						},
 					},

--- a/bundle/config/mutator/normalize_paths.go
+++ b/bundle/config/mutator/normalize_paths.go
@@ -72,7 +72,7 @@ func collectGitSourcePaths(b *bundle.Bundle) []dyn.Path {
 	var jobs []dyn.Path
 
 	for name, job := range b.Config.Resources.Jobs {
-		if job == nil || job.JobSettings == nil {
+		if job == nil {
 			continue
 		}
 		if job.GitSource != nil {

--- a/bundle/config/mutator/normalize_paths_test.go
+++ b/bundle/config/mutator/normalize_paths_test.go
@@ -22,7 +22,7 @@ func TestNormalizePaths(t *testing.T) {
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Tasks: []jobs.Task{
 							{
 								NotebookTask: &jobs.NotebookTask{

--- a/bundle/config/mutator/paths/job_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/job_paths_visitor_test.go
@@ -51,7 +51,7 @@ func TestVisitJobPaths(t *testing.T) {
 	}
 
 	job0 := &resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Tasks: []jobs.Task{
 				task0,
 				task1,
@@ -96,7 +96,7 @@ func TestVisitJobPaths_environments(t *testing.T) {
 		},
 	}
 	job0 := &resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Environments: []jobs.JobEnvironment{
 				environment0,
 			},
@@ -131,7 +131,7 @@ func TestVisitJobPaths_foreach(t *testing.T) {
 		},
 	}
 	job0 := &resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Tasks: []jobs.Task{
 				task0,
 			},

--- a/bundle/config/mutator/paths/pipeline_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/pipeline_paths_visitor_test.go
@@ -15,7 +15,7 @@ func TestVisitPipelinePaths(t *testing.T) {
 		Resources: config.Resources{
 			Pipelines: map[string]*resources.Pipeline{
 				"pipeline0": {
-					CreatePipeline: &pipelines.CreatePipeline{
+					CreatePipeline: pipelines.CreatePipeline{
 						Libraries: []pipelines.PipelineLibrary{
 							{
 								File: &pipelines.FileLibrary{

--- a/bundle/config/mutator/resolve_variable_references_test.go
+++ b/bundle/config/mutator/resolve_variable_references_test.go
@@ -48,7 +48,7 @@ func TestResolveVariableReferencesWithSourceLinkedDeployment(t *testing.T) {
 				Resources: config.Resources{
 					Pipelines: map[string]*resources.Pipeline{
 						"pipeline1": {
-							CreatePipeline: &pipelines.CreatePipeline{
+							CreatePipeline: pipelines.CreatePipeline{
 								Configuration: map[string]string{
 									"source": "${workspace.file_path}",
 								},

--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
@@ -30,12 +30,12 @@ func TestApplyBundlePermissions(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job_1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job_1",
 						},
 					},
 					"job_2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job_2",
 						},
 					},
@@ -139,7 +139,7 @@ func TestWarningOnOverlapPermission(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job_1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job_1",
 						},
 						Permissions: []resources.JobPermission{
@@ -147,7 +147,7 @@ func TestWarningOnOverlapPermission(t *testing.T) {
 						},
 					},
 					"job_2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job_2",
 						},
 						Permissions: []resources.JobPermission{

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -13,7 +13,6 @@ import (
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/textutil"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
@@ -163,9 +162,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 		if m == nil {
 			continue
 		}
-		if m.CreateRegisteredModelRequest == nil {
-			m.CreateRegisteredModelRequest = &catalog.CreateRegisteredModelRequest{}
-		}
 		m.Name = normalizePrefix(prefix) + m.Name
 
 		// As of 2024-06, registered models don't yet support tags
@@ -173,11 +169,7 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 
 	// Quality monitors presets: Schedule
 	if t.TriggerPauseStatus == config.Paused {
-		for key, q := range r.QualityMonitors {
-			if q.CreateMonitor == nil {
-				diags = diags.Extend(diag.Errorf("quality monitor %s is not defined", key))
-				continue
-			}
+		for _, q := range r.QualityMonitors {
 			// Remove all schedules from monitors, since they don't support pausing/unpausing.
 			// Quality monitors might support the "pause" property in the future, so at the
 			// CLI level we do respect that property if it is set to "unpaused."
@@ -191,9 +183,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	for _, s := range r.Schemas {
 		if s == nil {
 			continue
-		}
-		if s.CreateSchema == nil {
-			s.CreateSchema = &catalog.CreateSchema{}
 		}
 		s.Name = normalizePrefix(prefix) + s.Name
 		// HTTP API for schemas doesn't yet support tags. It's only supported in
@@ -222,9 +211,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	for _, dashboard := range r.Dashboards {
 		if dashboard == nil {
 			continue
-		}
-		if dashboard.Dashboard == nil {
-			dashboard.Dashboard = &dashboards.Dashboard{}
 		}
 		dashboard.DisplayName = prefix + dashboard.DisplayName
 	}

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -16,7 +16,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
-	"github.com/databricks/databricks-sdk-go/service/pipelines"
 	"github.com/databricks/databricks-sdk-go/service/serving"
 )
 
@@ -95,9 +94,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	for _, p := range r.Pipelines {
 		if p == nil {
 			continue
-		}
-		if p.CreatePipeline == nil {
-			p.CreatePipeline = &pipelines.CreatePipeline{}
 		}
 		p.Name = prefix + p.Name
 		if config.IsExplicitlyEnabled(t.PipelinesDevelopment) {

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -16,7 +16,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
-	"github.com/databricks/databricks-sdk-go/service/serving"
 )
 
 type applyPresets struct{}
@@ -153,9 +152,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	for _, e := range r.ModelServingEndpoints {
 		if e == nil {
 			continue
-		}
-		if e.CreateServingEndpoint == nil {
-			e.CreateServingEndpoint = &serving.CreateServingEndpoint{}
 		}
 		e.Name = normalizePrefix(prefix) + e.Name
 

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -58,9 +58,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 		if j == nil {
 			continue
 		}
-		if j.JobSettings == nil {
-			j.JobSettings = &jobs.JobSettings{}
-		}
 		j.Name = prefix + j.Name
 		if len(tags) > 0 {
 			if j.Tags == nil {

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -110,9 +110,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 		if m == nil {
 			continue
 		}
-		if m.Model == nil {
-			m.Model = &ml.Model{}
-		}
 		m.Name = prefix + m.Name
 		for _, t := range tags {
 			exists := slices.ContainsFunc(m.Tags, func(modelTag ml.ModelTag) bool {

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -127,9 +127,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 		if e == nil {
 			continue
 		}
-		if e.Experiment == nil {
-			e.Experiment = &ml.Experiment{}
-		}
 		filepath := e.Name
 		dir := path.Dir(filepath)
 		base := path.Base(filepath)

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -13,7 +13,6 @@ import (
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/textutil"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
@@ -222,9 +221,6 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	for _, c := range r.Clusters {
 		if c == nil {
 			continue
-		}
-		if c.ClusterSpec == nil {
-			c.ClusterSpec = &compute.ClusterSpec{}
 		}
 		c.ClusterName = prefix + c.ClusterName
 		if c.CustomTags == nil {

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -53,7 +53,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job1",
 							Schedule: &jobs.CronSchedule{
 								QuartzCronExpression: "* * * * *",
@@ -62,7 +62,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 						},
 					},
 					"job2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job2",
 							Schedule: &jobs.CronSchedule{
 								QuartzCronExpression: "* * * * *",
@@ -71,7 +71,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 						},
 					},
 					"job3": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job3",
 							Trigger: &jobs.TriggerSettings{
 								FileArrival: &jobs.FileArrivalTriggerConfiguration{
@@ -81,7 +81,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 						},
 					},
 					"job4": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job4",
 							Continuous: &jobs.Continuous{
 								PauseStatus: jobs.PauseStatusPaused,

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -136,7 +136,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"volume1": {CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{Name: "volume1"}},
 				},
 				Clusters: map[string]*resources.Cluster{
-					"cluster1": {ClusterSpec: &compute.ClusterSpec{ClusterName: "cluster1", SparkVersion: "13.2.x", NumWorkers: 1}},
+					"cluster1": {ClusterSpec: compute.ClusterSpec{ClusterName: "cluster1", SparkVersion: "13.2.x", NumWorkers: 1}},
 				},
 				Dashboards: map[string]*resources.Dashboard{
 					"dashboard1": {

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -147,7 +147,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 				},
 				Apps: map[string]*resources.App{
 					"app1": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "app1",
 						},
 					},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -97,7 +97,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"experiment2": {Experiment: &ml.Experiment{Name: "experiment2"}},
 				},
 				Models: map[string]*resources.MlflowModel{
-					"model1": {Model: &ml.Model{Name: "model1"}},
+					"model1": {Model: ml.Model{Name: "model1"}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"servingendpoint1": {CreateServingEndpoint: &serving.CreateServingEndpoint{Name: "servingendpoint1"}},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -100,7 +100,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"model1": {Model: ml.Model{Name: "model1"}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
-					"servingendpoint1": {CreateServingEndpoint: &serving.CreateServingEndpoint{Name: "servingendpoint1"}},
+					"servingendpoint1": {CreateServingEndpoint: serving.CreateServingEndpoint{Name: "servingendpoint1"}},
 				},
 				RegisteredModels: map[string]*resources.RegisteredModel{
 					"registeredmodel1": {CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{Name: "registeredmodel1"}},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -136,7 +136,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"volume1": {CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{Name: "volume1"}},
 				},
 				Clusters: map[string]*resources.Cluster{
-					"cluster1": {ClusterSpec: compute.ClusterSpec{ClusterName: "cluster1", SparkVersion: "13.2.x", NumWorkers: 1}},
+					"cluster1": {ClusterSpec: &compute.ClusterSpec{ClusterName: "cluster1", SparkVersion: "13.2.x", NumWorkers: 1}},
 				},
 				Dashboards: map[string]*resources.Dashboard{
 					"dashboard1": {

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -103,25 +103,25 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"servingendpoint1": {CreateServingEndpoint: serving.CreateServingEndpoint{Name: "servingendpoint1"}},
 				},
 				RegisteredModels: map[string]*resources.RegisteredModel{
-					"registeredmodel1": {CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{Name: "registeredmodel1"}},
+					"registeredmodel1": {CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{Name: "registeredmodel1"}},
 				},
 				QualityMonitors: map[string]*resources.QualityMonitor{
 					"qualityMonitor1": {
 						TableName: "qualityMonitor1",
-						CreateMonitor: &catalog.CreateMonitor{
+						CreateMonitor: catalog.CreateMonitor{
 							OutputSchemaName: "catalog.schema",
 						},
 					},
 					"qualityMonitor2": {
 						TableName: "qualityMonitor2",
-						CreateMonitor: &catalog.CreateMonitor{
+						CreateMonitor: catalog.CreateMonitor{
 							OutputSchemaName: "catalog.schema",
 							Schedule:         &catalog.MonitorCronSchedule{},
 						},
 					},
 					"qualityMonitor3": {
 						TableName: "qualityMonitor3",
-						CreateMonitor: &catalog.CreateMonitor{
+						CreateMonitor: catalog.CreateMonitor{
 							OutputSchemaName: "catalog.schema",
 							Schedule: &catalog.MonitorCronSchedule{
 								PauseStatus: catalog.MonitorCronSchedulePauseStatusUnpaused,
@@ -130,7 +130,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					},
 				},
 				Schemas: map[string]*resources.Schema{
-					"schema1": {CreateSchema: &catalog.CreateSchema{Name: "schema1"}},
+					"schema1": {CreateSchema: catalog.CreateSchema{Name: "schema1"}},
 				},
 				Volumes: map[string]*resources.Volume{
 					"volume1": {CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{Name: "volume1"}},
@@ -140,7 +140,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 				},
 				Dashboards: map[string]*resources.Dashboard{
 					"dashboard1": {
-						Dashboard: &dashboards.Dashboard{
+						Dashboard: dashboards.Dashboard{
 							DisplayName: "dashboard1",
 						},
 					},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -90,7 +90,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
-					"pipeline1": {CreatePipeline: &pipelines.CreatePipeline{Name: "pipeline1", Continuous: true}},
+					"pipeline1": {CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1", Continuous: true}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment1": {Experiment: &ml.Experiment{Name: "/Users/lennart.kats@databricks.com/experiment1"}},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -133,7 +133,7 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"schema1": {CreateSchema: &catalog.CreateSchema{Name: "schema1"}},
 				},
 				Volumes: map[string]*resources.Volume{
-					"volume1": {CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{Name: "volume1"}},
+					"volume1": {CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{Name: "volume1"}},
 				},
 				Clusters: map[string]*resources.Cluster{
 					"cluster1": {ClusterSpec: &compute.ClusterSpec{ClusterName: "cluster1", SparkVersion: "13.2.x", NumWorkers: 1}},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -93,8 +93,8 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"pipeline1": {CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1", Continuous: true}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
-					"experiment1": {Experiment: &ml.Experiment{Name: "/Users/lennart.kats@databricks.com/experiment1"}},
-					"experiment2": {Experiment: &ml.Experiment{Name: "experiment2"}},
+					"experiment1": {Experiment: ml.Experiment{Name: "/Users/lennart.kats@databricks.com/experiment1"}},
+					"experiment2": {Experiment: ml.Experiment{Name: "experiment2"}},
 				},
 				Models: map[string]*resources.MlflowModel{
 					"model1": {Model: ml.Model{Name: "model1"}},

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency.go
@@ -44,7 +44,7 @@ func findSchema(b *bundle.Bundle, catalogName, schemaName string) (string, *reso
 }
 
 func resolveVolume(v *resources.Volume, b *bundle.Bundle) {
-	if v == nil || v.CreateVolumeRequestContent == nil {
+	if v == nil {
 		return
 	}
 	schemaK, schema := findSchema(b, v.CatalogName, v.SchemaName)

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency.go
@@ -56,7 +56,7 @@ func resolveVolume(v *resources.Volume, b *bundle.Bundle) {
 }
 
 func resolvePipelineSchema(p *resources.Pipeline, b *bundle.Bundle) {
-	if p == nil || p.CreatePipeline == nil {
+	if p == nil {
 		return
 	}
 	if p.Schema == "" {
@@ -71,7 +71,7 @@ func resolvePipelineSchema(p *resources.Pipeline, b *bundle.Bundle) {
 }
 
 func resolvePipelineTarget(p *resources.Pipeline, b *bundle.Bundle) {
-	if p == nil || p.CreatePipeline == nil {
+	if p == nil {
 		return
 	}
 	if p.Target == "" {

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency.go
@@ -36,7 +36,7 @@ func findSchema(b *bundle.Bundle, catalogName, schemaName string) (string, *reso
 	}
 
 	for k, s := range b.Config.Resources.Schemas {
-		if s != nil && s.CreateSchema != nil && s.CatalogName == catalogName && s.Name == schemaName {
+		if s != nil && s.CatalogName == catalogName && s.Name == schemaName {
 			return k, s
 		}
 	}

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
@@ -118,43 +118,43 @@ func TestCaptureSchemaDependencyForPipelinesWithTarget(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline1": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog1",
 							Schema:  "foobar",
 						},
 					},
 					"pipeline2": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog2",
 							Schema:  "foobar",
 						},
 					},
 					"pipeline3": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog1",
 							Schema:  "barfoo",
 						},
 					},
 					"pipeline4": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalogX",
 							Schema:  "foobar",
 						},
 					},
 					"pipeline5": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog1",
 							Schema:  "schemaX",
 						},
 					},
 					"pipeline6": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "",
 							Schema:  "foobar",
 						},
 					},
 					"pipeline7": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "",
 							Schema:  "",
 							Name:    "whatever",
@@ -179,7 +179,7 @@ func TestCaptureSchemaDependencyForPipelinesWithTarget(t *testing.T) {
 	assert.Equal(t, "", b.Config.Resources.Pipelines["pipeline7"].Schema)
 
 	assert.Nil(t, b.Config.Resources.Pipelines["nilPipeline"])
-	assert.Nil(t, b.Config.Resources.Pipelines["emptyPipeline"].CreatePipeline)
+	assert.Empty(t, b.Config.Resources.Pipelines["emptyPipeline"].CreatePipeline.Catalog)
 
 	for _, k := range []string{"pipeline1", "pipeline2", "pipeline3", "pipeline4", "pipeline5", "pipeline6", "pipeline7"} {
 		assert.Empty(t, b.Config.Resources.Pipelines[k].Target)
@@ -214,43 +214,43 @@ func TestCaptureSchemaDependencyForPipelinesWithSchema(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline1": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog1",
 							Target:  "foobar",
 						},
 					},
 					"pipeline2": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog2",
 							Target:  "foobar",
 						},
 					},
 					"pipeline3": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog1",
 							Target:  "barfoo",
 						},
 					},
 					"pipeline4": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalogX",
 							Target:  "foobar",
 						},
 					},
 					"pipeline5": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "catalog1",
 							Target:  "schemaX",
 						},
 					},
 					"pipeline6": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "",
 							Target:  "foobar",
 						},
 					},
 					"pipeline7": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Catalog: "",
 							Target:  "",
 							Name:    "whatever",

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
@@ -41,31 +41,31 @@ func TestCaptureSchemaDependencyForVolume(t *testing.T) {
 				},
 				Volumes: map[string]*resources.Volume{
 					"volume1": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "catalog1",
 							SchemaName:  "foobar",
 						},
 					},
 					"volume2": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "catalog2",
 							SchemaName:  "foobar",
 						},
 					},
 					"volume3": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "catalog1",
 							SchemaName:  "barfoo",
 						},
 					},
 					"volume4": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "catalogX",
 							SchemaName:  "foobar",
 						},
 					},
 					"volume5": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "catalog1",
 							SchemaName:  "schemaX",
 						},
@@ -87,7 +87,7 @@ func TestCaptureSchemaDependencyForVolume(t *testing.T) {
 	assert.Equal(t, "schemaX", b.Config.Resources.Volumes["volume5"].CreateVolumeRequestContent.SchemaName)
 
 	assert.Nil(t, b.Config.Resources.Volumes["nilVolume"])
-	assert.Nil(t, b.Config.Resources.Volumes["emptyVolume"].CreateVolumeRequestContent)
+	// assert.Nil(t, b.Config.Resources.Volumes["emptyVolume"].CreateVolumeRequestContent)
 }
 
 func TestCaptureSchemaDependencyForPipelinesWithTarget(t *testing.T) {

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
@@ -19,19 +19,19 @@ func TestCaptureSchemaDependencyForVolume(t *testing.T) {
 			Resources: config.Resources{
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog1",
 							Name:        "foobar",
 						},
 					},
 					"schema2": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog2",
 							Name:        "foobar",
 						},
 					},
 					"schema3": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog1",
 							Name:        "barfoo",
 						},
@@ -96,19 +96,19 @@ func TestCaptureSchemaDependencyForPipelinesWithTarget(t *testing.T) {
 			Resources: config.Resources{
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog1",
 							Name:        "foobar",
 						},
 					},
 					"schema2": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog2",
 							Name:        "foobar",
 						},
 					},
 					"schema3": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog1",
 							Name:        "barfoo",
 						},
@@ -192,19 +192,19 @@ func TestCaptureSchemaDependencyForPipelinesWithSchema(t *testing.T) {
 			Resources: config.Resources{
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog1",
 							Name:        "foobar",
 						},
 					},
 					"schema2": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog2",
 							Name:        "foobar",
 						},
 					},
 					"schema3": {
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							CatalogName: "catalog1",
 							Name:        "barfoo",
 						},

--- a/bundle/config/mutator/resourcemutator/default_queueing.go
+++ b/bundle/config/mutator/resourcemutator/default_queueing.go
@@ -24,9 +24,6 @@ func (m *defaultQueueing) Name() string {
 func (m *defaultQueueing) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	r := b.Config.Resources
 	for i := range r.Jobs {
-		if r.Jobs[i].JobSettings == nil {
-			r.Jobs[i].JobSettings = &jobs.JobSettings{}
-		}
 		if r.Jobs[i].Queue != nil {
 			continue
 		}

--- a/bundle/config/mutator/resourcemutator/default_queueing_test.go
+++ b/bundle/config/mutator/resourcemutator/default_queueing_test.go
@@ -38,7 +38,7 @@ func TestDefaultQueueingApplyJobsAlreadyEnabled(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Queue: &jobs.QueueSettings{Enabled: true},
 						},
 					},
@@ -57,7 +57,7 @@ func TestDefaultQueueingApplyEnableQueueing(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job",
 						},
 					},
@@ -77,17 +77,17 @@ func TestDefaultQueueingApplyWithMultipleJobs(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Queue: &jobs.QueueSettings{Enabled: false},
 						},
 					},
 					"job2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job",
 						},
 					},
 					"job3": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Queue: &jobs.QueueSettings{Enabled: true},
 						},
 					},

--- a/bundle/config/mutator/resourcemutator/expand_pipeline_glob_paths_test.go
+++ b/bundle/config/mutator/resourcemutator/expand_pipeline_glob_paths_test.go
@@ -52,7 +52,7 @@ func TestExpandGlobPathsInPipelines(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									Notebook: &pipelines.NotebookLibrary{

--- a/bundle/config/mutator/resourcemutator/filter_current_user_test.go
+++ b/bundle/config/mutator/resourcemutator/filter_current_user_test.go
@@ -132,13 +132,13 @@ func testFixture(userName string) *bundle.Bundle {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job1",
 						},
 						Permissions: jobPermissions,
 					},
 					"job2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job2",
 						},
 						Permissions: jobPermissions,

--- a/bundle/config/mutator/resourcemutator/merge_apps_test.go
+++ b/bundle/config/mutator/resourcemutator/merge_apps_test.go
@@ -19,7 +19,7 @@ func TestMergeApps(t *testing.T) {
 			Resources: config.Resources{
 				Apps: map[string]*resources.App{
 					"foo": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "foo",
 							Resources: []apps.AppResource{
 								{

--- a/bundle/config/mutator/resourcemutator/merge_job_clusters_test.go
+++ b/bundle/config/mutator/resourcemutator/merge_job_clusters_test.go
@@ -20,7 +20,7 @@ func TestMergeJobClusters(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							JobClusters: []jobs.JobCluster{
 								{
 									JobClusterKey: "foo",
@@ -77,7 +77,7 @@ func TestMergeJobClustersWithNilKey(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							JobClusters: []jobs.JobCluster{
 								{
 									NewCluster: compute.ClusterSpec{

--- a/bundle/config/mutator/resourcemutator/merge_job_parameters_test.go
+++ b/bundle/config/mutator/resourcemutator/merge_job_parameters_test.go
@@ -19,7 +19,7 @@ func TestMergeJobParameters(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Parameters: []jobs.JobParameterDefinition{
 								{
 									Name:    "foo",
@@ -59,7 +59,7 @@ func TestMergeJobParametersWithNilKey(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Parameters: []jobs.JobParameterDefinition{
 								{
 									Default: "v1",

--- a/bundle/config/mutator/resourcemutator/merge_job_tasks_test.go
+++ b/bundle/config/mutator/resourcemutator/merge_job_tasks_test.go
@@ -20,7 +20,7 @@ func TestMergeJobTasks(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey: "foo",
@@ -89,7 +89,7 @@ func TestMergeJobTasksWithNilKey(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									NewCluster: &compute.ClusterSpec{

--- a/bundle/config/mutator/resourcemutator/merge_pipeline_clusters_test.go
+++ b/bundle/config/mutator/resourcemutator/merge_pipeline_clusters_test.go
@@ -20,7 +20,7 @@ func TestMergePipelineClusters(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"foo": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Clusters: []pipelines.PipelineCluster{
 								{
 									NodeTypeId: "i3.xlarge",
@@ -69,7 +69,7 @@ func TestMergePipelineClustersCaseInsensitive(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"foo": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Clusters: []pipelines.PipelineCluster{
 								{
 									Label:      "default",

--- a/bundle/config/mutator/resourcemutator/override_compute_test.go
+++ b/bundle/config/mutator/resourcemutator/override_compute_test.go
@@ -26,7 +26,7 @@ func TestOverrideComputeModeDevelopment(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Name: "job1",
 						Tasks: []jobs.Task{
 							{
@@ -73,7 +73,7 @@ func TestOverrideComputeModeDefaultIgnoresVariable(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Name: "job1",
 						Tasks: []jobs.Task{
 							{
@@ -102,7 +102,7 @@ func TestOverrideComputePipelineTask(t *testing.T) {
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Name: "job1",
 						Tasks: []jobs.Task{
 							{
@@ -127,7 +127,7 @@ func TestOverrideComputeForEachTask(t *testing.T) {
 		Config: config.Root{
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Name: "job1",
 						Tasks: []jobs.Task{
 							{
@@ -155,7 +155,7 @@ func TestOverrideComputeModeProduction(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Name: "job1",
 						Tasks: []jobs.Task{
 							{
@@ -188,7 +188,7 @@ func TestOverrideComputeModeProductionIgnoresVariable(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job1": {JobSettings: &jobs.JobSettings{
+					"job1": {JobSettings: jobs.JobSettings{
 						Name: "job1",
 						Tasks: []jobs.Task{
 							{

--- a/bundle/config/mutator/resourcemutator/run_as_test.go
+++ b/bundle/config/mutator/resourcemutator/run_as_test.go
@@ -66,17 +66,17 @@ func TestRunAsWorksForAllowedResources(t *testing.T) {
 		Resources: config.Resources{
 			Jobs: map[string]*resources.Job{
 				"job_one": {
-					JobSettings: &jobs.JobSettings{
+					JobSettings: jobs.JobSettings{
 						Name: "foo",
 					},
 				},
 				"job_two": {
-					JobSettings: &jobs.JobSettings{
+					JobSettings: jobs.JobSettings{
 						Name: "bar",
 					},
 				},
 				"job_three": {
-					JobSettings: &jobs.JobSettings{
+					JobSettings: jobs.JobSettings{
 						Name: "baz",
 					},
 				},

--- a/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
@@ -21,7 +21,7 @@ func TestValidateProductionPipelines(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Development: true,
 						},
 					},

--- a/bundle/config/mutator/rewrite_workspace_prefix_test.go
+++ b/bundle/config/mutator/rewrite_workspace_prefix_test.go
@@ -26,7 +26,7 @@ func TestNoWorkspacePrefixUsed(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"test_job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									SparkPythonTask: &jobs.SparkPythonTask{

--- a/bundle/config/mutator/translate_paths_apps_test.go
+++ b/bundle/config/mutator/translate_paths_apps_test.go
@@ -32,7 +32,7 @@ func TestTranslatePathsApps_FilePathRelativeSubDirectory(t *testing.T) {
 			Resources: config.Resources{
 				Apps: map[string]*resources.App{
 					"app": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "My App",
 						},
 						SourceCodePath: "../src/app",

--- a/bundle/config/mutator/translate_paths_dashboards_test.go
+++ b/bundle/config/mutator/translate_paths_dashboards_test.go
@@ -29,7 +29,7 @@ func TestTranslatePathsDashboards_FilePathRelativeSubDirectory(t *testing.T) {
 			Resources: config.Resources{
 				Dashboards: map[string]*resources.Dashboard{
 					"dashboard": {
-						Dashboard: &dashboards.Dashboard{
+						Dashboard: dashboards.Dashboard{
 							DisplayName: "My Dashboard",
 						},
 						FilePath: "../src/my_dashboard.lvdash.json",

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -53,7 +53,7 @@ func TestTranslatePathsSkippedWithGitSource(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							GitSource: &jobs.GitSource{
 								GitBranch:   "somebranch",
 								GitCommit:   "somecommit",
@@ -126,7 +126,7 @@ func TestTranslatePaths(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									NotebookTask: &jobs.NotebookTask{
@@ -303,7 +303,7 @@ func TestTranslatePathsInSubdirectories(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									SparkPythonTask: &jobs.SparkPythonTask{
@@ -399,7 +399,7 @@ func TestTranslatePathsOutsideSyncRoot(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									SparkPythonTask: &jobs.SparkPythonTask{
@@ -431,7 +431,7 @@ func TestJobNotebookDoesNotExistError(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									NotebookTask: &jobs.NotebookTask{
@@ -463,7 +463,7 @@ func TestJobFileDoesNotExistError(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									SparkPythonTask: &jobs.SparkPythonTask{
@@ -617,7 +617,7 @@ func TestJobSparkPythonTaskWithNotebookSourceError(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									SparkPythonTask: &jobs.SparkPythonTask{
@@ -653,7 +653,7 @@ func TestJobNotebookTaskWithFileSourceError(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									NotebookTask: &jobs.NotebookTask{
@@ -759,7 +759,7 @@ func TestTranslatePathJobEnvironments(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Environments: []jobs.JobEnvironment{
 								{
 									Spec: &compute.Environment{
@@ -816,7 +816,7 @@ func TestTranslatePathWithComplexVariables(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey: "test",
@@ -881,7 +881,7 @@ func TestTranslatePathsWithSourceLinkedDeployment(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									NotebookTask: &jobs.NotebookTask{

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -181,7 +181,7 @@ func TestTranslatePaths(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									Notebook: &pipelines.NotebookLibrary{
@@ -336,7 +336,7 @@ func TestTranslatePathsInSubdirectories(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									File: &pipelines.FileLibrary{
@@ -495,7 +495,7 @@ func TestPipelineNotebookDoesNotExistError(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									Notebook: &pipelines.NotebookLibrary{
@@ -540,7 +540,7 @@ func TestPipelineNotebookDoesNotExistErrorWithoutExtension(t *testing.T) {
 					Resources: config.Resources{
 						Pipelines: map[string]*resources.Pipeline{
 							"pipeline": {
-								CreatePipeline: &pipelines.CreatePipeline{
+								CreatePipeline: pipelines.CreatePipeline{
 									Libraries: []pipelines.PipelineLibrary{
 										{
 											Notebook: &pipelines.NotebookLibrary{
@@ -581,7 +581,7 @@ func TestPipelineFileDoesNotExistError(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									File: &pipelines.FileLibrary{
@@ -689,7 +689,7 @@ func TestPipelineNotebookLibraryWithFileSourceError(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									Notebook: &pipelines.NotebookLibrary{
@@ -725,7 +725,7 @@ func TestPipelineFileLibraryWithNotebookSourceError(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									File: &pipelines.FileLibrary{
@@ -931,7 +931,7 @@ func TestTranslatePathsWithSourceLinkedDeployment(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Libraries: []pipelines.PipelineLibrary{
 								{
 									Notebook: &pipelines.NotebookLibrary{

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -46,9 +46,6 @@ type ConfigResource interface {
 
 	// InitializeURL initializes the URL field of the resource.
 	InitializeURL(baseURL url.URL)
-
-	// IsNil returns true if the resource is nil, for example, when it was removed from the bundle.
-	IsNil() bool
 }
 
 // ResourceGroup represents a group of resources of the same type.
@@ -65,9 +62,6 @@ func collectResourceMap[T ConfigResource](
 ) ResourceGroup {
 	r := make(map[string]ConfigResource)
 	for key, resource := range input {
-		if resource.IsNil() {
-			continue
-		}
 		r[key] = resource
 	}
 	return ResourceGroup{

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -37,7 +37,7 @@ type App struct {
 	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string          `json:"url,omitempty" bundle:"internal"`
 
-	*apps.App
+	apps.App
 }
 
 func (a *App) UnmarshalJSON(b []byte) error {
@@ -88,5 +88,5 @@ func (a *App) GetURL() string {
 }
 
 func (a *App) IsNil() bool {
-	return a.App == nil
+	return false
 }

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -86,7 +86,3 @@ func (a *App) GetName() string {
 func (a *App) GetURL() string {
 	return a.URL
 }
-
-func (a *App) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -77,7 +77,3 @@ func (s *Cluster) GetName() string {
 func (s *Cluster) GetURL() string {
 	return s.URL
 }
-
-func (s *Cluster) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	ModifiedStatus ModifiedStatus      `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string              `json:"url,omitempty" bundle:"internal"`
 
-	*compute.ClusterSpec
+	compute.ClusterSpec
 }
 
 func (s *Cluster) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -79,5 +79,5 @@ func (s *Cluster) GetURL() string {
 }
 
 func (s *Cluster) IsNil() bool {
-	return s.ClusterSpec == nil
+	return false
 }

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -29,7 +29,7 @@ type Dashboard struct {
 	ModifiedStatus ModifiedStatus        `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string                `json:"url,omitempty" bundle:"internal"`
 
-	*dashboards.Dashboard
+	dashboards.Dashboard
 
 	// =========================
 	// === Additional fields ===
@@ -103,5 +103,5 @@ func (r *Dashboard) GetURL() string {
 }
 
 func (r *Dashboard) IsNil() bool {
-	return r.Dashboard == nil
+	return false
 }

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -101,7 +101,3 @@ func (r *Dashboard) GetName() string {
 func (r *Dashboard) GetURL() string {
 	return r.URL
 }
-
-func (r *Dashboard) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -84,7 +84,3 @@ func (j *Job) GetName() string {
 func (j *Job) GetURL() string {
 	return j.URL
 }
-
-func (j *Job) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -29,7 +29,7 @@ type Job struct {
 	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string          `json:"url,omitempty" bundle:"internal"`
 
-	*jobs.JobSettings
+	jobs.JobSettings
 }
 
 func (s *Job) UnmarshalJSON(b []byte) error {
@@ -86,5 +86,5 @@ func (j *Job) GetURL() string {
 }
 
 func (j *Job) IsNil() bool {
-	return j.JobSettings == nil
+	return false
 }

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -29,7 +29,7 @@ type Job struct {
 	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string          `json:"url,omitempty" bundle:"internal"`
 
-	jobs.JobSettings
+	jobs.JobSettings `json:",omitempty"`
 }
 
 func (s *Job) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -29,7 +29,7 @@ type Job struct {
 	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string          `json:"url,omitempty" bundle:"internal"`
 
-	jobs.JobSettings `json:",omitempty"`
+	jobs.JobSettings
 }
 
 func (s *Job) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -79,7 +79,3 @@ func (s *MlflowExperiment) GetName() string {
 func (s *MlflowExperiment) GetURL() string {
 	return s.URL
 }
-
-func (s *MlflowExperiment) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -28,7 +28,7 @@ type MlflowExperiment struct {
 	ModifiedStatus ModifiedStatus               `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string                       `json:"url,omitempty" bundle:"internal"`
 
-	*ml.Experiment
+	ml.Experiment
 }
 
 func (s *MlflowExperiment) UnmarshalJSON(b []byte) error {
@@ -81,5 +81,5 @@ func (s *MlflowExperiment) GetURL() string {
 }
 
 func (s *MlflowExperiment) IsNil() bool {
-	return s.Experiment == nil
+	return false
 }

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -28,7 +28,7 @@ type MlflowModel struct {
 	ModifiedStatus ModifiedStatus          `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string                  `json:"url,omitempty" bundle:"internal"`
 
-	*ml.Model
+	ml.Model
 }
 
 func (s *MlflowModel) UnmarshalJSON(b []byte) error {
@@ -81,5 +81,5 @@ func (s *MlflowModel) GetURL() string {
 }
 
 func (s *MlflowModel) IsNil() bool {
-	return s.Model == nil
+	return false
 }

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -79,7 +79,3 @@ func (s *MlflowModel) GetName() string {
 func (s *MlflowModel) GetURL() string {
 	return s.URL
 }
-
-func (s *MlflowModel) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -25,7 +25,7 @@ type ModelServingEndpointPermission struct {
 type ModelServingEndpoint struct {
 	// This represents the input args for terraform, and will get converted
 	// to a HCL representation for CRUD
-	*serving.CreateServingEndpoint
+	serving.CreateServingEndpoint
 
 	// This represents the id (ie serving_endpoint_id) that can be used
 	// as a reference in other resources. This value is returned by terraform.
@@ -89,5 +89,5 @@ func (s *ModelServingEndpoint) GetURL() string {
 }
 
 func (s *ModelServingEndpoint) IsNil() bool {
-	return s.CreateServingEndpoint == nil
+	return false
 }

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -87,7 +87,3 @@ func (s *ModelServingEndpoint) GetName() string {
 func (s *ModelServingEndpoint) GetURL() string {
 	return s.URL
 }
-
-func (s *ModelServingEndpoint) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -28,7 +28,7 @@ type Pipeline struct {
 	ModifiedStatus ModifiedStatus       `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string               `json:"url,omitempty" bundle:"internal"`
 
-	*pipelines.CreatePipeline
+	pipelines.CreatePipeline
 }
 
 func (s *Pipeline) UnmarshalJSON(b []byte) error {
@@ -81,5 +81,5 @@ func (s *Pipeline) GetURL() string {
 }
 
 func (s *Pipeline) IsNil() bool {
-	return s.CreatePipeline == nil
+	return false
 }

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -79,7 +79,3 @@ func (p *Pipeline) GetName() string {
 func (s *Pipeline) GetURL() string {
 	return s.URL
 }
-
-func (s *Pipeline) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/quality_monitor.go
+++ b/bundle/config/resources/quality_monitor.go
@@ -20,7 +20,7 @@ type QualityMonitor struct {
 	TableName string `json:"table_name"`
 
 	// This struct defines the creation payload for a monitor.
-	*catalog.CreateMonitor
+	catalog.CreateMonitor
 }
 
 func (s *QualityMonitor) UnmarshalJSON(b []byte) error {
@@ -73,5 +73,5 @@ func (s *QualityMonitor) GetURL() string {
 }
 
 func (s *QualityMonitor) IsNil() bool {
-	return s.CreateMonitor == nil
+	return false
 }

--- a/bundle/config/resources/quality_monitor.go
+++ b/bundle/config/resources/quality_monitor.go
@@ -71,7 +71,3 @@ func (s *QualityMonitor) GetName() string {
 func (s *QualityMonitor) GetURL() string {
 	return s.URL
 }
-
-func (s *QualityMonitor) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/registered_model.go
+++ b/bundle/config/resources/registered_model.go
@@ -23,7 +23,7 @@ type RegisteredModel struct {
 
 	// This represents the input args for terraform, and will get converted
 	// to a HCL representation for CRUD
-	*catalog.CreateRegisteredModelRequest
+	catalog.CreateRegisteredModelRequest
 
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string         `json:"url,omitempty" bundle:"internal"`
@@ -79,5 +79,5 @@ func (s *RegisteredModel) GetURL() string {
 }
 
 func (s *RegisteredModel) IsNil() bool {
-	return s.CreateRegisteredModelRequest == nil
+	return false
 }

--- a/bundle/config/resources/registered_model.go
+++ b/bundle/config/resources/registered_model.go
@@ -77,7 +77,3 @@ func (s *RegisteredModel) GetName() string {
 func (s *RegisteredModel) GetURL() string {
 	return s.URL
 }
-
-func (s *RegisteredModel) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/schema.go
+++ b/bundle/config/resources/schema.go
@@ -22,7 +22,7 @@ type Schema struct {
 	// the terraform state after deployment succeeds.
 	ID string `json:"id,omitempty" bundle:"readonly"`
 
-	*catalog.CreateSchema
+	catalog.CreateSchema
 
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string         `json:"url,omitempty" bundle:"internal"`
@@ -83,5 +83,5 @@ func (s Schema) MarshalJSON() ([]byte, error) {
 }
 
 func (s *Schema) IsNil() bool {
-	return s.CreateSchema == nil
+	return false
 }

--- a/bundle/config/resources/schema.go
+++ b/bundle/config/resources/schema.go
@@ -81,7 +81,3 @@ func (s *Schema) UnmarshalJSON(b []byte) error {
 func (s Schema) MarshalJSON() ([]byte, error) {
 	return marshal.Marshal(s)
 }
-
-func (s *Schema) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -81,7 +81,3 @@ func (v *Volume) GetURL() string {
 func (v *Volume) GetName() string {
 	return v.Name
 }
-
-func (v *Volume) IsNil() bool {
-	return false
-}

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -21,7 +21,7 @@ type Volume struct {
 	// the terraform state after deployment succeeds.
 	ID string `json:"id,omitempty" bundle:"readonly"`
 
-	*catalog.CreateVolumeRequestContent
+	catalog.CreateVolumeRequestContent
 
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string         `json:"url,omitempty" bundle:"internal"`
@@ -83,5 +83,5 @@ func (v *Volume) GetName() string {
 }
 
 func (v *Volume) IsNil() bool {
-	return v.CreateVolumeRequestContent == nil
+	return false
 }

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -143,7 +143,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Clusters: map[string]*resources.Cluster{
 			"my_cluster": {
-				ClusterSpec: compute.ClusterSpec{},
+				ClusterSpec: &compute.ClusterSpec{},
 			},
 		},
 		Dashboards: map[string]*resources.Dashboard{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -117,7 +117,7 @@ func TestResourcesBindSupport(t *testing.T) {
 	supportedResources := &Resources{
 		Jobs: map[string]*resources.Job{
 			"my_job": {
-				JobSettings: &jobs.JobSettings{},
+				JobSettings: jobs.JobSettings{},
 			},
 		},
 		Pipelines: map[string]*resources.Pipeline{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/apps"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
@@ -142,9 +141,7 @@ func TestResourcesBindSupport(t *testing.T) {
 			},
 		},
 		Clusters: map[string]*resources.Cluster{
-			"my_cluster": {
-				ClusterSpec: &compute.ClusterSpec{},
-			},
+			"my_cluster": {},
 		},
 		Dashboards: map[string]*resources.Dashboard{
 			"my_dashboard": {

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -143,7 +143,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Clusters: map[string]*resources.Cluster{
 			"my_cluster": {
-				ClusterSpec: &compute.ClusterSpec{},
+				ClusterSpec: compute.ClusterSpec{},
 			},
 		},
 		Dashboards: map[string]*resources.Dashboard{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -127,7 +127,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Experiments: map[string]*resources.MlflowExperiment{
 			"my_experiment": {
-				Experiment: &ml.Experiment{},
+				Experiment: ml.Experiment{},
 			},
 		},
 		RegisteredModels: map[string]*resources.RegisteredModel{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -153,7 +153,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Volumes: map[string]*resources.Volume{
 			"my_volume": {
-				CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{},
+				CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{},
 			},
 		},
 		Apps: map[string]*resources.App{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -165,7 +165,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 			"my_model_serving_endpoint": {
-				CreateServingEndpoint: &serving.CreateServingEndpoint{},
+				CreateServingEndpoint: serving.CreateServingEndpoint{},
 			},
 		},
 	}

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -158,7 +158,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Apps: map[string]*resources.App{
 			"my_app": {
-				App: &apps.App{},
+				App: apps.App{},
 			},
 		},
 		QualityMonitors: map[string]*resources.QualityMonitor{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -122,7 +122,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Pipelines: map[string]*resources.Pipeline{
 			"my_pipeline": {
-				CreatePipeline: &pipelines.CreatePipeline{},
+				CreatePipeline: pipelines.CreatePipeline{},
 			},
 		},
 		Experiments: map[string]*resources.MlflowExperiment{

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -132,12 +132,12 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		RegisteredModels: map[string]*resources.RegisteredModel{
 			"my_registered_model": {
-				CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{},
+				CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{},
 			},
 		},
 		Schemas: map[string]*resources.Schema{
 			"my_schema": {
-				CreateSchema: &catalog.CreateSchema{},
+				CreateSchema: catalog.CreateSchema{},
 			},
 		},
 		Clusters: map[string]*resources.Cluster{
@@ -145,7 +145,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Dashboards: map[string]*resources.Dashboard{
 			"my_dashboard": {
-				Dashboard: &dashboards.Dashboard{},
+				Dashboard: dashboards.Dashboard{},
 			},
 		},
 		Volumes: map[string]*resources.Volume{
@@ -160,7 +160,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		QualityMonitors: map[string]*resources.QualityMonitor{
 			"my_quality_monitor": {
-				CreateMonitor: &catalog.CreateMonitor{},
+				CreateMonitor: catalog.CreateMonitor{},
 			},
 		},
 		ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{

--- a/bundle/config/validate/job_cluster_key_defined_test.go
+++ b/bundle/config/validate/job_cluster_key_defined_test.go
@@ -18,7 +18,7 @@ func TestJobClusterKeyDefined(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job1",
 							JobClusters: []jobs.JobCluster{
 								{JobClusterKey: "do-not-exist"},
@@ -44,7 +44,7 @@ func TestJobClusterKeyNotDefined(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job1",
 							Tasks: []jobs.Task{
 								{JobClusterKey: "do-not-exist"},
@@ -69,7 +69,7 @@ func TestJobClusterKeyDefinedInDifferentJob(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job1",
 							Tasks: []jobs.Task{
 								{JobClusterKey: "do-not-exist"},
@@ -77,7 +77,7 @@ func TestJobClusterKeyDefinedInDifferentJob(t *testing.T) {
 						},
 					},
 					"job2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "job2",
 							JobClusters: []jobs.JobCluster{
 								{JobClusterKey: "do-not-exist"},

--- a/bundle/config/validate/job_task_cluster_spec_test.go
+++ b/bundle/config/validate/job_task_cluster_spec_test.go
@@ -168,7 +168,7 @@ Specify one of the following fields: job_cluster_key, environment_key, existing_
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			job := &resources.Job{
-				JobSettings: &jobs.JobSettings{
+				JobSettings: jobs.JobSettings{
 					Tasks: []jobs.Task{tc.task},
 				},
 			}

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -143,7 +143,7 @@ func TestValidateSingleNodeClusterFailForJobClusters(t *testing.T) {
 								JobSettings: &jobs.JobSettings{
 									JobClusters: []jobs.JobCluster{
 										{
-											NewCluster: &compute.ClusterSpec{
+											NewCluster: compute.ClusterSpec{
 												ClusterName: "my_cluster",
 												SparkConf:   tc.sparkConf,
 												CustomTags:  tc.customTags,
@@ -416,7 +416,7 @@ func TestValidateSingleNodeClusterPassJobClusters(t *testing.T) {
 								JobSettings: &jobs.JobSettings{
 									JobClusters: []jobs.JobCluster{
 										{
-											NewCluster: &compute.ClusterSpec{
+											NewCluster: compute.ClusterSpec{
 												ClusterName: "my_cluster",
 												SparkConf:   tc.sparkConf,
 												CustomTags:  tc.customTags,

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -99,7 +99,7 @@ func TestValidateSingleNodeClusterFailForInteractiveClusters(t *testing.T) {
 					Resources: config.Resources{
 						Clusters: map[string]*resources.Cluster{
 							"foo": {
-								ClusterSpec: &compute.ClusterSpec{
+								ClusterSpec: compute.ClusterSpec{
 									SparkConf:  tc.sparkConf,
 									CustomTags: tc.customTags,
 								},
@@ -289,7 +289,7 @@ func TestValidateSingleNodeClusterFailForJobForEachTaskCluster(t *testing.T) {
 										{
 											ForEachTask: &jobs.ForEachTask{
 												Task: jobs.Task{
-													NewCluster: &compute.ClusterSpec{
+													NewCluster: compute.ClusterSpec{
 														ClusterName: "my_cluster",
 														SparkConf:   tc.sparkConf,
 														CustomTags:  tc.customTags,

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -238,7 +238,7 @@ func TestValidateSingleNodeClusterFailForPipelineClusters(t *testing.T) {
 					Resources: config.Resources{
 						Pipelines: map[string]*resources.Pipeline{
 							"foo": {
-								CreatePipeline: &pipelines.CreatePipeline{
+								CreatePipeline: pipelines.CreatePipeline{
 									Clusters: []pipelines.PipelineCluster{
 										{
 											SparkConf:  tc.sparkConf,
@@ -493,7 +493,7 @@ func TestValidateSingleNodeClusterPassPipelineClusters(t *testing.T) {
 					Resources: config.Resources{
 						Pipelines: map[string]*resources.Pipeline{
 							"foo": {
-								CreatePipeline: &pipelines.CreatePipeline{
+								CreatePipeline: pipelines.CreatePipeline{
 									Clusters: []pipelines.PipelineCluster{
 										{
 											SparkConf:  tc.sparkConf,

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -140,7 +140,7 @@ func TestValidateSingleNodeClusterFailForJobClusters(t *testing.T) {
 					Resources: config.Resources{
 						Jobs: map[string]*resources.Job{
 							"foo": {
-								JobSettings: &jobs.JobSettings{
+								JobSettings: jobs.JobSettings{
 									JobClusters: []jobs.JobCluster{
 										{
 											NewCluster: compute.ClusterSpec{
@@ -189,7 +189,7 @@ func TestValidateSingleNodeClusterFailForJobTaskClusters(t *testing.T) {
 					Resources: config.Resources{
 						Jobs: map[string]*resources.Job{
 							"foo": {
-								JobSettings: &jobs.JobSettings{
+								JobSettings: jobs.JobSettings{
 									Tasks: []jobs.Task{
 										{
 											NewCluster: &compute.ClusterSpec{
@@ -284,7 +284,7 @@ func TestValidateSingleNodeClusterFailForJobForEachTaskCluster(t *testing.T) {
 					Resources: config.Resources{
 						Jobs: map[string]*resources.Job{
 							"foo": {
-								JobSettings: &jobs.JobSettings{
+								JobSettings: jobs.JobSettings{
 									Tasks: []jobs.Task{
 										{
 											ForEachTask: &jobs.ForEachTask{
@@ -413,7 +413,7 @@ func TestValidateSingleNodeClusterPassJobClusters(t *testing.T) {
 					Resources: config.Resources{
 						Jobs: map[string]*resources.Job{
 							"foo": {
-								JobSettings: &jobs.JobSettings{
+								JobSettings: jobs.JobSettings{
 									JobClusters: []jobs.JobCluster{
 										{
 											NewCluster: compute.ClusterSpec{
@@ -453,7 +453,7 @@ func TestValidateSingleNodeClusterPassJobTaskClusters(t *testing.T) {
 					Resources: config.Resources{
 						Jobs: map[string]*resources.Job{
 							"foo": {
-								JobSettings: &jobs.JobSettings{
+								JobSettings: jobs.JobSettings{
 									Tasks: []jobs.Task{
 										{
 											NewCluster: &compute.ClusterSpec{
@@ -530,7 +530,7 @@ func TestValidateSingleNodeClusterPassJobForEachTaskCluster(t *testing.T) {
 					Resources: config.Resources{
 						Jobs: map[string]*resources.Job{
 							"foo": {
-								JobSettings: &jobs.JobSettings{
+								JobSettings: jobs.JobSettings{
 									Tasks: []jobs.Task{
 										{
 											ForEachTask: &jobs.ForEachTask{

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -380,7 +380,7 @@ func TestValidateSingleNodeClusterPassInteractiveClusters(t *testing.T) {
 					Resources: config.Resources{
 						Clusters: map[string]*resources.Cluster{
 							"foo": {
-								ClusterSpec: &compute.ClusterSpec{
+								ClusterSpec: compute.ClusterSpec{
 									SparkConf:  tc.sparkConf,
 									CustomTags: tc.customTags,
 									PolicyId:   tc.policyId,

--- a/bundle/config/validate/single_node_cluster_test.go
+++ b/bundle/config/validate/single_node_cluster_test.go
@@ -143,7 +143,7 @@ func TestValidateSingleNodeClusterFailForJobClusters(t *testing.T) {
 								JobSettings: &jobs.JobSettings{
 									JobClusters: []jobs.JobCluster{
 										{
-											NewCluster: compute.ClusterSpec{
+											NewCluster: &compute.ClusterSpec{
 												ClusterName: "my_cluster",
 												SparkConf:   tc.sparkConf,
 												CustomTags:  tc.customTags,
@@ -289,7 +289,7 @@ func TestValidateSingleNodeClusterFailForJobForEachTaskCluster(t *testing.T) {
 										{
 											ForEachTask: &jobs.ForEachTask{
 												Task: jobs.Task{
-													NewCluster: compute.ClusterSpec{
+													NewCluster: &compute.ClusterSpec{
 														ClusterName: "my_cluster",
 														SparkConf:   tc.sparkConf,
 														CustomTags:  tc.customTags,
@@ -416,7 +416,7 @@ func TestValidateSingleNodeClusterPassJobClusters(t *testing.T) {
 								JobSettings: &jobs.JobSettings{
 									JobClusters: []jobs.JobCluster{
 										{
-											NewCluster: compute.ClusterSpec{
+											NewCluster: &compute.ClusterSpec{
 												ClusterName: "my_cluster",
 												SparkConf:   tc.sparkConf,
 												CustomTags:  tc.customTags,

--- a/bundle/config/validate/validate_artifact_path_test.go
+++ b/bundle/config/validate/validate_artifact_path_test.go
@@ -27,7 +27,7 @@ func TestValidateArtifactPathWithVolumeInBundle(t *testing.T) {
 			Resources: config.Resources{
 				Volumes: map[string]*resources.Volume{
 					"foo": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "catalogN",
 							Name:        "volumeN",
 							SchemaName:  "schemaN",
@@ -182,7 +182,7 @@ func TestFindVolumeInBundle(t *testing.T) {
 			Resources: config.Resources{
 				Volumes: map[string]*resources.Volume{
 					"foo": {
-						CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+						CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 							CatalogName: "main",
 							Name:        "my_volume",
 							SchemaName:  "my_schema",

--- a/bundle/deploy/metadata/annotate_jobs.go
+++ b/bundle/deploy/metadata/annotate_jobs.go
@@ -20,10 +20,6 @@ func (m *annotateJobs) Name() string {
 
 func (m *annotateJobs) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 	for _, job := range b.Config.Resources.Jobs {
-		if job.JobSettings == nil {
-			continue
-		}
-
 		job.JobSettings.Deployment = &jobs.JobDeployment{
 			Kind:             jobs.JobDeploymentKindBundle,
 			MetadataFilePath: metadataFilePath(b),

--- a/bundle/deploy/metadata/annotate_jobs_test.go
+++ b/bundle/deploy/metadata/annotate_jobs_test.go
@@ -21,12 +21,12 @@ func TestAnnotateJobsMutator(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"my-job-1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "My Job One",
 						},
 					},
 					"my-job-2": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "My Job Two",
 						},
 					},

--- a/bundle/deploy/metadata/annotate_pipelines.go
+++ b/bundle/deploy/metadata/annotate_pipelines.go
@@ -20,10 +20,6 @@ func (m *annotatePipelines) Name() string {
 
 func (m *annotatePipelines) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 	for _, pipeline := range b.Config.Resources.Pipelines {
-		if pipeline.CreatePipeline == nil {
-			continue
-		}
-
 		pipeline.CreatePipeline.Deployment = &pipelines.PipelineDeployment{
 			Kind:             pipelines.DeploymentKindBundle,
 			MetadataFilePath: metadataFilePath(b),

--- a/bundle/deploy/metadata/annotate_pipelines_test.go
+++ b/bundle/deploy/metadata/annotate_pipelines_test.go
@@ -21,12 +21,12 @@ func TestAnnotatePipelinesMutator(t *testing.T) {
 			Resources: config.Resources{
 				Pipelines: map[string]*resources.Pipeline{
 					"my-pipeline-1": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Name: "My Pipeline One",
 						},
 					},
 					"my-pipeline-2": {
-						CreatePipeline: &pipelines.CreatePipeline{
+						CreatePipeline: pipelines.CreatePipeline{
 							Name: "My Pipeline Two",
 						},
 					},

--- a/bundle/deploy/metadata/compute_test.go
+++ b/bundle/deploy/metadata/compute_test.go
@@ -37,13 +37,13 @@ func TestComputeMetadataMutator(t *testing.T) {
 				Jobs: map[string]*resources.Job{
 					"my-job-1": {
 						ID: "1111",
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "My Job One",
 						},
 					},
 					"my-job-2": {
 						ID: "2222",
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "My Job Two",
 						},
 					},

--- a/bundle/deploy/terraform/check_dashboards_modified_remotely_test.go
+++ b/bundle/deploy/terraform/check_dashboards_modified_remotely_test.go
@@ -29,7 +29,7 @@ func mockDashboardBundle(t *testing.T) *bundle.Bundle {
 			Resources: config.Resources{
 				Dashboards: map[string]*resources.Dashboard{
 					"dash1": {
-						Dashboard: &dashboards.Dashboard{
+						Dashboard: dashboards.Dashboard{
 							DisplayName: "My Special Dashboard",
 						},
 					},

--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -203,7 +203,7 @@ func TerraformToBundle(state *resourcesState, config *config.Root) error {
 				}
 				cur := config.Resources.Apps[resource.Name]
 				if cur == nil {
-					cur = &resources.App{ModifiedStatus: resources.ModifiedStatusDeleted, App: &apps.App{}}
+					cur = &resources.App{ModifiedStatus: resources.ModifiedStatusDeleted}
 				} else {
 					// If the app exists in terraform and bundle, we always set modified status to updated
 					// because we don't really know if the app source code was updated or not.

--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -9,7 +9,6 @@ import (
 	"github.com/databricks/cli/bundle/deploy/terraform/tfdyn"
 	"github.com/databricks/cli/bundle/internal/tf/schema"
 	"github.com/databricks/cli/libs/dyn"
-	"github.com/databricks/databricks-sdk-go/service/apps"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -203,7 +203,7 @@ func TestBundleToTerraformForEachTaskLibraries(t *testing.T) {
 
 func TestBundleToTerraformPipeline(t *testing.T) {
 	src := resources.Pipeline{
-		CreatePipeline: &pipelines.CreatePipeline{
+		CreatePipeline: pipelines.CreatePipeline{
 			Name: "my pipeline",
 			Libraries: []pipelines.PipelineLibrary{
 				{
@@ -759,7 +759,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Pipelines: map[string]*resources.Pipeline{
 				"test_pipeline": {
-					CreatePipeline: &pipelines.CreatePipeline{
+					CreatePipeline: pipelines.CreatePipeline{
 						Name: "test_pipeline",
 					},
 				},
@@ -898,12 +898,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Pipelines: map[string]*resources.Pipeline{
 				"test_pipeline": {
-					CreatePipeline: &pipelines.CreatePipeline{
+					CreatePipeline: pipelines.CreatePipeline{
 						Name: "test_pipeline",
 					},
 				},
 				"test_pipeline_new": {
-					CreatePipeline: &pipelines.CreatePipeline{
+					CreatePipeline: pipelines.CreatePipeline{
 						Name: "test_pipeline_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -815,7 +815,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Clusters: map[string]*resources.Cluster{
 				"test_cluster": {
-					ClusterSpec: &compute.ClusterSpec{
+					ClusterSpec: compute.ClusterSpec{
 						ClusterName: "test_cluster",
 					},
 				},
@@ -994,12 +994,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Clusters: map[string]*resources.Cluster{
 				"test_cluster": {
-					ClusterSpec: &compute.ClusterSpec{
+					ClusterSpec: compute.ClusterSpec{
 						ClusterName: "test_cluster",
 					},
 				},
 				"test_cluster_new": {
-					ClusterSpec: &compute.ClusterSpec{
+					ClusterSpec: compute.ClusterSpec{
 						ClusterName: "test_cluster_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -513,7 +513,7 @@ func TestBundleToTerraformModelServingPermissions(t *testing.T) {
 
 func TestBundleToTerraformRegisteredModel(t *testing.T) {
 	src := resources.RegisteredModel{
-		CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+		CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 			Name:        "name",
 			CatalogName: "catalog",
 			SchemaName:  "schema",
@@ -542,7 +542,7 @@ func TestBundleToTerraformRegisteredModel(t *testing.T) {
 
 func TestBundleToTerraformRegisteredModelGrants(t *testing.T) {
 	src := resources.RegisteredModel{
-		CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+		CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 			Name:        "name",
 			CatalogName: "catalog",
 			SchemaName:  "schema",
@@ -787,21 +787,21 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			RegisteredModels: map[string]*resources.RegisteredModel{
 				"test_registered_model": {
-					CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+					CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 						Name: "test_registered_model",
 					},
 				},
 			},
 			QualityMonitors: map[string]*resources.QualityMonitor{
 				"test_monitor": {
-					CreateMonitor: &catalog.CreateMonitor{
+					CreateMonitor: catalog.CreateMonitor{
 						TableName: "test_monitor",
 					},
 				},
 			},
 			Schemas: map[string]*resources.Schema{
 				"test_schema": {
-					CreateSchema: &catalog.CreateSchema{
+					CreateSchema: catalog.CreateSchema{
 						Name: "test_schema",
 					},
 				},
@@ -822,7 +822,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Dashboards: map[string]*resources.Dashboard{
 				"test_dashboard": {
-					Dashboard: &dashboards.Dashboard{
+					Dashboard: dashboards.Dashboard{
 						DisplayName: "test_dashboard",
 					},
 				},
@@ -946,36 +946,36 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			RegisteredModels: map[string]*resources.RegisteredModel{
 				"test_registered_model": {
-					CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+					CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 						Name: "test_registered_model",
 					},
 				},
 				"test_registered_model_new": {
-					CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+					CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 						Name: "test_registered_model_new",
 					},
 				},
 			},
 			QualityMonitors: map[string]*resources.QualityMonitor{
 				"test_monitor": {
-					CreateMonitor: &catalog.CreateMonitor{
+					CreateMonitor: catalog.CreateMonitor{
 						TableName: "test_monitor",
 					},
 				},
 				"test_monitor_new": {
-					CreateMonitor: &catalog.CreateMonitor{
+					CreateMonitor: catalog.CreateMonitor{
 						TableName: "test_monitor_new",
 					},
 				},
 			},
 			Schemas: map[string]*resources.Schema{
 				"test_schema": {
-					CreateSchema: &catalog.CreateSchema{
+					CreateSchema: catalog.CreateSchema{
 						Name: "test_schema",
 					},
 				},
 				"test_schema_new": {
-					CreateSchema: &catalog.CreateSchema{
+					CreateSchema: catalog.CreateSchema{
 						Name: "test_schema_new",
 					},
 				},
@@ -1006,12 +1006,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Dashboards: map[string]*resources.Dashboard{
 				"test_dashboard": {
-					Dashboard: &dashboards.Dashboard{
+					Dashboard: dashboards.Dashboard{
 						DisplayName: "test_dashboard",
 					},
 				},
 				"test_dashboard_new": {
-					Dashboard: &dashboards.Dashboard{
+					Dashboard: dashboards.Dashboard{
 						DisplayName: "test_dashboard_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -815,7 +815,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Clusters: map[string]*resources.Cluster{
 				"test_cluster": {
-					ClusterSpec: &compute.ClusterSpec{
+					ClusterSpec: compute.ClusterSpec{
 						ClusterName: "test_cluster",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -829,7 +829,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Apps: map[string]*resources.App{
 				"test_app": {
-					App: &apps.App{
+					App: apps.App{
 						Description: "test_app",
 					},
 				},
@@ -1018,12 +1018,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Apps: map[string]*resources.App{
 				"test_app": {
-					App: &apps.App{
+					App: apps.App{
 						Name: "test_app",
 					},
 				},
 				"test_app_new": {
-					App: &apps.App{
+					App: apps.App{
 						Name: "test_app_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -363,7 +363,7 @@ func TestBundleToTerraformModelPermissions(t *testing.T) {
 
 func TestBundleToTerraformExperiment(t *testing.T) {
 	src := resources.MlflowExperiment{
-		Experiment: &ml.Experiment{
+		Experiment: ml.Experiment{
 			Name: "name",
 		},
 	}
@@ -386,7 +386,7 @@ func TestBundleToTerraformExperiment(t *testing.T) {
 
 func TestBundleToTerraformExperimentPermissions(t *testing.T) {
 	src := resources.MlflowExperiment{
-		Experiment: &ml.Experiment{
+		Experiment: ml.Experiment{
 			Name: "name",
 		},
 		Permissions: []resources.MlflowExperimentPermission{
@@ -773,7 +773,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Experiments: map[string]*resources.MlflowExperiment{
 				"test_mlflow_experiment": {
-					Experiment: &ml.Experiment{
+					Experiment: ml.Experiment{
 						Name: "test_mlflow_experiment",
 					},
 				},
@@ -922,12 +922,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Experiments: map[string]*resources.MlflowExperiment{
 				"test_mlflow_experiment": {
-					Experiment: &ml.Experiment{
+					Experiment: ml.Experiment{
 						Name: "test_mlflow_experiment",
 					},
 				},
 				"test_mlflow_experiment_new": {
-					Experiment: &ml.Experiment{
+					Experiment: ml.Experiment{
 						Name: "test_mlflow_experiment_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -808,7 +808,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Volumes: map[string]*resources.Volume{
 				"test_volume": {
-					CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+					CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 						Name: "test_volume",
 					},
 				},
@@ -982,12 +982,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Volumes: map[string]*resources.Volume{
 				"test_volume": {
-					CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+					CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 						Name: "test_volume",
 					},
 				},
 				"test_volume_new": {
-					CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+					CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 						Name: "test_volume_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -292,7 +292,7 @@ func TestBundleToTerraformPipelinePermissions(t *testing.T) {
 
 func TestBundleToTerraformModel(t *testing.T) {
 	src := resources.MlflowModel{
-		Model: &ml.Model{
+		Model: ml.Model{
 			Name:        "name",
 			Description: "description",
 			Tags: []ml.ModelTag{
@@ -332,7 +332,7 @@ func TestBundleToTerraformModel(t *testing.T) {
 
 func TestBundleToTerraformModelPermissions(t *testing.T) {
 	src := resources.MlflowModel{
-		Model: &ml.Model{
+		Model: ml.Model{
 			Name: "name",
 		},
 		Permissions: []resources.MlflowModelPermission{
@@ -766,7 +766,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Models: map[string]*resources.MlflowModel{
 				"test_mlflow_model": {
-					Model: &ml.Model{
+					Model: ml.Model{
 						Name: "test_mlflow_model",
 					},
 				},
@@ -910,12 +910,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			Models: map[string]*resources.MlflowModel{
 				"test_mlflow_model": {
-					Model: &ml.Model{
+					Model: ml.Model{
 						Name: "test_mlflow_model",
 					},
 				},
 				"test_mlflow_model_new": {
-					Model: &ml.Model{
+					Model: ml.Model{
 						Name: "test_mlflow_model_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -815,7 +815,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Clusters: map[string]*resources.Cluster{
 				"test_cluster": {
-					ClusterSpec: compute.ClusterSpec{
+					ClusterSpec: &compute.ClusterSpec{
 						ClusterName: "test_cluster",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -417,7 +417,7 @@ func TestBundleToTerraformExperimentPermissions(t *testing.T) {
 
 func TestBundleToTerraformModelServing(t *testing.T) {
 	src := resources.ModelServingEndpoint{
-		CreateServingEndpoint: &serving.CreateServingEndpoint{
+		CreateServingEndpoint: serving.CreateServingEndpoint{
 			Name: "name",
 			Config: &serving.EndpointCoreConfigInput{
 				ServedModels: []serving.ServedModelInput{
@@ -464,7 +464,7 @@ func TestBundleToTerraformModelServing(t *testing.T) {
 
 func TestBundleToTerraformModelServingPermissions(t *testing.T) {
 	src := resources.ModelServingEndpoint{
-		CreateServingEndpoint: &serving.CreateServingEndpoint{
+		CreateServingEndpoint: serving.CreateServingEndpoint{
 			Name: "name",
 
 			// Need to specify this to satisfy the equivalence test:
@@ -780,7 +780,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 				"test_model_serving": {
-					CreateServingEndpoint: &serving.CreateServingEndpoint{
+					CreateServingEndpoint: serving.CreateServingEndpoint{
 						Name: "test_model_serving",
 					},
 				},
@@ -934,12 +934,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 			},
 			ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 				"test_model_serving": {
-					CreateServingEndpoint: &serving.CreateServingEndpoint{
+					CreateServingEndpoint: serving.CreateServingEndpoint{
 						Name: "test_model_serving",
 					},
 				},
 				"test_model_serving_new": {
-					CreateServingEndpoint: &serving.CreateServingEndpoint{
+					CreateServingEndpoint: serving.CreateServingEndpoint{
 						Name: "test_model_serving_new",
 					},
 				},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -45,7 +45,7 @@ func convertToResourceStruct[T any](t *testing.T, resource *T, data any) {
 
 func TestBundleToTerraformJob(t *testing.T) {
 	src := resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Name: "my job",
 			JobClusters: []jobs.JobCluster{
 				{
@@ -123,7 +123,7 @@ func TestBundleToTerraformJobPermissions(t *testing.T) {
 
 func TestBundleToTerraformJobTaskLibraries(t *testing.T) {
 	src := resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Name: "my job",
 			Tasks: []jobs.Task{
 				{
@@ -160,7 +160,7 @@ func TestBundleToTerraformJobTaskLibraries(t *testing.T) {
 
 func TestBundleToTerraformForEachTaskLibraries(t *testing.T) {
 	src := resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Name: "my job",
 			Tasks: []jobs.Task{
 				{
@@ -575,11 +575,11 @@ func TestBundleToTerraformRegisteredModelGrants(t *testing.T) {
 
 func TestBundleToTerraformDeletedResources(t *testing.T) {
 	job1 := resources.Job{
-		JobSettings: &jobs.JobSettings{},
+		JobSettings: jobs.JobSettings{},
 	}
 	job2 := resources.Job{
 		ModifiedStatus: resources.ModifiedStatusDeleted,
-		JobSettings:    &jobs.JobSettings{},
+		JobSettings:    jobs.JobSettings{},
 	}
 	config := config.Root{
 		Resources: config.Resources{
@@ -752,7 +752,7 @@ func TestTerraformToBundleEmptyRemoteResources(t *testing.T) {
 		Resources: config.Resources{
 			Jobs: map[string]*resources.Job{
 				"test_job": {
-					JobSettings: &jobs.JobSettings{
+					JobSettings: jobs.JobSettings{
 						Name: "test_job",
 					},
 				},
@@ -886,12 +886,12 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 		Resources: config.Resources{
 			Jobs: map[string]*resources.Job{
 				"test_job": {
-					JobSettings: &jobs.JobSettings{
+					JobSettings: jobs.JobSettings{
 						Name: "test_job",
 					},
 				},
 				"test_job_new": {
-					JobSettings: &jobs.JobSettings{
+					JobSettings: jobs.JobSettings{
 						Name: "test_job_new",
 					},
 				},

--- a/bundle/deploy/terraform/interpolate_test.go
+++ b/bundle/deploy/terraform/interpolate_test.go
@@ -51,7 +51,7 @@ func TestInterpolate(t *testing.T) {
 				},
 				Models: map[string]*resources.MlflowModel{
 					"my_model": {
-						Model: &ml.Model{
+						Model: ml.Model{
 							Name: "my_model",
 						},
 					},

--- a/bundle/deploy/terraform/interpolate_test.go
+++ b/bundle/deploy/terraform/interpolate_test.go
@@ -22,7 +22,7 @@ func TestInterpolate(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"my_job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tags: map[string]string{
 								"other_pipeline":         "${resources.pipelines.other_pipeline.id}",
 								"other_job":              "${resources.jobs.other_job.id}",
@@ -86,7 +86,7 @@ func TestInterpolateUnknownResourceType(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"my_job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tags: map[string]string{
 								"other_unknown": "${resources.unknown.other_unknown.id}",
 							},

--- a/bundle/deploy/terraform/tfdyn/convert_app_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_app_test.go
@@ -19,7 +19,7 @@ func TestConvertApp(t *testing.T) {
 		Config: map[string]any{
 			"command": []string{"python", "app.py"},
 		},
-		App: &apps.App{
+		App: apps.App{
 			Name:        "app_id",
 			Description: "app description",
 			Resources: []apps.AppResource{
@@ -104,7 +104,7 @@ func TestConvertAppWithNoDescription(t *testing.T) {
 		Config: map[string]any{
 			"command": []string{"python", "app.py"},
 		},
-		App: &apps.App{
+		App: apps.App{
 			Name: "app_id",
 			Resources: []apps.AppResource{
 				{

--- a/bundle/deploy/terraform/tfdyn/convert_cluster_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_cluster_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertCluster(t *testing.T) {
 	src := resources.Cluster{
-		ClusterSpec: compute.ClusterSpec{
+		ClusterSpec: &compute.ClusterSpec{
 			NumWorkers:   3,
 			SparkVersion: "13.3.x-scala2.12",
 			ClusterName:  "cluster",

--- a/bundle/deploy/terraform/tfdyn/convert_cluster_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_cluster_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertCluster(t *testing.T) {
 	src := resources.Cluster{
-		ClusterSpec: &compute.ClusterSpec{
+		ClusterSpec: compute.ClusterSpec{
 			NumWorkers:   3,
 			SparkVersion: "13.3.x-scala2.12",
 			ClusterName:  "cluster",

--- a/bundle/deploy/terraform/tfdyn/convert_dashboard_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_dashboard_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertDashboard(t *testing.T) {
 	src := resources.Dashboard{
-		Dashboard: &dashboards.Dashboard{
+		Dashboard: dashboards.Dashboard{
 			DisplayName: "my dashboard",
 			WarehouseId: "f00dcafe",
 			ParentPath:  "/some/path",

--- a/bundle/deploy/terraform/tfdyn/convert_experiment_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_experiment_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertExperiment(t *testing.T) {
 	src := resources.MlflowExperiment{
-		Experiment: &ml.Experiment{
+		Experiment: ml.Experiment{
 			Name: "name",
 		},
 		Permissions: []resources.MlflowExperimentPermission{

--- a/bundle/deploy/terraform/tfdyn/convert_job_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_job_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestConvertJob(t *testing.T) {
 	src := resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Name: "my job",
 			JobClusters: []jobs.JobCluster{
 				{

--- a/bundle/deploy/terraform/tfdyn/convert_model_serving_endpoint_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_model_serving_endpoint_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertModelServingEndpoint(t *testing.T) {
 	src := resources.ModelServingEndpoint{
-		CreateServingEndpoint: &serving.CreateServingEndpoint{
+		CreateServingEndpoint: serving.CreateServingEndpoint{
 			Name: "name",
 			Config: &serving.EndpointCoreConfigInput{
 				ServedModels: []serving.ServedModelInput{

--- a/bundle/deploy/terraform/tfdyn/convert_model_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_model_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertModel(t *testing.T) {
 	src := resources.MlflowModel{
-		Model: &ml.Model{
+		Model: ml.Model{
 			Name:        "name",
 			Description: "description",
 			Tags: []ml.ModelTag{

--- a/bundle/deploy/terraform/tfdyn/convert_pipeline_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_pipeline_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertPipeline(t *testing.T) {
 	src := resources.Pipeline{
-		CreatePipeline: &pipelines.CreatePipeline{
+		CreatePipeline: pipelines.CreatePipeline{
 			Name: "my pipeline",
 			// This fields is not part of TF schema yet, but once we upgrade to TF version that supports it, this test will fail because run_as
 			// will be exposed which is expected and test will need to be updated.

--- a/bundle/deploy/terraform/tfdyn/convert_quality_monitor_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_quality_monitor_test.go
@@ -16,7 +16,7 @@ import (
 func TestConvertQualityMonitor(t *testing.T) {
 	src := resources.QualityMonitor{
 		TableName: "test_table_name",
-		CreateMonitor: &catalog.CreateMonitor{
+		CreateMonitor: catalog.CreateMonitor{
 			AssetsDir:        "assets_dir",
 			OutputSchemaName: "output_schema_name",
 			InferenceLog: &catalog.MonitorInferenceLog{

--- a/bundle/deploy/terraform/tfdyn/convert_registered_model_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_registered_model_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertRegisteredModel(t *testing.T) {
 	src := resources.RegisteredModel{
-		CreateRegisteredModelRequest: &catalog.CreateRegisteredModelRequest{
+		CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 			Name:        "name",
 			CatalogName: "catalog",
 			SchemaName:  "schema",

--- a/bundle/deploy/terraform/tfdyn/convert_schema_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_schema_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertSchema(t *testing.T) {
 	src := resources.Schema{
-		CreateSchema: &catalog.CreateSchema{
+		CreateSchema: catalog.CreateSchema{
 			Name:        "name",
 			CatalogName: "catalog",
 			Comment:     "comment",

--- a/bundle/deploy/terraform/tfdyn/convert_volume_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_volume_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertVolume(t *testing.T) {
 	src := resources.Volume{
-		CreateVolumeRequestContent: &catalog.CreateVolumeRequestContent{
+		CreateVolumeRequestContent: catalog.CreateVolumeRequestContent{
 			CatalogName:     "catalog",
 			Comment:         "comment",
 			Name:            "name",

--- a/bundle/libraries/expand_glob_references_test.go
+++ b/bundle/libraries/expand_glob_references_test.go
@@ -29,7 +29,7 @@ func TestGlobReferencesExpandedForTaskLibraries(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey: "task",
@@ -110,7 +110,7 @@ func TestGlobReferencesExpandedForForeachTaskLibraries(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey: "task",
@@ -195,7 +195,7 @@ func TestGlobReferencesExpandedForEnvironmentsDeps(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey:        "task",

--- a/bundle/libraries/match_test.go
+++ b/bundle/libraries/match_test.go
@@ -23,7 +23,7 @@ func TestValidateEnvironments(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Environments: []jobs.JobEnvironment{
 								{
 									Spec: &compute.Environment{
@@ -55,7 +55,7 @@ func TestValidateEnvironmentsNoFile(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Environments: []jobs.JobEnvironment{
 								{
 									Spec: &compute.Environment{
@@ -89,7 +89,7 @@ func TestValidateTaskLibraries(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{
@@ -122,7 +122,7 @@ func TestValidateTaskLibrariesNoFile(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{

--- a/bundle/libraries/switch_to_patched_wheels.go
+++ b/bundle/libraries/switch_to_patched_wheels.go
@@ -25,11 +25,7 @@ func (c switchToPatchedWheels) Apply(ctx context.Context, b *bundle.Bundle) diag
 			continue
 		}
 
-		job := jobRef.JobSettings
-
-		if job == nil {
-			continue
-		}
+		job := &jobRef.JobSettings
 
 		for taskInd, task := range job.Tasks {
 			// Update resources.jobs.*.task[*].libraries[*].whl

--- a/bundle/libraries/upload_test.go
+++ b/bundle/libraries/upload_test.go
@@ -40,7 +40,7 @@ func TestArtifactUploadForWorkspace(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{
@@ -128,7 +128,7 @@ func TestArtifactUploadForVolumes(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{
@@ -248,7 +248,7 @@ func TestUploadMultipleLibraries(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{

--- a/bundle/permissions/validate_test.go
+++ b/bundle/permissions/validate_test.go
@@ -24,8 +24,8 @@ func TestValidateSharedRootPermissionsForShared(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job_1": {JobSettings: &jobs.JobSettings{Name: "job_1"}},
-					"job_2": {JobSettings: &jobs.JobSettings{Name: "job_2"}},
+					"job_1": {JobSettings: jobs.JobSettings{Name: "job_1"}},
+					"job_2": {JobSettings: jobs.JobSettings{Name: "job_2"}},
 				},
 			},
 		},
@@ -49,8 +49,8 @@ func TestValidateSharedRootPermissionsForSharedError(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job_1": {JobSettings: &jobs.JobSettings{Name: "job_1"}},
-					"job_2": {JobSettings: &jobs.JobSettings{Name: "job_2"}},
+					"job_1": {JobSettings: jobs.JobSettings{Name: "job_1"}},
+					"job_2": {JobSettings: jobs.JobSettings{Name: "job_2"}},
 				},
 			},
 		},

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -46,8 +46,8 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 					"model_2": {Model: ml.Model{}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
-					"experiment_1": {Experiment: &ml.Experiment{}},
-					"experiment_2": {Experiment: &ml.Experiment{}},
+					"experiment_1": {Experiment: ml.Experiment{}},
+					"experiment_2": {Experiment: ml.Experiment{}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint_1": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
@@ -106,8 +106,8 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 					"model_2": {Model: ml.Model{}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
-					"experiment_1": {Experiment: &ml.Experiment{}},
-					"experiment_2": {Experiment: &ml.Experiment{}},
+					"experiment_1": {Experiment: ml.Experiment{}},
+					"experiment_2": {Experiment: ml.Experiment{}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint_1": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -34,8 +34,8 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job_1": {JobSettings: &jobs.JobSettings{Name: "job_1"}},
-					"job_2": {JobSettings: &jobs.JobSettings{Name: "job_2"}},
+					"job_1": {JobSettings: jobs.JobSettings{Name: "job_1"}},
+					"job_2": {JobSettings: jobs.JobSettings{Name: "job_2"}},
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline_1": {CreatePipeline: &pipelines.CreatePipeline{}},
@@ -94,8 +94,8 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 			},
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
-					"job_1": {JobSettings: &jobs.JobSettings{Name: "job_1"}},
-					"job_2": {JobSettings: &jobs.JobSettings{Name: "job_2"}},
+					"job_1": {JobSettings: jobs.JobSettings{Name: "job_1"}},
+					"job_2": {JobSettings: jobs.JobSettings{Name: "job_2"}},
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline_1": {CreatePipeline: &pipelines.CreatePipeline{}},

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -38,8 +38,8 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 					"job_2": {JobSettings: jobs.JobSettings{Name: "job_2"}},
 				},
 				Pipelines: map[string]*resources.Pipeline{
-					"pipeline_1": {CreatePipeline: &pipelines.CreatePipeline{}},
-					"pipeline_2": {CreatePipeline: &pipelines.CreatePipeline{}},
+					"pipeline_1": {CreatePipeline: pipelines.CreatePipeline{}},
+					"pipeline_2": {CreatePipeline: pipelines.CreatePipeline{}},
 				},
 				Models: map[string]*resources.MlflowModel{
 					"model_1": {Model: &ml.Model{}},
@@ -98,8 +98,8 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 					"job_2": {JobSettings: jobs.JobSettings{Name: "job_2"}},
 				},
 				Pipelines: map[string]*resources.Pipeline{
-					"pipeline_1": {CreatePipeline: &pipelines.CreatePipeline{}},
-					"pipeline_2": {CreatePipeline: &pipelines.CreatePipeline{}},
+					"pipeline_1": {CreatePipeline: pipelines.CreatePipeline{}},
+					"pipeline_2": {CreatePipeline: pipelines.CreatePipeline{}},
 				},
 				Models: map[string]*resources.MlflowModel{
 					"model_1": {Model: &ml.Model{}},

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -50,8 +50,8 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 					"experiment_2": {Experiment: ml.Experiment{}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
-					"endpoint_1": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
-					"endpoint_2": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
+					"endpoint_1": {CreateServingEndpoint: serving.CreateServingEndpoint{}},
+					"endpoint_2": {CreateServingEndpoint: serving.CreateServingEndpoint{}},
 				},
 			},
 		},
@@ -110,8 +110,8 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 					"experiment_2": {Experiment: ml.Experiment{}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
-					"endpoint_1": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
-					"endpoint_2": {CreateServingEndpoint: &serving.CreateServingEndpoint{}},
+					"endpoint_1": {CreateServingEndpoint: serving.CreateServingEndpoint{}},
+					"endpoint_2": {CreateServingEndpoint: serving.CreateServingEndpoint{}},
 				},
 			},
 		},

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -42,8 +42,8 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 					"pipeline_2": {CreatePipeline: pipelines.CreatePipeline{}},
 				},
 				Models: map[string]*resources.MlflowModel{
-					"model_1": {Model: &ml.Model{}},
-					"model_2": {Model: &ml.Model{}},
+					"model_1": {Model: ml.Model{}},
+					"model_2": {Model: ml.Model{}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment_1": {Experiment: &ml.Experiment{}},
@@ -102,8 +102,8 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 					"pipeline_2": {CreatePipeline: pipelines.CreatePipeline{}},
 				},
 				Models: map[string]*resources.MlflowModel{
-					"model_1": {Model: &ml.Model{}},
-					"model_2": {Model: &ml.Model{}},
+					"model_1": {Model: ml.Model{}},
+					"model_2": {Model: ml.Model{}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment_1": {Experiment: &ml.Experiment{}},

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -537,7 +537,7 @@ func TestRenderSummary(t *testing.T) {
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
 						ID: "catalog.schema",
-						CreateSchema: &catalog.CreateSchema{
+						CreateSchema: catalog.CreateSchema{
 							Name: "schema",
 						},
 						// no URL

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -514,16 +514,12 @@ func TestRenderSummary(t *testing.T) {
 					"job1": {
 						ID:          "1",
 						URL:         "https://url1",
-						JobSettings: &jobs.JobSettings{Name: "job1-name"},
+						JobSettings: jobs.JobSettings{Name: "job1-name"},
 					},
 					"job2": {
 						ID:          "2",
 						URL:         "https://url2",
-						JobSettings: &jobs.JobSettings{Name: "job2-name"},
-					},
-					"job3": {
-						ID:  "3",
-						URL: "https://url3", // This emulates deleted job
+						JobSettings: jobs.JobSettings{Name: "job2-name"},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -546,7 +546,7 @@ func TestRenderSummary(t *testing.T) {
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint1": {
 						ID: "7",
-						CreateServingEndpoint: &serving.CreateServingEndpoint{
+						CreateServingEndpoint: serving.CreateServingEndpoint{
 							Name: "my_serving_endpoint",
 						},
 						URL: "https://url4",

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -526,12 +526,12 @@ func TestRenderSummary(t *testing.T) {
 					"pipeline2": {
 						ID: "4",
 						// no URL
-						CreatePipeline: &pipelines.CreatePipeline{Name: "pipeline2-name"},
+						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline2-name"},
 					},
 					"pipeline1": {
 						ID:             "3",
 						URL:            "https://url3",
-						CreatePipeline: &pipelines.CreatePipeline{Name: "pipeline1-name"},
+						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1-name"},
 					},
 				},
 				Schemas: map[string]*resources.Schema{

--- a/bundle/resources/completion_test.go
+++ b/bundle/resources/completion_test.go
@@ -25,7 +25,7 @@ func TestCompletions_SkipDuplicates(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"foo": {
-						CreatePipeline: &pipelines.CreatePipeline{},
+						CreatePipeline: pipelines.CreatePipeline{},
 					},
 				},
 			},
@@ -50,7 +50,7 @@ func TestCompletions_Filter(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"bar": {
-						CreatePipeline: &pipelines.CreatePipeline{},
+						CreatePipeline: pipelines.CreatePipeline{},
 					},
 				},
 			},

--- a/bundle/resources/completion_test.go
+++ b/bundle/resources/completion_test.go
@@ -17,10 +17,10 @@ func TestCompletions_SkipDuplicates(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 					"bar": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
@@ -45,7 +45,7 @@ func TestCompletions_Filter(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{

--- a/bundle/resources/lookup_test.go
+++ b/bundle/resources/lookup_test.go
@@ -56,7 +56,7 @@ func TestLookup_MultipleFound(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"foo": {
-						CreatePipeline: &pipelines.CreatePipeline{},
+						CreatePipeline: pipelines.CreatePipeline{},
 					},
 				},
 			},
@@ -107,7 +107,7 @@ func TestLookup_NominalWithFilters(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"bar": {
-						CreatePipeline: &pipelines.CreatePipeline{},
+						CreatePipeline: pipelines.CreatePipeline{},
 					},
 				},
 			},

--- a/bundle/resources/lookup_test.go
+++ b/bundle/resources/lookup_test.go
@@ -30,10 +30,10 @@ func TestLookup_NotFound(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 					"bar": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 				},
 			},
@@ -51,7 +51,7 @@ func TestLookup_MultipleFound(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
@@ -74,7 +74,7 @@ func TestLookup_Nominal(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Name: "Foo job",
 						},
 					},
@@ -102,7 +102,7 @@ func TestLookup_NominalWithFilters(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"foo": {
-						JobSettings: &jobs.JobSettings{},
+						JobSettings: jobs.JobSettings{},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{

--- a/bundle/run/app_test.go
+++ b/bundle/run/app_test.go
@@ -55,7 +55,7 @@ func setupBundle(t *testing.T) (context.Context, *bundle.Bundle, *mocks.MockWork
 			Resources: config.Resources{
 				Apps: map[string]*resources.App{
 					"my_app": {
-						App: &apps.App{
+						App: apps.App{
 							Name: "my_app",
 						},
 						SourceCodePath: "./my_app",

--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -31,7 +31,7 @@ type jobRunner struct {
 }
 
 func (r *jobRunner) Name() string {
-	if r.job == nil || r.job.JobSettings == nil {
+	if r.job == nil {
 		return ""
 	}
 	return r.job.JobSettings.Name

--- a/bundle/run/job_args.go
+++ b/bundle/run/job_args.go
@@ -121,7 +121,7 @@ const (
 
 func (r *jobRunner) posArgsHandler() argsHandler {
 	job := r.job
-	if job == nil || job.JobSettings == nil {
+	if job == nil {
 		return nopArgsHandler{}
 	}
 

--- a/bundle/run/job_args_test.go
+++ b/bundle/run/job_args_test.go
@@ -11,7 +11,7 @@ import (
 func TestJobParameterArgs(t *testing.T) {
 	a := jobParameterArgs{
 		&resources.Job{
-			JobSettings: &jobs.JobSettings{
+			JobSettings: jobs.JobSettings{
 				Parameters: []jobs.JobParameterDefinition{
 					{
 						Name:    "foo",
@@ -70,7 +70,7 @@ func TestJobParameterArgs(t *testing.T) {
 func TestJobTaskNotebookParamArgs(t *testing.T) {
 	a := jobTaskNotebookParamArgs{
 		&resources.Job{
-			JobSettings: &jobs.JobSettings{
+			JobSettings: jobs.JobSettings{
 				Tasks: []jobs.Task{
 					{
 						NotebookTask: &jobs.NotebookTask{

--- a/bundle/run/job_options_test.go
+++ b/bundle/run/job_options_test.go
@@ -188,7 +188,7 @@ func TestJobOptionsSqlParamsMultiple(t *testing.T) {
 
 func TestJobOptionsValidateIfJobHasJobParameters(t *testing.T) {
 	job := &resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Parameters: []jobs.JobParameterDefinition{
 				{
 					Name:    "param",
@@ -219,7 +219,7 @@ func TestJobOptionsValidateIfJobHasJobParameters(t *testing.T) {
 
 func TestJobOptionsValidateIfJobHasNoJobParameters(t *testing.T) {
 	job := &resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Parameters: []jobs.JobParameterDefinition{},
 		},
 	}

--- a/bundle/run/job_test.go
+++ b/bundle/run/job_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestConvertPythonParams(t *testing.T) {
 	job := &resources.Job{
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Tasks: []jobs.Task{
 				{PythonWheelTask: &jobs.PythonWheelTask{
 					PackageName: "my_test_code",
@@ -132,7 +132,7 @@ func TestJobRunnerCancelWithNoActiveRuns(t *testing.T) {
 }
 
 func TestJobRunnerRestart(t *testing.T) {
-	for _, jobSettings := range []*jobs.JobSettings{
+	for _, jobSettings := range []jobs.JobSettings{
 		{},
 		{
 			Continuous: &jobs.Continuous{
@@ -209,7 +209,7 @@ func TestJobRunnerRestart(t *testing.T) {
 func TestJobRunnerRestartForContinuousUnpausedJobs(t *testing.T) {
 	job := &resources.Job{
 		ID: "123",
-		JobSettings: &jobs.JobSettings{
+		JobSettings: jobs.JobSettings{
 			Continuous: &jobs.Continuous{
 				PauseStatus: jobs.PauseStatusUnpaused,
 			},

--- a/bundle/run/pipeline.go
+++ b/bundle/run/pipeline.go
@@ -79,7 +79,7 @@ type pipelineRunner struct {
 }
 
 func (r *pipelineRunner) Name() string {
-	if r.pipeline == nil || r.pipeline.CreatePipeline == nil {
+	if r.pipeline == nil {
 		return ""
 	}
 	return r.pipeline.CreatePipeline.Name

--- a/bundle/tests/run_as_test.go
+++ b/bundle/tests/run_as_test.go
@@ -52,7 +52,7 @@ func TestRunAsForAllowed(t *testing.T) {
 	assert.Equal(t, "", jobs["job_three"].RunAs.UserName)
 
 	// Assert other resources are not affected.
-	assert.Equal(t, ml.Model{Name: "skynet"}, *b.Config.Resources.Models["model_one"].Model)
+	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
 	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
 	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, *b.Config.Resources.Experiments["experiment_one"].Experiment)
 }
@@ -92,7 +92,7 @@ func TestRunAsForAllowedWithTargetOverride(t *testing.T) {
 	assert.Equal(t, "", jobs["job_three"].RunAs.UserName)
 
 	// Assert other resources are not affected.
-	assert.Equal(t, ml.Model{Name: "skynet"}, *b.Config.Resources.Models["model_one"].Model)
+	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
 	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
 	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, *b.Config.Resources.Experiments["experiment_one"].Experiment)
 }
@@ -308,7 +308,7 @@ func TestLegacyRunAs(t *testing.T) {
 	}, pipelines["nyc_taxi_pipeline"].Permissions[1])
 
 	// Assert other resources are not affected.
-	assert.Equal(t, ml.Model{Name: "skynet"}, *b.Config.Resources.Models["model_one"].Model)
+	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
 	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
 	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, *b.Config.Resources.Experiments["experiment_one"].Experiment)
 	assert.Equal(t, serving.CreateServingEndpoint{Name: "skynet"}, *b.Config.Resources.ModelServingEndpoints["model_serving_one"].CreateServingEndpoint)

--- a/bundle/tests/run_as_test.go
+++ b/bundle/tests/run_as_test.go
@@ -54,7 +54,7 @@ func TestRunAsForAllowed(t *testing.T) {
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
 	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
-	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, *b.Config.Resources.Experiments["experiment_one"].Experiment)
+	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, b.Config.Resources.Experiments["experiment_one"].Experiment)
 }
 
 func TestRunAsForAllowedWithTargetOverride(t *testing.T) {
@@ -94,7 +94,7 @@ func TestRunAsForAllowedWithTargetOverride(t *testing.T) {
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
 	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
-	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, *b.Config.Resources.Experiments["experiment_one"].Experiment)
+	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, b.Config.Resources.Experiments["experiment_one"].Experiment)
 }
 
 func TestRunAsErrorForPipelines(t *testing.T) {
@@ -310,6 +310,6 @@ func TestLegacyRunAs(t *testing.T) {
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
 	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
-	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, *b.Config.Resources.Experiments["experiment_one"].Experiment)
-	assert.Equal(t, serving.CreateServingEndpoint{Name: "skynet"}, *b.Config.Resources.ModelServingEndpoints["model_serving_one"].CreateServingEndpoint)
+	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, b.Config.Resources.Experiments["experiment_one"].Experiment)
+	assert.Equal(t, serving.CreateServingEndpoint{Name: "skynet"}, b.Config.Resources.ModelServingEndpoints["model_serving_one"].CreateServingEndpoint)
 }

--- a/bundle/tests/run_as_test.go
+++ b/bundle/tests/run_as_test.go
@@ -53,7 +53,7 @@ func TestRunAsForAllowed(t *testing.T) {
 
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
-	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
+	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
 	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, b.Config.Resources.Experiments["experiment_one"].Experiment)
 }
 
@@ -93,7 +93,7 @@ func TestRunAsForAllowedWithTargetOverride(t *testing.T) {
 
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
-	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
+	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
 	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, b.Config.Resources.Experiments["experiment_one"].Experiment)
 }
 
@@ -309,7 +309,7 @@ func TestLegacyRunAs(t *testing.T) {
 
 	// Assert other resources are not affected.
 	assert.Equal(t, ml.Model{Name: "skynet"}, b.Config.Resources.Models["model_one"].Model)
-	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, *b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
+	assert.Equal(t, catalog.CreateRegisteredModelRequest{Name: "skynet (in UC)"}, b.Config.Resources.RegisteredModels["model_two"].CreateRegisteredModelRequest)
 	assert.Equal(t, ml.Experiment{Name: "experiment_one"}, b.Config.Resources.Experiments["experiment_one"].Experiment)
 	assert.Equal(t, serving.CreateServingEndpoint{Name: "skynet"}, b.Config.Resources.ModelServingEndpoints["model_serving_one"].CreateServingEndpoint)
 }

--- a/bundle/trampoline/conditional_transform_test.go
+++ b/bundle/trampoline/conditional_transform_test.go
@@ -29,7 +29,7 @@ func TestNoTransformByDefault(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey: "key1",
@@ -78,7 +78,7 @@ func TestTransformWithExperimentalSettingSetToTrue(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey: "key1",

--- a/bundle/trampoline/python_dbr_warning_test.go
+++ b/bundle/trampoline/python_dbr_warning_test.go
@@ -20,7 +20,7 @@ func TestIncompatibleWheelTasksWithNewCluster(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey:         "key1",
@@ -60,7 +60,7 @@ func TestIncompatibleWheelTasksWithJobClusterKey(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							JobClusters: []jobs.JobCluster{
 								{
 									JobClusterKey: "cluster1",
@@ -113,7 +113,7 @@ func TestIncompatibleWheelTasksWithExistingClusterId(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey:           "key1",
@@ -160,7 +160,7 @@ func TestNoIncompatibleWheelTasks(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							JobClusters: []jobs.JobCluster{
 								{
 									JobClusterKey: "cluster1",
@@ -266,7 +266,7 @@ func TestTasksWithPyPiPackageAreCompatible(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							JobClusters: []jobs.JobCluster{
 								{
 									JobClusterKey: "cluster1",
@@ -310,7 +310,7 @@ func TestNoWarningWhenPythonWheelWrapperIsOn(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey:         "key1",

--- a/bundle/trampoline/python_wheel_test.go
+++ b/bundle/trampoline/python_wheel_test.go
@@ -77,7 +77,7 @@ func TestTransformFiltersWheelTasksOnly(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey:         "key1",
@@ -123,7 +123,7 @@ func TestNoPanicWithNoPythonWheelTasks(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"test": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									TaskKey:      "notebook_task",

--- a/bundle/trampoline/trampoline_test.go
+++ b/bundle/trampoline/trampoline_test.go
@@ -69,7 +69,7 @@ func TestGenerateTrampoline(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"test": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: tasks,
 						},
 					},

--- a/integration/bundle/artifacts_test.go
+++ b/integration/bundle/artifacts_test.go
@@ -63,7 +63,7 @@ func TestUploadArtifactFileToCorrectRemotePath(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"test": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{
@@ -127,7 +127,7 @@ func TestUploadArtifactFileToCorrectRemotePathWithEnvironments(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"test": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Environments: []jobs.JobEnvironment{
 								{
 									Spec: &compute.Environment{
@@ -196,7 +196,7 @@ func TestUploadArtifactFileToCorrectRemotePathForVolumes(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"test": {
-						JobSettings: &jobs.JobSettings{
+						JobSettings: jobs.JobSettings{
 							Tasks: []jobs.Task{
 								{
 									Libraries: []compute.Library{


### PR DESCRIPTION
## Changes
- Embed struct by value not by pointer in all the resources.
- Remove IsNil method from the resource interface and implementations (it's never true).

## Why
- Prevents a class of crashes related to nil pointer, like https://github.com/databricks/cli/pull/2776 and https://github.com/databricks/cli/pull/1937 
- Simplify user code, no need to check nilness as much.

## Tests
Existing tests.
