### PR TITLE
acc: `pipelines dry-run` for flags and command

### DIFF
--- a/acceptance/pipelines/dry-run/dry-run-pipeline/databricks.yml
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/databricks.yml
@@ -1,0 +1,6 @@
+bundle:
+  name: test-pipeline-run
+resources:
+  pipelines:
+    my_pipeline:
+      name: test-pipeline

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/output.txt
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/output.txt
@@ -1,0 +1,18 @@
+
+>>> [PIPELINES] deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-pipeline-run/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Dry running pipeline, should have validate_only set to true
+>>> [PIPELINES] dry-run my_pipeline
+Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+
+{
+  "body": {
+    "validate_only": true
+  },
+  "method": "POST",
+  "path": "/api/2.0/pipelines/[UUID]/updates"
+}

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/script
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/script
@@ -1,0 +1,10 @@
+print_requests() {
+    jq --sort-keys 'select(.method != "GET" and (.path | contains("/pipelines")))' < out.requests.txt
+    rm out.requests.txt
+}
+
+trace $PIPELINES deploy
+rm out.requests.txt
+title "Dry running pipeline, should have validate_only set to true"
+trace $PIPELINES dry-run my_pipeline
+print_requests

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/test.toml
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/test.toml
@@ -1,0 +1,1 @@
+RecordRequests = true

--- a/acceptance/pipelines/dry-run/no-wait/databricks.yml
+++ b/acceptance/pipelines/dry-run/no-wait/databricks.yml
@@ -1,0 +1,6 @@
+bundle:
+  name: test-pipeline-run-flags
+resources:
+  pipelines:
+    my_pipeline:
+      name: test-pipeline-flags

--- a/acceptance/pipelines/dry-run/no-wait/out.test.toml
+++ b/acceptance/pipelines/dry-run/no-wait/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/dry-run/no-wait/output.txt
+++ b/acceptance/pipelines/dry-run/no-wait/output.txt
@@ -1,0 +1,12 @@
+
+>>> [PIPELINES] deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-pipeline-run-flags/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Dry running pipeline with --no-wait flag
+>>> [PIPELINES] dry-run my_pipeline --no-wait
+Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+
+<EOL>

--- a/acceptance/pipelines/dry-run/no-wait/script
+++ b/acceptance/pipelines/dry-run/no-wait/script
@@ -1,0 +1,5 @@
+trace $PIPELINES deploy
+title "Dry running pipeline with --no-wait flag"
+trace $PIPELINES dry-run my_pipeline --no-wait
+# This printf is here to fix the whitespace linter error (ensures exactly one newline at end)
+printf "<EOL>\n"

--- a/acceptance/pipelines/dry-run/restart/databricks.yml
+++ b/acceptance/pipelines/dry-run/restart/databricks.yml
@@ -1,0 +1,6 @@
+bundle:
+  name: test-pipeline-run-flags
+resources:
+  pipelines:
+    my_pipeline:
+      name: test-pipeline-flags

--- a/acceptance/pipelines/dry-run/restart/out.test.toml
+++ b/acceptance/pipelines/dry-run/restart/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/dry-run/restart/output.txt
+++ b/acceptance/pipelines/dry-run/restart/output.txt
@@ -1,0 +1,24 @@
+
+>>> [PIPELINES] deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-pipeline-run-flags/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Dry running pipeline with --restart flag, should stop the current pipeline and start a new run
+>>> [PIPELINES] dry-run my_pipeline --restart
+Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+
+
+>>> print_requests
+{
+  "method": "POST",
+  "path": "/api/2.0/pipelines/[UUID]/stop"
+}
+{
+  "body": {
+    "validate_only": true
+  },
+  "method": "POST",
+  "path": "/api/2.0/pipelines/[UUID]/updates"
+}

--- a/acceptance/pipelines/dry-run/restart/script
+++ b/acceptance/pipelines/dry-run/restart/script
@@ -1,0 +1,11 @@
+print_requests() {
+    jq --sort-keys 'select(.method != "GET" and (.path | contains("/pipelines")))' < out.requests.txt
+    rm out.requests.txt
+}
+
+trace $PIPELINES deploy
+rm out.requests.txt
+
+title "Dry running pipeline with --restart flag, should stop the current pipeline and start a new run"
+trace $PIPELINES dry-run my_pipeline --restart
+trace print_requests

--- a/acceptance/pipelines/dry-run/restart/test.toml
+++ b/acceptance/pipelines/dry-run/restart/test.toml
@@ -1,0 +1,1 @@
+RecordRequests = true


### PR DESCRIPTION
## Changes
Adding acceptance tests to new `pipelines dry-run` command.

## Tests
Add acceptance tests for
- dry-run command without flags
- dry-run with --restart flag
- dry-run with --no-wait flag

Follows #3218