### PR TITLE
Add metrics for compute type used

### DIFF
--- a/acceptance/bundle/paths/fallback_metric/output.txt
+++ b/acceptance/bundle/paths/fallback_metric/output.txt
@@ -17,6 +17,18 @@ Deployment complete!
   {
     "key": "python_wheel_wrapper_is_set",
     "value": false
+  },
+  {
+    "key": "has_serverless_compute",
+    "value": false
+  },
+  {
+    "key": "has_classic_job_compute",
+    "value": true
+  },
+  {
+    "key": "has_classic_interactive_compute",
+    "value": false
   }
 ]
 [
@@ -26,6 +38,18 @@ Deployment complete!
   },
   {
     "key": "python_wheel_wrapper_is_set",
+    "value": false
+  },
+  {
+    "key": "has_serverless_compute",
+    "value": false
+  },
+  {
+    "key": "has_classic_job_compute",
+    "value": true
+  },
+  {
+    "key": "has_classic_interactive_compute",
     "value": false
   }
 ]

--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/output.txt
@@ -36,6 +36,18 @@ Deployment complete!
       {
         "key": "python_wheel_wrapper_is_set",
         "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
       }
     ],
     "bundle_mode": "TYPE_UNSPECIFIED",
@@ -67,6 +79,18 @@ Deployment complete!
     "bool_values": [
       {
         "key": "python_wheel_wrapper_is_set",
+        "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
         "value": false
       }
     ],

--- a/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
@@ -60,3 +60,6 @@ targets:
               existing_cluster_id: "1234"
               spark_python_task:
                 python_file: ./test.py
+            - task_key: task2
+              notebook_task:
+                notebook_path: ./notebook.py

--- a/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
@@ -1,0 +1,62 @@
+bundle:
+  name: deploy-compute-type
+
+resources:
+  jobs:
+    my_job:
+      environments:
+      - environment_key: "env"
+        spec:
+          client: "1"
+          dependencies:
+            - "test_package"
+
+targets:
+  one:
+    resources:
+      jobs:
+        my_job:
+          tasks:
+            - task_key: task1
+              notebook_task:
+                notebook_path: ./notebook.py
+
+  two:
+   resources:
+      jobs:
+        my_job:
+          tasks:
+            - task_key: task1
+              environment_key: env
+              spark_python_task:
+                python_file: ./test.py
+
+  three:
+   resources:
+      jobs:
+        my_job:
+          tasks:
+            - task_key: task1
+              new_cluster:
+                spark_version: 15.4.x-scala2.12
+                node_type_id: i3.xlarge
+                data_security_mode: SINGLE_USER
+                num_workers: 0
+                spark_conf:
+                    spark.master: "local[*, 4]"
+                    spark.databricks.cluster.profile: singleNode
+                custom_tags:
+                  ResourceClass: SingleNode
+
+              spark_python_task:
+                python_file: ./test.py
+
+  four:
+   resources:
+      jobs:
+        my_job:
+          tasks:
+            - task_key: task1
+              existing_cluster_id: "1234"
+              spark_python_task:
+                python_file: ./test.py

--- a/acceptance/bundle/telemetry/deploy-compute-type/notebook.py
+++ b/acceptance/bundle/telemetry/deploy-compute-type/notebook.py
@@ -1,0 +1,2 @@
+# Databricks notebook source
+1 + 1

--- a/acceptance/bundle/telemetry/deploy-compute-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-compute-type/output.txt
@@ -24,191 +24,75 @@ Updating deployment state...
 Deployment complete!
 
 >>> cat out.requests.txt
-{
-  "bundle_uuid": "[UUID]",
-  "deployment_id": "[UUID]",
-  "resource_count": 1,
-  "resource_job_count": 1,
-  "resource_pipeline_count": 0,
-  "resource_model_count": 0,
-  "resource_experiment_count": 0,
-  "resource_model_serving_endpoint_count": 0,
-  "resource_registered_model_count": 0,
-  "resource_quality_monitor_count": 0,
-  "resource_schema_count": 0,
-  "resource_volume_count": 0,
-  "resource_cluster_count": 0,
-  "resource_dashboard_count": 0,
-  "resource_app_count": 0,
-  "resource_job_ids": [
-    "1"
-  ],
-  "experimental": {
-    "configuration_file_count": 1,
-    "variable_count": 0,
-    "complex_variable_count": 0,
-    "lookup_variable_count": 0,
-    "target_count": 4,
-    "bool_values": [
-      {
-        "key": "python_wheel_wrapper_is_set",
-        "value": false
-      },
-      {
-        "key": "has_serverless_compute",
-        "value": true
-      },
-      {
-        "key": "has_classic_job_compute",
-        "value": false
-      },
-      {
-        "key": "has_classic_interactive_compute",
-        "value": false
-      }
-    ],
-    "bundle_mode": "TYPE_UNSPECIFIED",
-    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+[
+  {
+    "key": "python_wheel_wrapper_is_set",
+    "value": false
+  },
+  {
+    "key": "has_serverless_compute",
+    "value": true
+  },
+  {
+    "key": "has_classic_job_compute",
+    "value": false
+  },
+  {
+    "key": "has_classic_interactive_compute",
+    "value": false
   }
-}
-{
-  "bundle_uuid": "[UUID]",
-  "deployment_id": "[UUID]",
-  "resource_count": 1,
-  "resource_job_count": 1,
-  "resource_pipeline_count": 0,
-  "resource_model_count": 0,
-  "resource_experiment_count": 0,
-  "resource_model_serving_endpoint_count": 0,
-  "resource_registered_model_count": 0,
-  "resource_quality_monitor_count": 0,
-  "resource_schema_count": 0,
-  "resource_volume_count": 0,
-  "resource_cluster_count": 0,
-  "resource_dashboard_count": 0,
-  "resource_app_count": 0,
-  "resource_job_ids": [
-    "2"
-  ],
-  "experimental": {
-    "configuration_file_count": 1,
-    "variable_count": 0,
-    "complex_variable_count": 0,
-    "lookup_variable_count": 0,
-    "target_count": 4,
-    "bool_values": [
-      {
-        "key": "python_wheel_wrapper_is_set",
-        "value": false
-      },
-      {
-        "key": "has_serverless_compute",
-        "value": true
-      },
-      {
-        "key": "has_classic_job_compute",
-        "value": false
-      },
-      {
-        "key": "has_classic_interactive_compute",
-        "value": false
-      }
-    ],
-    "bundle_mode": "TYPE_UNSPECIFIED",
-    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+]
+[
+  {
+    "key": "python_wheel_wrapper_is_set",
+    "value": false
+  },
+  {
+    "key": "has_serverless_compute",
+    "value": true
+  },
+  {
+    "key": "has_classic_job_compute",
+    "value": false
+  },
+  {
+    "key": "has_classic_interactive_compute",
+    "value": false
   }
-}
-{
-  "bundle_uuid": "[UUID]",
-  "deployment_id": "[UUID]",
-  "resource_count": 1,
-  "resource_job_count": 1,
-  "resource_pipeline_count": 0,
-  "resource_model_count": 0,
-  "resource_experiment_count": 0,
-  "resource_model_serving_endpoint_count": 0,
-  "resource_registered_model_count": 0,
-  "resource_quality_monitor_count": 0,
-  "resource_schema_count": 0,
-  "resource_volume_count": 0,
-  "resource_cluster_count": 0,
-  "resource_dashboard_count": 0,
-  "resource_app_count": 0,
-  "resource_job_ids": [
-    "3"
-  ],
-  "experimental": {
-    "configuration_file_count": 1,
-    "variable_count": 0,
-    "complex_variable_count": 0,
-    "lookup_variable_count": 0,
-    "target_count": 4,
-    "bool_values": [
-      {
-        "key": "python_wheel_wrapper_is_set",
-        "value": false
-      },
-      {
-        "key": "has_serverless_compute",
-        "value": false
-      },
-      {
-        "key": "has_classic_job_compute",
-        "value": true
-      },
-      {
-        "key": "has_classic_interactive_compute",
-        "value": false
-      }
-    ],
-    "bundle_mode": "TYPE_UNSPECIFIED",
-    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+]
+[
+  {
+    "key": "python_wheel_wrapper_is_set",
+    "value": false
+  },
+  {
+    "key": "has_serverless_compute",
+    "value": false
+  },
+  {
+    "key": "has_classic_job_compute",
+    "value": true
+  },
+  {
+    "key": "has_classic_interactive_compute",
+    "value": false
   }
-}
-{
-  "bundle_uuid": "[UUID]",
-  "deployment_id": "[UUID]",
-  "resource_count": 1,
-  "resource_job_count": 1,
-  "resource_pipeline_count": 0,
-  "resource_model_count": 0,
-  "resource_experiment_count": 0,
-  "resource_model_serving_endpoint_count": 0,
-  "resource_registered_model_count": 0,
-  "resource_quality_monitor_count": 0,
-  "resource_schema_count": 0,
-  "resource_volume_count": 0,
-  "resource_cluster_count": 0,
-  "resource_dashboard_count": 0,
-  "resource_app_count": 0,
-  "resource_job_ids": [
-    "4"
-  ],
-  "experimental": {
-    "configuration_file_count": 1,
-    "variable_count": 0,
-    "complex_variable_count": 0,
-    "lookup_variable_count": 0,
-    "target_count": 4,
-    "bool_values": [
-      {
-        "key": "python_wheel_wrapper_is_set",
-        "value": false
-      },
-      {
-        "key": "has_serverless_compute",
-        "value": true
-      },
-      {
-        "key": "has_classic_job_compute",
-        "value": false
-      },
-      {
-        "key": "has_classic_interactive_compute",
-        "value": true
-      }
-    ],
-    "bundle_mode": "TYPE_UNSPECIFIED",
-    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+]
+[
+  {
+    "key": "python_wheel_wrapper_is_set",
+    "value": false
+  },
+  {
+    "key": "has_serverless_compute",
+    "value": true
+  },
+  {
+    "key": "has_classic_job_compute",
+    "value": false
+  },
+  {
+    "key": "has_classic_interactive_compute",
+    "value": true
   }
-}
+]

--- a/acceptance/bundle/telemetry/deploy-compute-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-compute-type/output.txt
@@ -197,7 +197,7 @@ Deployment complete!
       },
       {
         "key": "has_serverless_compute",
-        "value": false
+        "value": true
       },
       {
         "key": "has_classic_job_compute",

--- a/acceptance/bundle/telemetry/deploy-compute-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-compute-type/output.txt
@@ -1,0 +1,214 @@
+
+>>> [CLI] bundle deploy -t one
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-compute-type/one/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle deploy -t two
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-compute-type/two/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle deploy -t three
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-compute-type/three/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle deploy -t four
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-compute-type/four/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> cat out.requests.txt
+{
+  "bundle_uuid": "[UUID]",
+  "deployment_id": "[UUID]",
+  "resource_count": 1,
+  "resource_job_count": 1,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "resource_job_ids": [
+    "1"
+  ],
+  "experimental": {
+    "configuration_file_count": 1,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 4,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": true
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
+      }
+    ],
+    "bundle_mode": "TYPE_UNSPECIFIED",
+    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+  }
+}
+{
+  "bundle_uuid": "[UUID]",
+  "deployment_id": "[UUID]",
+  "resource_count": 1,
+  "resource_job_count": 1,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "resource_job_ids": [
+    "2"
+  ],
+  "experimental": {
+    "configuration_file_count": 1,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 4,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": true
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
+      }
+    ],
+    "bundle_mode": "TYPE_UNSPECIFIED",
+    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+  }
+}
+{
+  "bundle_uuid": "[UUID]",
+  "deployment_id": "[UUID]",
+  "resource_count": 1,
+  "resource_job_count": 1,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "resource_job_ids": [
+    "3"
+  ],
+  "experimental": {
+    "configuration_file_count": 1,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 4,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": true
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
+      }
+    ],
+    "bundle_mode": "TYPE_UNSPECIFIED",
+    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+  }
+}
+{
+  "bundle_uuid": "[UUID]",
+  "deployment_id": "[UUID]",
+  "resource_count": 1,
+  "resource_job_count": 1,
+  "resource_pipeline_count": 0,
+  "resource_model_count": 0,
+  "resource_experiment_count": 0,
+  "resource_model_serving_endpoint_count": 0,
+  "resource_registered_model_count": 0,
+  "resource_quality_monitor_count": 0,
+  "resource_schema_count": 0,
+  "resource_volume_count": 0,
+  "resource_cluster_count": 0,
+  "resource_dashboard_count": 0,
+  "resource_app_count": 0,
+  "resource_job_ids": [
+    "4"
+  ],
+  "experimental": {
+    "configuration_file_count": 1,
+    "variable_count": 0,
+    "complex_variable_count": 0,
+    "lookup_variable_count": 0,
+    "target_count": 4,
+    "bool_values": [
+      {
+        "key": "python_wheel_wrapper_is_set",
+        "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": true
+      }
+    ],
+    "bundle_mode": "TYPE_UNSPECIFIED",
+    "workspace_artifact_path_type": "WORKSPACE_FILE_SYSTEM"
+  }
+}

--- a/acceptance/bundle/telemetry/deploy-compute-type/script
+++ b/acceptance/bundle/telemetry/deploy-compute-type/script
@@ -1,0 +1,8 @@
+trace $CLI bundle deploy -t one
+trace $CLI bundle deploy -t two
+trace $CLI bundle deploy -t three
+trace $CLI bundle deploy -t four
+
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
+
+rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-compute-type/script
+++ b/acceptance/bundle/telemetry/deploy-compute-type/script
@@ -3,6 +3,6 @@ trace $CLI bundle deploy -t two
 trace $CLI bundle deploy -t three
 trace $CLI bundle deploy -t four
 
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event'
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values'
 
 rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-compute-type/test.py
+++ b/acceptance/bundle/telemetry/deploy-compute-type/test.py
@@ -1,0 +1,1 @@
+print("Hello world!")

--- a/acceptance/bundle/telemetry/deploy-compute-type/test.toml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/test.toml
@@ -1,0 +1,15 @@
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/volumes/main.a.b"
+Response.Body = '''
+{
+  "catalog_name": "main",
+  "schema_name": "a",
+  "name": "b",
+  "volume_type": "MANAGED",
+  "full_name": "main.a.b"
+}
+'''
+
+[[Server]]
+Pattern = "PUT /api/2.0/fs/directories/Volumes/main/a/b/c/.internal"
+Response.StatusCode = 200

--- a/acceptance/bundle/telemetry/deploy-config-file-count/out.telemetry.txt
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/out.telemetry.txt
@@ -36,6 +36,18 @@
             {
               "key": "python_wheel_wrapper_is_set",
               "value": false
+            },
+            {
+              "key": "has_serverless_compute",
+              "value": false
+            },
+            {
+              "key": "has_classic_job_compute",
+              "value": false
+            },
+            {
+              "key": "has_classic_interactive_compute",
+              "value": false
             }
           ],
           "bundle_mode": "TYPE_UNSPECIFIED",

--- a/acceptance/bundle/telemetry/deploy-mode/output.txt
+++ b/acceptance/bundle/telemetry/deploy-mode/output.txt
@@ -42,6 +42,18 @@ A common practice is to use a username or principal name in this path, i.e. use
       {
         "key": "python_wheel_wrapper_is_set",
         "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
       }
     ],
     "bundle_mode": "DEVELOPMENT",
@@ -73,6 +85,18 @@ A common practice is to use a username or principal name in this path, i.e. use
     "bool_values": [
       {
         "key": "python_wheel_wrapper_is_set",
+        "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
         "value": false
       }
     ],

--- a/acceptance/bundle/telemetry/deploy-no-uuid/out.telemetry.txt
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/out.telemetry.txt
@@ -39,6 +39,18 @@
             {
               "key": "python_wheel_wrapper_is_set",
               "value": false
+            },
+            {
+              "key": "has_serverless_compute",
+              "value": false
+            },
+            {
+              "key": "has_classic_job_compute",
+              "value": false
+            },
+            {
+              "key": "has_classic_interactive_compute",
+              "value": false
             }
           ],
           "bundle_mode": "TYPE_UNSPECIFIED",

--- a/acceptance/bundle/telemetry/deploy-target-count/output.txt
+++ b/acceptance/bundle/telemetry/deploy-target-count/output.txt
@@ -31,6 +31,18 @@ Deployment complete!
       {
         "key": "python_wheel_wrapper_is_set",
         "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
       }
     ],
     "bundle_mode": "TYPE_UNSPECIFIED",

--- a/acceptance/bundle/telemetry/deploy-variable-count/output.txt
+++ b/acceptance/bundle/telemetry/deploy-variable-count/output.txt
@@ -31,6 +31,18 @@ Deployment complete!
       {
         "key": "python_wheel_wrapper_is_set",
         "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
       }
     ],
     "bundle_mode": "TYPE_UNSPECIFIED",

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -48,6 +48,18 @@ Deployment complete!
       {
         "key": "python_wheel_wrapper_is_set",
         "value": false
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
       }
     ],
     "bundle_mode": "TYPE_UNSPECIFIED",
@@ -92,6 +104,18 @@ Deployment complete!
       {
         "key": "python_wheel_wrapper_is_set",
         "value": true
+      },
+      {
+        "key": "has_serverless_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_job_compute",
+        "value": false
+      },
+      {
+        "key": "has_classic_interactive_compute",
+        "value": false
       }
     ],
     "bundle_mode": "TYPE_UNSPECIFIED",

--- a/acceptance/bundle/telemetry/deploy/out.telemetry.txt
+++ b/acceptance/bundle/telemetry/deploy/out.telemetry.txt
@@ -45,6 +45,18 @@
             {
               "key": "python_wheel_wrapper_is_set",
               "value": false
+            },
+            {
+              "key": "has_serverless_compute",
+              "value": false
+            },
+            {
+              "key": "has_classic_job_compute",
+              "value": false
+            },
+            {
+              "key": "has_classic_interactive_compute",
+              "value": false
             }
           ],
           "bundle_mode": "TYPE_UNSPECIFIED",

--- a/bundle/metrics/track_used_compute.go
+++ b/bundle/metrics/track_used_compute.go
@@ -40,12 +40,6 @@ func (c *trackUsedCompute) Apply(ctx context.Context, b *bundle.Bundle) diag.Dia
 				continue
 			}
 
-			// If existing_cluster_id is set - then classic interactive compute is used
-			if task.ExistingClusterId != "" {
-				hasClassicInteractiveCompute = true
-				continue
-			}
-
 			// For notebook tasks if nothing is set it means serverless compute is used
 			if task.NotebookTask != nil {
 				hasServerlessCompute = true

--- a/bundle/metrics/track_used_compute.go
+++ b/bundle/metrics/track_used_compute.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+)
+
+type trackUsedCompute struct{}
+
+func (c *trackUsedCompute) Name() string {
+	return "trackUsedCompute"
+}
+
+func (c *trackUsedCompute) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	// Track different types of compute used
+	hasServerlessCompute := false
+	hasClassicJobCompute := false
+	hasClassicInteractiveCompute := false
+
+	// Iterate over all tasks in bundle
+	for _, job := range b.Config.Resources.Jobs {
+		for _, task := range job.Tasks {
+			// If the environment_key is set - then serverless compute is used
+			if task.EnvironmentKey != "" {
+				hasServerlessCompute = true
+				continue
+			}
+
+			// If the new_cluster or job_cluster_key is set - then classic job compute is used
+			if task.NewCluster != nil || task.JobClusterKey != "" {
+				hasClassicJobCompute = true
+				continue
+			}
+
+			// If existing_cluster_id is set - then classic interactive compute is used
+			if task.ExistingClusterId != "" {
+				hasClassicInteractiveCompute = true
+				continue
+			}
+
+			// If existing_cluster_id is set - then classic interactive compute is used
+			if task.ExistingClusterId != "" {
+				hasClassicInteractiveCompute = true
+				continue
+			}
+
+			// For notebook tasks if nothing is set it means serverless compute is used
+			if task.NotebookTask != nil {
+				hasServerlessCompute = true
+			}
+		}
+	}
+
+	b.Metrics.AddBoolValue("has_serverless_compute", hasServerlessCompute)
+	b.Metrics.AddBoolValue("has_classic_job_compute", hasClassicJobCompute)
+	b.Metrics.AddBoolValue("has_classic_interactive_compute", hasClassicInteractiveCompute)
+
+	return nil
+}
+
+func TrackUsedCompute() bundle.Mutator {
+	return &trackUsedCompute{}
+}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/metadata"
 	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/libraries"
+	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/bundle/permissions"
 	"github.com/databricks/cli/bundle/scripts"
 	"github.com/databricks/cli/bundle/trampoline"
@@ -207,6 +208,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 		terraform.Interpolate(),
 		terraform.Write(),
 		terraform.Plan(terraform.PlanGoal("deploy")),
+		metrics.TrackUsedCompute(),
 	)
 
 	if diags.HasError() {


### PR DESCRIPTION
## Changes
Add metrics for compute type used 

## Why
This allows us to track which compute (serverless or classic and which type) is used in bundle tasks.

## Tests
Added acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
