### PR TITLE
Preserve folder structure for app source code in bundle generate

### DIFF
--- a/acceptance/bundle/generate/app_subfolders/databricks.yml
+++ b/acceptance/bundle/generate/app_subfolders/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: app_subfolders

--- a/acceptance/bundle/generate/app_subfolders/out.app.yml
+++ b/acceptance/bundle/generate/app_subfolders/out.app.yml
@@ -1,0 +1,6 @@
+resources:
+  apps:
+    out:
+      name: my_app
+      description: This is a test app
+      source_code_path: out

--- a/acceptance/bundle/generate/app_subfolders/out/sub/folder/1.py
+++ b/acceptance/bundle/generate/app_subfolders/out/sub/folder/1.py
@@ -1,0 +1,3 @@
+{
+    "content": "print('Hello, World!')"
+}

--- a/acceptance/bundle/generate/app_subfolders/output.txt
+++ b/acceptance/bundle/generate/app_subfolders/output.txt
@@ -1,0 +1,3 @@
+Loading app 'my_app' configuration
+File successfully saved to out/sub/folder/1.py
+App configuration successfully saved to out.app.yml

--- a/acceptance/bundle/generate/app_subfolders/script
+++ b/acceptance/bundle/generate/app_subfolders/script
@@ -1,0 +1,1 @@
+$CLI bundle generate app --existing-app-name my_app --config-dir . --key out --source-dir out

--- a/acceptance/bundle/generate/app_subfolders/test.toml
+++ b/acceptance/bundle/generate/app_subfolders/test.toml
@@ -1,0 +1,39 @@
+[[Server]]
+Pattern = "GET /api/2.0/apps/my_app"
+Response.Body = '''
+{
+    "app_id": "1234567890",
+    "name": "my_app",
+    "description": "This is a test app",
+    "default_source_code_path": "/Workspace/Users/foo@bar.com/my_app"
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.0/workspace/list"
+Response.Body = '''
+{
+    "objects": [
+        {
+            "path": "/Workspace/Users/foo@bar.com/my_app/sub/folder/1.py",
+            "object_type": "FILE"
+        }
+    ]
+}
+'''
+[[Server]]
+Pattern = "GET /api/2.0/workspace/get-status"
+Response.Body = '''
+{
+    "path": "/Workspace/Users/foo@bar.com/my_app/sub/folder/1.py",
+    "object_type": "FILE"
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.0/workspace/export"
+Response.Body = '''
+{
+    "content": "print('Hello, World!')"
+}
+'''


### PR DESCRIPTION
## Changes
Preserve folder structure for app source code in bundle generate

## Why
App source code is often complex and contains many subfolders so we need to keep the folder structure so the generated app is working correctly.

## Tests
Added acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
