### PR TITLE
Upgrade Terraform dependency to v1.12.2

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Notable Changes
 
 ### Dependency updates
+* Upgrade Terraform dependency to v1.12.2 ([#3040](https://github.com/databricks/cli/pull/3040))
 
 ### CLI
 

--- a/NOTICE
+++ b/NOTICE
@@ -38,7 +38,7 @@ License - https://github.com/hashicorp/terraform-json/blob/main/LICENSE
 
 hashicorp/terraform - https://github.com/hashicorp/terraform
 Copyright 2014 HashiCorp, Inc.
-License - https://github.com/hashicorp/terraform/blob/v1.5.5/LICENSE
+License - https://github.com/hashicorp/terraform/blob/v1.12.2/LICENSE
 
 ---
 

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -21,7 +21,7 @@ Response.Body = '{}'
 
 [[Repls]]
 # for some reason leading number is lost converting "%H%M%S" 061234 to 61234
-Old = '\d{5,}'
+Old = '\d{4,}'
 New = '[NUMBER]'
 
 [[Repls]]

--- a/acceptance/install_terraform.py
+++ b/acceptance/install_terraform.py
@@ -24,7 +24,7 @@ if os_name == "windows" and arch not in ("386", "amd64"):
     # terraform 1.5.5 only has builds for these two.
     arch = "amd64"
 
-terraform_version = "1.5.5"
+terraform_version = "1.12.2"
 terraform_file = f"terraform_{terraform_version}_{os_name}_{arch}.zip"
 terraform_url = f"https://releases.hashicorp.com/terraform/{terraform_version}/{terraform_file}"
 terraform_binary = "terraform.exe" if os_name == "windows" else "terraform"

--- a/acceptance/terraform/main.tf
+++ b/acceptance/terraform/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
   }
 
-  required_version = "= 1.5.5"
+  required_version = "= 1.12.2"
 }
 
 provider "databricks" {

--- a/acceptance/terraform/output.txt
+++ b/acceptance/terraform/output.txt
@@ -1,13 +1,10 @@
 
 >>> [TERRAFORM] init -no-color -get=false
-
 Initializing the backend...
-
 Initializing provider plugins...
 - Finding databricks/databricks versions matching "1.81.0"...
 - Installing databricks/databricks v1.81.0...
 - Installed databricks/databricks v1.81.0 (unauthenticated)
-
 Terraform has created a lock file .terraform.lock.hcl to record the provider
 selections it made above. Include this file in your version control repository
 so that Terraform can guarantee to make the same selections by default when
@@ -24,7 +21,6 @@ calculate lock file checksums locally for the following providers:
 To calculate additional checksums for another platform, run:
   terraform providers lock -platform=linux_amd64
 (where linux_amd64 is the platform to generate)
-
 Terraform has been successfully initialized!
 
 You may now begin working with Terraform. Try running "terraform plan" to see

--- a/bundle/deploy/terraform/check_dashboards_modified_remotely_test.go
+++ b/bundle/deploy/terraform/check_dashboards_modified_remotely_test.go
@@ -142,7 +142,7 @@ func writeFakeDashboardState(t *testing.T, ctx context.Context, b *bundle.Bundle
 	testutil.WriteFile(t, filepath.Join(tfDir, TerraformStateFileName), `
     {
       "version": 4,
-      "terraform_version": "1.5.5",
+      "terraform_version": "1.12.2",
       "resources": [
         {
           "mode": "managed",

--- a/bundle/deploy/terraform/pkg.go
+++ b/bundle/deploy/terraform/pkg.go
@@ -22,17 +22,17 @@ const (
 // Terraform CLI version to use and the corresponding checksums for it. The
 // checksums are used to verify the integrity of the downloaded binary. Please
 // update the checksums when the Terraform version is updated. The checksums
-// were obtained from https://releases.hashicorp.com/terraform/1.5.5.
+// were obtained from https://releases.hashicorp.com/terraform/1.12.2.
 //
 // These hashes are not used inside the CLI. They are only co-located here to be
 // output in the "databricks bundle debug terraform" output. Downstream applications
 // like the CLI docker image use these checksums to verify the integrity of the
 // downloaded Terraform archive.
-var TerraformVersion = version.Must(version.NewVersion("1.5.5"))
+var TerraformVersion = version.Must(version.NewVersion("1.12.2"))
 
 const (
-	checksumLinuxArm64 = "b055aefe343d0b710d8a7afd31aeb702b37bbf4493bb9385a709991e48dfbcd2"
-	checksumLinuxAmd64 = "ad0c696c870c8525357b5127680cd79c0bdf58179af9acd091d43b1d6482da4a"
+	checksumLinuxArm64 = "f8a0347dc5e68e6d60a9fa2db361762e7943ed084a773f28a981d988ceb6fdc9"
+	checksumLinuxAmd64 = "1eaed12ca41fcfe094da3d76a7e9aa0639ad3409c43be0103ee9f5a1ff4b7437"
 )
 
 type Checksum struct {

--- a/bundle/internal/tf/codegen/schema/generate.go
+++ b/bundle/internal/tf/codegen/schema/generate.go
@@ -43,7 +43,7 @@ func (s *Schema) installTerraform(ctx context.Context) (path string, err error) 
 
 	installer := &releases.ExactVersion{
 		Product:    product.Terraform,
-		Version:    version.Must(version.NewVersion("1.5.5")),
+		Version:    version.Must(version.NewVersion("1.12.2")),
 		InstallDir: installDir,
 	}
 


### PR DESCRIPTION
## Changes

This change updates the Terraform dependency to 1.12.2 (latest).