### PR TITLE
acc: Support milliseconds and tz in default timestamp replacement

### DIFF
--- a/acceptance/bundle/resources/clusters/run/spark_python_task/test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/test.toml
@@ -9,10 +9,6 @@ Ignore = [
 ]
 
 [[Repls]]
-Old = '2\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d'
-New = "[TIMESTAMP]"
-
-[[Repls]]
 Old = '\d{5,}'
 New = "[NUMID]"
 

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -66,6 +66,6 @@ New = "[NUMID]"
 Order = 10
 
 [[Repls]]
-Old = '2\d\d\d-\d\d-\d\d(T| )\d\d:\d\d:\d\d'
+Old = '2\d\d\d-\d\d-\d\d(T| )\d\d:\d\d:\d\d(\.\d+(Z|\+\d\d:\d\d)?)?'
 New = "[TIMESTAMP]"
 Order = 10


### PR DESCRIPTION
## Why
Using it in https://github.com/databricks/cli/pull/3042
