### PR TITLE
Call visit on intermediate nodes during WalkType

### DIFF
--- a/libs/structwalk/util_test.go
+++ b/libs/structwalk/util_test.go
@@ -44,7 +44,7 @@ type Types struct {
 	FuncField func() string `json:"-"`
 	ChanField chan string   `json:"-"`
 
-	// List of field names to be force-sent even if they hold zero values.
+	// // List of field names to be force-sent even if they hold zero values.
 	ForceSendFields []string `json:"-"`
 }
 

--- a/libs/structwalk/util_test.go
+++ b/libs/structwalk/util_test.go
@@ -44,7 +44,7 @@ type Types struct {
 	FuncField func() string `json:"-"`
 	ChanField chan string   `json:"-"`
 
-	// // List of field names to be force-sent even if they hold zero values.
+	// List of field names to be force-sent even if they hold zero values.
 	ForceSendFields []string `json:"-"`
 }
 

--- a/libs/structwalk/walktype.go
+++ b/libs/structwalk/walktype.go
@@ -8,7 +8,7 @@ import (
 	"github.com/databricks/cli/libs/structdiff/structpath"
 )
 
-// VisitTypeFunc is invoked for fields encountered while walking t. This includes both leaf nodes as well as any
+// VisitTypeFunc is invoked for fields encountered while walking typ. This includes both leaf nodes as well as any
 // intermediate nodes encountered while walking the struct tree.
 //
 //   path         PathNode representing the JSON-style path to the field.
@@ -22,8 +22,8 @@ import (
 // The walk is depth-first and deterministic (map keys are sorted lexicographically).
 //
 // Example:
-//   err := structwalk.WalkType(reflect.TypeOf(cfg), func(path *structpath.PathNode, t reflect.Type) {
-//       fmt.Printf("%s = %v\n", path.String(), t)
+//   err := structwalk.WalkType(reflect.TypeOf(cfg), func(path *structpath.PathNode, typ reflect.Type) {
+//       fmt.Printf("%s = %v\n", path.String(), typ)
 //   })
 //
 // ******************************************************************************************************
@@ -48,12 +48,10 @@ func walkTypeValue(path *structpath.PathNode, typ reflect.Type, visit VisitTypeF
 		return
 	}
 
-	// Call visit on all nodes except the root node. We call visit before
+	// Call visit on all nodes including the root node. We call visit before
 	// dereferencing pointers to ensure that the visit callback receives
 	// the actual type of the field.
-	if !path.IsRoot() {
-		visit(path, typ)
-	}
+	visit(path, typ)
 
 	// Dereference pointers.
 	for typ.Kind() == reflect.Pointer {

--- a/libs/structwalk/walktype_test.go
+++ b/libs/structwalk/walktype_test.go
@@ -154,8 +154,8 @@ func TestWalkTypeVisited(t *testing.T) {
 	}
 
 	type Outer struct {
-		Inner Inner
-		MapInner map[string]*Inner
+		Inner      Inner
+		MapInner   map[string]*Inner
 		SliceInner []Inner
 
 		C string
@@ -163,9 +163,10 @@ func TestWalkTypeVisited(t *testing.T) {
 	}
 
 	var visited []string
-	WalkType(reflect.TypeOf(Outer{}), func(path *structpath.PathNode, typ reflect.Type) {
+	err := WalkType(reflect.TypeOf(Outer{}), func(path *structpath.PathNode, typ reflect.Type) {
 		visited = append(visited, path.String())
 	})
+	require.NoError(t, err)
 
 	assert.Equal(t, []string{
 		".Inner",

--- a/libs/structwalk/walktype_test.go
+++ b/libs/structwalk/walktype_test.go
@@ -35,6 +35,10 @@ func TestTypeNil(t *testing.T) {
 	assert.Equal(t, map[string]any{}, getScalarFields(t, reflect.TypeOf(nil)))
 }
 
+func TestTypeScalar(t *testing.T) {
+	assert.Equal(t, map[string]any{"": 0}, getScalarFields(t, reflect.TypeOf(5)))
+}
+
 func TestTypes(t *testing.T) {
 	assert.Equal(t, map[string]any{
 		".ArrayString[*]":     "",
@@ -164,6 +168,9 @@ func TestWalkTypeVisited(t *testing.T) {
 
 	var visited []string
 	err := WalkType(reflect.TypeOf(Outer{}), func(path *structpath.PathNode, typ reflect.Type) {
+		if path == nil {
+			return
+		}
 		visited = append(visited, path.String())
 	})
 	require.NoError(t, err)

--- a/libs/structwalk/walktype_test.go
+++ b/libs/structwalk/walktype_test.go
@@ -14,6 +14,9 @@ import (
 func getScalarFields(t *testing.T, typ reflect.Type) map[string]any {
 	results := make(map[string]any)
 	err := WalkType(typ, func(path *structpath.PathNode, typ reflect.Type) {
+		for typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
 		if isScalar(typ.Kind()) {
 			results[path.String()] = reflect.Zero(typ).Interface()
 		}

--- a/libs/structwalk/walktype_test.go
+++ b/libs/structwalk/walktype_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func getFields(t *testing.T, typ reflect.Type) map[string]any {
+func getScalarFields(t *testing.T, typ reflect.Type) map[string]any {
 	results := make(map[string]any)
 	err := WalkType(typ, func(path *structpath.PathNode, typ reflect.Type) {
-		results[path.String()] = reflect.Zero(typ).Interface()
+		if isScalar(typ.Kind()) {
+			results[path.String()] = reflect.Zero(typ).Interface()
+		}
 	})
 	require.NoError(t, err)
 	return results
@@ -27,11 +29,7 @@ func TestTypeNilCallback(t *testing.T) {
 }
 
 func TestTypeNil(t *testing.T) {
-	assert.Equal(t, map[string]any{}, getFields(t, reflect.TypeOf(nil)))
-}
-
-func TestTypeScalar(t *testing.T) {
-	assert.Equal(t, map[string]any{"": 0}, getFields(t, reflect.TypeOf(5)))
+	assert.Equal(t, map[string]any{}, getScalarFields(t, reflect.TypeOf(nil)))
 }
 
 func TestTypes(t *testing.T) {
@@ -55,7 +53,7 @@ func TestTypes(t *testing.T) {
 		".omit_str":           "",
 		".valid_field":        "",
 		".valid_field_ptr":    "",
-	}, getFields(t, reflect.TypeOf(Types{})))
+	}, getScalarFields(t, reflect.TypeOf(Types{})))
 }
 
 func TestTypeSelf(t *testing.T) {
@@ -69,11 +67,11 @@ func TestTypeSelf(t *testing.T) {
 		".SelfReference.valid_field":     "",
 		".SelfSlicePtr[*].valid_field":   "",
 		".SelfSlice[*].valid_field":      "",
-	}, getFields(t, reflect.TypeOf(Self{})))
+	}, getScalarFields(t, reflect.TypeOf(Self{})))
 }
 
 func testStruct(t *testing.T, typ reflect.Type, minLen, maxLen int, present map[string]any, notPresent []string) {
-	results := getFields(t, typ)
+	results := getScalarFields(t, typ)
 
 	assert.Greater(t, len(results), minLen, "Expected to find many fields in %s", typ)
 	assert.Less(t, len(results), maxLen, "Expected to find not so many fields in %s", typ)
@@ -144,4 +142,41 @@ func TestTypeRoot(t *testing.T) {
 		},
 		nil,
 	)
+}
+
+func TestWalkTypeVisited(t *testing.T) {
+	type Inner struct {
+		A int
+		B ***int
+	}
+
+	type Outer struct {
+		Inner Inner
+		MapInner map[string]*Inner
+		SliceInner []Inner
+
+		C string
+		D bool
+	}
+
+	var visited []string
+	WalkType(reflect.TypeOf(Outer{}), func(path *structpath.PathNode, typ reflect.Type) {
+		visited = append(visited, path.String())
+	})
+
+	assert.Equal(t, []string{
+		".Inner",
+		".Inner.A",
+		".Inner.B",
+		".MapInner",
+		".MapInner[*]",
+		".MapInner[*].A",
+		".MapInner[*].B",
+		".SliceInner",
+		".SliceInner[*]",
+		".SliceInner[*].A",
+		".SliceInner[*].B",
+		".C",
+		".D",
+	}, visited)
 }


### PR DESCRIPTION
## Why
Walking intermediate nodes is a more general extension of `WalkType` and is useful for required / enum validation codegen.

## Tests
New unit test and existing unit tests.
