### PR TITLE
Implement neutral ShowPlanFile wrapper

### DIFF
--- a/acceptance/bundle/deploy/mlops-stacks/output.txt
+++ b/acceptance/bundle/deploy/mlops-stacks/output.txt
@@ -90,12 +90,8 @@ Warning: unknown field: description
 The following resources will be deleted:
   delete job batch_inference_job
   delete job model_training_job
-  delete mlflow_experiment experiment
-  delete mlflow_model model
-  delete permissions job_batch_inference_job
-  delete permissions job_model_training_job
-  delete permissions mlflow_experiment_experiment
-  delete permissions mlflow_model_model
+  delete experiment experiment
+  delete model model
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev
 

--- a/acceptance/bundle/deploy/secret-scope/output.txt
+++ b/acceptance/bundle/deploy/secret-scope/output.txt
@@ -43,8 +43,6 @@ Deployment complete!
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
-  delete secret_acl secret_acl_secret_scope1_0
-  delete secret_acl secret_acl_secret_scope1_1
   delete secret_scope secret_scope1
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-secret-scope-test-[UNIQUE_NAME]/default

--- a/acceptance/bundle/deploy/volume/recreate/output.txt
+++ b/acceptance/bundle/deploy/volume/recreate/output.txt
@@ -65,7 +65,6 @@ Deployment complete!
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
-  delete grants volume_foo
   delete schema schema1
   delete schema schema2
   delete volume foo

--- a/bundle/deploy/terraform/showplanfile.go
+++ b/bundle/deploy/terraform/showplanfile.go
@@ -1,0 +1,72 @@
+package terraform
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// GetActions converts Terraform resource changes into deployplan.Action values.
+// The returned slice can be filtered using deployplan.Filter and FilterGroup helpers.
+func GetActions(changes []*tfjson.ResourceChange) []deployplan.Action {
+	supported := config.SupportedResources()
+	typeToGroup := make(map[string]string, len(supported))
+	for group, desc := range supported {
+		typeToGroup[desc.TerraformResourceName] = group
+	}
+
+	var result []deployplan.Action
+
+	for _, rc := range changes {
+		if rc.Change == nil {
+			continue
+		}
+
+		var actionType deployplan.ActionType
+		switch {
+		case rc.Change.Actions.Delete():
+			actionType = deployplan.ActionTypeDelete
+		case rc.Change.Actions.Replace():
+			actionType = deployplan.ActionTypeRecreate
+		case rc.Change.Actions.Create():
+			actionType = deployplan.ActionTypeCreate
+		case rc.Change.Actions.Update():
+			actionType = deployplan.ActionTypeUpdate
+		default:
+			continue
+		}
+
+		group, ok := typeToGroup[rc.Type]
+		if !ok {
+			// Happens for databricks_grant, databricks_permissions, databricks_secrets_acl.
+			// These are automatically created by DABs, no need to show them.
+			continue
+		}
+
+		result = append(result, deployplan.Action{
+			Action: actionType,
+			Group:  group,
+			Name:   rc.Name,
+		})
+	}
+
+	return result
+}
+
+// ShowPlanFile reads a Terraform plan file located at planPath using the provided tfexec.Terraform handle
+// and converts it into a slice of deployplan.Action.
+//
+// The conversion maps Terraform resource types (e.g. "databricks_pipeline") to bundle configuration
+// resource groups (e.g. "pipelines") using config.SupportedResources(). If a resource type is not
+// recognised we fall back to the raw Terraform resource type so that the information is not lost.
+func ShowPlanFile(ctx context.Context, tf *tfexec.Terraform, planPath string) ([]deployplan.Action, error) {
+	plan, err := tf.ShowPlanFile(ctx, planPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetActions(plan.ResourceChanges), nil
+}

--- a/bundle/deployplan/plan.go
+++ b/bundle/deployplan/plan.go
@@ -44,8 +44,6 @@ const (
 	ActionTypeCreate   ActionType = "create"
 	ActionTypeDelete   ActionType = "delete"
 	ActionTypeUpdate   ActionType = "update"
-	ActionTypeNoOp     ActionType = "no-op"
-	ActionTypeRead     ActionType = "read"
 	ActionTypeRecreate ActionType = "recreate"
 )
 

--- a/bundle/deployplan/plan.go
+++ b/bundle/deployplan/plan.go
@@ -28,8 +28,7 @@ func (a Action) String() string {
 	return fmt.Sprintf("  %s %s %s", a.Action, typ, a.Name)
 }
 
-// IsInplaceSupported returns false since deployplan actions are simple log messages and
-// should always be appended rather than rendered in-place.
+// Implements cmdio.Event for cmdio.Log
 func (a Action) IsInplaceSupported() bool {
 	return false
 }

--- a/bundle/deployplan/plan.go
+++ b/bundle/deployplan/plan.go
@@ -1,6 +1,9 @@
 package deployplan
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type Plan struct {
 	// Path to the plan
@@ -11,20 +14,23 @@ type Plan struct {
 }
 
 type Action struct {
-	// Type and name of the resource
-	ResourceType string `json:"resource_type"`
-	ResourceName string `json:"resource_name"`
+	// Resource group in the config, e.g. "jobs", "pipelines" etc
+	Group string
 
-	Action ActionType `json:"action"`
+	// Key of the resource the config
+	Name string
+
+	Action ActionType
 }
 
 func (a Action) String() string {
-	// terraform resources have the databricks_ prefix, which is not needed.
-	rtype := strings.TrimPrefix(a.ResourceType, "databricks_")
-	return strings.Join([]string{" ", string(a.Action), rtype, a.ResourceName}, " ")
+	typ, _ := strings.CutSuffix(a.Group, "s")
+	return fmt.Sprintf("  %s %s %s", a.Action, typ, a.Name)
 }
 
-func (c Action) IsInplaceSupported() bool {
+// IsInplaceSupported returns false since deployplan actions are simple log messages and
+// should always be appended rather than rendered in-place.
+func (a Action) IsInplaceSupported() bool {
 	return false
 }
 
@@ -42,3 +48,32 @@ const (
 	ActionTypeRead     ActionType = "read"
 	ActionTypeRecreate ActionType = "recreate"
 )
+
+// Filter returns actions that match the specified action type
+func Filter(changes []Action, actionType ActionType) []Action {
+	var result []Action
+	for _, action := range changes {
+		if action.Action == actionType {
+			result = append(result, action)
+		}
+	}
+	return result
+}
+
+// FilterGroup returns actions that match the specified group and any of the specified action types
+func FilterGroup(changes []Action, group string, actionTypes ...ActionType) []Action {
+	var result []Action
+
+	// Create a set of action types for efficient lookup
+	actionTypeSet := make(map[ActionType]bool)
+	for _, actionType := range actionTypes {
+		actionTypeSet[actionType] = true
+	}
+
+	for _, action := range changes {
+		if action.Group == group && actionTypeSet[action.Action] {
+			result = append(result, action)
+		}
+	}
+	return result
+}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -25,36 +25,7 @@ import (
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/sync"
-	tfjson "github.com/hashicorp/terraform-json"
 )
-
-func filterDeleteOrRecreateActions(changes []*tfjson.ResourceChange, resourceType string) []deployplan.Action {
-	var res []deployplan.Action
-	for _, rc := range changes {
-		if rc.Type != resourceType {
-			continue
-		}
-
-		var actionType deployplan.ActionType
-		switch {
-		case rc.Change.Actions.Delete():
-			actionType = deployplan.ActionTypeDelete
-		case rc.Change.Actions.Replace():
-			actionType = deployplan.ActionTypeRecreate
-		default:
-			// Filter other action types..
-			continue
-		}
-
-		res = append(res, deployplan.Action{
-			Action:       actionType,
-			ResourceType: rc.Type,
-			ResourceName: rc.Name,
-		})
-	}
-
-	return res
-}
 
 func approvalForDeploy(ctx context.Context, b *bundle.Bundle) (bool, error) {
 	tf := b.Terraform
@@ -63,15 +34,16 @@ func approvalForDeploy(ctx context.Context, b *bundle.Bundle) (bool, error) {
 	}
 
 	// read plan file
-	plan, err := tf.ShowPlanFile(ctx, b.Plan.Path)
+	actions, err := terraform.ShowPlanFile(ctx, tf, b.Plan.Path)
 	if err != nil {
 		return false, err
 	}
 
-	schemaActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_schema")
-	dltActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_pipeline")
-	volumeActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_volume")
-	dashboardActions := filterDeleteOrRecreateActions(plan.ResourceChanges, "databricks_dashboard")
+	types := []deployplan.ActionType{deployplan.ActionTypeRecreate, deployplan.ActionTypeDelete}
+	schemaActions := deployplan.FilterGroup(actions, "schemas", types...)
+	dltActions := deployplan.FilterGroup(actions, "pipelines", types...)
+	volumeActions := deployplan.FilterGroup(actions, "volumes", types...)
+	dashboardActions := deployplan.FilterGroup(actions, "dashboards", types...)
 
 	// We don't need to display any prompts in this case.
 	if len(schemaActions) == 0 && len(dltActions) == 0 && len(volumeActions) == 0 && len(dashboardActions) == 0 {

--- a/bundle/phases/deploy_test.go
+++ b/bundle/phases/deploy_test.go
@@ -3,6 +3,7 @@ package phases
 import (
 	"testing"
 
+	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/deployplan"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
@@ -40,18 +41,19 @@ func TestParseTerraformActions(t *testing.T) {
 		},
 	}
 
-	res := filterDeleteOrRecreateActions(changes, "databricks_pipeline")
+	actions := terraform.GetActions(changes)
+	res := deployplan.FilterGroup(actions, "pipelines", deployplan.ActionTypeDelete, deployplan.ActionTypeRecreate)
 
 	assert.Equal(t, []deployplan.Action{
 		{
-			Action:       deployplan.ActionTypeDelete,
-			ResourceType: "databricks_pipeline",
-			ResourceName: "delete pipeline",
+			Action: deployplan.ActionTypeDelete,
+			Group:  "pipelines",
+			Name:   "delete pipeline",
 		},
 		{
-			Action:       deployplan.ActionTypeRecreate,
-			ResourceType: "databricks_pipeline",
-			ResourceName: "recreate pipeline",
+			Action: deployplan.ActionTypeRecreate,
+			Group:  "pipelines",
+			Name:   "recreate pipeline",
 		},
 	}, res)
 }


### PR DESCRIPTION
## Changes
- Modify deployplan.Action to be deployment method-neutral: use resource group name ("jobs") instead of terraform resource ("databricks_jobs").
- Implement ShowPlanFile, a wrapper for tf.ShowPlanFile which returns neutral []deployplan.Action.
- Use this wrapper in deploy and destroy.
- Implement deployplan.Filter and deployplan.FilterGroup helper methods and use those.
- Do not show auxiliary resources (grants, permissions, secret_acls) in diff output.

## Why
This abstracts terraform away, facilitating addition of direct deployment method: https://github.com/databricks/cli/pull/2926

## Tests
Existing tests.