### PR TITLE
testserver: better error message in resource not found case

### DIFF
--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -70,6 +70,7 @@ func MapGet[T any](w *FakeWorkspace, collection map[string]T, key string) Respon
 	if !ok {
 		return Response{
 			StatusCode: 404,
+			Body:       map[string]string{"message": fmt.Sprintf("Resource %T not found: %v", value, key)},
 		}
 	}
 	return Response{


### PR DESCRIPTION
## Changes

New 404 message looks like this: Resource catalog.VolumeInfo not found: main.myschema.myvolume

## Why

This allows distinguishing between handler not set up correct and object not found issues.

## Tests
Manually.