### PR TITLE
Fix typo in error message for metastore lookup

### DIFF
--- a/bundle/config/variable/resolve_metastore.go
+++ b/bundle/config/variable/resolve_metastore.go
@@ -29,11 +29,11 @@ func (l resolveMetastore) Resolve(ctx context.Context, w *databricks.WorkspaceCl
 	// Return the ID of the first matching metastore.
 	switch len(entities) {
 	case 0:
-		return "", fmt.Errorf("metastoren named %q does not exist", l.name)
+		return "", fmt.Errorf("metastore named %q does not exist", l.name)
 	case 1:
 		return entities[0].MetastoreId, nil
 	default:
-		return "", fmt.Errorf("there are %d instances of clusters named %q", len(entities), l.name)
+		return "", fmt.Errorf("there are %d instances of metastores named %q", len(entities), l.name)
 	}
 }
 

--- a/bundle/config/variable/resolve_metastore_test.go
+++ b/bundle/config/variable/resolve_metastore_test.go
@@ -41,7 +41,25 @@ func TestResolveMetastore_ResolveNotFound(t *testing.T) {
 	ctx := context.Background()
 	l := resolveMetastore{name: "metastore"}
 	_, err := l.Resolve(ctx, m.WorkspaceClient)
-	require.ErrorContains(t, err, "metastoren named \"metastore\" does not exist")
+	require.ErrorContains(t, err, "metastore named \"metastore\" does not exist")
+}
+
+func TestResolveMetastore_ResolveMultiple(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+
+	api := m.GetMockMetastoresAPI()
+	api.EXPECT().
+		ListAll(mock.Anything, mock.Anything).
+		Return([]catalog.MetastoreInfo{
+			{MetastoreId: "abcd", Name: "metastore"},
+			{MetastoreId: "efgh", Name: "metastore"},
+		}, nil)
+
+	ctx := context.Background()
+	l := resolveMetastore{name: "metastore"}
+	_, err := l.Resolve(ctx, m.WorkspaceClient)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "there are 2 instances of metastores named \"metastore\"")
 }
 
 func TestResolveMetastore_String(t *testing.T) {


### PR DESCRIPTION
## Changes

Fix typo in error message for metastore lookup.

Spotted while reviewing #3013.

## Tests

Unit tests still pass.