### PR TITLE
Fix .vscode/settings.json: replace --fast with --fast-only

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     },
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
-        "--fast"
+        "--fast-only"
     ],
     "go.useLanguageServer": true,
     "gopls": {


### PR DESCRIPTION
This was changed in golangci-lint 2.0.0: https://github.com/golangci/golangci-lint/blob/main/CHANGELOG.md#v200
