### PR TITLE
Always set default value for source field for tasks if not explicitly set already

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,5 +10,6 @@
 * Show "DEFAULT" as the default profile for `databricks auth login` [#3252](https://github.com/databricks/cli/pull/3252)
 
 ### Bundles
+* Always set default value for source field for tasks if not explicitly set already ([#3359](https://github.com/databricks/cli/pull/3359))
 
 ### API Changes

--- a/acceptance/bundle/artifacts/whl_implicit_notebook/output.txt
+++ b/acceptance/bundle/artifacts/whl_implicit_notebook/output.txt
@@ -21,7 +21,8 @@ dist/my_test_code-0.0.1-py3-none-any.whl
       }
     ],
     "notebook_task": {
-      "notebook_path": "/notebook.py"
+      "notebook_path": "/notebook.py",
+      "source": "WORKSPACE"
     },
     "task_key": "TestTask"
   }

--- a/acceptance/bundle/deploy/experimental-python/output.txt
+++ b/acceptance/bundle/deploy/experimental-python/output.txt
@@ -24,7 +24,8 @@ Deployment complete!
       "tasks": [
         {
           "notebook_task": {
-            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/my_notebook"
+            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/my_notebook",
+            "source": "WORKSPACE"
           },
           "task_key": "my_notebook"
         }

--- a/acceptance/bundle/deploy/jobs/check-metadata/output.txt
+++ b/acceptance/bundle/deploy/jobs/check-metadata/output.txt
@@ -23,7 +23,8 @@
         "spark_version": "13.3.x-snapshot-scala2.12"
       },
       "notebook_task": {
-        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/foo"
+        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/foo",
+        "source": "WORKSPACE"
       },
       "task_key": "my_notebook_task"
     }
@@ -62,7 +63,8 @@ Deployment complete!
         "spark_version": "13.3.x-snapshot-scala2.12"
       },
       "notebook_task": {
-        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/foo"
+        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/foo",
+        "source": "WORKSPACE"
       },
       "task_key": "my_notebook_task"
     }

--- a/acceptance/bundle/deploy/jobs/task-source/databricks.yml
+++ b/acceptance/bundle/deploy/jobs/task-source/databricks.yml
@@ -10,38 +10,38 @@ resources:
         git_provider: github
 
       tasks:
-      - task_key: test_task_no_source
-        notebook_task:
-          notebook_path: ./notebook
-      - task_key: test_task_source_workspace
-        notebook_task:
-          notebook_path: ./notebook.py
-          source: WORKSPACE
-      - task_key: test_task_foreach_no_source
-        for_each_task:
-          inputs: "[1]"
-          task:
-            task_key: test_task_foreach_no_source
-            notebook_task:
-              notebook_path: ./notebook.py
-      - task_key: test_task_foreach_workspace
-        for_each_task:
-          inputs: "[1]"
-          task:
-            task_key: test_task_foreach_workspace
-            notebook_task:
-              notebook_path: ./notebook.py
-              source: WORKSPACE
+        - task_key: test_task_no_source
+          notebook_task:
+            notebook_path: ./notebook
+        - task_key: test_task_source_workspace
+          notebook_task:
+            notebook_path: ./notebook.py
+            source: WORKSPACE
+        - task_key: test_task_foreach_no_source
+          for_each_task:
+            inputs: "[1]"
+            task:
+              task_key: test_task_foreach_no_source
+              notebook_task:
+                notebook_path: ./notebook.py
+        - task_key: test_task_foreach_workspace
+          for_each_task:
+            inputs: "[1]"
+            task:
+              task_key: test_task_foreach_workspace
+              notebook_task:
+                notebook_path: ./notebook.py
+                source: WORKSPACE
 
     workspace_job:
       tasks:
-      - task_key: test_task_no_source
-        notebook_task:
-          notebook_path: ./notebook.py
-      - task_key: test_task_foreach
-        for_each_task:
-          inputs: "[1]"
-          task:
-            task_key: test_task_foreach_no_source
-            notebook_task:
-              notebook_path: ./notebook.py
+        - task_key: test_task_no_source
+          notebook_task:
+            notebook_path: ./notebook.py
+        - task_key: test_task_foreach
+          for_each_task:
+            inputs: "[1]"
+            task:
+              task_key: test_task_foreach_no_source
+              notebook_task:
+                notebook_path: ./notebook.py

--- a/acceptance/bundle/deploy/jobs/task-source/databricks.yml
+++ b/acceptance/bundle/deploy/jobs/task-source/databricks.yml
@@ -1,0 +1,47 @@
+bundle:
+  name: task-source
+
+resources:
+  jobs:
+    git_job:
+      git_source:
+        git_branch: main
+        git_url: https://github.com/databricks/cli.git
+        git_provider: github
+
+      tasks:
+      - task_key: test_task_no_source
+        notebook_task:
+          notebook_path: ./notebook
+      - task_key: test_task_source_workspace
+        notebook_task:
+          notebook_path: ./notebook.py
+          source: WORKSPACE
+      - task_key: test_task_foreach_no_source
+        for_each_task:
+          inputs: "[1]"
+          task:
+            task_key: test_task_foreach_no_source
+            notebook_task:
+              notebook_path: ./notebook.py
+      - task_key: test_task_foreach_workspace
+        for_each_task:
+          inputs: "[1]"
+          task:
+            task_key: test_task_foreach_workspace
+            notebook_task:
+              notebook_path: ./notebook.py
+              source: WORKSPACE
+
+    workspace_job:
+      tasks:
+      - task_key: test_task_no_source
+        notebook_task:
+          notebook_path: ./notebook.py
+      - task_key: test_task_foreach
+        for_each_task:
+          inputs: "[1]"
+          task:
+            task_key: test_task_foreach_no_source
+            notebook_task:
+              notebook_path: ./notebook.py

--- a/acceptance/bundle/deploy/jobs/task-source/databricks.yml
+++ b/acceptance/bundle/deploy/jobs/task-source/databricks.yml
@@ -4,6 +4,7 @@ bundle:
 resources:
   jobs:
     git_job:
+      name: git_job
       git_source:
         git_branch: main
         git_url: https://github.com/databricks/cli.git
@@ -34,6 +35,7 @@ resources:
                 source: WORKSPACE
 
     workspace_job:
+      name: workspace_job
       tasks:
         - task_key: test_task_no_source
           notebook_task:

--- a/acceptance/bundle/deploy/jobs/task-source/notebook.py
+++ b/acceptance/bundle/deploy/jobs/task-source/notebook.py
@@ -1,0 +1,5 @@
+# Databricks notebook source
+# %%
+print("Hello, World!")
+
+# %%

--- a/acceptance/bundle/deploy/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/deploy/jobs/task-source/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/deploy/jobs/task-source/output.txt
+++ b/acceptance/bundle/deploy/jobs/task-source/output.txt
@@ -5,42 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> jq -s .[] | select(.path=="/api/2.2/jobs/create") | .body out.requests.txt
-{
-  "deployment": {
-    "kind": "BUNDLE",
-    "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/state/metadata.json"
-  },
-  "edit_mode": "UI_LOCKED",
-  "format": "MULTI_TASK",
-  "max_concurrent_runs": 1,
-  "name": "Untitled",
-  "queue": {
-    "enabled": true
-  },
-  "tasks": [
-    {
-      "for_each_task": {
-        "inputs": "[1]",
-        "task": {
-          "notebook_task": {
-            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/files/notebook",
-            "source": "WORKSPACE"
-          },
-          "task_key": "test_task_foreach_no_source"
-        }
-      },
-      "task_key": "test_task_foreach"
-    },
-    {
-      "notebook_task": {
-        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/files/notebook",
-        "source": "WORKSPACE"
-      },
-      "task_key": "test_task_no_source"
-    }
-  ]
-}
+>>> jq -s .[] | select(.path=="/api/2.2/jobs/create") | select(.body.name=="git_job") | .body out.requests.txt
 {
   "deployment": {
     "kind": "BUNDLE",
@@ -54,7 +19,7 @@ Deployment complete!
     "git_url": "https://github.com/databricks/cli.git"
   },
   "max_concurrent_runs": 1,
-  "name": "Untitled",
+  "name": "git_job",
   "queue": {
     "enabled": true
   },
@@ -98,6 +63,43 @@ Deployment complete!
         "source": "WORKSPACE"
       },
       "task_key": "test_task_source_workspace"
+    }
+  ]
+}
+
+>>> jq -s .[] | select(.path=="/api/2.2/jobs/create") | select(.body.name=="workspace_job") | .body out.requests.txt
+{
+  "deployment": {
+    "kind": "BUNDLE",
+    "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/state/metadata.json"
+  },
+  "edit_mode": "UI_LOCKED",
+  "format": "MULTI_TASK",
+  "max_concurrent_runs": 1,
+  "name": "workspace_job",
+  "queue": {
+    "enabled": true
+  },
+  "tasks": [
+    {
+      "for_each_task": {
+        "inputs": "[1]",
+        "task": {
+          "notebook_task": {
+            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/files/notebook",
+            "source": "WORKSPACE"
+          },
+          "task_key": "test_task_foreach_no_source"
+        }
+      },
+      "task_key": "test_task_foreach"
+    },
+    {
+      "notebook_task": {
+        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/files/notebook",
+        "source": "WORKSPACE"
+      },
+      "task_key": "test_task_no_source"
     }
   ]
 }

--- a/acceptance/bundle/deploy/jobs/task-source/output.txt
+++ b/acceptance/bundle/deploy/jobs/task-source/output.txt
@@ -1,0 +1,103 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/task-source/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> jq -s .[] | select(.path=="/api/2.2/jobs/create") | .body out.requests.txt
+{
+  "deployment": {
+    "kind": "BUNDLE",
+    "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/state/metadata.json"
+  },
+  "edit_mode": "UI_LOCKED",
+  "format": "MULTI_TASK",
+  "max_concurrent_runs": 1,
+  "name": "Untitled",
+  "queue": {
+    "enabled": true
+  },
+  "tasks": [
+    {
+      "for_each_task": {
+        "inputs": "[1]",
+        "task": {
+          "notebook_task": {
+            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/files/notebook",
+            "source": "WORKSPACE"
+          },
+          "task_key": "test_task_foreach_no_source"
+        }
+      },
+      "task_key": "test_task_foreach"
+    },
+    {
+      "notebook_task": {
+        "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/files/notebook",
+        "source": "WORKSPACE"
+      },
+      "task_key": "test_task_no_source"
+    }
+  ]
+}
+{
+  "deployment": {
+    "kind": "BUNDLE",
+    "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/task-source/default/state/metadata.json"
+  },
+  "edit_mode": "UI_LOCKED",
+  "format": "MULTI_TASK",
+  "git_source": {
+    "git_branch": "main",
+    "git_provider": "github",
+    "git_url": "https://github.com/databricks/cli.git"
+  },
+  "max_concurrent_runs": 1,
+  "name": "Untitled",
+  "queue": {
+    "enabled": true
+  },
+  "tasks": [
+    {
+      "for_each_task": {
+        "inputs": "[1]",
+        "task": {
+          "notebook_task": {
+            "notebook_path": "./notebook.py",
+            "source": "GIT"
+          },
+          "task_key": "test_task_foreach_no_source"
+        }
+      },
+      "task_key": "test_task_foreach_no_source"
+    },
+    {
+      "for_each_task": {
+        "inputs": "[1]",
+        "task": {
+          "notebook_task": {
+            "notebook_path": "./notebook.py",
+            "source": "WORKSPACE"
+          },
+          "task_key": "test_task_foreach_workspace"
+        }
+      },
+      "task_key": "test_task_foreach_workspace"
+    },
+    {
+      "notebook_task": {
+        "notebook_path": "./notebook",
+        "source": "GIT"
+      },
+      "task_key": "test_task_no_source"
+    },
+    {
+      "notebook_task": {
+        "notebook_path": "./notebook.py",
+        "source": "WORKSPACE"
+      },
+      "task_key": "test_task_source_workspace"
+    }
+  ]
+}

--- a/acceptance/bundle/deploy/jobs/task-source/script
+++ b/acceptance/bundle/deploy/jobs/task-source/script
@@ -1,5 +1,6 @@
 trace $CLI bundle deploy
 
-trace jq -s '.[] | select(.path=="/api/2.2/jobs/create") | .body' out.requests.txt
+trace jq -s '.[] | select(.path=="/api/2.2/jobs/create") | select(.body.name=="git_job") | .body' out.requests.txt | jq --sort-keys
+trace jq -s '.[] | select(.path=="/api/2.2/jobs/create") | select(.body.name=="workspace_job") | .body' out.requests.txt | jq --sort-keys
 
 rm out.requests.txt

--- a/acceptance/bundle/deploy/jobs/task-source/script
+++ b/acceptance/bundle/deploy/jobs/task-source/script
@@ -1,0 +1,5 @@
+trace $CLI bundle deploy
+
+trace jq -s '.[] | select(.path=="/api/2.2/jobs/create") | .body' out.requests.txt
+
+rm out.requests.txt

--- a/acceptance/bundle/deploy/jobs/task-source/test.toml
+++ b/acceptance/bundle/deploy/jobs/task-source/test.toml
@@ -1,0 +1,4 @@
+Cloud = false
+Local = true
+
+RecordRequests = true

--- a/acceptance/bundle/deploy/python-notebook/output.txt
+++ b/acceptance/bundle/deploy/python-notebook/output.txt
@@ -24,7 +24,8 @@ Deployment complete!
       "tasks": [
         {
           "notebook_task": {
-            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/my_notebook"
+            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/my_notebook",
+            "source": "WORKSPACE"
           },
           "task_key": "my_notebook"
         }

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/output.txt
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/output.txt
@@ -27,7 +27,8 @@ Deployment complete!
       {
         "task_key": "my_notebook_task",
         "spark_python_task": {
-          "python_file": "/Workspace/Users/[USERNAME]/.bundle/test-bind-job-[UNIQUE_NAME]/files/hello_world.py"
+          "python_file": "/Workspace/Users/[USERNAME]/.bundle/test-bind-job-[UNIQUE_NAME]/files/hello_world.py",
+          "source": "WORKSPACE"
         }
       }
     ]
@@ -58,7 +59,8 @@ Destroy complete!
       {
         "task_key": "my_notebook_task",
         "spark_python_task": {
-          "python_file": "/Workspace/Users/[USERNAME]/.bundle/test-bind-job-[UNIQUE_NAME]/files/hello_world.py"
+          "python_file": "/Workspace/Users/[USERNAME]/.bundle/test-bind-job-[UNIQUE_NAME]/files/hello_world.py",
+          "source": "WORKSPACE"
         }
       }
     ]

--- a/acceptance/bundle/override/job_tasks/output.txt
+++ b/acceptance/bundle/override/job_tasks/output.txt
@@ -13,7 +13,8 @@
         "spark_version": "13.3.x-scala2.12"
       },
       "spark_python_task": {
-        "python_file": "test1.py"
+        "python_file": "test1.py",
+        "source": "WORKSPACE"
       },
       "task_key": "key1"
     },
@@ -22,7 +23,8 @@
         "spark_version": "13.3.x-scala2.12"
       },
       "spark_python_task": {
-        "python_file": "test2.py"
+        "python_file": "test2.py",
+        "source": "WORKSPACE"
       },
       "task_key": "key2"
     }
@@ -47,7 +49,8 @@ Exit code: 1
         "spark_version": "13.3.x-scala2.12"
       },
       "spark_python_task": {
-        "python_file": "test1.py"
+        "python_file": "test1.py",
+        "source": "WORKSPACE"
       },
       "task_key": "key1"
     },
@@ -58,7 +61,8 @@ Exit code: 1
         "spark_version": "13.3.x-scala2.12"
       },
       "spark_python_task": {
-        "python_file": "test3.py"
+        "python_file": "test3.py",
+        "source": "WORKSPACE"
       },
       "task_key": "key2"
     }

--- a/acceptance/bundle/paths/fallback/output.job.json
+++ b/acceptance/bundle/paths/fallback/output.job.json
@@ -13,7 +13,8 @@
   {
     "job_cluster_key": "default",
     "notebook_task": {
-      "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/fallback/development/files/src/notebook"
+      "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/fallback/development/files/src/notebook",
+      "source": "WORKSPACE"
     },
     "task_key": "notebook_example"
   },
@@ -50,7 +51,8 @@
   {
     "job_cluster_key": "default",
     "spark_python_task": {
-      "python_file": "/Workspace/Users/[USERNAME]/.bundle/fallback/development/files/src/file.py"
+      "python_file": "/Workspace/Users/[USERNAME]/.bundle/fallback/development/files/src/file.py",
+      "source": "WORKSPACE"
     },
     "task_key": "spark_python_example"
   },

--- a/acceptance/bundle/paths/nominal/output.job.json
+++ b/acceptance/bundle/paths/nominal/output.job.json
@@ -14,7 +14,8 @@
     "for_each_task": {
       "task": {
         "notebook_task": {
-          "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/notebook"
+          "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/notebook",
+          "source": "WORKSPACE"
         }
       }
     },
@@ -26,7 +27,8 @@
       "task": {
         "job_cluster_key": "default",
         "spark_python_task": {
-          "python_file": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/file.py"
+          "python_file": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/file.py",
+          "source": "WORKSPACE"
         }
       }
     },
@@ -35,7 +37,8 @@
   {
     "job_cluster_key": "default",
     "notebook_task": {
-      "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/notebook"
+      "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/notebook",
+      "source": "WORKSPACE"
     },
     "task_key": "notebook_example"
   },
@@ -72,7 +75,8 @@
   {
     "job_cluster_key": "default",
     "spark_python_task": {
-      "python_file": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/file.py"
+      "python_file": "/Workspace/Users/[USERNAME]/.bundle/nominal/development/files/src/file.py",
+      "source": "WORKSPACE"
     },
     "task_key": "spark_python_example"
   },

--- a/acceptance/bundle/paths/relative_path_outside_root/output.txt
+++ b/acceptance/bundle/paths/relative_path_outside_root/output.txt
@@ -19,7 +19,8 @@
         "tasks": [
           {
             "notebook_task": {
-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/relative_path_outside_root/default/files/src/notebook"
+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/relative_path_outside_root/default/files/src/notebook",
+              "source": "WORKSPACE"
             },
             "task_key": "task_key"
           }

--- a/acceptance/bundle/python/resolve-variable/output.txt
+++ b/acceptance/bundle/python/resolve-variable/output.txt
@@ -26,13 +26,15 @@
         "tasks": [
           {
             "notebook_task": {
-              "notebook_path": "/Workspace/cde"
+              "notebook_path": "/Workspace/cde",
+              "source": "WORKSPACE"
             },
             "task_key": "abc"
           },
           {
             "notebook_task": {
-              "notebook_path": "/Workspace/ghi"
+              "notebook_path": "/Workspace/ghi",
+              "source": "WORKSPACE"
             },
             "task_key": "def"
           }

--- a/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
@@ -96,7 +96,8 @@
           {
             "job_cluster_key": "job_cluster",
             "notebook_task": {
-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook"
+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook",
+              "source": "WORKSPACE"
             },
             "task_key": "notebook_task"
           },

--- a/acceptance/bundle/templates/default-python/integration_classic/output.txt
+++ b/acceptance/bundle/templates/default-python/integration_classic/output.txt
@@ -60,7 +60,7 @@ Resources:
 +        "id": "[NUMID]",
          "job_clusters": [
            {
-@@ -119,5 +120,6 @@
+@@ -120,5 +121,6 @@
              "unit": "DAYS"
            }
 -        }
@@ -68,13 +68,13 @@ Resources:
 +        "url": "[DATABRICKS_URL]/jobs/[NUMID]"
        }
      },
-@@ -134,4 +136,5 @@
+@@ -135,4 +137,5 @@
          "development": true,
          "edition": "ADVANCED",
 +        "id": "[UUID]",
          "libraries": [
            {
-@@ -143,5 +146,6 @@
+@@ -144,5 +147,6 @@
          "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_pipeline",
          "permissions": [],
 -        "schema": "project_name_[UNIQUE_NAME]_dev"
@@ -180,18 +180,18 @@ Validation OK!
 @@ -97,5 +84,5 @@
              "job_cluster_key": "job_cluster",
              "notebook_task": {
--              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook"
-+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook"
+-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook",
++              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook",
+               "source": "WORKSPACE"
              },
-             "task_key": "notebook_task"
-@@ -114,5 +101,5 @@
+@@ -115,5 +102,5 @@
          ],
          "trigger": {
 -          "pause_status": "PAUSED",
 +          "pause_status": "UNPAUSED",
            "periodic": {
              "interval": 1,
-@@ -126,22 +113,21 @@
+@@ -127,22 +114,21 @@
          "channel": "CURRENT",
          "configuration": {
 -          "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src"
@@ -219,7 +219,7 @@ Validation OK!
 +        "schema": "project_name_[UNIQUE_NAME]_prod"
        }
      }
-@@ -153,10 +139,10 @@
+@@ -154,10 +140,10 @@
    },
    "workspace": {
 -    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",
@@ -338,18 +338,18 @@ Resources:
 @@ -98,5 +85,5 @@
              "job_cluster_key": "job_cluster",
              "notebook_task": {
--              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook"
-+              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook"
+-              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook",
++              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook",
+               "source": "WORKSPACE"
              },
-             "task_key": "notebook_task"
-@@ -115,5 +102,5 @@
+@@ -116,5 +103,5 @@
          ],
          "trigger": {
 -          "pause_status": "PAUSED",
 +          "pause_status": "UNPAUSED",
            "periodic": {
              "interval": 1,
-@@ -128,11 +115,10 @@
+@@ -129,11 +116,10 @@
          "channel": "CURRENT",
          "configuration": {
 -          "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src"
@@ -363,7 +363,7 @@ Resources:
 -        "development": true,
          "edition": "ADVANCED",
          "id": "[UUID]",
-@@ -140,11 +126,11 @@
+@@ -141,11 +127,11 @@
            {
              "notebook": {
 -              "path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/dlt_pipeline"
@@ -378,7 +378,7 @@ Resources:
 +        "schema": "project_name_[UNIQUE_NAME]_prod",
          "url": "[DATABRICKS_URL]/pipelines/[UUID]"
        }
-@@ -157,10 +143,10 @@
+@@ -158,10 +144,10 @@
    },
    "workspace": {
 -    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
@@ -67,7 +67,8 @@ Warning: Ignoring Databricks CLI version constraint for development build. Requi
         {
           "job_cluster_key": "job_cluster",
           "notebook_task": {
-            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/my_jobs_as_code/dev/files/src/notebook"
+            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/my_jobs_as_code/dev/files/src/notebook",
+            "source": "WORKSPACE"
           },
           "task_key": "notebook_task"
         }

--- a/acceptance/terraform/output.txt
+++ b/acceptance/terraform/output.txt
@@ -37,6 +37,7 @@ commands will detect it and remind you to do so if necessary.
 
 >>> [TERRAFORM] plan -no-color
 data.databricks_current_user.me: Reading...
+data.databricks_current_user.me: Still reading... [10s elapsed]
 data.databricks_current_user.me: Read complete after (redacted) [id=[USERID]]
 
 Changes to Outputs:

--- a/acceptance/terraform/output.txt
+++ b/acceptance/terraform/output.txt
@@ -37,7 +37,6 @@ commands will detect it and remind you to do so if necessary.
 
 >>> [TERRAFORM] plan -no-color
 data.databricks_current_user.me: Reading...
-data.databricks_current_user.me: Still reading... [10s elapsed]
 data.databricks_current_user.me: Read complete after (redacted) [id=[USERID]]
 
 Changes to Outputs:

--- a/bundle/config/mutator/resourcemutator/apply_default_task_source.go
+++ b/bundle/config/mutator/resourcemutator/apply_default_task_source.go
@@ -14,23 +14,23 @@ func ApplyDefaultTaskSource() bundle.Mutator {
 	return &applyDefaultTaskSource{}
 }
 
+var pattern = dyn.NewPattern(
+	dyn.Key("resources"),
+	dyn.Key("jobs"),
+	dyn.AnyKey(),
+)
+
+var taskPattern = dyn.NewPattern(
+	dyn.Key("tasks"),
+	dyn.AnyIndex(),
+)
+
+var foreachTaskPattern = dyn.NewPattern(
+	dyn.Key("for_each_task"),
+	dyn.Key("task"),
+)
+
 func (a *applyDefaultTaskSource) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	pattern := dyn.NewPattern(
-		dyn.Key("resources"),
-		dyn.Key("jobs"),
-		dyn.AnyKey(),
-	)
-
-	taskPattern := dyn.NewPattern(
-		dyn.Key("tasks"),
-		dyn.AnyIndex(),
-	)
-
-	foreachTaskPattern := dyn.NewPattern(
-		dyn.Key("for_each_task"),
-		dyn.Key("task"),
-	)
-
 	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
 		return dyn.MapByPattern(v, pattern, func(p dyn.Path, job dyn.Value) (dyn.Value, error) {
 			defaultSource := "WORKSPACE"

--- a/bundle/config/mutator/resourcemutator/apply_default_task_source.go
+++ b/bundle/config/mutator/resourcemutator/apply_default_task_source.go
@@ -1,0 +1,90 @@
+package resourcemutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+)
+
+type applyDefaultTaskSource struct{}
+
+func ApplyDefaultTaskSource() bundle.Mutator {
+	return &applyDefaultTaskSource{}
+}
+
+func (a *applyDefaultTaskSource) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	pattern := dyn.NewPattern(
+		dyn.Key("resources"),
+		dyn.Key("jobs"),
+		dyn.AnyKey(),
+	)
+
+	taskPattern := dyn.NewPattern(
+		dyn.Key("tasks"),
+		dyn.AnyIndex(),
+	)
+
+	foreachTaskPattern := dyn.NewPattern(
+		dyn.Key("for_each_task"),
+		dyn.Key("task"),
+	)
+
+	err := b.Config.Mutate(func(v dyn.Value) (dyn.Value, error) {
+		return dyn.MapByPattern(v, pattern, func(p dyn.Path, job dyn.Value) (dyn.Value, error) {
+			defaultSource := "WORKSPACE"
+
+			// Check if the job has git_source set and set the default source to GIT if it does
+			_, err := dyn.Get(job, "git_source")
+			if err == nil {
+				defaultSource = "GIT"
+			}
+
+			// Then iterate over the tasks and set the source to the default if it's not set
+			return dyn.MapByPattern(job, taskPattern, func(p dyn.Path, task dyn.Value) (dyn.Value, error) {
+				// Then iterate over the foreach tasks and set the source to the default if it's not set
+				task, err = dyn.MapByPattern(task, foreachTaskPattern, func(p dyn.Path, foreachTask dyn.Value) (dyn.Value, error) {
+					return setSourceIfNotSet(foreachTask, defaultSource)
+				})
+				if err != nil {
+					return task, err
+				}
+
+				return setSourceIfNotSet(task, defaultSource)
+			})
+		})
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// These are the task types that support the source field
+// https://docs.databricks.com/api/workspace/jobs/create
+var supportedTypeTasks = []string{
+	"db_task",
+	"notebook_task",
+	"spark_python_task",
+}
+
+func setSourceIfNotSet(task dyn.Value, defaultSource string) (dyn.Value, error) {
+	for _, taskType := range supportedTypeTasks {
+		t, err := dyn.Get(task, taskType)
+		if err != nil {
+			continue
+		}
+
+		_, err = dyn.Get(t, "source")
+		if err != nil {
+			return dyn.Set(task, taskType+".source", dyn.V(defaultSource))
+		}
+	}
+	return task, nil
+}
+
+func (a *applyDefaultTaskSource) Name() string {
+	return "ApplyDefaultTaskSource"
+}

--- a/bundle/config/mutator/resourcemutator/resource_mutator.go
+++ b/bundle/config/mutator/resourcemutator/resource_mutator.go
@@ -112,6 +112,8 @@ func applyInitializeMutators(ctx context.Context, b *bundle.Bundle) {
 		// Updates (dynamic): resources.*.*.permissions (removes permissions entries where user_name or service_principal_name matches current user)
 		// Removes the current user from all resource permissions as the Terraform provider implicitly grants ownership
 		FilterCurrentUser(),
+
+		ApplyDefaultTaskSource(),
 	)
 }
 


### PR DESCRIPTION
## Changes
If the job has `git_source` set, DABs will set `source: GIT` to all the tasks where source is not already set
If the job has no `git_source` set, DABs will set `source: WORKSPACE` to all the tasks where source is not already set

We only do this for a subset of task types which support source field as per https://docs.databricks.com/api/workspace/jobs/create

## Why
Fixes https://github.com/databricks/cli/issues/2561

## Tests
Added an acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
