### PR TITLE
Allow users to override the Terraform version to use

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -43,8 +43,11 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 		return tf.ExecPath, nil
 	}
 
+	// Resolve the version of the Terraform CLI to use.
+	tv := GetTerraformVersion(ctx)
+
 	// Load exec path from the environment if it matches the currently used version.
-	envExecPath, err := getEnvVarWithMatchingVersion(ctx, TerraformExecPathEnv, TerraformVersionEnv, TerraformVersion.String())
+	envExecPath, err := getEnvVarWithMatchingVersion(ctx, TerraformExecPathEnv, TerraformVersionEnv, tv.Version.String())
 	if err != nil {
 		return "", err
 	}
@@ -74,7 +77,7 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 	// Download Terraform to private bin directory.
 	installer := &releases.ExactVersion{
 		Product:    product.Terraform,
-		Version:    TerraformVersion,
+		Version:    tv.Version,
 		InstallDir: binDir,
 		Timeout:    1 * time.Minute,
 	}

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -389,7 +389,7 @@ func TestFindExecPathFromEnvironmentWithCorrectVersionAndNoBinary(t *testing.T) 
 	cacheDir, _ := b.CacheDir(ctx, "bin")
 	existingExecPath := createTempFile(t, cacheDir, product.Terraform.BinaryName(), true)
 
-	ctx = env.Set(ctx, "DATABRICKS_TF_VERSION", TerraformVersion.String())
+	ctx = env.Set(ctx, "DATABRICKS_TF_VERSION", GetTerraformVersion(ctx).Version.String())
 	ctx = env.Set(ctx, "DATABRICKS_TF_EXEC_PATH", "/tmp/terraform")
 	_, err := m.findExecPath(ctx, b, b.Config.Bundle.Terraform)
 	require.NoError(t, err)
@@ -413,7 +413,7 @@ func TestFindExecPathFromEnvironmentWithCorrectVersionAndBinary(t *testing.T) {
 	createTempFile(t, cacheDir, product.Terraform.BinaryName(), true)
 	// Create a new terraform binary and expose it through env vars
 	tmpBinPath := createTempFile(t, t.TempDir(), "terraform-bin", true)
-	ctx = env.Set(ctx, "DATABRICKS_TF_VERSION", TerraformVersion.String())
+	ctx = env.Set(ctx, "DATABRICKS_TF_VERSION", GetTerraformVersion(ctx).Version.String())
 	ctx = env.Set(ctx, "DATABRICKS_TF_EXEC_PATH", tmpBinPath)
 	_, err := m.findExecPath(ctx, b, b.Config.Bundle.Terraform)
 	require.NoError(t, err)

--- a/bundle/deploy/terraform/pkg.go
+++ b/bundle/deploy/terraform/pkg.go
@@ -1,7 +1,10 @@
 package terraform
 
 import (
+	"context"
+
 	"github.com/databricks/cli/bundle/internal/tf/schema"
+	"github.com/databricks/cli/libs/env"
 	"github.com/hashicorp/go-version"
 )
 
@@ -10,30 +13,56 @@ const (
 	TerraformConfigFileName = "bundle.tf.json"
 )
 
-// Users can provide their own terraform binary and databricks terraform provider by setting the following environment variables.
+// Users can provide their own Terraform binary and Databricks Terraform provider by setting the following environment variables.
 // This allows users to use the CLI in an air-gapped environments. See the `debug terraform` command.
 const (
 	TerraformExecPathEnv        = "DATABRICKS_TF_EXEC_PATH"
 	TerraformVersionEnv         = "DATABRICKS_TF_VERSION"
 	TerraformCliConfigPathEnv   = "DATABRICKS_TF_CLI_CONFIG_FILE"
 	TerraformProviderVersionEnv = "DATABRICKS_TF_PROVIDER_VERSION"
+
+	// TerraformVersionOverrideEnv is an environment variable that allows users to override the Terraform version to use.
+	// This is useful for testing and development purposes.
+	TerraformVersionOverrideEnv = "DATABRICKS_TF_VERSION_OVERRIDE"
 )
+
+// TerraformVersion represents the version of the Terraform CLI to use.
+// It allows for users overriding the default version.
+type TerraformVersion struct {
+	Version *version.Version
+
+	// These hashes are not used inside the CLI. They are only co-located here to be
+	// output in the "databricks bundle debug terraform" output. Downstream applications
+	// like the CLI docker image use these checksums to verify the integrity of the
+	// downloaded Terraform archive.
+	ChecksumLinuxArm64 string
+	ChecksumLinuxAmd64 string
+}
 
 // Terraform CLI version to use and the corresponding checksums for it. The
 // checksums are used to verify the integrity of the downloaded binary. Please
 // update the checksums when the Terraform version is updated. The checksums
 // were obtained from https://releases.hashicorp.com/terraform/1.5.5.
-//
-// These hashes are not used inside the CLI. They are only co-located here to be
-// output in the "databricks bundle debug terraform" output. Downstream applications
-// like the CLI docker image use these checksums to verify the integrity of the
-// downloaded Terraform archive.
-var TerraformVersion = version.Must(version.NewVersion("1.5.5"))
+var defaultTerraformVersion = TerraformVersion{
+	Version: version.Must(version.NewVersion("1.5.5")),
 
-const (
-	checksumLinuxArm64 = "b055aefe343d0b710d8a7afd31aeb702b37bbf4493bb9385a709991e48dfbcd2"
-	checksumLinuxAmd64 = "ad0c696c870c8525357b5127680cd79c0bdf58179af9acd091d43b1d6482da4a"
-)
+	ChecksumLinuxArm64: "b055aefe343d0b710d8a7afd31aeb702b37bbf4493bb9385a709991e48dfbcd2",
+	ChecksumLinuxAmd64: "ad0c696c870c8525357b5127680cd79c0bdf58179af9acd091d43b1d6482da4a",
+}
+
+// GetTerraformVersion returns the Terraform version to use.
+// The user can configure the Terraform version to use by setting the
+// DATABRICKS_TF_VERSION_OVERRIDE environment variable to the desired version.
+func GetTerraformVersion(ctx context.Context) TerraformVersion {
+	versionOverride, ok := env.Lookup(ctx, TerraformVersionOverrideEnv)
+	if !ok {
+		return defaultTerraformVersion
+	}
+
+	return TerraformVersion{
+		Version: version.Must(version.NewVersion(versionOverride)),
+	}
+}
 
 type Checksum struct {
 	LinuxArm64 string `json:"linux_arm64"`
@@ -48,12 +77,13 @@ type TerraformMetadata struct {
 	ProviderVersion string   `json:"providerVersion"`
 }
 
-func NewTerraformMetadata() *TerraformMetadata {
+func NewTerraformMetadata(ctx context.Context) *TerraformMetadata {
+	tv := GetTerraformVersion(ctx)
 	return &TerraformMetadata{
-		Version: TerraformVersion.String(),
+		Version: tv.Version.String(),
 		Checksum: Checksum{
-			LinuxArm64: checksumLinuxArm64,
-			LinuxAmd64: checksumLinuxAmd64,
+			LinuxArm64: tv.ChecksumLinuxArm64,
+			LinuxAmd64: tv.ChecksumLinuxAmd64,
 		},
 		ProviderHost:    schema.ProviderHost,
 		ProviderSource:  schema.ProviderSource,

--- a/cmd/bundle/debug/terraform.go
+++ b/cmd/bundle/debug/terraform.go
@@ -56,7 +56,7 @@ For more information about filesystem mirrors, see the Terraform documentation: 
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		dependencies := &Dependencies{
-			Terraform: terraform.NewTerraformMetadata(),
+			Terraform: terraform.NewTerraformMetadata(cmd.Context()),
 		}
 		switch root.OutputType(cmd) {
 		case flags.OutputText:


### PR DESCRIPTION
## Changes

Read the `DATABRICKS_TF_VERSION_OVERRIDE` environment variable and, if set, interpret its value as the Terraform version to use with bundles. The value must be a valid version string, e.g. `1.12.2`. The CLI will panic if this string is not a valid version.

## Why

To allow users to use newer version of the Terraform CLI.

## Tests

* Unit tests pass.
* Manual verification of integration tests with the latest Terraform version.