### PR TITLE
Fix slash in bundle/integration_whl acceptance tests

### DIFF
--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -3,3 +3,7 @@ Local = false
 
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true
+
+[[Repls]]
+Old = '\\'
+New = '/'

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/test.toml
@@ -1,2 +1,6 @@
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true
+
+[[Repls]]
+Old = '\\'
+New = '/'


### PR DESCRIPTION
## Changes
Reverts: https://github.com/databricks/cli/pull/3195

## Why
These tests started failing because of the missing repl. Diff:
```
->>> cp [TESTROOT]/bundle/resources/clusters/run/spark_python_task/../../deploy/simple/hello_world.py .
+>>> cp [TESTROOT]\bundle\resources\clusters\run\spark_python_task/../../deploy/simple/hello_world.py .
```