### PR TITLE
Deprecate TerraformResourceName from ResourceDescription

### DIFF
--- a/bundle/apps/interpolate_variables.go
+++ b/bundle/apps/interpolate_variables.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/dyn/dynvar"
@@ -20,15 +20,10 @@ func (i *interpolateVariables) Apply(ctx context.Context, b *bundle.Bundle) diag
 		dyn.Key("config"),
 	)
 
-	tfToConfigMap := map[string]string{}
-	for k, r := range config.SupportedResources() {
-		tfToConfigMap[r.TerraformResourceName] = k
-	}
-
 	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
 		return dyn.MapByPattern(root, pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 			return dynvar.Resolve(v, func(path dyn.Path) (dyn.Value, error) {
-				key, ok := tfToConfigMap[path[0].Key()]
+				key, ok := terraform.TerraformToGroupName[path[0].Key()]
 				if ok {
 					path = dyn.NewPath(dyn.Key("resources"), dyn.Key(key)).Append(path[1:]...)
 				}

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -168,7 +168,7 @@ func (r *Resources) FindResourceByConfigKey(key string) (ConfigResource, error) 
 	if len(found) > 1 {
 		keys := make([]string, 0, len(found))
 		for _, r := range found {
-			keys = append(keys, fmt.Sprintf("%s:%s", r.ResourceDescription().TerraformResourceName, key))
+			keys = append(keys, fmt.Sprintf("%s.%s", r.ResourceDescription().PluralName, key))
 		}
 		return nil, fmt.Errorf("ambiguous: %s (can resolve to all of %s)", key, keys)
 	}

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -59,11 +59,10 @@ func (a *App) Exists(ctx context.Context, w *databricks.WorkspaceClient, name st
 
 func (*App) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "app",
-		PluralName:            "apps",
-		SingularTitle:         "App",
-		PluralTitle:           "Apps",
-		TerraformResourceName: "databricks_app",
+		SingularName:  "app",
+		PluralName:    "apps",
+		SingularTitle: "App",
+		PluralTitle:   "Apps",
 	}
 }
 

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -50,11 +50,10 @@ func (s *Cluster) Exists(ctx context.Context, w *databricks.WorkspaceClient, id 
 
 func (*Cluster) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "cluster",
-		PluralName:            "clusters",
-		SingularTitle:         "Cluster",
-		PluralTitle:           "Clusters",
-		TerraformResourceName: "databricks_cluster",
+		SingularName:  "cluster",
+		PluralName:    "clusters",
+		SingularTitle: "Cluster",
+		PluralTitle:   "Clusters",
 	}
 }
 

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -75,11 +75,10 @@ func (*Dashboard) Exists(ctx context.Context, w *databricks.WorkspaceClient, id 
 
 func (*Dashboard) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "dashboard",
-		PluralName:            "dashboards",
-		SingularTitle:         "Dashboard",
-		PluralTitle:           "Dashboards",
-		TerraformResourceName: "databricks_dashboard",
+		SingularName:  "dashboard",
+		PluralName:    "dashboards",
+		SingularTitle: "Dashboard",
+		PluralTitle:   "Dashboards",
 	}
 }
 

--- a/bundle/config/resources/description.go
+++ b/bundle/config/resources/description.go
@@ -8,6 +8,4 @@ type ResourceDescription struct {
 	// Singular and plural title when used in summaries / terminal UI.
 	SingularTitle string
 	PluralTitle   string
-
-	TerraformResourceName string
 }

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -57,11 +57,10 @@ func (j *Job) Exists(ctx context.Context, w *databricks.WorkspaceClient, id stri
 
 func (j *Job) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "job",
-		PluralName:            "jobs",
-		SingularTitle:         "Job",
-		PluralTitle:           "Jobs",
-		TerraformResourceName: "databricks_job",
+		SingularName:  "job",
+		PluralName:    "jobs",
+		SingularTitle: "Job",
+		PluralTitle:   "Jobs",
 	}
 }
 

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -52,11 +52,10 @@ func (s *MlflowExperiment) Exists(ctx context.Context, w *databricks.WorkspaceCl
 
 func (j *MlflowExperiment) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "experiment",
-		PluralName:            "experiments",
-		SingularTitle:         "Experiment",
-		PluralTitle:           "Experiments",
-		TerraformResourceName: "databricks_mlflow_experiment",
+		SingularName:  "experiment",
+		PluralName:    "experiments",
+		SingularTitle: "Experiment",
+		PluralTitle:   "Experiments",
 	}
 }
 

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -52,11 +52,10 @@ func (s *MlflowModel) Exists(ctx context.Context, w *databricks.WorkspaceClient,
 
 func (j *MlflowModel) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "model",
-		PluralName:            "models",
-		SingularTitle:         "Model",
-		PluralTitle:           "Models",
-		TerraformResourceName: "databricks_mlflow_model",
+		SingularName:  "model",
+		PluralName:    "models",
+		SingularTitle: "Model",
+		PluralTitle:   "Models",
 	}
 }
 

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -60,11 +60,10 @@ func (s *ModelServingEndpoint) Exists(ctx context.Context, w *databricks.Workspa
 
 func (j *ModelServingEndpoint) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "model_serving_endpoint",
-		PluralName:            "model_serving_endpoints",
-		SingularTitle:         "Model Serving Endpoint",
-		PluralTitle:           "Model Serving Endpoints",
-		TerraformResourceName: "databricks_model_serving",
+		SingularName:  "model_serving_endpoint",
+		PluralName:    "model_serving_endpoints",
+		SingularTitle: "Model Serving Endpoint",
+		PluralTitle:   "Model Serving Endpoints",
 	}
 }
 

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -52,11 +52,10 @@ func (p *Pipeline) Exists(ctx context.Context, w *databricks.WorkspaceClient, id
 
 func (j *Pipeline) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "pipeline",
-		PluralName:            "pipelines",
-		SingularTitle:         "Pipeline",
-		PluralTitle:           "Pipelines",
-		TerraformResourceName: "databricks_pipeline",
+		SingularName:  "pipeline",
+		PluralName:    "pipelines",
+		SingularTitle: "Pipeline",
+		PluralTitle:   "Pipelines",
 	}
 }
 

--- a/bundle/config/resources/quality_monitor.go
+++ b/bundle/config/resources/quality_monitor.go
@@ -44,11 +44,10 @@ func (s *QualityMonitor) Exists(ctx context.Context, w *databricks.WorkspaceClie
 
 func (*QualityMonitor) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "quality_monitor",
-		PluralName:            "quality_monitors",
-		SingularTitle:         "Quality Monitor",
-		PluralTitle:           "Quality Monitors",
-		TerraformResourceName: "databricks_quality_monitor",
+		SingularName:  "quality_monitor",
+		PluralName:    "quality_monitors",
+		SingularTitle: "Quality Monitor",
+		PluralTitle:   "Quality Monitors",
 	}
 }
 

--- a/bundle/config/resources/registered_model.go
+++ b/bundle/config/resources/registered_model.go
@@ -50,11 +50,10 @@ func (s *RegisteredModel) Exists(ctx context.Context, w *databricks.WorkspaceCli
 
 func (*RegisteredModel) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "registered_model",
-		PluralName:            "registered_models",
-		SingularTitle:         "Registered Model",
-		PluralTitle:           "Registered Models",
-		TerraformResourceName: "databricks_registered_model",
+		SingularName:  "registered_model",
+		PluralName:    "registered_models",
+		SingularTitle: "Registered Model",
+		PluralTitle:   "Registered Models",
 	}
 }
 

--- a/bundle/config/resources/schema.go
+++ b/bundle/config/resources/schema.go
@@ -46,11 +46,10 @@ func (s *Schema) Exists(ctx context.Context, w *databricks.WorkspaceClient, full
 
 func (*Schema) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "schema",
-		PluralName:            "schemas",
-		SingularTitle:         "Schema",
-		PluralTitle:           "Schemas",
-		TerraformResourceName: "databricks_schema",
+		SingularName:  "schema",
+		PluralName:    "schemas",
+		SingularTitle: "Schema",
+		PluralTitle:   "Schemas",
 	}
 }
 

--- a/bundle/config/resources/secret_scope.go
+++ b/bundle/config/resources/secret_scope.go
@@ -74,11 +74,10 @@ func (s SecretScope) Exists(ctx context.Context, w *databricks.WorkspaceClient, 
 
 func (s SecretScope) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "secret_scope",
-		PluralName:            "secret_scopes",
-		SingularTitle:         "Secret Scope",
-		PluralTitle:           "Secret Scopes",
-		TerraformResourceName: "databricks_secret_scope",
+		SingularName:  "secret_scope",
+		PluralName:    "secret_scopes",
+		SingularTitle: "Secret Scope",
+		PluralTitle:   "Secret Scopes",
 	}
 }
 

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -54,11 +54,10 @@ func (v *Volume) Exists(ctx context.Context, w *databricks.WorkspaceClient, full
 
 func (*Volume) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
-		SingularName:          "volume",
-		PluralName:            "volumes",
-		SingularTitle:         "Volume",
-		PluralTitle:           "Volumes",
-		TerraformResourceName: "databricks_volume",
+		SingularName:  "volume",
+		PluralName:    "volumes",
+		SingularTitle: "Volume",
+		PluralTitle:   "Volumes",
 	}
 }
 

--- a/bundle/deploy/terraform/pkg.go
+++ b/bundle/deploy/terraform/pkg.go
@@ -60,3 +60,27 @@ func NewTerraformMetadata() *TerraformMetadata {
 		ProviderVersion: schema.ProviderVersion,
 	}
 }
+
+var GroupToTerraformName = map[string]string{
+	"jobs":                    "databricks_job",
+	"pipelines":               "databricks_pipeline",
+	"models":                  "databricks_mlflow_model",
+	"experiments":             "databricks_mlflow_experiment",
+	"model_serving_endpoints": "databricks_model_serving",
+	"registered_models":       "databricks_registered_model",
+	"quality_monitors":        "databricks_quality_monitor",
+	"schemas":                 "databricks_schema",
+	"clusters":                "databricks_cluster",
+	"dashboards":              "databricks_dashboard",
+	"volumes":                 "databricks_volume",
+	"apps":                    "databricks_app",
+	"secret_scopes":           "databricks_secret_scope",
+}
+
+var TerraformToGroupName = func() map[string]string {
+	m := make(map[string]string, len(GroupToTerraformName))
+	for k, v := range GroupToTerraformName {
+		m[v] = k
+	}
+	return m
+}()

--- a/bundle/deploy/terraform/showplanfile.go
+++ b/bundle/deploy/terraform/showplanfile.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"context"
 
-	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/deployplan"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
@@ -12,12 +11,6 @@ import (
 // GetActions converts Terraform resource changes into deployplan.Action values.
 // The returned slice can be filtered using deployplan.Filter and FilterGroup helpers.
 func GetActions(changes []*tfjson.ResourceChange) []deployplan.Action {
-	supported := config.SupportedResources()
-	typeToGroup := make(map[string]string, len(supported))
-	for group, desc := range supported {
-		typeToGroup[desc.TerraformResourceName] = group
-	}
-
 	var result []deployplan.Action
 
 	for _, rc := range changes {
@@ -39,7 +32,7 @@ func GetActions(changes []*tfjson.ResourceChange) []deployplan.Action {
 			continue
 		}
 
-		group, ok := typeToGroup[rc.Type]
+		group, ok := TerraformToGroupName[rc.Type]
 		if !ok {
 			// Happens for databricks_grant, databricks_permissions, databricks_secrets_acl.
 			// These are automatically created by DABs, no need to show them.
@@ -58,10 +51,6 @@ func GetActions(changes []*tfjson.ResourceChange) []deployplan.Action {
 
 // ShowPlanFile reads a Terraform plan file located at planPath using the provided tfexec.Terraform handle
 // and converts it into a slice of deployplan.Action.
-//
-// The conversion maps Terraform resource types (e.g. "databricks_pipeline") to bundle configuration
-// resource groups (e.g. "pipelines") using config.SupportedResources(). If a resource type is not
-// recognised we fall back to the raw Terraform resource type so that the information is not lost.
 func ShowPlanFile(ctx context.Context, tf *tfexec.Terraform, planPath string) ([]deployplan.Action, error) {
 	plan, err := tf.ShowPlanFile(ctx, planPath)
 	if err != nil {

--- a/cmd/bundle/deployment/bind.go
+++ b/cmd/bundle/deployment/bind.go
@@ -58,9 +58,10 @@ func newBindCommand() *cobra.Command {
 			return nil
 		})
 
+		tfName := terraform.GroupToTerraformName[resource.ResourceDescription().PluralName]
 		diags = diags.Extend(phases.Bind(ctx, b, &terraform.BindOptions{
 			AutoApprove:  autoApprove,
-			ResourceType: resource.ResourceDescription().TerraformResourceName,
+			ResourceType: tfName,
 			ResourceKey:  args[0],
 			ResourceId:   args[1],
 		}))

--- a/cmd/bundle/deployment/unbind.go
+++ b/cmd/bundle/deployment/unbind.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/cmd/bundle/utils"
 	"github.com/databricks/cli/cmd/root"
@@ -44,7 +45,8 @@ func newUnbindCommand() *cobra.Command {
 			return nil
 		})
 
-		diags = diags.Extend(phases.Unbind(ctx, b, resource.ResourceDescription().TerraformResourceName, args[0]))
+		tfName := terraform.GroupToTerraformName[resource.ResourceDescription().PluralName]
+		diags = diags.Extend(phases.Unbind(ctx, b, tfName, args[0]))
 		if err := diags.Error(); err != nil {
 			return fmt.Errorf("failed to unbind the resource, err: %w", err)
 		}


### PR DESCRIPTION
## Changes
- Remove TerraformResourceName from ResourceDescription object
- Keep a mapping between DABs and TF names in bundle/deploy/terraform package.

## Why
- TerraformResourceName is implementation detail of TF deployment method. We are adding a different method where those names are irrelevant https://github.com/databricks/cli/pull/2926
- Map is what the users of this field want. All client code got simpler as a result.
- Having the mapping defined in one place is a good overview of what's happening. It's explicit, as discussed in https://github.com/databricks/cli/pull/2994#issuecomment-2979374912

## Tests
Existing tests.
