### PR TITLE
Refactor deletes in direct deployment

### DIFF
--- a/acceptance/bundle/destroy/all-resources/databricks.yml
+++ b/acceptance/bundle/destroy/all-resources/databricks.yml
@@ -1,0 +1,13 @@
+resources:
+  pipelines:
+    my_pipeline:
+      name: test-pipeline
+      libraries:
+        - file:
+            path: "./foo.py"
+
+  schemas:
+    my_schema:
+      name: test-schema
+      catalog_name: main
+      comment: COMMENT1

--- a/acceptance/bundle/destroy/all-resources/output.txt
+++ b/acceptance/bundle/destroy/all-resources/output.txt
@@ -1,0 +1,16 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete pipeline my_pipeline
+  delete schema my_schema
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/destroy/all-resources/script
+++ b/acceptance/bundle/destroy/all-resources/script
@@ -1,0 +1,2 @@
+trace $CLI bundle deploy
+trace $CLI bundle destroy --auto-approve

--- a/bundle/terranova/apply.go
+++ b/bundle/terranova/apply.go
@@ -207,7 +207,7 @@ func (d *Deployer) Create(ctx context.Context, resource tnresources.IResource, c
 }
 
 func (d *Deployer) Recreate(ctx context.Context, oldResource tnresources.IResource, oldID string, config any) error {
-	err := oldResource.DoDelete(ctx, oldID)
+	err := tnresources.DeleteResource(ctx, d.client, d.group, oldID)
 	if err != nil {
 		return fmt.Errorf("deleting old id=%s: %w", oldID, err)
 	}
@@ -267,7 +267,7 @@ func (d *Deployer) Update(ctx context.Context, resource tnresources.IResource, o
 
 func (d *Deployer) Delete(ctx context.Context, resource tnresources.IResource, oldID string) error {
 	// TODO: recognize 404 and 403 as "deleted" and proceed to removing state
-	err := resource.DoDelete(ctx, oldID)
+	err := tnresources.DeleteResource(ctx, d.client, d.group, oldID)
 	if err != nil {
 		return fmt.Errorf("deleting id=%s: %w", oldID, err)
 	}

--- a/bundle/terranova/tnresources/app.go
+++ b/bundle/terranova/tnresources/app.go
@@ -54,7 +54,7 @@ func (r *ResourceApp) DoUpdate(ctx context.Context, id string) (string, error) {
 	return response.Name, nil
 }
 
-func (r *ResourceApp) DoDelete(ctx context.Context, id string) error {
+func DeleteApp(ctx context.Context, client *databricks.WorkspaceClient, id string) error {
 	// TODO: implement app deletion
 	return nil
 }

--- a/bundle/terranova/tnresources/job.go
+++ b/bundle/terranova/tnresources/job.go
@@ -52,12 +52,12 @@ func (r *ResourceJob) DoUpdate(ctx context.Context, id string) (string, error) {
 	return id, nil
 }
 
-func (r *ResourceJob) DoDelete(ctx context.Context, id string) error {
+func DeleteJob(ctx context.Context, client *databricks.WorkspaceClient, id string) error {
 	idInt, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
 		return err
 	}
-	err = r.client.Jobs.DeleteByJobId(ctx, idInt)
+	err = client.Jobs.DeleteByJobId(ctx, idInt)
 	if err != nil {
 		return SDKError{Method: "Jobs.DeleteByJobId", Err: err}
 	}

--- a/bundle/terranova/tnresources/pipeline.go
+++ b/bundle/terranova/tnresources/pipeline.go
@@ -49,8 +49,8 @@ func (r *ResourcePipeline) DoUpdate(ctx context.Context, id string) (string, err
 	return id, nil
 }
 
-func (r *ResourcePipeline) DoDelete(ctx context.Context, id string) error {
-	err := r.client.Pipelines.DeleteByPipelineId(ctx, id)
+func DeletePipeline(ctx context.Context, client *databricks.WorkspaceClient, id string) error {
+	err := client.Pipelines.DeleteByPipelineId(ctx, id)
 	if err != nil {
 		return SDKError{Method: "Pipelines.DeleteByPipelineId", Err: err}
 	}

--- a/bundle/terranova/tnresources/resource.go
+++ b/bundle/terranova/tnresources/resource.go
@@ -11,28 +11,35 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 )
 
+const (
+	_jobs      = "jobs"
+	_pipelines = "pipelines"
+	_schemas   = "schemas"
+	_apps      = "apps"
+)
+
 var supportedResources = map[string]reflect.Value{
-	"jobs":      reflect.ValueOf(NewResourceJob),
-	"pipelines": reflect.ValueOf(NewResourcePipeline),
-	"schemas":   reflect.ValueOf(NewResourceSchema),
-	"apps":      reflect.ValueOf(NewResourceApp),
+	_jobs:      reflect.ValueOf(NewResourceJob),
+	_pipelines: reflect.ValueOf(NewResourcePipeline),
+	_schemas:   reflect.ValueOf(NewResourceSchema),
+	_apps:      reflect.ValueOf(NewResourceApp),
 }
 
 // This types matches what Config() returns and should match 'config' field in the resource struct
 var supportedResourcesTypes = map[string]reflect.Type{
-	"jobs":      reflect.TypeOf(ResourceJob{}.config),
-	"pipelines": reflect.TypeOf(ResourcePipeline{}.config),
-	"schemas":   reflect.TypeOf(ResourceSchema{}.config),
-	"apps":      reflect.TypeOf(ResourceApp{}.config),
+	_jobs:      reflect.TypeOf(ResourceJob{}.config),
+	_pipelines: reflect.TypeOf(ResourcePipeline{}.config),
+	_schemas:   reflect.TypeOf(ResourceSchema{}.config),
+	_apps:      reflect.TypeOf(ResourceApp{}.config),
 }
 
 type DeleteResourceFN = func(ctx context.Context, client *databricks.WorkspaceClient, oldID string) error
 
 var deletableResources = map[string]DeleteResourceFN{
-	"jobs":      DeleteJob,
-	"pipelines": DeletePipeline,
-	"schemas":   DeleteSchema,
-	"apps":      DeleteApp,
+	_jobs:      DeleteJob,
+	_pipelines: DeletePipeline,
+	_schemas:   DeleteSchema,
+	_apps:      DeleteApp,
 }
 
 type IResource interface {

--- a/bundle/terranova/tnresources/schema.go
+++ b/bundle/terranova/tnresources/schema.go
@@ -51,7 +51,7 @@ func (r *ResourceSchema) DoUpdate(ctx context.Context, id string) (string, error
 	return response.FullName, nil
 }
 
-func (r *ResourceSchema) DoDelete(ctx context.Context, id string) error {
+func DeleteSchema(ctx context.Context, client *databricks.WorkspaceClient, id string) error {
 	// TODO: implement schema deletion
 	return nil
 }


### PR DESCRIPTION
## Changes
Remove DoDelete method from IResource, add a static function per resource.

## Why
Delete operation is special - it does not require config. In fact, it is often run when config is gone. 

On the other hand all other operations need config. 

To support both delete and non-delete operation in one class we would need to have constant checks/asserts config != nil. To avoid this complication, I'm taking delete out of IResource.

## Tests
Existing tests.