### PR TITLE
acc: Fix dashboard/detect-change test

### DIFF
--- a/acceptance/bundle/deploy/dashboard/detect-change/test.toml
+++ b/acceptance/bundle/deploy/dashboard/detect-change/test.toml
@@ -17,6 +17,6 @@ New = "[ALPHANUMID]"
 
 [[Repls]]
 # clean up ?o=<num> suffix after URL since not all workspaces have that
-Old = '\?o=\[(NUMBER|NUMID)\]'
+Old = '\?o=\[(NUMID|ALPHANUM)\]'
 New = ''
 Order = 1000


### PR DESCRIPTION
It still fails with

```
        -  "url": "[DATABRICKS_URL]/dashboardsv3/[ALPHANUMID]/published",
        +  "url": "[DATABRICKS_URL]/dashboardsv3/[ALPHANUMID]/published?o=[ALPHANUMID]",
```

On there other hand NUMBER replacement does not exist.

Follow up to #3144