### PR TITLE
Change execv to use current directory as a working directory if no directory is provided

### DIFF
--- a/libs/exec/execv.go
+++ b/libs/exec/execv.go
@@ -10,7 +10,9 @@ type ExecvOptions struct {
 	// Env is set the environment variables to set in the child process.
 	Env []string
 
-	// Dir is the working directory of the child process.
+	// Dir specifies the working directory of the command.
+	// If Dir is an empty string, Execv runs the command in the
+	// calling process's current directory.
 	Dir string
 
 	// It is not possible to execute a cmd.exe script inlined as a argument

--- a/libs/exec/execv_unix.go
+++ b/libs/exec/execv_unix.go
@@ -10,9 +10,11 @@ import (
 )
 
 func execv(opts ExecvOptions) error {
-	err := os.Chdir(opts.Dir)
-	if err != nil {
-		return fmt.Errorf("changing directory to %s failed: %w", opts.Dir, err)
+	if opts.Dir != "" {
+		err := os.Chdir(opts.Dir)
+		if err != nil {
+			return fmt.Errorf("changing directory to %s failed: %w", opts.Dir, err)
+		}
 	}
 
 	// execve syscall does not perform PATH lookup. Thus we need to query path

--- a/libs/lakebase/connect.go
+++ b/libs/lakebase/connect.go
@@ -53,12 +53,6 @@ func Connect(ctx context.Context, databaseInstanceName string, extraArgs ...stri
 	}
 	cmdio.LogString(ctx, "Successfully fetched database credentials")
 
-	// Get current working directory
-	dir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("error getting working directory: %w", err)
-	}
-
 	// Check if database name and port are already specified in extra arguments
 	hasDbName := false
 	hasPort := false
@@ -103,6 +97,5 @@ func Connect(ctx context.Context, databaseInstanceName string, extraArgs ...stri
 	return exec.Execv(exec.ExecvOptions{
 		Args: args,
 		Env:  cmdEnv,
-		Dir:  dir,
 	})
 }


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

This is a follow-up for the comment in the previous PR #3128 : https://github.com/databricks/cli/pull/3128#discussion_r2205016022

## Tests
<!-- How have you tested the changes? -->
- Existing acceptance test on cmd/psql is still passing even though the production code is not specifying a directory
- Manually checked that when executed with `pwd` the process prints current working directory on Mac and on Windows

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
