### PR TITLE
Return error when bundle run fails to start a job

### DIFF
--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -188,7 +188,7 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 
 	waiter, err := w.Jobs.RunNow(ctx, *req)
 	if err != nil {
-		return nil, errors.New("cannot start job")
+		return nil, fmt.Errorf("cannot start job: %w", err)
 	}
 
 	if opts.NoWait {


### PR DESCRIPTION
## Why
We overlooked returning the error itself when starting a job run. This PR fixes that. 
