### PR TITLE
Add ShellExecv method

### DIFF
--- a/libs/exec/shell_execv.go
+++ b/libs/exec/shell_execv.go
@@ -1,12 +1,6 @@
 package exec
 
-import "errors"
-
-func shellExecvOpts(content string, opts ExecvOptions) (ExecvOptions, error) {
-	if opts.Args != nil {
-		return ExecvOptions{}, errors.New("ShellExecv: Args is not supported")
-	}
-
+func shellExecvOpts(content, dir string, env []string) (ExecvOptions, error) {
 	shell, err := findShell()
 	if err != nil {
 		return ExecvOptions{}, err
@@ -22,14 +16,14 @@ func shellExecvOpts(content string, opts ExecvOptions) (ExecvOptions, error) {
 
 	return ExecvOptions{
 		Args: args,
-		Env:  opts.Env,
-		Dir:  opts.Dir,
+		Env:  env,
+		Dir:  dir,
 	}, nil
 }
 
 // Variant of [Execv] that runs the given script through a shell
-func ShellExecv(content string, opts ExecvOptions) error {
-	newOpts, err := shellExecvOpts(content, opts)
+func ShellExecv(content, dir string, env []string) error {
+	newOpts, err := shellExecvOpts(content, dir, env)
 	if err != nil {
 		return err
 	}

--- a/libs/exec/shell_execv.go
+++ b/libs/exec/shell_execv.go
@@ -1,0 +1,38 @@
+package exec
+
+import "errors"
+
+func shellExecvOpts(content string, opts ExecvOptions) (ExecvOptions, error) {
+	if opts.Args != nil {
+		return ExecvOptions{}, errors.New("ShellExecv: Args is not supported")
+	}
+
+	shell, err := findShell()
+	if err != nil {
+		return ExecvOptions{}, err
+	}
+
+	ec, err := shell.prepare(content)
+	if err != nil {
+		return ExecvOptions{}, err
+	}
+
+	args := []string{ec.executable}
+	args = append(args, ec.args...)
+
+	return ExecvOptions{
+		Args: args,
+		Env:  opts.Env,
+		Dir:  opts.Dir,
+	}, nil
+}
+
+// Variant of [Execv] that runs the given script through a shell
+func ShellExecv(content string, opts ExecvOptions) error {
+	newOpts, err := shellExecvOpts(content, opts)
+	if err != nil {
+		return err
+	}
+
+	return Execv(newOpts)
+}

--- a/libs/exec/shell_execv.go
+++ b/libs/exec/shell_execv.go
@@ -28,5 +28,15 @@ func ShellExecv(content, dir string, env []string) error {
 		return err
 	}
 
+	// Note: To execute the content of the script, we write a temporary file and execute that
+	// using a shell. Since execv does not return control to the CLI process, we need to
+	// clean up the temporary file here.
+	// This is fine for Unix and Mac OS systems because files in /tmp are automatically
+	// cleaned up.
+	// ref1: https://serverfault.com/questions/377348/when-does-tmp-get-cleared
+	// ref2: https://superuser.com/questions/187071/in-macos-how-often-is-tmp-deleted
+	//
+	// For windows the temp files are not automatically cleaned up. Automatic cleanup
+	// is a opt-in behavior.
 	return Execv(newOpts)
 }

--- a/libs/exec/shell_execv_test.go
+++ b/libs/exec/shell_execv_test.go
@@ -10,12 +10,7 @@ import (
 )
 
 func TestShellExecvOpts(t *testing.T) {
-	opts := ExecvOptions{
-		Env: []string{"key1=value1", "key2=value2"},
-		Dir: "/a/b/c",
-	}
-
-	newOpts, err := shellExecvOpts("echo hello", opts)
+	newOpts, err := shellExecvOpts("echo hello", "/a/b/c", []string{"key1=value1", "key2=value2"})
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"key1=value1", "key2=value2"}, newOpts.Env)

--- a/libs/exec/shell_execv_test.go
+++ b/libs/exec/shell_execv_test.go
@@ -1,0 +1,29 @@
+package exec
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShellExecvOpts(t *testing.T) {
+	opts := ExecvOptions{
+		Env: []string{"key1=value1", "key2=value2"},
+		Dir: "/a/b/c",
+	}
+
+	newOpts, err := shellExecvOpts("echo hello", opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"key1=value1", "key2=value2"}, newOpts.Env)
+	assert.Equal(t, "/a/b/c", newOpts.Dir)
+
+	bashPath, err := exec.LookPath("bash")
+	require.NoError(t, err)
+	assert.Equal(t, bashPath, newOpts.Args[0])
+	assert.Equal(t, "-e", newOpts.Args[1])
+	assert.Equal(t, "echo hello", testutil.ReadFile(t, newOpts.Args[2]))
+}


### PR DESCRIPTION
## Changes
ShellExecv is a variant of the Execv method that also configures a shell to be used before running the command.

## Why
We need it for the scripts section in DABs: https://github.com/databricks/cli/pull/2813.

Why:
1. We'll need to perform lexical analysis to figure out where the boundaries for args in the script are. It's better to defer that to a shell.
2. Direct calls to execv do not perform any environment variable interpolation, so we need to go through a shell. This is neat because it provides customers a way to configure inputs to their scripts.
3. Multiline scripts require a shell since, without them, we cannot parse where a command ends.

Note: This uses the same priority order for shells as the `artifacts.build` field, that is bash > sh > powershell.

## Tests
Unit test. Also acceptance tests in https://github.com/databricks/cli/pull/2813
