### PR TITLE
Revert "acc: Do not auto enable EnvRepl for short strings (#2943)"

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -482,9 +482,7 @@ func runTest(t *testing.T,
 		require.Len(t, items, 2)
 		key := items[0]
 		value := items[1]
-		// Only add replacement by default if value is part of EnvMatrix with more than 1 option and length is 4 or more chars
-		// (to avoid matching "yes" and "no" values from template input parameters)
-		cmd.Env = addEnvVar(t, cmd.Env, &repls, key, value, config.EnvRepl, len(config.EnvMatrix[key]) > 1 && len(value) >= 4)
+		cmd.Env = addEnvVar(t, cmd.Env, &repls, key, value, config.EnvRepl, len(config.EnvMatrix[key]) > 1)
 	}
 
 	absDir, err := filepath.Abs(dir)

--- a/acceptance/selftest/envmatrix/inner/script
+++ b/acceptance/selftest/envmatrix/inner/script
@@ -1,4 +1,4 @@
-[ "$FIRST" = "one111" ] || [ "$FIRST" = "two222" ]
+[ "$FIRST" = "one" ] || [ "$FIRST" = "two" ]
 [ "$SECOND" = "variantA" ] || [ "$SECOND" = "variantB" ]
 
 echo "FIRST=$FIRST"

--- a/acceptance/selftest/envmatrix/inner/test.toml
+++ b/acceptance/selftest/envmatrix/inner/test.toml
@@ -1,4 +1,4 @@
 [EnvMatrix]
 B_REGULAR_VAR = ["hello"]
-FIRST = ["one111", "two222"]
+FIRST = ["one", "two"]
 SECOND = ["variantA", "variantB"]


### PR DESCRIPTION
## Changes

This reverts commit e18dd155204e53b6b50ccf459a3fcd250f7216b9.

It broke the expected replacement of a short string:
```
           >>> python -c import sys; print("%s.%s" % sys.version_info[:2])
          -[UV_PYTHON]
          +3.9
```