### PR TITLE
Remove redundant include stanza from dashboard acceptance tests

### DIFF
--- a/acceptance/bundle/deploy/dashboard/simple_outside_bundle_root/databricks.yml.tmpl
+++ b/acceptance/bundle/deploy/dashboard/simple_outside_bundle_root/databricks.yml.tmpl
@@ -9,8 +9,6 @@ bundle:
 sync:
   paths:
     - ..
-  include:
-    - ..
 
 resources:
   dashboards:

--- a/acceptance/bundle/deploy/dashboard/simple_syncroot/databricks.yml.tmpl
+++ b/acceptance/bundle/deploy/dashboard/simple_syncroot/databricks.yml.tmpl
@@ -9,8 +9,6 @@ bundle:
 sync:
   paths:
     - ..
-  include:
-    - ..
 
 resources:
   dashboards:


### PR DESCRIPTION
## Changes

The includes for file synchronization are unrelated to dashboards.

## Why

Thread in https://github.com/databricks/cli/pull/3006/files#r2140059656