### PR TITLE
Fixed normalising requirements file path in dependencies section

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,5 +10,6 @@
 
 ### Bundles
 * Removed unused fields from resources.models schema: creation\_timestamp, last\_updated\_timestamp, latest\_versions and user\_id. Using them now raises a warning.
+* Fixed normalising requirements file path in dependencies section ([#2861](https://github.com/databricks/cli/pull/2861))
 
 ### API Changes

--- a/acceptance/bundle/environments/dependencies/databricks.yml
+++ b/acceptance/bundle/environments/dependencies/databricks.yml
@@ -1,6 +1,8 @@
 bundle:
   name: "dependencies"
 
+include:
+  - resources/*.yml
 
 resources:
   jobs:

--- a/acceptance/bundle/environments/dependencies/output.txt
+++ b/acceptance/bundle/environments/dependencies/output.txt
@@ -33,18 +33,44 @@ Deployment complete!
         "requests[security] @ https://github.com/psf/requests/archive/refs/heads/main.zip"
       ]
     }
+  },
+  {
+    "environment_key": "test_env_2",
+    "spec": {
+      "client": "1",
+      "dependencies": [
+        "-r /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/requirements.txt"
+      ]
+    }
   }
 ]
 
 >>> [CLI] bundle validate -o json
 [
-  "-r /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/requirements.txt",
-  "test_package",
-  "test_package==2.0.1",
-  "test_package>=2.0.1",
-  "./dist/*.whl",
-  "/Workspace/Users/test@databricks.com/test-package.whl",
-  "beautifulsoup4>=1.0.0,~=1.2.0,<2.0.0",
-  "beautifulsoup4[security, tests] ~= 4.12.3",
-  "requests[security] @ https://github.com/psf/requests/archive/refs/heads/main.zip"
+  {
+    "environment_key": "test_env",
+    "spec": {
+      "client": "1",
+      "dependencies": [
+        "-r /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/requirements.txt",
+        "test_package",
+        "test_package==2.0.1",
+        "test_package>=2.0.1",
+        "./dist/*.whl",
+        "/Workspace/Users/test@databricks.com/test-package.whl",
+        "beautifulsoup4>=1.0.0,~=1.2.0,<2.0.0",
+        "beautifulsoup4[security, tests] ~= 4.12.3",
+        "requests[security] @ https://github.com/psf/requests/archive/refs/heads/main.zip"
+      ]
+    }
+  },
+  {
+    "environment_key": "test_env_2",
+    "spec": {
+      "client": "1",
+      "dependencies": [
+        "-r /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/requirements.txt"
+      ]
+    }
+  }
 ]

--- a/acceptance/bundle/environments/dependencies/resources/job.yml
+++ b/acceptance/bundle/environments/dependencies/resources/job.yml
@@ -1,0 +1,13 @@
+targets:
+  default:
+    default: true
+    resources:
+      jobs:
+        test_job:
+          name: "Test Job"
+          environments:
+            - environment_key: "test_env_2"
+              spec:
+                client: "1"
+                dependencies:
+                  - "-r ../requirements.txt"

--- a/acceptance/bundle/environments/dependencies/script
+++ b/acceptance/bundle/environments/dependencies/script
@@ -5,5 +5,5 @@ trace $CLI bundle validate
 
 trace $CLI bundle deploy
 trace jq -s '.[] | select(.path=="/api/2.2/jobs/create") | .body.environments' out.requests.txt
-trace $CLI bundle validate -o json | jq '.resources.jobs.test_job.environments[0].spec.dependencies'
+trace $CLI bundle validate -o json | jq '.resources.jobs.test_job.environments'
 rm out.requests.txt

--- a/bundle/config/mutator/normalize_paths.go
+++ b/bundle/config/mutator/normalize_paths.go
@@ -89,6 +89,7 @@ func normalizePath(path string, location dyn.Location, bundleRootPath string) (s
 	reqPath, ok := strings.CutPrefix(path, "-r ")
 	if ok {
 		// Normalize the path part
+		reqPath = strings.TrimSpace(reqPath)
 		normalizedPath, err := normalizePath(reqPath, location, bundleRootPath)
 		if err != nil {
 			return "", err

--- a/bundle/config/mutator/normalize_paths.go
+++ b/bundle/config/mutator/normalize_paths.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	pathlib "path"
 	"path/filepath"
+	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/mutator/paths"
@@ -84,6 +85,19 @@ func collectGitSourcePaths(b *bundle.Bundle) []dyn.Path {
 }
 
 func normalizePath(path string, location dyn.Location, bundleRootPath string) (string, error) {
+	// Handle requirements file paths with -r flag
+	reqPath, ok := strings.CutPrefix(path, "-r ")
+	if ok {
+		// Normalize the path part
+		normalizedPath, err := normalizePath(reqPath, location, bundleRootPath)
+		if err != nil {
+			return "", err
+		}
+
+		// Reconstruct the path with -r flag
+		return "-r " + normalizedPath, nil
+	}
+
 	pathAsUrl, err := url.Parse(path)
 	if err != nil {
 		return "", err

--- a/bundle/config/mutator/normalize_paths_test.go
+++ b/bundle/config/mutator/normalize_paths_test.go
@@ -73,6 +73,10 @@ func TestNormalizePath_requirementsFile(t *testing.T) {
 	value, err := normalizePath("-r ../requirements.txt", location, tmpDir)
 	assert.NoError(t, err)
 	assert.Equal(t, "-r requirements.txt", value)
+
+	value, err = normalizePath("-r      ../requirements.txt", location, tmpDir)
+	assert.NoError(t, err)
+	assert.Equal(t, "-r requirements.txt", value)
 }
 
 func TestLocationDirectory(t *testing.T) {

--- a/bundle/config/mutator/normalize_paths_test.go
+++ b/bundle/config/mutator/normalize_paths_test.go
@@ -67,6 +67,14 @@ func TestNormalizePath_url(t *testing.T) {
 	assert.Equal(t, "s3:///path/to/notebook.py", value)
 }
 
+func TestNormalizePath_requirementsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	location := dyn.Location{File: filepath.Join(tmpDir, "resources", "job_1.yml")}
+	value, err := normalizePath("-r ../requirements.txt", location, tmpDir)
+	assert.NoError(t, err)
+	assert.Equal(t, "-r requirements.txt", value)
+}
+
 func TestLocationDirectory(t *testing.T) {
 	loc := dyn.Location{File: "file", Line: 1, Column: 2}
 	dir, err := locationDirectory(loc)


### PR DESCRIPTION
## Changes
Fixed normalising requirements file path in dependencies section

Fixes #2849 

## Why
Previously we incorrectly normalised requirements file passed not treating `-r` prefix in such paths.
Instead we should normalise the path after `-r` and then prefix it with `-r` again/

## Tests
Added acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
