### PR TITLE
Add a panic if a resource description is empty when collecting AllResources

### DIFF
--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -57,6 +57,10 @@ func collectResourceMap[T ConfigResource](
 	description resources.ResourceDescription,
 	input map[string]T,
 ) ResourceGroup {
+	if description.PluralName == "" {
+		panic("description of a resource group cannot be empty")
+	}
+
 	r := make(map[string]ConfigResource)
 	for key, resource := range input {
 		r[key] = resource


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
This change slightly improves developer experience when introducing a new resource type to the asset bundle. 

Before it was easy to miss that in

```
func (r *Resources) AllResources() []ResourceGroup {
	descriptions := SupportedResources()
	return []ResourceGroup{
		collectResourceMap(descriptions["jobs"], r.Jobs),
		collectResourceMap(descriptions["pipelines"], r.Pipelines),
		collectResourceMap(descriptions["models"], r.Models),
		collectResourceMap(descriptions["experiments"], r.Experiments),
		collectResourceMap(descriptions["model_serving_endpoints"], r.ModelServingEndpoints),
		collectResourceMap(descriptions["registered_models"], r.RegisteredModels),
		collectResourceMap(descriptions["quality_monitors"], r.QualityMonitors),
		collectResourceMap(descriptions["schemas"], r.Schemas),
		collectResourceMap(descriptions["clusters"], r.Clusters),
		collectResourceMap(descriptions["dashboards"], r.Dashboards),
		collectResourceMap(descriptions["volumes"], r.Volumes),
		collectResourceMap(descriptions["apps"], r.Apps),
		collectResourceMap(descriptions["my_new_resources"], r.NewResource), // <-- developer added a new line here
	}
}
```

`descriptions["my_new_resources"]` can be empty and golang does not catch that. This results in a difficult-to-understand behaviour, when `bundle summary` returns your new resources, but it has an empty group name. Adding this panic ensures that the developer does not miss adding the new resource to `SupportedResources` as well.

## Tests
<!-- How have you tested the changes? -->
Manual check - this code panics when a new resource is added to `AllResources`, but not `SupportedResources`. This can only happen during development when adding a new resource.

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
