### PR TITLE
Update integration tests for the fs command

### DIFF
--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -41,14 +41,16 @@ func assertTargetFile(t *testing.T, ctx context.Context, f filer.Filer, relPath 
 
 func assertFileContent(t *testing.T, ctx context.Context, f filer.Filer, path, expectedContent string) {
 	r, err := f.Read(ctx, path)
-	if !assert.NoError(t, err) {
+	if err != nil {
+		assert.NoError(t, err)
 		return
 	}
 
 	defer r.Close()
 
 	b, err := io.ReadAll(r)
-	if !assert.NoError(t, err) {
+	if err != nil {
+		assert.NoError(t, err)
 		return
 	}
 

--- a/integration/cmd/fs/cp_test.go
+++ b/integration/cmd/fs/cp_test.go
@@ -36,22 +36,22 @@ func setupSourceFile(t *testing.T, ctx context.Context, f filer.Filer) {
 }
 
 func assertTargetFile(t *testing.T, ctx context.Context, f filer.Filer, relPath string) {
-	var err error
-
-	r, err := f.Read(ctx, relPath)
-	assert.NoError(t, err)
-	defer r.Close()
-	b, err := io.ReadAll(r)
-	require.NoError(t, err)
-	assert.Equal(t, "abc", string(b))
+	assertFileContent(t, ctx, f, relPath, "abc")
 }
 
 func assertFileContent(t *testing.T, ctx context.Context, f filer.Filer, path, expectedContent string) {
 	r, err := f.Read(ctx, path)
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	defer r.Close()
+
 	b, err := io.ReadAll(r)
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	assert.Equal(t, expectedContent, string(b))
 }
 
@@ -132,11 +132,11 @@ func TestFsCpDir(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", sourceDir, targetDir, "--recursive")
 
-			assertTargetDir(t, context.Background(), targetFiler)
+			assertTargetDir(t, ctx, targetFiler)
 		})
 	}
 }
@@ -151,11 +151,10 @@ func TestFsCpFileToFile(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceFile(t, context.Background(), sourceFiler)
+			setupSourceFile(t, ctx, sourceFiler)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "foo.txt"), path.Join(targetDir, "bar.txt"))
-
-			assertTargetFile(t, context.Background(), targetFiler, "bar.txt")
+			assertTargetFile(t, ctx, targetFiler, "bar.txt")
 		})
 	}
 }
@@ -170,11 +169,11 @@ func TestFsCpFileToDir(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceFile(t, context.Background(), sourceFiler)
+			setupSourceFile(t, ctx, sourceFiler)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "foo.txt"), targetDir)
 
-			assertTargetFile(t, context.Background(), targetFiler, "foo.txt")
+			assertTargetFile(t, ctx, targetFiler, "foo.txt")
 		})
 	}
 }
@@ -205,16 +204,16 @@ func TestFsCpDirToDirFileNotOverwritten(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "a/b/c/hello.txt", strings.NewReader("this should not be overwritten"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "a/b/c/hello.txt", strings.NewReader("this should not be overwritten"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", sourceDir, targetDir, "--recursive")
-			assertFileContent(t, context.Background(), targetFiler, "a/b/c/hello.txt", "this should not be overwritten")
-			assertFileContent(t, context.Background(), targetFiler, "query.sql", "SELECT 1")
-			assertFileContent(t, context.Background(), targetFiler, "pyNb.py", "# Databricks notebook source\nprint(123)")
+			assertFileContent(t, ctx, targetFiler, "a/b/c/hello.txt", "this should not be overwritten")
+			assertFileContent(t, ctx, targetFiler, "query.sql", "SELECT 1")
+			assertFileContent(t, ctx, targetFiler, "pyNb.py", "# Databricks notebook source\nprint(123)")
 		})
 	}
 }
@@ -229,14 +228,14 @@ func TestFsCpFileToDirFileNotOverwritten(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "a/b/c/hello.txt", strings.NewReader("this should not be overwritten"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "a/b/c/hello.txt", strings.NewReader("this should not be overwritten"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "a/b/c/hello.txt"), path.Join(targetDir, "a/b/c"))
-			assertFileContent(t, context.Background(), targetFiler, "a/b/c/hello.txt", "this should not be overwritten")
+			assertFileContent(t, ctx, targetFiler, "a/b/c/hello.txt", "this should not be overwritten")
 		})
 	}
 }
@@ -251,14 +250,14 @@ func TestFsCpFileToFileFileNotOverwritten(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "a/b/c/dontoverwrite.txt", strings.NewReader("this should not be overwritten"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "a/b/c/dontoverwrite.txt", strings.NewReader("this should not be overwritten"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "a/b/c/hello.txt"), path.Join(targetDir, "a/b/c/dontoverwrite.txt"))
-			assertFileContent(t, context.Background(), targetFiler, "a/b/c/dontoverwrite.txt", "this should not be overwritten")
+			assertFileContent(t, ctx, targetFiler, "a/b/c/dontoverwrite.txt", "this should not be overwritten")
 		})
 	}
 }
@@ -273,14 +272,14 @@ func TestFsCpDirToDirWithOverwriteFlag(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "a/b/c/hello.txt", strings.NewReader("this should be overwritten"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "a/b/c/hello.txt", strings.NewReader("this should be overwritten"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", sourceDir, targetDir, "--recursive", "--overwrite")
-			assertTargetDir(t, context.Background(), targetFiler)
+			assertTargetDir(t, ctx, targetFiler)
 		})
 	}
 }
@@ -295,14 +294,14 @@ func TestFsCpFileToFileWithOverwriteFlag(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "a/b/c/overwritten.txt", strings.NewReader("this should be overwritten"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "a/b/c/overwritten.txt", strings.NewReader("this should be overwritten"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "a/b/c/hello.txt"), path.Join(targetDir, "a/b/c/overwritten.txt"), "--overwrite")
-			assertFileContent(t, context.Background(), targetFiler, "a/b/c/overwritten.txt", "hello, world\n")
+			assertFileContent(t, ctx, targetFiler, "a/b/c/overwritten.txt", "hello, world\n")
 		})
 	}
 }
@@ -317,14 +316,14 @@ func TestFsCpFileToDirWithOverwriteFlag(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "a/b/c/hello.txt", strings.NewReader("this should be overwritten"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "a/b/c/hello.txt", strings.NewReader("this should be overwritten"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			testcli.RequireSuccessfulRun(t, ctx, "fs", "cp", path.Join(sourceDir, "a/b/c/hello.txt"), path.Join(targetDir, "a/b/c"), "--overwrite")
-			assertFileContent(t, context.Background(), targetFiler, "a/b/c/hello.txt", "hello, world\n")
+			assertFileContent(t, ctx, targetFiler, "a/b/c/hello.txt", "hello, world\n")
 		})
 	}
 }
@@ -362,10 +361,10 @@ func TestFsCpSourceIsDirectoryButTargetIsFile(t *testing.T) {
 			ctx := context.Background()
 			sourceFiler, sourceDir := testCase.setupSource(t)
 			targetFiler, targetDir := testCase.setupTarget(t)
-			setupSourceDir(t, context.Background(), sourceFiler)
+			setupSourceDir(t, ctx, sourceFiler)
 
 			// Write a conflicting file to target
-			err := targetFiler.Write(context.Background(), "my_target", strings.NewReader("I'll block any attempts to recursively copy"), filer.CreateParentDirectories)
+			err := targetFiler.Write(ctx, "my_target", strings.NewReader("I'll block any attempts to recursively copy"), filer.CreateParentDirectories)
 			require.NoError(t, err)
 
 			_, _, err = testcli.RequireErrorRun(t, ctx, "fs", "cp", sourceDir, path.Join(targetDir, "my_target"), "--recursive")


### PR DESCRIPTION
## Changes

* Fix potential panic
* Reuse ctx variable

## Why

I observed the following panic. The code could access `r` after a failed assertion here:
https://github.com/databricks/cli/blob/fb2b646997789ef15d89c805f2b77548e4665dfe/integration/cmd/fs/cp_test.go#L41-L46

```
=== FAIL: integration/cmd/fs TestFsCpFileToFile (99.64s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11e4b13]

goroutine 344 [running]:
testing.tRunner.func1.2({0x1450540, 0x25334c0})
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/testing/testing.go:1737 +0x35e
panic({0x1450540?, 0x25334c0?})
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/runtime/panic.go:792 +0x132
github.com/databricks/cli/integration/cmd/fs_test.assertTargetFile(0xc0004b4540, {0x19b5c60?, 0x2589080?}, {0x19bc0b0?, 0xc00111c980?}, {0x1734a1a?, 0xc0004b4540?})
	/home/runner/work/eng-dev-ecosystem/eng-dev-ecosystem/ext/cli/integration/cmd/fs/cp_test.go:43 +0x93
github.com/databricks/cli/integration/cmd/fs_test.TestFsCpFileToFile.func1(0xc0004b4540)
	/home/runner/work/eng-dev-ecosystem/eng-dev-ecosystem/ext/cli/integration/cmd/fs/cp_test.go:158 +0x2a5
testing.tRunner(0xc0004b4540, 0xc000551170)
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 96
	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.linux-amd64/src/testing/testing.go:1851 +0x413
```

## Tests

Tests still pass.