### PR TITLE
make testserver pipelines 404 match real backend

### DIFF
--- a/acceptance/bin/read_state.py
+++ b/acceptance/bin/read_state.py
@@ -32,7 +32,7 @@ def print_resource_terraform(section, name, *attrs):
                 print(section, name, " ".join(values))
                 found += 1
     if not found:
-        print(f"Resource {(resource_type, name)} not found. Available: {available}")
+        print(f"State not found for {section}.{name}")
 
 
 print_resource_terraform(*sys.argv[1:])

--- a/acceptance/bundle/resources/pipelines/output.txt
+++ b/acceptance/bundle/resources/pipelines/output.txt
@@ -88,3 +88,25 @@ pipelines my id='[UUID]' name='test-pipeline-[UNIQUE_NAME]'
   },
   "state":"IDLE"
 }
+
+=== Destroy the pipeline and verify that it's removed from the state and from remote
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete pipeline my
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!
+
+>>> print_requests
+{
+  "method": "DELETE",
+  "path": "/api/2.0/pipelines/[UUID]"
+}
+State not found for pipelines.my
+
+>>> musterr [CLI] pipelines get [UUID]
+Error: The specified pipeline [UUID] was not found.
+
+Exit code (musterr): 1

--- a/acceptance/bundle/resources/pipelines/script
+++ b/acceptance/bundle/resources/pipelines/script
@@ -15,5 +15,13 @@ trace update_file.py databricks.yml foo.py bar.py
 trace $CLI bundle deploy
 trace print_requests
 
-trace $CLI pipelines get $(read_id.py pipelines my)
+ppid=`read_id.py pipelines my`
+trace $CLI pipelines get $ppid
+rm out.requests.txt
+
+title "Destroy the pipeline and verify that it's removed from the state and from remote"
+trace $CLI bundle destroy --auto-approve
+
+trace print_requests
+trace musterr $CLI pipelines get $ppid
 rm out.requests.txt

--- a/acceptance/internal/handlers.go
+++ b/acceptance/internal/handlers.go
@@ -255,7 +255,7 @@ func addDefaultHandlers(server *testserver.Server) {
 	// Pipelines:
 
 	server.Handle("GET", "/api/2.0/pipelines/{pipeline_id}", func(req testserver.Request) any {
-		return testserver.MapGet(req.Workspace, req.Workspace.Pipelines, req.Vars["pipeline_id"])
+		return req.Workspace.PipelineGet(req.Vars["pipeline_id"])
 	})
 
 	server.Handle("POST", "/api/2.0/pipelines", func(req testserver.Request) any {

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -11,6 +11,21 @@ errcode() {
     fi
 }
 
+musterr() {
+    # Temporarily disable 'set -e' to prevent the script from exiting on error
+    set +e
+    # Execute the provided command with all arguments
+    "$@"
+    local exit_code=$?
+    # Re-enable 'set -e' if it was previously set
+    set -e
+    if [ $exit_code -eq 0 ]; then
+        >&2 printf "\nUnexpected success\n"
+        exit 1
+    fi
+    >&2 printf "\nExit code (musterr): $exit_code\n"
+}
+
 trace() {
     >&2 printf "\n>>> %s\n" "$*"
 

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -17,7 +17,7 @@ musterr() {
     # Execute the provided command with all arguments
     "$@"
     local exit_code=$?
-    # Re-enable 'set -e' if it was previously set
+    # Re-enable 'set -e'
     set -e
     if [ $exit_code -eq 0 ]; then
         >&2 printf "\nUnexpected success\n"

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -9,6 +9,21 @@ import (
 	"github.com/google/uuid"
 )
 
+func (s *FakeWorkspace) PipelineGet(pipelineId string) Response {
+	defer s.LockUnlock()()
+
+	value, ok := s.Pipelines[pipelineId]
+	if !ok {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": fmt.Sprintf("The specified pipeline %s was not found.", pipelineId)},
+		}
+	}
+	return Response{
+		Body: value,
+	}
+}
+
 func (s *FakeWorkspace) PipelineCreate(req Request) Response {
 	defer s.LockUnlock()()
 


### PR DESCRIPTION
## Changes
- Update testserver's pipeline/get to match the output of the real server.
- Update resources/pipelines test to test destruction of resources.
- Add 'musterr' helper to better show intent that command must fail.

## Why
Using this test in https://github.com/databricks/cli/pull/2926
