### PR TITLE
acc: Disable UNIX_TIME_MICROS replacement

### DIFF
--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -34,10 +34,11 @@ Old = '\d{17,}'
 New = "[NUMID]"
 Order = 10
 
-[[Repls]]
-Old = '1[78]\d{14}'
-New = '[UNIX_TIME_MICROS]'
-Order = 10
+#[[Repls]]
+# This makes certain integration tests flaky as experiment IDs overlap in range with this regex
+#Old = '1[78]\d{14}'
+#New = '[UNIX_TIME_MICROS]'
+#Order = 10
 
 [[Repls]]
 Old = '\d{14,}'


### PR DESCRIPTION
It was added for completeness, not because it is actually used but  it makes certain integration tests flaky:

```
FAIL acceptance.TestAccept/bundle/deployment/bind/experiment (18.05s)
          -Successfully bound experiment with an id '[NUMID]'. Run 'bundle deploy' to deploy changes to your workspace736
          +Successfully bound experiment with an id '[UNIX_TIME_MICROS]'. Run 'bundle deploy' to deploy changes to your workspace

FAIL acceptance.TestAccept/bundle/deploy/mlops-stacks (28.72s)
          -  "experiment_id": "[NUMID]",
          +  "experiment_id": "[UNIX_TIME_MICROS]",
```