### PR TITLE
Preserve `allow_duplicate_names` field in the pipeline resource 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,5 +9,6 @@
 ### CLI
 
 ### Bundles
+- Fixed an issue where `allow_duplicate_names` field on the pipeline definition was ignored by the bundle ([#3274](https://github.com/databricks/cli/pull/3274))
 
 ### API Changes

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/databricks.yml.tmpl
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/databricks.yml.tmpl
@@ -1,0 +1,11 @@
+bundle:
+  name: acc-bundle-deploy-pipeline-duplicate-names-$UNIQUE_NAME
+
+resources:
+  pipelines:
+    pipeline_one:
+      name: test-pipeline-same-name-$UNIQUE_NAME
+      allow_duplicate_names: true
+      libraries:
+        - file:
+            path: "./foo.py"

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = true
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/output.txt
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/output.txt
@@ -2,24 +2,16 @@
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-bundle-deploy-pipeline-duplicate-names-[UNIQUE_NAME]/default/files...
 Deploying resources...
-Error: terraform apply: exit status 1
-
-Error: cannot create pipeline: The pipeline name 'test-pipeline-same-name-[UNIQUE_NAME]' is already used by another pipeline. This check can be skipped by setting `allow_duplicate_names = true` in the request.
-
-  with databricks_pipeline.pipeline_one,
-  on bundle.tf.json line 30, in resource.databricks_pipeline.pipeline_one:
-  30:       }
-
-
-
 Updating deployment state...
+Deployment complete!
 
 >>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete pipeline pipeline_one
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/acc-bundle-deploy-pipeline-duplicate-names-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!
 
 >>> [CLI] pipelines delete [UUID]
-
-Exit code: 1

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/output.txt
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/output.txt
@@ -5,6 +5,43 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
+>>> print_requests
+{
+  "body": {
+    "libraries": [
+      {
+        "file": {
+          "path": "/some-script.py"
+        }
+      }
+    ],
+    "name": "test-pipeline-same-name-[UNIQUE_NAME]"
+  },
+  "method": "POST",
+  "path": "/api/2.0/pipelines"
+}
+{
+  "body": {
+    "allow_duplicate_names": true,
+    "channel": "CURRENT",
+    "deployment": {
+      "kind": "BUNDLE",
+      "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/acc-bundle-deploy-pipeline-duplicate-names-[UNIQUE_NAME]/default/state/metadata.json"
+    },
+    "edition": "ADVANCED",
+    "libraries": [
+      {
+        "file": {
+          "path": "/Workspace/Users/[USERNAME]/.bundle/acc-bundle-deploy-pipeline-duplicate-names-[UNIQUE_NAME]/default/files/foo.py"
+        }
+      }
+    ],
+    "name": "test-pipeline-same-name-[UNIQUE_NAME]"
+  },
+  "method": "POST",
+  "path": "/api/2.0/pipelines"
+}
+
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
   delete pipeline pipeline_one

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/output.txt
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/output.txt
@@ -1,0 +1,25 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-bundle-deploy-pipeline-duplicate-names-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Error: terraform apply: exit status 1
+
+Error: cannot create pipeline: The pipeline name 'test-pipeline-same-name-[UNIQUE_NAME]' is already used by another pipeline. This check can be skipped by setting `allow_duplicate_names = true` in the request.
+
+  with databricks_pipeline.pipeline_one,
+  on bundle.tf.json line 30, in resource.databricks_pipeline.pipeline_one:
+  30:       }
+
+
+
+Updating deployment state...
+
+>>> [CLI] bundle destroy --auto-approve
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/acc-bundle-deploy-pipeline-duplicate-names-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!
+
+>>> [CLI] pipelines delete [UUID]
+
+Exit code: 1

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/pipeline.json.tmpl
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/pipeline.json.tmpl
@@ -1,0 +1,11 @@
+{
+    "name": "test-pipeline-same-name-$UNIQUE_NAME",
+    "allow_duplicate_names": true,
+    "libraries": [
+        {
+            "file": {
+                "path": "/some-script.py"
+            }
+        }
+    ]
+}

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/pipeline.json.tmpl
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/pipeline.json.tmpl
@@ -1,6 +1,5 @@
 {
     "name": "test-pipeline-same-name-$UNIQUE_NAME",
-    "allow_duplicate_names": true,
     "libraries": [
         {
             "file": {

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/script
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/script
@@ -1,0 +1,16 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+envsubst < pipeline.json.tmpl > pipeline.json
+touch foo.py
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+  trace $CLI pipelines delete ${PIPELINE_ID}
+}
+trap cleanup EXIT
+
+# Create a pre-existing pipeline:
+PIPELINE_ID=$($CLI pipelines create --json @pipeline.json | jq -r .pipeline_id)
+export PIPELINE_ID
+
+# Deploy the bundle that has a pipeline with the same name:
+trace $CLI bundle deploy

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/script
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/script
@@ -5,6 +5,7 @@ touch foo.py
 cleanup() {
   trace $CLI bundle destroy --auto-approve
   trace $CLI pipelines delete ${PIPELINE_ID}
+  rm out.requests.txt
 }
 trap cleanup EXIT
 
@@ -14,3 +15,8 @@ export PIPELINE_ID
 
 # Deploy the bundle that has a pipeline with the same name:
 trace $CLI bundle deploy
+
+print_requests() {
+    jq --sort-keys 'select(.method != "GET" and (.path | contains("/pipelines")))' < out.requests.txt
+}
+trace print_requests

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/test.toml
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/test.toml
@@ -1,3 +1,2 @@
-Badness = "allow_duplicate_names field does not allow to create a pipeline with a duplicate name"
 Cloud = true
 Ignore = ["foo.py","pipeline.json"]

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/test.toml
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/test.toml
@@ -1,0 +1,3 @@
+Badness = "allow_duplicate_names field does not allow to create a pipeline with a duplicate name"
+Cloud = true
+Ignore = ["foo.py","pipeline.json"]

--- a/acceptance/bundle/deploy/pipeline/allow-duplicate-names/test.toml
+++ b/acceptance/bundle/deploy/pipeline/allow-duplicate-names/test.toml
@@ -1,2 +1,3 @@
 Cloud = true
 Ignore = ["foo.py","pipeline.json"]
+RecordRequests = true

--- a/bundle/deploy/terraform/tfdyn/convert_pipeline.go
+++ b/bundle/deploy/terraform/tfdyn/convert_pipeline.go
@@ -21,7 +21,7 @@ func convertPipelineResource(ctx context.Context, vin dyn.Value) (dyn.Value, err
 		return dyn.InvalidValue, err
 	}
 
-	vout, err = dyn.DropKeys(vout, []string{"allow_duplicate_names", "dry_run"})
+	vout, err = dyn.DropKeys(vout, []string{"dry_run"})
 	if err != nil {
 		return dyn.InvalidValue, err
 	}

--- a/bundle/deploy/terraform/tfdyn/convert_pipeline_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_pipeline_test.go
@@ -116,6 +116,7 @@ func TestConvertPipeline(t *testing.T) {
 				},
 			},
 		},
+		"allow_duplicate_names": true,
 		"cluster": []any{
 			map[string]any{
 				"label":       "default",

--- a/bundle/internal/schema/main.go
+++ b/bundle/internal/schema/main.go
@@ -115,7 +115,6 @@ func removePipelineFields(typ reflect.Type, s jsonschema.Schema) jsonschema.Sche
 		// Even though DABs supports this field, TF provider does not. Thus, we
 		// should not expose it to the user.
 		delete(s.Properties, "dry_run")
-		delete(s.Properties, "allow_duplicate_names")
 
 		// These fields are only meant to be set by the DABs client (ie the CLI)
 		// and thus should not be exposed to the user. These are used to annotate

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -990,6 +990,10 @@
                   {
                     "type": "object",
                     "properties": {
+                      "allow_duplicate_names": {
+                        "description": "If false, deployment will fail if name conflicts with that of another pipeline.",
+                        "$ref": "#/$defs/bool"
+                      },
                       "budget_policy_id": {
                         "description": "Budget policy of this pipeline.",
                         "$ref": "#/$defs/string",

--- a/experimental/python/databricks/bundles/pipelines/_models/pipeline.py
+++ b/experimental/python/databricks/bundles/pipelines/_models/pipeline.py
@@ -59,6 +59,11 @@ if TYPE_CHECKING:
 class Pipeline(Resource):
     """"""
 
+    allow_duplicate_names: VariableOrOptional[bool] = None
+    """
+    If false, deployment will fail if name conflicts with that of another pipeline.
+    """
+
     budget_policy_id: VariableOrOptional[str] = None
     """
     :meta private: [EXPERIMENTAL]
@@ -211,6 +216,11 @@ class Pipeline(Resource):
 
 class PipelineDict(TypedDict, total=False):
     """"""
+
+    allow_duplicate_names: VariableOrOptional[bool]
+    """
+    If false, deployment will fail if name conflicts with that of another pipeline.
+    """
 
     budget_policy_id: VariableOrOptional[str]
     """


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
- Fixed pipeline resource conversion to preserve `allow_duplicate_names` configuration field
- Updated schema and codegen to reflect the `allow_duplicate_names` field

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
 The `allow_duplicate_names` field was being dropped from pipeline resources during conversion, preventing users from configuring pipelines that allow duplicate names. This change ensures the field is properly preserved and passed through to the Terraform Provider

## Tests
<!-- How have you tested the changes? -->
- Added a new acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
