### PR TITLE
acc: Use more specific regex in default-python/combinations

### DIFF
--- a/acceptance/bundle/templates/default-python/combinations/check_output.py
+++ b/acceptance/bundle/templates/default-python/combinations/check_output.py
@@ -12,7 +12,7 @@ if CLOUD_ENV and SERVERLESS and not os.environ.get("TEST_METASTORE_ID"):
     sys.exit(f"SKIP_TEST SERVERLESS=yes but TEST_METASTORE_ID is empty in this env {CLOUD_ENV=}")
 
 BUILDING = "Building python_artifact"
-UPLOADING_WHL = re.compile("Uploading .*whl")
+UPLOADING_WHL = re.compile(r"^Uploading .*whl\.\.\.$", re.M)
 STATE = "Updating deployment state"
 
 


### PR DESCRIPTION
This test uses regex to verify that if include_python is set to "yes" then we have a line like this:

    Uploading .databricks/bundle/dev/patched_wheels/python_artifact_x[UNIQUE_NAME]/x[UNIQUE_NAME]-0.0.1+[UNIX_TIME_NANOS]-py3-none-any.whl...

and if include_python is set to "no" then we don't have a line like that in the output.

However, we also always print a line like this:

    Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/X[UNIQUE_NAME]/dev/files...

Since UNIQUE_NAME is random string, it sometimes contains "whl", causing regex to match where it should not.
