### PR TITLE
Force Python scripts in acceptance tests to use UTF-8

### DIFF
--- a/acceptance/selftest/diff/out_dir_a/output.txt
+++ b/acceptance/selftest/diff/out_dir_a/output.txt
@@ -1,4 +1,4 @@
-Hello!
+Hello! 🚀
 {
     "id": "[USERID]",
     "userName": "[USERNAME]"

--- a/acceptance/selftest/diff/out_dir_b/output.txt
+++ b/acceptance/selftest/diff/out_dir_b/output.txt
@@ -1,4 +1,4 @@
-Hello!
+Hello! 🚀
 {
     "id": "[UUID]",
     "userName": "[USERNAME]"

--- a/acceptance/selftest/diff/output.txt
+++ b/acceptance/selftest/diff/output.txt
@@ -5,7 +5,7 @@ Only in out_dir_b: only_in_b
 --- out_dir_a/output.txt
 +++ out_dir_b/output.txt
 @@ -1,5 +1,5 @@
- Hello!
+ Hello! 🚀
  {
 -    "id": "[USERID]",
 +    "id": "[UUID]",
@@ -18,7 +18,7 @@ Only in ../out_dir_b: only_in_b
 --- output.txt
 +++ ../out_dir_b/output.txt
 @@ -1,5 +1,5 @@
- Hello!
+ Hello! 🚀
  {
 -    "id": "[USERID]",
 +    "id": "[UUID]",
@@ -29,7 +29,7 @@ Only in ../out_dir_b: only_in_b
 --- out_dir_a/output.txt
 +++ out_dir_b/output.txt
 @@ -1,5 +1,5 @@
- Hello!
+ Hello! 🚀
  {
 -    "id": "[USERID]",
 +    "id": "[UUID]",

--- a/acceptance/selftest/diff/script
+++ b/acceptance/selftest/diff/script
@@ -4,8 +4,8 @@ mkdir out_dir_b
 touch out_dir_a/only_in_a
 touch out_dir_b/only_in_b
 
-echo Hello! >> out_dir_a/output.txt
-echo Hello! >> out_dir_b/output.txt
+echo "Hello! 🚀" >> out_dir_a/output.txt
+echo "Hello! 🚀" >> out_dir_b/output.txt
 
 curl -s $DATABRICKS_HOST/api/2.0/preview/scim/v2/Me >> out_dir_a/output.txt
 printf "\n\nFooter\n" >> out_dir_a/output.txt

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -13,6 +13,7 @@ TimeoutCloud = '25m'
 
 Env.PYTHONDONTWRITEBYTECODE = "1"
 Env.PYTHONUNBUFFERED = "1"
+Env.PYTHONUTF8 = "1"
 
 EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
 EnvRepl.DATABRICKS_CLI_DEPLOYMENT = false


### PR DESCRIPTION
## Changes

A test failure in #3254 shows the Python scripts called from our acceptance tests were using `cp1252` encoding on Windows, which is incompatible with tests using UTF-8. This change makes these tests always use UTF-8.

## Tests

Adds an emoji to the diff selftest.