### PR TITLE
Added missing asserts for secret scopes in StateToBundle tests

### DIFF
--- a/bundle/statemgmt/state_load_test.go
+++ b/bundle/statemgmt/state_load_test.go
@@ -104,6 +104,9 @@ func TestStateToBundleEmptyLocalResources(t *testing.T) {
 	assert.Equal(t, "", config.Resources.Apps["test_app"].Name)
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Apps["test_app"].ModifiedStatus)
 
+	assert.Equal(t, "secret_scope1", config.Resources.SecretScopes["test_secret_scope"].ID)
+	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.SecretScopes["test_secret_scope"].ModifiedStatus)
+
 	AssertFullResourceCoverage(t, &config)
 }
 
@@ -242,6 +245,9 @@ func TestStateToBundleEmptyRemoteResources(t *testing.T) {
 
 	assert.Equal(t, "", config.Resources.Apps["test_app"].Name)
 	assert.Equal(t, resources.ModifiedStatusCreated, config.Resources.Apps["test_app"].ModifiedStatus)
+
+	assert.Equal(t, "", config.Resources.SecretScopes["test_secret_scope"].ID)
+	assert.Equal(t, resources.ModifiedStatusCreated, config.Resources.SecretScopes["test_secret_scope"].ModifiedStatus)
 
 	AssertFullResourceCoverage(t, &config)
 }
@@ -456,6 +462,10 @@ func TestStateToBundleModifiedResources(t *testing.T) {
 			"test_app":     {ID: "test_app"},
 			"test_app_old": {ID: "test_app_old"},
 		},
+		"secret_scopes": map[string]ResourceState{
+			"test_secret_scope":     {ID: "test_secret_scope"},
+			"test_secret_scope_old": {ID: "test_secret_scope_old"},
+		},
 	}
 	err := StateToBundle(context.Background(), state, &config)
 	assert.NoError(t, err)
@@ -544,6 +554,14 @@ func TestStateToBundleModifiedResources(t *testing.T) {
 	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.Apps["test_app_old"].ModifiedStatus)
 	assert.Equal(t, "test_app_new", config.Resources.Apps["test_app_new"].Name)
 	assert.Equal(t, resources.ModifiedStatusCreated, config.Resources.Apps["test_app_new"].ModifiedStatus)
+
+	assert.Equal(t, "test_secret_scope", config.Resources.SecretScopes["test_secret_scope"].Name)
+	assert.Equal(t, "", config.Resources.SecretScopes["test_secret_scope"].ModifiedStatus)
+	assert.Equal(t, "test_secret_scope_old", config.Resources.SecretScopes["test_secret_scope_old"].ID)
+	assert.Equal(t, "", config.Resources.SecretScopes["test_secret_scope_old"].Name)
+	assert.Equal(t, resources.ModifiedStatusDeleted, config.Resources.SecretScopes["test_secret_scope_old"].ModifiedStatus)
+	assert.Equal(t, "test_secret_scope_new", config.Resources.SecretScopes["test_secret_scope_new"].Name)
+	assert.Equal(t, resources.ModifiedStatusCreated, config.Resources.SecretScopes["test_secret_scope_new"].ModifiedStatus)
 
 	AssertFullResourceCoverage(t, &config)
 }


### PR DESCRIPTION
## Changes
Added missing asserts for secret scopes in StateToBundle tests

## Why
It appears to be an oversight that the asserts were not added

## Tests
Existing tests

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
