### PR TITLE
acc: Improve testserver pipelines; add update test local+cloud

### DIFF
--- a/acceptance/bin/read_id.py
+++ b/acceptance/bin/read_id.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Print selected attributes from terraform state.
+
+Usage: <section> <name> [attr...]
+"""
+
+import sys
+import os
+import json
+
+
+def print_resource_terraform(section, name):
+    resource_type = "databricks_" + section[:-1]
+    filename = ".databricks/bundle/default/terraform/terraform.tfstate"
+    raw = open(filename).read()
+    data = json.loads(raw)
+    found = 0
+    for r in data["resources"]:
+        r_type = r["type"]
+        r_name = r["name"]
+        if r_type != resource_type:
+            continue
+        if r_name != name:
+            continue
+        for inst in r["instances"]:
+            attribute_values = inst.get("attributes") or {}
+            print(attribute_values.get("id"))
+            return
+
+
+print_resource_terraform(*sys.argv[1:])

--- a/acceptance/bundle/resources/pipelines/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/pipelines/databricks.yml.tmpl
@@ -1,0 +1,10 @@
+bundle:
+  name: acc-$UNIQUE_NAME
+
+resources:
+  pipelines:
+    my:
+      name: test-pipeline-$UNIQUE_NAME
+      libraries:
+        - file:
+            path: "./foo.py"

--- a/acceptance/bundle/resources/pipelines/output.txt
+++ b/acceptance/bundle/resources/pipelines/output.txt
@@ -1,0 +1,90 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> print_requests
+{
+  "body": {
+    "channel": "CURRENT",
+    "deployment": {
+      "kind": "BUNDLE",
+      "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/state/metadata.json"
+    },
+    "edition": "ADVANCED",
+    "libraries": [
+      {
+        "file": {
+          "path": "/Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files/foo.py"
+        }
+      }
+    ],
+    "name": "test-pipeline-[UNIQUE_NAME]"
+  },
+  "method": "POST",
+  "path": "/api/2.0/pipelines"
+}
+pipelines my id='[UUID]' name='test-pipeline-[UNIQUE_NAME]'
+
+>>> update_file.py databricks.yml foo.py bar.py
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> print_requests
+{
+  "body": {
+    "channel": "CURRENT",
+    "deployment": {
+      "kind": "BUNDLE",
+      "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/state/metadata.json"
+    },
+    "edition": "ADVANCED",
+    "id": "[UUID]",
+    "libraries": [
+      {
+        "file": {
+          "path": "/Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files/bar.py"
+        }
+      }
+    ],
+    "name": "test-pipeline-[UNIQUE_NAME]",
+    "storage": "dbfs:/pipelines/[UUID]"
+  },
+  "method": "PUT",
+  "path": "/api/2.0/pipelines/[UUID]"
+}
+pipelines my id='[UUID]' name='test-pipeline-[UNIQUE_NAME]'
+
+>>> [CLI] pipelines get [UUID]
+{
+  "creator_user_name":"[USERNAME]",
+  "last_modified":[TIMESTAMP_MS],
+  "name":"test-pipeline-[UNIQUE_NAME]",
+  "pipeline_id":"[UUID]",
+  "run_as_user_name":"[USERNAME]",
+  "spec": {
+    "channel":"CURRENT",
+    "deployment": {
+      "kind":"BUNDLE",
+      "metadata_file_path":"/Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/state/metadata.json"
+    },
+    "edition":"ADVANCED",
+    "id":"[UUID]",
+    "libraries": [
+      {
+        "file": {
+          "path":"/Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files/bar.py"
+        }
+      }
+    ],
+    "name":"test-pipeline-[UNIQUE_NAME]",
+    "storage":"dbfs:/pipelines/[UUID]"
+  },
+  "state":"IDLE"
+}

--- a/acceptance/bundle/resources/pipelines/script
+++ b/acceptance/bundle/resources/pipelines/script
@@ -1,0 +1,19 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+touch foo.py
+touch bar.py
+trace $CLI bundle deploy
+
+print_requests() {
+    jq --sort-keys 'select(.method != "GET" and (.path | contains("/pipelines")))' < out.requests.txt
+    rm out.requests.txt
+    read_state.py pipelines my id name
+}
+
+trace print_requests
+
+trace update_file.py databricks.yml foo.py bar.py
+trace $CLI bundle deploy
+trace print_requests
+
+trace $CLI pipelines get $(read_id.py pipelines my)
+rm out.requests.txt

--- a/acceptance/bundle/resources/pipelines/test.toml
+++ b/acceptance/bundle/resources/pipelines/test.toml
@@ -1,0 +1,6 @@
+Cloud = true
+Ignore = ["bar.py", "foo.py"]
+
+[[Repls]]
+Old = '174\d{10}'
+New = '[TIMESTAMP_MS]'

--- a/acceptance/internal/handlers.go
+++ b/acceptance/internal/handlers.go
@@ -255,7 +255,7 @@ func addDefaultHandlers(server *testserver.Server) {
 	// Pipelines:
 
 	server.Handle("GET", "/api/2.0/pipelines/{pipeline_id}", func(req testserver.Request) any {
-		return req.Workspace.PipelineGet(req.Vars["pipeline_id"])
+		return testserver.MapGet(req.Workspace, req.Workspace.Pipelines, req.Vars["pipeline_id"])
 	})
 
 	server.Handle("POST", "/api/2.0/pipelines", func(req testserver.Request) any {

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -40,7 +40,7 @@ type FakeWorkspace struct {
 	Jobs         map[int64]jobs.Job
 	JobRuns      map[int64]jobs.Run
 
-	Pipelines map[string]pipelines.PipelineSpec
+	Pipelines map[string]pipelines.GetPipelineResponse
 	Monitors  map[string]catalog.MonitorInfo
 	Apps      map[string]apps.App
 	Schemas   map[string]catalog.SchemaInfo
@@ -112,7 +112,7 @@ func NewFakeWorkspace(url string) *FakeWorkspace {
 		JobRuns:      map[int64]jobs.Run{},
 		nextJobId:    TestJobID,
 		nextJobRunId: TestRunID,
-		Pipelines:    map[string]pipelines.PipelineSpec{},
+		Pipelines:    map[string]pipelines.GetPipelineResponse{},
 		Monitors:     map[string]catalog.MonitorInfo{},
 		Apps:         map[string]apps.App{},
 		Schemas:      map[string]catalog.SchemaInfo{},


### PR DESCRIPTION
## Changes
- Update testserver pipeline to populate fields same way as real server does it.
- Add new pipeline server that exercises Create and Update.

## Why
Using this test in https://github.com/databricks/cli/pull/2926

## Tests
New acceptance local + integration test.
