### PR TITLE
Refactor: extract translatePathsDashboards into a separate mutator

### DIFF
--- a/acceptance/bundle/debug/out.stderr.txt
+++ b/acceptance/bundle/debug/out.stderr.txt
@@ -44,7 +44,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=ResolveVariableReferences(resources)
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=NormalizePaths
-10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=TranslatePaths
+10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=TranslatePathsDashboards
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load)
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(init)
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load_resources)

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -47,9 +47,9 @@ func (err ErrIsNotNotebook) Error() string {
 	return fmt.Sprintf("file at %s is not a notebook", err.path)
 }
 
-type translatePaths struct {
-	dashboardsOnly bool
-}
+type translatePaths struct{}
+
+type translatePathsDashboards struct{}
 
 // TranslatePaths converts paths to local notebook files into paths in the workspace file system.
 func TranslatePaths() bundle.Mutator {
@@ -58,13 +58,15 @@ func TranslatePaths() bundle.Mutator {
 
 // TranslatePathsDashboards converts paths to local dashboard files into paths in the workspace file system.
 func TranslatePathsDashboards() bundle.Mutator {
-	return &translatePaths{
-		dashboardsOnly: true,
-	}
+	return &translatePathsDashboards{}
 }
 
 func (m *translatePaths) Name() string {
 	return "TranslatePaths"
+}
+
+func (m *translatePathsDashboards) Name() string {
+	return "TranslatePathsDashboards"
 }
 
 // translateContext is a context for rewriting paths in a config.
@@ -290,12 +292,7 @@ func (t *translateContext) rewriteValue(ctx context.Context, p dyn.Path, v dyn.V
 	return dyn.NewValue(out, v.Locations()), nil
 }
 
-func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	t := &translateContext{
-		b:    b,
-		seen: make(map[string]string),
-	}
-
+func applyTranslations(ctx context.Context, b *bundle.Bundle, t *translateContext, translations []func(context.Context, dyn.Value) (dyn.Value, error)) diag.Diagnostics {
 	// Set the remote root to the sync root if source-linked deployment is enabled.
 	// Otherwise, set it to the workspace file path.
 	if config.IsExplicitlyEnabled(t.b.Config.Presets.SourceLinkedDeployment) {
@@ -307,19 +304,6 @@ func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
 		var err error
 
-		translations := []func(context.Context, dyn.Value) (dyn.Value, error){
-			t.applyJobTranslations,
-			t.applyPipelineTranslations,
-			t.applyArtifactTranslations,
-			t.applyAppsTranslations,
-		}
-
-		if m.dashboardsOnly {
-			translations = []func(context.Context, dyn.Value) (dyn.Value, error){
-				t.applyDashboardTranslations,
-			}
-		}
-
 		for _, fn := range translations {
 			v, err = fn(ctx, v)
 			if err != nil {
@@ -330,6 +314,31 @@ func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	})
 
 	return diag.FromErr(err)
+}
+
+func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	t := &translateContext{
+		b:    b,
+		seen: make(map[string]string),
+	}
+
+	return applyTranslations(ctx, b, t, []func(context.Context, dyn.Value) (dyn.Value, error){
+		t.applyJobTranslations,
+		t.applyPipelineTranslations,
+		t.applyArtifactTranslations,
+		t.applyAppsTranslations,
+	})
+}
+
+func (m *translatePathsDashboards) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	t := &translateContext{
+		b:    b,
+		seen: make(map[string]string),
+	}
+
+	return applyTranslations(ctx, b, t, []func(context.Context, dyn.Value) (dyn.Value, error){
+		t.applyDashboardTranslations,
+	})
 }
 
 // gatherFallbackPaths collects the fallback paths for relative paths in the configuration.


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
This change was suggested in #3006 [comment](https://github.com/databricks/cli/pull/3006#discussion_r2139375127)

This simplifies the translatePaths mutator and adds explicit naming for the translatePathsDashboards, which is visible in debug logs.

## Tests
<!-- How have you tested the changes? -->
Existing acceptance tests for dashboards deployment

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
