### PR TITLE
Allow paths to start with `~/` in development mode

### DIFF
--- a/bundle/config/mutator/resourcemutator/validate_target_mode.go
+++ b/bundle/config/mutator/resourcemutator/validate_target_mode.go
@@ -89,7 +89,7 @@ func findNonUserPath(b *bundle.Bundle) string {
 	containsName := func(path string) bool {
 		username := b.Config.Workspace.CurrentUser.UserName
 		shortname := b.Config.Workspace.CurrentUser.ShortName
-		return strings.Contains(path, username) || strings.Contains(path, shortname)
+		return strings.HasPrefix(path, "~/") || strings.Contains(path, username) || strings.Contains(path, shortname)
 	}
 
 	if b.Config.Workspace.RootPath != "" && !containsName(b.Config.Workspace.RootPath) {

--- a/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
@@ -192,4 +192,10 @@ func TestValidateDevelopmentMode(t *testing.T) {
 	b.Config.Workspace.ResourcePath = "/Users/lennart@company.com/.bundle/x/y/resources"
 	diags = validateDevelopmentMode(b)
 	require.NoError(t, diags.Error())
+
+	// Test with development mode with root path inside a home folder:
+	b = mockBundle(config.Development)
+	b.Config.Workspace.RootPath = "~/Workspace/my_project/${var.global_branch_name}/${bundle.name}/${bundle.target}"
+	diags = validateDevelopmentMode(b)
+	require.NoError(t, diags.Error())
 }


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
This change allows users to specify a root_path for the bundle in their home folder without requiring the user name to be in the path in development mode

## Tests
<!-- How have you tested the changes? -->
1. Added a new unit test
2. Existing tests are passing

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
