### PR TITLE
Increase test timeout to 30m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PACKAGES=./acceptance/... ./libs/... ./internal/... ./cmd/... ./bundle/... .
 
 GOTESTSUM_FORMAT ?= pkgname-and-test-fails
 GOTESTSUM_CMD ?= go tool gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=skipped --jsonfile test-output.json
+LOCAL_TIMEOUT ?= 30m
 
 
 lintfull:
@@ -46,13 +47,13 @@ links:
 checks: tidy ws links
 
 test:
-	${GOTESTSUM_CMD} -- ${PACKAGES}
+	${GOTESTSUM_CMD} -- ${PACKAGES} -timeout=${LOCAL_TIMEOUT}
 
 # Updates acceptance test output (local tests)
 test-update:
-	-go test ./acceptance -run '^TestAccept$$' -update
+	-go test ./acceptance -run '^TestAccept$$' -update -timeout=${LOCAL_TIMEOUT}
 	@# at the moment second pass is required because some tests show diff against output of another test for easier review
-	-go test ./acceptance -run '^TestAccept$$' -update
+	-go test ./acceptance -run '^TestAccept$$' -update -timeout=${LOCAL_TIMEOUT}
 
 # Updates acceptance test output (integration tests, requires access)
 test-update-aws:
@@ -65,7 +66,7 @@ slowest:
 
 cover:
 	rm -fr ./acceptance/build/cover/
-	VERBOSE_TEST=1 CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES}
+	VERBOSE_TEST=1 CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} -- -coverprofile=coverage.txt ${PACKAGES} -timeout=${LOCAL_TIMEOUT}
 	rm -fr ./acceptance/build/cover-merged/
 	mkdir -p acceptance/build/cover-merged/
 	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/


### PR DESCRIPTION
Inspired by this https://github.com/databricks/cli/actions/runs/16021325523/job/45198831160

```
=== FAIL: acceptance  (0.00s)
panic: test timed out after 10m0s
	running tests:
		TestAccept/cmd/workspace/apps/run-local/DATABRICKS_CLI_DEPLOYMENT=terraform (2m44s)

goroutine 10059 [running]:
testing.(*M).startAlarm.func1()
	C:/Users/runneradmin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.windows-amd64/src/testing/testing.go:2484 +0x394
created by time.goFunc
	C:/Users/runneradmin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.windows-amd64/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive, 8 minutes]:
testing.(*T).Run(0xc0000036c0, {0x182d05c?, 0x7ffb6b657690?}, 0x193d280)
	C:/Users/runneradmin/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.2.windows-amd64/src/testing/testing.go:1859 +0x414
...
```