### PR TITLE
This PR fixes the behaviour of the `databricks fs cp` command when a file Is begin copied to non existing directory.

### DIFF
--- a/hello.txt
+++ b/hello.txt
@@ -1,0 +1,1 @@
+this is my first commit

--- a/test_cp/newdir
+++ b/test_cp/newdir
@@ -1,0 +1,1 @@
+test content

--- a/test_cp/source.txt
+++ b/test_cp/source.txt
@@ -1,0 +1,1 @@
+test content


### PR DESCRIPTION
## Changes
- Added handling for trailing slashes in target paths
- When a target path ends with a slash, it is treated as a directory
- The file is copied into the directory with its original name

Fixes
#2835