### PR TITLE
Add trie for patterns

### DIFF
--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -1,6 +1,8 @@
 package dyn
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // PatternTrie is a trie data structure for storing and querying patterns.
 // It supports both exact matches and wildcard matches. You can insert [Pattern]s
@@ -84,7 +86,7 @@ func (t *PatternTrie) Insert(pattern Pattern) error {
 				}
 				next = current.pathKey[key]
 			} else {
-				return fmt.Errorf("specific index patterns are not supported")
+				return fmt.Errorf("fixed index patterns are not supported: %#v", pattern)
 			}
 		}
 

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -22,7 +22,9 @@ type PatternTrie struct {
 // Similarly, it's valid for both anyIndex and pathIndex to be set at the same time.
 // For example, adding both "foo[*].bar" and "foo[0]" to a trie is valid.
 //
-// Note: While we do not perform validation that both key and index are not set at the same time.
+// Note: Setting both key (one of pathKey or anyKey) and index (one of pathIndex or anyIndex)
+// is not supported by the [PatternTrie.SearchPath] method. We don't perform validation for this
+// case because it's not expected to arise in practice where a field is either a map or an array.
 type trieNode struct {
 	// If set this indicates the trie node is an anyKey node.
 	// Maps to the [AnyKey] component.

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -147,7 +147,9 @@ func (t *PatternTrie) searchPathRecursive(node *trieNode, path Path, prefix Patt
 	// the semantics of [MustPatternFromString] which returns nil for the empty string.
 	//
 	// We cannot return a Pattern{} object here because then MustPatternFromString(""), which
-	// returns nil will not be equal to the Pattern{} object returned by this function.
+	// returns nil will not be equal to the Pattern{} object returned by this function. An equality
+	// is useful because users of this function can use it to check whether the root / empty pattern
+	// had been inserted into the trie.
 	if len(path) == 0 {
 		return nil, node.isEnd
 	}

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -119,7 +119,7 @@ func (t *PatternTrie) SearchPath(path Path) (Pattern, bool) {
 // - index: the current index in the path / prefix
 //
 // Note we always expect the path and prefix to be the same length because wildcards like * and [*]
-// only match a single
+// only match a single path component.
 func (t *PatternTrie) searchPathRecursive(node *trieNode, path Path, prefix Pattern, index int) (Pattern, bool) {
 	if node == nil {
 		return nil, false

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -26,7 +26,8 @@ type trieNode struct {
 	pathIndex map[int]*trieNode
 
 	// Indicates if this node is the end of a pattern. Encountering a node
-	// with isEnd set to true in a trie means the input path matches the pattern.
+	// with isEnd set to true in a trie means the pattern from the root to this
+	// node is a complete pattern.
 	isEnd bool
 }
 
@@ -106,7 +107,6 @@ func (t *PatternTrie) SearchPath(path Path) (Pattern, bool) {
 	return pattern, ok
 }
 
-// searchPathRecursive is a helper function that recursively checks if a path matches any pattern.
 func (t *PatternTrie) searchPathRecursive(node *trieNode, path Path, index int, prefix Pattern) (Pattern, bool) {
 	if node == nil {
 		return nil, false

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -11,18 +11,33 @@ type PatternTrie struct {
 }
 
 // trieNode represents a node in the pattern trie.
-// Note that it can only be one of anyKey, anyIndex, collection of pathKeys, or collection of pathIndexes.
+// Each node in the array represents one or more of:
+// 1. An [AnyKey] component. This is the "*" wildcard which matches any map key.
+// 2. An [AnyIndex] component. This is the "*" wildcard which matches any array index.
+// 3. Multiple [Key] components. These are multiple static path keys for this this node would match.
+// 4. Multiple [Index] components. These are multiple static path indices for this this node would match.
+//
+// Note: It's valid for both anyKey and pathKey to be set at the same time.
+// For example, adding both "foo.*.bar" and "foo.bar" to a trie is valid.
+// Similarly, it's valid for both anyIndex and pathIndex to be set at the same time.
+// For example, adding both "foo[*].bar" and "foo[0]" to a trie is valid.
+//
+// Note: While we do not perform validation that both key and index are not set at the same time.
 type trieNode struct {
 	// If set this indicates the trie node is an anyKey node.
+	// Maps to the [AnyKey] component.
 	anyKey *trieNode
 
 	// Indicates the trie node is an anyIndex node.
+	// Maps to the [AnyIndex] component.
 	anyIndex *trieNode
 
 	// Set of strings which this trie node matches.
+	// Maps to the [Key] component.
 	pathKey map[string]*trieNode
 
 	// Set of indices which this trie node matches.
+	// Maps to the [Index] component.
 	pathIndex map[int]*trieNode
 
 	// Indicates if this node is the end of a pattern. Encountering a node

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -13,7 +13,7 @@ type PatternTrie struct {
 // trieNode represents a node in the pattern trie.
 // Each node in the array represents one or more of:
 // 1. An [AnyKey] component. This is the "*" wildcard which matches any map key.
-// 2. An [AnyIndex] component. This is the "*" wildcard which matches any array index.
+// 2. An [AnyIndex] component. This is the "[*]" wildcard which matches any array index.
 // 3. Multiple [Key] components. These are multiple static path keys for this this node would match.
 // 4. Multiple [Index] components. These are multiple static path indices for this this node would match.
 //

--- a/libs/dyn/pattern_trie.go
+++ b/libs/dyn/pattern_trie.go
@@ -24,7 +24,8 @@ type PatternTrie struct {
 //
 // Note: Setting both key (one of pathKey or anyKey) and index (one of pathIndex or anyIndex)
 // is not supported by the [PatternTrie.SearchPath] method. We don't perform validation for this
-// case because it's not expected to arise in practice where a field is either a map or an array.
+// case because it's not expected to arise in practice where a field is either a map or an array,
+// but not both.
 type trieNode struct {
 	// If set this indicates the trie node is an anyKey node.
 	// Maps to the [AnyKey] component.

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -1,0 +1,190 @@
+package dyn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatternTrie_SearchPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		pattern     string
+		expected    []string
+		notExpected []string
+	}{
+		{
+			name:        "empty pattern",
+			pattern:     "",
+			expected:    []string{""},
+			notExpected: []string{"foo"},
+		},
+		{
+			name:        "simple key pattern",
+			pattern:     "foo",
+			expected:    []string{"foo"},
+			notExpected: []string{"foo.bar", "foo[0]", "bar"},
+		},
+		{
+			name:        "simple index pattern",
+			pattern:     "[0]",
+			expected:    []string{"[0]"},
+			notExpected: []string{"foo[0]", "foo.bar", "bar"},
+		},
+		{
+			name:        "nested key pattern",
+			pattern:     "foo.bar",
+			expected:    []string{"foo.bar"},
+			notExpected: []string{"foo", "foo[0]", "bar.foo", "foo.baz"},
+		},
+		{
+			name:        "root wildcard",
+			pattern:     "*",
+			expected:    []string{"foo", "bar"},
+			notExpected: []string{"", "bar.foo", "foo.baz"},
+		},
+		{
+			name:        "wildcard * after foo",
+			pattern:     "foo.*",
+			expected:    []string{"foo.bar", "foo.baz"},
+			notExpected: []string{"foo", "bar", "foo.bar.baz"},
+		},
+		{
+			name:        "wildcard [*] after foo",
+			pattern:     "foo[*]",
+			expected:    []string{"foo[0]", "foo[1]", "foo[2025]"},
+			notExpected: []string{"foo", "bar", "foo[0].bar"},
+		},
+		{
+			name:        "key after * wildcard",
+			pattern:     "foo.*.bar",
+			expected:    []string{"foo.abc.bar", "foo.def.bar"},
+			notExpected: []string{"foo", "bar", "foo.bar.baz"},
+		},
+		{
+			name:        "key after [*] wildcard",
+			pattern:     "foo[*].bar",
+			expected:    []string{"foo[0].bar", "foo[1].bar", "foo[2025].bar"},
+			notExpected: []string{"foo", "bar", "foo[0].baz"},
+		},
+		{
+			name:        "multiple * wildcards",
+			pattern:     "*.*.*",
+			expected:    []string{"foo.bar.baz", "foo.bar.qux"},
+			notExpected: []string{"foo", "bar", "foo.bar", "foo.bar.baz.qux"},
+		},
+		{
+			name:        "multiple [*] wildcards",
+			pattern:     "foo[*][*]",
+			expected:    []string{"foo[0][0]", "foo[1][1]", "foo[2025][2025]"},
+			notExpected: []string{"foo", "bar", "foo[0][0][0]"},
+		},
+		{
+			name:        "[*] after * wildcard",
+			pattern:     "*[*]",
+			expected:    []string{"foo[0]", "foo[1]", "foo[2025]"},
+			notExpected: []string{"foo", "bar", "foo[0].bar", "[0].foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trie := NewPatternTrie()
+			pattern := MustPatternFromString(tt.pattern)
+
+			// None of the expected paths should match yet.
+			for _, path := range tt.expected {
+				_, ok := trie.SearchPath(MustPathFromString(path))
+				assert.False(t, ok)
+			}
+			for _, path := range tt.notExpected {
+				_, ok := trie.SearchPath(MustPathFromString(path))
+				assert.False(t, ok)
+			}
+
+			err := trie.Insert(pattern)
+			assert.NoError(t, err)
+
+			// Now all the expected paths should match.
+			for _, path := range tt.expected {
+				pattern, ok := trie.SearchPath(MustPathFromString(path))
+				assert.True(t, ok)
+				assert.Equal(t, MustPatternFromString(tt.pattern), pattern)
+			}
+			for _, path := range tt.notExpected {
+				_, ok := trie.SearchPath(MustPathFromString(path))
+				assert.False(t, ok)
+			}
+		})
+	}
+}
+
+func TestPatternTrie_MultiplePatterns(t *testing.T) {
+	trie := NewPatternTrie()
+
+	patterns := []string{
+		"foo.bar",
+		"foo.*.baz",
+		"abc[0]",
+		"def[*]",
+	}
+
+	expected := map[string]string{
+		"foo.bar":     "foo.bar",
+		"foo.abc.baz": "foo.*.baz",
+		"foo.def.baz": "foo.*.baz",
+		"abc[0]":      "abc[0]",
+		"def[0]":      "def[*]",
+		"def[1]":      "def[*]",
+	}
+
+	notExpected := []string{
+		"foo",
+		"abc[1]",
+		"def[2].x",
+		"foo.y",
+		"foo.bar.baz.qux",
+	}
+
+	for _, pattern := range patterns {
+		err := trie.Insert(MustPatternFromString(pattern))
+		assert.NoError(t, err)
+	}
+
+	for path, expectedPattern := range expected {
+		pattern, ok := trie.SearchPath(MustPathFromString(path))
+		assert.True(t, ok)
+		assert.Equal(t, MustPatternFromString(expectedPattern), pattern)
+	}
+
+	for _, path := range notExpected {
+		_, ok := trie.SearchPath(MustPathFromString(path))
+		assert.False(t, ok)
+	}
+}
+
+func TestPatternTrie_OverlappingPatterns(t *testing.T) {
+	trie := NewPatternTrie()
+
+	// Insert overlapping patterns
+	patterns := []string{
+		"foo.bar",
+		"foo.*",
+		"*.bar",
+		"*.*",
+	}
+
+	for _, pattern := range patterns {
+		err := trie.Insert(MustPatternFromString(pattern))
+		assert.NoError(t, err)
+	}
+
+	for _, path := range []string{
+		"foo.bar",
+		"foo.baz",
+		"baz.bar",
+		"baz.qux",
+	} {
+		_, ok := trie.SearchPath(MustPathFromString(path))
+		assert.True(t, ok)
+	}
+}

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -3,7 +3,7 @@ package dyn
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/databricks/cli/libs/dyn/dynassert"
 )
 
 func TestPatternTrie_SearchPath(t *testing.T) {
@@ -94,25 +94,25 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 			// None of the expected paths should match yet.
 			for _, path := range tt.expected {
 				_, ok := trie.SearchPath(MustPathFromString(path))
-				assert.False(t, ok)
+				dynassert.False(t, ok)
 			}
 			for _, path := range tt.notExpected {
 				_, ok := trie.SearchPath(MustPathFromString(path))
-				assert.False(t, ok)
+				dynassert.False(t, ok)
 			}
 
 			err := trie.Insert(pattern)
-			assert.NoError(t, err)
+			dynassert.NoError(t, err)
 
 			// Now all the expected paths should match.
 			for _, path := range tt.expected {
 				pattern, ok := trie.SearchPath(MustPathFromString(path))
-				assert.True(t, ok)
-				assert.Equal(t, MustPatternFromString(tt.pattern), pattern)
+				dynassert.True(t, ok)
+				dynassert.Equal(t, MustPatternFromString(tt.pattern), pattern)
 			}
 			for _, path := range tt.notExpected {
 				_, ok := trie.SearchPath(MustPathFromString(path))
-				assert.False(t, ok)
+				dynassert.False(t, ok)
 			}
 		})
 	}
@@ -147,18 +147,18 @@ func TestPatternTrie_MultiplePatterns(t *testing.T) {
 
 	for _, pattern := range patterns {
 		err := trie.Insert(MustPatternFromString(pattern))
-		assert.NoError(t, err)
+		dynassert.NoError(t, err)
 	}
 
 	for path, expectedPattern := range expected {
 		pattern, ok := trie.SearchPath(MustPathFromString(path))
-		assert.True(t, ok)
-		assert.Equal(t, MustPatternFromString(expectedPattern), pattern)
+		dynassert.True(t, ok)
+		dynassert.Equal(t, MustPatternFromString(expectedPattern), pattern)
 	}
 
 	for _, path := range notExpected {
 		_, ok := trie.SearchPath(MustPathFromString(path))
-		assert.False(t, ok)
+		dynassert.False(t, ok)
 	}
 }
 
@@ -175,7 +175,7 @@ func TestPatternTrie_OverlappingPatterns(t *testing.T) {
 
 	for _, pattern := range patterns {
 		err := trie.Insert(MustPatternFromString(pattern))
-		assert.NoError(t, err)
+		dynassert.NoError(t, err)
 	}
 
 	for _, path := range []string{
@@ -185,6 +185,6 @@ func TestPatternTrie_OverlappingPatterns(t *testing.T) {
 		"baz.qux",
 	} {
 		_, ok := trie.SearchPath(MustPathFromString(path))
-		assert.True(t, ok)
+		dynassert.True(t, ok)
 	}
 }

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -84,7 +84,7 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			trie := dyn.NewPatternTrie()
+			trie := &dyn.TrieNode{}
 			pattern := dyn.MustPatternFromString(tt.pattern)
 
 			// None of the expected paths should match yet.
@@ -115,7 +115,7 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 }
 
 func TestPatternTrie_MultiplePatterns(t *testing.T) {
-	trie := dyn.NewPatternTrie()
+	trie := &dyn.TrieNode{}
 
 	patterns := []string{
 		"foo.bar",
@@ -158,7 +158,7 @@ func TestPatternTrie_MultiplePatterns(t *testing.T) {
 }
 
 func TestPatternTrie_OverlappingPatterns(t *testing.T) {
-	trie := dyn.NewPatternTrie()
+	trie := &dyn.TrieNode{}
 
 	// Insert overlapping patterns
 	patterns := []string{
@@ -185,7 +185,7 @@ func TestPatternTrie_OverlappingPatterns(t *testing.T) {
 }
 
 func TestPatternTrie_FixedIndexPatterns(t *testing.T) {
-	trie := dyn.NewPatternTrie()
+	trie := &dyn.TrieNode{}
 
 	err := trie.Insert(dyn.MustPatternFromString("foo[0]"))
 	assert.EqualError(t, err, "fixed index patterns are not supported: dyn.Pattern{dyn.pathComponent{key:\"foo\", index:0}, dyn.pathComponent{key:\"\", index:0}}")

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -183,3 +183,13 @@ func TestPatternTrie_OverlappingPatterns(t *testing.T) {
 		assert.True(t, ok)
 	}
 }
+
+func TestPatternTrie_FixedIndexPatterns(t *testing.T) {
+	trie := dyn.NewPatternTrie()
+
+	err := trie.Insert(dyn.MustPatternFromString("foo[0]"))
+	assert.EqualError(t, err, "fixed index patterns are not supported: dyn.Pattern{dyn.pathComponent{key:\"foo\", index:0}, dyn.pathComponent{key:\"\", index:0}}")
+
+	err = trie.Insert(dyn.MustPatternFromString("foo[2]"))
+	assert.EqualError(t, err, "fixed index patterns are not supported: dyn.Pattern{dyn.pathComponent{key:\"foo\", index:0}, dyn.pathComponent{key:\"\", index:2}}")
+}

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -1,9 +1,10 @@
-package dyn
+package dyn_test
 
 import (
 	"testing"
 
-	"github.com/databricks/cli/libs/dyn/dynassert"
+	"github.com/databricks/cli/libs/dyn"
+	assert "github.com/databricks/cli/libs/dyn/dynassert"
 )
 
 func TestPatternTrie_SearchPath(t *testing.T) {
@@ -88,38 +89,38 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			trie := NewPatternTrie()
-			pattern := MustPatternFromString(tt.pattern)
+			trie := dyn.NewPatternTrie()
+			pattern := dyn.MustPatternFromString(tt.pattern)
 
 			// None of the expected paths should match yet.
 			for _, path := range tt.expected {
-				_, ok := trie.SearchPath(MustPathFromString(path))
-				dynassert.False(t, ok)
+				_, ok := trie.SearchPath(dyn.MustPathFromString(path))
+				assert.False(t, ok)
 			}
 			for _, path := range tt.notExpected {
-				_, ok := trie.SearchPath(MustPathFromString(path))
-				dynassert.False(t, ok)
+				_, ok := trie.SearchPath(dyn.MustPathFromString(path))
+				assert.False(t, ok)
 			}
 
 			err := trie.Insert(pattern)
-			dynassert.NoError(t, err)
+			assert.NoError(t, err)
 
 			// Now all the expected paths should match.
 			for _, path := range tt.expected {
-				pattern, ok := trie.SearchPath(MustPathFromString(path))
-				dynassert.True(t, ok)
-				dynassert.Equal(t, MustPatternFromString(tt.pattern), pattern)
+				pattern, ok := trie.SearchPath(dyn.MustPathFromString(path))
+				assert.True(t, ok)
+				assert.Equal(t, dyn.MustPatternFromString(tt.pattern), pattern)
 			}
 			for _, path := range tt.notExpected {
-				_, ok := trie.SearchPath(MustPathFromString(path))
-				dynassert.False(t, ok)
+				_, ok := trie.SearchPath(dyn.MustPathFromString(path))
+				assert.False(t, ok)
 			}
 		})
 	}
 }
 
 func TestPatternTrie_MultiplePatterns(t *testing.T) {
-	trie := NewPatternTrie()
+	trie := dyn.NewPatternTrie()
 
 	patterns := []string{
 		"foo.bar",
@@ -146,24 +147,24 @@ func TestPatternTrie_MultiplePatterns(t *testing.T) {
 	}
 
 	for _, pattern := range patterns {
-		err := trie.Insert(MustPatternFromString(pattern))
-		dynassert.NoError(t, err)
+		err := trie.Insert(dyn.MustPatternFromString(pattern))
+		assert.NoError(t, err)
 	}
 
 	for path, expectedPattern := range expected {
-		pattern, ok := trie.SearchPath(MustPathFromString(path))
-		dynassert.True(t, ok)
-		dynassert.Equal(t, MustPatternFromString(expectedPattern), pattern)
+		pattern, ok := trie.SearchPath(dyn.MustPathFromString(path))
+		assert.True(t, ok)
+		assert.Equal(t, dyn.MustPatternFromString(expectedPattern), pattern)
 	}
 
 	for _, path := range notExpected {
-		_, ok := trie.SearchPath(MustPathFromString(path))
-		dynassert.False(t, ok)
+		_, ok := trie.SearchPath(dyn.MustPathFromString(path))
+		assert.False(t, ok)
 	}
 }
 
 func TestPatternTrie_OverlappingPatterns(t *testing.T) {
-	trie := NewPatternTrie()
+	trie := dyn.NewPatternTrie()
 
 	// Insert overlapping patterns
 	patterns := []string{
@@ -174,8 +175,8 @@ func TestPatternTrie_OverlappingPatterns(t *testing.T) {
 	}
 
 	for _, pattern := range patterns {
-		err := trie.Insert(MustPatternFromString(pattern))
-		dynassert.NoError(t, err)
+		err := trie.Insert(dyn.MustPatternFromString(pattern))
+		assert.NoError(t, err)
 	}
 
 	for _, path := range []string{
@@ -184,7 +185,7 @@ func TestPatternTrie_OverlappingPatterns(t *testing.T) {
 		"baz.bar",
 		"baz.qux",
 	} {
-		_, ok := trie.SearchPath(MustPathFromString(path))
-		dynassert.True(t, ok)
+		_, ok := trie.SearchPath(dyn.MustPathFromString(path))
+		assert.True(t, ok)
 	}
 }

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -26,12 +26,7 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 			mustMatch:    []string{"foo"},
 			mustNotMatch: []string{"foo.bar", "foo[0]", "bar"},
 		},
-		{
-			name:         "simple index pattern",
-			pattern:      "[0]",
-			mustMatch:    []string{"[0]"},
-			mustNotMatch: []string{"foo[0]", "foo.bar", "bar"},
-		},
+
 		{
 			name:         "nested key pattern",
 			pattern:      "foo.bar",
@@ -125,21 +120,20 @@ func TestPatternTrie_MultiplePatterns(t *testing.T) {
 	patterns := []string{
 		"foo.bar",
 		"foo.*.baz",
-		"abc[0]",
 		"def[*]",
 	}
 
-	expected := map[string]string{
+	mustMatch := map[string]string{
 		"foo.bar":     "foo.bar",
 		"foo.abc.baz": "foo.*.baz",
 		"foo.def.baz": "foo.*.baz",
-		"abc[0]":      "abc[0]",
 		"def[0]":      "def[*]",
 		"def[1]":      "def[*]",
 	}
 
-	notExpected := []string{
+	mustNotMatch := []string{
 		"foo",
+		"abc[0]",
 		"abc[1]",
 		"def[2].x",
 		"foo.y",
@@ -151,13 +145,13 @@ func TestPatternTrie_MultiplePatterns(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	for path, expectedPattern := range expected {
+	for path, expectedPattern := range mustMatch {
 		pattern, ok := trie.SearchPath(dyn.MustPathFromString(path))
 		assert.True(t, ok)
 		assert.Equal(t, dyn.MustPatternFromString(expectedPattern), pattern)
 	}
 
-	for _, path := range notExpected {
+	for _, path := range mustNotMatch {
 		_, ok := trie.SearchPath(dyn.MustPathFromString(path))
 		assert.False(t, ok)
 	}

--- a/libs/dyn/pattern_trie_test.go
+++ b/libs/dyn/pattern_trie_test.go
@@ -9,82 +9,82 @@ import (
 
 func TestPatternTrie_SearchPath(t *testing.T) {
 	tests := []struct {
-		name        string
-		pattern     string
-		expected    []string
-		notExpected []string
+		name         string
+		pattern      string
+		mustMatch    []string
+		mustNotMatch []string
 	}{
 		{
-			name:        "empty pattern",
-			pattern:     "",
-			expected:    []string{""},
-			notExpected: []string{"foo"},
+			name:         "empty pattern",
+			pattern:      "",
+			mustMatch:    []string{""},
+			mustNotMatch: []string{"foo"},
 		},
 		{
-			name:        "simple key pattern",
-			pattern:     "foo",
-			expected:    []string{"foo"},
-			notExpected: []string{"foo.bar", "foo[0]", "bar"},
+			name:         "simple key pattern",
+			pattern:      "foo",
+			mustMatch:    []string{"foo"},
+			mustNotMatch: []string{"foo.bar", "foo[0]", "bar"},
 		},
 		{
-			name:        "simple index pattern",
-			pattern:     "[0]",
-			expected:    []string{"[0]"},
-			notExpected: []string{"foo[0]", "foo.bar", "bar"},
+			name:         "simple index pattern",
+			pattern:      "[0]",
+			mustMatch:    []string{"[0]"},
+			mustNotMatch: []string{"foo[0]", "foo.bar", "bar"},
 		},
 		{
-			name:        "nested key pattern",
-			pattern:     "foo.bar",
-			expected:    []string{"foo.bar"},
-			notExpected: []string{"foo", "foo[0]", "bar.foo", "foo.baz"},
+			name:         "nested key pattern",
+			pattern:      "foo.bar",
+			mustMatch:    []string{"foo.bar"},
+			mustNotMatch: []string{"foo", "foo[0]", "bar.foo", "foo.baz"},
 		},
 		{
-			name:        "root wildcard",
-			pattern:     "*",
-			expected:    []string{"foo", "bar"},
-			notExpected: []string{"", "bar.foo", "foo.baz"},
+			name:         "root wildcard",
+			pattern:      "*",
+			mustMatch:    []string{"foo", "bar"},
+			mustNotMatch: []string{"", "bar.foo", "foo.baz"},
 		},
 		{
-			name:        "wildcard * after foo",
-			pattern:     "foo.*",
-			expected:    []string{"foo.bar", "foo.baz"},
-			notExpected: []string{"foo", "bar", "foo.bar.baz"},
+			name:         "wildcard * after foo",
+			pattern:      "foo.*",
+			mustMatch:    []string{"foo.bar", "foo.baz"},
+			mustNotMatch: []string{"foo", "bar", "foo.bar.baz"},
 		},
 		{
-			name:        "wildcard [*] after foo",
-			pattern:     "foo[*]",
-			expected:    []string{"foo[0]", "foo[1]", "foo[2025]"},
-			notExpected: []string{"foo", "bar", "foo[0].bar"},
+			name:         "wildcard [*] after foo",
+			pattern:      "foo[*]",
+			mustMatch:    []string{"foo[0]", "foo[1]", "foo[2025]"},
+			mustNotMatch: []string{"foo", "bar", "foo[0].bar"},
 		},
 		{
-			name:        "key after * wildcard",
-			pattern:     "foo.*.bar",
-			expected:    []string{"foo.abc.bar", "foo.def.bar"},
-			notExpected: []string{"foo", "bar", "foo.bar.baz"},
+			name:         "key after * wildcard",
+			pattern:      "foo.*.bar",
+			mustMatch:    []string{"foo.abc.bar", "foo.def.bar"},
+			mustNotMatch: []string{"foo", "bar", "foo.bar.baz"},
 		},
 		{
-			name:        "key after [*] wildcard",
-			pattern:     "foo[*].bar",
-			expected:    []string{"foo[0].bar", "foo[1].bar", "foo[2025].bar"},
-			notExpected: []string{"foo", "bar", "foo[0].baz"},
+			name:         "key after [*] wildcard",
+			pattern:      "foo[*].bar",
+			mustMatch:    []string{"foo[0].bar", "foo[1].bar", "foo[2025].bar"},
+			mustNotMatch: []string{"foo", "bar", "foo[0].baz"},
 		},
 		{
-			name:        "multiple * wildcards",
-			pattern:     "*.*.*",
-			expected:    []string{"foo.bar.baz", "foo.bar.qux"},
-			notExpected: []string{"foo", "bar", "foo.bar", "foo.bar.baz.qux"},
+			name:         "multiple * wildcards",
+			pattern:      "*.*.*",
+			mustMatch:    []string{"foo.bar.baz", "foo.bar.qux"},
+			mustNotMatch: []string{"foo", "bar", "foo.bar", "foo.bar.baz.qux"},
 		},
 		{
-			name:        "multiple [*] wildcards",
-			pattern:     "foo[*][*]",
-			expected:    []string{"foo[0][0]", "foo[1][1]", "foo[2025][2025]"},
-			notExpected: []string{"foo", "bar", "foo[0][0][0]"},
+			name:         "multiple [*] wildcards",
+			pattern:      "foo[*][*]",
+			mustMatch:    []string{"foo[0][0]", "foo[1][1]", "foo[2025][2025]"},
+			mustNotMatch: []string{"foo", "bar", "foo[0][0][0]"},
 		},
 		{
-			name:        "[*] after * wildcard",
-			pattern:     "*[*]",
-			expected:    []string{"foo[0]", "foo[1]", "foo[2025]"},
-			notExpected: []string{"foo", "bar", "foo[0].bar", "[0].foo"},
+			name:         "[*] after * wildcard",
+			pattern:      "*[*]",
+			mustMatch:    []string{"foo[0]", "foo[1]", "foo[2025]"},
+			mustNotMatch: []string{"foo", "bar", "foo[0].bar", "[0].foo"},
 		},
 	}
 	for _, tt := range tests {
@@ -93,11 +93,11 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 			pattern := dyn.MustPatternFromString(tt.pattern)
 
 			// None of the expected paths should match yet.
-			for _, path := range tt.expected {
+			for _, path := range tt.mustMatch {
 				_, ok := trie.SearchPath(dyn.MustPathFromString(path))
 				assert.False(t, ok)
 			}
-			for _, path := range tt.notExpected {
+			for _, path := range tt.mustNotMatch {
 				_, ok := trie.SearchPath(dyn.MustPathFromString(path))
 				assert.False(t, ok)
 			}
@@ -106,12 +106,12 @@ func TestPatternTrie_SearchPath(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Now all the expected paths should match.
-			for _, path := range tt.expected {
+			for _, path := range tt.mustMatch {
 				pattern, ok := trie.SearchPath(dyn.MustPathFromString(path))
 				assert.True(t, ok)
 				assert.Equal(t, dyn.MustPatternFromString(tt.pattern), pattern)
 			}
-			for _, path := range tt.notExpected {
+			for _, path := range tt.mustNotMatch {
 				_, ok := trie.SearchPath(dyn.MustPathFromString(path))
 				assert.False(t, ok)
 			}


### PR DESCRIPTION
## Why
A prefix tree datastructure for patterns allows us to do quick lookup for patterns. This will be useful for required and enum field validation.

Downstream validation PR: https://github.com/databricks/cli/pull/3044

## Tests
Unit tests.
