### PR TITLE
Tolerate URLs copied from the browser with `databricks auth login`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Notable Changes
 
+* Fix `databricks auth login` to tolerate URLs copied from the browser ([#3001](https://github.com/databricks/cli/pull/3001)).
+
 ### Dependency updates
 
 ### CLI

--- a/libs/auth/arguments.go
+++ b/libs/auth/arguments.go
@@ -18,8 +18,9 @@ func (a AuthArguments) ToOAuthArgument() (u2m.OAuthArgument, error) {
 		Host:      a.Host,
 		AccountID: a.AccountID,
 	}
+	host := cfg.CanonicalHostName()
 	if cfg.IsAccountClient() {
-		return u2m.NewBasicAccountOAuthArgument(cfg.Host, cfg.AccountID)
+		return u2m.NewBasicAccountOAuthArgument(host, cfg.AccountID)
 	}
-	return u2m.NewBasicWorkspaceOAuthArgument(cfg.Host)
+	return u2m.NewBasicWorkspaceOAuthArgument(host)
 }

--- a/libs/auth/arguments_test.go
+++ b/libs/auth/arguments_test.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/credentials/u2m"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToOAuthArgument(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      AuthArguments
+		wantHost  string
+		wantError bool
+	}{
+		{
+			name: "workspace with no scheme",
+			args: AuthArguments{
+				Host: "my-workspace.cloud.databricks.com",
+			},
+			wantHost: "https://my-workspace.cloud.databricks.com",
+		},
+		{
+			name: "workspace with https",
+			args: AuthArguments{
+				Host: "https://my-workspace.cloud.databricks.com",
+			},
+			wantHost: "https://my-workspace.cloud.databricks.com",
+		},
+		{
+			name: "account with no scheme",
+			args: AuthArguments{
+				Host:      "accounts.cloud.databricks.com",
+				AccountID: "123456789",
+			},
+			wantHost: "https://accounts.cloud.databricks.com",
+		},
+		{
+			name: "account with https",
+			args: AuthArguments{
+				Host:      "https://accounts.cloud.databricks.com",
+				AccountID: "123456789",
+			},
+			wantHost: "https://accounts.cloud.databricks.com",
+		},
+		{
+			name: "workspace with query parameter",
+			args: AuthArguments{
+				Host: "https://my-workspace.cloud.databricks.com?o=123456789",
+			},
+			wantHost: "https://my-workspace.cloud.databricks.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.args.ToOAuthArgument()
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Check if we got the right type of argument and verify the hostname
+			if tt.args.AccountID != "" {
+				arg, ok := got.(u2m.AccountOAuthArgument)
+				assert.True(t, ok, "expected AccountOAuthArgument for account ID")
+				assert.Equal(t, tt.wantHost, arg.GetAccountHost())
+			} else {
+				arg, ok := got.(u2m.WorkspaceOAuthArgument)
+				assert.True(t, ok, "expected WorkspaceOAuthArgument for workspace")
+				assert.Equal(t, tt.wantHost, arg.GetWorkspaceHost())
+			}
+		})
+	}
+}

--- a/libs/auth/arguments_test.go
+++ b/libs/auth/arguments_test.go
@@ -51,6 +51,13 @@ func TestToOAuthArgument(t *testing.T) {
 			},
 			wantHost: "https://my-workspace.cloud.databricks.com",
 		},
+		{
+			name: "workspace with query parameter and path",
+			args: AuthArguments{
+				Host: "https://my-workspace.cloud.databricks.com/path?o=123456789",
+			},
+			wantHost: "https://my-workspace.cloud.databricks.com",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes
It's a common flow for a user to copy the URL of their workspace from the browser to login with the CLI. All that we need to successfully login is the hostname, but the URL contains much more information, such as the path of the page they were on or their workspace ID as a query parameter.

Today, if a user tries to use this URL verbatim with `databricks auth login`, they get an error like `Error: fetching oauth config: fetching OAuth endpoints: databricks OAuth is not supported for this host`.

This PR ensures that the CLI uses the same normalization as the Go SDK config on the provided hostname before starting the OAuth login flow, resolving this error.

## Why
This reduces friction for those logging in with the CLI.

## Tests
Unit tests to verify that such URLs are tolerated.
