### PR TITLE
acc: Flush requests to disk

### DIFF
--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -104,6 +104,12 @@ func startDedicatedServer(t *testing.T,
 
 			_, err = f.WriteString(string(reqJson) + "\n")
 			assert.NoError(t, err)
+
+			// Sync the file to ensure that the request is written to disk.
+			// This can help avoid race conditions when file is not flushed to
+			// disk but is being read by the test.
+			err = f.Sync()
+			assert.NoError(t, err)
 		}
 	}
 


### PR DESCRIPTION
## Why
We are seeing failures in CI that indicate that `out.requests.txt` is not being flushed to disk once the $CLI invocation has terminated and next commands are reading the file. Eg: https://github.com/databricks/cli/actions/runs/14886324401/job/41806781111

This change forces every request recorded to be flushed to disk.

## Tests
Not tested. I'm unable to reproduce the flake locally.