### PR TITLE
acc: include tools in PATH

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -149,8 +149,16 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("CLI", execPath)
 	repls.SetPath(execPath, "[CLI]")
 
-	// Make helper scripts available
-	t.Setenv("PATH", fmt.Sprintf("%s%c%s", filepath.Join(cwd, "bin"), os.PathListSeparator, os.Getenv("PATH")))
+	paths := []string{
+		// Make helper scripts available
+		filepath.Join(cwd, "bin"),
+
+		// Make tools scripts available (e.g. yamlfmt)
+		filepath.Join(cwd, "..", "tools"),
+
+		os.Getenv("PATH"),
+	}
+	t.Setenv("PATH", strings.Join(paths, string(os.PathListSeparator)))
 
 	tempHomeDir := t.TempDir()
 	repls.SetPath(tempHomeDir, "[TMPHOME]")

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -153,7 +153,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 		// Make helper scripts available
 		filepath.Join(cwd, "bin"),
 
-		// Make tools scripts available (e.g. yamlfmt)
+		// Make ./tools/ available (e.g. yamlfmt)
 		filepath.Join(cwd, "..", "tools"),
 
 		os.Getenv("PATH"),

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -153,7 +153,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 		// Make helper scripts available
 		filepath.Join(cwd, "bin"),
 
-		// Make ./tools/ available (e.g. yamlfmt)
+		// Make <ROOT>/tools/ available (e.g. yamlfmt)
 		filepath.Join(cwd, "..", "tools"),
 
 		os.Getenv("PATH"),


### PR DESCRIPTION
## Changes
Made ./tools/ available for acceptance tests.

## Why
Some tools are useful both in project and in tests, for example yamlfmt (https://github.com/databricks/cli/pull/3026) is useful to check templates without materializing them (https://github.com/databricks/cli/pull/3032).