### PR TITLE
Return error when glob pattern matching fails for apps

### DIFF
--- a/libs/apps/python.go
+++ b/libs/apps/python.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,7 +89,7 @@ func (p *PythonApp) GetCommand(debug bool) ([]string, error) {
 	if len(spec.Command) == 0 {
 		files, err := filepath.Glob(filepath.Join(spec.config.AppPath, "*.py"))
 		if err != nil {
-			return nil, errors.New("Error reading source code directory")
+			return nil, fmt.Errorf("Error reading source code directory: %w", err)
 		}
 
 		if len(files) > 0 {


### PR DESCRIPTION
## Why
Minor UX improvement. Provides users with context for why searching for *.py files failed for them. Prompted by: https://github.com/databricks/cli/pull/2843#pullrequestreview-2832190899

## Tests
Not tested.