### PR TITLE
Add tools/yamlfmt to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__
 
 # Test results from 'make test'
 test-output.json
+
+# Binary downloaded when acceptance tests are run.
+tools/yamlfmt


### PR DESCRIPTION
This binary is downloaded when acceptance tests are run to assert that YAML files like those generated by templates are properly formatted. 

Since we do not want to commit the binary, we should add it to .gitignore.