### PR TITLE
Enable yaml formatter; fix formatting in default-python & dbt-sql

### DIFF
--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -29,25 +29,25 @@ jobs:
 
       - name: Delete old comments
         env:
-           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            # Delete previous comment if it exists
-            previous_comment_ids=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --jq '.[] | select(.body | startswith("<!-- INTEGRATION_TESTS_MANUAL -->")) | .id')
-            echo "Previous comment IDs: $previous_comment_ids"
-            # Iterate over each comment ID and delete the comment
-            if [ ! -z "$previous_comment_ids" ]; then
-              echo "$previous_comment_ids" | while read -r comment_id; do
-                echo "Deleting comment with ID: $comment_id"
-                gh api "repos/${{ github.repository }}/issues/comments/$comment_id" -X DELETE
-              done
-            fi
+          # Delete previous comment if it exists
+          previous_comment_ids=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- INTEGRATION_TESTS_MANUAL -->")) | .id')
+          echo "Previous comment IDs: $previous_comment_ids"
+          # Iterate over each comment ID and delete the comment
+          if [ ! -z "$previous_comment_ids" ]; then
+            echo "$previous_comment_ids" | while read -r comment_id; do
+              echo "Deleting comment with ID: $comment_id"
+              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" -X DELETE
+            done
+          fi
 
       - name: Comment on PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
+        run: |-
           gh pr comment ${{ github.event.pull_request.number }} --body \
           "<!-- INTEGRATION_TESTS_MANUAL -->
           An authorized user can trigger integration tests manually by following the instructions below:

--- a/.github/workflows/integration-approve.yml
+++ b/.github/workflows/integration-approve.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
-        run: |
+        run: |-
           gh api -X POST -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/statuses/${{ github.sha }} \

--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Trigger Workflow in Another Repo
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
+        run: |-
           gh workflow run cli-isolated-nightly.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
           --ref main \
           -f commit_sha=${{ github.event.after }}

--- a/.github/workflows/integration-pr.yml
+++ b/.github/workflows/integration-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Trigger Workflow in Another Repo
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
+        run: |-
           gh workflow run cli-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
           --ref main \
           -f pull_request_number=${{ github.event.pull_request.number }} \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 0,12 * * *'  # Runs at 00:00 and 12:00 UTC daily
+    - cron: '0 0,12 * * *' # Runs at 00:00 and 12:00 UTC daily
 
 env:
   GOTESTSUM_FORMAT: github-actions
@@ -192,7 +192,7 @@ jobs:
 
       - name: Verify that python/codegen is up to date
         working-directory: experimental/python
-        run: |
+        run: |-
           make codegen
 
           if ! ( git diff --exit-code ); then

--- a/.github/workflows/python_push.yml
+++ b/.github/workflows/python_push.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyVersion: [ '3.10', '3.11', '3.12', '3.13' ]
+        pyVersion: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -94,6 +94,6 @@ jobs:
           prerelease: true
           tag_name: snapshot
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: |
+          files: |-
             dist/databricks_cli_*.zip
             dist/databricks_cli_*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,6 @@ jobs:
 
     needs: goreleaser
 
-
     # IMPORTANT:
     # - 'id-token: write' is mandatory for OIDC and trusted publishing to PyPi
     # - 'environment: release' is a part of OIDC assertion done by PyPi

--- a/.github/workflows/start-integration-tests.yml
+++ b/.github/workflows/start-integration-tests.yml
@@ -37,5 +37,5 @@ jobs:
       - name: Run start_integration_tests.py
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
+        run: |-
           python3 ./start_integration_tests.py -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} --yes

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -11,7 +11,6 @@ on:
 concurrency:
   group: "tagging"
 
-
 jobs:
   tag:
     environment: "release-is"
@@ -47,5 +46,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
+        run: |-
           python internal/genkit/tagging.py

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,40 +5,40 @@ before:
     - go mod download
 
 builds:
-- env:
-    - CGO_ENABLED=0
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  ldflags:
-    - '-s -w'
-    - -X github.com/databricks/cli/internal/build.buildProjectName={{ .ProjectName }}
-    - -X github.com/databricks/cli/internal/build.buildVersion={{ .Version }}
+  - env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w'
+      - -X github.com/databricks/cli/internal/build.buildProjectName={{ .ProjectName }}
+      - -X github.com/databricks/cli/internal/build.buildVersion={{ .Version }}
 
-    # Git information
-    - -X github.com/databricks/cli/internal/build.buildBranch={{ .Branch }}
-    - -X github.com/databricks/cli/internal/build.buildTag={{ .Tag }}
-    - -X github.com/databricks/cli/internal/build.buildShortCommit={{ .ShortCommit }}
-    - -X github.com/databricks/cli/internal/build.buildFullCommit={{ .FullCommit }}
-    - -X github.com/databricks/cli/internal/build.buildCommitTimestamp={{ .CommitTimestamp }}
-    - -X github.com/databricks/cli/internal/build.buildSummary={{ .Summary }}
+      # Git information
+      - -X github.com/databricks/cli/internal/build.buildBranch={{ .Branch }}
+      - -X github.com/databricks/cli/internal/build.buildTag={{ .Tag }}
+      - -X github.com/databricks/cli/internal/build.buildShortCommit={{ .ShortCommit }}
+      - -X github.com/databricks/cli/internal/build.buildFullCommit={{ .FullCommit }}
+      - -X github.com/databricks/cli/internal/build.buildCommitTimestamp={{ .CommitTimestamp }}
+      - -X github.com/databricks/cli/internal/build.buildSummary={{ .Summary }}
 
-    # Version information
-    - -X github.com/databricks/cli/internal/build.buildMajor={{ .Major }}
-    - -X github.com/databricks/cli/internal/build.buildMinor={{ .Minor }}
-    - -X github.com/databricks/cli/internal/build.buildPatch={{ .Patch }}
-    - -X github.com/databricks/cli/internal/build.buildPrerelease={{ .Prerelease }}
-    - -X github.com/databricks/cli/internal/build.buildIsSnapshot={{ .IsSnapshot }}
-    - -X github.com/databricks/cli/internal/build.buildTimestamp={{ .Timestamp }}
+      # Version information
+      - -X github.com/databricks/cli/internal/build.buildMajor={{ .Major }}
+      - -X github.com/databricks/cli/internal/build.buildMinor={{ .Minor }}
+      - -X github.com/databricks/cli/internal/build.buildPatch={{ .Patch }}
+      - -X github.com/databricks/cli/internal/build.buildPrerelease={{ .Prerelease }}
+      - -X github.com/databricks/cli/internal/build.buildIsSnapshot={{ .IsSnapshot }}
+      - -X github.com/databricks/cli/internal/build.buildTimestamp={{ .Timestamp }}
 
-  goos:
-    - windows
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - arm64
-  binary: databricks
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: databricks
 
 archives:
   - formats: ["zip", "tar.gz"]
@@ -89,7 +89,6 @@ docker_manifests:
       - ghcr.io/databricks/cli:latest-amd64
       - ghcr.io/databricks/cli:latest-arm64
 
-
 checksum:
   name_template: 'databricks_cli_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
@@ -101,5 +100,5 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - '^docs:'
+      - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ links:
 	./tools/update_github_links.py
 
 # Checks other than 'fmt' and 'lint'; these are fast, so can be run first
-checks: tidy ws links
+checks: tidy ws links yamlfmt
 
 test:
 	${GOTESTSUM_CMD} -- ${PACKAGES}

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,12 @@ fmt:
 	ruff format -n
 	./tools/lintdiff.py fmt
 
-yamlfmt:
-	go tool yamlfmt .
+# pre-building yamlfmt because I also want to call it from tests
+tools/yamlfmt: go.mod
+	go build -o tools/yamlfmt github.com/google/yamlfmt/cmd/yamlfmt
+
+yamlfmt: tools/yamlfmt
+	./tools/yamlfmt .
 
 ws:
 	./tools/validate_whitespace.py

--- a/Makefile
+++ b/Makefile
@@ -19,20 +19,19 @@ tidy:
 lintcheck:
 	golangci-lint run ./...
 
-fmtfull:
+fmtfull: tools/yamlfmt
 	ruff format -n
 	golangci-lint fmt
+	./tools/yamlfmt .
 
-fmt:
+fmt: tools/yamlfmt
 	ruff format -n
 	./tools/lintdiff.py fmt
+	./tools/yamlfmt .
 
 # pre-building yamlfmt because I also want to call it from tests
 tools/yamlfmt: go.mod
 	go build -o tools/yamlfmt github.com/google/yamlfmt/cmd/yamlfmt
-
-yamlfmt: tools/yamlfmt
-	./tools/yamlfmt .
 
 ws:
 	./tools/validate_whitespace.py
@@ -41,7 +40,7 @@ links:
 	./tools/update_github_links.py
 
 # Checks other than 'fmt' and 'lint'; these are fast, so can be run first
-checks: tidy ws links yamlfmt
+checks: tidy ws links
 
 test:
 	${GOTESTSUM_CMD} -- ${PACKAGES}

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ fmt:
 	ruff format -n
 	./tools/lintdiff.py fmt
 
+yamlfmt:
+	go tool yamlfmt .
+
 ws:
 	./tools/validate_whitespace.py
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -15,5 +15,6 @@
 * Fix "bundle summary -o json" to render null values properly ([#2990](https://github.com/databricks/cli/pull/2990))
 * Fixed null pointer de-reference if artifacts missing fields ([#3022](https://github.com/databricks/cli/pull/3022))
 * Update bundle templates to also include `resources/*/*.yml` ([#3024](https://github.com/databricks/cli/pull/3024))
+* Apply YAML formatter on default-python and dbt-sql templates ([#3026](https://github.com/databricks/cli/pull/3026))
 
 ### API Changes

--- a/acceptance/bundle/artifacts/glob_exact_whl/databricks.yml
+++ b/acceptance/bundle/artifacts/glob_exact_whl/databricks.yml
@@ -1,8 +1,8 @@
 artifacts:
-    my_prebuilt_whl:
-      type: whl
-      files:
-        - source: prebuilt/other_test_code-0.0.1-py3-none-any.whl
+  my_prebuilt_whl:
+    type: whl
+    files:
+      - source: prebuilt/other_test_code-0.0.1-py3-none-any.whl
 
 resources:
   jobs:
@@ -15,4 +15,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: prebuilt/other_test_code-0.0.1-py3-none-any.whl
+            - whl: prebuilt/other_test_code-0.0.1-py3-none-any.whl

--- a/acceptance/bundle/artifacts/nil_artifacts/databricks.yml
+++ b/acceptance/bundle/artifacts/nil_artifacts/databricks.yml
@@ -5,6 +5,6 @@ artifacts:
   # This reproduces the issue from GitHub #3017
   # where artifacts have empty definitions (only comments)
   my_artifact:
-    # build: <first_option_command>
-    # path: <path>
-    # build: <second_option_command>
+# build: <first_option_command>
+# path: <path>
+# build: <second_option_command>

--- a/acceptance/bundle/artifacts/nil_artifacts/databricks.yml
+++ b/acceptance/bundle/artifacts/nil_artifacts/databricks.yml
@@ -5,6 +5,6 @@ artifacts:
   # This reproduces the issue from GitHub #3017
   # where artifacts have empty definitions (only comments)
   my_artifact:
-# build: <first_option_command>
-# path: <path>
-# build: <second_option_command>
+  # build: <first_option_command>
+  # path: <path>
+  # build: <second_option_command>

--- a/acceptance/bundle/artifacts/nil_artifacts/databricks.yml
+++ b/acceptance/bundle/artifacts/nil_artifacts/databricks.yml
@@ -5,6 +5,6 @@ artifacts:
   # This reproduces the issue from GitHub #3017
   # where artifacts have empty definitions (only comments)
   my_artifact:
-  # build: <first_option_command>
-  # path: <path>
-  # build: <second_option_command>
+# build: <first_option_command>
+# path: <path>
+# build: <second_option_command>

--- a/acceptance/bundle/artifacts/same_name_libraries/databricks.yml
+++ b/acceptance/bundle/artifacts/same_name_libraries/databricks.yml
@@ -9,8 +9,8 @@ variables:
       data_security_mode: SINGLE_USER
       num_workers: 0
       spark_conf:
-          spark.master: "local[*, 4]"
-          spark.databricks.cluster.profile: singleNode
+        spark.master: "local[*, 4]"
+        spark.databricks.cluster.profile: singleNode
       custom_tags:
         ResourceClass: SingleNode
 

--- a/acceptance/bundle/artifacts/shell/bash/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/bash/databricks.yml
@@ -5,7 +5,7 @@ artifacts:
   my_artifact:
     executable: bash
     # echo in bash does not treat \n as a newline.
-    build: |
+    build: |-
       echo "\n\n\n should not see new lines" > out.shell.txt
       echo "multiline scripts should work" >> out.shell.txt
       pwd >> out.shell.txt

--- a/acceptance/bundle/artifacts/shell/basic/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/basic/databricks.yml
@@ -3,6 +3,6 @@ bundle:
 
 artifacts:
   my_artifact:
-    build: |
+    build: |-
       echo "Hello, World!" > out.shell.txt
       echo "Bye, World!" >> out.shell.txt

--- a/acceptance/bundle/artifacts/shell/cmd/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/cmd/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 artifacts:
   my_artifact:
     executable: cmd
-    build: |
+    build: |-
       if defined CMDCMDLINE (
         echo shell is cmd.exe> out.shell.txt
       )

--- a/acceptance/bundle/artifacts/shell/default/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/default/databricks.yml
@@ -4,7 +4,7 @@ bundle:
 artifacts:
   my_artifact:
     # Default shell is bash. echo in bash does not treat \n as a newline.
-    build: |
+    build: |-
       echo "\n\n\n should not see new lines" > out.shell.txt
       echo "multiline scripts should work" >> out.shell.txt
       pwd >> out.shell.txt

--- a/acceptance/bundle/artifacts/shell/sh/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/sh/databricks.yml
@@ -5,7 +5,7 @@ artifacts:
   my_artifact:
     executable: sh
     # echo in sh treats \n as a newline.
-    build: |
+    build: |-
       echo "\n\n\nshould see new lines" > out.shell.txt
       echo "multiline scripts should work" >> out.shell.txt
       pwd >> out.shell.txt

--- a/acceptance/bundle/artifacts/unique_name_libraries/databricks.yml
+++ b/acceptance/bundle/artifacts/unique_name_libraries/databricks.yml
@@ -6,8 +6,8 @@ variables:
       data_security_mode: SINGLE_USER
       num_workers: 0
       spark_conf:
-          spark.master: "local[*, 4]"
-          spark.databricks.cluster.profile: singleNode
+        spark.master: "local[*, 4]"
+        spark.databricks.cluster.profile: singleNode
       custom_tags:
         ResourceClass: SingleNode
 

--- a/acceptance/bundle/artifacts/whl_dbfs/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_dbfs/databricks.yml
@@ -9,4 +9,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: dbfs:/path/to/dist/mywheel.whl
+            - whl: dbfs:/path/to/dist/mywheel.whl

--- a/acceptance/bundle/artifacts/whl_dynamic/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_dynamic/databricks.yml
@@ -8,7 +8,7 @@ artifacts:
   my_prebuilt_whl:
     type: whl
     files:
-    - source: prebuilt/other_test_code-0.0.1-py3-none-any.whl
+      - source: prebuilt/other_test_code-0.0.1-py3-none-any.whl
     dynamic_version: true
 
 resources:
@@ -16,32 +16,32 @@ resources:
     test_job:
       name: "[${bundle.target}] My Wheel Job"
       tasks:
-      - task_key: TestTask
-        existing_cluster_id: "0717-132531-5opeqon1"
-        python_wheel_task:
-          package_name: "my_test_code"
-          entry_point: "run"
-        libraries:
-        - whl: ./my_test_code/dist/*.whl
-        - whl: prebuilt/other_test_code-0.0.1-py3-none-any.whl
-        for_each_task:
-          inputs: "[1]"
-          task:
-            task_key: SubTask
-            existing_cluster_id: "0717-132531-5opeqon1"
-            python_wheel_task:
-              package_name: "my_test_code"
-              entry_point: "run"
-            libraries:
+        - task_key: TestTask
+          existing_cluster_id: "0717-132531-5opeqon1"
+          python_wheel_task:
+            package_name: "my_test_code"
+            entry_point: "run"
+          libraries:
             - whl: ./my_test_code/dist/*.whl
-      - task_key: ServerlessTestTask
-        python_wheel_task:
-          package_name: "my_test_code"
-          entry_point: "run"
-        environment_key:  "test_env"
+            - whl: prebuilt/other_test_code-0.0.1-py3-none-any.whl
+          for_each_task:
+            inputs: "[1]"
+            task:
+              task_key: SubTask
+              existing_cluster_id: "0717-132531-5opeqon1"
+              python_wheel_task:
+                package_name: "my_test_code"
+                entry_point: "run"
+              libraries:
+                - whl: ./my_test_code/dist/*.whl
+        - task_key: ServerlessTestTask
+          python_wheel_task:
+            package_name: "my_test_code"
+            entry_point: "run"
+          environment_key: "test_env"
       environments:
-      - environment_key:  "test_env"
-        spec:
-          client: "1"
-          dependencies:
-          - ./my_test_code/dist/*.whl
+        - environment_key: "test_env"
+          spec:
+            client: "1"
+            dependencies:
+              - ./my_test_code/dist/*.whl

--- a/acceptance/bundle/artifacts/whl_explicit/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_explicit/databricks.yml
@@ -1,9 +1,9 @@
 artifacts:
-    my_test_code:
-      type: whl
-      path: "./my_test_code"
-      # using 'python' there because 'python3' does not exist in virtualenv on windows
-      build: python setup.py bdist_wheel
+  my_test_code:
+    type: whl
+    path: "./my_test_code"
+    # using 'python' there because 'python3' does not exist in virtualenv on windows
+    build: python setup.py bdist_wheel
 
 resources:
   jobs:
@@ -16,4 +16,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./my_test_code/dist/*.whl
+            - whl: ./my_test_code/dist/*.whl

--- a/acceptance/bundle/artifacts/whl_implicit/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_implicit/databricks.yml
@@ -9,4 +9,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./dist/*.whl
+            - whl: ./dist/*.whl

--- a/acceptance/bundle/artifacts/whl_implicit_custom_path/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_implicit_custom_path/databricks.yml
@@ -12,4 +12,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./package/*.whl
+            - whl: ./package/*.whl

--- a/acceptance/bundle/artifacts/whl_implicit_notebook/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_implicit_notebook/databricks.yml
@@ -3,9 +3,9 @@ resources:
     test_job:
       name: "[${bundle.target}] My Wheel Job"
       tasks:
-      - task_key: TestTask
-        existing_cluster_id: "0717-aaaaa-bbbbbb"
-        notebook_task:
-          notebook_path: "/notebook.py"
-        libraries:
-        - whl: ./dist/*.whl
+        - task_key: TestTask
+          existing_cluster_id: "0717-aaaaa-bbbbbb"
+          notebook_task:
+            notebook_path: "/notebook.py"
+          libraries:
+            - whl: ./dist/*.whl

--- a/acceptance/bundle/artifacts/whl_multiple/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_multiple/databricks.yml
@@ -1,12 +1,12 @@
 artifacts:
-    my_test_code:
-      type: whl
-      path: "./my_test_code"
-      build: "python setup.py bdist_wheel"
-    my_test_code_2:
-      type: whl
-      path: "./my_test_code"
-      build: "python setup2.py bdist_wheel"
+  my_test_code:
+    type: whl
+    path: "./my_test_code"
+    build: "python setup.py bdist_wheel"
+  my_test_code_2:
+    type: whl
+    path: "./my_test_code"
+    build: "python setup2.py bdist_wheel"
 
 resources:
   jobs:
@@ -19,4 +19,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./my_test_code/dist/*.whl
+            - whl: ./my_test_code/dist/*.whl

--- a/acceptance/bundle/artifacts/whl_no_cleanup/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_no_cleanup/databricks.yml
@@ -12,4 +12,4 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./dist/*.whl
+            - whl: ./dist/*.whl

--- a/acceptance/bundle/artifacts/whl_prebuilt_multiple/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_multiple/databricks.yml
@@ -9,5 +9,5 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ./dist/*.whl
-          - whl: ./dist/lib/other_test_code-0.0.1-py3-none-any.whl
+            - whl: ./dist/*.whl
+            - whl: ./dist/lib/other_test_code-0.0.1-py3-none-any.whl

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside/this_dab/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside/this_dab/databricks.yml
@@ -3,9 +3,9 @@ bundle:
 
 sync:
   paths:
-  - ../other_dab
+    - ../other_dab
   exclude:
-  - ../other_dab/**
+    - ../other_dab/**
 
 resources:
   jobs:
@@ -18,5 +18,5 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ../other_dab/dist/*.whl
-          - whl: ../other_dab/dist/lib/other_test_code-0.0.1-py3-none-any.whl
+            - whl: ../other_dab/dist/*.whl
+            - whl: ../other_dab/dist/lib/other_test_code-0.0.1-py3-none-any.whl

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/this_dab/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/this_dab/databricks.yml
@@ -15,9 +15,9 @@ artifacts:
 
 sync:
   paths:
-  - ../other_dab
+    - ../other_dab
   exclude:
-  - ../other_dab/**
+    - ../other_dab/**
 
 resources:
   jobs:
@@ -30,17 +30,17 @@ resources:
             package_name: "my_test_code"
             entry_point: "run"
           libraries:
-          - whl: ../other_dab/dist/*.whl
-          - whl: ../other_dab/dist/lib/other_test_code-0.0.1-py3-none-any.whl
+            - whl: ../other_dab/dist/*.whl
+            - whl: ../other_dab/dist/lib/other_test_code-0.0.1-py3-none-any.whl
         - task_key: ServerlessTestTask
           python_wheel_task:
             package_name: "my_test_code"
             entry_point: "run"
-          environment_key:  "test_env"
+          environment_key: "test_env"
       environments:
-        - environment_key:  "test_env"
+        - environment_key: "test_env"
           spec:
             client: "1"
             dependencies:
-             - ../other_dab/dist/*.whl
-             - ../other_dab/dist/lib/other_test_code-0.0.1-py3-none-any.whl
+              - ../other_dab/dist/*.whl
+              - ../other_dab/dist/lib/other_test_code-0.0.1-py3-none-any.whl

--- a/acceptance/bundle/artifacts/whl_via_environment_key/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_via_environment_key/databricks.yml
@@ -1,8 +1,8 @@
 artifacts:
-    my_test_code:
-      type: whl
-      path: "./my_test_code"
-      build: python setup.py bdist_wheel
+  my_test_code:
+    type: whl
+    path: "./my_test_code"
+    build: python setup.py bdist_wheel
 
 resources:
   jobs:
@@ -14,9 +14,9 @@ resources:
           python_wheel_task:
             package_name: "my_test_code"
             entry_point: "run"
-          environment_key:  "test_env"
+          environment_key: "test_env"
       environments:
-        - environment_key:  "test_env"
+        - environment_key: "test_env"
           spec:
             client: "1"
             dependencies:

--- a/acceptance/bundle/deploy/experimental-python/databricks.yml
+++ b/acceptance/bundle/deploy/experimental-python/databricks.yml
@@ -1,4 +1,4 @@
-sync: { paths: [] } # dont need to copy files
+sync: {paths: []} # dont need to copy files
 
 experimental:
   python:

--- a/acceptance/bundle/deploy/fail-on-active-runs/databricks.yml
+++ b/acceptance/bundle/deploy/fail-on-active-runs/databricks.yml
@@ -3,6 +3,6 @@ resources:
     my_job:
       name: My Job
       tasks:
-      - task_key: my_notebook
-        notebook_task:
-          notebook_path: my_notebook.py
+        - task_key: my_notebook
+          notebook_task:
+            notebook_path: my_notebook.py

--- a/acceptance/bundle/deploy/python-notebook/databricks.yml
+++ b/acceptance/bundle/deploy/python-notebook/databricks.yml
@@ -1,10 +1,10 @@
-sync: { paths: [] } # dont need to copy files
+sync: {paths: []} # dont need to copy files
 
 resources:
   jobs:
     my_job:
       name: My Job
       tasks:
-      - task_key: my_notebook
-        notebook_task:
-          notebook_path: my_notebook.py
+        - task_key: my_notebook
+          notebook_task:
+            notebook_path: my_notebook.py

--- a/acceptance/bundle/includes/include_outside_root/databricks.yml
+++ b/acceptance/bundle/includes/include_outside_root/databricks.yml
@@ -2,4 +2,4 @@ bundle:
   name: include_outside_root
 
 include:
- - a.yml
+  - a.yml

--- a/acceptance/bundle/includes/non_yaml_in_include/databricks.yml
+++ b/acceptance/bundle/includes/non_yaml_in_include/databricks.yml
@@ -2,5 +2,5 @@ bundle:
   name: non_yaml_in_includes
 
 include:
- - test.py
- - resources/*.yml
+  - test.py
+  - resources/*.yml

--- a/acceptance/bundle/includes/non_yaml_in_include/output.txt
+++ b/acceptance/bundle/includes/non_yaml_in_include/output.txt
@@ -1,5 +1,5 @@
 Error: Files in the 'include' configuration section must be YAML or JSON files.
-  in databricks.yml:5:4
+  in databricks.yml:5:5
 
 The file test.py in the 'include' configuration section is not a YAML or JSON file, and only such files are supported. To include files to sync, specify them in the 'sync.include' configuration section instead.
 

--- a/acceptance/bundle/libraries/maven/databricks.yml
+++ b/acceptance/bundle/libraries/maven/databricks.yml
@@ -1,7 +1,6 @@
 bundle:
   name: maven
 
-
 resources:
   jobs:
     testjob:
@@ -12,8 +11,8 @@ resources:
             main_class_name: com.databricks.example.Main
 
           libraries:
-          - maven:
-              coordinates: org.jsoup:jsoup:1.7.2
+            - maven:
+                coordinates: org.jsoup:jsoup:1.7.2
 
           new_cluster:
             spark_version: 15.4.x-scala2.12
@@ -21,7 +20,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/libraries/pypi/databricks.yml
+++ b/acceptance/bundle/libraries/pypi/databricks.yml
@@ -1,7 +1,6 @@
 bundle:
   name: pypi
 
-
 resources:
   jobs:
     testjob:
@@ -12,13 +11,13 @@ resources:
             project_directory: ./
             profiles_directory: dbt_profiles/
             commands:
-            - 'dbt deps --target=${bundle.target}'
-            - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
-            - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              - 'dbt deps --target=${bundle.target}'
+              - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
 
           libraries:
-          - pypi:
-              package: dbt-databricks>=1.8.0,<2.0.0
+            - pypi:
+                package: dbt-databricks>=1.8.0,<2.0.0
 
           new_cluster:
             spark_version: 15.4.x-scala2.12
@@ -26,7 +25,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/paths/fallback_metric/resources/job.yml
+++ b/acceptance/bundle/paths/fallback_metric/resources/job.yml
@@ -10,8 +10,8 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode
           notebook_task:

--- a/acceptance/bundle/paths/invalid_pipeline_globs/databricks.yml
+++ b/acceptance/bundle/paths/invalid_pipeline_globs/databricks.yml
@@ -5,7 +5,7 @@ resources:
   pipelines:
     nyc_taxi_pipeline:
       libraries:
-        - notebook: { path: "${var.notebook_dir}/*.ipynb" }
+        - notebook: {path: "${var.notebook_dir}/*.ipynb"}
 
 variables:
   notebook_dir:

--- a/acceptance/bundle/paths/pipeline_expected_file_got_notebook/resources/pipeline.yml
+++ b/acceptance/bundle/paths/pipeline_expected_file_got_notebook/resources/pipeline.yml
@@ -3,4 +3,4 @@ resources:
     nyc_taxi_pipeline:
       libraries:
         # path points to a notebook, not a file, it should error out
-        - file: { path: "../${var.notebook_dir}/*.py" }
+        - file: {path: "../${var.notebook_dir}/*.py"}

--- a/acceptance/bundle/paths/pipeline_globs/root/resources/pipeline.yml
+++ b/acceptance/bundle/paths/pipeline_globs/root/resources/pipeline.yml
@@ -3,16 +3,16 @@ resources:
     nyc_taxi_pipeline:
       libraries:
         # globs for notebooks and files are expanded
-        - notebook: { path: "../${var.notebook_dir}/*" }
-        - file: { path: "../${var.file_dir}/*" }
+        - notebook: {path: "../${var.notebook_dir}/*"}
+        - file: {path: "../${var.file_dir}/*"}
         # globs can include file extensions
-        - notebook: { path: "../${var.notebook_dir}/*.py" }
-        - file: { path: "../${var.file_dir}/*.py" }
+        - notebook: {path: "../${var.notebook_dir}/*.py"}
+        - file: {path: "../${var.file_dir}/*.py"}
         # non-glob files work
-        - notebook: { path: "../${var.notebook_dir}/nyc_taxi_loader.py" }
+        - notebook: {path: "../${var.notebook_dir}/nyc_taxi_loader.py"}
         # maven libraries and jars remain as-is
-        - maven: { coordinates: "org.jsoup:jsoup:1.7.2" }
+        - maven: {coordinates: "org.jsoup:jsoup:1.7.2"}
         - jar: "*/*.jar"
         # absolute paths and paths using URLs remain as-is
-        - notebook: { path: "/Workspace/Users/me@company.com/*.ipynb" }
-        - notebook: { path: "s3://notebooks/*.ipynb" }
+        - notebook: {path: "/Workspace/Users/me@company.com/*.ipynb"}
+        - notebook: {path: "s3://notebooks/*.ipynb"}

--- a/acceptance/bundle/python/mutator-ordering/databricks.yml
+++ b/acceptance/bundle/python/mutator-ordering/databricks.yml
@@ -1,13 +1,13 @@
 bundle:
   name: my_project
 
-sync: { paths: [] } # don't need to copy files
+sync: {paths: []} # don't need to copy files
 
 experimental:
   python:
     mutators:
-    - "mutators:add_task_1"
-    - "mutators:add_task_2"
+      - "mutators:add_task_1"
+      - "mutators:add_task_2"
 
 resources:
   jobs:

--- a/acceptance/bundle/python/pipelines-support/databricks.yml
+++ b/acceptance/bundle/python/pipelines-support/databricks.yml
@@ -1,7 +1,7 @@
 bundle:
   name: my_project
 
-sync: { paths: [ ] } # don't need to copy files
+sync: {paths: []} # don't need to copy files
 
 experimental:
   python:

--- a/acceptance/bundle/python/resolve-variable/databricks.yml
+++ b/acceptance/bundle/python/resolve-variable/databricks.yml
@@ -1,7 +1,7 @@
 bundle:
   name: my_project
 
-sync: { paths: [] } # don't need to copy files
+sync: {paths: []} # don't need to copy files
 
 experimental:
   python:
@@ -20,9 +20,9 @@ variables:
   bool_variable_false:
     default: false
   list_variable:
-    default: [ 1, 2, 3 ]
+    default: [1, 2, 3]
   dict_variable:
-    default: { "a": 1, "b": 2 }
+    default: {"a": 1, "b": 2}
   complex_variable:
     default:
       task_key: "abc"

--- a/acceptance/bundle/python/resource-loading/databricks.yml
+++ b/acceptance/bundle/python/resource-loading/databricks.yml
@@ -1,13 +1,13 @@
 bundle:
   name: my_project
 
-sync: { paths: [] } # don't need to copy files
+sync: {paths: []} # don't need to copy files
 
 experimental:
   python:
     resources:
-    - "resources:load_resources_1"
-    - "resources:load_resources_2"
+      - "resources:load_resources_1"
+      - "resources:load_resources_2"
 
 resources:
   jobs:

--- a/acceptance/bundle/python/restricted-execution/databricks.yml
+++ b/acceptance/bundle/python/restricted-execution/databricks.yml
@@ -1,13 +1,12 @@
 bundle:
   name: my_project
 
-sync: { paths: [] } # don't need to copy files
+sync: {paths: []} # don't need to copy files
 
 experimental:
   python:
     mutators:
-    - "mutators:read_envs"
-
+      - "mutators:read_envs"
 
 resources:
   jobs:

--- a/acceptance/bundle/python/unicode-support/databricks.yml
+++ b/acceptance/bundle/python/unicode-support/databricks.yml
@@ -1,7 +1,7 @@
 bundle:
   name: my_project
 
-sync: { paths: [] } # don't need to copy files
+sync: {paths: []} # don't need to copy files
 
 experimental:
   python:

--- a/acceptance/bundle/quality_monitor/databricks.yml
+++ b/acceptance/bundle/quality_monitor/databricks.yml
@@ -9,9 +9,9 @@ resources:
       output_schema_name: "main.dev"
       inference_log:
         granularities: ["1 day"]
-        timestamp_col:  "timestamp"
+        timestamp_col: "timestamp"
         prediction_col: "prediction"
-        model_id_col:  "model_id"
+        model_id_col: "model_id"
         problem_type: "PROBLEM_TYPE_REGRESSION"
       schedule:
         quartz_cron_expression: "0 0 12 * * ?" # every day at noon
@@ -41,7 +41,7 @@ targets:
           output_schema_name: "main.prod"
           inference_log:
             granularities: ["1 hour"]
-            timestamp_col:  "timestamp_prod"
+            timestamp_col: "timestamp_prod"
             prediction_col: "prediction_prod"
-            model_id_col:  "model_id_prod"
+            model_id_col: "model_id_prod"
             problem_type: "PROBLEM_TYPE_REGRESSION"

--- a/acceptance/bundle/run/basic/databricks.yml
+++ b/acceptance/bundle/run/basic/databricks.yml
@@ -1,7 +1,6 @@
 bundle:
   name: caterpillar
 
-
 resources:
   jobs:
     foo:

--- a/acceptance/bundle/state/databricks.yml
+++ b/acceptance/bundle/state/databricks.yml
@@ -15,7 +15,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/databricks.yml
@@ -5,11 +5,11 @@ resources:
   jobs:
     my_job:
       environments:
-      - environment_key: "env"
-        spec:
-          client: "1"
-          dependencies:
-            - "test_package"
+        - environment_key: "env"
+          spec:
+            client: "1"
+            dependencies:
+              - "test_package"
 
 targets:
   one:
@@ -31,15 +31,15 @@ targets:
                 data_security_mode: SINGLE_USER
                 num_workers: 0
                 spark_conf:
-                    spark.master: "local[*, 4]"
-                    spark.databricks.cluster.profile: singleNode
+                  spark.master: "local[*, 4]"
+                  spark.databricks.cluster.profile: singleNode
                 custom_tags:
                   ResourceClass: SingleNode
               spark_python_task:
                 python_file: ./test.py
 
   two:
-   resources:
+    resources:
       jobs:
         my_job:
           tasks:

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
@@ -1,38 +1,38 @@
 
 # This file defines dbt profiles for deployed dbt jobs.
 my_dbt_sql:
-    target: dev # default target
-    outputs:
+  target: dev # default target
+  outputs:
 
-    # Doing local development with the dbt CLI?
-    # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
-    # (See README.md)
+  # Doing local development with the dbt CLI?
+  # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
+  # (See README.md)
 
-    # The default target when deployed with the Databricks CLI
-    # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
-    dev:
-      type: databricks
-      method: http
-      catalog: main
-      schema: "{{ var('dev_schema') }}"
+  # The default target when deployed with the Databricks CLI
+  # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
+  dev:
+    type: databricks
+    method: http
+    catalog: main
+    schema: "{{ var('dev_schema') }}"
 
-      http_path: /sql/2.0/warehouses/f00dcafe
+    http_path: /sql/2.0/warehouses/f00dcafe
 
-      # The workspace host / token are provided by Databricks
-      # see databricks.yml for the workspace host used for 'dev'
-      host: "{{ env_var('DBT_HOST') }}"
-      token: "{{ env_var('DBT_ACCESS_TOKEN') }}"
+    # The workspace host / token are provided by Databricks
+    # see databricks.yml for the workspace host used for 'dev'
+    host: "{{ env_var('DBT_HOST') }}"
+    token: "{{ env_var('DBT_ACCESS_TOKEN') }}"
 
-    # The production target when deployed with the Databricks CLI
-    prod:
-      type: databricks
-      method: http
-      catalog: main
-      schema: default
+  # The production target when deployed with the Databricks CLI
+  prod:
+    type: databricks
+    method: http
+    catalog: main
+    schema: default
 
-      http_path: /sql/2.0/warehouses/f00dcafe
+    http_path: /sql/2.0/warehouses/f00dcafe
 
-      # The workspace host / token are provided by Databricks
-      # see databricks.yml for the workspace host used for 'prod'
-      host: "{{ env_var('DBT_HOST') }}"
-      token: "{{ env_var('DBT_ACCESS_TOKEN') }}"
+    # The workspace host / token are provided by Databricks
+    # see databricks.yml for the workspace host used for 'prod'
+    host: "{{ env_var('DBT_HOST') }}"
+    token: "{{ env_var('DBT_ACCESS_TOKEN') }}"

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
@@ -1,8 +1,8 @@
 
 # This file defines dbt profiles for deployed dbt jobs.
 my_dbt_sql:
-   target: dev # default target
-   outputs:
+  target: dev # default target
+  outputs:
 
     # Doing local development with the dbt CLI?
     # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
@@ -1,8 +1,8 @@
 
 # This file defines dbt profiles for deployed dbt jobs.
 my_dbt_sql:
-  target: dev # default target
-  outputs:
+    target: dev # default target
+    outputs:
 
     # Doing local development with the dbt CLI?
     # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_project.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_project.yml
@@ -15,7 +15,7 @@ seed-paths: ["src/seeds"]
 macro-paths: ["src/macros"]
 snapshot-paths: ["src/snapshots"]
 
-clean-targets:         # directories to be removed by `dbt clean`
+clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
@@ -15,16 +15,15 @@ resources:
 
       tasks:
         - task_key: dbt
-
           dbt_task:
             project_directory: ../
             # The default schema, catalog, etc. are defined in ../dbt_profiles/profiles.yml
             profiles_directory: dbt_profiles/
             commands:
-              # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
-              - 'dbt deps --target=${bundle.target}'
-              - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
-              - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+            # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
+            - 'dbt deps --target=${bundle.target}'
+            - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+            - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
 
           libraries:
             - pypi:
@@ -36,7 +35,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-              spark.master: "local[*, 4]"
-              spark.databricks.cluster.profile: singleNode
+                spark.master: "local[*, 4]"
+                spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
@@ -20,10 +20,10 @@ resources:
             # The default schema, catalog, etc. are defined in ../dbt_profiles/profiles.yml
             profiles_directory: dbt_profiles/
             commands:
-            # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
-            - 'dbt deps --target=${bundle.target}'
-            - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
-            - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
+              - 'dbt deps --target=${bundle.target}'
+              - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
 
           libraries:
             - pypi:
@@ -35,7 +35,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
@@ -21,14 +21,14 @@ resources:
             # The default schema, catalog, etc. are defined in ../dbt_profiles/profiles.yml
             profiles_directory: dbt_profiles/
             commands:
-            # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
-            - 'dbt deps --target=${bundle.target}'
-            - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
-            - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
+              - 'dbt deps --target=${bundle.target}'
+              - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
 
           libraries:
-          - pypi:
-              package: dbt-databricks>=1.8.0,<2.0.0
+            - pypi:
+                package: dbt-databricks>=1.8.0,<2.0.0
 
           new_cluster:
             spark_version: 15.4.x-scala2.12
@@ -36,7 +36,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
@@ -35,7 +35,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-              spark.master: "local[*, 4]"
-              spark.databricks.cluster.profile: singleNode
+                spark.master: "local[*, 4]"
+                spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
@@ -35,7 +35,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
+++ b/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
@@ -37,8 +37,8 @@
 +            node_type_id: [NODE_TYPE_ID]
 +            data_security_mode: SINGLE_USER
 +            autoscale:
-+                min_workers: 1
-+                max_workers: 4
++              min_workers: 1
++              max_workers: 4
 --- [TESTROOT]/bundle/templates/default-python/classic/../serverless/output/my_default_python/resources/my_default_python.pipeline.yml
 +++ output/my_default_python/resources/my_default_python.pipeline.yml
 @@ -4,8 +4,7 @@

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/resources/my_default_python.job.yml
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/resources/my_default_python.job.yml
@@ -46,5 +46,5 @@ resources:
             node_type_id: [NODE_TYPE_ID]
             data_security_mode: SINGLE_USER
             autoscale:
-                min_workers: 1
-                max_workers: 4
+              min_workers: 1
+              max_workers: 4

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/resources/my_default_python.job.yml
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/resources/my_default_python.job.yml
@@ -46,5 +46,5 @@ resources:
             node_type_id: [NODE_TYPE_ID]
             data_security_mode: SINGLE_USER
             autoscale:
-              min_workers: 1
-              max_workers: 4
+                min_workers: 1
+                max_workers: 4

--- a/acceptance/bundle/trampoline/warning_message/databricks.yml
+++ b/acceptance/bundle/trampoline/warning_message/databricks.yml
@@ -12,7 +12,6 @@ targets:
         interactive_cluster:
           spark_version: 14.2.x-cpu-ml-scala2.12
 
-
 resources:
   clusters:
     interactive_cluster:

--- a/acceptance/bundle/variables/complex/databricks.yml
+++ b/acceptance/bundle/variables/complex/databricks.yml
@@ -8,11 +8,11 @@ resources:
         - job_cluster_key: key
           new_cluster: ${var.cluster}
       tasks:
-      - task_key: test
-        job_cluster_key: key
-        libraries: ${variables.libraries.value}
-        # specific fields of complex variable are referenced:
-        task_key: "task with spark version ${var.cluster.spark_version} and jar ${var.libraries[0].jar}"
+        - task_key: test
+          job_cluster_key: key
+          libraries: ${variables.libraries.value}
+          # specific fields of complex variable are referenced:
+          task_key: "task with spark version ${var.cluster.spark_version} and jar ${var.libraries[0].jar}"
 
 variables:
   node_type:

--- a/acceptance/bundle/variables/complex_multiple_files/databricks.yml
+++ b/acceptance/bundle/variables/complex_multiple_files/databricks.yml
@@ -37,7 +37,6 @@ variables:
 include:
   - ./variables/*.yml
 
-
 targets:
   default:
   dev:

--- a/acceptance/bundle/variables/issue_2436/databricks.yml
+++ b/acceptance/bundle/variables/issue_2436/databricks.yml
@@ -26,7 +26,6 @@ resources:
     job_two:
       tasks: ${var.job_tasks}
 
-
 targets:
   dev:
     mode: development

--- a/acceptance/bundle/variables/variable_overrides_in_target/databricks.yml
+++ b/acceptance/bundle/variables/variable_overrides_in_target/databricks.yml
@@ -9,8 +9,6 @@ resources:
       clusters:
         - num_workers: ${var.bar}
 
-
-
 variables:
   foo:
     default: "a_string"

--- a/acceptance/cmd/workspace/apps/run-local/app/test.yml
+++ b/acceptance/cmd/workspace/apps/run-local/app/test.yml
@@ -1,4 +1,4 @@
 command:
-- python
-- -c
-- "print('Hello, world')"
+  - python
+  - -c
+  - "print('Hello, world')"

--- a/acceptance/cmd/workspace/apps/run-local/app/value-from.yml
+++ b/acceptance/cmd/workspace/apps/run-local/app/value-from.yml
@@ -1,7 +1,7 @@
 command:
-- python
-- -c
-- "print('Hello, world')"
+  - python
+  - -c
+  - "print('Hello, world')"
 
 env:
   - name: VALUE_FROM

--- a/bundle/internal/schema/testdata/pass/run_job_task.yml
+++ b/bundle/internal/schema/testdata/pass/run_job_task.yml
@@ -3,7 +3,6 @@ bundle:
   databricks_cli_version: 0.200.0
   compute_id: "mycompute"
 
-
 variables:
   simplevar:
     default: 5678

--- a/bundle/tests/environment_key_only/databricks.yml
+++ b/bundle/tests/environment_key_only/databricks.yml
@@ -11,6 +11,6 @@ resources:
           python_wheel_task:
             package_name: "my_test_code"
             entry_point: "run"
-          environment_key:  "test_env"
+          environment_key: "test_env"
       environments:
-        - environment_key:  "test_env"
+        - environment_key: "test_env"

--- a/bundle/tests/job_cluster_key/databricks.yml
+++ b/bundle/tests/job_cluster_key/databricks.yml
@@ -11,8 +11,8 @@ targets:
         foo:
           name: job
           tasks:
-          - task_key: test
-            job_cluster_key: key
+            - task_key: test
+              job_cluster_key: key
   development:
     resources:
       jobs:
@@ -23,5 +23,5 @@ targets:
                 node_type_id: i3.xlarge
                 num_workers: 1
           tasks:
-          - task_key: test
-            job_cluster_key: key
+            - task_key: test
+              job_cluster_key: key

--- a/bundle/tests/relative_path_with_includes/subfolder/include.yml
+++ b/bundle/tests/relative_path_with_includes/subfolder/include.yml
@@ -9,7 +9,6 @@ artifacts:
     type: whl
     path: ./artifact_b
 
-
 resources:
   jobs:
     job_b:

--- a/bundle/tests/run_as/legacy/databricks.yml
+++ b/bundle/tests/run_as/legacy/databricks.yml
@@ -50,7 +50,6 @@ resources:
         - notebook:
             path: ./dlt/nyc_taxi_loader
 
-
   models:
     model_one:
       name: "skynet"

--- a/bundle/tests/yaml_anchors_separate_block/databricks.yml
+++ b/bundle/tests/yaml_anchors_separate_block/databricks.yml
@@ -10,6 +10,6 @@ resources:
   jobs:
     my_job:
       tasks:
-      - task_key: yaml_anchors_separate_block
+        - task_key: yaml_anchors_separate_block
       tags:
         <<: *custom_tags

--- a/cmd/labs/project/testdata/installed-in-home/.databricks/labs/blueprint/lib/labs.yml
+++ b/cmd/labs/project/testdata/installed-in-home/.databricks/labs/blueprint/lib/labs.yml
@@ -1,4 +1,3 @@
----
 version: 1
 name: blueprint
 description: Blueprint Project
@@ -28,7 +27,7 @@ commands:
         description: second flag description
   - name: table
     description: something that renders a table
-    table_template: |
+    table_template: |-
       Key	Value
       {{range .records}}{{.key}}	{{.value}}
       {{end}}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -56,15 +57,18 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/yamlfmt v0.17.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/zclconf/go-cty v1.16.2 // indirect
@@ -85,4 +89,7 @@ require (
 	gotest.tools/gotestsum v1.12.1 // indirect
 )
 
-tool gotest.tools/gotestsum
+tool (
+	github.com/google/yamlfmt/cmd/yamlfmt
+	gotest.tools/gotestsum
+)

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/bitfield/gotestdox v0.2.2 h1:x6RcPAbBbErKLnapz1QeAlf3ospg8efBsedU93CDsnE=
 github.com/bitfield/gotestdox v0.2.2/go.mod h1:D+gwtS0urjBrzguAkTM2wodsTQYFHdpx8eqRJ3N+9pY=
+github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
+github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/briandowns/spinner v1.23.1 h1:t5fDPmScwUjozhDj4FA46p5acZWIPXYE30qW2Ptu650=
 github.com/briandowns/spinner v1.23.1/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -101,6 +103,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/yamlfmt v0.17.0 h1:/tdp01rIlvLz3LgJ2NtMLnqgAadZm33P7GcPU680b+w=
+github.com/google/yamlfmt v0.17.0/go.mod h1:gs0UEklJOYkUJ+OOCG0hg9n+DzucKDPlJElTUasVNK8=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.4 h1:9gWcmF85Wvq4ryPFvGFaOgPIs1AQX0d0bcbGw4Z96qg=
@@ -146,6 +150,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nwidger/jsoncolor v0.3.2 h1:rVJJlwAWDJShnbTYOQ5RM7yTA20INyKXlJ/fg4JMhHQ=
 github.com/nwidger/jsoncolor v0.3.2/go.mod h1:Cs34umxLbJvgBMnVNVqhji9BhoT/N/KinHqZptQ7cf4=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_profiles/profiles.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_profiles/profiles.yml.tmpl
@@ -4,8 +4,8 @@
 {{- end}}
 # This file defines dbt profiles for deployed dbt jobs.
 {{.project_name}}:
-   target: dev # default target
-   outputs:
+    target: dev # default target
+    outputs:
 
     # Doing local development with the dbt CLI?
     # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_profiles/profiles.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_profiles/profiles.yml.tmpl
@@ -4,42 +4,42 @@
 {{- end}}
 # This file defines dbt profiles for deployed dbt jobs.
 {{.project_name}}:
-    target: dev # default target
-    outputs:
+  target: dev # default target
+  outputs:
 
-    # Doing local development with the dbt CLI?
-    # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
-    # (See README.md)
+  # Doing local development with the dbt CLI?
+  # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
+  # (See README.md)
 
-    # The default target when deployed with the Databricks CLI
-    # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
-    dev:
-      type: databricks
-      method: http
-      catalog: {{$catalog}}
+  # The default target when deployed with the Databricks CLI
+  # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
+  dev:
+    type: databricks
+    method: http
+    catalog: {{$catalog}}
 {{- if (regexp "^yes").MatchString .personal_schemas}}
-      schema: "{{"{{"}} var('dev_schema') {{"}}"}}"
+    schema: "{{"{{"}} var('dev_schema') {{"}}"}}"
 {{- else}}
-      schema: "{{.shared_schema}}"
+    schema: "{{.shared_schema}}"
 {{- end}}
 
-      http_path: {{.http_path}}
+    http_path: {{.http_path}}
 
-      # The workspace host / token are provided by Databricks
-      # see databricks.yml for the workspace host used for 'dev'
-      host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
-      token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"
+    # The workspace host / token are provided by Databricks
+    # see databricks.yml for the workspace host used for 'dev'
+    host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
+    token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"
 
-    # The production target when deployed with the Databricks CLI
-    prod:
-      type: databricks
-      method: http
-      catalog: {{$catalog}}
-      schema: {{.shared_schema}}
+  # The production target when deployed with the Databricks CLI
+  prod:
+    type: databricks
+    method: http
+    catalog: {{$catalog}}
+    schema: {{.shared_schema}}
 
-      http_path: {{.http_path}}
+    http_path: {{.http_path}}
 
-      # The workspace host / token are provided by Databricks
-      # see databricks.yml for the workspace host used for 'prod'
-      host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
-      token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"
+    # The workspace host / token are provided by Databricks
+    # see databricks.yml for the workspace host used for 'prod'
+    host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
+    token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_project.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_project.yml.tmpl
@@ -15,7 +15,7 @@ seed-paths: ["src/seeds"]
 macro-paths: ["src/macros"]
 snapshot-paths: ["src/snapshots"]
 
-clean-targets:         # directories to be removed by `dbt clean`
+clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -15,7 +15,6 @@ resources:
 
       tasks:
         - task_key: dbt
-
           dbt_task:
             project_directory: ../
             # The default schema, catalog, etc. are defined in ../dbt_profiles/profiles.yml
@@ -34,8 +33,8 @@ resources:
 {{- end}}
 
           libraries:
-          - pypi:
-              package: dbt-databricks>=1.8.0,<2.0.0
+            - pypi:
+                package: dbt-databricks>=1.8.0,<2.0.0
 
           new_cluster:
             spark_version: {{template "latest_lts_dbr_version"}}

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -21,15 +21,15 @@ resources:
             profiles_directory: dbt_profiles/
             commands:
 {{- if (regexp "^yes").MatchString .personal_schemas}}
-            # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
-            - 'dbt deps --target=${bundle.target}'
-            - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
-            - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              # The dbt commands to run (see also dbt_profiles/profiles.yml; dev_schema is used in the dev profile)
+              - 'dbt deps --target=${bundle.target}'
+              - 'dbt seed --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
+              - 'dbt run --target=${bundle.target} --vars "{ dev_schema: ${workspace.current_user.short_name} }"'
 {{- else}}
-            # The dbt commands to run (see also the dev/prod profiles in dbt_profiles/profiles.yml)
-            - 'dbt deps --target=${bundle.target}'
-            - 'dbt seed --target=${bundle.target}'
-            - 'dbt run --target=${bundle.target}'
+              # The dbt commands to run (see also the dev/prod profiles in dbt_profiles/profiles.yml)
+              - 'dbt deps --target=${bundle.target}'
+              - 'dbt seed --target=${bundle.target}'
+              - 'dbt run --target=${bundle.target}'
 {{- end}}
 
           libraries:

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -42,7 +42,7 @@ resources:
             data_security_mode: SINGLE_USER
             num_workers: 0
             spark_conf:
-                spark.master: "local[*, 4]"
-                spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*, 4]"
+              spark.databricks.cluster.profile: singleNode
             custom_tags:
               ResourceClass: SingleNode

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -85,6 +85,6 @@ resources:
             node_type_id: {{smallest_node_type}}
             data_security_mode: SINGLE_USER
             autoscale:
-                min_workers: 1
-                max_workers: 4
+              min_workers: 1
+              max_workers: 4
 {{end -}}

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,0 +1,10 @@
+exclude:
+  - libs/dyn/yamlloader/testdata
+  - acceptance/selftest/bundleconfig
+formatter:
+  type: basic
+  retain_line_breaks_single: true
+  trim_trailing_whitespace: true
+  disable_alias_key_correction: true
+  scan_folded_as_literal: true
+  drop_merge_tag: true

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,6 +1,6 @@
 exclude:
   - libs/dyn/yamlloader/testdata
-  - acceptance/selftest/bundleconfig
+  - acceptance/selftest/bundleconfig # https://github.com/google/yamlfmt/issues/254
   - acceptance/bundle/artifacts/nil_artifacts/databricks.yml # https://github.com/google/yamlfmt/issues/253
 formatter:
   type: basic

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,6 +1,7 @@
 exclude:
   - libs/dyn/yamlloader/testdata
   - acceptance/selftest/bundleconfig
+  - acceptance/bundle/artifacts/nil_artifacts/databricks.yml # https://github.com/google/yamlfmt/issues/253
 formatter:
   type: basic
   retain_line_breaks_single: true


### PR DESCRIPTION
## Changes
- Update 'make fmt' to format yaml with https://github.com/google/yamlfmt/
- Templates dbt-sql and default-python updated to have consistent indentation according to formatter.

## Why
For templates with a lot of options (default-python) it's easy to introduce formatting issues - too many empty lines or not enough in the output. I'd like to use formatter also on non-materialized templates in default-python/combinations to ensure that resulting yamls are formatted well for any possible combination of options. Related: https://github.com/databricks/cli/pull/3004