### PR TITLE
acc: `pipelines --version` and `pipelines version`

### DIFF
--- a/acceptance/pipelines/version/out.test.toml
+++ b/acceptance/pipelines/version/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/pipelines/version/output.txt
+++ b/acceptance/pipelines/version/output.txt
@@ -1,0 +1,8 @@
+
+=== Testing pipelines --version
+>>> [PIPELINES] --version
+Pipelines CLI v[DEV_VERSION] (based on Databricks CLI v[DEV_VERSION])
+
+=== Testing pipelines version command
+>>> [PIPELINES] version
+Pipelines CLI v[DEV_VERSION] (based on Databricks CLI v[DEV_VERSION])

--- a/acceptance/pipelines/version/script
+++ b/acceptance/pipelines/version/script
@@ -1,0 +1,5 @@
+title "Testing pipelines --version"
+trace $PIPELINES --version
+
+title "Testing pipelines version command"
+trace $PIPELINES version


### PR DESCRIPTION
## Changes
Acceptance tests for `pipelines --version` and `pipelines version` commands.
Following up on #3221