### PR TITLE
Remove 'go mod vendor' and '-mod=vendor' option to 'go build'

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Pull external libraries
         run: |
-          make vendor
+          go mod download
           pip3 install wheel==0.45.1
 
       - name: Run tests without coverage

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ cli
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-vendor/
-
 *.log
 coverage.txt
 coverage-acceptance.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default: tidy vendor fmt lint ws
+default: tidy fmt lint ws
 
 PACKAGES=./acceptance/... ./libs/... ./internal/... ./cmd/... ./bundle/... .
 
@@ -43,14 +43,11 @@ showcover:
 acc-showcover:
 	go tool cover -html=coverage-acceptance.txt
 
-build: tidy vendor
-	go build -mod vendor
+build: tidy
+	go build
 
 snapshot:
 	go build -o .databricks/databricks
-
-vendor:
-	go mod vendor
 
 schema:
 	go run ./bundle/internal/schema ./bundle/internal/schema ./bundle/schema/jsonschema.json
@@ -60,10 +57,10 @@ docs:
 
 INTEGRATION = go tool gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./acceptance ./integration/..." -- -parallel 4 -timeout=2h
 
-integration: vendor
+integration:
 	$(INTEGRATION)
 
-integration-short: vendor
+integration-short:
 	VERBOSE_TEST=1 $(INTEGRATION) -short
 
 generate:
@@ -72,4 +69,4 @@ generate:
 	[ ! -f .github/workflows/next-changelog.yml ] || rm .github/workflows/next-changelog.yml
 	pushd experimental/python && make codegen
 
-.PHONY: lint tidy lintcheck fmt test cover showcover build snapshot vendor schema integration integration-short acc-cover acc-showcover docs ws
+.PHONY: lint tidy lintcheck fmt test cover showcover build snapshot schema integration integration-short acc-cover acc-showcover docs ws

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -653,9 +653,7 @@ func BuildCLI(t *testing.T, buildDir, coverDir string) string {
 	}
 
 	args := []string{
-		"go", "build",
-		"-mod", "vendor",
-		"-o", execPath,
+		"go", "build", "-o", execPath,
 	}
 
 	if coverDir != "" {

--- a/bundle/docsgen/README.md
+++ b/bundle/docsgen/README.md
@@ -1,7 +1,7 @@
 ## docs-autogen
 
 1. Install [Golang](https://go.dev/doc/install)
-2. Run `make vendor docs` from the repo
+2. Run `make docs` from the repo
 3. See generated documents in `./bundle/docsgen/output` directory
 4. To change descriptions update content in `./bundle/internal/schema/annotations.yml` or `./bundle/internal/schema/annotations_openapi_overrides.yml` and re-run `make docs`
 

--- a/libs/git/repository_test.go
+++ b/libs/git/repository_test.go
@@ -138,8 +138,8 @@ func TestRepository(t *testing.T) {
 	// Check that top level ignores work.
 	assert.True(t, tr.Ignore(".DS_Store"))
 	assert.True(t, tr.Ignore("foo.pyc"))
-	assert.False(t, tr.Ignore("vendor"))
-	assert.True(t, tr.Ignore("vendor/"))
+	assert.False(t, tr.Ignore("vendor/"))
+	assert.True(t, tr.Ignore("__pycache__/"))
 
 	// Check that ignores under testdata work.
 	assert.True(t, tr.Ignore("libs/git/testdata/root.ignoreme"))


### PR DESCRIPTION
## Changes
- Remove 'make vendor' (go mod vendor) from everywhere.
- When building CLI, do not pass '-mod=vendor'

## Why
There is no need to populate vendor directory (since we don't commit it to the repo), the modules are already transparently cached in go module cache.

When switching branches, today you always get an error about inconsistency between vendor/ and go.sum (until you run 'make vendor'), this goes with this PR.