### PR TITLE
Add GetDefinition to libs/jsonschema

### DIFF
--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -103,7 +103,7 @@ func anyToSchema(a any) (*Schema, error) {
 	return res, nil
 }
 
-func (s *Schema) GetReference(p string) (*Schema, error) {
+func (s *Schema) GetDefinition(p string) (*Schema, error) {
 	parts := strings.Split(p, "/")
 	if parts[0] != "#" || parts[1] != "$defs" {
 		return nil, fmt.Errorf("invalid reference %q. References must start with #/$defs/", p)

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -122,6 +122,9 @@ func (s *Schema) GetDefinition(p string) (*Schema, error) {
 		}
 	}
 
+	// Leaf nodes in definitions are of type map[string]any when loaded
+	// via [json.Unmarshal]. This function call is necessary to convert
+	// the map to a [Schema] object.
 	return anyToSchema(curr)
 }
 

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/databricks/cli/internal/build"
 	"golang.org/x/mod/semver"
@@ -85,6 +86,43 @@ type Schema struct {
 	// in the future.
 	// https://json-schema.org/understanding-json-schema/reference/annotations
 	Deprecated bool `json:"deprecated,omitempty"`
+}
+
+func anyToSchema(a any) (*Schema, error) {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal any to schema: %w", err)
+	}
+
+	res := &Schema{}
+	err = json.Unmarshal(b, res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal any to schema: %w", err)
+	}
+
+	return res, nil
+}
+
+func (s *Schema) GetReference(p string) (*Schema, error) {
+	parts := strings.Split(p, "/")
+	if parts[0] != "#" || parts[1] != "$defs" {
+		return nil, fmt.Errorf("invalid reference %q. References must start with #/$defs/", p)
+	}
+
+	curr := s.Definitions
+	var ok bool
+	for i, part := range parts[2:] {
+		if i == len(parts)-3 {
+			return anyToSchema(curr[part])
+		}
+
+		curr, ok = curr[part].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("invalid reference %q. Failed to resolve reference at %q", p, part)
+		}
+	}
+
+	return nil, fmt.Errorf("invalid reference %q. Expected more than 2 tokens", p)
 }
 
 // Default value defined in a JSON Schema, represented as a string.

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -109,20 +109,20 @@ func (s *Schema) GetDefinition(p string) (*Schema, error) {
 		return nil, fmt.Errorf("invalid reference %q. References must start with #/$defs/", p)
 	}
 
+	if len(parts) <= 2 {
+		return nil, fmt.Errorf("invalid reference %q. Expected more than 2 tokens", p)
+	}
+
 	curr := s.Definitions
 	var ok bool
-	for i, part := range parts[2:] {
-		if i == len(parts)-3 {
-			return anyToSchema(curr[part])
-		}
-
+	for _, part := range parts[2:] {
 		curr, ok = curr[part].(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("invalid reference %q. Failed to resolve reference at %q", p, part)
 		}
 	}
 
-	return nil, fmt.Errorf("invalid reference %q. Expected more than 2 tokens", p)
+	return anyToSchema(curr)
 }
 
 // Default value defined in a JSON Schema, represented as a string.

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -91,13 +91,13 @@ type Schema struct {
 func anyToSchema(a any) (*Schema, error) {
 	b, err := json.Marshal(a)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal any to schema: %w", err)
+		return nil, fmt.Errorf("failed to marshal any to bytes: %w", err)
 	}
 
 	res := &Schema{}
 	err = json.Unmarshal(b, res)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal any to schema: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal bytes to JSON schema: %w", err)
 	}
 
 	return res, nil

--- a/libs/jsonschema/schema_test.go
+++ b/libs/jsonschema/schema_test.go
@@ -313,7 +313,7 @@ func TestSchema_LoadFS(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSchemaGetReference(t *testing.T) {
+func TestSchemaGetDefinition(t *testing.T) {
 	s := &Schema{
 		Definitions: map[string]any{
 			"foo": map[string]any{
@@ -328,24 +328,24 @@ func TestSchemaGetReference(t *testing.T) {
 		},
 	}
 
-	ns, err := s.GetReference("#/$defs/foo")
+	ns, err := s.GetDefinition("#/$defs/foo")
 	assert.NoError(t, err)
 	assert.Equal(t, &Schema{
 		Type: "string",
 	}, ns)
 
-	ns, err = s.GetReference("#/$defs/bar/baz")
+	ns, err = s.GetDefinition("#/$defs/bar/baz")
 	assert.NoError(t, err)
 	assert.Equal(t, &Schema{
 		Type: "integer",
 	}, ns)
 
-	_, err = s.GetReference("a/b/c")
+	_, err = s.GetDefinition("a/b/c")
 	assert.EqualError(t, err, "invalid reference \"a/b/c\". References must start with #/$defs/")
 
-	_, err = s.GetReference("#/$defs/invalid/abc")
+	_, err = s.GetDefinition("#/$defs/invalid/abc")
 	assert.EqualError(t, err, "invalid reference \"#/$defs/invalid/abc\". Failed to resolve reference at \"invalid\"")
 
-	_, err = s.GetReference("#/$defs")
+	_, err = s.GetDefinition("#/$defs")
 	assert.EqualError(t, err, "invalid reference \"#/$defs\". Expected more than 2 tokens")
 }


### PR DESCRIPTION
## Why
This method is useful for https://github.com/databricks/cli/pull/2940. It's needed to traverse the bundle schema and retrieve the required fields in the bundle config tree.

## Tests
Unit test.