### PR TITLE
No Empty Responses in Go SDK in future.

### DIFF
--- a/.codegen/service.go.tmpl
+++ b/.codegen/service.go.tmpl
@@ -305,7 +305,7 @@ func new{{.PascalName}}() *cobra.Command {
 			return err
 		}
 		if {{.CamelName}}SkipWait {
-			{{if not .Response.IsEmpty -}}
+			{{if not ( or .Response.IsGoogleEmpty .Response.IsLegacyEmptyResponse) -}}
 			return cmdio.Render(ctx, wait.Response)
 			{{- else -}}
 			return nil
@@ -358,7 +358,7 @@ func new{{.PascalName}}() *cobra.Command {
 // end service {{.Name}}{{end}}
 
 {{- define "method-call" -}}
-		{{if not .Response.IsEmpty -}}
+		{{if not ( or .Response.IsGoogleEmpty .Response.IsLegacyEmptyResponse) -}}
 		  response{{ if not .Pagination}}, err{{end}} :=
 		{{- else -}}
 		  err =
@@ -376,7 +376,7 @@ func new{{.PascalName}}() *cobra.Command {
 			return err
 		}
 		{{- end}}
-		{{ if not .Response.IsEmpty -}}
+		{{ if not ( or .Response.IsGoogleEmpty .Response.IsLegacyEmptyResponse) -}}
 			{{- if .IsResponseByteStream -}}
 			defer response.{{.ResponseBodyField.PascalName}}.Close()
 			return cmdio.Render{{ if .Pagination}}Iterator{{end}}(ctx, response.{{.ResponseBodyField.PascalName}})


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
This PR updates templates such that only legacyEmptyResponse and googleEmpty are not rendered. Otherwise, it assumes that the Go SDK will return a response.
GoogleEmpty - a google well known proto that ensures that we will never add a field in it.
LegactEmptyResponse - Responses that are empty and not rendered in the Go SDK because of legacy reasons. Rendering it will be a breaking change for the users as it changes the method signature.
  
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
We have decided in the Go SDK that we will not omit the Response in the method signature if it is empty in the future. As it restricts adding new fields in the response. So, to remove this restriction, we need to return an object from the beginning. So, this PR updates the template to take into account.

## Tests
<!-- How have you tested the changes? -->
Generated CLI with zero diff. 

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
