### PR TITLE
Always download notebooks as Python source files on bundle generate

### DIFF
--- a/acceptance/bundle/generate/ipynb_job/databricks.yml
+++ b/acceptance/bundle/generate/ipynb_job/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: git_job

--- a/acceptance/bundle/generate/ipynb_job/out.job.yml
+++ b/acceptance/bundle/generate/ipynb_job/out.job.yml
@@ -1,0 +1,11 @@
+resources:
+  jobs:
+    out:
+      name: gitjob
+      tasks:
+        - task_key: test_task
+          notebook_task:
+            notebook_path: src/notebook.py
+        - task_key: test_task_2
+          notebook_task:
+            notebook_path: src/notebook.py

--- a/acceptance/bundle/generate/ipynb_job/out.test.toml
+++ b/acceptance/bundle/generate/ipynb_job/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/generate/ipynb_job/output.txt
+++ b/acceptance/bundle/generate/ipynb_job/output.txt
@@ -1,0 +1,2 @@
+File successfully saved to src/notebook.py
+Job configuration successfully saved to out.job.yml

--- a/acceptance/bundle/generate/ipynb_job/script
+++ b/acceptance/bundle/generate/ipynb_job/script
@@ -1,0 +1,1 @@
+$CLI bundle generate job --existing-job-id 1234 --config-dir . --key out --force

--- a/acceptance/bundle/generate/ipynb_job/src/notebook.py
+++ b/acceptance/bundle/generate/ipynb_job/src/notebook.py
@@ -1,0 +1,1 @@
+print("Hello, World!")

--- a/acceptance/bundle/generate/ipynb_job/test.toml
+++ b/acceptance/bundle/generate/ipynb_job/test.toml
@@ -1,0 +1,40 @@
+[[Server]]
+Pattern = "GET /api/2.2/jobs/get"
+Response.Body = '''
+{
+    "job_id": 11223344,
+    "settings": {
+        "name": "gitjob",
+        "tasks": [
+            {
+                "task_key": "test_task",
+                "notebook_task": {
+                    "notebook_path": "/Workspace/Users/tester@databricks.com/notebook"
+                }
+            },
+            {
+                "task_key": "test_task_2",
+                "notebook_task": {
+                    "notebook_path": "/Workspace/Users/tester@databricks.com/notebook.ipynb"
+                }
+            }
+        ]
+    }
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.0/workspace/get-status"
+Response.Body = '''
+{
+    "path": "/Workspace/Users/tester@databricks.com/notebook",
+    "object_type": "NOTEBOOK",
+    "language": "PYTHON"
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.0/workspace/export"
+Response.Body = '''
+print("Hello, World!")
+'''

--- a/bundle/generate/downloader.go
+++ b/bundle/generate/downloader.go
@@ -108,7 +108,14 @@ func (n *Downloader) markNotebookForDownload(ctx context.Context, notebookPath *
 		return err
 	}
 
-	relPath := n.relativePath(*notebookPath) + notebook.GetExtensionByLanguage(info)
+	relPath := n.relativePath(*notebookPath)
+	// If the path has any extension, strip it
+	ext := path.Ext(relPath)
+	if ext != "" {
+		relPath = strings.TrimSuffix(relPath, ext)
+	}
+
+	relPath = relPath + notebook.GetExtensionByLanguage(info)
 	targetPath := filepath.Join(n.sourceDir, relPath)
 
 	n.files[targetPath] = *notebookPath
@@ -161,7 +168,7 @@ func (n *Downloader) FlushToDisk(ctx context.Context, force bool) error {
 			return err
 		}
 		errs.Go(func() error {
-			reader, err := n.w.Workspace.Download(errCtx, filePath)
+			reader, err := n.w.Workspace.Download(errCtx, filePath, workspace.DownloadFormat(workspace.ExportFormatSource))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Changes
Always download notebooks as Python source files on `bundle generate`

## Why
Notebooks in the Databricks workspace can be exported in 2 formats: Python source code (.py) or Jupyter (.ipynb).
In UI, users can choose their preferred format of exporting.
Often, the notebooks are stored without the extension in Workspace FS, but sometimes they can have `.py` or `.ipynb`

At the moment, there is no programmatic way of distinguishing which default export format the user has chosen.
Providing `format: AUTO` for the export command also does not use the default export format set.
Instead of using a possibly available extension of the notebooks in remotely stored notebooks to identify them, we just always export in Python source code format. 

## Tests
Added acceptance test

<!-- If your PR needs to be included in the release notes for the next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
