### PR TITLE
acc: pipelines and bundle run --refresh and --full-refresh flags

### DIFF
--- a/acceptance/bundle/run/refresh-flags/databricks.yml
+++ b/acceptance/bundle/run/refresh-flags/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: test-bundle-run-flags
+
+resources:
+  pipelines:
+    my_pipeline:
+      name: test-pipeline-flags
+      libraries:
+        - file:
+            path: pipeline_file.py

--- a/acceptance/bundle/run/refresh-flags/out.test.toml
+++ b/acceptance/bundle/run/refresh-flags/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/run/refresh-flags/output.txt
+++ b/acceptance/bundle/run/refresh-flags/output.txt
@@ -1,12 +1,12 @@
 
->>> [PIPELINES] deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-pipeline-run-flags/default/files...
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-run-flags/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
 
 === Running pipeline with --refresh flag and specific tables
->>> [PIPELINES] run --refresh table1,table2
+>>> [CLI] bundle run my_pipeline --refresh table1,table2
 Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 
 
@@ -23,7 +23,7 @@ Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 }
 
 === Running pipeline with --full-refresh-all flag
->>> [PIPELINES] run --full-refresh-all
+>>> [CLI] bundle run my_pipeline --full-refresh-all
 Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 
 
@@ -37,7 +37,7 @@ Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 }
 
 === Running pipeline with --full-refresh flag and specific tables
->>> [PIPELINES] run --full-refresh table1,table2
+>>> [CLI] bundle run my_pipeline --full-refresh table1,table2
 Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 
 
@@ -54,7 +54,7 @@ Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 }
 
 === Running pipeline with --full-refresh flag and --refresh flag
->>> [PIPELINES] run --full-refresh table1,table2 --refresh table3,table4
+>>> [CLI] bundle run my_pipeline --full-refresh table1,table2 --refresh table3,table4
 Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
 
 

--- a/acceptance/bundle/run/refresh-flags/pipeline_file.py
+++ b/acceptance/bundle/run/refresh-flags/pipeline_file.py
@@ -1,0 +1,7 @@
+import dlt
+from pyspark.sql import SparkSession
+
+
+@dlt.table
+def my_table():
+    return spark.range(10)

--- a/acceptance/bundle/run/refresh-flags/script
+++ b/acceptance/bundle/run/refresh-flags/script
@@ -3,21 +3,21 @@ print_requests() {
     rm out.requests.txt
 }
 
-trace $PIPELINES deploy
+trace $CLI bundle deploy
 rm out.requests.txt
 
 title "Running pipeline with --refresh flag and specific tables"
-trace $PIPELINES run --refresh table1,table2
+trace $CLI bundle run my_pipeline --refresh table1,table2
 trace print_requests
 
 title "Running pipeline with --full-refresh-all flag"
-trace $PIPELINES run --full-refresh-all
+trace $CLI bundle run my_pipeline --full-refresh-all
 trace print_requests
 
 title "Running pipeline with --full-refresh flag and specific tables"
-trace $PIPELINES run --full-refresh table1,table2
+trace $CLI bundle run my_pipeline --full-refresh table1,table2
 trace print_requests
 
 title "Running pipeline with --full-refresh flag and --refresh flag"
-trace $PIPELINES run --full-refresh table1,table2 --refresh table3,table4
+trace $CLI bundle run my_pipeline --full-refresh table1,table2 --refresh table3,table4
 trace print_requests

--- a/acceptance/bundle/run/refresh-flags/test.toml
+++ b/acceptance/bundle/run/refresh-flags/test.toml
@@ -1,0 +1,1 @@
+RecordRequests = true

--- a/bundle/run/pipeline_options.go
+++ b/bundle/run/pipeline_options.go
@@ -37,24 +37,25 @@ func (o *PipelineOptions) Define(fs *flag.FlagSet) {
 
 // Validate returns if the combination of options is valid.
 func (o *PipelineOptions) Validate(pipeline *resources.Pipeline) error {
-	var mutuallyExclusiveFlags []string
-
+	var set []string
 	if o.RefreshAll {
-		mutuallyExclusiveFlags = append(mutuallyExclusiveFlags, "--refresh-all")
+		set = append(set, "--refresh-all")
+	}
+	if len(o.Refresh) > 0 {
+		set = append(set, "--refresh")
 	}
 	if o.FullRefreshAll {
-		mutuallyExclusiveFlags = append(mutuallyExclusiveFlags, "--full-refresh-all")
+		set = append(set, "--full-refresh-all")
+	}
+	if len(o.FullRefresh) > 0 {
+		set = append(set, "--full-refresh")
 	}
 	if o.ValidateOnly {
-		mutuallyExclusiveFlags = append(mutuallyExclusiveFlags, "--validate-only")
+		set = append(set, "--validate-only")
 	}
-
-	if len(mutuallyExclusiveFlags) > 1 {
-		return fmt.Errorf("%s pipeline run flags are mutually exclusive", strings.Join(mutuallyExclusiveFlags, ", "))
-	} else if len(mutuallyExclusiveFlags) == 1 && (len(o.Refresh) > 0 || len(o.FullRefresh) > 0) {
-		return fmt.Errorf("cannot use --refresh or --full-refresh together with %s: these flags are mutually exclusive", strings.Join(mutuallyExclusiveFlags, ""))
+	if len(set) > 1 {
+		return fmt.Errorf("pipeline run arguments are mutually exclusive (got %s)", strings.Join(set, ", "))
 	}
-
 	return nil
 }
 

--- a/bundle/run/pipeline_options.go
+++ b/bundle/run/pipeline_options.go
@@ -37,25 +37,24 @@ func (o *PipelineOptions) Define(fs *flag.FlagSet) {
 
 // Validate returns if the combination of options is valid.
 func (o *PipelineOptions) Validate(pipeline *resources.Pipeline) error {
-	var set []string
+	var mutuallyExclusiveFlags []string
+
 	if o.RefreshAll {
-		set = append(set, "--refresh-all")
-	}
-	if len(o.Refresh) > 0 {
-		set = append(set, "--refresh")
+		mutuallyExclusiveFlags = append(mutuallyExclusiveFlags, "--refresh-all")
 	}
 	if o.FullRefreshAll {
-		set = append(set, "--full-refresh-all")
-	}
-	if len(o.FullRefresh) > 0 {
-		set = append(set, "--full-refresh")
+		mutuallyExclusiveFlags = append(mutuallyExclusiveFlags, "--full-refresh-all")
 	}
 	if o.ValidateOnly {
-		set = append(set, "--validate-only")
+		mutuallyExclusiveFlags = append(mutuallyExclusiveFlags, "--validate-only")
 	}
-	if len(set) > 1 {
-		return fmt.Errorf("pipeline run arguments are mutually exclusive (got %s)", strings.Join(set, ", "))
+
+	if len(mutuallyExclusiveFlags) > 1 {
+		return fmt.Errorf("%s pipeline run flags are mutually exclusive", strings.Join(mutuallyExclusiveFlags, ", "))
+	} else if len(mutuallyExclusiveFlags) == 1 && (len(o.Refresh) > 0 || len(o.FullRefresh) > 0) {
+		return fmt.Errorf("cannot use --refresh or --full-refresh together with %s: these flags are mutually exclusive", strings.Join(mutuallyExclusiveFlags, ""))
 	}
+
 	return nil
 }
 

--- a/bundle/run/pipeline_options_test.go
+++ b/bundle/run/pipeline_options_test.go
@@ -67,20 +67,12 @@ func TestPipelineOptionsValidateSuccessWithSingleOption(t *testing.T) {
 	}
 }
 
-func TestPipelineOptionsValidateSuccessWithRefreshAndFullRefresh(t *testing.T) {
-	fs, opts := setupPipelineOptions(t)
-	err := fs.Parse([]string{`--refresh=arg1,arg2`, `--full-refresh=arg3,arg4`})
-	require.NoError(t, err)
-	err = opts.Validate(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"arg1", "arg2"}, opts.Refresh)
-	assert.Equal(t, []string{"arg3", "arg4"}, opts.FullRefresh)
-}
-
 func TestPipelineOptionsValidateFailureWithMultipleOptions(t *testing.T) {
 	args := []string{
 		`--refresh-all`,
+		`--refresh=arg1,arg2,arg3`,
 		`--full-refresh-all`,
+		`--full-refresh=arg1,arg2,arg3`,
 		`--validate-only`,
 	}
 	for i := range args {
@@ -92,29 +84,7 @@ func TestPipelineOptionsValidateFailureWithMultipleOptions(t *testing.T) {
 			err := fs.Parse([]string{args[i], args[j]})
 			require.NoError(t, err)
 			err = opts.Validate(nil)
-			assert.ErrorContains(t, err, "pipeline run flags are mutually exclusive")
-		}
-	}
-}
-
-func TestPipelineOptionsValidateFailureWithRefreshAndMutuallyExclusiveFlags(t *testing.T) {
-	args := []string{
-		`--refresh=arg1`,
-		`--full-refresh=arg1`,
-	}
-	mutuallyExclusiveArgs := []string{
-		`--refresh-all`,
-		`--full-refresh-all`,
-		`--validate-only`,
-	}
-
-	for _, refreshArg := range args {
-		for _, exclusiveArg := range mutuallyExclusiveArgs {
-			fs, opts := setupPipelineOptions(t)
-			err := fs.Parse([]string{refreshArg, exclusiveArg})
-			require.NoError(t, err)
-			err = opts.Validate(nil)
-			assert.ErrorContains(t, err, "cannot use --refresh or --full-refresh together with")
+			assert.ErrorContains(t, err, "pipeline run arguments are mutually exclusive")
 		}
 	}
 }


### PR DESCRIPTION
## Changes
Added acceptance tests to check if both flags can be specified at once, --refresh and --full-refresh flags
Added tests for bundle run pipeline [refresh-flags]

Acceptance tests:
- for pipelines, adds one new test for --full-refresh table1,table2 --refresh table3,table4
- for bundles, adds all tests to match tests present in the pipelines tests

Follows https://github.com/databricks/cli/pull/3300