### PR TITLE
Rename CacheDir to LocalStateDir

### DIFF
--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -29,7 +29,7 @@ func (m *build) Name() string {
 }
 
 func (m *build) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	cacheDir, err := b.CacheDir(ctx)
+	cacheDir, err := b.LocalStateDir(ctx)
 	if err != nil {
 		logdiag.LogDiag(ctx, diag.Diagnostic{
 			Severity: diag.Warning,

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -217,9 +217,9 @@ func (b *Bundle) SetWorkpaceClient(w *databricks.WorkspaceClient) {
 	b.client = w
 }
 
-// CacheDir returns directory to use for temporary files for this bundle.
+// LocalStateDir returns directory to use for temporary files for this bundle.
 // Scoped to the bundle's target.
-func (b *Bundle) CacheDir(ctx context.Context, paths ...string) (string, error) {
+func (b *Bundle) LocalStateDir(ctx context.Context, paths ...string) (string, error) {
 	if b.Config.Bundle.Target == "" {
 		panic("target not set")
 	}
@@ -259,7 +259,7 @@ func (b *Bundle) CacheDir(ctx context.Context, paths ...string) (string, error) 
 // This directory is used to store and automaticaly sync internal bundle files, such as, f.e
 // notebook trampoline files for Python wheel and etc.
 func (b *Bundle) InternalDir(ctx context.Context) (string, error) {
-	cacheDir, err := b.CacheDir(ctx)
+	cacheDir, err := b.LocalStateDir(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -346,13 +346,13 @@ func (b *Bundle) StateFilename() string {
 
 func (b *Bundle) StateLocalPath(ctx context.Context) (string, error) {
 	if b.DirectDeployment {
-		cacheDir, err := b.CacheDir(ctx)
+		cacheDir, err := b.LocalStateDir(ctx)
 		if err != nil {
 			return "", err
 		}
 		return filepath.Join(cacheDir, resourcesFilename), nil
 	} else {
-		cacheDir, err := b.CacheDir(ctx, "terraform")
+		cacheDir, err := b.LocalStateDir(ctx, "terraform")
 		if err != nil {
 			return "", err
 		}

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -50,7 +50,7 @@ func TestLoadExists(t *testing.T) {
 	assert.NotNil(t, b)
 }
 
-func TestBundleCacheDir(t *testing.T) {
+func TestBundleLocalStateDir(t *testing.T) {
 	ctx := context.Background()
 	projectDir := t.TempDir()
 	f1, err := os.Create(filepath.Join(projectDir, "databricks.yml"))
@@ -67,14 +67,14 @@ func TestBundleCacheDir(t *testing.T) {
 	// unset env variable in case it's set
 	t.Setenv("DATABRICKS_BUNDLE_TMP", "")
 
-	cacheDir, err := bundle.CacheDir(ctx)
+	cacheDir, err := bundle.LocalStateDir(ctx)
 
 	// format is <CWD>/.databricks/bundle/<target>
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(projectDir, ".databricks", "bundle", "default"), cacheDir)
 }
 
-func TestBundleCacheDirOverride(t *testing.T) {
+func TestBundleLocalStateDirOverride(t *testing.T) {
 	ctx := context.Background()
 	projectDir := t.TempDir()
 	bundleTmpDir := t.TempDir()
@@ -92,7 +92,7 @@ func TestBundleCacheDirOverride(t *testing.T) {
 	// now we expect to use 'bundleTmpDir' instead of CWD/.databricks/bundle
 	t.Setenv("DATABRICKS_BUNDLE_TMP", bundleTmpDir)
 
-	cacheDir, err := bundle.CacheDir(ctx)
+	cacheDir, err := bundle.LocalStateDir(ctx)
 
 	// format is <DATABRICKS_BUNDLE_TMP>/<target>
 	assert.NoError(t, err)

--- a/bundle/config/mutator/python/python_mutator.go
+++ b/bundle/config/mutator/python/python_mutator.go
@@ -241,9 +241,9 @@ func (m *pythonMutator) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagno
 }
 
 func createCacheDir(ctx context.Context) (string, error) {
-	// b.CacheDir doesn't work because target isn't yet selected
+	// b.LocalStateDir doesn't work because target isn't yet selected
 
-	// support the same env variable as in b.CacheDir
+	// support the same env variable as in b.LocalStateDir
 	if tempDir, exists := env.TempDir(ctx); exists {
 		// use 'default' as target name
 		cacheDir := filepath.Join(tempDir, "default", "python")

--- a/bundle/deploy/files/sync.go
+++ b/bundle/deploy/files/sync.go
@@ -17,7 +17,7 @@ func GetSync(ctx context.Context, b *bundle.Bundle) (*sync.Sync, error) {
 }
 
 func GetSyncOptions(ctx context.Context, b *bundle.Bundle) (*sync.SyncOptions, error) {
-	cacheDir, err := b.CacheDir(ctx)
+	cacheDir, err := b.LocalStateDir(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get bundle cache directory: %w", err)
 	}

--- a/bundle/deploy/state.go
+++ b/bundle/deploy/state.go
@@ -178,7 +178,7 @@ func loadState(r io.Reader) (*DeploymentState, error) {
 }
 
 func getPathToStateFile(ctx context.Context, b *bundle.Bundle) (string, error) {
-	cacheDir, err := b.CacheDir(ctx)
+	cacheDir, err := b.LocalStateDir(ctx)
 	if err != nil {
 		return "", fmt.Errorf("cannot get bundle cache directory: %w", err)
 	}

--- a/bundle/deploy/terraform/dir.go
+++ b/bundle/deploy/terraform/dir.go
@@ -9,5 +9,5 @@ import (
 // Dir returns the Terraform working directory for a given bundle.
 // The working directory is emphemeral and nested under the bundle's cache directory.
 func Dir(ctx context.Context, b *bundle.Bundle) (string, error) {
-	return b.CacheDir(ctx, "terraform")
+	return b.LocalStateDir(ctx, "terraform")
 }

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -91,7 +91,7 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 		return tf.ExecPath, nil
 	}
 
-	binDir, err := b.CacheDir(ctx, "bin")
+	binDir, err := b.LocalStateDir(ctx, "bin")
 	if err != nil {
 		return "", err
 	}
@@ -243,7 +243,7 @@ func setTempDirEnvVars(ctx context.Context, environ map[string]string, b *bundle
 		} else if v, ok := env.Lookup(ctx, "TEMP"); ok {
 			environ["TEMP"] = v
 		} else {
-			tmpDir, err := b.CacheDir(ctx, "tmp")
+			tmpDir, err := b.LocalStateDir(ctx, "tmp")
 			if err != nil {
 				return err
 			}

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -194,8 +194,8 @@ func TestSetTempDirEnvVarsForWindowsWithoutAnyTempDirEnvVarsSet(t *testing.T) {
 	err := setTempDirEnvVars(context.Background(), env, b)
 	require.NoError(t, err)
 
-	// assert TMP is set to b.CacheDir("tmp")
-	tmpDir, err := b.CacheDir(context.Background(), "tmp")
+	// assert TMP is set to b.LocalStateDir("tmp")
+	tmpDir, err := b.LocalStateDir(context.Background(), "tmp")
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
 		"TMP": tmpDir,
@@ -456,7 +456,7 @@ func TestFindExecPath_UseExistingBinary(t *testing.T) {
 	}
 
 	// Create a pre-existing Terraform binary to avoid downloading it
-	cacheDir, _ := b.CacheDir(ctx, "bin")
+	cacheDir, _ := b.LocalStateDir(ctx, "bin")
 	createFakeTerraformBinary(t, cacheDir, "1.2.3")
 
 	// Verify that the pre-existing Terraform binary is used.

--- a/bundle/statemgmt/state_test.go
+++ b/bundle/statemgmt/state_test.go
@@ -21,7 +21,7 @@ func identityFiler(f filer.Filer) deploy.FilerFactory {
 }
 
 func localStateFile(t *testing.T, ctx context.Context, b *bundle.Bundle) string {
-	dir, err := b.CacheDir(ctx, "terraform")
+	dir, err := b.LocalStateDir(ctx, "terraform")
 	require.NoError(t, err)
 	return filepath.Join(dir, b.StateFilename())
 }

--- a/libs/git/view_test.go
+++ b/libs/git/view_test.go
@@ -209,7 +209,7 @@ func TestViewABInTempDir(t *testing.T) {
 	assert.False(t, tv.Ignore("newfile"))
 }
 
-func TestViewAlwaysIgnoresCacheDir(t *testing.T) {
+func TestViewAlwaysIgnoresLocalStateDir(t *testing.T) {
 	repoPath := createFakeRepo(t, "testdata")
 
 	v, err := NewViewAtRoot(vfs.MustNew(repoPath))


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
1. Rename `CacheDir` interface to `LocalStateDir`
2. Rename tests that mention `CacheDir` so that they mention `LocalStateDir` now

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
`CacheDir` is a term that is not semantically correct since it contains not only cache, but also the state of the bundle.

## Tests
<!-- How have you tested the changes? -->
Existing tests are passing

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
