### PR TITLE
acc: Speed up deploy-compute-type telemetry test

### DIFF
--- a/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
@@ -20,23 +20,11 @@ targets:
             - task_key: task1
               notebook_task:
                 notebook_path: ./notebook.py
-
-  two:
-   resources:
-      jobs:
-        my_job:
-          tasks:
-            - task_key: task1
-              environment_key: env
+            - task_key: task2
+              existing_cluster_id: "1234"
               spark_python_task:
                 python_file: ./test.py
-
-  three:
-   resources:
-      jobs:
-        my_job:
-          tasks:
-            - task_key: task1
+            - task_key: task3
               new_cluster:
                 spark_version: 15.4.x-scala2.12
                 node_type_id: i3.xlarge
@@ -47,19 +35,15 @@ targets:
                     spark.databricks.cluster.profile: singleNode
                 custom_tags:
                   ResourceClass: SingleNode
-
               spark_python_task:
                 python_file: ./test.py
 
-  four:
+  two:
    resources:
       jobs:
         my_job:
           tasks:
             - task_key: task1
-              existing_cluster_id: "1234"
+              environment_key: env
               spark_python_task:
                 python_file: ./test.py
-            - task_key: task2
-              notebook_task:
-                notebook_path: ./notebook.py

--- a/acceptance/bundle/telemetry/deploy-compute-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-compute-type/output.txt
@@ -11,18 +11,6 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] bundle deploy -t three
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-compute-type/three/files...
-Deploying resources...
-Updating deployment state...
-Deployment complete!
-
->>> [CLI] bundle deploy -t four
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-compute-type/four/files...
-Deploying resources...
-Updating deployment state...
-Deployment complete!
-
 >>> cat out.requests.txt
 [
   {
@@ -35,11 +23,11 @@ Deployment complete!
   },
   {
     "key": "has_classic_job_compute",
-    "value": false
+    "value": true
   },
   {
     "key": "has_classic_interactive_compute",
-    "value": false
+    "value": true
   }
 ]
 [
@@ -58,41 +46,5 @@ Deployment complete!
   {
     "key": "has_classic_interactive_compute",
     "value": false
-  }
-]
-[
-  {
-    "key": "python_wheel_wrapper_is_set",
-    "value": false
-  },
-  {
-    "key": "has_serverless_compute",
-    "value": false
-  },
-  {
-    "key": "has_classic_job_compute",
-    "value": true
-  },
-  {
-    "key": "has_classic_interactive_compute",
-    "value": false
-  }
-]
-[
-  {
-    "key": "python_wheel_wrapper_is_set",
-    "value": false
-  },
-  {
-    "key": "has_serverless_compute",
-    "value": true
-  },
-  {
-    "key": "has_classic_job_compute",
-    "value": false
-  },
-  {
-    "key": "has_classic_interactive_compute",
-    "value": true
   }
 ]

--- a/acceptance/bundle/telemetry/deploy-compute-type/script
+++ b/acceptance/bundle/telemetry/deploy-compute-type/script
@@ -1,7 +1,5 @@
 trace $CLI bundle deploy -t one
 trace $CLI bundle deploy -t two
-trace $CLI bundle deploy -t three
-trace $CLI bundle deploy -t four
 
 trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values'
 


### PR DESCRIPTION
## Changes
Speed up deploy-compute-type telemetry test

## Why
It's enough to have 2 targets (instead of 4) with multiple tasks to have the same coverage but we can do 2 times less deployments

## Tests
Existing tets pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
