### PR TITLE
Print help for 'databricks sync' without args

### DIFF
--- a/acceptance/cmd/sync-without-args/output.txt
+++ b/acceptance/cmd/sync-without-args/output.txt
@@ -1,0 +1,26 @@
+
+>>> errcode [CLI] sync
+Error: accepts 2 arg(s), received 0
+
+Usage:
+  databricks sync [flags] SRC DST
+
+Flags:
+      --dry-run               simulate sync execution without making actual changes
+      --exclude strings       patterns to exclude from sync (can be specified multiple times)
+      --exclude-from string   file containing patterns to exclude from sync (one pattern per line)
+      --full                  perform full synchronization (default is incremental)
+  -h, --help                  help for sync
+      --include strings       patterns to include in sync (can be specified multiple times)
+      --include-from string   file containing patterns to include to sync (one pattern per line)
+      --interval duration     file system polling interval (for --watch) (default 1s)
+      --output type           type of output format (default text)
+      --watch                 watch local file system for changes
+
+Global Flags:
+      --debug            enable debug logging
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+
+
+Exit code: 1

--- a/acceptance/cmd/sync-without-args/script
+++ b/acceptance/cmd/sync-without-args/script
@@ -1,0 +1,1 @@
+trace errcode $CLI sync

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -94,8 +93,8 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 }
 
 func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*sync.SyncOptions, error) {
-	if len(args) != 2 {
-		return nil, flag.ErrHelp
+	if err := root.ExactArgs(2)(cmd, args); err != nil {
+		return nil, err
 	}
 
 	var outputFunc func(context.Context, <-chan sync.Event, io.Writer)


### PR DESCRIPTION
## Changes

Update argument checker to return an error that includes the help output.

Fixes #1061.

## Why

This is the current output:
```
$ databricks sync
Error: flag: help requested
```

## Tests

New acceptance test.