### PR TITLE
acc: Enable default-python/combinations on cloud

### DIFF
--- a/acceptance/bundle/templates/default-python/combinations/check_output.py
+++ b/acceptance/bundle/templates/default-python/combinations/check_output.py
@@ -3,6 +3,9 @@ import sys
 import os
 import subprocess
 
+CLOUD_ENV = os.environ.get("CLOUD_ENV")
+if CLOUD_ENV and os.environ["SERVERLESS"] == "yes" and not os.environ.get("TEST_METASTORE_ID"):
+    sys.exit(f"SKIP_TEST SERVERLESS=yes but TEST_METASTORE_ID is empty in this env {CLOUD_ENV=}")
 
 BUILDING = "Building python_artifact"
 UPLOADING = "Uploading dist/"

--- a/acceptance/bundle/templates/default-python/combinations/input.json.tmpl
+++ b/acceptance/bundle/templates/default-python/combinations/input.json.tmpl
@@ -1,5 +1,5 @@
 {
-    "project_name": "my_default_python",
+    "project_name": "X$UNIQUE_NAME",
     "include_notebook": "$INCLUDE_NOTEBOOK",
     "include_dlt": "$INCLUDE_DLT",
     "include_python": "$INCLUDE_PYTHON",

--- a/acceptance/bundle/templates/default-python/combinations/output.txt
+++ b/acceptance/bundle/templates/default-python/combinations/output.txt
@@ -2,34 +2,34 @@
 >>> [CLI] bundle init default-python --config-file ./input.json
 
 Welcome to the default Python template for Databricks Asset Bundles!
-Workspace to use (auto-detected, edit in 'my_default_python/databricks.yml'): [DATABRICKS_URL]
+Workspace to use (auto-detected, edit in 'X[UNIQUE_NAME]/databricks.yml'): [DATABRICKS_URL]
 
-✨ Your new project has been created in the 'my_default_python' directory!
+✨ Your new project has been created in the 'X[UNIQUE_NAME]' directory!
 
 Please refer to the README.md file for "getting started" instructions.
 See also the documentation at https://docs.databricks.com/dev-tools/bundles/index.html.
 
 >>> [CLI] bundle validate -t dev
-Name: my_default_python
+Name: X[UNIQUE_NAME]
 Target: dev
 Workspace:
   Host: [DATABRICKS_URL]
   User: [USERNAME]
-  Path: /Workspace/Users/[USERNAME]/.bundle/my_default_python/dev
+  Path: /Workspace/Users/[USERNAME]/.bundle/X[UNIQUE_NAME]/dev
 
 Validation OK!
 
 >>> [CLI] bundle validate -t prod
-Name: my_default_python
+Name: X[UNIQUE_NAME]
 Target: prod
 Workspace:
   Host: [DATABRICKS_URL]
   User: [USERNAME]
-  Path: /Workspace/Users/[USERNAME]/.bundle/my_default_python/prod
+  Path: /Workspace/Users/[USERNAME]/.bundle/X[UNIQUE_NAME]/prod
 
 Validation OK!
 
 >>> ../check_output.py [CLI] bundle deploy -t dev
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/X[UNIQUE_NAME]/dev/files...
 Deploying resources...
 Deployment complete!

--- a/acceptance/bundle/templates/default-python/combinations/script
+++ b/acceptance/bundle/templates/default-python/combinations/script
@@ -1,7 +1,7 @@
 envsubst < input.json.tmpl > input.json
 trace $CLI bundle init default-python --config-file ./input.json
 
-cd ./my_default_python
+cd ./X*
 trace $CLI bundle validate -t dev
 trace $CLI bundle validate -t prod
 
@@ -13,3 +13,5 @@ trace ../check_output.py $CLI bundle deploy -t dev
 # Do not affect this repository's git behaviour #2318
 mv .gitignore out.gitignore
 rm .databricks/.gitignore
+cd ..
+rm -fr X*

--- a/acceptance/bundle/templates/default-python/combinations/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/test.toml
@@ -1,4 +1,6 @@
-Ignore = ["my_default_python", "input.json"]
+Cloud = true
+
+Ignore = ["input.json"]
 EnvMatrix.INCLUDE_NOTEBOOK = ["yes", "no"]
 EnvMatrix.INCLUDE_DLT = ["yes", "no"]
 EnvMatrix.INCLUDE_PYTHON = ["yes", "no"]


### PR DESCRIPTION
This checks all combinations of input parameters against cloud environments.

Relies on https://github.com/databricks/cli/pull/2894 to skip environments + configurations that cannot work together.