### PR TITLE
Show "DEFAULT" as the default profile for `databricks auth login`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Dependency updates
 
 ### CLI
-* Show "DEFAULT" as the default profile for `databricks auth login` [#3251](https://github.com/databricks/cli/pull/3251)
+* Show "DEFAULT" as the default profile for `databricks auth login` [#3252](https://github.com/databricks/cli/pull/3252)
 
 ### Bundles
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Dependency updates
 
 ### CLI
+* Show "DEFAULT" as the default profile for `databricks auth login` [#3251](https://github.com/databricks/cli/pull/3251)
 
 ### Bundles
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -25,10 +25,15 @@ func promptForProfile(ctx context.Context, defaultValue string) (string, error) 
 	}
 
 	prompt := cmdio.Prompt(ctx)
-	prompt.Label = "Databricks profile name"
-	prompt.Default = defaultValue
+	prompt.Label = "Databricks profile name [" + defaultValue + "]"
 	prompt.AllowEdit = true
-	return prompt.Run()
+	result, err := prompt.Run()
+	if result == "" {
+		// Manually return the default value. We could use the prompt.Default
+		// field, but be inconsistent with other prompts in the CLI.
+		return defaultValue, err
+	}
+	return result, err
 }
 
 const (
@@ -100,7 +105,11 @@ depends on the existing profiles you have set in your configuration file
 		// If the user has not specified a profile name, prompt for one.
 		if profileName == "" {
 			var err error
-			profileName, err = promptForProfile(ctx, getProfileName(authArguments))
+			profileName = getProfileName(authArguments)
+			if profileName == "" {
+				profileName = "DEFAULT"
+			}
+			profileName, err = promptForProfile(ctx, profileName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Changes
Show `"DEFAULT"` as the default profile for the `databricks auth login` command. This change uses the same UX as seen in the `databricks bundle init` command, i.e. it shows the default value between square backets rather than in the input field.

## Why
This change aims to make `databricks auth login` more self-documenting. I want to reference it from templates in the future.