### PR TITLE
Remove IResource.GetType() method

### DIFF
--- a/bundle/terranova/apply.go
+++ b/bundle/terranova/apply.go
@@ -120,7 +120,7 @@ func (d *Deployer) destroy(ctx context.Context, inputConfig any) error {
 		return nil
 	}
 
-	resource, err := tnresources.New(d.client, d.section, d.resourceName, inputConfig)
+	resource, _, err := tnresources.New(d.client, d.section, d.resourceName, inputConfig)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (d *Deployer) destroy(ctx context.Context, inputConfig any) error {
 func (d *Deployer) deploy(ctx context.Context, inputConfig any, actionType deployplan.ActionType) error {
 	entry, hasEntry := d.db.GetResourceEntry(d.section, d.resourceName)
 
-	resource, err := tnresources.New(d.client, d.section, d.resourceName, inputConfig)
+	resource, cfgType, err := tnresources.New(d.client, d.section, d.resourceName, inputConfig)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (d *Deployer) deploy(ctx context.Context, inputConfig any, actionType deplo
 		return errors.New("invalid state: empty id")
 	}
 
-	savedState, err := typeConvert(resource.GetType(), entry.State)
+	savedState, err := typeConvert(cfgType, entry.State)
 	if err != nil {
 		return fmt.Errorf("interpreting state: %w", err)
 	}
@@ -218,7 +218,7 @@ func (d *Deployer) Recreate(ctx context.Context, oldResource tnresources.IResour
 		return fmt.Errorf("deleting state: %w", err)
 	}
 
-	newResource, err := tnresources.New(d.client, d.section, d.resourceName, config)
+	newResource, _, err := tnresources.New(d.client, d.section, d.resourceName, config)
 	if err != nil {
 		return fmt.Errorf("initializing: %w", err)
 	}

--- a/bundle/terranova/plan.go
+++ b/bundle/terranova/plan.go
@@ -25,7 +25,7 @@ type Planner struct {
 func (d *Planner) Plan(ctx context.Context, inputConfig any) (deployplan.ActionType, error) {
 	entry, hasEntry := d.db.GetResourceEntry(d.section, d.resourceName)
 
-	resource, err := tnresources.New(d.client, d.section, d.resourceName, inputConfig)
+	resource, cfgType, err := tnresources.New(d.client, d.section, d.resourceName, inputConfig)
 	if err != nil {
 		return "", err
 	}
@@ -41,7 +41,7 @@ func (d *Planner) Plan(ctx context.Context, inputConfig any) (deployplan.ActionT
 		return "", errors.New("invalid state: empty id")
 	}
 
-	savedState, err := typeConvert(resource.GetType(), entry.State)
+	savedState, err := typeConvert(cfgType, entry.State)
 	if err != nil {
 		return "", fmt.Errorf("interpreting state: %w", err)
 	}

--- a/bundle/terranova/tnresources/app.go
+++ b/bundle/terranova/tnresources/app.go
@@ -2,7 +2,6 @@ package tnresources
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/bundle/deployplan"
@@ -73,10 +72,4 @@ func (r *ResourceApp) WaitAfterUpdate(ctx context.Context) error {
 func (r *ResourceApp) ClassifyChanges(changes []structdiff.Change) deployplan.ActionType {
 	// TODO: changing name is recreation
 	return deployplan.ActionTypeUpdate
-}
-
-var appType = reflect.TypeOf(ResourceApp{}.config)
-
-func (r *ResourceApp) GetType() reflect.Type {
-	return appType
 }

--- a/bundle/terranova/tnresources/job.go
+++ b/bundle/terranova/tnresources/job.go
@@ -2,7 +2,6 @@ package tnresources
 
 import (
 	"context"
-	"reflect"
 	"strconv"
 
 	"github.com/databricks/cli/bundle/config/resources"
@@ -85,12 +84,6 @@ func makeCreateJob(config jobs.JobSettings) (jobs.CreateJob, error) {
 	// Unset AccessControlList
 	err := copyViaJSON(&result, config)
 	return result, err
-}
-
-var jobSettingsType = reflect.TypeOf(jobs.JobSettings{})
-
-func (r *ResourceJob) GetType() reflect.Type {
-	return jobSettingsType
 }
 
 func makeResetJob(config jobs.JobSettings, id string) (jobs.ResetJob, error) {

--- a/bundle/terranova/tnresources/pipeline.go
+++ b/bundle/terranova/tnresources/pipeline.go
@@ -2,7 +2,6 @@ package tnresources
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/bundle/deployplan"
@@ -73,10 +72,4 @@ func (r *ResourcePipeline) WaitAfterUpdate(ctx context.Context) error {
 
 func (r *ResourcePipeline) ClassifyChanges(changes []structdiff.Change) deployplan.ActionType {
 	return deployplan.ActionTypeUpdate
-}
-
-var pipelineType = reflect.TypeOf(ResourcePipeline{}.config)
-
-func (r *ResourcePipeline) GetType() reflect.Type {
-	return pipelineType
 }

--- a/bundle/terranova/tnresources/resource_test.go
+++ b/bundle/terranova/tnresources/resource_test.go
@@ -1,6 +1,7 @@
 package tnresources
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/databricks/cli/bundle/config/resources"
@@ -18,12 +19,14 @@ func TestNewJobResource(t *testing.T) {
 		},
 	}
 
-	res, err := New(client, "jobs", "test-job", cfg)
+	res, cfgType, err := New(client, "jobs", "test-job", cfg)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
 	// Ensure we received the correct resource type.
 	require.IsType(t, &ResourceJob{}, res)
+	require.IsType(t, reflect.TypeOf(ResourceJob{}.config), cfgType)
+	require.IsType(t, reflect.TypeOf(jobs.JobSettings{}), cfgType)
 
 	// The underlying config should match what we passed in.
 	r := res.(*ResourceJob)

--- a/bundle/terranova/tnresources/schema.go
+++ b/bundle/terranova/tnresources/schema.go
@@ -2,7 +2,6 @@ package tnresources
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/bundle/deployplan"
@@ -69,10 +68,4 @@ func (r *ResourceSchema) WaitAfterUpdate(ctx context.Context) error {
 
 func (r *ResourceSchema) ClassifyChanges(changes []structdiff.Change) deployplan.ActionType {
 	return deployplan.ActionTypeUpdate
-}
-
-var schemaType = reflect.TypeOf(ResourceSchema{}.config)
-
-func (r *ResourceSchema) GetType() reflect.Type {
-	return schemaType
 }


### PR DESCRIPTION
## Why
There is no need for this to be a method, since type is static. Better to track it centrally, since it defines schema in resources.json.