### PR TITLE
acc: Fix local inprocess tests when run from IDE

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -50,9 +50,6 @@ var (
 // the test name there, e.g. "bundle/variables/empty".
 // Then install your breakpoints and click "debug test" near TestInprocessMode in VSCODE.
 //
-// To debug integration tests you can run the "deco env flip workspace" command to configure a workspace
-// and then click on "debug test" near TestInprocessMode.
-
 // If enabled, instead of compiling and running CLI externally, we'll start in-process server that accepts and runs
 // CLI commands. The $CLI in test scripts is a helper that just forwards command-line arguments to this server (see bin/callserver.py).
 // Also disables parallelism in tests.
@@ -111,6 +108,7 @@ func TestInprocessMode(t *testing.T) {
 
 	// Uncomment to load  ~/.databricks/debug-env.json to debug integration tests
 	// testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
+	// Run the "deco env flip workspace" command to configure a workspace.
 
 	require.Equal(t, 1, testAccept(t, true, "selftest/basic"))
 	require.Equal(t, 1, testAccept(t, true, "selftest/server"))

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -105,6 +105,9 @@ func TestInprocessMode(t *testing.T) {
 	if InprocessMode && !Forcerun {
 		t.Skip("Already tested by TestAccept")
 	}
+	if os.Getenv("CLOUD_ENV") != "" {
+		t.Skip("No need to run this as integration test.")
+	}
 
 	// Uncomment to load  ~/.databricks/debug-env.json to debug integration tests
 	// testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -113,11 +113,6 @@ func TestInprocessMode(t *testing.T) {
 }
 
 func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
-	// Load debug environment when debugging a single test run from an IDE.
-	if singleTest != "" && inprocessMode {
-		testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
-	}
-
 	repls := testdiff.ReplacementsContext{}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -281,7 +276,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 
 	t.Logf("Summary (dirs): %d/%d/%d run/selected/total, %d skipped", selectedDirs-skippedDirs, selectedDirs, totalDirs, skippedDirs)
 
-	return len(testDirs)
+	return selectedDirs - skippedDirs
 }
 
 func getEnvFilters(t *testing.T) []string {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -108,6 +108,10 @@ func TestInprocessMode(t *testing.T) {
 	if InprocessMode && !Forcerun {
 		t.Skip("Already tested by TestAccept")
 	}
+
+	// Uncomment to load  ~/.databricks/debug-env.json to debug integration tests
+	// testutil.LoadDebugEnvIfRunFromIDE(t, "workspace")
+
 	require.Equal(t, 1, testAccept(t, true, "selftest/basic"))
 	require.Equal(t, 1, testAccept(t, true, "selftest/server"))
 }

--- a/acceptance/selftest/basic/test.toml
+++ b/acceptance/selftest/basic/test.toml
@@ -1,7 +1,7 @@
 # Badness = "Brief description of what's wrong with the test output, if anything"
 
+Cloud = false # do not run this test as integration test
 Ignore = ['ignore*']
-
 
 #[GOOS]
 # Disable on Windows

--- a/acceptance/selftest/basic/test.toml
+++ b/acceptance/selftest/basic/test.toml
@@ -1,7 +1,7 @@
 # Badness = "Brief description of what's wrong with the test output, if anything"
 
-Cloud = false # do not run this test as integration test
 Ignore = ['ignore*']
+
 
 #[GOOS]
 # Disable on Windows


### PR DESCRIPTION
## Changes
- Do not load env variables from ~/.databricks/debug-env.json, revert https://github.com/databricks/cli/pull/2765
- Better check in TestInprocess that test is actually run and not selected.

## Why
Loading those env vars sets CLOUD_ENV which makes test runner ignore local tests.

## Tests
Manually. Set selftest/basic Cloud=false and run it via IDE.