### PR TITLE
internal: Bundle: replace *Plan with Plan

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -101,7 +101,7 @@ type Bundle struct {
 	// Stores the locker responsible for acquiring/releasing a deployment lock.
 	Locker *locker.Locker
 
-	Plan *deployplan.Plan
+	Plan deployplan.Plan
 
 	// if true, we skip approval checks for deploy, destroy resources and delete
 	// files

--- a/bundle/deploy/terraform/plan.go
+++ b/bundle/deploy/terraform/plan.go
@@ -51,7 +51,7 @@ func (p *plan) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	}
 
 	// Set plan in main bundle struct for downstream mutators
-	b.Plan = &deployplan.Plan{
+	b.Plan = deployplan.Plan{
 		Path:    planPath,
 		IsEmpty: !notEmpty,
 	}


### PR DESCRIPTION
## Why
Pointer is unnecessary. User code already checks Plan.Path == "" rather than Path == nil.
