### PR TITLE
acc: Do not auto enable EnvRepl for short strings

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -482,7 +482,9 @@ func runTest(t *testing.T,
 		require.Len(t, items, 2)
 		key := items[0]
 		value := items[1]
-		cmd.Env = addEnvVar(t, cmd.Env, &repls, key, value, config.EnvRepl, len(config.EnvMatrix[key]) > 1)
+		// Only add replacement by default if value is part of EnvMatrix with more than 1 option and length is 4 or more chars
+		// (to avoid matching "yes" and "no" values from template input parameters)
+		cmd.Env = addEnvVar(t, cmd.Env, &repls, key, value, config.EnvRepl, len(config.EnvMatrix[key]) > 1 && len(value) >= 4)
 	}
 
 	absDir, err := filepath.Abs(dir)

--- a/acceptance/selftest/envmatrix/inner/script
+++ b/acceptance/selftest/envmatrix/inner/script
@@ -1,4 +1,4 @@
-[ "$FIRST" = "one" ] || [ "$FIRST" = "two" ]
+[ "$FIRST" = "one111" ] || [ "$FIRST" = "two222" ]
 [ "$SECOND" = "variantA" ] || [ "$SECOND" = "variantB" ]
 
 echo "FIRST=$FIRST"

--- a/acceptance/selftest/envmatrix/inner/test.toml
+++ b/acceptance/selftest/envmatrix/inner/test.toml
@@ -1,4 +1,4 @@
 [EnvMatrix]
 B_REGULAR_VAR = ["hello"]
-FIRST = ["one", "two"]
+FIRST = ["one111", "two222"]
 SECOND = ["variantA", "variantB"]


### PR DESCRIPTION
Mainly to exclude "yes" and "no" in templates tests that cause messages like this:

`Error: can[SERVERLESS]t create pipeline: The service at /api/2.0/pipelines is taking too long to process your request.`