### PR TITLE
acc: Use unique name in deploy/empty-bundle

### DIFF
--- a/acceptance/bundle/deploy/empty-bundle/databricks.yml
+++ b/acceptance/bundle/deploy/empty-bundle/databricks.yml
@@ -1,2 +1,0 @@
-bundle:
-  name: empty-bundle

--- a/acceptance/bundle/deploy/empty-bundle/databricks.yml.tmpl
+++ b/acceptance/bundle/deploy/empty-bundle/databricks.yml.tmpl
@@ -1,0 +1,2 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME

--- a/acceptance/bundle/deploy/empty-bundle/output.txt
+++ b/acceptance/bundle/deploy/empty-bundle/output.txt
@@ -1,11 +1,11 @@
 
->>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/empty-bundle/default/files...
+>>> [CLI] bundle deploy --force-lock
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Deployment complete!
 
 >>> [CLI] bundle destroy --auto-approve
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/empty-bundle/default
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/deploy/empty-bundle/output.txt
+++ b/acceptance/bundle/deploy/empty-bundle/output.txt
@@ -1,5 +1,5 @@
 
->>> [CLI] bundle deploy --force-lock
+>>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Deployment complete!

--- a/acceptance/bundle/deploy/empty-bundle/script
+++ b/acceptance/bundle/deploy/empty-bundle/script
@@ -1,6 +1,7 @@
+envsubst < databricks.yml.tmpl > databricks.yml
 cleanup() {
     trace $CLI bundle destroy --auto-approve
 }
 trap cleanup EXIT
 
-trace $CLI bundle deploy
+trace $CLI bundle deploy --force-lock

--- a/acceptance/bundle/deploy/empty-bundle/script
+++ b/acceptance/bundle/deploy/empty-bundle/script
@@ -4,4 +4,4 @@ cleanup() {
 }
 trap cleanup EXIT
 
-trace $CLI bundle deploy --force-lock
+trace $CLI bundle deploy


### PR DESCRIPTION
Otherwise there are conflicts when running on cloud.

```
Error: Failed to acquire deployment lock: deploy lock acquired by [USERNAME] at [TIMESTAMP].[NUMID] +0000 UTC. Use --force-lock to override
Error: deploy lock acquired by [USERNAME] at [TIMESTAMP].[NUMID] +0000 UTC. Use --force-lock to override
```