### PR TITLE
Enable "direct" deployment method tests on CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,7 +44,7 @@ jobs:
           - windows-latest
         deployment:
           - "terraform"
-          - "direct-exp"
+          - "direct"
 
     steps:
       - name: Checkout repository and submodules

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,7 +44,7 @@ jobs:
           - windows-latest
         deployment:
           - "terraform"
-          - "direct"
+          - "direct-exp"
 
     steps:
       - name: Checkout repository and submodules

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -304,6 +304,7 @@ func getEnvFilters(t *testing.T) []string {
 	}
 
 	filters := strings.Split(envFilterValue, ",")
+	outFilters := make([]string, len(filters))
 
 	for _, filter := range filters {
 		items := strings.Split(filter, "=")
@@ -313,9 +314,17 @@ func getEnvFilters(t *testing.T) []string {
 		key := items[0]
 		// Clear it just to be sure, since it's going to be part of os.Environ() and we're going to add different value based on settings.
 		os.Unsetenv(key)
+
+		if key == "DATABRICKS_CLI_DEPLOYMENT" && items[1] == "direct" {
+			// CLI only recognizes "direct-exp" at the moment, but in the future will recognize "direct" as well.
+			// On CI we set "direct". To avoid renaming jobs in CI on the future, we correct direct -> direct-exp here
+			items[1] = "direct-exp"
+		}
+
+		outFilters = append(outFilters, key+"="+items[1])
 	}
 
-	return filters
+	return outFilters
 }
 
 func getTests(t *testing.T) []string {


### PR DESCRIPTION
The "direct deployment" PR has a last minute change of env var value from "direct" to "direct-exp" (https://github.com/databricks/cli/pull/2926/commits/b47b1f60f738261c61629182fa8cba7bb6a7bf0c) but CI settings were not updated, thus disabling direct tests on CI. This enables them back 

## Tests
Manually:

```
~/work/cli/acceptance/bundle/resources/jobs % ENVFILTER=DATABRICKS_CLI_DEPLOYMENT=terraform testme -v -count=1 | egrep 'PASS|SKIP|FAIL'
+ go test ../../.. -run ^TestAccept$/^bundle$/^resources$/^jobs$ -v -count=1
        --- SKIP: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=direct-exp (0.01s)
        --- PASS: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=terraform (4.74s)

~/work/cli/acceptance/bundle/resources/jobs % ENVFILTER=DATABRICKS_CLI_DEPLOYMENT=direct testme -v -count=1 | egrep 'PASS|SKIP|FAIL'
+ go test ../../.. -run ^TestAccept$/^bundle$/^resources$/^jobs$ -v -count=1
--- PASS: TestAccept (1.07s)
    --- PASS: TestAccept/bundle/resources/jobs (0.00s)
        --- SKIP: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=terraform (0.01s)
        --- PASS: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=direct-exp (2.34s)

~/work/cli/acceptance/bundle/resources/jobs % ENVFILTER=DATABRICKS_CLI_DEPLOYMENT=direct-exp testme -v -count=1 | egrep 'PASS|SKIP|FAIL'
+ go test ../../.. -run ^TestAccept$/^bundle$/^resources$/^jobs$ -v -count=1
--- PASS: TestAccept (1.04s)
    --- PASS: TestAccept/bundle/resources/jobs (0.00s)
        --- SKIP: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=terraform (0.01s)
        --- PASS: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=direct-exp (2.37s)

~/work/cli/acceptance/bundle/resources/jobs % ENVFILTER=DATABRICKS_CLI_DEPLOYMENT=bla testme -v -count=1 | egrep 'PASS|SKIP|FAIL'
+ go test ../../.. -run ^TestAccept$/^bundle$/^resources$/^jobs$ -v -count=1
--- PASS: TestAccept (1.02s)
    --- PASS: TestAccept/bundle/resources/jobs (0.00s)
        --- SKIP: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=direct-exp (0.00s)
        --- SKIP: TestAccept/bundle/resources/jobs/DATABRICKS_CLI_DEPLOYMENT=terraform (0.00s)
```