### PR TITLE
Make FromSlice and ToSlice methods private to the `deploy` package

### DIFF
--- a/bundle/deploy/state.go
+++ b/bundle/deploy/state.go
@@ -101,7 +101,7 @@ func (e *entry) Info() (fs.FileInfo, error) {
 	return e.info, nil
 }
 
-func FromSlice(files []fileset.File) (Filelist, error) {
+func fromSlice(files []fileset.File) (Filelist, error) {
 	var f Filelist
 	for k := range files {
 		file := &files[k]
@@ -117,7 +117,7 @@ func FromSlice(files []fileset.File) (Filelist, error) {
 	return f, nil
 }
 
-func (f Filelist) ToSlice(root vfs.Path) []fileset.File {
+func (f Filelist) toSlice(root vfs.Path) []fileset.File {
 	var files []fileset.File
 	for _, file := range f {
 		entry := newEntry(root, filepath.ToSlash(file.LocalPath))

--- a/bundle/deploy/state_pull.go
+++ b/bundle/deploy/state_pull.go
@@ -91,7 +91,7 @@ func (s *statePull) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostic
 	}
 
 	log.Infof(ctx, "Creating new snapshot")
-	snapshot, err := sync.NewSnapshot(state.Files.ToSlice(b.SyncRoot), opts)
+	snapshot, err := sync.NewSnapshot(state.Files.toSlice(b.SyncRoot), opts)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/deploy/state_test.go
+++ b/bundle/deploy/state_test.go
@@ -21,7 +21,7 @@ func TestFromSlice(t *testing.T) {
 	files, err := fileset.Files()
 	require.NoError(t, err)
 
-	f, err := FromSlice(files)
+	f, err := fromSlice(files)
 	require.NoError(t, err)
 	require.Len(t, f, 3)
 
@@ -41,11 +41,11 @@ func TestToSlice(t *testing.T) {
 	files, err := fileset.Files()
 	require.NoError(t, err)
 
-	f, err := FromSlice(files)
+	f, err := fromSlice(files)
 	require.NoError(t, err)
 	require.Len(t, f, 3)
 
-	s := f.ToSlice(root)
+	s := f.toSlice(root)
 	require.Len(t, s, 3)
 
 	for _, file := range s {

--- a/bundle/deploy/state_update.go
+++ b/bundle/deploy/state_update.go
@@ -40,7 +40,7 @@ func (s *stateUpdate) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnost
 	state.Version = DeploymentStateVersion
 
 	// Update the state with the current list of synced files.
-	fl, err := FromSlice(b.Files)
+	fl, err := fromSlice(b.Files)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

Keeping methods private to the package makes the code easier to comprehend - private methods are used only inside the package where they are defined

## Tests
<!-- How have you tested the changes? -->
Existing tests

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
