### PR TITLE
Fix stdin test for inline script execution

### DIFF
--- a/acceptance/bundle/run/inline-script/basic/output.txt
+++ b/acceptance/bundle/run/inline-script/basic/output.txt
@@ -14,7 +14,7 @@ Exit code: 5
 >>> cat stderr.txt
 Hello
 
->>> cat -
+>>> [CLI] bundle run -- cat -
 abc
 
 >>> [CLI] bundle run -- printf hello

--- a/acceptance/bundle/run/inline-script/basic/script
+++ b/acceptance/bundle/run/inline-script/basic/script
@@ -14,7 +14,7 @@ rm stderr.txt
 
 # stdin should be passed through
 echo "abc" > abc.txt
-trace cat - < abc.txt
+trace $CLI bundle run -- cat - < abc.txt
 rm abc.txt
 
 # no newline


### PR DESCRIPTION
## Why
This PR fixes a typo where the `cat -` command was supposed to be run via the inline script execution functionality but was not.
