### PR TITLE
Increase waitForCompletionMarker timeout in sync integration tests

### DIFF
--- a/integration/cmd/sync/sync_test.go
+++ b/integration/cmd/sync/sync_test.go
@@ -104,7 +104,7 @@ func setupSyncTest(t *testing.T, args ...string) (context.Context, *syncTest) {
 }
 
 func (s *syncTest) waitForCompletionMarker() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	for {


### PR DESCRIPTION
## Why
Tests run into this timeout, especially during integration test runs when we put a lot of load on our test workspace. Increasing this timeout should help reduce flakyness:

logs:
```
=== FAIL: integration/cmd/sync TestSyncIncrementalFileOverwritesFolder (re-run 2) (120.09s)
    sync_test.go:76: CLOUD_ENV=***
    fixtures.go:23: Creating workspace directory /Users/***/integration-test-sync-9308e0589a2a45db9fcc68e53f472319
Warn: Failed to read git info: stat /.git: no such file or directory
    sync_test.go:113: timed out waiting for sync to complete
```