### PR TITLE
Convert TestBundleInitOnMlopsStacks into an acceptance test 

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -431,6 +431,11 @@ func runTest(t *testing.T,
 	cmd.Env = append(cmd.Env, "UNIQUE_NAME="+uniqueName)
 	cmd.Env = append(cmd.Env, "TEST_TMP_DIR="+tmpDir)
 
+	// populate CLOUD_ENV_BASE
+	envBase := getCloudEnvBase(cloudEnv)
+	cmd.Env = append(cmd.Env, "CLOUD_ENV_BASE="+envBase)
+	repls.Set(envBase, "[CLOUD_ENV_BASE]")
+
 	// Must be added PrepareReplacementsUser, otherwise conflicts with [USERNAME]
 	testdiff.PrepareReplacementsUUID(t, &repls)
 

--- a/acceptance/bundle/deploy/mlops-stacks/config.json.tmpl
+++ b/acceptance/bundle/deploy/mlops-stacks/config.json.tmpl
@@ -1,0 +1,6 @@
+{
+  "input_project_name": "project_name_$UNIQUE_NAME",
+  "input_root_dir": "test_repo_mlops_stacks",
+  "input_include_models_in_unity_catalog": "no",
+  "input_cloud": "$CLOUD_ENV_BASE"
+}

--- a/acceptance/bundle/deploy/mlops-stacks/output.txt
+++ b/acceptance/bundle/deploy/mlops-stacks/output.txt
@@ -1,0 +1,387 @@
+
+>>> cat config.json
+{
+  "input_project_name": "project_name_[UNIQUE_NAME]",
+  "input_root_dir": "test_repo_mlops_stacks",
+  "input_include_models_in_unity_catalog": "no",
+  "input_cloud": "[CLOUD_ENV_BASE]"
+}
+
+>>> [CLI] bundle init mlops-stacks --config-file config.json
+Welcome to MLOps Stacks. For detailed information on project generation, see the README at https://github.com/databricks/mlops-stacks/blob/main/README.md.
+
+*** Your MLOps Stack has been created in the 'test_repo_mlops_stacks/project_name_[UNIQUE_NAME]' directory! ***
+
+Please refer to the README.md for further instructions on getting started.
+
+>>> cat test_repo_mlops_stacks/README.md
+# test_repo_mlops_stacks
+
+This directory contains an ML project based on the default
+[Databricks MLOps Stacks](https://github.com/databricks/mlops-stacks),
+
+>>> [CLI] bundle summary
+Name: project_name_[UNIQUE_NAME]
+Target: dev
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev
+Resources:
+  Experiments:
+    experiment:
+      Name: /Users/[USERNAME]/[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-experiment
+      URL:  (not deployed)
+  Jobs:
+    batch_inference_job:
+      Name: [dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-batch-inference-job
+      URL:  (not deployed)
+    model_training_job:
+      Name: [dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model-training-job
+      URL:  (not deployed)
+  Models:
+    model:
+      Name: [dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model
+      URL:  (not deployed)
+
+>>> [CLI] bundle validate
+Warning: expected a string value, found null
+  at targets.dev.workspace.host
+  in databricks.yml:[NUMBER]:[NUMBER]
+
+Warning: unknown field: description
+  at resources.experiments.experiment
+  in resources/ml-artifacts-resource.yml:[NUMBER]:[NUMBER]
+
+Name: project_name_[UNIQUE_NAME]
+Target: dev
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev
+
+Found [NUMBER] warnings
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+Warning: expected a string value, found null
+  at targets.dev.workspace.host
+  in databricks.yml:[NUMBER]:[NUMBER]
+
+Warning: unknown field: description
+  at resources.experiments.experiment
+  in resources/ml-artifacts-resource.yml:[NUMBER]:[NUMBER]
+
+
+>>> [CLI] bundle summary --output json
+{
+  "variables": {
+    "experiment_name": {
+      "default": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment",
+      "description": "Experiment name for the model training.",
+      "value": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment"
+    },
+    "model_name": {
+      "default": "dev-project_name_[UNIQUE_NAME]-model",
+      "description": "Model name for the model training.",
+      "value": "dev-project_name_[UNIQUE_NAME]-model"
+    }
+  },
+  "bundle": {
+    "name": "project_name_[UNIQUE_NAME]",
+    "target": "dev",
+    "environment": "dev",
+    "terraform": {
+      "exec_path": "[TERRAFORM]"
+    },
+    "git": {
+      "bundle_root_path": "."
+    },
+    "mode": "development",
+    "deployment": {
+      "lock": {
+        "enabled": false
+      }
+    },
+    "uuid": "[UUID]"
+  },
+  "include": [
+    "resources/batch-inference-workflow-resource.yml",
+    "resources/ml-artifacts-resource.yml",
+    "resources/model-workflow-resource.yml"
+  ],
+  "workspace": {
+    "current_user": {
+      "active": true,
+      "displayName": "[USERNAME]",
+      "emails": [
+        {
+          "primary": true,
+          "type": "work",
+          "value": "[USERNAME]"
+        }
+      ],
+      "entitlements": [
+        {
+          "value": "allow-cluster-create"
+        },
+        {
+          "value": "allow-instance-pool-create"
+        }
+      ],
+      "groups": [
+        {
+          "$ref": "Groups/[USERGROUP]",
+          "display": "admins",
+          "type": "direct",
+          "value": "[USERGROUP]"
+        }
+      ],
+      "id": "[USERID]",
+      "name": {
+        "givenName": "[USERNAME]"
+      },
+      "schemas": [
+        "urn:ietf:params:scim:schemas:core:[NUMBER].[NUMBER]:User",
+        "urn:ietf:params:scim:schemas:extension:workspace:[NUMBER].[NUMBER]:User"
+      ],
+      "short_name": "[USERNAME]",
+      "userName": "[USERNAME]"
+    },
+    "root_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev",
+    "file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files",
+    "resource_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/resources",
+    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",
+    "state_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/state"
+  },
+  "resources": {
+    "jobs": {
+      "batch_inference_job": {
+        "deployment": {
+          "kind": "BUNDLE",
+          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/state/metadata.json"
+        },
+        "edit_mode": "UI_LOCKED",
+        "format": "MULTI_TASK",
+        "id": "[NUMBER]",
+        "max_concurrent_runs": [NUMBER],
+        "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-batch-inference-job",
+        "permissions": [
+          {
+            "level": "CAN_VIEW",
+            "group_name": "users"
+          }
+        ],
+        "queue": {
+          "enabled": true
+        },
+        "schedule": {
+          "pause_status": "PAUSED",
+          "quartz_cron_expression": "[NUMBER] [NUMBER] [NUMBER] * * ?",
+          "timezone_id": "UTC"
+        },
+        "tags": {
+          "dev": "[USERNAME]"
+        },
+        "tasks": [
+          {
+            "new_cluster": {
+              "custom_tags": {
+                "clusterSource": "mlops-stacks_[NUMBER].[NUMBER]"
+              },
+              "data_security_mode": "SINGLE_USER",
+              "node_type_id": "[NODE_TYPE_ID]",
+              "num_workers": [NUMBER],
+              "spark_version": "[NUMBER].[NUMBER].x-cpu-ml-scala[NUMBER].[NUMBER]"
+            },
+            "notebook_task": {
+              "base_parameters": {
+                "env": "dev",
+                "git_source_info": "url:; branch:; commit:",
+                "input_table_name": "taxi_scoring_sample",
+                "model_name": "dev-project_name_[UNIQUE_NAME]-model",
+                "output_table_name": "dev_project_name_[UNIQUE_NAME]_predictions"
+              },
+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/deployment/batch_inference/notebooks/BatchInference"
+            },
+            "task_key": "batch_inference_job"
+          }
+        ],
+        "url": "[DATABRICKS_URL]/jobs/[NUMBER]?o=[NUMBER]"
+      },
+      "model_training_job": {
+        "deployment": {
+          "kind": "BUNDLE",
+          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/state/metadata.json"
+        },
+        "edit_mode": "UI_LOCKED",
+        "format": "MULTI_TASK",
+        "id": "[NUMBER]",
+        "job_clusters": [
+          {
+            "job_cluster_key": "model_training_job_cluster",
+            "new_cluster": {
+              "custom_tags": {
+                "clusterSource": "mlops-stacks_[NUMBER].[NUMBER]"
+              },
+              "data_security_mode": "SINGLE_USER",
+              "node_type_id": "[NODE_TYPE_ID]",
+              "num_workers": [NUMBER],
+              "spark_version": "[NUMBER].[NUMBER].x-cpu-ml-scala[NUMBER].[NUMBER]"
+            }
+          }
+        ],
+        "max_concurrent_runs": [NUMBER],
+        "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model-training-job",
+        "permissions": [
+          {
+            "level": "CAN_VIEW",
+            "group_name": "users"
+          }
+        ],
+        "queue": {
+          "enabled": true
+        },
+        "schedule": {
+          "pause_status": "PAUSED",
+          "quartz_cron_expression": "[NUMBER] [NUMBER] [NUMBER] * * ?",
+          "timezone_id": "UTC"
+        },
+        "tags": {
+          "dev": "[USERNAME]"
+        },
+        "tasks": [
+          {
+            "job_cluster_key": "model_training_job_cluster",
+            "notebook_task": {
+              "base_parameters": {
+                "env": "dev",
+                "experiment_name": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment",
+                "git_source_info": "url:; branch:; commit:",
+                "model_name": "dev-project_name_[UNIQUE_NAME]-model",
+                "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
+              },
+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/training/notebooks/Train"
+            },
+            "task_key": "Train"
+          },
+          {
+            "depends_on": [
+              {
+                "task_key": "Train"
+              }
+            ],
+            "job_cluster_key": "model_training_job_cluster",
+            "notebook_task": {
+              "base_parameters": {
+                "custom_metrics_loader_function": "custom_metrics",
+                "enable_baseline_comparison": "false",
+                "evaluator_config_loader_function": "evaluator_config",
+                "experiment_name": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment",
+                "git_source_info": "url:; branch:; commit:",
+                "model_type": "regressor",
+                "run_mode": "dry_run",
+                "targets": "fare_amount",
+                "validation_input": "SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`",
+                "validation_thresholds_loader_function": "validation_thresholds"
+              },
+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/validation/notebooks/ModelValidation"
+            },
+            "task_key": "ModelValidation"
+          },
+          {
+            "depends_on": [
+              {
+                "task_key": "ModelValidation"
+              }
+            ],
+            "job_cluster_key": "model_training_job_cluster",
+            "notebook_task": {
+              "base_parameters": {
+                "env": "dev",
+                "git_source_info": "url:; branch:; commit:"
+              },
+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/deployment/model_deployment/notebooks/ModelDeployment"
+            },
+            "task_key": "ModelDeployment"
+          }
+        ],
+        "url": "[DATABRICKS_URL]/jobs/[NUMBER]?o=[NUMBER]"
+      }
+    },
+    "models": {
+      "model": {
+        "description": "MLflow registered model for the \"project_name_[UNIQUE_NAME]\" ML Project for dev deployment target.",
+        "id": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model",
+        "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model",
+        "permissions": [
+          {
+            "level": "CAN_READ",
+            "group_name": "users"
+          }
+        ],
+        "tags": [
+          {
+            "key": "dev",
+            "value": "[USERNAME]"
+          }
+        ],
+        "url": "[DATABRICKS_URL]/ml/models/%[NUMBER]Bdev%[NUMBER][USERNAME]%[NUMBER]D%[NUMBER]dev-project_name_[UNIQUE_NAME]-model?o=[NUMBER]"
+      }
+    },
+    "experiments": {
+      "experiment": {
+        "id": "[NUMBER]",
+        "name": "/Users/[USERNAME]/[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-experiment",
+        "permissions": [
+          {
+            "level": "CAN_READ",
+            "group_name": "users"
+          }
+        ],
+        "tags": [
+          {
+            "key": "dev",
+            "value": "[USERNAME]"
+          }
+        ],
+        "url": "[DATABRICKS_URL]/ml/experiments/[NUMBER]?o=[NUMBER]"
+      }
+    }
+  },
+  "sync": {
+    "paths": [
+      "."
+    ]
+  },
+  "presets": {
+    "name_prefix": "[dev [USERNAME]] ",
+    "pipelines_development": true,
+    "trigger_pause_status": "PAUSED",
+    "jobs_max_concurrent_runs": [NUMBER],
+    "tags": {
+      "dev": "[USERNAME]"
+    }
+  }
+}
+
+=== Assert the batch inference job actually exists{
+  "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-batch-inference-job"
+}
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete job batch_inference_job
+  delete job model_training_job
+  delete mlflow_experiment experiment
+  delete mlflow_model model
+  delete permissions job_batch_inference_job
+  delete permissions job_model_training_job
+  delete permissions mlflow_experiment_experiment
+  delete permissions mlflow_model_model
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/deploy/mlops-stacks/output.txt
+++ b/acceptance/bundle/deploy/mlops-stacks/output.txt
@@ -46,11 +46,11 @@ Resources:
 >>> [CLI] bundle validate
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:[NUMBER]:[NUMBER]
+  in databricks.yml:34:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:[NUMBER]:[NUMBER]
+  in resources/ml-artifacts-resource.yml:21:7
 
 Name: project_name_[UNIQUE_NAME]
 Target: dev
@@ -58,7 +58,7 @@ Workspace:
   User: [USERNAME]
   Path: /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev
 
-Found [NUMBER] warnings
+Found 2 warnings
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files...
@@ -67,303 +67,19 @@ Updating deployment state...
 Deployment complete!
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:[NUMBER]:[NUMBER]
+  in databricks.yml:34:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:[NUMBER]:[NUMBER]
+  in resources/ml-artifacts-resource.yml:21:7
 
 
->>> [CLI] bundle summary --output json
+>>> [CLI] bundle summary -o json
 {
-  "variables": {
-    "experiment_name": {
-      "default": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment",
-      "description": "Experiment name for the model training.",
-      "value": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment"
-    },
-    "model_name": {
-      "default": "dev-project_name_[UNIQUE_NAME]-model",
-      "description": "Model name for the model training.",
-      "value": "dev-project_name_[UNIQUE_NAME]-model"
-    }
-  },
-  "bundle": {
-    "name": "project_name_[UNIQUE_NAME]",
-    "target": "dev",
-    "environment": "dev",
-    "terraform": {
-      "exec_path": "[TERRAFORM]"
-    },
-    "git": {
-      "bundle_root_path": "."
-    },
-    "mode": "development",
-    "deployment": {
-      "lock": {
-        "enabled": false
-      }
-    },
-    "uuid": "[UUID]"
-  },
-  "include": [
-    "resources/batch-inference-workflow-resource.yml",
-    "resources/ml-artifacts-resource.yml",
-    "resources/model-workflow-resource.yml"
-  ],
-  "workspace": {
-    "current_user": {
-      "active": true,
-      "displayName": "[USERNAME]",
-      "emails": [
-        {
-          "primary": true,
-          "type": "work",
-          "value": "[USERNAME]"
-        }
-      ],
-      "entitlements": [
-        {
-          "value": "allow-cluster-create"
-        },
-        {
-          "value": "allow-instance-pool-create"
-        }
-      ],
-      "groups": [
-        {
-          "$ref": "Groups/[USERGROUP]",
-          "display": "admins",
-          "type": "direct",
-          "value": "[USERGROUP]"
-        }
-      ],
-      "id": "[USERID]",
-      "name": {
-        "givenName": "[USERNAME]"
-      },
-      "schemas": [
-        "urn:ietf:params:scim:schemas:core:[NUMBER].[NUMBER]:User",
-        "urn:ietf:params:scim:schemas:extension:workspace:[NUMBER].[NUMBER]:User"
-      ],
-      "short_name": "[USERNAME]",
-      "userName": "[USERNAME]"
-    },
-    "root_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev",
-    "file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files",
-    "resource_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/resources",
-    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",
-    "state_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/state"
-  },
-  "resources": {
-    "jobs": {
-      "batch_inference_job": {
-        "deployment": {
-          "kind": "BUNDLE",
-          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/state/metadata.json"
-        },
-        "edit_mode": "UI_LOCKED",
-        "format": "MULTI_TASK",
-        "id": "[NUMBER]",
-        "max_concurrent_runs": [NUMBER],
-        "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-batch-inference-job",
-        "permissions": [
-          {
-            "level": "CAN_VIEW",
-            "group_name": "users"
-          }
-        ],
-        "queue": {
-          "enabled": true
-        },
-        "schedule": {
-          "pause_status": "PAUSED",
-          "quartz_cron_expression": "[NUMBER] [NUMBER] [NUMBER] * * ?",
-          "timezone_id": "UTC"
-        },
-        "tags": {
-          "dev": "[USERNAME]"
-        },
-        "tasks": [
-          {
-            "new_cluster": {
-              "custom_tags": {
-                "clusterSource": "mlops-stacks_[NUMBER].[NUMBER]"
-              },
-              "data_security_mode": "SINGLE_USER",
-              "node_type_id": "[NODE_TYPE_ID]",
-              "num_workers": [NUMBER],
-              "spark_version": "[NUMBER].[NUMBER].x-cpu-ml-scala[NUMBER].[NUMBER]"
-            },
-            "notebook_task": {
-              "base_parameters": {
-                "env": "dev",
-                "git_source_info": "url:; branch:; commit:",
-                "input_table_name": "taxi_scoring_sample",
-                "model_name": "dev-project_name_[UNIQUE_NAME]-model",
-                "output_table_name": "dev_project_name_[UNIQUE_NAME]_predictions"
-              },
-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/deployment/batch_inference/notebooks/BatchInference"
-            },
-            "task_key": "batch_inference_job"
-          }
-        ],
-        "url": "[DATABRICKS_URL]/jobs/[NUMBER]?o=[NUMBER]"
-      },
-      "model_training_job": {
-        "deployment": {
-          "kind": "BUNDLE",
-          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/state/metadata.json"
-        },
-        "edit_mode": "UI_LOCKED",
-        "format": "MULTI_TASK",
-        "id": "[NUMBER]",
-        "job_clusters": [
-          {
-            "job_cluster_key": "model_training_job_cluster",
-            "new_cluster": {
-              "custom_tags": {
-                "clusterSource": "mlops-stacks_[NUMBER].[NUMBER]"
-              },
-              "data_security_mode": "SINGLE_USER",
-              "node_type_id": "[NODE_TYPE_ID]",
-              "num_workers": [NUMBER],
-              "spark_version": "[NUMBER].[NUMBER].x-cpu-ml-scala[NUMBER].[NUMBER]"
-            }
-          }
-        ],
-        "max_concurrent_runs": [NUMBER],
-        "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model-training-job",
-        "permissions": [
-          {
-            "level": "CAN_VIEW",
-            "group_name": "users"
-          }
-        ],
-        "queue": {
-          "enabled": true
-        },
-        "schedule": {
-          "pause_status": "PAUSED",
-          "quartz_cron_expression": "[NUMBER] [NUMBER] [NUMBER] * * ?",
-          "timezone_id": "UTC"
-        },
-        "tags": {
-          "dev": "[USERNAME]"
-        },
-        "tasks": [
-          {
-            "job_cluster_key": "model_training_job_cluster",
-            "notebook_task": {
-              "base_parameters": {
-                "env": "dev",
-                "experiment_name": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment",
-                "git_source_info": "url:; branch:; commit:",
-                "model_name": "dev-project_name_[UNIQUE_NAME]-model",
-                "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
-              },
-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/training/notebooks/Train"
-            },
-            "task_key": "Train"
-          },
-          {
-            "depends_on": [
-              {
-                "task_key": "Train"
-              }
-            ],
-            "job_cluster_key": "model_training_job_cluster",
-            "notebook_task": {
-              "base_parameters": {
-                "custom_metrics_loader_function": "custom_metrics",
-                "enable_baseline_comparison": "false",
-                "evaluator_config_loader_function": "evaluator_config",
-                "experiment_name": "/Users/[USERNAME]/dev-project_name_[UNIQUE_NAME]-experiment",
-                "git_source_info": "url:; branch:; commit:",
-                "model_type": "regressor",
-                "run_mode": "dry_run",
-                "targets": "fare_amount",
-                "validation_input": "SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`",
-                "validation_thresholds_loader_function": "validation_thresholds"
-              },
-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/validation/notebooks/ModelValidation"
-            },
-            "task_key": "ModelValidation"
-          },
-          {
-            "depends_on": [
-              {
-                "task_key": "ModelValidation"
-              }
-            ],
-            "job_cluster_key": "model_training_job_cluster",
-            "notebook_task": {
-              "base_parameters": {
-                "env": "dev",
-                "git_source_info": "url:; branch:; commit:"
-              },
-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/deployment/model_deployment/notebooks/ModelDeployment"
-            },
-            "task_key": "ModelDeployment"
-          }
-        ],
-        "url": "[DATABRICKS_URL]/jobs/[NUMBER]?o=[NUMBER]"
-      }
-    },
-    "models": {
-      "model": {
-        "description": "MLflow registered model for the \"project_name_[UNIQUE_NAME]\" ML Project for dev deployment target.",
-        "id": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model",
-        "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model",
-        "permissions": [
-          {
-            "level": "CAN_READ",
-            "group_name": "users"
-          }
-        ],
-        "tags": [
-          {
-            "key": "dev",
-            "value": "[USERNAME]"
-          }
-        ],
-        "url": "[DATABRICKS_URL]/ml/models/%[NUMBER]Bdev%[NUMBER][USERNAME]%[NUMBER]D%[NUMBER]dev-project_name_[UNIQUE_NAME]-model?o=[NUMBER]"
-      }
-    },
-    "experiments": {
-      "experiment": {
-        "id": "[NUMBER]",
-        "name": "/Users/[USERNAME]/[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-experiment",
-        "permissions": [
-          {
-            "level": "CAN_READ",
-            "group_name": "users"
-          }
-        ],
-        "tags": [
-          {
-            "key": "dev",
-            "value": "[USERNAME]"
-          }
-        ],
-        "url": "[DATABRICKS_URL]/ml/experiments/[NUMBER]?o=[NUMBER]"
-      }
-    }
-  },
-  "sync": {
-    "paths": [
-      "."
-    ]
-  },
-  "presets": {
-    "name_prefix": "[dev [USERNAME]] ",
-    "pipelines_development": true,
-    "trigger_pause_status": "PAUSED",
-    "jobs_max_concurrent_runs": [NUMBER],
-    "tags": {
-      "dev": "[USERNAME]"
-    }
-  }
+  "experiment_id": "[NUMID]",
+  "model_id": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model",
+  "inference_job_id": "[NUMID]",
+  "training_job_id": "[NUMID]"
 }
 
 === Assert the batch inference job actually exists{

--- a/acceptance/bundle/deploy/mlops-stacks/script
+++ b/acceptance/bundle/deploy/mlops-stacks/script
@@ -1,7 +1,3 @@
-if [ -z "${CLOUD_ENV_BASE}" ]; then
-    CLOUD_ENV_BASE="azure" # pick one of the clouds for the local test (other valid values: "aws", "gcp")
-fi
-
 envsubst < config.json.tmpl > config.json
 trace cat config.json
 

--- a/acceptance/bundle/deploy/mlops-stacks/script
+++ b/acceptance/bundle/deploy/mlops-stacks/script
@@ -20,7 +20,8 @@ cd "test_repo_mlops_stacks/project_name_${UNIQUE_NAME}" || exit 1
 trace $CLI bundle summary
 trace $CLI bundle validate
 trace $CLI bundle deploy
-trace $CLI bundle summary --output json
+
+trace $CLI bundle summary -o json | jq -r '{experiment_id: .resources.experiments.experiment.id, model_id: .resources.models.model.id, inference_job_id: .resources.jobs.batch_inference_job.id, training_job_id: .resources.jobs.model_training_job.id}'
 
 title "Assert the batch inference job actually exists"
 JOB_ID=$($CLI bundle summary -o json | jq -r '.resources.jobs.batch_inference_job.id')

--- a/acceptance/bundle/deploy/mlops-stacks/script
+++ b/acceptance/bundle/deploy/mlops-stacks/script
@@ -1,3 +1,15 @@
+# This test tests the MLOps Stacks DAB e2e and thus there's a couple of special
+# considerations to take note of:
+#
+#  1. Upstream changes to the MLOps Stacks DAB can cause this test to fail.
+#     In which case we should do one of:
+#     (a) Update this test to reflect the changes
+#     (b) Update the MLOps Stacks DAB to not break this test. Skip this test
+#     temporarily until the MLOps Stacks DAB is updated
+#
+#  2. While rare and to be avoided if possible, the CLI reserves the right to
+#     make changes that can break the MLOps Stacks DAB. In which case we should
+#     skip this test until the MLOps Stacks DAB is updated to work again.
 envsubst < config.json.tmpl > config.json
 trace cat config.json
 

--- a/acceptance/bundle/deploy/mlops-stacks/script
+++ b/acceptance/bundle/deploy/mlops-stacks/script
@@ -1,0 +1,27 @@
+if [ -z "${CLOUD_ENV_BASE}" ]; then
+    CLOUD_ENV_BASE="azure" # pick one of the clouds for the local test (other valid values: "aws", "gcp")
+fi
+
+envsubst < config.json.tmpl > config.json
+trace cat config.json
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+  cd ../..
+  rm -rf test_repo_mlops_stacks
+}
+trap cleanup EXIT
+
+trace $CLI bundle init mlops-stacks --config-file config.json
+trace cat test_repo_mlops_stacks/README.md | head -n 4
+
+cd "test_repo_mlops_stacks/project_name_${UNIQUE_NAME}" || exit 1
+
+trace $CLI bundle summary
+trace $CLI bundle validate
+trace $CLI bundle deploy
+trace $CLI bundle summary --output json
+
+title "Assert the batch inference job actually exists"
+JOB_ID=$($CLI bundle summary -o json | jq -r '.resources.jobs.batch_inference_job.id')
+$CLI jobs get "${JOB_ID}" | jq '{name: .settings.name}'

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -10,5 +10,5 @@ Old = "[0-9]{12,}"
 New = "[NUMID]"
 
 [[Repls]]
-Old = "\\"
-New = "/"
+Old = '\\'
+New = '/'

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -1,6 +1,8 @@
 Cloud=true
 Local=false
 
+Badness = "the newly initialized bundle from the 'mlops-stacks' template contains two validation warnings in the configuration"
+
 Ignore = [
     "config.json"
 ]

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -6,5 +6,5 @@ Ignore = [
 ]
 
 [[Repls]]
-Old = "[0-9]{1,}"
-New = "[NUMBER]"
+Old = "[0-9]{12,}"
+New = "[NUMID]"

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -1,0 +1,10 @@
+Cloud=true
+Local=true
+
+Ignore = [
+    "config.json"
+]
+
+[[Repls]]
+Old = "[0-9]{1,}"
+New = "[NUMBER]"

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -8,3 +8,7 @@ Ignore = [
 [[Repls]]
 Old = "[0-9]{12,}"
 New = "[NUMID]"
+
+[[Repls]]
+Old = "\\"
+New = "/"

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -1,5 +1,5 @@
 Cloud=true
-Local=true
+Local=false
 
 Ignore = [
     "config.json"

--- a/integration/bundle/init_test.go
+++ b/integration/bundle/init_test.go
@@ -2,15 +2,11 @@ package bundle_test
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 
-	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/integration/internal/acc"
 	"github.com/databricks/cli/internal/testcli"
 	"github.com/databricks/cli/internal/testutil"
@@ -24,79 +20,6 @@ func TestBundleInitErrorOnUnknownFields(t *testing.T) {
 	tmpDir := t.TempDir()
 	_, _, err := testcli.RequireErrorRun(t, ctx, "bundle", "init", "./testdata/init/field-does-not-exist", "--output-dir", tmpDir)
 	assert.EqualError(t, err, "failed to compute file content for bar.tmpl. variable \"does_not_exist\" not defined")
-}
-
-// This test tests the MLOps Stacks DAB e2e and thus there's a couple of special
-// considerations to take note of:
-//
-//  1. Upstream changes to the MLOps Stacks DAB can cause this test to fail.
-//     In which case we should do one of:
-//     (a) Update this test to reflect the changes
-//     (b) Update the MLOps Stacks DAB to not break this test. Skip this test
-//     temporarily until the MLOps Stacks DAB is updated
-//
-//  2. While rare and to be avoided if possible, the CLI reserves the right to
-//     make changes that can break the MLOps Stacks DAB. In which case we should
-//     skip this test until the MLOps Stacks DAB is updated to work again.
-func TestBundleInitOnMlopsStacks(t *testing.T) {
-	ctx, wt := acc.WorkspaceTest(t)
-	w := wt.W
-
-	tmpDir1 := t.TempDir()
-	tmpDir2 := t.TempDir()
-
-	projectName := testutil.RandomName("project_name_")
-	env := testutil.GetCloud(t).String()
-
-	// Create a config file with the project name and root dir
-	initConfig := map[string]string{
-		"input_project_name":                    projectName,
-		"input_root_dir":                        "repo_name",
-		"input_include_models_in_unity_catalog": "no",
-		"input_cloud":                           strings.ToLower(env),
-	}
-	b, err := json.Marshal(initConfig)
-	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(tmpDir1, "config.json"), b, 0o644)
-	require.NoError(t, err)
-
-	// Run bundle init
-	assert.NoFileExists(t, filepath.Join(tmpDir2, "repo_name", projectName, "README.md"))
-	testcli.RequireSuccessfulRun(t, ctx, "bundle", "init", "mlops-stacks", "--output-dir", tmpDir2, "--config-file", filepath.Join(tmpDir1, "config.json"))
-
-	// Assert that the README.md file was created
-	contents := testutil.ReadFile(t, filepath.Join(tmpDir2, "repo_name", projectName, "README.md"))
-	assert.Contains(t, contents, "# "+projectName)
-
-	// Validate the stack
-	testutil.Chdir(t, filepath.Join(tmpDir2, "repo_name", projectName))
-	testcli.RequireSuccessfulRun(t, ctx, "bundle", "validate")
-
-	// Deploy the stack
-	testcli.RequireSuccessfulRun(t, ctx, "bundle", "deploy")
-	t.Cleanup(func() {
-		// Delete the stack
-		testcli.RequireSuccessfulRun(t, ctx, "bundle", "destroy", "--auto-approve")
-	})
-
-	// Get summary of the bundle deployment
-	stdout, _ := testcli.RequireSuccessfulRun(t, ctx, "bundle", "summary", "--output", "json")
-	summary := &config.Root{}
-	err = json.Unmarshal(stdout.Bytes(), summary)
-	require.NoError(t, err)
-
-	// Assert resource Ids are not empty
-	assert.NotEmpty(t, summary.Resources.Experiments["experiment"].ID)
-	assert.NotEmpty(t, summary.Resources.Models["model"].ID)
-	assert.NotEmpty(t, summary.Resources.Jobs["batch_inference_job"].ID)
-	assert.NotEmpty(t, summary.Resources.Jobs["model_training_job"].ID)
-
-	// Assert the batch inference job actually exists
-	batchJobId, err := strconv.ParseInt(summary.Resources.Jobs["batch_inference_job"].ID, 10, 64)
-	require.NoError(t, err)
-	job, err := w.Jobs.GetByJobId(context.Background(), batchJobId)
-	assert.NoError(t, err)
-	assert.Contains(t, job.Settings.Name, fmt.Sprintf("dev-%s-batch-inference-job", projectName))
 }
 
 func TestBundleInitHelpers(t *testing.T) {


### PR DESCRIPTION
## Changes
1. Convert TestBundleInitOnMlopsStacks into an acceptance test
2. Make `CLOUD_ENV_BASE` environment variable (with possible values of: "azure", "aws", "gcp") available to the acceptance tests' script

## Why 
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

One change in the series of changes for converting integration tests into acceptance tests.
This will allow for easier testing of various backing solutions for bundle deployment
