### PR TITLE
Rename libs/terraform to libs/deployplan

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -18,13 +18,13 @@ import (
 	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/bundle/metadata"
 	"github.com/databricks/cli/libs/auth"
+	"github.com/databricks/cli/libs/deployplan"
 	"github.com/databricks/cli/libs/fileset"
 	"github.com/databricks/cli/libs/locker"
 	"github.com/databricks/cli/libs/log"
 	libsync "github.com/databricks/cli/libs/sync"
 	"github.com/databricks/cli/libs/tags"
 	"github.com/databricks/cli/libs/telemetry/protos"
-	"github.com/databricks/cli/libs/terraform"
 	"github.com/databricks/cli/libs/vfs"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/google/uuid"
@@ -101,7 +101,7 @@ type Bundle struct {
 	// Stores the locker responsible for acquiring/releasing a deployment lock.
 	Locker *locker.Locker
 
-	Plan *terraform.Plan
+	Plan *deployplan.Plan
 
 	// if true, we skip approval checks for deploy, destroy resources and delete
 	// files

--- a/bundle/deploy/terraform/plan.go
+++ b/bundle/deploy/terraform/plan.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/deployplan"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
-	"github.com/databricks/cli/libs/terraform"
 	"github.com/hashicorp/terraform-exec/tfexec"
 )
 
@@ -51,7 +51,7 @@ func (p *plan) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	}
 
 	// Set plan in main bundle struct for downstream mutators
-	b.Plan = &terraform.Plan{
+	b.Plan = &deployplan.Plan{
 		Path:    planPath,
 		IsEmpty: !notEmpty,
 	}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -21,32 +21,32 @@ import (
 	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/bundle/trampoline"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/deployplan"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/sync"
-	terraformlib "github.com/databricks/cli/libs/terraform"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func filterDeleteOrRecreateActions(changes []*tfjson.ResourceChange, resourceType string) []terraformlib.Action {
-	var res []terraformlib.Action
+func filterDeleteOrRecreateActions(changes []*tfjson.ResourceChange, resourceType string) []deployplan.Action {
+	var res []deployplan.Action
 	for _, rc := range changes {
 		if rc.Type != resourceType {
 			continue
 		}
 
-		var actionType terraformlib.ActionType
+		var actionType deployplan.ActionType
 		switch {
 		case rc.Change.Actions.Delete():
-			actionType = terraformlib.ActionTypeDelete
+			actionType = deployplan.ActionTypeDelete
 		case rc.Change.Actions.Replace():
-			actionType = terraformlib.ActionTypeRecreate
+			actionType = deployplan.ActionTypeRecreate
 		default:
 			// Filter other action types..
 			continue
 		}
 
-		res = append(res, terraformlib.Action{
+		res = append(res, deployplan.Action{
 			Action:       actionType,
 			ResourceType: rc.Type,
 			ResourceName: rc.Name,

--- a/bundle/phases/deploy_test.go
+++ b/bundle/phases/deploy_test.go
@@ -3,7 +3,7 @@ package phases
 import (
 	"testing"
 
-	terraformlib "github.com/databricks/cli/libs/terraform"
+	"github.com/databricks/cli/libs/deployplan"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,14 +42,14 @@ func TestParseTerraformActions(t *testing.T) {
 
 	res := filterDeleteOrRecreateActions(changes, "databricks_pipeline")
 
-	assert.Equal(t, []terraformlib.Action{
+	assert.Equal(t, []deployplan.Action{
 		{
-			Action:       terraformlib.ActionTypeDelete,
+			Action:       deployplan.ActionTypeDelete,
 			ResourceType: "databricks_pipeline",
 			ResourceName: "delete pipeline",
 		},
 		{
-			Action:       terraformlib.ActionTypeRecreate,
+			Action:       deployplan.ActionTypeRecreate,
 			ResourceType: "databricks_pipeline",
 			ResourceName: "recreate pipeline",
 		},

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -14,8 +14,8 @@ import (
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
 
+	"github.com/databricks/cli/libs/deployplan"
 	"github.com/databricks/cli/libs/log"
-	terraformlib "github.com/databricks/cli/libs/terraform"
 	"github.com/databricks/databricks-sdk-go/apierr"
 )
 
@@ -44,11 +44,11 @@ func approvalForDestroy(ctx context.Context, b *bundle.Bundle) (bool, error) {
 		return false, err
 	}
 
-	var deleteActions []terraformlib.Action
+	var deleteActions []deployplan.Action
 	for _, rc := range plan.ResourceChanges {
 		if rc.Change.Actions.Delete() {
-			deleteActions = append(deleteActions, terraformlib.Action{
-				Action:       terraformlib.ActionTypeDelete,
+			deleteActions = append(deleteActions, deployplan.Action{
+				Action:       deployplan.ActionTypeDelete,
 				ResourceType: rc.Type,
 				ResourceName: rc.Name,
 			})

--- a/libs/deployplan/plan.go
+++ b/libs/deployplan/plan.go
@@ -1,4 +1,4 @@
-package terraform
+package deployplan
 
 import "strings"
 


### PR DESCRIPTION
## Changes
Pure rename, no other changes.

## Why
This is going to be working with both terraform and direct deployment (https://github.com/databricks/cli/pull/2926).
