### PR TITLE
testserver: log error on "method not allowed" same as "not found"

### DIFF
--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/test.toml
@@ -13,3 +13,10 @@ Response.Body = '''
 [[Server]]
 Pattern = "PUT /api/2.0/fs/directories/Volumes/main/a/b/c/.internal"
 Response.StatusCode = 200
+
+[[Server]]
+Pattern = "GET /api/2.0/fs/directories/Volumes/main/a/b/c/.internal"
+Response.Body = '{}'
+# I'm adding 405 because that's what this test originally do. It's somewhat
+# surprising though that CLI can receive 405 and that does not result in error anywhere.
+Response.StatusCode = 405

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -190,7 +190,7 @@ func New(t testutil.TestingT) *Server {
 	}
 
 	// Set up the not found handler as fallback
-	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	notFoundFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pattern := r.Method + " " + r.URL.Path
 		bodyBytes, err := io.ReadAll(r.Body)
 		var body string
@@ -227,6 +227,8 @@ Response.Body = '<response body here>'
 			t.Errorf("Response write error: %s", err)
 		}
 	})
+	router.NotFoundHandler = notFoundFunc
+	router.MethodNotAllowedHandler = notFoundFunc
 
 	return s
 }


### PR DESCRIPTION
This is both informational and also prevents shipping tests that do not provide required handlers.
