### PR TITLE
acc: Improve dashboards testserver; enable detect-change test on local

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -189,6 +189,14 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 
 	if cloudEnv == "" {
 		internal.StartDefaultServer(t)
+		if os.Getenv("TEST_DEFAULT_WAREHOUSE_ID") == "" {
+			t.Setenv("TEST_DEFAULT_WAREHOUSE_ID", "8ec9edc1-db0c-40df-af8d-7580020fe61e")
+		}
+	}
+
+	testDefaultWarehouseId := os.Getenv("TEST_DEFAULT_WAREHOUSE_ID")
+	if testDefaultWarehouseId != "" {
+		repls.Set(testDefaultWarehouseId, "[TEST_DEFAULT_WAREHOUSE_ID]")
 	}
 
 	terraformrcPath := filepath.Join(buildDir, ".terraformrc")

--- a/acceptance/bundle/deploy/dashboard/detect-change/test.toml
+++ b/acceptance/bundle/deploy/dashboard/detect-change/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/generate/dashboard-inplace/output.txt
+++ b/acceptance/bundle/generate/dashboard-inplace/output.txt
@@ -13,6 +13,7 @@ Deployment complete!
 >>> [CLI] lakeview update [DASHBOARD_ID] --serialized-dashboard {"a":"b"}
 {
   "etag":"[UUID]",
+  "lifecycle_state":"ACTIVE",
   "serialized_dashboard":"{\"a\":\"b\"}"
 }
 

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/google/uuid"
 )
 
@@ -48,6 +49,13 @@ func (s *FakeWorkspace) DashboardCreate(req Request) Response {
 	}
 
 	s.Dashboards[dashboard.DashboardId] = dashboard
+	s.files[dashboard.Path] = FileEntry{
+		Info: workspace.ObjectInfo{
+			ObjectType: "DASHBOARD",
+			Path:       dashboard.Path,
+		},
+		Data: []byte(dashboard.SerializedDashboard),
+	}
 
 	return Response{
 		Body: dashboards.Dashboard{
@@ -69,6 +77,9 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 
 	// Update the etag for the dashboard.
 	dashboard.Etag = uuid.New().String()
+
+	// All dashboards are active by default:
+	dashboard.LifecycleState = dashboards.LifecycleStateActive
 
 	dashboardId := req.Vars["dashboard_id"]
 	s.Dashboards[dashboardId] = dashboard

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -28,13 +28,18 @@ const (
 	TestRunID = 2305843009213693969
 )
 
+type FileEntry struct {
+	Info workspace.ObjectInfo
+	Data []byte
+}
+
 // FakeWorkspace holds a state of a workspace for acceptance tests.
 type FakeWorkspace struct {
 	mu  sync.Mutex
 	url string
 
 	directories map[string]bool
-	files       map[string][]byte
+	files       map[string]FileEntry
 	// normally, ids are not sequential, but we make them sequential for deterministic diff
 	nextJobId    int64
 	nextJobRunId int64
@@ -109,7 +114,7 @@ func NewFakeWorkspace(url string) *FakeWorkspace {
 		directories: map[string]bool{
 			"/Workspace": true,
 		},
-		files:        map[string][]byte{},
+		files:        make(map[string]FileEntry),
 		Jobs:         map[int64]jobs.Job{},
 		JobRuns:      map[int64]jobs.Run{},
 		nextJobId:    TestJobID,
@@ -132,13 +137,9 @@ func (s *FakeWorkspace) WorkspaceGetStatus(path string) Response {
 				Path:       path,
 			},
 		}
-	} else if _, ok := s.files[path]; ok {
+	} else if entry, ok := s.files[path]; ok {
 		return Response{
-			Body: &workspace.ObjectInfo{
-				ObjectType: "FILE",
-				Path:       path,
-				Language:   "SCALA",
-			},
+			Body: entry.Info,
 		}
 	} else {
 		return Response{
@@ -155,17 +156,17 @@ func (s *FakeWorkspace) WorkspaceMkdirs(request workspace.Mkdirs) {
 
 func (s *FakeWorkspace) WorkspaceExport(path string) []byte {
 	defer s.LockUnlock()()
-	return s.files[path]
+	return s.files[path].Data
 }
 
 func (s *FakeWorkspace) WorkspaceDelete(path string, recursive bool) {
 	defer s.LockUnlock()()
 	if !recursive {
-		s.files[path] = nil
+		delete(s.files, path)
 	} else {
 		for key := range s.files {
 			if strings.HasPrefix(key, path) {
-				s.files[key] = nil
+				delete(s.files, key)
 			}
 		}
 	}
@@ -178,7 +179,14 @@ func (s *FakeWorkspace) WorkspaceFilesImportFile(filePath string, body []byte) {
 
 	defer s.LockUnlock()()
 
-	s.files[filePath] = body
+	s.files[filePath] = FileEntry{
+		Info: workspace.ObjectInfo{
+			ObjectType: "FILE",
+			Path:       filePath,
+			Language:   "SCALA",
+		},
+		Data: body,
+	}
 
 	// Add all directories in the path to the directories map
 	for dir := path.Dir(filePath); dir != "/"; dir = path.Dir(dir) {
@@ -193,7 +201,7 @@ func (s *FakeWorkspace) WorkspaceFilesExportFile(path string) []byte {
 
 	defer s.LockUnlock()()
 
-	return s.files[path]
+	return s.files[path].Data
 }
 
 func (s *FakeWorkspace) JobsCreate(request jobs.CreateJob) Response {


### PR DESCRIPTION
## Changes
- Improve dashboards in test server to better match real ones.
- Improve testserver's file system to track metadata.
- Enable TEST_DEFAULT_WAREHOUSE_ID in local tests.
- Enable dashboard/detect-change test to run locally in addition to cloud.

## Why
Running tests on local server gives faster feedback.