### PR TITLE
acc: expand run_as test with empty dictionary

### DIFF
--- a/acceptance/bundle/run_as/empty_run_as_dict/databricks.yml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/databricks.yml
@@ -1,0 +1,9 @@
+bundle:
+  name: "abc"
+
+run_as: {}
+
+resources:
+  jobs:
+    foo:
+      name: foo

--- a/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/run_as/empty_run_as_dict/output.txt
+++ b/acceptance/bundle/run_as/empty_run_as_dict/output.txt
@@ -1,0 +1,6 @@
+Error: run_as section must specify exactly one identity. Neither service_principal_name nor user_name is specified
+  in databricks.yml:4:9
+
+
+Exit code (musterr): 1
+  "run_as": {},

--- a/acceptance/bundle/run_as/empty_run_as_dict/script
+++ b/acceptance/bundle/run_as/empty_run_as_dict/script
@@ -1,0 +1,1 @@
+musterr $CLI bundle validate -o json | grep run_as


### PR DESCRIPTION
## Why
The semantics of nulls is going to change in https://github.com/databricks/cli/pull/3230 but empty dictionary behaviour should stay the same. This test ensures that.
