### PR TITLE
Disable non-serverless integration_whl tests on direct

### DIFF
--- a/acceptance/bundle/integration_whl/base/test.toml
+++ b/acceptance/bundle/integration_whl/base/test.toml
@@ -1,4 +1,1 @@
-# Temporarily disabling due to DBR release breakage.
-CloudEnvs.gcp = false
-
 EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/custom_params/test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/test.toml
@@ -1,4 +1,1 @@
-# Temporarily disabling due to DBR release breakage.
-CloudEnvs.gcp = false
-
 EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/interactive_cluster/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/test.toml
@@ -1,4 +1,1 @@
-# Temporarily disabling due to DBR release breakage.
-CloudEnvs.gcp = false
-
 EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/interactive_single_user/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/test.toml
@@ -1,4 +1,1 @@
-# Temporarily disabling due to DBR release breakage.
-CloudEnvs.gcp = false
-
 EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/test.toml
@@ -1,2 +1,4 @@
 # Temporarily disabling due to DBR release breakage.
 CloudEnvs.gcp = false
+
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."


### PR DESCRIPTION
It was enabled prematurely in https://github.com/databricks/terraform-provider-databricks/pull/3162

