### PR TITLE
pipelines: updated descriptions and inconsistencies

### DIFF
--- a/cmd/pipelines/deploy.go
+++ b/cmd/pipelines/deploy.go
@@ -19,10 +19,8 @@ func deployCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy pipelines",
-		Long: `Deploy all pipelines defined in the project to the target workspace.
-This command will create or update pipelines in the workspace based on the configuration in .pipelines.yml.
-The deployment process includes validation, building, and applying the pipeline configurations.
-By default, targets the 'dev' environment unless specified otherwise.`,
+		Long: `Deploy pipelines and files defined in the project to the target workspace.
+This command will create or update pipelines in the workspace based on the configuration in .pipelines.yml.`,
 		Args: root.NoArgs,
 	}
 

--- a/cmd/pipelines/deploy.go
+++ b/cmd/pipelines/deploy.go
@@ -19,7 +19,11 @@ func deployCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy pipelines",
-		Args:  root.NoArgs,
+		Long: `Deploy all pipelines defined in the project to the target workspace.
+This command will create or update pipelines in the workspace based on the configuration in .pipelines.yml.
+The deployment process includes validation, building, and applying the pipeline configurations.
+By default, targets the 'dev' environment unless specified otherwise.`,
+		Args: root.NoArgs,
 	}
 
 	var forceLock bool

--- a/cmd/pipelines/dry_run.go
+++ b/cmd/pipelines/dry_run.go
@@ -23,10 +23,11 @@ import (
 
 func dryRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "dry-run [KEY]",
+		Use:   "dry-run [flags] [KEY]",
 		Short: "Validate correctness of the pipeline's graph",
 		Long: `Validates correctness of the pipeline's graph, identified by KEY. Does not materialize or publish any datasets.
-The KEY is the unique identifier of the pipeline to run.`,
+The KEY is the unique identifier of the pipeline to run.
+If there is only one pipeline in the project, KEY is optional and the pipeline will be auto-selected.`,
 	}
 
 	var noWait bool

--- a/cmd/pipelines/open.go
+++ b/cmd/pipelines/open.go
@@ -63,9 +63,12 @@ func resolveOpenArgument(ctx context.Context, b *bundle.Bundle, args []string) (
 
 func openCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "open",
+		Use:   "open [KEY]",
 		Short: "Open a pipeline in the browser",
-		Args:  root.MaximumNArgs(1),
+		Long: `Open a pipeline in the browser, identified by KEY.
+The KEY is the pipeline resource name in the .pipelines.yml file of the pipeline to open.
+If there is only one pipeline in the project, KEY is optional and the pipeline will be auto-selected.`,
+		Args: root.MaximumNArgs(1),
 	}
 
 	var forcePull bool

--- a/cmd/pipelines/run.go
+++ b/cmd/pipelines/run.go
@@ -27,7 +27,8 @@ func runCommand() *cobra.Command {
 		Use:   "run [flags] [KEY]",
 		Short: "Run a pipeline",
 		Long: `Run the pipeline identified by KEY.
-The KEY is the unique identifier of the pipeline to run.`,
+The KEY is the pipeline resource name in the .pipelines.yml file of the pipeline to run.
+If there is only one pipeline in the project, KEY is optional and the pipeline will be auto-selected.`,
 	}
 
 	var refreshAll bool


### PR DESCRIPTION
## Changes
- Added deploy description
- made [flags] [KEY] be consistent
- added [KEY] to open: this is unlike Bundle implementation but is more consistent with the other functions
- specified that run, dryrun, and open will auto-select when there is only one pipeline
- `Args:` limits are added to match bundle counterparts

## Why
Bugbash feedback and consistency
