### PR TITLE
Add diagnostics warning test for pipelines deploy

### DIFF
--- a/acceptance/pipelines/deploy/render-diagnostics-warning/databricks.yml
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/databricks.yml
@@ -1,0 +1,8 @@
+bundle:
+  name: render-diagnostics-warning-pipeline
+
+resources:
+  pipelines:
+    test-pipeline:
+      # This is an unknown property that should trigger a warning
+      unknown_property: "this_should_trigger_a_warning"

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/output.txt
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/output.txt
@@ -8,3 +8,4 @@ Warning: unknown field: unknown_property
   at resources.pipelines.test-pipeline
   in databricks.yml:8:7
 
+<EOL>

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/output.txt
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/output.txt
@@ -1,0 +1,10 @@
+
+>>> [PIPELINES] deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/render-diagnostics-warning-pipeline/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+Warning: unknown field: unknown_property
+  at resources.pipelines.test-pipeline
+  in databricks.yml:8:7
+

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/script
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/script
@@ -1,0 +1,1 @@
+trace $PIPELINES deploy

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/script
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/script
@@ -1,1 +1,3 @@
 trace $PIPELINES deploy
+# print newline to comply with whitespace linter
+printf "<EOL>\n"

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/test.toml
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]


### PR DESCRIPTION
## Changes
Added acceptance test for rendering diagnostics warnings when unknown properties are encountered during pipeline deployment.

## Why
Follow-up to [PR #3107](https://github.com/databricks/cli/pull/3107) - ensures the diagnostics system correctly identifies and reports unknown properties in pipeline configurations, providing users with helpful feedback about potential configuration issues.

## Tests
Added acceptance test case `render-diagnostics-warning` that verifies warning messages are properly displayed for unknown bundle configuration properties.
