### PR TITLE
acc: Replace new lines and spaces in dashboard output on GCP

### DIFF
--- a/acceptance/bundle/deploy/dashboard/detect-change/test.toml
+++ b/acceptance/bundle/deploy/dashboard/detect-change/test.toml
@@ -14,3 +14,8 @@ MSYS_NO_PATHCONV = "1"
 [[Repls]]
 Old = "[0-9a-z]{16,}"
 New = "[ALPHANUMID]"
+
+# Remove newlines and extra spaces from the output which is present in GCP
+[[Repls]]
+Old = "\\n\\s+"
+New = ""


### PR DESCRIPTION
## Changes
acc: Replace new lines and spaces in dashboard output on GCP

## Why
Integrations tests failing because of it

## Tests
Covered by existing tests
