### PR TITLE
Mark environments field as deprecated

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -53,7 +53,7 @@ type Root struct {
 	Targets map[string]*Target `json:"targets,omitempty"`
 
 	// DEPRECATED. Left for backward compatibility with Targets
-	Environments map[string]*Target `json:"environments,omitempty"`
+	Environments map[string]*Target `json:"environments,omitempty" bundle:"deprecated"`
 
 	// Sync section specifies options for files synchronization
 	Sync Sync `json:"sync,omitempty"`


### PR DESCRIPTION
## Why
Fields with the `deprecated` annotation will not have required / enum validation code generated for them. This PR marks the `environments` section as deprecated since we do not want codegen for it.

## Tests
Not tested yet.
