### PR TITLE
Normalize output paths when downloading files

### DIFF
--- a/bundle/generate/downloader.go
+++ b/bundle/generate/downloader.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/notebook"
+	"github.com/databricks/cli/libs/textutil"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
@@ -135,7 +136,13 @@ func (n *Downloader) relativePath(fullPath string) string {
 		relPath = relPath[1:]
 	}
 
-	return relPath
+	// Normalize path components.
+	components := strings.Split(relPath, "/")
+	for i, component := range components {
+		components[i] = textutil.NormalizePathComponent(component)
+	}
+
+	return strings.Join(components, "/")
 }
 
 func (n *Downloader) FlushToDisk(ctx context.Context, force bool) error {

--- a/bundle/generate/downloader_test.go
+++ b/bundle/generate/downloader_test.go
@@ -2,7 +2,10 @@ package generate
 
 import (
 	"context"
+	"maps"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
@@ -39,4 +42,70 @@ func TestDownloader_MarkFileReturnsRelativePath(t *testing.T) {
 	err = downloader.markFileForDownload(ctx, &f2)
 	require.NoError(t, err)
 	assert.Equal(t, filepath.FromSlash("../source/d"), f2)
+}
+
+func TestDownloader_NormalizeFilePath(t *testing.T) {
+	ctx := context.Background()
+	m := mocks.NewMockWorkspaceClient(t)
+
+	dir := "base/dir/doesnt/matter"
+	sourceDir := filepath.Join(dir, "source")
+	configDir := filepath.Join(dir, "config")
+	downloader := NewDownloader(m.WorkspaceClient, sourceDir, configDir)
+
+	var err error
+
+	// Test that the path is normalized to be relative to the config directory.
+	f1 := "/a/b/foo: <bar> (1).sql.   "
+	m.GetMockWorkspaceAPI().EXPECT().GetStatusByPath(ctx, f1).Return(&workspace.ObjectInfo{
+		Path: f1,
+	}, nil)
+	err = downloader.markFileForDownload(ctx, &f1)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.FromSlash("../source/foo_ _bar_ (1).sql"), f1)
+}
+
+func TestDownloader_NormalizeDirectoryPath(t *testing.T) {
+	ctx := context.Background()
+	m := mocks.NewMockWorkspaceClient(t)
+
+	dir := "base/dir/doesnt/matter"
+	sourceDir := filepath.Join(dir, "source")
+	configDir := filepath.Join(dir, "config")
+	downloader := NewDownloader(m.WorkspaceClient, sourceDir, configDir)
+
+	var err error
+
+	// Test that the path is normalized to be relative to the config directory.
+	f1 := "/a/b"
+	files := []workspace.ObjectInfo{
+		{
+			Path: path.Join(f1, "foo: <bar> (1).sql"),
+		},
+		{
+			Path: path.Join(f1, "con/nul/COM1/path.txt."),
+		},
+	}
+
+	m.GetMockWorkspaceAPI().EXPECT().GetStatusByPath(ctx, f1).Return(&workspace.ObjectInfo{
+		Path: f1,
+	}, nil)
+	m.GetMockWorkspaceAPI().EXPECT().RecursiveList(ctx, f1).Return(files, nil)
+	for _, file := range files {
+		m.GetMockWorkspaceAPI().EXPECT().GetStatusByPath(ctx, file.Path).Return(&file, nil)
+	}
+
+	err = downloader.MarkDirectoryForDownload(ctx, &f1)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.FromSlash("../source"), f1)
+
+	// Collect the output paths.
+	var outputs []string
+	for key := range maps.Keys(downloader.files) {
+		outputs = append(outputs, strings.TrimPrefix(key, sourceDir))
+	}
+
+	// Confirm that the output paths for the listed files are normalized.
+	assert.Contains(t, outputs, filepath.FromSlash("/foo_ _bar_ (1).sql"))
+	assert.Contains(t, outputs, filepath.FromSlash("/con_/nul_/COM1_/path.txt"))
 }

--- a/libs/textutil/textutil.go
+++ b/libs/textutil/textutil.go
@@ -2,6 +2,7 @@ package textutil
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -12,11 +13,11 @@ func NormalizeString(name string) string {
 	name = strings.ToLower(name)
 	s := strings.Map(replaceNonAlphanumeric, name)
 
-	// replacing multiple underscores with a single one
+	// Replacing multiple underscores with a single one.
 	re := regexp.MustCompile(`_+`)
 	s = re.ReplaceAllString(s, "_")
 
-	// removing leading and trailing underscores
+	// Removing leading and trailing underscores.
 	return strings.Trim(s, "_")
 }
 
@@ -25,4 +26,70 @@ func replaceNonAlphanumeric(r rune) rune {
 		return r
 	}
 	return '_'
+}
+
+// NormalizePathComponent creates a filesystem-safe filename by filtering out
+// characters that are not allowed in filenames, especially on Windows.
+// Windows-incompatible characters: < > : " | ? * \ /
+// It also handles reserved Windows filenames and ensures the result
+// is not empty, properly trimmed, and within length limits.
+// See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+func NormalizePathComponent(name string) string {
+	// Filter out filesystem-incompatible characters.
+	s := strings.Map(filterFilesystemIncompatible, name)
+
+	// Check for reserved Windows filenames (case-insensitive)
+	reservedNames := []string{
+		"CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+	}
+
+	// Remove file extension for comparison
+	baseName := s
+	if dotIndex := strings.LastIndex(s, "."); dotIndex != -1 {
+		baseName = s[:dotIndex]
+	}
+
+	// Check if the base name matches any reserved name (case-insensitive)
+	for _, reserved := range reservedNames {
+		if strings.EqualFold(baseName, reserved) {
+			// If it's a reserved name, append underscore to make it valid
+			if dotIndex := strings.LastIndex(s, "."); dotIndex != -1 {
+				// Has extension: insert underscore before extension
+				s = s[:dotIndex] + "_" + s[dotIndex:]
+			} else {
+				// No extension: append underscore
+				s = s + "_"
+			}
+			break
+		}
+	}
+
+	// Remove trailing spaces and periods from the filename
+	s = strings.TrimRight(s, " .")
+
+	// Ensure the filename is not empty after filtering.
+	if s == "" {
+		s = "untitled"
+	}
+
+	// Windows has a 255 character limit for filenames, so truncate if necessary.
+	if len(s) > 255 {
+		s = s[:255]
+	}
+
+	return s
+}
+
+var incompatibleRunes = []rune{'<', '>', ':', '"', '|', '?', '*', '\\', '/'}
+
+func filterFilesystemIncompatible(r rune) rune {
+	// Reject Windows-incompatible characters by returning -1 (which removes them).
+	if slices.Contains(incompatibleRunes, r) {
+		return '_'
+	}
+
+	// Keep all other characters.
+	return r
 }

--- a/libs/textutil/textutil_test.go
+++ b/libs/textutil/textutil_test.go
@@ -1,6 +1,7 @@
 package textutil
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +57,175 @@ func TestNormalizeString(t *testing.T) {
 	for _, c := range cases {
 		assert.Equal(t, c.expected, NormalizeString(c.input))
 	}
+}
+
+func TestNormalizePathComponent(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		// Basic cases
+		{
+			input:    "test",
+			expected: "test",
+		},
+		{
+			input:    "test-test",
+			expected: "test-test",
+		},
+		{
+			input:    "test_test",
+			expected: "test_test",
+		},
+		{
+			input:    "test.test",
+			expected: "test.test",
+		},
+		{
+			input:    "file with spaces.txt",
+			expected: "file with spaces.txt",
+		},
+		{
+			input:    "MixedCase File.txt",
+			expected: "MixedCase File.txt",
+		},
+		{
+			input:    "UPPERCASE_FILE.TXT",
+			expected: "UPPERCASE_FILE.TXT",
+		},
+		{
+			input:    "lowercase_file.txt",
+			expected: "lowercase_file.txt",
+		},
+		// Windows-incompatible characters
+		{
+			input:    "test/test",
+			expected: "test_test",
+		},
+		{
+			input:    "test/test.test",
+			expected: "test_test.test",
+		},
+		{
+			input:    ".test//test..test",
+			expected: ".test__test..test",
+		},
+		{
+			input:    "Test DLT: First Test",
+			expected: "Test DLT_ First Test",
+		},
+		{
+			input:    "Test DLT: First Test with multiple: colons and spaces",
+			expected: "Test DLT_ First Test with multiple_ colons and spaces",
+		},
+		{
+			input:    "Test DLT: First Test with special chars: < > : \" | ? * \\ /",
+			expected: "Test DLT_ First Test with special chars_ _ _ _ _ _ _ _ _ _",
+		},
+		{
+			input:    "file with <incompatible> chars",
+			expected: "file with _incompatible_ chars",
+		},
+		// Reserved Windows filenames
+		{
+			input:    "CON",
+			expected: "CON_",
+		},
+		{
+			input:    "COM1",
+			expected: "COM1_",
+		},
+		{
+			input:    "LPT1",
+			expected: "LPT1_",
+		},
+		{
+			input:    "CON.txt",
+			expected: "CON_.txt",
+		},
+		// Case-insensitive reserved names
+		{
+			input:    "con",
+			expected: "con_",
+		},
+		{
+			input:    "CON.TXT",
+			expected: "CON_.TXT",
+		},
+		// Trailing spaces and periods
+		{
+			input:    "test ",
+			expected: "test",
+		},
+		{
+			input:    "test  ",
+			expected: "test",
+		},
+		{
+			input:    "test.",
+			expected: "test",
+		},
+		{
+			input:    "test..",
+			expected: "test",
+		},
+		{
+			input:    "test .",
+			expected: "test",
+		},
+		{
+			input:    "test . ",
+			expected: "test",
+		},
+		{
+			input:    "test.txt ",
+			expected: "test.txt",
+		},
+		{
+			input:    "test.txt.",
+			expected: "test.txt",
+		},
+		{
+			input:    "test.txt .",
+			expected: "test.txt",
+		},
+		// Empty and invalid cases
+		{
+			input:    "",
+			expected: "untitled",
+		},
+		{
+			input:    ":::",
+			expected: "___",
+		},
+		{
+			input:    "***",
+			expected: "___",
+		},
+		{
+			input:    "   ",
+			expected: "untitled",
+		},
+		{
+			input:    "...",
+			expected: "untitled",
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.expected, NormalizePathComponent(c.input))
+	}
+}
+
+func TestNormalizePathComponentLengthLimit(t *testing.T) {
+	// Test that very long filenames are truncated
+	longName := strings.Repeat("a", 300)
+	result := NormalizePathComponent(longName)
+	assert.Len(t, result, 255)
+	assert.True(t, strings.HasSuffix(result, "a"))
+
+	// Test that truncation works correctly for long names
+	longNameWithSpaces := strings.Repeat("a ", 150)
+	result = NormalizePathComponent(longNameWithSpaces)
+	assert.Len(t, result, 255)
 }


### PR DESCRIPTION
## Changes

The "bundle generate" suite of commands generate bundle configuration and download relevant files from the workspace to the local file tree. Some paths that are valid in the Databricks workspace are not valid on Windows. This change normalizes path components to always be Windows-compatible.

## Why

Fix the class of issues demonstrated by #2528.

## Tests

* New unit tests.
* Manually confirmed that running "bundle generate" for a pipeline with a source file that includes incompatible characters now works as expected on Windows.