### PR TITLE
Add a capability of providing a dev_override for the Databricks Terraform provider

### DIFF
--- a/acceptance/install_terraform.py
+++ b/acceptance/install_terraform.py
@@ -103,12 +103,22 @@ def main():
     terraformrc_path = target / ".terraformrc"
     if not terraformrc_path.exists():
         path = json.dumps(str(tfplugins_path.absolute()))
+        
+        # Check for dev override environment variable
+        dev_override_path = os.environ.get("DATABRICKS_TF_PROVIDER_DEV_OVERRIDE")
+        dev_overrides_section = ""
+        if dev_override_path:
+            dev_overrides_section = f"""    dev_overrides {{
+        "databricks/databricks" = "{dev_override_path}"
+    }}
+"""
+        
         text = f"""# Set these env variables before running databricks cli:
 # export DATABRICKS_TF_CLI_CONFIG_FILE={terraformrc_path.absolute()}
 # export DATABRICKS_TF_EXEC_PATH={terraform_path.absolute()}
 
 provider_installation {{
-    filesystem_mirror {{
+{dev_overrides_section}    filesystem_mirror {{
         path = {path}
         include = ["registry.terraform.io/databricks/databricks"]
     }}

--- a/acceptance/install_terraform.py
+++ b/acceptance/install_terraform.py
@@ -103,7 +103,7 @@ def main():
     terraformrc_path = target / ".terraformrc"
     if not terraformrc_path.exists():
         path = json.dumps(str(tfplugins_path.absolute()))
-        
+
         # Check for dev override environment variable
         dev_override_path = os.environ.get("DATABRICKS_TF_PROVIDER_DEV_OVERRIDE")
         dev_overrides_section = ""
@@ -112,7 +112,7 @@ def main():
         "databricks/databricks" = "{dev_override_path}"
     }}
 """
-        
+
         text = f"""# Set these env variables before running databricks cli:
 # export DATABRICKS_TF_CLI_CONFIG_FILE={terraformrc_path.absolute()}
 # export DATABRICKS_TF_EXEC_PATH={terraform_path.absolute()}


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->

Add a capability of providing a dev_override for the Databricks Terraform provider in acceptance tests via an environment variable.

Usage:
`DATABRICKS_TF_PROVIDER_DEV_OVERRIDE=<PATH_TO_LOCAL_FOLDER> make test`

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

This allows CLI developers to use a "dev preview" of Databricks Terraform Provider in the acceptance tests.

## Tests
<!-- How have you tested the changes? -->
Manually checked that in the absence of `DATABRICKS_TF_PROVIDER_DEV_OVERRIDE` the generated .terraformrc remains intact. When `DATABRICKS_TF_PROVIDER_DEV_OVERRIDE` is provided a new section is added to the file and acceptance tests start using a local custom version of the Databricks Terraform provider:

```
# Set these env variables before running databricks cli:
# export DATABRICKS_TF_CLI_CONFIG_FILE=<REDACTED>
# export DATABRICKS_TF_EXEC_PATH=<REDACTED>

provider_installation {
    dev_overrides {
        "databricks/databricks" = <REDACTED>
    }
    filesystem_mirror {
        path = <REDACTED>
        include = ["registry.terraform.io/databricks/databricks"]
    }
}

```

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
