### PR TITLE
Increase timeout of bundle/resources/pipelines acc test to 30s

### DIFF
--- a/acceptance/bundle/resources/pipelines/test.toml
+++ b/acceptance/bundle/resources/pipelines/test.toml
@@ -1,2 +1,3 @@
+Timeout = '30s'
 Cloud = true
 Ignore = ["bar.py", "foo.py"]


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

Saw that this test is failing due to 20s timeout here: https://github.com/databricks/cli/actions/runs/15776275558/job/44471399166?pr=3089
