### PR TITLE
When collecting libraries, convert them to absolute path

### DIFF
--- a/bundle/libraries/upload.go
+++ b/bundle/libraries/upload.go
@@ -73,7 +73,10 @@ func collectLocalLibraries(b *bundle.Bundle) (map[string][]configLocation, error
 					return v, nil
 				}
 
-				source = filepath.Join(b.SyncRootPath, source)
+				if !filepath.IsAbs(source) {
+					source = filepath.Join(b.SyncRootPath, source)
+				}
+
 				libs[source] = append(libs[source], configLocation{
 					configPath: p,
 					location:   v.Location(),
@@ -120,7 +123,9 @@ func collectLocalLibraries(b *bundle.Bundle) (map[string][]configLocation, error
 
 			// Need to convert relative path to absolute so that paths collected above match paths collected here
 			// artifacts.*.files[*].source are relative to bundle root, not sync root AFAIK
-			source = filepath.Join(b.BundleRootPath, source)
+			if !filepath.IsAbs(source) {
+				source = filepath.Join(b.BundleRootPath, source)
+			}
 
 			libs[source] = append(libs[source], configLocation{
 				configPath: p.Append(dyn.Key("remote_path")),

--- a/bundle/libraries/upload.go
+++ b/bundle/libraries/upload.go
@@ -118,6 +118,10 @@ func collectLocalLibraries(b *bundle.Bundle) (map[string][]configLocation, error
 				}
 			}
 
+			// Need to convert relative path to absolute so that paths collected above match paths collected here
+			// artifacts.*.files[*].source are relative to bundle root, not sync root AFAIK
+			source = filepath.Join(b.BundleRootPath, source)
+
 			libs[source] = append(libs[source], configLocation{
 				configPath: p.Append(dyn.Key("remote_path")),
 				location:   v.Location(),


### PR DESCRIPTION
Otherwise if some paths are relative, they could be registered more than once. 

Discovered while working on https://github.com/databricks/cli/pull/2982 however not sure if it's a bug in practice or there is some other code that converts those paths to absolute.

Also wrap filepath.Join with IsAbs check, it does not do that automatically.