### PR TITLE
fix databricks fs cp command

### DIFF
--- a/cmd/fs/cp.go
+++ b/cmd/fs/cp.go
@@ -215,7 +215,7 @@ func newCpCommand() *cobra.Command {
 		}
 
 		// Check if target path ends with a slash, indicating it should be treated as a directory
-		if strings.HasSuffix(fullTargetPath, "/") || strings.HasSuffix(targetPath, "/") {
+		if strings.HasSuffix(fullTargetPath, "/")  {
 			return c.cpFileToDir(sourcePath, targetPath)
 		}
 


### PR DESCRIPTION
If the destination directory does't exists cp command throws and error similar to linux cp command.

Fixes
#2835