### PR TITLE
Fix flaky repos integration tests

### DIFF
--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,12 +1,11 @@
 package testutil
 
 import (
-	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,15 +22,12 @@ const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 // RandomName gives random name with optional prefix. e.g. qa.RandomName("tf-")
 func RandomName(prefix ...string) string {
-	randLen := 12
-	b := make([]byte, randLen)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+	out := ""
+	for _, p := range prefix {
+		out += p
 	}
-	if len(prefix) > 0 {
-		return fmt.Sprintf("%s%s", strings.Join(prefix, ""), b)
-	}
-	return string(b)
+	out += uuid.New().String()
+	return out
 }
 
 func SkipUntil(t TestingT, date string) {

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -18,15 +18,13 @@ func GetEnvOrSkipTest(t TestingT, name string) string {
 	return value
 }
 
-const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
 // RandomName gives random name with optional prefix. e.g. qa.RandomName("tf-")
 func RandomName(prefix ...string) string {
 	out := ""
 	for _, p := range prefix {
 		out += p
 	}
-	out += uuid.New().String()
+	out += strings.ReplaceAll(uuid.New().String(), "-", "")
 	return out
 }
 


### PR DESCRIPTION
## Why
We often see repos integration tests fail with object already exists errors. One hypothesis is that the Random string generator is not truly random and pulls from a small seed pool in CI. This PR attempts to fix that hypothetical issue by using UUIDs instead to generate the random string.

Example failure:
```
=== FAIL: integration/cmd/repos TestReposGet (3.83s)
    repos_test.go:80: CLOUD_ENV=***
    repos_test.go:47: 
        	Error Trace:	C:/a/eng-dev-ecosystem/eng-dev-ecosystem/ext/cli/integration/cmd/repos/repos_test.go:47
        	            				C:/a/eng-dev-ecosystem/eng-dev-ecosystem/ext/cli/integration/cmd/repos/repos_test.go:83
        	Error:      	Received unexpected error:
        	            	a Workspace object at path /Repos/***/empty-repo-integration-pIdzKaCkfhBq already exists. Try a different path for your Repo or rename the existing Workspace object.
        	            	
        	            	Request ID: 2a601c0f-75d2-4568-a7ac-7fc8a3423932
        	Test:       	TestReposGet
```

