### PR TITLE
dyn: Modify FieldValues to return ordered fields

### DIFF
--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -102,7 +102,9 @@ func fromTypedStruct(src reflect.Value, ref dyn.Value, options ...fromTypedOptio
 	refm, _ := ref.AsMap()
 	out := dyn.NewMapping()
 	info := getStructInfo(src.Type())
-	for k, v := range info.FieldValues(src) {
+	for _, fieldval := range info.FieldValues(src) {
+		k := fieldval.Key
+		v := fieldval.Value
 		pair, ok := refm.GetPairByString(k)
 		refloc := pair.Key.Locations()
 		refv := pair.Value

--- a/libs/dyn/convert/struct_info_test.go
+++ b/libs/dyn/convert/struct_info_test.go
@@ -103,8 +103,10 @@ func TestStructInfoFieldValues(t *testing.T) {
 	si := getStructInfo(reflect.TypeOf(Tmp{}))
 	fv := si.FieldValues(reflect.ValueOf(src))
 	assert.Len(t, fv, 2)
-	assert.Equal(t, "foo", fv["foo"].String())
-	assert.Equal(t, "bar", fv["bar"].String())
+	assert.Equal(t, "foo", fv[0].Key)
+	assert.True(t, reflect.ValueOf("foo").Equal(fv[0].Value))
+	assert.Equal(t, "bar", fv[1].Key)
+	assert.True(t, reflect.ValueOf("bar").Equal(fv[1].Value))
 }
 
 func TestStructInfoFieldValuesAnonymousByValue(t *testing.T) {
@@ -133,8 +135,8 @@ func TestStructInfoFieldValuesAnonymousByValue(t *testing.T) {
 	si := getStructInfo(reflect.TypeOf(Tmp{}))
 	fv := si.FieldValues(reflect.ValueOf(src))
 	assert.Len(t, fv, 2)
-	assert.Equal(t, "foo", fv["foo"].String())
-	assert.Equal(t, "bar", fv["bar"].String())
+	assert.Equal(t, "foo", fv[0].Key)
+	assert.Equal(t, "bar", fv[1].Key)
 }
 
 func TestStructInfoFieldValuesAnonymousByPointer(t *testing.T) {
@@ -165,8 +167,8 @@ func TestStructInfoFieldValuesAnonymousByPointer(t *testing.T) {
 		si := getStructInfo(reflect.TypeOf(Tmp{}))
 		fv := si.FieldValues(reflect.ValueOf(src))
 		assert.Len(t, fv, 2)
-		assert.Equal(t, "foo", fv["foo"].String())
-		assert.Equal(t, "bar", fv["bar"].String())
+		assert.Equal(t, "foo", fv[0].Key)
+		assert.Equal(t, "bar", fv[1].Key)
 	})
 
 	// Test that fields of embedded types are skipped if the embedded type is nil.
@@ -181,7 +183,7 @@ func TestStructInfoFieldValuesAnonymousByPointer(t *testing.T) {
 		si := getStructInfo(reflect.TypeOf(Tmp{}))
 		fv := si.FieldValues(reflect.ValueOf(src))
 		assert.Len(t, fv, 1)
-		assert.Equal(t, "foo", fv["foo"].String())
+		assert.Equal(t, "foo", fv[0].Key)
 	})
 
 	// Test that fields of embedded types are skipped if the embedded type is nil.


### PR DESCRIPTION
The fields have natural order, existing API destroys it by returning map.

This PR changes FieldValues() to return a more appropriate data structure. Needed for / extracted from #3230