### PR TITLE
Pass through OIDC token env variable to Terraform

### DIFF
--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -158,6 +158,12 @@ func inheritEnvVars(ctx context.Context, environ map[string]string) error {
 		}
 	}
 
+	// If there's a DATABRICKS_OIDC_TOKEN_ENV set, we need to pass the value of the environment variable defined in DATABRICKS_OIDC_TOKEN_ENV to Terraform.
+	// This is necessary to ensure that Terraform can use the same OIDC token as the CLI.
+	if oidcTokenEnv, ok := env.Lookup(ctx, "DATABRICKS_OIDC_TOKEN_ENV"); ok {
+		environ[oidcTokenEnv] = env.Get(ctx, oidcTokenEnv)
+	}
+
 	// Map $DATABRICKS_TF_CLI_CONFIG_FILE to $TF_CLI_CONFIG_FILE
 	// VSCode extension provides a file with the "provider_installation.filesystem_mirror" configuration.
 	// We only use it if the provider version matches the currently used version,

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -160,8 +160,14 @@ func inheritEnvVars(ctx context.Context, environ map[string]string) error {
 
 	// If there's a DATABRICKS_OIDC_TOKEN_ENV set, we need to pass the value of the environment variable defined in DATABRICKS_OIDC_TOKEN_ENV to Terraform.
 	// This is necessary to ensure that Terraform can use the same OIDC token as the CLI.
-	if oidcTokenEnv, ok := env.Lookup(ctx, "DATABRICKS_OIDC_TOKEN_ENV"); ok {
-		environ[oidcTokenEnv] = env.Get(ctx, oidcTokenEnv)
+	oidcTokenEnv, ok := env.Lookup(ctx, "DATABRICKS_OIDC_TOKEN_ENV")
+	if !ok {
+		oidcTokenEnv = "DATABRICKS_OIDC_TOKEN"
+	}
+
+	oidcToken, ok := env.Lookup(ctx, oidcTokenEnv)
+	if ok {
+		environ[oidcTokenEnv] = oidcToken
 	}
 
 	// Map $DATABRICKS_TF_CLI_CONFIG_FILE to $TF_CLI_CONFIG_FILE

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -287,8 +287,18 @@ func TestInheritEnvVars(t *testing.T) {
 	}
 }
 
+func TestInheritOIDCTokenEnvCustom(t *testing.T) {
+	t.Setenv("DATABRICKS_OIDC_TOKEN_ENV", "custom_DATABRICKS_OIDC_TOKEN")
+	t.Setenv("custom_DATABRICKS_OIDC_TOKEN", "foobar")
+
+	ctx := context.Background()
+	env := map[string]string{}
+	err := inheritEnvVars(ctx, env)
+	require.NoError(t, err)
+	assert.Equal(t, "foobar", env["custom_DATABRICKS_OIDC_TOKEN"])
+}
+
 func TestInheritOIDCTokenEnv(t *testing.T) {
-	t.Setenv("DATABRICKS_OIDC_TOKEN_ENV", "DATABRICKS_OIDC_TOKEN")
 	t.Setenv("DATABRICKS_OIDC_TOKEN", "foobar")
 
 	ctx := context.Background()

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -287,6 +287,17 @@ func TestInheritEnvVars(t *testing.T) {
 	}
 }
 
+func TestInheritOIDCTokenEnv(t *testing.T) {
+	t.Setenv("DATABRICKS_OIDC_TOKEN_ENV", "DATABRICKS_OIDC_TOKEN")
+	t.Setenv("DATABRICKS_OIDC_TOKEN", "foobar")
+
+	ctx := context.Background()
+	env := map[string]string{}
+	err := inheritEnvVars(ctx, env)
+	require.NoError(t, err)
+	assert.Equal(t, "foobar", env["DATABRICKS_OIDC_TOKEN"])
+}
+
 func TestSetUserProfileFromInheritEnvVars(t *testing.T) {
 	t.Setenv("USERPROFILE", "c:\\foo\\c")
 


### PR DESCRIPTION
## Changes
Pass through OIDC token env variable to Terraform

## Why
This allows OIDC auth to correctly work in DABs, otherwise it fails with 
```
Error: cannot create job: failed during request visitor: env-oidc auth: missing env var "DATABRICKS_OIDC_TOKEN". Config: host=*** client_id=***. Env: DATABRICKS_HOST, DATABRICKS_CLIENT_ID
```

## Tests
Added unit test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
