### PR TITLE
Render full diagnostics in `bundle run`

### DIFF
--- a/acceptance/bundle/run/diagnostics/databricks.yml
+++ b/acceptance/bundle/run/diagnostics/databricks.yml
@@ -1,0 +1,5 @@
+bundle:
+  name: run diagnostics
+
+workspace:
+  file_path: /Volumes/test

--- a/acceptance/bundle/run/diagnostics/output.txt
+++ b/acceptance/bundle/run/diagnostics/output.txt
@@ -1,0 +1,10 @@
+
+>>> [CLI] bundle run foo
+Error: workspace.file_path /Volumes/test starts with /Volumes. /Volumes can only be used with workspace.artifact_path.
+  at workspace.file_path
+  in databricks.yml:5:14
+
+For more information, see https://docs.databricks.com/aws/en/dev-tools/bundles/settings#workspace
+
+
+Exit code: 1

--- a/acceptance/bundle/run/diagnostics/script
+++ b/acceptance/bundle/run/diagnostics/script
@@ -1,0 +1,1 @@
+trace $CLI bundle run foo

--- a/acceptance/bundle/run/inline-script/no-bundle/output.txt
+++ b/acceptance/bundle/run/inline-script/no-bundle/output.txt
@@ -2,4 +2,5 @@
 >>> [CLI] bundle run -- echo hello
 Error: unable to locate bundle root: databricks.yml not found
 
+
 Exit code: 1

--- a/acceptance/bundle/run/inline-script/no-separator/output.txt
+++ b/acceptance/bundle/run/inline-script/no-separator/output.txt
@@ -2,4 +2,5 @@
 >>> [CLI] bundle run echo hello
 Error: unable to locate bundle root: databricks.yml not found
 
+
 Exit code: 1

--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -3,6 +3,7 @@ package bundle
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/validate"
@@ -84,18 +85,21 @@ func newDeployCommand() *cobra.Command {
 			}
 		}
 
-		renderOpts := render.RenderOptions{RenderSummaryTable: false}
-		err := render.RenderDiagnostics(cmd.OutOrStdout(), b, diags, renderOpts)
-		if err != nil {
-			return fmt.Errorf("failed to render output: %w", err)
-		}
+		return renderDiagnostics(cmd.OutOrStdout(), b, diags)
+	}
+	return cmd
+}
 
-		if diags.HasError() {
-			return root.ErrAlreadyPrinted
-		}
-
-		return nil
+func renderDiagnostics(w io.Writer, b *bundle.Bundle, diags diag.Diagnostics) error {
+	renderOpts := render.RenderOptions{RenderSummaryTable: false}
+	err := render.RenderDiagnostics(w, b, diags, renderOpts)
+	if err != nil {
+		return fmt.Errorf("failed to render output: %w", err)
 	}
 
-	return cmd
+	if diags.HasError() {
+		return root.ErrAlreadyPrinted
+	}
+
+	return nil
 }

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -127,7 +127,7 @@ Example usage:
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		b, diags := utils.ConfigureBundleWithVariables(cmd)
-		if err := diags.Error(); err != nil {
+		if diags.HasError() {
 			return renderDiagnostics(cmd.OutOrStdout(), b, diags)
 		}
 
@@ -138,8 +138,8 @@ Example usage:
 			return executeInline(cmd, args, b)
 		}
 
-		diags = phases.Initialize(ctx, b)
-		if err := diags.Error(); err != nil {
+		diags = diags.Extend(phases.Initialize(ctx, b))
+		if diags.HasError() {
 			return renderDiagnostics(cmd.OutOrStdout(), b, diags)
 		}
 
@@ -148,13 +148,13 @@ Example usage:
 			return err
 		}
 
-		diags = bundle.ApplySeq(ctx, b,
+		diags = diags.Extend(bundle.ApplySeq(ctx, b,
 			terraform.Interpolate(),
 			terraform.Write(),
 			terraform.StatePull(),
 			terraform.Load(terraform.ErrorOnEmptyState),
-		)
-		if err := diags.Error(); err != nil {
+		))
+		if diags.HasError() {
 			return renderDiagnostics(cmd.OutOrStdout(), b, diags)
 		}
 

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -128,7 +128,7 @@ Example usage:
 		ctx := cmd.Context()
 		b, diags := utils.ConfigureBundleWithVariables(cmd)
 		if err := diags.Error(); err != nil {
-			return diags.Error()
+			return renderDiagnostics(cmd.OutOrStdout(), b, diags)
 		}
 
 		// If user runs the bundle run command as:
@@ -140,7 +140,7 @@ Example usage:
 
 		diags = phases.Initialize(ctx, b)
 		if err := diags.Error(); err != nil {
-			return err
+			return renderDiagnostics(cmd.OutOrStdout(), b, diags)
 		}
 
 		key, args, err := resolveRunArgument(ctx, b, args)
@@ -155,7 +155,7 @@ Example usage:
 			terraform.Load(terraform.ErrorOnEmptyState),
 		)
 		if err := diags.Error(); err != nil {
-			return err
+			return renderDiagnostics(cmd.OutOrStdout(), b, diags)
 		}
 
 		runner, err := keyToRunner(b, key)


### PR DESCRIPTION
## Why
`diags.Error()` only returns the`Details` in the diagnostic, and only returns `Summary` if the details are empty. We should render both In `bundle run` to be consistent with `bundle deploy`.

At the same time, this PR also renders all `warnings` and `recommendations` if the user encounters an error. These warnings could have helpful context on what they need to fix in their configuration.

## Tests
New acceptance test. Existing tests pass.
