### PR TITLE
CI test stats: collapse test results if more than 5

### DIFF
--- a/tools/gh_report.py
+++ b/tools/gh_report.py
@@ -117,7 +117,10 @@ def download_run_id(run_id, repo, rm):
         if rm:
             run(["rm", "-fr", target_dir])
         else:
-            print(f"Already exists: {target_dir}. If that directory contains partial results, delete it to re-download: rm -fr .gh-logs/{run_id}")
+            print(
+                f"Already exists: {target_dir}. If that directory contains partial results, delete it to re-download: rm -fr .gh-logs/{run_id}",
+                file=sys.stderr,
+            )
             return target_dir
     cmd = ["gh", "run", "-R", repo, "download", str(run_id), "-D", target_dir]
     run(cmd)


### PR DESCRIPTION
## Changes
- Wrap tests table in `<details>` so that it is collapsed.
- Fix log message in gh_report.py to go to stderr as intended.

## Tests
Manually: `/tools/gh_report.py --markdown --commit b56f2455a57c089c678d1c1126917346d3a0ddc5 | pbcopy`
Result: https://github.com/databricks/cli/pull/3139#issuecomment-3018822736
