### PR TITLE
acc: Make CloudSlow equivalent of Cloud

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -382,9 +382,12 @@ func getSkipReason(config *internal.TestConfig, configPath string) string {
 		}
 
 		if isTruePtr(config.CloudSlow) {
-			if testing.Short() {
-				return fmt.Sprintf("Disabled via CloudSlow setting in %s (CLOUD_ENV=%s, Short=%v)", configPath, cloudEnv, testing.Short())
-			}
+			config.Cloud = config.CloudSlow
+			// Not running this tests on PRs makes it easy to miss test failures (and real bugs).
+			// Debugging these in nightly is not as pleasant as ensuring the PRs go in do not break it.
+			//if testing.Short() {
+			//	return fmt.Sprintf("Disabled via CloudSlow setting in %s (CLOUD_ENV=%s, Short=%v)", configPath, cloudEnv, testing.Short())
+			//}
 		}
 
 		isCloudEnabled := isTruePtr(config.Cloud) || isTruePtr(config.CloudSlow)

--- a/acceptance/bundle/integration_whl/base/out.test.toml
+++ b/acceptance/bundle/integration_whl/base/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/integration_whl/base/out.test.toml
+++ b/acceptance/bundle/integration_whl/base/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]

--- a/acceptance/bundle/integration_whl/base/test.toml
+++ b/acceptance/bundle/integration_whl/base/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/integration_whl/custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]

--- a/acceptance/bundle/integration_whl/custom_params/test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]

--- a/acceptance/bundle/integration_whl/interactive_cluster/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]

--- a/acceptance/bundle/integration_whl/interactive_single_user/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # clusters resource; Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/serverless/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 

--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -6,4 +6,4 @@ CloudSlow = true
   gcp = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [CloudEnvs]

--- a/acceptance/bundle/integration_whl/wrapper/test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/test.toml
@@ -1,2 +1,4 @@
 # Temporarily disabling due to DBR release breakage.
 CloudEnvs.gcp = false
+
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -6,4 +6,4 @@ CloudSlow = true
   gcp = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [CloudEnvs]

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/test.toml
@@ -1,2 +1,4 @@
 # Temporarily disabling due to DBR release breakage.
 CloudEnvs.gcp = false
+
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # Error: deploying jobs.some_other_job: creating: Method=Jobs.Create *retries.Err *apierr.APIError StatusCode=400 ErrorCode="INVALID_PARAMETER_VALUE" Message="The field 'node_type_id' cannot be supplied when an instance pool ID is provided."

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]

--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -1,5 +1,5 @@
 Local = false
-Cloud = false
+Cloud = true
 CloudSlow = true
 
 [EnvMatrix]


### PR DESCRIPTION
## Changes
CloudSlow is now alias for Cloud.

## Why
Not running this tests on PRs makes it easy to miss test failures (and real bugs).
