### PR TITLE
Fix crash in "bundle summary"

### DIFF
--- a/acceptance/bundle/summary/missing-libraries-file-path/output.txt
+++ b/acceptance/bundle/summary/missing-libraries-file-path/output.txt
@@ -2,21 +2,6 @@
 === Initial view of resources without id and modified_status=created
 >>> [CLI] bundle summary -o json
 Error: file intentionally-missing.py not found
-Please report this issue to Databricks in the form of a GitHub issue at:
-https://github.com/databricks/cli
 
-Panic Payload: runtime error: invalid memory address or nil pointer dereference
-goroutine 1 [running]:
-runtime/debug.Stack()
-github.com/databricks/cli/cmd/root.Execute.func1()
-panic({HEX?, HEX?})
-github.com/databricks/cli/cmd/bundle.renderJsonOutput(HEX, HEX?)
-github.com/databricks/cli/cmd/bundle.renderBundle(HEX, HEX, {HEX, HEX, HEX}, HEX)
-github.com/databricks/cli/cmd/bundle.newSummaryCommand.func1(HEX, {HEX?, HEX?, HEX?})
-github.com/spf13/cobra.(*Command).execute(HEX, {HEX, HEX, HEX})
-github.com/spf13/cobra.(*Command).ExecuteC(HEX)
-github.com/spf13/cobra.(*Command).ExecuteContextC(...)
-github.com/databricks/cli/cmd/root.Execute({HEX, HEX}, HEX)
-main.main()
 
 Exit code: 1

--- a/acceptance/bundle/summary/missing-libraries-file-path/test.toml
+++ b/acceptance/bundle/summary/missing-libraries-file-path/test.toml
@@ -1,9 +1,0 @@
-Badness = "Unexpected panic"
-
-[[Repls]]
-Old = '0x[0-9a-f]{1,}'
-New = 'HEX'
-
-[[Repls]]
-Old = '\n\s+.*\n'
-New = "\n"

--- a/cmd/bundle/validate.go
+++ b/cmd/bundle/validate.go
@@ -18,6 +18,9 @@ import (
 )
 
 func renderJsonOutput(cmd *cobra.Command, b *bundle.Bundle) error {
+	if b == nil {
+		return nil
+	}
 	buf, err := json.MarshalIndent(b.Config.Value().AsAny(), "", "  ")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Changes
Fix crash in "bundle summary" when there was an error. Crash introduced in https://github.com/databricks/cli/pull/3123 (not released yet).

## Tests
New acceptance test added in https://github.com/databricks/cli/pull/3138
