### PR TITLE
Inject delay in filer tests on GCP

### DIFF
--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/filer"
@@ -456,6 +457,13 @@ func TestFilerWorkspaceNotebook(t *testing.T) {
 			// Try uploading the notebook again with overwrite flag. This time it should succeed.
 			err = f.Write(ctx, tc.name, strings.NewReader(tc.content2), filer.OverwriteIfExists)
 			require.NoError(t, err)
+
+			// @pietern on 2025-06-23: We're debugging a read-after-write delay on GCP.
+			// Include sleep to make tests pass...
+			if testutil.GetCloud(t) == testutil.GCP {
+				t.Logf("Running on GCP; sleeping for 5 seconds to make tests pass...")
+				time.Sleep(5 * time.Second)
+			}
 
 			// Assert contents after second upload
 			filerTest{t, f}.assertContents(ctx, tc.nameWithoutExt, tc.expected2)


### PR DESCRIPTION
## Changes

Temporary workaround to make tests pass while debugging.

## Why

Hypothesis: I'm unable to repro the same situation through the Python SDK, and suspect that the Go SDK performs a reconnect under the hood. This might route us to a different backend instance and return a cached copy where reusing the original connection would return the right contents.

## Tests

Tests pass with the workaround.