### PR TITLE
acc: Increase timeout for run-local test to 2 minutes

### DIFF
--- a/acceptance/cmd/workspace/apps/run-local/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/test.toml
@@ -1,5 +1,5 @@
 RecordRequests = false
-Timeout = '1m'
+Timeout = '2m'
 TimeoutWindows = '10m'
 
 Ignore = [


### PR DESCRIPTION
## Changes
Increase timeout for run-local test to 2 minutes

## Why
It might take longer than 60 seconds to prepare and start the app occasionally (see https://github.com/databricks/cli/actions/runs/15068042617/job/42357268504?pr=2894)

## Tests
Existing tests pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
