### PR TITLE
ResourceDescription: calculate PluralName/Title/TerraformResourceName

### DIFF
--- a/bundle/apps/interpolate_variables.go
+++ b/bundle/apps/interpolate_variables.go
@@ -22,7 +22,7 @@ func (i *interpolateVariables) Apply(ctx context.Context, b *bundle.Bundle) diag
 
 	tfToConfigMap := map[string]string{}
 	for k, r := range config.SupportedResources() {
-		tfToConfigMap[r.TerraformResourceName] = k
+		tfToConfigMap[r.TerraformResourceName()] = k
 	}
 
 	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {

--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
@@ -178,9 +178,10 @@ func TestAllResourcesExplicitlyDefinedForPermissionsSupport(t *testing.T) {
 	}
 
 	for _, resource := range r.AllResources() {
-		_, ok := levelsMap[resource.Description.PluralName]
-		if !slices.Contains(unsupportedResources, resource.Description.PluralName) && !ok {
-			assert.Fail(t, fmt.Sprintf("Resource %s is not explicitly defined in levelsMap or unsupportedResources", resource.Description.PluralName))
+		pluralName := resource.Description.PluralName()
+		_, ok := levelsMap[pluralName]
+		if !slices.Contains(unsupportedResources, pluralName) && !ok {
+			assert.Fail(t, fmt.Sprintf("Resource %s is not explicitly defined in levelsMap or unsupportedResources", pluralName))
 		}
 	}
 }

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -58,13 +58,7 @@ func (a *App) Exists(ctx context.Context, w *databricks.WorkspaceClient, name st
 }
 
 func (*App) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "app",
-		PluralName:            "apps",
-		SingularTitle:         "App",
-		PluralTitle:           "Apps",
-		TerraformResourceName: "databricks_app",
-	}
+	return ResourceDescription{SingularName: "app"}
 }
 
 func (a *App) TerraformResourceName() string {

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -49,13 +49,7 @@ func (s *Cluster) Exists(ctx context.Context, w *databricks.WorkspaceClient, id 
 }
 
 func (*Cluster) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "cluster",
-		PluralName:            "clusters",
-		SingularTitle:         "Cluster",
-		PluralTitle:           "Clusters",
-		TerraformResourceName: "databricks_cluster",
-	}
+	return ResourceDescription{SingularName: "cluster"}
 }
 
 func (s *Cluster) TerraformResourceName() string {

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -72,13 +72,7 @@ func (*Dashboard) Exists(ctx context.Context, w *databricks.WorkspaceClient, id 
 }
 
 func (*Dashboard) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "dashboard",
-		PluralName:            "dashboards",
-		SingularTitle:         "Dashboard",
-		PluralTitle:           "Dashboards",
-		TerraformResourceName: "databricks_dashboard",
-	}
+	return ResourceDescription{SingularName: "dashboard"}
 }
 
 func (*Dashboard) TerraformResourceName() string {

--- a/bundle/config/resources/description.go
+++ b/bundle/config/resources/description.go
@@ -11,7 +11,7 @@ type ResourceDescription struct {
 // PluralName returns the plural snake-case identifier of the resource type.
 // Currently all resource names pluralise by suffixing an "s".
 func (r ResourceDescription) PluralName() string {
-	return pluralize(r.SingularName)
+	return r.SingularName + "s"
 }
 
 // SingularTitle returns a human-readable singular title (e.g. "Model Serving Endpoint").
@@ -32,14 +32,6 @@ func (r ResourceDescription) TerraformResourceName() string {
 	default:
 		return "databricks_" + r.SingularName
 	}
-}
-
-// pluralize performs the naïve pluralisation by appending "s" unless already present.
-func pluralize(s string) string {
-	if strings.HasSuffix(s, "s") {
-		return s
-	}
-	return s + "s"
 }
 
 // humanize converts snake_case to Title Case with spaces.

--- a/bundle/config/resources/description.go
+++ b/bundle/config/resources/description.go
@@ -1,13 +1,55 @@
 package resources
 
+import "strings"
+
 type ResourceDescription struct {
-	// Singular and plural name when used to refer to the configuration.
+	// SingularName is the canonical identifier of the resource type.
+	// It is the only piece of static data stored; all other views are derived.
 	SingularName string
-	PluralName   string
+}
 
-	// Singular and plural title when used in summaries / terminal UI.
-	SingularTitle string
-	PluralTitle   string
+// PluralName returns the plural snake-case identifier of the resource type.
+// Currently all resource names pluralise by suffixing an "s".
+func (r ResourceDescription) PluralName() string {
+	return pluralize(r.SingularName)
+}
 
-	TerraformResourceName string
+// SingularTitle returns a human-readable singular title (e.g. "Model Serving Endpoint").
+func (r ResourceDescription) SingularTitle() string {
+	return humanize(r.SingularName)
+}
+
+// PluralTitle returns a human-readable plural title (e.g. "Model Serving Endpoints").
+func (r ResourceDescription) PluralTitle() string {
+	return humanize(r.PluralName())
+}
+
+// TerraformResourceName returns the Terraform resource name corresponding to this resource.
+func (r ResourceDescription) TerraformResourceName() string {
+	switch r.SingularName {
+	case "experiment", "model":
+		return "databricks_mlflow_" + r.SingularName
+	default:
+		return "databricks_" + r.SingularName
+	}
+}
+
+// pluralize performs the naïve pluralisation by appending "s" unless already present.
+func pluralize(s string) string {
+	if strings.HasSuffix(s, "s") {
+		return s
+	}
+	return s + "s"
+}
+
+// humanize converts snake_case to Title Case with spaces.
+func humanize(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
 }

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -56,13 +56,7 @@ func (j *Job) Exists(ctx context.Context, w *databricks.WorkspaceClient, id stri
 }
 
 func (j *Job) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "job",
-		PluralName:            "jobs",
-		SingularTitle:         "Job",
-		PluralTitle:           "Jobs",
-		TerraformResourceName: "databricks_job",
-	}
+	return ResourceDescription{SingularName: "job"}
 }
 
 func (j *Job) TerraformResourceName() string {

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -51,13 +51,7 @@ func (s *MlflowExperiment) Exists(ctx context.Context, w *databricks.WorkspaceCl
 }
 
 func (j *MlflowExperiment) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "experiment",
-		PluralName:            "experiments",
-		SingularTitle:         "Experiment",
-		PluralTitle:           "Experiments",
-		TerraformResourceName: "databricks_mlflow_experiment",
-	}
+	return ResourceDescription{SingularName: "experiment"}
 }
 
 func (s *MlflowExperiment) TerraformResourceName() string {

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -51,13 +51,7 @@ func (s *MlflowModel) Exists(ctx context.Context, w *databricks.WorkspaceClient,
 }
 
 func (j *MlflowModel) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "model",
-		PluralName:            "models",
-		SingularTitle:         "Model",
-		PluralTitle:           "Models",
-		TerraformResourceName: "databricks_mlflow_model",
-	}
+	return ResourceDescription{SingularName: "model"}
 }
 
 func (s *MlflowModel) TerraformResourceName() string {

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -59,13 +59,7 @@ func (s *ModelServingEndpoint) Exists(ctx context.Context, w *databricks.Workspa
 }
 
 func (j *ModelServingEndpoint) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "model_serving_endpoint",
-		PluralName:            "model_serving_endpoints",
-		SingularTitle:         "Model Serving Endpoint",
-		PluralTitle:           "Model Serving Endpoints",
-		TerraformResourceName: "databricks_model_serving_endpoint",
-	}
+	return ResourceDescription{SingularName: "model_serving_endpoint"}
 }
 
 func (s *ModelServingEndpoint) TerraformResourceName() string {

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -51,13 +51,7 @@ func (p *Pipeline) Exists(ctx context.Context, w *databricks.WorkspaceClient, id
 }
 
 func (j *Pipeline) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "pipeline",
-		PluralName:            "pipelines",
-		SingularTitle:         "Pipeline",
-		PluralTitle:           "Pipelines",
-		TerraformResourceName: "databricks_pipeline",
-	}
+	return ResourceDescription{SingularName: "pipeline"}
 }
 
 func (p *Pipeline) TerraformResourceName() string {

--- a/bundle/config/resources/quality_monitor.go
+++ b/bundle/config/resources/quality_monitor.go
@@ -43,13 +43,7 @@ func (s *QualityMonitor) Exists(ctx context.Context, w *databricks.WorkspaceClie
 }
 
 func (*QualityMonitor) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "quality_monitor",
-		PluralName:            "quality_monitors",
-		SingularTitle:         "Quality Monitor",
-		PluralTitle:           "Quality Monitors",
-		TerraformResourceName: "databricks_quality_monitor",
-	}
+	return ResourceDescription{SingularName: "quality_monitor"}
 }
 
 func (s *QualityMonitor) TerraformResourceName() string {

--- a/bundle/config/resources/registered_model.go
+++ b/bundle/config/resources/registered_model.go
@@ -49,13 +49,7 @@ func (s *RegisteredModel) Exists(ctx context.Context, w *databricks.WorkspaceCli
 }
 
 func (*RegisteredModel) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "registered_model",
-		PluralName:            "registered_models",
-		SingularTitle:         "Registered Model",
-		PluralTitle:           "Registered Models",
-		TerraformResourceName: "databricks_registered_model",
-	}
+	return ResourceDescription{SingularName: "registered_model"}
 }
 
 func (s *RegisteredModel) TerraformResourceName() string {

--- a/bundle/config/resources/schema.go
+++ b/bundle/config/resources/schema.go
@@ -45,13 +45,7 @@ func (s *Schema) Exists(ctx context.Context, w *databricks.WorkspaceClient, full
 }
 
 func (*Schema) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "schema",
-		PluralName:            "schemas",
-		SingularTitle:         "Schema",
-		PluralTitle:           "Schemas",
-		TerraformResourceName: "databricks_schema",
-	}
+	return ResourceDescription{SingularName: "schema"}
 }
 
 func (s *Schema) TerraformResourceName() string {

--- a/bundle/config/resources/secret_scope.go
+++ b/bundle/config/resources/secret_scope.go
@@ -73,13 +73,7 @@ func (s SecretScope) Exists(ctx context.Context, w *databricks.WorkspaceClient, 
 }
 
 func (s SecretScope) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "secret_scope",
-		PluralName:            "secret_scopes",
-		SingularTitle:         "Secret Scope",
-		PluralTitle:           "Secret Scopes",
-		TerraformResourceName: "databricks_secret_scope",
-	}
+	return ResourceDescription{SingularName: "secret_scope"}
 }
 
 func (s SecretScope) TerraformResourceName() string {

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -53,13 +53,7 @@ func (v *Volume) Exists(ctx context.Context, w *databricks.WorkspaceClient, full
 }
 
 func (*Volume) ResourceDescription() ResourceDescription {
-	return ResourceDescription{
-		SingularName:          "volume",
-		PluralName:            "volumes",
-		SingularTitle:         "Volume",
-		PluralTitle:           "Volumes",
-		TerraformResourceName: "databricks_volume",
-	}
+	return ResourceDescription{SingularName: "volume"}
 }
 
 func (v *Volume) TerraformResourceName() string {

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -87,7 +87,7 @@ func TestResourcesAllResourcesCompleteness(t *testing.T) {
 	// Collect set of includes resource types
 	var types []string
 	for _, group := range r.AllResources() {
-		types = append(types, group.Description.PluralName)
+		types = append(types, group.Description.PluralName())
 	}
 
 	for i := range rt.NumField() {
@@ -111,7 +111,7 @@ func TestSupportedResources(t *testing.T) {
 		field := typ.Field(i)
 		jsonTags := strings.Split(field.Tag.Get("json"), ",")
 		pluralName := jsonTags[0]
-		assert.Equal(t, actual[pluralName].PluralName, pluralName)
+		assert.Equal(t, actual[pluralName].PluralName(), pluralName)
 	}
 }
 

--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -205,7 +205,7 @@ func RenderSummary(ctx context.Context, out io.Writer, b *bundle.Bundle) error {
 
 		if len(resources) > 0 {
 			resourceGroups = append(resourceGroups, ResourceGroup{
-				GroupName: group.Description.PluralTitle,
+				GroupName: group.Description.PluralTitle(),
 				Resources: resources,
 			})
 		}

--- a/bundle/resources/lookup.go
+++ b/bundle/resources/lookup.go
@@ -58,7 +58,7 @@ func References(b *bundle.Bundle, filters ...Filter) (Map, Map) {
 		for k, v := range group.Resources {
 			ref := Reference{
 				Key:         k,
-				KeyWithType: fmt.Sprintf("%s.%s", group.Description.PluralName, k),
+				KeyWithType: fmt.Sprintf("%s.%s", group.Description.PluralName(), k),
 				Description: group.Description,
 				Resource:    v,
 			}

--- a/cmd/bundle/open.go
+++ b/cmd/bundle/open.go
@@ -25,7 +25,7 @@ func promptOpenArgument(ctx context.Context, b *bundle.Bundle) (string, error) {
 	// Compute map of "Human readable name of resource" -> "resource key".
 	inv := make(map[string]string)
 	for k, ref := range resources.Completions(b) {
-		title := fmt.Sprintf("%s: %s", ref.Description.SingularTitle, ref.Resource.GetName())
+		title := fmt.Sprintf("%s: %s", ref.Description.SingularTitle(), ref.Resource.GetName())
 		inv[title] = k
 	}
 

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -29,7 +29,7 @@ func promptRunArgument(ctx context.Context, b *bundle.Bundle) (string, error) {
 	// Compute map of "Human readable name of resource" -> "resource key".
 	inv := make(map[string]string)
 	for k, ref := range resources.Completions(b, run.IsRunnable) {
-		title := fmt.Sprintf("%s: %s", ref.Description.SingularTitle, ref.Resource.GetName())
+		title := fmt.Sprintf("%s: %s", ref.Description.SingularTitle(), ref.Resource.GetName())
 		inv[title] = k
 	}
 


### PR DESCRIPTION
## Changes
Instead of hard-coding plural names, titles, terraform names, calculate those to methods from SingleName.

## Why
Makes it easy to see and enforce the pattern. Makes it easy to see the exceptions as well.

## Tests
Existing tests.
