### PR TITLE
Disable TestSecretsPutSecret*Value on aws-prod-ucws

### DIFF
--- a/integration/cmd/secrets/secrets_test.go
+++ b/integration/cmd/secrets/secrets_test.go
@@ -95,6 +95,10 @@ func TestSecretsPutSecretStringValue(tt *testing.T) {
 }
 
 func TestSecretsPutSecretBytesValue(tt *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		tt.Skip("Skipping to unblock PRs; re-enable if works")
+	}
+
 	ctx, t := acc.WorkspaceTest(tt)
 	scope := temporarySecretScope(ctx, t)
 	key := "test-key"

--- a/integration/cmd/secrets/secrets_test.go
+++ b/integration/cmd/secrets/secrets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/databricks/cli/integration/internal/acc"
@@ -65,6 +66,21 @@ func assertSecretBytesValue(t *acc.WorkspaceT, scope, key string, expected []byt
 }
 
 func TestSecretsPutSecretStringValue(tt *testing.T) {
+	// aws-prod-ucws sets CLOUD_ENV to "ucws"
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		/*
+					FAIL integration/cmd/secrets.TestSecretsPutSecretStringValue (re-run 2) (1201.25s)
+			      secrets_test.go:73:   args: secrets, put-secret, cli-acc-c4ea35e34b52466cbf9a090c431d6a0b, test-key, --string-value, test-value
+			          with-newlines
+			      secrets_test.go:40:
+			          	Error Trace:	/home/runner/work/eng-dev-ecosystem/eng-dev-ecosystem/ext/cli/integration/internal/acc/workspace.go:75
+			          	Error:      	Received unexpected error:
+			          	            	wait: timed out: Finding instances for new nodes, acquiring more instances if necessary
+			          	Messages:   	Unexpected error from EnsureClusterIsRunning for clusterID=***
+		*/
+		tt.Skip("Skipping to unblock PRs; re-enable if works")
+	}
+
 	ctx, t := acc.WorkspaceTest(tt)
 	scope := temporarySecretScope(ctx, t)
 	key := "test-key"


### PR DESCRIPTION
Started to fail consistently with

```
FAIL integration/cmd/secrets.TestSecretsPutSecretStringValue (re-run 2) (1201.25s)
      secrets_test.go:73:   args: secrets, put-secret, cli-acc-c4ea35e34b52466cbf9a090c431d6a0b, test-key, --string-value, test-value
          with-newlines
      secrets_test.go:40:
          	Error Trace:	/home/runner/work/eng-dev-ecosystem/eng-dev-ecosystem/ext/cli/integration/internal/acc/workspace.go:75
          	Error:      	Received unexpected error:
          	            	wait: timed out: Finding instances for new nodes, acquiring more instances if necessary
          	Messages:   	Unexpected error from EnsureClusterIsRunning for clusterID=***
```