### PR TITLE
Sort file names in sync events before the events are emitted

### DIFF
--- a/libs/sync/event.go
+++ b/libs/sync/event.go
@@ -55,11 +55,9 @@ func (e *EventChanges) IsEmpty() bool {
 func (e *EventChanges) String() string {
 	var changes []string
 	if len(e.Put) > 0 {
-		sort.Strings(e.Put)
 		changes = append(changes, "PUT: "+strings.Join(e.Put, ", "))
 	}
 	if len(e.Delete) > 0 {
-		sort.Strings(e.Delete)
 		changes = append(changes, "DELETE: "+strings.Join(e.Delete, ", "))
 	}
 	return strings.Join(changes, ", ")
@@ -79,6 +77,8 @@ func (e *EventStart) String() string {
 }
 
 func newEventStart(seq int, put, delete []string, dryRun bool) Event {
+	sort.Strings(put)
+	sort.Strings(delete)
 	return &EventStart{
 		EventBase:    newEventBase(seq, EventTypeStart, dryRun),
 		EventChanges: &EventChanges{Put: put, Delete: delete},
@@ -139,6 +139,8 @@ func (e *EventSyncComplete) String() string {
 }
 
 func newEventComplete(seq int, put, delete []string, dryRun bool) Event {
+	sort.Strings(put)
+	sort.Strings(delete)
 	return &EventSyncComplete{
 		EventBase:    newEventBase(seq, EventTypeComplete, dryRun),
 		EventChanges: &EventChanges{Put: put, Delete: delete},


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

In #2824 sorting was added on event read, which caused the slices to be mutated and changed the order of the sync operations.

In

## Tests
<!-- How have you tested the changes? -->

Existing acceptance test run with hyperfine

```
hyperfine -m 100 --show-output 'go test ./acceptance -run ^TestAccept$/^bundle$/^sync$/^dryrun$ -count=1'
```

was consistently failing on 20-30th iteration before this change and is not failing on 100 iterations after the change.

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
