### PR TITLE
acc: enable pipelines tests on direct

### DIFF
--- a/acceptance/pipelines/deploy/auto-approve/out.test.toml
+++ b/acceptance/pipelines/deploy/auto-approve/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/deploy/auto-approve/test.toml
+++ b/acceptance/pipelines/deploy/auto-approve/test.toml
@@ -1,1 +1,0 @@
-EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/pipelines/deploy/create-pipeline/out.test.toml
+++ b/acceptance/pipelines/deploy/create-pipeline/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/deploy/create-pipeline/test.toml
+++ b/acceptance/pipelines/deploy/create-pipeline/test.toml
@@ -1,1 +1,0 @@
-EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/out.test.toml
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/test.toml
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/test.toml
@@ -1,1 +1,0 @@
-EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/pipelines/deploy/var-flag/out.test.toml
+++ b/acceptance/pipelines/deploy/var-flag/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/deploy/var-flag/test.toml
+++ b/acceptance/pipelines/deploy/var-flag/test.toml
@@ -1,1 +1,0 @@
-EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]


### PR DESCRIPTION
## Why
Pipelines are supported by direct backend.
