### PR TITLE
summary/run/open: pull App and SecretScope's name into ID field, not Name

### DIFF
--- a/acceptance/bundle/deploy/secret-scope/output.txt
+++ b/acceptance/bundle/deploy/secret-scope/output.txt
@@ -8,6 +8,7 @@ Deployment complete!
 >>> [CLI] bundle summary --output json
 {
   "backend_type": "DATABRICKS",
+  "id": "my-secrets-[UUID]",
   "modified_status": "created",
   "name": "my-secrets-[UUID]",
   "permissions": [

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -23,6 +23,10 @@ type AppPermission struct {
 }
 
 type App struct {
+	// This is app's name pulled from the state. Usually the same as Name but may be different if Name in the config
+	// was changed but the app was not re-deployed yet.
+	ID string `json:"id,omitempty" bundle:"readonly"`
+
 	// SourceCodePath is a required field used by DABs to point to Databricks app source code
 	// on local disk and to the corresponding workspace path during app deployment.
 	SourceCodePath string `json:"source_code_path"`
@@ -70,11 +74,15 @@ func (a *App) InitializeURL(baseURL url.URL) {
 	if a.ModifiedStatus == "" || a.ModifiedStatus == ModifiedStatusCreated {
 		return
 	}
-	baseURL.Path = "apps/" + a.Name
+	baseURL.Path = "apps/" + a.GetName()
 	a.URL = baseURL.String()
 }
 
 func (a *App) GetName() string {
+	// Prefer name from the state - that is what is actually deployed
+	if a.ID != "" {
+		return a.ID
+	}
 	return a.Name
 }
 

--- a/bundle/config/resources/secret_scope.go
+++ b/bundle/config/resources/secret_scope.go
@@ -23,6 +23,9 @@ type SecretScopePermission struct {
 }
 
 type SecretScope struct {
+	// ID is Name that is stored in resources state, usually the same as Name unless re-deployment is pending.
+	ID string `json:"id,omitempty" bundle:"readonly"`
+
 	// A unique name to identify the secret scope.
 	Name string `json:"name"`
 
@@ -82,6 +85,9 @@ func (s SecretScope) ResourceDescription() ResourceDescription {
 }
 
 func (s SecretScope) GetName() string {
+	if s.ID != "" {
+		return s.ID
+	}
 	return s.Name
 }
 

--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -208,7 +208,6 @@ func TerraformToBundle(state *resourcesState, config *config.Root) error {
 					// because we don't really know if the app source code was updated or not.
 					cur.ModifiedStatus = resources.ModifiedStatusUpdated
 				}
-				cur.Name = instance.Attributes.Name
 				config.Resources.Apps[resource.Name] = cur
 			case "databricks_secret_scope":
 				if config.Resources.SecretScopes == nil {
@@ -218,7 +217,6 @@ func TerraformToBundle(state *resourcesState, config *config.Root) error {
 				if cur == nil {
 					cur = &resources.SecretScope{ModifiedStatus: resources.ModifiedStatusDeleted}
 				}
-				cur.Name = instance.Attributes.Name
 				config.Resources.SecretScopes[resource.Name] = cur
 			case "databricks_permissions":
 			case "databricks_grants":

--- a/bundle/deploy/terraform/convert.go
+++ b/bundle/deploy/terraform/convert.go
@@ -208,6 +208,7 @@ func TerraformToBundle(state *resourcesState, config *config.Root) error {
 					// because we don't really know if the app source code was updated or not.
 					cur.ModifiedStatus = resources.ModifiedStatusUpdated
 				}
+				cur.ID = instance.Attributes.Name
 				config.Resources.Apps[resource.Name] = cur
 			case "databricks_secret_scope":
 				if config.Resources.SecretScopes == nil {
@@ -217,6 +218,7 @@ func TerraformToBundle(state *resourcesState, config *config.Root) error {
 				if cur == nil {
 					cur = &resources.SecretScope{ModifiedStatus: resources.ModifiedStatusDeleted}
 				}
+				cur.ID = instance.Attributes.Name
 				config.Resources.SecretScopes[resource.Name] = cur
 			case "databricks_permissions":
 			case "databricks_grants":

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -749,6 +749,7 @@ func TestTerraformToBundleEmptyLocalResources(t *testing.T) {
 	assert.Equal(t, "1", config.Resources.Dashboards["test_dashboard"].ID)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Dashboards["test_dashboard"].ModifiedStatus)
 
+	assert.Equal(t, "app1", config.Resources.Apps["test_app"].ID)
 	assert.Equal(t, "", config.Resources.Apps["test_app"].Name)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Apps["test_app"].ModifiedStatus)
 
@@ -1335,6 +1336,7 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 
 	assert.Equal(t, "test_app", config.Resources.Apps["test_app"].Name)
 	assert.Equal(t, resources.ModifiedStatusUpdated, config.Resources.Apps["test_app"].ModifiedStatus)
+	assert.Equal(t, "test_app_old", config.Resources.Apps["test_app_old"].ID)
 	assert.Equal(t, "", config.Resources.Apps["test_app_old"].Name)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Apps["test_app_old"].ModifiedStatus)
 	assert.Equal(t, "test_app_new", config.Resources.Apps["test_app_new"].Name)

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -749,7 +749,7 @@ func TestTerraformToBundleEmptyLocalResources(t *testing.T) {
 	assert.Equal(t, "1", config.Resources.Dashboards["test_dashboard"].ID)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Dashboards["test_dashboard"].ModifiedStatus)
 
-	assert.Equal(t, "app1", config.Resources.Apps["test_app"].Name)
+	assert.Equal(t, "", config.Resources.Apps["test_app"].Name)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Apps["test_app"].ModifiedStatus)
 
 	AssertFullResourceCoverage(t, &config)
@@ -1335,7 +1335,7 @@ func TestTerraformToBundleModifiedResources(t *testing.T) {
 
 	assert.Equal(t, "test_app", config.Resources.Apps["test_app"].Name)
 	assert.Equal(t, resources.ModifiedStatusUpdated, config.Resources.Apps["test_app"].ModifiedStatus)
-	assert.Equal(t, "test_app_old", config.Resources.Apps["test_app_old"].Name)
+	assert.Equal(t, "", config.Resources.Apps["test_app_old"].Name)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Apps["test_app_old"].ModifiedStatus)
 	assert.Equal(t, "test_app_new", config.Resources.Apps["test_app_new"].Name)
 	assert.Equal(t, resources.ModifiedStatusCreated, config.Resources.Apps["test_app_new"].ModifiedStatus)


### PR DESCRIPTION
## Changes
When doing Terraform.Load (bundle summary/run/open), do not override app.name and secret_scope.name fields that come from the config with the one stored in Terraform state. Instead store state value in the "id" field.

## Why
Conceptually, we separate configuration field (Name) and stored state field (ID, which is Name from last deployment). This means as a user I can see both. Today, configuration's Name is lost in "bundle summary". However, in "bundle validate" Name would be equal to the one from the config, which is confusing -- potentially they could be different.

Internally, this makes TerraformToBundle simpler - it only updates ID field and ModifiedStatus (both are always computed and don't come from the user). This means configuration is preserved and also we can make TerraformToBundle generic so that it does not need to have per-resource code (which becomes 2x when we add direct deployment method support).

## Tests
Existing tests.