### PR TITLE
Validate that source_code_path for app resources is not empty

### DIFF
--- a/acceptance/bundle/validate/empty_resources/empty_dict/output.txt
+++ b/acceptance/bundle/validate/empty_resources/empty_dict/output.txt
@@ -102,6 +102,11 @@
 }
 
 === resources.apps.rname ===
+Error: Missing app source code path
+  in databricks.yml:6:12
+
+app resource 'rname' is missing required source_code_path field
+
 {
   "apps": {
     "rname": {

--- a/acceptance/bundle/validate/empty_resources/with_grants/output.txt
+++ b/acceptance/bundle/validate/empty_resources/with_grants/output.txt
@@ -139,6 +139,11 @@ Warning: unknown field: grants
   at resources.apps.rname
   in databricks.yml:7:7
 
+Error: Missing app source code path
+  in databricks.yml:7:7
+
+app resource 'rname' is missing required source_code_path field
+
 {
   "apps": {
     "rname": {

--- a/acceptance/bundle/validate/empty_resources/with_permissions/output.txt
+++ b/acceptance/bundle/validate/empty_resources/with_permissions/output.txt
@@ -120,6 +120,11 @@ Warning: unknown field: permissions
 }
 
 === resources.apps.rname ===
+Error: Missing app source code path
+  in databricks.yml:7:7
+
+app resource 'rname' is missing required source_code_path field
+
 {
   "apps": {
     "rname": {

--- a/bundle/apps/validate.go
+++ b/bundle/apps/validate.go
@@ -15,6 +15,16 @@ func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics
 	usedSourceCodePaths := make(map[string]string)
 
 	for key, app := range b.Config.Resources.Apps {
+		if app.SourceCodePath == "" {
+			diags = append(diags, diag.Diagnostic{
+				Severity:  diag.Error,
+				Summary:   "Missing app source code path",
+				Detail:    fmt.Sprintf("app resource '%s' is missing required source_code_path field", key),
+				Locations: b.Config.GetLocations(fmt.Sprintf("resources.apps.%s", key)),
+			})
+			continue
+		}
+
 		if _, ok := usedSourceCodePaths[app.SourceCodePath]; ok {
 			diags = append(diags, diag.Diagnostic{
 				Severity:  diag.Error,

--- a/bundle/apps/validate.go
+++ b/bundle/apps/validate.go
@@ -20,7 +20,7 @@ func (v *validate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics
 				Severity:  diag.Error,
 				Summary:   "Missing app source code path",
 				Detail:    fmt.Sprintf("app resource '%s' is missing required source_code_path field", key),
-				Locations: b.Config.GetLocations(fmt.Sprintf("resources.apps.%s", key)),
+				Locations: b.Config.GetLocations("resources.apps." + key),
 			})
 			continue
 		}

--- a/bundle/apps/validate_test.go
+++ b/bundle/apps/validate_test.go
@@ -55,35 +55,3 @@ func TestAppsValidateSameSourcePath(t *testing.T) {
 	require.Equal(t, "Duplicate app source code path", diags[0].Summary)
 	require.Contains(t, diags[0].Detail, "has the same source code path as app resource")
 }
-
-func TestAppsValidateEmptySourcePath(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	b := &bundle.Bundle{
-		BundleRootPath: tmpDir,
-		SyncRootPath:   tmpDir,
-		SyncRoot:       vfs.MustNew(tmpDir),
-		Config: config.Root{
-			Workspace: config.Workspace{
-				FilePath: "/foo/bar/",
-			},
-			Resources: config.Resources{
-				Apps: map[string]*resources.App{
-					"app1": {
-						App: apps.App{
-							Name: "app1",
-						},
-						SourceCodePath: "",
-					},
-				},
-			},
-		},
-	}
-
-	bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(tmpDir, "databricks.yml")}})
-
-	diags := bundle.ApplySeq(context.Background(), b, mutator.TranslatePaths(), Validate())
-	require.Len(t, diags, 1)
-	require.Equal(t, "Missing app source code path", diags[0].Summary)
-	require.Contains(t, diags[0].Detail, "is missing required source_code_path field")
-}

--- a/bundle/apps/validate_test.go
+++ b/bundle/apps/validate_test.go
@@ -55,3 +55,35 @@ func TestAppsValidateSameSourcePath(t *testing.T) {
 	require.Equal(t, "Duplicate app source code path", diags[0].Summary)
 	require.Contains(t, diags[0].Detail, "has the same source code path as app resource")
 }
+
+func TestAppsValidateEmptySourcePath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	b := &bundle.Bundle{
+		BundleRootPath: tmpDir,
+		SyncRootPath:   tmpDir,
+		SyncRoot:       vfs.MustNew(tmpDir),
+		Config: config.Root{
+			Workspace: config.Workspace{
+				FilePath: "/foo/bar/",
+			},
+			Resources: config.Resources{
+				Apps: map[string]*resources.App{
+					"app1": {
+						App: apps.App{
+							Name: "app1",
+						},
+						SourceCodePath: "",
+					},
+				},
+			},
+		},
+	}
+
+	bundletest.SetLocation(b, ".", []dyn.Location{{File: filepath.Join(tmpDir, "databricks.yml")}})
+
+	diags := bundle.ApplySeq(context.Background(), b, mutator.TranslatePaths(), Validate())
+	require.Len(t, diags, 1)
+	require.Equal(t, "Missing app source code path", diags[0].Summary)
+	require.Contains(t, diags[0].Detail, "is missing required source_code_path field")
+}


### PR DESCRIPTION
## Changes
Validate that source_code_path for app resources is not empty

## Why
`source_code_path` is a required field for apps, so we need to fail the validation if it's not provided.

## Tests
Added unit test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
