### PR TITLE
Add bundle/statemgmt from terraform/state_{pull,push}.go

### DIFF
--- a/bundle/phases/bind.go
+++ b/bundle/phases/bind.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/deploy/lock"
 	"github.com/databricks/cli/bundle/deploy/terraform"
+	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 )
@@ -23,11 +24,11 @@ func Bind(ctx context.Context, b *bundle.Bundle, opts *terraform.BindOptions) (d
 	}()
 
 	diags = diags.Extend(bundle.ApplySeq(ctx, b,
-		terraform.StatePull(),
+		statemgmt.StatePull(),
 		terraform.Interpolate(),
 		terraform.Write(),
 		terraform.Import(opts),
-		terraform.StatePush(),
+		statemgmt.StatePush(),
 	))
 
 	return diags
@@ -46,11 +47,11 @@ func Unbind(ctx context.Context, b *bundle.Bundle, resourceType, resourceKey str
 	}()
 
 	diags = diags.Extend(bundle.ApplySeq(ctx, b,
-		terraform.StatePull(),
+		statemgmt.StatePull(),
 		terraform.Interpolate(),
 		terraform.Write(),
 		terraform.Unbind(resourceType, resourceKey),
-		terraform.StatePush(),
+		statemgmt.StatePush(),
 	))
 
 	return diags

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/bundle/permissions"
 	"github.com/databricks/cli/bundle/scripts"
+	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/bundle/trampoline"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
@@ -148,7 +149,7 @@ func deployCore(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	// following original logic, continuing with sequence below even if terraform had errors
 
 	diags = diags.Extend(bundle.ApplySeq(ctx, b,
-		terraform.StatePush(),
+		statemgmt.StatePush(),
 		terraform.Load(),
 		apps.InterpolateVariables(),
 		apps.UploadConfig(),
@@ -185,7 +186,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 	}()
 
 	diags = bundle.ApplySeq(ctx, b,
-		terraform.StatePull(),
+		statemgmt.StatePull(),
 		terraform.CheckDashboardsModifiedRemotely(),
 		deploy.StatePull(),
 		mutator.ValidateGitDetails(),

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/files"
 	"github.com/databricks/cli/bundle/deploy/lock"
 	"github.com/databricks/cli/bundle/deploy/terraform"
+	"github.com/databricks/cli/bundle/statemgmt"
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
@@ -116,7 +117,7 @@ func Destroy(ctx context.Context, b *bundle.Bundle) (diags diag.Diagnostics) {
 	}()
 
 	diags = diags.Extend(bundle.ApplySeq(ctx, b,
-		terraform.StatePull(),
+		statemgmt.StatePull(),
 		terraform.Interpolate(),
 		terraform.Write(),
 		terraform.Plan(terraform.PlanGoal("destroy")),

--- a/bundle/statemgmt/state_pull.go
+++ b/bundle/statemgmt/state_pull.go
@@ -1,4 +1,4 @@
-package terraform
+package statemgmt
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/deploy"
+	tf "github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 )
@@ -34,7 +35,7 @@ func (l *statePull) remoteState(ctx context.Context, b *bundle.Bundle) (*tfState
 		return nil, nil, err
 	}
 
-	r, err := f.Read(ctx, TerraformStateFileName)
+	r, err := f.Read(ctx, tf.TerraformStateFileName)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,12 +56,12 @@ func (l *statePull) remoteState(ctx context.Context, b *bundle.Bundle) (*tfState
 }
 
 func (l *statePull) localState(ctx context.Context, b *bundle.Bundle) (*tfState, error) {
-	dir, err := Dir(ctx, b)
+	dir, err := tf.Dir(ctx, b)
 	if err != nil {
 		return nil, err
 	}
 
-	content, err := os.ReadFile(filepath.Join(dir, TerraformStateFileName))
+	content, err := os.ReadFile(filepath.Join(dir, tf.TerraformStateFileName))
 	if err != nil {
 		return nil, err
 	}
@@ -75,12 +76,12 @@ func (l *statePull) localState(ctx context.Context, b *bundle.Bundle) (*tfState,
 }
 
 func (l *statePull) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	dir, err := Dir(ctx, b)
+	dir, err := tf.Dir(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	localStatePath := filepath.Join(dir, TerraformStateFileName)
+	localStatePath := filepath.Join(dir, tf.TerraformStateFileName)
 
 	// Case: Remote state file does not exist. In this case we fallback to using the
 	// local Terraform state. This allows users to change the "root_path" their bundle is

--- a/bundle/statemgmt/state_pull_test.go
+++ b/bundle/statemgmt/state_pull_test.go
@@ -1,4 +1,4 @@
-package terraform
+package statemgmt
 
 import (
 	"bytes"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	tf "github.com/databricks/cli/bundle/deploy/terraform"
 	mockfiler "github.com/databricks/cli/internal/mocks/libs/filer"
 	"github.com/databricks/cli/libs/filer"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func mockStateFilerForPull(t *testing.T, contents map[string]any, merr error) fi
 	f := mockfiler.NewMockFiler(t)
 	f.
 		EXPECT().
-		Read(mock.Anything, TerraformStateFileName).
+		Read(mock.Anything, tf.TerraformStateFileName).
 		Return(io.NopCloser(bytes.NewReader(buf)), merr).
 		Times(1)
 	return f

--- a/bundle/statemgmt/state_push.go
+++ b/bundle/statemgmt/state_push.go
@@ -1,4 +1,4 @@
-package terraform
+package statemgmt
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/deploy"
+	tf "github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/filer"
@@ -29,13 +30,13 @@ func (l *statePush) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostic
 		return diag.FromErr(err)
 	}
 
-	dir, err := Dir(ctx, b)
+	dir, err := tf.Dir(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	// Expect the state file to live under dir.
-	local, err := os.Open(filepath.Join(dir, TerraformStateFileName))
+	local, err := os.Open(filepath.Join(dir, tf.TerraformStateFileName))
 	if errors.Is(err, fs.ErrNotExist) {
 		// The state file can be absent if terraform apply is skipped because
 		// there are no changes to apply in the plan.
@@ -50,7 +51,7 @@ func (l *statePush) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostic
 	// Upload state file from local cache directory to filer.
 	cmdio.LogString(ctx, "Updating deployment state...")
 	log.Infof(ctx, "Writing local state file to remote state directory")
-	err = f.Write(ctx, TerraformStateFileName, local, filer.CreateParentDirectories, filer.OverwriteIfExists)
+	err = f.Write(ctx, tf.TerraformStateFileName, local, filer.CreateParentDirectories, filer.OverwriteIfExists)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/statemgmt/state_push_test.go
+++ b/bundle/statemgmt/state_push_test.go
@@ -1,4 +1,4 @@
-package terraform
+package statemgmt
 
 import (
 	"context"

--- a/bundle/statemgmt/state_test.go
+++ b/bundle/statemgmt/state_test.go
@@ -1,4 +1,4 @@
-package terraform
+package statemgmt
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/deploy"
+	tf "github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/libs/filer"
 	"github.com/stretchr/testify/require"
 )
@@ -21,9 +22,9 @@ func identityFiler(f filer.Filer) deploy.FilerFactory {
 }
 
 func localStateFile(t *testing.T, ctx context.Context, b *bundle.Bundle) string {
-	dir, err := Dir(ctx, b)
+	dir, err := tf.Dir(ctx, b)
 	require.NoError(t, err)
-	return filepath.Join(dir, TerraformStateFileName)
+	return filepath.Join(dir, tf.TerraformStateFileName)
 }
 
 func readLocalState(t *testing.T, ctx context.Context, b *bundle.Bundle) map[string]any {

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -18,6 +18,7 @@ import (
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/bundle/render"
 	"github.com/databricks/cli/bundle/resources"
+	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
@@ -353,7 +354,7 @@ func (d *dashboard) runForResource(ctx context.Context, b *bundle.Bundle) diag.D
 	diags = diags.Extend(bundle.ApplySeq(ctx, b,
 		terraform.Interpolate(),
 		terraform.Write(),
-		terraform.StatePull(),
+		statemgmt.StatePull(),
 		terraform.Load(),
 	))
 	if diags.HasError() {

--- a/cmd/bundle/open.go
+++ b/cmd/bundle/open.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/bundle/resources"
+	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdio"
@@ -87,7 +88,7 @@ func newOpenCommand() *cobra.Command {
 
 		if forcePull || noCache {
 			diags = bundle.ApplySeq(ctx, b,
-				terraform.StatePull(),
+				statemgmt.StatePull(),
 				terraform.Interpolate(),
 				terraform.Write(),
 			)

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/databricks/cli/bundle/resources"
 	"github.com/databricks/cli/bundle/run"
 	"github.com/databricks/cli/bundle/run/output"
+	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/auth"
@@ -151,7 +152,7 @@ Example usage:
 		diags = diags.Extend(bundle.ApplySeq(ctx, b,
 			terraform.Interpolate(),
 			terraform.Write(),
-			terraform.StatePull(),
+			statemgmt.StatePull(),
 			terraform.Load(terraform.ErrorOnEmptyState),
 		))
 		if diags.HasError() {

--- a/cmd/bundle/summary.go
+++ b/cmd/bundle/summary.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/bundle/render"
+	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/flags"
@@ -53,7 +54,7 @@ func newSummaryCommand() *cobra.Command {
 
 		if forcePull || noCache {
 			diags = bundle.ApplySeq(ctx, b,
-				terraform.StatePull(),
+				statemgmt.StatePull(),
 				terraform.Interpolate(),
 				terraform.Write(),
 			)


### PR DESCRIPTION
## Changes
Extract state file management into its own package. No other changes, just pure move.

## Why
As part of adding "direct deployment" method (https://github.com/databricks/cli/pull/2926), this package will be extended to handle state both for terraform and direct. 

## Tests
Existing tests.
