### PR TITLE
fix: bug for `cli-pipelines` template include path

### DIFF
--- a/acceptance/pipelines/init/error-cases/output/my_project/databricks.yml
+++ b/acceptance/pipelines/init/error-cases/output/my_project/databricks.yml
@@ -7,7 +7,7 @@ bundle:
 include:
   - resources/*.yml
   - resources/*/*.yml
-  - ./*.yml
+  - ./*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/pipelines/init/python/output/my_python_project/databricks.yml
+++ b/acceptance/pipelines/init/python/output/my_python_project/databricks.yml
@@ -7,7 +7,7 @@ bundle:
 include:
   - resources/*.yml
   - resources/*/*.yml
-  - ./*.yml
+  - ./*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/pipelines/init/sql/output/my_sql_project/databricks.yml
+++ b/acceptance/pipelines/init/sql/output/my_sql_project/databricks.yml
@@ -7,7 +7,7 @@ bundle:
 include:
   - resources/*.yml
   - resources/*/*.yml
-  - ./*.yml
+  - ./*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/libs/template/templates/cli-pipelines/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/cli-pipelines/template/{{.project_name}}/databricks.yml.tmpl
@@ -7,7 +7,7 @@ bundle:
 include:
   - resources/*.yml
   - resources/*/*.yml
-  - ./*.yml
+  - ./*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:


### PR DESCRIPTION
## Changes
Changed include path in `databricks.yml` for `cli-pipelines` template to include project/*.yml files.

## Why
Bug in include path has `bundle deploy` not recognize pipelines as resources.

## Tests
Modified sample templates in tests to use new path.