### PR TITLE
Add `resources/*/*.yml` as default include in templates

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,5 +14,6 @@
 ### Bundles
 * Fix "bundle summary -o json" to render null values properly ([#2990](https://github.com/databricks/cli/pull/2990))
 * Fixed null pointer de-reference if artifacts missing fields ([#3022](https://github.com/databricks/cli/pull/3022))
+* Update bundle templates to also include `resources/*/*.yml` ([#3024](https://github.com/databricks/cli/pull/3024))
 
 ### API Changes

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/databricks.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/databricks.yml
@@ -7,6 +7,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 # Deployment targets.
 # The default schema, catalog, etc. for dbt are defined in dbt_profiles/profiles.yml

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/databricks.yml
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/databricks.yml
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 targets:
   dev:

--- a/acceptance/bundle/templates/default-python/serverless/output/my_default_python/databricks.yml
+++ b/acceptance/bundle/templates/default-python/serverless/output/my_default_python/databricks.yml
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 targets:
   dev:

--- a/acceptance/bundle/templates/default-sql/output/my_default_sql/databricks.yml
+++ b/acceptance/bundle/templates/default-sql/output/my_default_sql/databricks.yml
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/databricks.yml
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/databricks.yml
@@ -24,6 +24,7 @@ artifacts:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 targets:
   dev:

--- a/acceptance/bundle/templates/telemetry/dbt-sql/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/out.databricks.yml
@@ -7,6 +7,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 # Deployment targets.
 # The default schema, catalog, etc. for dbt are defined in dbt_profiles/profiles.yml

--- a/acceptance/bundle/templates/telemetry/default-python/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/default-python/out.databricks.yml
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 targets:
   dev:

--- a/acceptance/bundle/templates/telemetry/default-sql/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/default-sql/out.databricks.yml
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -7,6 +7,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 # Deployment targets.
 # The default schema, catalog, etc. for dbt are defined in dbt_profiles/profiles.yml

--- a/libs/template/templates/default-python/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/databricks.yml.tmpl
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 targets:
   dev:

--- a/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -6,6 +6,7 @@ bundle:
 
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/databricks.yml.tmpl
@@ -26,6 +26,7 @@ artifacts:
 {{ end -}}
 include:
   - resources/*.yml
+  - resources/*/*.yml
 
 targets:
   dev:

--- a/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
+++ b/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
@@ -14,7 +14,7 @@
             "default": "{{default_catalog}}",
             "pattern": "^\\w*$",
             "pattern_match_failure_message": "Invalid catalog name.",
-            "description": "\nInitial catalog.\ndefault_catalog",
+            "description": "\nInitial catalog:\ndefault_catalog",
             "order": 3
         },
         "personal_schemas": {


### PR DESCRIPTION
## Changes

Update default includes to allow pipeline folders under the `resources` folder.

## Why

DABs in the Workspace is adding a feature that adds pipeline folders under `resources/`. This change makes sure that projects initialized from templates don't need to be modified in order to includes these pipelines.

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
