### PR TITLE
[Python] Fix missing support for floats

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -17,5 +17,6 @@
 * Fix default-python template not to add environments when serverless=yes and include\_python=no ([#2866](https://github.com/databricks/cli/pull/2866))
 * Fix handling of Unicode characters in Python support ([#2873](https://github.com/databricks/cli/pull/2873))
 * Add support for secret scopes in DABs ([#2744](https://github.com/databricks/cli/pull/2744))
+* Fix support for `spot_bid_max_price` field in Python support ([#2883](https://github.com/databricks/cli/pull/2883))
 
 ### API Changes

--- a/experimental/python/databricks/bundles/core/_transform.py
+++ b/experimental/python/databricks/bundles/core/_transform.py
@@ -195,6 +195,8 @@ def _transform(cls: Type[_T], value: Any) -> _T:
         return str(value)  # type:ignore
     elif cls is int:
         return int(value)  # type:ignore
+    elif cls is float:
+        return float(value)  # type:ignore
     elif cls is bool:
         if isinstance(value, bool):
             return value  # type:ignore

--- a/experimental/python/databricks_tests/core/test_transform.py
+++ b/experimental/python/databricks_tests/core/test_transform.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
@@ -332,3 +333,15 @@ def test_forward_ref():
     out = _transform(A, {"field": {"color": "red"}})
 
     assert out == A(field=MyDataclass(color=Color.RED))
+
+
+def test_transform_float():
+    value = float(math.pi)
+
+    @dataclass
+    class Fake:
+        field: Optional[float] = None
+
+    out = _transform(Fake, {"field": value})
+
+    assert out == Fake(field=value)


### PR DESCRIPTION
## Changes
Add support for floats to Python code. Previously, attempting to deserialize a float resulted in an error.

There is only one example of a float. It's in `spot_bid_max_price` in `compute.AzureAttributes`, which was previously unsupported. Implement support for floats with all implications of precision loss.

## Why
Fixes https://github.com/databricks/cli/issues/2875

## Tests
Unit tests and manually