### PR TITLE
Remove the integration test TestDeployBasicBundleLogs

### DIFF
--- a/integration/bundle/deploy_test.go
+++ b/integration/bundle/deploy_test.go
@@ -2,46 +2,16 @@ package bundle_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/databricks/cli/integration/internal/acc"
 	"github.com/databricks/cli/internal/testcli"
-	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestDeployBasicBundleLogs(t *testing.T) {
-	ctx, wt := acc.WorkspaceTest(t)
-
-	nodeTypeId := testutil.GetCloud(t).NodeTypeID()
-	uniqueId := uuid.New().String()
-	root := initTestTemplate(t, ctx, "basic", map[string]any{
-		"unique_id":     uniqueId,
-		"node_type_id":  nodeTypeId,
-		"spark_version": defaultSparkVersion,
-	})
-
-	t.Cleanup(func() {
-		destroyBundle(t, ctx, root)
-	})
-
-	currentUser, err := wt.W.CurrentUser.Me(ctx)
-	require.NoError(t, err)
-
-	stdout, stderr := blackBoxRun(t, ctx, root, "bundle", "deploy")
-	assert.Equal(t, strings.Join([]string{
-		fmt.Sprintf("Uploading bundle files to /Workspace/Users/%s/.bundle/%s/files...", currentUser.UserName, uniqueId),
-		"Deploying resources...",
-		"Updating deployment state...",
-		"Deployment complete!\n",
-	}, "\n"), stderr)
-	assert.Equal(t, "", stdout)
-}
 
 func TestDeployUcVolume(t *testing.T) {
 	ctx, wt := acc.UcWorkspaceTest(t)

--- a/integration/bundle/helpers_test.go
+++ b/integration/bundle/helpers_test.go
@@ -1,12 +1,10 @@
 package bundle_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/flags"
-	"github.com/databricks/cli/libs/folders"
 	"github.com/databricks/cli/libs/template"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/stretchr/testify/require"
@@ -154,33 +151,4 @@ func getBundleRemoteRootPath(w *databricks.WorkspaceClient, t testutil.TestingT,
 	require.NoError(t, err)
 	root := fmt.Sprintf("/Workspace/Users/%s/.bundle/%s", me.UserName, uniqueId)
 	return root
-}
-
-func blackBoxRun(t testutil.TestingT, ctx context.Context, root string, args ...string) (stdout, stderr string) {
-	gitRoot, err := folders.FindDirWithLeaf(".", ".git")
-	require.NoError(t, err)
-
-	// Create the command
-	cmd := exec.Command("go", append([]string{"run", "main.go"}, args...)...)
-	cmd.Dir = gitRoot
-
-	// Configure the environment
-	ctx = env.Set(ctx, "BUNDLE_ROOT", root)
-	for key, value := range env.All(ctx) {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
-	}
-
-	// Create buffers to capture output
-	var outBuffer, errBuffer bytes.Buffer
-	cmd.Stdout = &outBuffer
-	cmd.Stderr = &errBuffer
-
-	// Run the command
-	err = cmd.Run()
-	require.NoError(t, err)
-
-	// Get the output
-	stdout = outBuffer.String()
-	stderr = errBuffer.String()
-	return
 }


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

Remove a regression test introduced in #1711. This test aimed to capture leaked logs to stderr. This test is obsolete with the new style of acceptance tests, which compares the binary output with the golden file - these existing tests will capture this kind of regression.

## Tests
Added an unconditional output line to stderr and confirmed that acceptance tests capture it and fail the suite.