### PR TITLE
acc: Enable destroy/jobs-and-pipeline on direct

### DIFF
--- a/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
@@ -2,4 +2,4 @@ Local = false
 Cloud = true
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
@@ -1,8 +1,6 @@
 Local = false
 Cloud = true
 
-EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # requires "bundle summary"
-
 Ignore = [
     "databricks.yml",
     "resources.yml",


### PR DESCRIPTION
It requires "bundle summary" which we have since https://github.com/databricks/cli/pull/3162
