### PR TITLE
Use CliComment for summary + description

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -205,7 +205,7 @@ func new{{.PascalName}}() *cobra.Command {
 	cmd.Use = "{{.KebabName}}{{if $hasPosArgs}}{{range .RequiredPositionalArguments}} {{.ConstantName}}{{end}}{{end}}"
 	{{- if .Description }}
 	cmd.Short = `{{.Summary | without "`"}}`
-	cmd.Long = `{{.Comment  "  " 80 | without "`"}}
+	cmd.Long = `{{.CliComment  "  " 80 | without "`"}}
 	{{- if $atleastOneArgumentWithDescription }}
 
   Arguments:

--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -203,7 +203,7 @@ func new{{.PascalName}}() *cobra.Command {
 	{{- end -}}
 
 	cmd.Use = "{{.KebabName}}{{if $hasPosArgs}}{{range .RequiredPositionalArguments}} {{.ConstantName}}{{end}}{{end}}"
-	{{- if .Description }}
+	{{- if .CliComment  "  " 80 }}
 	cmd.Short = `{{.Summary | without "`"}}`
 	cmd.Long = `{{.CliComment  "  " 80 | without "`"}}
 	{{- if $atleastOneArgumentWithDescription }}


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
Change Comment to CliComment for Methods.

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
Currently, Comment returns the summary + description for a method. But for the SDKs, the summary does not make sense, as it is almost the same as the method name. So, we are removing the summary for the comment. But the CLI does not have a method name, so it makes sense to have a summary in the comment. This change will be a no-op for the CLI, as the CliComment outputs the same string as the Current Comment.

## Tests
<!-- How have you tested the changes? -->
Generated CLI no diff.

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
