### PR TITLE
Fix: Pass -e to sh and bash during command execution

### DIFF
--- a/.wsignore
+++ b/.wsignore
@@ -17,6 +17,10 @@ experimental/python/docs/images/databricks-logo.svg
 # In order to prevent that difference, hello.txt does not have a trailing newline.
 acceptance/selftest/record_cloud/volume-io/hello.txt
 
+# error output when artifact build fails contains trailing whitespace:
+acceptance/bundle/artifacts/shell/err-bash/output.txt
+acceptance/bundle/artifacts/shell/err-sh/output.txt
+
 # "bundle init" has trailing whitespace:
 acceptance/bundle/templates-machinery/helpers-error/output.txt
 

--- a/acceptance/bundle/artifacts/shell/err-bash/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/err-bash/databricks.yml
@@ -1,0 +1,8 @@
+artifacts:
+  my_artifact:
+    executable: bash
+    build: |-
+      echo "hello" > out.shell.txt
+      echo "world" >> out.shell.txt
+      false
+      echo "this should not be printed since bash is run with -e" >> out.shell.txt

--- a/acceptance/bundle/artifacts/shell/err-bash/out.shell.txt
+++ b/acceptance/bundle/artifacts/shell/err-bash/out.shell.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/acceptance/bundle/artifacts/shell/err-bash/output.txt
+++ b/acceptance/bundle/artifacts/shell/err-bash/output.txt
@@ -1,0 +1,7 @@
+
+>>> [CLI] bundle deploy
+Building my_artifact...
+Error: build failed my_artifact, error: exit status 1, output: 
+
+
+Exit code: 1

--- a/acceptance/bundle/artifacts/shell/err-bash/script
+++ b/acceptance/bundle/artifacts/shell/err-bash/script
@@ -1,0 +1,1 @@
+trace $CLI bundle deploy

--- a/acceptance/bundle/artifacts/shell/err-sh/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/err-sh/databricks.yml
@@ -1,0 +1,11 @@
+bundle:
+  name: shell-sh
+
+artifacts:
+  my_artifact:
+    executable: sh
+    build: |-
+      echo "hello" > out.shell.txt
+      echo "world" >> out.shell.txt
+      false
+      echo "this should not be printed since sh is run with -e" >> out.shell.txt

--- a/acceptance/bundle/artifacts/shell/err-sh/databricks.yml
+++ b/acceptance/bundle/artifacts/shell/err-sh/databricks.yml
@@ -1,6 +1,3 @@
-bundle:
-  name: shell-sh
-
 artifacts:
   my_artifact:
     executable: sh

--- a/acceptance/bundle/artifacts/shell/err-sh/out.shell.txt
+++ b/acceptance/bundle/artifacts/shell/err-sh/out.shell.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/acceptance/bundle/artifacts/shell/err-sh/output.txt
+++ b/acceptance/bundle/artifacts/shell/err-sh/output.txt
@@ -1,0 +1,7 @@
+
+>>> [CLI] bundle deploy
+Building my_artifact...
+Error: build failed my_artifact, error: exit status 1, output: 
+
+
+Exit code: 1

--- a/acceptance/bundle/artifacts/shell/err-sh/script
+++ b/acceptance/bundle/artifacts/shell/err-sh/script
@@ -1,0 +1,1 @@
+trace $CLI bundle deploy

--- a/libs/exec/shell_bash.go
+++ b/libs/exec/shell_bash.go
@@ -13,7 +13,7 @@ type bashShell struct {
 func (s bashShell) prepare(command string) (*execContext, error) {
 	return &execContext{
 		executable: s.executable,
-		args:       []string{"-c", command},
+		args:       []string{"-ec", command},
 	}, nil
 }
 

--- a/libs/exec/shell_execv_test.go
+++ b/libs/exec/shell_execv_test.go
@@ -18,6 +18,6 @@ func TestShellExecvOpts(t *testing.T) {
 	bashPath, err := exec.LookPath("bash")
 	require.NoError(t, err)
 	assert.Equal(t, bashPath, opts.Args[0])
-	assert.Equal(t, "-c", opts.Args[1])
+	assert.Equal(t, "-ec", opts.Args[1])
 	assert.Equal(t, "echo hello", opts.Args[2])
 }

--- a/libs/exec/shell_sh.go
+++ b/libs/exec/shell_sh.go
@@ -12,7 +12,7 @@ type shShell struct {
 func (s shShell) prepare(command string) (*execContext, error) {
 	return &execContext{
 		executable: s.executable,
-		args:       []string{"-c", command},
+		args:       []string{"-ec", command},
 	}, nil
 }
 


### PR DESCRIPTION
## Changes
This PR fixes a regression introduced in https://github.com/databricks/cli/pull/2896 where we stopped passing the `-e` flag to the shell, which makes both sh and bash bail out at the first command with a non-zero exit code.

## Why
Adding back `-e` keeps the behaviour consistent with the one before https://github.com/databricks/cli/pull/2896 was introduced.

## Tests
Newly added regression tests 
