### PR TITLE
Expand coverage for "bundle summary"

### DIFF
--- a/acceptance/bundle/deploy/dashboard/detect-change/output.txt
+++ b/acceptance/bundle/deploy/dashboard/detect-change/output.txt
@@ -1,4 +1,16 @@
 
+=== Check summary before deployment -- should not have id but should have modified_status=created
+>>> [CLI] bundle summary --output json
+{
+  "display_name": "test-dashboard-[UNIQUE_NAME]",
+  "embed_credentials": false,
+  "file_path": "dashboard.lvdash.json",
+  "modified_status": "created",
+  "parent_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources",
+  "permissions": [],
+  "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
+}
+
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files...
 Deploying resources...
@@ -10,6 +22,21 @@ Deployment complete!
 {
   "object_type": "DASHBOARD",
   "path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources/test-dashboard-[UNIQUE_NAME].lvdash.json"
+}
+
+=== Check summary again -- should have id but no modified_status
+>>> [CLI] bundle summary --output json
+
+>>> cat out.summary.json
+{
+  "display_name": "test-dashboard-[UNIQUE_NAME]",
+  "embed_credentials": false,
+  "file_path": "dashboard.lvdash.json",
+  "id": "[ALPHANUMID]",
+  "parent_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources",
+  "permissions": [],
+  "url": "[DATABRICKS_URL]/dashboardsv3/[ALPHANUMID]/published?o=[NUMID]",
+  "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
 }
 
 === Load the dashboard by its ID and confirm its display name: {

--- a/acceptance/bundle/deploy/dashboard/detect-change/script
+++ b/acceptance/bundle/deploy/dashboard/detect-change/script
@@ -5,6 +5,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+title "Check summary before deployment -- should not have id but should have modified_status=created"
+trace $CLI bundle summary --output json | jq '.resources.dashboards.file_reference' | jq 'del(.serialized_dashboard)'
 trace $CLI bundle deploy
 
 title "Assert that the dashboard exists at the expected path and is, indeed, a dashboard:"
@@ -12,8 +14,12 @@ RESOURCE_PATH=$($CLI bundle validate -o json | jq -r '.workspace.resource_path')
 DASHBOARD_PATH="${RESOURCE_PATH}/test-dashboard-${UNIQUE_NAME}.lvdash.json"
 trace $CLI workspace get-status "${DASHBOARD_PATH}" | jq '{object_type,path}'
 
+title "Check summary again -- should have id but no modified_status"
+trace $CLI bundle summary --output json | jq '.resources.dashboards.file_reference' | jq 'del(.serialized_dashboard)' > out.summary.json
+trace cat out.summary.json
+DASHBOARD_ID=$(jq -r '.id' out.summary.json)
+rm out.summary.json
 title "Load the dashboard by its ID and confirm its display name: "
-DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.file_reference.id')
 $CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name,page_display_name: (.serialized_dashboard | fromjson | .pages[0].displayName)}'
 
 title "Make an out of band modification to the dashboard and confirm that it is detected:\n"

--- a/acceptance/bundle/deploy/jobs/check-metadata/output.txt
+++ b/acceptance/bundle/deploy/jobs/check-metadata/output.txt
@@ -1,9 +1,74 @@
 
+=== First summary, should not have id and modified_status should be created
+>>> [CLI] bundle summary -o json
+{
+  "deployment": {
+    "kind": "BUNDLE",
+    "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/state/metadata.json"
+  },
+  "edit_mode": "UI_LOCKED",
+  "format": "MULTI_TASK",
+  "max_concurrent_runs": 1,
+  "modified_status": "created",
+  "name": "test-job-metadata-1-[UNIQUE_NAME]",
+  "permissions": [],
+  "queue": {
+    "enabled": true
+  },
+  "tasks": [
+    {
+      "new_cluster": {
+        "node_type_id": "[NODE_TYPE_ID]",
+        "num_workers": 1,
+        "spark_version": "13.3.x-snapshot-scala2.12"
+      },
+      "notebook_task": {
+        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/foo"
+      },
+      "task_key": "my_notebook_task"
+    }
+  ]
+}
+
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
+
+=== Second summary, should have id and modified status should be absent
+>>> [CLI] bundle summary -o json
+
+>>> cat out.summary.json
+{
+  "deployment": {
+    "kind": "BUNDLE",
+    "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/state/metadata.json"
+  },
+  "edit_mode": "UI_LOCKED",
+  "format": "MULTI_TASK",
+  "id": "[NUMID]",
+  "max_concurrent_runs": 1,
+  "name": "test-job-metadata-1-[UNIQUE_NAME]",
+  "permissions": [],
+  "queue": {
+    "enabled": true
+  },
+  "tasks": [
+    {
+      "new_cluster": {
+        "node_type_id": "[NODE_TYPE_ID]",
+        "num_workers": 1,
+        "spark_version": "13.3.x-snapshot-scala2.12"
+      },
+      "notebook_task": {
+        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/foo"
+      },
+      "task_key": "my_notebook_task"
+    }
+  ],
+  "url": "[DATABRICKS_URL]/jobs/[NUMID]?o=[NUMID]"
+}
 
 === Assert job 1 is created
 {

--- a/acceptance/bundle/deploy/jobs/check-metadata/script
+++ b/acceptance/bundle/deploy/jobs/check-metadata/script
@@ -6,10 +6,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
+title "First summary, should not have id and modified_status should be created"
+trace $CLI bundle summary -o json | jq '.resources.jobs.foo'
 trace $CLI bundle deploy
 
+title "Second summary, should have id and modified status should be absent"
+trace $CLI bundle summary -o json | jq '.resources.jobs.foo' > out.summary.json
+trace cat out.summary.json
+JOB_1_ID=$(jq -r '.id' out.summary.json)
+rm out.summary.json
 title "Assert job 1 is created\n"
-JOB_1_ID=$($CLI bundle summary -o json | jq -r '.resources.jobs.foo.id')
 $CLI jobs get "${JOB_1_ID}" | jq '{name: .settings.name}'
 
 title "Assert job 2 is created\n"

--- a/acceptance/bundle/deploy/secret-scope/output.txt
+++ b/acceptance/bundle/deploy/secret-scope/output.txt
@@ -1,10 +1,29 @@
 
+=== Print summary before deploy; it should have modified_status=created and no id
+>>> [CLI] bundle summary --output json
+{
+  "backend_type": "DATABRICKS",
+  "modified_status": "created",
+  "name": "my-secrets-[UUID]",
+  "permissions": [
+    {
+      "level": "WRITE",
+      "user_name": "admins"
+    },
+    {
+      "level": "READ",
+      "user_name": "users"
+    }
+  ]
+}
+
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-secret-scope-test-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
 
+=== Print summary after deploy; it should have id and no modified_status. Badness: incorrectly shows modified_status=created
 >>> [CLI] bundle summary --output json
 {
   "backend_type": "DATABRICKS",

--- a/acceptance/bundle/deploy/secret-scope/script
+++ b/acceptance/bundle/deploy/secret-scope/script
@@ -11,7 +11,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
+title "Print summary before deploy; it should have modified_status=created and no id"
+trace $CLI bundle summary --output json | jq '.resources.secret_scopes.secret_scope1'
 trace $CLI bundle deploy
+title "Print summary after deploy; it should have id and no modified_status. Badness: incorrectly shows modified_status=created"
 trace $CLI bundle summary --output json | jq '.resources.secret_scopes.secret_scope1'
 trace $CLI secrets list-scopes -o json | jq --arg value ${SECRET_SCOPE_NAME} '.[] | select(.name == $value)'
 


### PR DESCRIPTION
## Tests
For jobs,  dashboards, secret scopes check that "id" and "modified_status" fields are set correctly by printing more output from "bundle summary".

This highlights the issue with secret scopes - modified_status is not correct there.

## Why
To support refactoring (https://github.com/databricks/cli/pull/3134) and adding support for direct deployment to bundle summary.