### PR TITLE
internal: move resource.go from tnresources to terranova

### DIFF
--- a/bundle/terranova/plan.go
+++ b/bundle/terranova/plan.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/deployplan"
-	"github.com/databricks/cli/bundle/terranova/tnresources"
 	"github.com/databricks/cli/bundle/terranova/tnstate"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/utils"
@@ -19,13 +18,13 @@ type Planner struct {
 	db           *tnstate.TerranovaState
 	group        string
 	resourceName string
-	settings     tnresources.ResourceSettings
+	settings     ResourceSettings
 }
 
 func (d *Planner) Plan(ctx context.Context, inputConfig any) (deployplan.ActionType, error) {
 	entry, hasEntry := d.db.GetResourceEntry(d.group, d.resourceName)
 
-	resource, cfgType, err := tnresources.New(d.client, d.group, d.resourceName, inputConfig)
+	resource, cfgType, err := New(d.client, d.group, d.resourceName, inputConfig)
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +74,7 @@ func CalculateDeployActions(ctx context.Context, b *bundle.Bundle) ([]deployplan
 			group := p[1].Key()
 			name := p[2].Key()
 
-			settings, ok := tnresources.SupportedResources[group]
+			settings, ok := SupportedResources[group]
 			if !ok {
 				return v, nil
 			}

--- a/bundle/terranova/resource.go
+++ b/bundle/terranova/resource.go
@@ -1,4 +1,4 @@
-package tnresources
+package terranova
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/cli/bundle/terranova/tnresources"
 	"github.com/databricks/cli/libs/structdiff"
 	"github.com/databricks/databricks-sdk-go"
 )
@@ -57,16 +58,21 @@ func (s *ResourceSettings) MustRecreate(changes []structdiff.Change) bool {
 	return false
 }
 
+// TypeOfConfig returns the reflect.Type of the configuration returned by the resource's Config() method.
+func TypeOfConfig(resource IResource) reflect.Type {
+	return reflect.TypeOf(resource.Config())
+}
+
 var SupportedResources = map[string]ResourceSettings{
 	"jobs": {
-		New:        reflect.ValueOf(NewResourceJob),
-		ConfigType: reflect.TypeOf(ResourceJob{}.config),
-		DeleteFN:   DeleteJob,
+		New:        reflect.ValueOf(tnresources.NewResourceJob),
+		ConfigType: TypeOfConfig(&tnresources.ResourceJob{}),
+		DeleteFN:   tnresources.DeleteJob,
 	},
 	"pipelines": {
-		New:        reflect.ValueOf(NewResourcePipeline),
-		ConfigType: reflect.TypeOf(ResourcePipeline{}.config),
-		DeleteFN:   DeletePipeline,
+		New:        reflect.ValueOf(tnresources.NewResourcePipeline),
+		ConfigType: TypeOfConfig(&tnresources.ResourcePipeline{}),
+		DeleteFN:   tnresources.DeletePipeline,
 		// See TF's ForceNew fields:
 		// https://github.com/databricks/terraform-provider-databricks/blob/8ae24ac/pipelines/resource_pipeline.go#L207
 		RecreateFields: mkMap(
@@ -77,9 +83,9 @@ var SupportedResources = map[string]ResourceSettings{
 		),
 	},
 	"schemas": {
-		New:        reflect.ValueOf(NewResourceSchema),
-		ConfigType: reflect.TypeOf(ResourceSchema{}.config),
-		DeleteFN:   DeleteSchema,
+		New:        reflect.ValueOf(tnresources.NewResourceSchema),
+		ConfigType: TypeOfConfig(&tnresources.ResourceSchema{}),
+		DeleteFN:   tnresources.DeleteSchema,
 		// TF: https://github.com/databricks/terraform-provider-databricks/blob/03a2515/catalog/resource_schema.go#L14
 		RecreateFields: mkMap(
 			".name",
@@ -88,9 +94,9 @@ var SupportedResources = map[string]ResourceSettings{
 		),
 	},
 	"volumes": {
-		New:        reflect.ValueOf(NewResourceVolume),
-		ConfigType: reflect.TypeOf(ResourceVolume{}.config),
-		DeleteFN:   DeleteVolume,
+		New:        reflect.ValueOf(tnresources.NewResourceVolume),
+		ConfigType: TypeOfConfig(&tnresources.ResourceVolume{}),
+		DeleteFN:   tnresources.DeleteVolume,
 		// TF: https://github.com/databricks/terraform-provider-databricks/blob/f5fce0f/catalog/resource_volume.go#L19
 		RecreateFields: mkMap(
 			".catalog_name",
@@ -100,14 +106,14 @@ var SupportedResources = map[string]ResourceSettings{
 		),
 	},
 	"apps": {
-		New:        reflect.ValueOf(NewResourceApp),
-		ConfigType: reflect.TypeOf(ResourceApp{}.config),
-		DeleteFN:   DeleteApp,
+		New:        reflect.ValueOf(tnresources.NewResourceApp),
+		ConfigType: TypeOfConfig(&tnresources.ResourceApp{}),
+		DeleteFN:   tnresources.DeleteApp,
 	},
 	"sql_warehouses": {
-		New:        reflect.ValueOf(NewResourceSqlWarehouse),
-		ConfigType: reflect.TypeOf(ResourceSqlWarehouse{}.config),
-		DeleteFN:   DeleteSqlWarehouse,
+		New:        reflect.ValueOf(tnresources.NewResourceSqlWarehouse),
+		ConfigType: TypeOfConfig(&tnresources.ResourceSqlWarehouse{}),
+		DeleteFN:   tnresources.DeleteSqlWarehouse,
 	},
 }
 

--- a/bundle/terranova/resource_test.go
+++ b/bundle/terranova/resource_test.go
@@ -1,10 +1,11 @@
-package tnresources
+package terranova
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/terranova/tnresources"
 	"github.com/databricks/cli/libs/structdiff/structpath"
 	"github.com/databricks/cli/libs/structwalk"
 	"github.com/databricks/databricks-sdk-go"
@@ -26,13 +27,12 @@ func TestNewJobResource(t *testing.T) {
 	require.NotNil(t, res)
 
 	// Ensure we received the correct resource type.
-	require.IsType(t, &ResourceJob{}, res)
-	require.IsType(t, reflect.TypeOf(ResourceJob{}.config), cfgType)
+	require.IsType(t, &tnresources.ResourceJob{}, res)
 	require.IsType(t, reflect.TypeOf(jobs.JobSettings{}), cfgType)
 
 	// The underlying config should match what we passed in.
-	r := res.(*ResourceJob)
-	require.Equal(t, cfg.JobSettings, r.config)
+	r := res.(*tnresources.ResourceJob)
+	require.Equal(t, cfg.JobSettings, r.Config())
 }
 
 // validateFields uses structwalk to generate all valid field paths and checks membership.


### PR DESCRIPTION
## Changes
Move resource.go from bundle/terranova/tnresources to bundle/terranova. No functional changes.

## Why
- resource.go is more framework-related while the rest of tnresources is focussed on implementing specific resources.
- I want to apply more linters on tnresources (specifically exhauststruct to ensure structs are copied fully).