### PR TITLE
Add required query parameters as positional arguments in CLI commands

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,7 +3,17 @@
 ## Release v0.261.0
 
 ### Notable Changes
-Some of CLI commands such as "update-alert" and etc. now have a required positional argument "UPDATE_MASK"
+The following CLI commands now have a required positional argument "UPDATE_MASK":
+* `alerts update` - Update an alert
+* `alerts-v2 update-alert` - Update an alert (v2)
+* `clusters update` - Update a cluster
+* `database update-database-instance` - Update a database instance
+* `external-lineage update-external-lineage-relationship` - Update an external lineage relationship
+* `external-metadata update-external-metadata` - Update external metadata
+* `feature-store update-online-store` - Update an online store
+* `network-connectivity update-private-endpoint-rule` - Update a private endpoint rule
+* `queries update` - Update a query
+* `query-visualizations update` - Update a query visualization
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,12 +3,14 @@
 ## Release v0.261.0
 
 ### Notable Changes
+Some of CLI commands such as "update-alert" and etc. now have a required positional argument "UPDATE_MASK"
 
 ### Dependency updates
 
 ### CLI
+* Add required query parameters as positional arguments in CLI commands ([#3289](https://github.com/databricks/cli/pull/3289))
 
 ### Bundles
-- Fixed an issue where `allow_duplicate_names` field on the pipeline definition was ignored by the bundle ([#3274](https://github.com/databricks/cli/pull/3274))
+* Fixed an issue where `allow_duplicate_names` field on the pipeline definition was ignored by the bundle ([#3274](https://github.com/databricks/cli/pull/3274))
 
 ### API Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,17 +3,17 @@
 ## Release v0.261.0
 
 ### Notable Changes
-The following CLI commands now have a required positional argument "UPDATE_MASK":
-* `alerts update` - Update an alert
-* `alerts-v2 update-alert` - Update an alert (v2)
-* `clusters update` - Update a cluster
-* `database update-database-instance` - Update a database instance
-* `external-lineage update-external-lineage-relationship` - Update an external lineage relationship
-* `external-metadata update-external-metadata` - Update external metadata
-* `feature-store update-online-store` - Update an online store
-* `network-connectivity update-private-endpoint-rule` - Update a private endpoint rule
-* `queries update` - Update a query
-* `query-visualizations update` - Update a query visualization
+The following CLI commands now have additional required positional arguments:
+* `alerts-v2 update-alert ID UPDATE_MASK` - Update an alert (v2)
+* `database update-database-instance NAME UPDATE_MASK` - Update a database instance
+* `external-lineage create-external-lineage-relationship SOURCE TARGET` - Create an external lineage relationship
+* `external-lineage update-external-lineage-relationship UPDATE_MASK SOURCE TARGET` - Update an external lineage relationship
+* `external-metadata update-external-metadata NAME UPDATE_MASK SYSTEM_TYPE ENTITY_TYPE` - Update external metadata
+* `feature-store update-online-store NAME UPDATE_MASK CAPACITY` - Update an online store
+* `lakeview create-schedule DASHBOARD_ID CRON_SCHEDULE` - Create a schedule
+* `lakeview create-subscription DASHBOARD_ID SCHEDULE_ID SUBSCRIBER` - Create a subscription
+* `lakeview update-schedule DASHBOARD_ID SCHEDULE_ID CRON_SCHEDULE` - Update a schedule
+* `network-connectivity update-private-endpoint-rule NETWORK_CONNECTIVITY_CONFIG_ID PRIVATE_ENDPOINT_RULE_ID UPDATE_MASK` - Update a private endpoint rule
 
 ### Dependency updates
 

--- a/cmd/account/network-connectivity/network-connectivity.go
+++ b/cmd/account/network-connectivity/network-connectivity.go
@@ -604,7 +604,7 @@ func newUpdatePrivateEndpointRule() *cobra.Command {
 	cmd.Flags().BoolVar(&updatePrivateEndpointRuleReq.PrivateEndpointRule.Enabled, "enabled", updatePrivateEndpointRuleReq.PrivateEndpointRule.Enabled, `Only used by private endpoints towards an AWS S3 service.`)
 	// TODO: array: resource_names
 
-	cmd.Use = "update-private-endpoint-rule NETWORK_CONNECTIVITY_CONFIG_ID PRIVATE_ENDPOINT_RULE_ID"
+	cmd.Use = "update-private-endpoint-rule NETWORK_CONNECTIVITY_CONFIG_ID PRIVATE_ENDPOINT_RULE_ID UPDATE_MASK"
 	cmd.Short = `Update a private endpoint rule.`
 	cmd.Long = `Update a private endpoint rule.
   
@@ -614,12 +614,18 @@ func newUpdatePrivateEndpointRule() *cobra.Command {
   Arguments:
     NETWORK_CONNECTIVITY_CONFIG_ID: The ID of a network connectivity configuration, which is the parent
       resource of this private endpoint rule object.
-    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.`
+    PRIVATE_ENDPOINT_RULE_ID: Your private endpoint rule ID.
+    UPDATE_MASK: The field mask must be a single string, with multiple fields separated by
+      commas (no spaces). The field path is relative to the resource object,
+      using a dot (.) to navigate sub-fields (e.g., author.given_name).
+      Specification of elements in sequence or map fields is not allowed, as
+      only the entire collection field can be specified. Field names must
+      exactly match the resource field names.`
 
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		check := root.ExactArgs(2)
+		check := root.ExactArgs(3)
 		return check(cmd, args)
 	}
 
@@ -642,6 +648,7 @@ func newUpdatePrivateEndpointRule() *cobra.Command {
 		}
 		updatePrivateEndpointRuleReq.NetworkConnectivityConfigId = args[0]
 		updatePrivateEndpointRuleReq.PrivateEndpointRuleId = args[1]
+		updatePrivateEndpointRuleReq.UpdateMask = args[2]
 
 		response, err := a.NetworkConnectivity.UpdatePrivateEndpointRule(ctx, updatePrivateEndpointRuleReq)
 		if err != nil {

--- a/cmd/workspace/alerts-v2/alerts-v2.go
+++ b/cmd/workspace/alerts-v2/alerts-v2.go
@@ -333,19 +333,30 @@ func newUpdateAlert() *cobra.Command {
 	// TODO: complex arg: schedule
 	cmd.Flags().StringVar(&updateAlertReq.Alert.WarehouseId, "warehouse-id", updateAlertReq.Alert.WarehouseId, `ID of the SQL warehouse attached to the alert.`)
 
-	cmd.Use = "update-alert ID"
+	cmd.Use = "update-alert ID UPDATE_MASK"
 	cmd.Short = `Update an alert.`
 	cmd.Long = `Update an alert.
   
   Update alert
 
   Arguments:
-    ID: UUID identifying the alert.`
+    ID: UUID identifying the alert.
+    UPDATE_MASK: The field mask must be a single string, with multiple fields separated by
+      commas (no spaces). The field path is relative to the resource object,
+      using a dot (.) to navigate sub-fields (e.g., author.given_name).
+      Specification of elements in sequence or map fields is not allowed, as
+      only the entire collection field can be specified. Field names must
+      exactly match the resource field names.
+      
+      A field mask of * indicates full replacement. It’s recommended to
+      always explicitly list the fields being updated and avoid using *
+      wildcards, as it can lead to unintended results if the API changes in the
+      future.`
 
 	cmd.Annotations = make(map[string]string)
 
 	cmd.Args = func(cmd *cobra.Command, args []string) error {
-		check := root.ExactArgs(1)
+		check := root.ExactArgs(2)
 		return check(cmd, args)
 	}
 
@@ -367,6 +378,7 @@ func newUpdateAlert() *cobra.Command {
 			}
 		}
 		updateAlertReq.Id = args[0]
+		updateAlertReq.UpdateMask = args[1]
 
 		response, err := w.AlertsV2.UpdateAlert(ctx, updateAlertReq)
 		if err != nil {

--- a/cmd/workspace/external-lineage/external-lineage.go
+++ b/cmd/workspace/external-lineage/external-lineage.go
@@ -70,14 +70,30 @@ func newCreateExternalLineageRelationship() *cobra.Command {
 	// TODO: array: columns
 	// TODO: map via StringToStringVar: properties
 
-	cmd.Use = "create-external-lineage-relationship"
+	cmd.Use = "create-external-lineage-relationship SOURCE TARGET"
 	cmd.Short = `Create an external lineage relationship.`
 	cmd.Long = `Create an external lineage relationship.
   
   Creates an external lineage relationship between a Databricks or external
-  metadata object and another external metadata object.`
+  metadata object and another external metadata object.
+
+  Arguments:
+    SOURCE: Source object of the external lineage relationship.
+    TARGET: Target object of the external lineage relationship.`
 
 	cmd.Annotations = make(map[string]string)
+
+	cmd.Args = func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("json") {
+			err := root.ExactArgs(0)(cmd, args)
+			if err != nil {
+				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'source', 'target' in your JSON input")
+			}
+			return nil
+		}
+		check := root.ExactArgs(2)
+		return check(cmd, args)
+	}
 
 	cmd.PreRunE = root.MustWorkspaceClient
 	cmd.RunE = func(cmd *cobra.Command, args []string) (err error) {
@@ -95,8 +111,18 @@ func newCreateExternalLineageRelationship() *cobra.Command {
 					return err
 				}
 			}
-		} else {
-			return fmt.Errorf("please provide command input in JSON format by specifying the --json flag")
+		}
+		if !cmd.Flags().Changed("json") {
+			_, err = fmt.Sscan(args[0], &createExternalLineageRelationshipReq.ExternalLineageRelationship.Source)
+			if err != nil {
+				return fmt.Errorf("invalid SOURCE: %s", args[0])
+			}
+		}
+		if !cmd.Flags().Changed("json") {
+			_, err = fmt.Sscan(args[1], &createExternalLineageRelationshipReq.ExternalLineageRelationship.Target)
+			if err != nil {
+				return fmt.Errorf("invalid TARGET: %s", args[1])
+			}
 		}
 
 		response, err := w.ExternalLineage.CreateExternalLineageRelationship(ctx, createExternalLineageRelationshipReq)
@@ -269,14 +295,41 @@ func newUpdateExternalLineageRelationship() *cobra.Command {
 	// TODO: array: columns
 	// TODO: map via StringToStringVar: properties
 
-	cmd.Use = "update-external-lineage-relationship"
+	cmd.Use = "update-external-lineage-relationship UPDATE_MASK SOURCE TARGET"
 	cmd.Short = `Update an external lineage relationship.`
 	cmd.Long = `Update an external lineage relationship.
   
   Updates an external lineage relationship between a Databricks or external
-  metadata object and another external metadata object.`
+  metadata object and another external metadata object.
+
+  Arguments:
+    UPDATE_MASK: The field mask must be a single string, with multiple fields separated by
+      commas (no spaces). The field path is relative to the resource object,
+      using a dot (.) to navigate sub-fields (e.g., author.given_name).
+      Specification of elements in sequence or map fields is not allowed, as
+      only the entire collection field can be specified. Field names must
+      exactly match the resource field names.
+      
+      A field mask of * indicates full replacement. It’s recommended to
+      always explicitly list the fields being updated and avoid using *
+      wildcards, as it can lead to unintended results if the API changes in the
+      future.
+    SOURCE: Source object of the external lineage relationship.
+    TARGET: Target object of the external lineage relationship.`
 
 	cmd.Annotations = make(map[string]string)
+
+	cmd.Args = func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("json") {
+			err := root.ExactArgs(0)(cmd, args)
+			if err != nil {
+				return fmt.Errorf("when --json flag is specified, no positional arguments are required. Provide 'source', 'target' in your JSON input")
+			}
+			return nil
+		}
+		check := root.ExactArgs(3)
+		return check(cmd, args)
+	}
 
 	cmd.PreRunE = root.MustWorkspaceClient
 	cmd.RunE = func(cmd *cobra.Command, args []string) (err error) {
@@ -294,8 +347,19 @@ func newUpdateExternalLineageRelationship() *cobra.Command {
 					return err
 				}
 			}
-		} else {
-			return fmt.Errorf("please provide command input in JSON format by specifying the --json flag")
+		}
+		updateExternalLineageRelationshipReq.UpdateMask = args[0]
+		if !cmd.Flags().Changed("json") {
+			_, err = fmt.Sscan(args[1], &updateExternalLineageRelationshipReq.ExternalLineageRelationship.Source)
+			if err != nil {
+				return fmt.Errorf("invalid SOURCE: %s", args[1])
+			}
+		}
+		if !cmd.Flags().Changed("json") {
+			_, err = fmt.Sscan(args[2], &updateExternalLineageRelationshipReq.ExternalLineageRelationship.Target)
+			if err != nil {
+				return fmt.Errorf("invalid TARGET: %s", args[2])
+			}
 		}
 
 		response, err := w.ExternalLineage.UpdateExternalLineageRelationship(ctx, updateExternalLineageRelationshipReq)

--- a/cmd/workspace/external-metadata/external-metadata.go
+++ b/cmd/workspace/external-metadata/external-metadata.go
@@ -363,7 +363,7 @@ func newUpdateExternalMetadata() *cobra.Command {
 	// TODO: map via StringToStringVar: properties
 	cmd.Flags().StringVar(&updateExternalMetadataReq.ExternalMetadata.Url, "url", updateExternalMetadataReq.ExternalMetadata.Url, `URL associated with the external metadata object.`)
 
-	cmd.Use = "update-external-metadata NAME SYSTEM_TYPE ENTITY_TYPE"
+	cmd.Use = "update-external-metadata NAME UPDATE_MASK SYSTEM_TYPE ENTITY_TYPE"
 	cmd.Short = `Update an external metadata object.`
 	cmd.Long = `Update an external metadata object.
   
@@ -375,6 +375,17 @@ func newUpdateExternalMetadata() *cobra.Command {
 
   Arguments:
     NAME: Name of the external metadata object.
+    UPDATE_MASK: The field mask must be a single string, with multiple fields separated by
+      commas (no spaces). The field path is relative to the resource object,
+      using a dot (.) to navigate sub-fields (e.g., author.given_name).
+      Specification of elements in sequence or map fields is not allowed, as
+      only the entire collection field can be specified. Field names must
+      exactly match the resource field names.
+      
+      A field mask of * indicates full replacement. It’s recommended to
+      always explicitly list the fields being updated and avoid using *
+      wildcards, as it can lead to unintended results if the API changes in the
+      future.
     SYSTEM_TYPE: Type of external system. 
       Supported values: [
         AMAZON_REDSHIFT,
@@ -412,7 +423,7 @@ func newUpdateExternalMetadata() *cobra.Command {
 			}
 			return nil
 		}
-		check := root.ExactArgs(3)
+		check := root.ExactArgs(4)
 		return check(cmd, args)
 	}
 
@@ -434,14 +445,15 @@ func newUpdateExternalMetadata() *cobra.Command {
 			}
 		}
 		updateExternalMetadataReq.Name = args[0]
+		updateExternalMetadataReq.UpdateMask = args[1]
 		if !cmd.Flags().Changed("json") {
-			_, err = fmt.Sscan(args[1], &updateExternalMetadataReq.ExternalMetadata.SystemType)
+			_, err = fmt.Sscan(args[2], &updateExternalMetadataReq.ExternalMetadata.SystemType)
 			if err != nil {
-				return fmt.Errorf("invalid SYSTEM_TYPE: %s", args[1])
+				return fmt.Errorf("invalid SYSTEM_TYPE: %s", args[2])
 			}
 		}
 		if !cmd.Flags().Changed("json") {
-			updateExternalMetadataReq.ExternalMetadata.EntityType = args[2]
+			updateExternalMetadataReq.ExternalMetadata.EntityType = args[3]
 		}
 
 		response, err := w.ExternalMetadata.UpdateExternalMetadata(ctx, updateExternalMetadataReq)

--- a/cmd/workspace/feature-store/feature-store.go
+++ b/cmd/workspace/feature-store/feature-store.go
@@ -389,13 +389,14 @@ func newUpdateOnlineStore() *cobra.Command {
 
 	cmd.Flags().IntVar(&updateOnlineStoreReq.OnlineStore.ReadReplicaCount, "read-replica-count", updateOnlineStoreReq.OnlineStore.ReadReplicaCount, `The number of read replicas for the online store.`)
 
-	cmd.Use = "update-online-store NAME CAPACITY"
+	cmd.Use = "update-online-store NAME UPDATE_MASK CAPACITY"
 	cmd.Short = `Update an Online Feature Store.`
 	cmd.Long = `Update an Online Feature Store.
 
   Arguments:
     NAME: The name of the online store. This is the unique identifier for the online
       store.
+    UPDATE_MASK: The list of fields to update.
     CAPACITY: The capacity of the online store. Valid values are "CU_1", "CU_2", "CU_4",
       "CU_8".`
 
@@ -409,7 +410,7 @@ func newUpdateOnlineStore() *cobra.Command {
 			}
 			return nil
 		}
-		check := root.ExactArgs(2)
+		check := root.ExactArgs(3)
 		return check(cmd, args)
 	}
 
@@ -431,8 +432,9 @@ func newUpdateOnlineStore() *cobra.Command {
 			}
 		}
 		updateOnlineStoreReq.Name = args[0]
+		updateOnlineStoreReq.UpdateMask = args[1]
 		if !cmd.Flags().Changed("json") {
-			updateOnlineStoreReq.OnlineStore.Capacity = args[1]
+			updateOnlineStoreReq.OnlineStore.Capacity = args[2]
 		}
 
 		response, err := w.FeatureStore.UpdateOnlineStore(ctx, updateOnlineStoreReq)


### PR DESCRIPTION
## Changes
Add required query parameters as positional arguments in CLI commands

## Why
Fixes #3271

Relies on a fix in the genkit code

## Tests
Manually. Regenerated on fixed genkit

