### PR TITLE
Enable more of staticheck linter rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,8 +49,6 @@ linters:
         - all
         # disabled checks:
         - -ST1003
-        - -ST1016
-        - -ST1005
     testifylint:
       enable-all: true
       disable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,7 +51,6 @@ linters:
         - -ST1003
         - -ST1016
         - -ST1005
-        - -ST1023
     testifylint:
       enable-all: true
       disable:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,13 +52,6 @@ linters:
         - -ST1016
         - -ST1005
         - -ST1023
-        - -QF1001
-        - -QF1003
-        - -QF1007
-        - -QF1008
-        - -QF1009
-        - -QF1011
-        - -QF1012
     testifylint:
       enable-all: true
       disable:

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -372,7 +372,7 @@ func (b *Bundle) OpenResourceDatabase(ctx context.Context) error {
 
 	err = b.ResourceDatabase.Open(statePath)
 	if err != nil {
-		return fmt.Errorf("Failed to open/create resoruce database in %s: %s", statePath, err)
+		return fmt.Errorf("failed to open/create resoruce database in %s: %s", statePath, err)
 	}
 
 	return nil

--- a/bundle/config/mutator/resolve_variable_references_test.go
+++ b/bundle/config/mutator/resolve_variable_references_test.go
@@ -20,7 +20,7 @@ func TestResolveVariableReferencesWithSourceLinkedDeployment(t *testing.T) {
 			true,
 			func(t *testing.T, b *bundle.Bundle) {
 				// Variables that use workspace file path should have SyncRootValue during resolution phase
-				require.Equal(t, "sync/root/path", b.Config.Resources.Pipelines["pipeline1"].CreatePipeline.Configuration["source"])
+				require.Equal(t, "sync/root/path", b.Config.Resources.Pipelines["pipeline1"].Configuration["source"])
 
 				// The file path itself should remain the same
 				require.Equal(t, "file/path", b.Config.Workspace.FilePath)
@@ -29,7 +29,7 @@ func TestResolveVariableReferencesWithSourceLinkedDeployment(t *testing.T) {
 		{
 			false,
 			func(t *testing.T, b *bundle.Bundle) {
-				require.Equal(t, "file/path", b.Config.Resources.Pipelines["pipeline1"].CreatePipeline.Configuration["source"])
+				require.Equal(t, "file/path", b.Config.Resources.Pipelines["pipeline1"].Configuration["source"])
 				require.Equal(t, "file/path", b.Config.Workspace.FilePath)
 			},
 		},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -197,16 +197,16 @@ func TestProcessTargetModeDevelopment(t *testing.T) {
 	// Pipeline 1
 	assert.Equal(t, "[dev lennart] pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
 	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].Continuous)
-	assert.True(t, b.Config.Resources.Pipelines["pipeline1"].CreatePipeline.Development)
+	assert.True(t, b.Config.Resources.Pipelines["pipeline1"].Development)
 
 	// Experiment 1
 	assert.Equal(t, "/Users/lennart.kats@databricks.com/[dev lennart] experiment1", b.Config.Resources.Experiments["experiment1"].Name)
-	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
+	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
 	assert.Equal(t, "dev", b.Config.Resources.Experiments["experiment1"].Experiment.Tags[0].Key)
 
 	// Experiment 2
 	assert.Equal(t, "[dev lennart] experiment2", b.Config.Resources.Experiments["experiment2"].Name)
-	assert.Contains(t, b.Config.Resources.Experiments["experiment2"].Experiment.Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
+	assert.Contains(t, b.Config.Resources.Experiments["experiment2"].Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
 
 	// Model 1
 	assert.Equal(t, "[dev lennart] model1", b.Config.Resources.Models["model1"].Name)
@@ -282,7 +282,7 @@ func TestProcessTargetModeDefault(t *testing.T) {
 	require.NoError(t, diags.Error())
 	assert.Equal(t, "job1", b.Config.Resources.Jobs["job1"].Name)
 	assert.Equal(t, "pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
-	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].CreatePipeline.Development)
+	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].Development)
 	assert.Equal(t, "servingendpoint1", b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
 	assert.Equal(t, "registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 	assert.Equal(t, "qualityMonitor1", b.Config.Resources.QualityMonitors["qualityMonitor1"].TableName)
@@ -446,5 +446,5 @@ func TestPipelinesDevelopmentDisabled(t *testing.T) {
 	diags := bundle.ApplySeq(context.Background(), b, ApplyTargetMode(), ApplyPresets())
 	require.NoError(t, diags.Error())
 
-	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].CreatePipeline.Development)
+	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].Development)
 }

--- a/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
+++ b/bundle/config/mutator/resourcemutator/capture_schema_dependency_test.go
@@ -80,11 +80,11 @@ func TestCaptureSchemaDependencyForVolume(t *testing.T) {
 	d := bundle.Apply(context.Background(), b, CaptureSchemaDependency())
 	require.Nil(t, d)
 
-	assert.Equal(t, "${resources.schemas.schema1.name}", b.Config.Resources.Volumes["volume1"].CreateVolumeRequestContent.SchemaName)
-	assert.Equal(t, "${resources.schemas.schema2.name}", b.Config.Resources.Volumes["volume2"].CreateVolumeRequestContent.SchemaName)
-	assert.Equal(t, "${resources.schemas.schema3.name}", b.Config.Resources.Volumes["volume3"].CreateVolumeRequestContent.SchemaName)
-	assert.Equal(t, "foobar", b.Config.Resources.Volumes["volume4"].CreateVolumeRequestContent.SchemaName)
-	assert.Equal(t, "schemaX", b.Config.Resources.Volumes["volume5"].CreateVolumeRequestContent.SchemaName)
+	assert.Equal(t, "${resources.schemas.schema1.name}", b.Config.Resources.Volumes["volume1"].SchemaName)
+	assert.Equal(t, "${resources.schemas.schema2.name}", b.Config.Resources.Volumes["volume2"].SchemaName)
+	assert.Equal(t, "${resources.schemas.schema3.name}", b.Config.Resources.Volumes["volume3"].SchemaName)
+	assert.Equal(t, "foobar", b.Config.Resources.Volumes["volume4"].SchemaName)
+	assert.Equal(t, "schemaX", b.Config.Resources.Volumes["volume5"].SchemaName)
 
 	assert.Nil(t, b.Config.Resources.Volumes["nilVolume"])
 	// assert.Nil(t, b.Config.Resources.Volumes["emptyVolume"].CreateVolumeRequestContent)
@@ -179,7 +179,7 @@ func TestCaptureSchemaDependencyForPipelinesWithTarget(t *testing.T) {
 	assert.Equal(t, "", b.Config.Resources.Pipelines["pipeline7"].Schema)
 
 	assert.Nil(t, b.Config.Resources.Pipelines["nilPipeline"])
-	assert.Empty(t, b.Config.Resources.Pipelines["emptyPipeline"].CreatePipeline.Catalog)
+	assert.Empty(t, b.Config.Resources.Pipelines["emptyPipeline"].Catalog)
 
 	for _, k := range []string{"pipeline1", "pipeline2", "pipeline3", "pipeline4", "pipeline5", "pipeline6", "pipeline7"} {
 		assert.Empty(t, b.Config.Resources.Pipelines[k].Target)

--- a/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/validate_target_mode_test.go
@@ -102,7 +102,7 @@ func TestProcessTargetModeProduction(t *testing.T) {
 
 	assert.Equal(t, "job1", b.Config.Resources.Jobs["job1"].Name)
 	assert.Equal(t, "pipeline1", b.Config.Resources.Pipelines["pipeline1"].Name)
-	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].CreatePipeline.Development)
+	assert.False(t, b.Config.Resources.Pipelines["pipeline1"].Development)
 	assert.Equal(t, "servingendpoint1", b.Config.Resources.ModelServingEndpoints["servingendpoint1"].Name)
 	assert.Equal(t, "registeredmodel1", b.Config.Resources.RegisteredModels["registeredmodel1"].Name)
 	assert.Equal(t, "qualityMonitor1", b.Config.Resources.QualityMonitors["qualityMonitor1"].TableName)

--- a/bundle/config/mutator/rewrite_workspace_prefix_test.go
+++ b/bundle/config/mutator/rewrite_workspace_prefix_test.go
@@ -76,9 +76,9 @@ func TestNoWorkspacePrefixUsed(t *testing.T) {
 		delete(expectedErrors, d.Summary)
 	}
 
-	require.Equal(t, "${workspace.root_path}/file1.py", b.Config.Resources.Jobs["test_job"].JobSettings.Tasks[0].SparkPythonTask.PythonFile)
-	require.Equal(t, "${workspace.file_path}/notebook1", b.Config.Resources.Jobs["test_job"].JobSettings.Tasks[1].NotebookTask.NotebookPath)
+	require.Equal(t, "${workspace.root_path}/file1.py", b.Config.Resources.Jobs["test_job"].Tasks[0].SparkPythonTask.PythonFile)
+	require.Equal(t, "${workspace.file_path}/notebook1", b.Config.Resources.Jobs["test_job"].Tasks[1].NotebookTask.NotebookPath)
 	require.Equal(t, "${workspace.artifact_path}/jar1.jar", b.Config.Resources.Jobs["test_job"].JobSettings.Tasks[1].Libraries[0].Jar)
-	require.Equal(t, "${workspace.file_path}/notebook2", b.Config.Resources.Jobs["test_job"].JobSettings.Tasks[2].NotebookTask.NotebookPath)
+	require.Equal(t, "${workspace.file_path}/notebook2", b.Config.Resources.Jobs["test_job"].Tasks[2].NotebookTask.NotebookPath)
 	require.Equal(t, "${workspace.artifact_path}/jar2.jar", b.Config.Resources.Jobs["test_job"].JobSettings.Tasks[2].Libraries[0].Jar)
 }

--- a/bundle/config/mutator/translate_paths_test.go
+++ b/bundle/config/mutator/translate_paths_test.go
@@ -786,13 +786,13 @@ func TestTranslatePathJobEnvironments(t *testing.T) {
 	diags := bundle.ApplySeq(context.Background(), b, mutator.NormalizePaths(), mutator.TranslatePaths())
 	require.NoError(t, diags.Error())
 
-	assert.Equal(t, "./job/dist/env1.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[0])
-	assert.Equal(t, "./dist/env2.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[1])
-	assert.Equal(t, "simplejson", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[2])
-	assert.Equal(t, "/Workspace/Users/foo@bar.com/test.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[3])
-	assert.Equal(t, "--extra-index-url https://name:token@gitlab.com/api/v4/projects/9876/packages/pypi/simple foobar", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[4])
-	assert.Equal(t, "foobar --extra-index-url https://name:token@gitlab.com/api/v4/projects/9876/packages/pypi/simple", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[5])
-	assert.Equal(t, "https://foo@bar.com/packages/pypi/simple", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[6])
+	assert.Equal(t, "./job/dist/env1.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[0])
+	assert.Equal(t, "./dist/env2.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[1])
+	assert.Equal(t, "simplejson", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[2])
+	assert.Equal(t, "/Workspace/Users/foo@bar.com/test.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[3])
+	assert.Equal(t, "--extra-index-url https://name:token@gitlab.com/api/v4/projects/9876/packages/pypi/simple foobar", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[4])
+	assert.Equal(t, "foobar --extra-index-url https://name:token@gitlab.com/api/v4/projects/9876/packages/pypi/simple", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[5])
+	assert.Equal(t, "https://foo@bar.com/packages/pypi/simple", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[6])
 }
 
 func TestTranslatePathWithComplexVariables(t *testing.T) {

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -32,12 +32,12 @@ type Job struct {
 	jobs.JobSettings
 }
 
-func (s *Job) UnmarshalJSON(b []byte) error {
-	return marshal.Unmarshal(b, s)
+func (j *Job) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, j)
 }
 
-func (s Job) MarshalJSON() ([]byte, error) {
-	return marshal.Marshal(s)
+func (j Job) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(j)
 }
 
 func (j *Job) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -50,7 +50,7 @@ func (s *MlflowExperiment) Exists(ctx context.Context, w *databricks.WorkspaceCl
 	return true, nil
 }
 
-func (j *MlflowExperiment) ResourceDescription() ResourceDescription {
+func (s *MlflowExperiment) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
 		SingularName:  "experiment",
 		PluralName:    "experiments",

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -50,7 +50,7 @@ func (s *MlflowModel) Exists(ctx context.Context, w *databricks.WorkspaceClient,
 	return true, nil
 }
 
-func (j *MlflowModel) ResourceDescription() ResourceDescription {
+func (s *MlflowModel) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
 		SingularName:  "model",
 		PluralName:    "models",

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -58,7 +58,7 @@ func (s *ModelServingEndpoint) Exists(ctx context.Context, w *databricks.Workspa
 	return true, nil
 }
 
-func (j *ModelServingEndpoint) ResourceDescription() ResourceDescription {
+func (s *ModelServingEndpoint) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
 		SingularName:  "model_serving_endpoint",
 		PluralName:    "model_serving_endpoints",

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -31,12 +31,12 @@ type Pipeline struct {
 	pipelines.CreatePipeline
 }
 
-func (s *Pipeline) UnmarshalJSON(b []byte) error {
-	return marshal.Unmarshal(b, s)
+func (p *Pipeline) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, p)
 }
 
-func (s Pipeline) MarshalJSON() ([]byte, error) {
-	return marshal.Marshal(s)
+func (p Pipeline) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(p)
 }
 
 func (p *Pipeline) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {
@@ -50,7 +50,7 @@ func (p *Pipeline) Exists(ctx context.Context, w *databricks.WorkspaceClient, id
 	return true, nil
 }
 
-func (j *Pipeline) ResourceDescription() ResourceDescription {
+func (p *Pipeline) ResourceDescription() ResourceDescription {
 	return ResourceDescription{
 		SingularName:  "pipeline",
 		PluralName:    "pipelines",
@@ -71,6 +71,6 @@ func (p *Pipeline) GetName() string {
 	return p.Name
 }
 
-func (s *Pipeline) GetURL() string {
-	return s.URL
+func (p *Pipeline) GetURL() string {
+	return p.URL
 }

--- a/bundle/config/resources/sql_warehouses.go
+++ b/bundle/config/resources/sql_warehouses.go
@@ -30,12 +30,12 @@ type SqlWarehouse struct {
 	sql.CreateWarehouseRequest
 }
 
-func (w *SqlWarehouse) UnmarshalJSON(b []byte) error {
-	return marshal.Unmarshal(b, w)
+func (sw *SqlWarehouse) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, sw)
 }
 
-func (w SqlWarehouse) MarshalJSON() ([]byte, error) {
-	return marshal.Marshal(w)
+func (sw SqlWarehouse) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(sw)
 }
 
 func (sw *SqlWarehouse) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {

--- a/bundle/deploy/metadata/annotate_jobs.go
+++ b/bundle/deploy/metadata/annotate_jobs.go
@@ -20,12 +20,12 @@ func (m *annotateJobs) Name() string {
 
 func (m *annotateJobs) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 	for _, job := range b.Config.Resources.Jobs {
-		job.JobSettings.Deployment = &jobs.JobDeployment{
+		job.Deployment = &jobs.JobDeployment{
 			Kind:             jobs.JobDeploymentKindBundle,
 			MetadataFilePath: metadataFilePath(b),
 		}
-		job.JobSettings.EditMode = jobs.JobEditModeUiLocked
-		job.JobSettings.Format = jobs.FormatMultiTask
+		job.EditMode = jobs.JobEditModeUiLocked
+		job.Format = jobs.FormatMultiTask
 	}
 
 	return nil

--- a/bundle/deploy/metadata/annotate_jobs_test.go
+++ b/bundle/deploy/metadata/annotate_jobs_test.go
@@ -43,7 +43,7 @@ func TestAnnotateJobsMutator(t *testing.T) {
 			Kind:             jobs.JobDeploymentKindBundle,
 			MetadataFilePath: "/a/b/c/metadata.json",
 		},
-		b.Config.Resources.Jobs["my-job-1"].JobSettings.Deployment)
+		b.Config.Resources.Jobs["my-job-1"].Deployment)
 	assert.Equal(t, jobs.JobEditModeUiLocked, b.Config.Resources.Jobs["my-job-1"].EditMode)
 	assert.Equal(t, jobs.FormatMultiTask, b.Config.Resources.Jobs["my-job-1"].Format)
 
@@ -52,7 +52,7 @@ func TestAnnotateJobsMutator(t *testing.T) {
 			Kind:             jobs.JobDeploymentKindBundle,
 			MetadataFilePath: "/a/b/c/metadata.json",
 		},
-		b.Config.Resources.Jobs["my-job-2"].JobSettings.Deployment)
+		b.Config.Resources.Jobs["my-job-2"].Deployment)
 	assert.Equal(t, jobs.JobEditModeUiLocked, b.Config.Resources.Jobs["my-job-2"].EditMode)
 	assert.Equal(t, jobs.FormatMultiTask, b.Config.Resources.Jobs["my-job-2"].Format)
 }

--- a/bundle/deploy/metadata/annotate_pipelines.go
+++ b/bundle/deploy/metadata/annotate_pipelines.go
@@ -20,7 +20,7 @@ func (m *annotatePipelines) Name() string {
 
 func (m *annotatePipelines) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
 	for _, pipeline := range b.Config.Resources.Pipelines {
-		pipeline.CreatePipeline.Deployment = &pipelines.PipelineDeployment{
+		pipeline.Deployment = &pipelines.PipelineDeployment{
 			Kind:             pipelines.DeploymentKindBundle,
 			MetadataFilePath: metadataFilePath(b),
 		}

--- a/bundle/deploy/metadata/annotate_pipelines_test.go
+++ b/bundle/deploy/metadata/annotate_pipelines_test.go
@@ -43,14 +43,14 @@ func TestAnnotatePipelinesMutator(t *testing.T) {
 			Kind:             pipelines.DeploymentKindBundle,
 			MetadataFilePath: "/a/b/c/metadata.json",
 		},
-		b.Config.Resources.Pipelines["my-pipeline-1"].CreatePipeline.Deployment)
+		b.Config.Resources.Pipelines["my-pipeline-1"].Deployment)
 
 	assert.Equal(t,
 		&pipelines.PipelineDeployment{
 			Kind:             pipelines.DeploymentKindBundle,
 			MetadataFilePath: "/a/b/c/metadata.json",
 		},
-		b.Config.Resources.Pipelines["my-pipeline-2"].CreatePipeline.Deployment)
+		b.Config.Resources.Pipelines["my-pipeline-2"].Deployment)
 }
 
 func TestAnnotatePipelinesMutatorPipelineWithoutASpec(t *testing.T) {

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -64,7 +64,7 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 		if !actualVersion.Equal(expectedVersion) {
 			if isDefault {
 				return "", fmt.Errorf(
-					"Terraform binary at %s (from $%s) is %s but expected version is %s. Set %s to %s to continue.",
+					"terraform binary at %s (from $%s) is %s but expected version is %s. Set %s to %s to continue",
 					execPathValue,
 					TerraformExecPathEnv,
 					actualVersion.String(),
@@ -74,7 +74,7 @@ func (m *initialize) findExecPath(ctx context.Context, b *bundle.Bundle, tf *con
 				)
 			} else {
 				return "", fmt.Errorf(
-					"Terraform binary at %s (from $%s) is %s but expected version is %s (from $%s). Update $%s and $%s so that versions match.",
+					"terraform binary at %s (from $%s) is %s but expected version is %s (from $%s). Update $%s and $%s so that versions match",
 					execPathValue,
 					TerraformExecPathEnv,
 					actualVersion.String(),

--- a/bundle/deploy/terraform/init_test.go
+++ b/bundle/deploy/terraform/init_test.go
@@ -387,11 +387,11 @@ func createFakeTerraformBinaryWindows(t *testing.T, binPath, jsonPayload, versio
 	tmpJsonPath := filepath.Join(t.TempDir(), "payload.json")
 	err = os.WriteFile(tmpJsonPath, []byte(jsonPayload), 0o644)
 	require.NoError(t, err)
-	_, err = f.WriteString(fmt.Sprintf(`@echo off
+	_, err = fmt.Fprintf(f, `@echo off
 REM This is a fake Terraform binary that returns the JSON payload.
 REM It stubs version %s.
 type "%s"
-`, version, tmpJsonPath))
+`, version, tmpJsonPath)
 	require.NoError(t, err)
 	return binPath
 }
@@ -405,12 +405,12 @@ func createFakeTerraformBinaryOther(t *testing.T, binPath, jsonPayload, version 
 	}()
 	err = f.Chmod(0o777)
 	require.NoError(t, err)
-	_, err = f.WriteString(fmt.Sprintf(`#!/bin/sh
+	_, err = fmt.Fprintf(f, `#!/bin/sh
 # This is a fake Terraform binary that returns the JSON payload.
 # It stubs version %s.
 cat <<EOF
 %sEOF
-`, version, jsonPayload))
+`, version, jsonPayload)
 	require.NoError(t, err)
 	return binPath
 }

--- a/bundle/deploy/terraform/interpolate_test.go
+++ b/bundle/deploy/terraform/interpolate_test.go
@@ -79,7 +79,7 @@ func TestInterpolate(t *testing.T) {
 	assert.Equal(t, "${databricks_sql_endpoint.other_sql_warehouse.id}", j.Tags["other_sql_warehouse"])
 
 	m := b.Config.Resources.Models["my_model"]
-	assert.Equal(t, "my_model", m.CreateModelRequest.Name)
+	assert.Equal(t, "my_model", m.Name)
 }
 
 func TestInterpolateUnknownResourceType(t *testing.T) {

--- a/bundle/libraries/expand_glob_references_test.go
+++ b/bundle/libraries/expand_glob_references_test.go
@@ -68,7 +68,7 @@ func TestGlobReferencesExpandedForTaskLibraries(t *testing.T) {
 	require.Empty(t, diags)
 
 	job := b.Config.Resources.Jobs["job"]
-	task := job.JobSettings.Tasks[0]
+	task := job.Tasks[0]
 	require.Equal(t, []compute.Library{
 		{
 			Whl: filepath.Join("whl", "my1.whl"),
@@ -153,7 +153,7 @@ func TestGlobReferencesExpandedForForeachTaskLibraries(t *testing.T) {
 	require.Empty(t, diags)
 
 	job := b.Config.Resources.Jobs["job"]
-	task := job.JobSettings.Tasks[0].ForEachTask.Task
+	task := job.Tasks[0].ForEachTask.Task
 	require.Equal(t, []compute.Library{
 		{
 			Whl: filepath.Join("whl", "my1.whl"),
@@ -228,7 +228,7 @@ func TestGlobReferencesExpandedForEnvironmentsDeps(t *testing.T) {
 	require.Empty(t, diags)
 
 	job := b.Config.Resources.Jobs["job"]
-	env := job.JobSettings.Environments[0]
+	env := job.Environments[0]
 	require.Equal(t, []string{
 		filepath.Join("whl", "my1.whl"),
 		filepath.Join("whl", "my2.whl"),

--- a/bundle/libraries/libraries.go
+++ b/bundle/libraries/libraries.go
@@ -9,7 +9,7 @@ func findAllTasks(b *bundle.Bundle) map[string]([]jobs.Task) {
 	r := b.Config.Resources
 	result := make(map[string]([]jobs.Task), 0)
 	for k := range b.Config.Resources.Jobs {
-		result[k] = append(result[k], r.Jobs[k].JobSettings.Tasks...)
+		result[k] = append(result[k], r.Jobs[k].Tasks...)
 	}
 
 	return result

--- a/bundle/libraries/upload_test.go
+++ b/bundle/libraries/upload_test.go
@@ -99,8 +99,8 @@ func TestArtifactUploadForWorkspace(t *testing.T) {
 	// Test that libraries path is updated
 	require.Equal(t, "/Workspace/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[0].Libraries[0].Whl)
 	require.Equal(t, "/Workspace/Users/foo@bar.com/mywheel.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[0].Libraries[1].Whl)
-	require.Equal(t, "/Workspace/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[0])
-	require.Equal(t, "/Workspace/Users/foo@bar.com/mywheel.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[1])
+	require.Equal(t, "/Workspace/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[0])
+	require.Equal(t, "/Workspace/Users/foo@bar.com/mywheel.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[1])
 	require.Equal(t, "/Workspace/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[1].ForEachTask.Task.Libraries[0].Whl)
 	require.Equal(t, "/Workspace/Users/foo@bar.com/mywheel.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[1].ForEachTask.Task.Libraries[1].Whl)
 }
@@ -187,8 +187,8 @@ func TestArtifactUploadForVolumes(t *testing.T) {
 	// Test that libraries path is updated
 	require.Equal(t, "/Volumes/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[0].Libraries[0].Whl)
 	require.Equal(t, "/Volumes/some/path/mywheel.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[0].Libraries[1].Whl)
-	require.Equal(t, "/Volumes/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[0])
-	require.Equal(t, "/Volumes/some/path/mywheel.whl", b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies[1])
+	require.Equal(t, "/Volumes/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[0])
+	require.Equal(t, "/Volumes/some/path/mywheel.whl", b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies[1])
 	require.Equal(t, "/Volumes/foo/bar/artifacts/.internal/source.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[1].ForEachTask.Task.Libraries[0].Whl)
 	require.Equal(t, "/Volumes/some/path/mywheel.whl", b.Config.Resources.Jobs["job"].JobSettings.Tasks[1].ForEachTask.Task.Libraries[1].Whl)
 }
@@ -322,10 +322,10 @@ func TestUploadMultipleLibraries(t *testing.T) {
 	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Tasks[0].Libraries, compute.Library{Whl: "/Workspace/foo/bar/artifacts/.internal/source4.whl"})
 	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Tasks[0].Libraries, compute.Library{Whl: "/Workspace/Users/foo@bar.com/mywheel.whl"})
 
-	require.Len(t, b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies, 5)
-	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source1.whl")
-	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source2.whl")
-	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source3.whl")
-	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source4.whl")
-	require.Contains(t, b.Config.Resources.Jobs["job"].JobSettings.Environments[0].Spec.Dependencies, "/Workspace/Users/foo@bar.com/mywheel.whl")
+	require.Len(t, b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies, 5)
+	require.Contains(t, b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source1.whl")
+	require.Contains(t, b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source2.whl")
+	require.Contains(t, b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source3.whl")
+	require.Contains(t, b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies, "/Workspace/foo/bar/artifacts/.internal/source4.whl")
+	require.Contains(t, b.Config.Resources.Jobs["job"].Environments[0].Spec.Dependencies, "/Workspace/Users/foo@bar.com/mywheel.whl")
 }

--- a/bundle/permissions/permission_diagnostics.go
+++ b/bundle/permissions/permission_diagnostics.go
@@ -122,7 +122,7 @@ func analyzeBundlePermissions(b *bundle.Bundle) (bool, string) {
 }
 
 func isGroupOfCurrentUser(b *bundle.Bundle, groupName string) bool {
-	currentUserGroups := b.Config.Workspace.CurrentUser.User.Groups
+	currentUserGroups := b.Config.Workspace.CurrentUser.Groups
 
 	for _, g := range currentUserGroups {
 		if g.Display == groupName {

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -229,11 +229,12 @@ func IsDirectDeployment(ctx context.Context) (bool, error) {
 	// We use "direct-exp" while direct backend is not suitable for end users.
 	// Once we consider it usable we'll change the value to "direct".
 	// This is to prevent accidentally running direct backend with older CLI versions where it was still considered experimental.
-	if deployment == "direct-exp" {
+	switch deployment {
+	case "direct-exp":
 		return true, nil
-	} else if deployment == "terraform" || deployment == "" {
+	case "terraform", "":
 		return false, nil
-	} else {
+	default:
 		return false, fmt.Errorf("Unexpected setting for DATABRICKS_CLI_DEPLOYMENT=%#v (expected 'terraform' or 'direct-exp' or absent/empty which means 'terraform')", deployment)
 	}
 }

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -235,6 +235,6 @@ func IsDirectDeployment(ctx context.Context) (bool, error) {
 	case "terraform", "":
 		return false, nil
 	default:
-		return false, fmt.Errorf("Unexpected setting for DATABRICKS_CLI_DEPLOYMENT=%#v (expected 'terraform' or 'direct-exp' or absent/empty which means 'terraform')", deployment)
+		return false, fmt.Errorf("unexpected setting for DATABRICKS_CLI_DEPLOYMENT=%#v (expected 'terraform' or 'direct-exp' or absent/empty which means 'terraform')", deployment)
 	}
 }

--- a/bundle/phases/telemetry.go
+++ b/bundle/phases/telemetry.go
@@ -133,9 +133,10 @@ func logDeployTelemetry(ctx context.Context, b *bundle.Bundle) {
 	}
 
 	mode := protos.BundleModeUnspecified
-	if b.Config.Bundle.Mode == config.Development {
+	switch b.Config.Bundle.Mode {
+	case config.Development:
 		mode = protos.BundleModeDevelopment
-	} else if b.Config.Bundle.Mode == config.Production {
+	case config.Production:
 		mode = protos.BundleModeProduction
 	}
 

--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -34,7 +34,7 @@ func (r *jobRunner) Name() string {
 	if r.job == nil {
 		return ""
 	}
-	return r.job.JobSettings.Name
+	return r.job.Name
 }
 
 func isFailed(task jobs.RunTask) bool {
@@ -324,7 +324,7 @@ func (r *jobRunner) Restart(ctx context.Context, opts *Options) (output.RunOutpu
 	// /jobs/run-now will not cancel existing runs if the job is continuous and paused.
 	// New job runs will be queued instead and will wait for existing runs to finish.
 	// In this case, we need to cancel the existing runs before starting a new one.
-	continuous := r.job.JobSettings.Continuous
+	continuous := r.job.Continuous
 	if continuous != nil && continuous.PauseStatus == jobs.PauseStatusUnpaused {
 		return r.Run(ctx, opts)
 	}

--- a/bundle/run/pipeline.go
+++ b/bundle/run/pipeline.go
@@ -82,7 +82,7 @@ func (r *pipelineRunner) Name() string {
 	if r.pipeline == nil {
 		return ""
 	}
-	return r.pipeline.CreatePipeline.Name
+	return r.pipeline.Name
 }
 
 func (r *pipelineRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, error) {

--- a/bundle/scripts/scripts.go
+++ b/bundle/scripts/scripts.go
@@ -71,7 +71,7 @@ func executeHook(ctx context.Context, executor *exec.Executor, b *bundle.Bundle,
 
 	// Don't run any arbitrary code when restricted execution is enabled.
 	if _, ok := env.RestrictedExecution(ctx); ok {
-		return nil, nil, errors.New("Running scripts is not allowed when DATABRICKS_BUNDLE_RESTRICTED_CODE_EXECUTION is set")
+		return nil, nil, errors.New("running scripts is not allowed when DATABRICKS_BUNDLE_RESTRICTED_CODE_EXECUTION is set")
 	}
 
 	cmd, err := executor.StartCommand(ctx, string(command))

--- a/bundle/set_default.go
+++ b/bundle/set_default.go
@@ -49,13 +49,13 @@ func (m *setDefault) Apply(ctx context.Context, b *Bundle) diag.Diagnostics {
 func SetDefault(ctx context.Context, b *Bundle, pattern string, value any) {
 	pat, err := dyn.NewPatternFromString(pattern)
 	if err != nil {
-		logdiag.LogError(ctx, fmt.Errorf("Internal error: invalid pattern: %s: %w", pattern, err))
+		logdiag.LogError(ctx, fmt.Errorf("internal error: invalid pattern: %s: %w", pattern, err))
 		return
 	}
 
 	pat, key := pat.SplitKey()
 	if pat == nil || key == "" {
-		logdiag.LogError(ctx, fmt.Errorf("Internal error: invalid pattern: %s", pattern))
+		logdiag.LogError(ctx, fmt.Errorf("internal error: invalid pattern: %s", pattern))
 		return
 	}
 

--- a/bundle/terranova/tnstate/state.go
+++ b/bundle/terranova/tnstate/state.go
@@ -87,7 +87,7 @@ func (db *TerranovaState) Open(path string) error {
 		if db.Path == path {
 			return nil
 		}
-		return fmt.Errorf("Already read state %v, cannot open %v", db.Path, path)
+		return fmt.Errorf("already read state %v, cannot open %v", db.Path, path)
 	}
 
 	data, err := os.ReadFile(path)

--- a/bundle/trampoline/python_wheel.go
+++ b/bundle/trampoline/python_wheel.go
@@ -111,7 +111,7 @@ func (t *pythonTrampoline) GetTasks(b *bundle.Bundle) []TaskWithJobKey {
 	r := b.Config.Resources
 	var result []TaskWithJobKey
 	for k := range b.Config.Resources.Jobs {
-		tasks := r.Jobs[k].JobSettings.Tasks
+		tasks := r.Jobs[k].Tasks
 		for i := range tasks {
 			task := &tasks[i]
 

--- a/cmd/bundle/run.go
+++ b/cmd/bundle/run.go
@@ -159,7 +159,7 @@ Example usage:
 
 		if _, ok := b.Config.Scripts[key]; ok {
 			if len(args) > 0 {
-				return fmt.Errorf("additional arguments are not supported for scripts. Got: %v. We recommend using environment variables to pass runtime arguments to a script. For example: FOO=bar databricks bundle run my_script.", args)
+				return fmt.Errorf("additional arguments are not supported for scripts. Got: %v. We recommend using environment variables to pass runtime arguments to a script. For example: FOO=bar databricks bundle run my_script", args)
 			}
 
 			content := b.Config.Scripts[key].Content

--- a/cmd/labs/project/fetcher.go
+++ b/cmd/labs/project/fetcher.go
@@ -145,17 +145,17 @@ func (f *fetcher) checkReleasedVersions(cmd *cobra.Command, version string, offl
 	return version, nil
 }
 
-func (i *fetcher) loadRemoteProjectDefinition(cmd *cobra.Command, version string, offlineInstall bool) (*Project, error) {
+func (f *fetcher) loadRemoteProjectDefinition(cmd *cobra.Command, version string, offlineInstall bool) (*Project, error) {
 	ctx := cmd.Context()
 	var raw []byte
 	var err error
 	if !offlineInstall {
-		raw, err = github.ReadFileFromRef(ctx, "databrickslabs", i.name, version, "labs.yml")
+		raw, err = github.ReadFileFromRef(ctx, "databrickslabs", f.name, version, "labs.yml")
 		if err != nil {
 			return nil, fmt.Errorf("read labs.yml from GitHub: %w", err)
 		}
 	} else {
-		libDir, _ := PathInLabs(ctx, i.name, "lib")
+		libDir, _ := PathInLabs(ctx, f.name, "lib")
 		fileName := filepath.Join(libDir, "labs.yml")
 		raw, err = os.ReadFile(fileName)
 		if err != nil {

--- a/cmd/labs/project/project.go
+++ b/cmd/labs/project/project.go
@@ -159,7 +159,7 @@ func (p *Project) Register(parent *cobra.Command) {
 	parent.AddCommand(group)
 	for _, cp := range p.Commands {
 		cp.register(group)
-		cp.Entrypoint.Project = p
+		cp.Project = p
 	}
 }
 

--- a/cmd/labs/show.go
+++ b/cmd/labs/show.go
@@ -40,7 +40,7 @@ func newShowCommand() *cobra.Command {
 			for _, v := range installed {
 				isDev := name == "." && v.IsDeveloperMode()
 				isMatch := name == v.Name
-				if !(isDev || isMatch) {
+				if !isDev && !isMatch {
 					continue
 				}
 				return cmdio.Render(ctx, map[string]any{

--- a/cmd/labs/unpack/zipball.go
+++ b/cmd/labs/unpack/zipball.go
@@ -26,7 +26,7 @@ func (v GitHubZipball) UnpackTo(libTarget string) error {
 		return fmt.Errorf("zip: %w", err)
 	}
 	// GitHub packages entire repo contents into a top-level folder, e.g. databrickslabs-ucx-2800c6b
-	rootDirInZIP := zipReader.File[0].FileHeader.Name
+	rootDirInZIP := zipReader.File[0].Name
 	for _, zf := range zipReader.File {
 		if zf.Name == rootDirInZIP {
 			continue

--- a/cmd/pipelines/root/progress_logger.go
+++ b/cmd/pipelines/root/progress_logger.go
@@ -66,6 +66,6 @@ func initProgressLoggerFlag(cmd *cobra.Command, logFlags *logFlags) *progressLog
 	flags := cmd.PersistentFlags()
 	flags.Var(&f.ProgressLogFormat, "progress-format", "format for progress logs (append, inplace, json)")
 	flags.MarkHidden("progress-format")
-	cmd.RegisterFlagCompletionFunc("progress-format", f.ProgressLogFormat.Complete)
+	cmd.RegisterFlagCompletionFunc("progress-format", f.Complete)
 	return &f
 }

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -46,7 +46,7 @@ func isCannotConfigureAuth(err error) bool {
 }
 
 // Referenced by cmd/labs/project/entrypoint.go.
-var ErrCannotConfigureAuth = errors.New("cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method.")
+var ErrCannotConfigureAuth = errors.New("cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method")
 
 func initProfileFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringP("profile", "p", "", "~/.databrickscfg profile")

--- a/cmd/root/progress_logger.go
+++ b/cmd/root/progress_logger.go
@@ -65,6 +65,6 @@ func initProgressLoggerFlag(cmd *cobra.Command, logFlags *logFlags) *progressLog
 	flags := cmd.PersistentFlags()
 	flags.Var(&f.ProgressLogFormat, "progress-format", "format for progress logs (append, inplace, json)")
 	flags.MarkHidden("progress-format")
-	cmd.RegisterFlagCompletionFunc("progress-format", f.ProgressLogFormat.Complete)
+	cmd.RegisterFlagCompletionFunc("progress-format", f.Complete)
 	return &f
 }

--- a/cmd/root/progress_logger_test.go
+++ b/cmd/root/progress_logger_test.go
@@ -28,7 +28,7 @@ func initializeProgressLoggerTest(t *testing.T) (
 	}
 	plt.logFlags = initLogFlags(plt.Command)
 	plt.progressLoggerFlag = initProgressLoggerFlag(plt.Command, plt.logFlags)
-	return plt, &plt.logFlags.level, &plt.logFlags.file, &plt.progressLoggerFlag.ProgressLogFormat
+	return plt, &plt.level, &plt.file, &plt.ProgressLogFormat
 }
 
 func TestInitializeErrorOnIncompatibleConfig(t *testing.T) {

--- a/integration/bundle/artifacts_test.go
+++ b/integration/bundle/artifacts_test.go
@@ -149,7 +149,7 @@ func TestUploadArtifactFileToCorrectRemotePathWithEnvironments(t *testing.T) {
 	// The job environment deps path should have been updated to the remote path.
 	require.Regexp(t,
 		path.Join("/Workspace", regexp.QuoteMeta(wsDir), `.internal/test\.whl`),
-		b.Config.Resources.Jobs["test"].JobSettings.Environments[0].Spec.Dependencies[0],
+		b.Config.Resources.Jobs["test"].Environments[0].Spec.Dependencies[0],
 	)
 }
 

--- a/integration/cmd/sync/sync_test.go
+++ b/integration/cmd/sync/sync_test.go
@@ -103,18 +103,18 @@ func setupSyncTest(t *testing.T, args ...string) (context.Context, *syncTest) {
 	}
 }
 
-func (s *syncTest) waitForCompletionMarker() {
+func (a *syncTest) waitForCompletionMarker() {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	for {
 		select {
 		case <-ctx.Done():
-			s.t.Fatal("timed out waiting for sync to complete")
-		case line := <-s.c.StdoutLines:
+			a.t.Fatal("timed out waiting for sync to complete")
+		case line := <-a.c.StdoutLines:
 			var event sync.EventBase
 			err := json.Unmarshal([]byte(line), &event)
-			require.NoError(s.t, err)
+			require.NoError(a.t, err)
 			if event.Type == sync.EventTypeComplete {
 				return
 			}

--- a/libs/apps/python.go
+++ b/libs/apps/python.go
@@ -92,7 +92,7 @@ func (p *PythonApp) GetCommand(debug bool) ([]string, error) {
 	if len(spec.Command) == 0 {
 		files, err := filepath.Glob(filepath.Join(spec.config.AppPath, "*.py"))
 		if err != nil {
-			return nil, fmt.Errorf("Error reading source code directory: %w", err)
+			return nil, fmt.Errorf("error reading source code directory: %w", err)
 		}
 
 		if len(files) > 0 {
@@ -100,7 +100,7 @@ func (p *PythonApp) GetCommand(debug bool) ([]string, error) {
 		}
 
 		if len(spec.Command) == 0 {
-			return nil, errors.New("No python file found")
+			return nil, errors.New("no python file found")
 		}
 
 	} else {

--- a/libs/apps/spec.go
+++ b/libs/apps/spec.go
@@ -54,8 +54,8 @@ func ReadAppSpecFile(config *Config) (*AppSpec, error) {
 	return spec, nil
 }
 
-func (spec *AppSpec) LoadEnvVars(ctx context.Context, customEnv []string) ([]string, error) {
-	for _, envVar := range spec.EnvVars {
+func (a *AppSpec) LoadEnvVars(ctx context.Context, customEnv []string) ([]string, error) {
+	for _, envVar := range a.EnvVars {
 		if envVar.Value != nil {
 			customEnv = append(customEnv, envVar.Name+"="+*envVar.Value)
 		}
@@ -74,7 +74,7 @@ func (spec *AppSpec) LoadEnvVars(ctx context.Context, customEnv []string) ([]str
 			}
 			if !found {
 				return customEnv, fmt.Errorf("%s defined in %s with valueFrom property and can't be resolved locally. "+
-					"Please set %s environment variable in your terminal or using --env flag", envVar.Name, spec.fileName, envVar.Name)
+					"Please set %s environment variable in your terminal or using --env flag", envVar.Name, a.fileName, envVar.Name)
 			}
 		}
 	}

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -511,7 +511,7 @@ func TestFromTypedStringEmptyOverwrite(t *testing.T) {
 }
 
 func TestFromTypedStringNonEmpty(t *testing.T) {
-	var src string = "new"
+	src := "new"
 	ref := dyn.NilValue
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -519,7 +519,7 @@ func TestFromTypedStringNonEmpty(t *testing.T) {
 }
 
 func TestFromTypedStringNonEmptyOverwrite(t *testing.T) {
-	var src string = "new"
+	src := "new"
 	ref := dyn.V("old")
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -530,7 +530,7 @@ func TestFromTypedStringRetainsLocations(t *testing.T) {
 	ref := dyn.NewValue("foo", []dyn.Location{{File: "foo"}})
 
 	// case: value has not been changed
-	var src string = "foo"
+	src := "foo"
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
 	assert.Equal(t, dyn.NewValue("foo", []dyn.Location{{File: "foo"}}), nv)
@@ -543,7 +543,7 @@ func TestFromTypedStringRetainsLocations(t *testing.T) {
 }
 
 func TestFromTypedStringTypeError(t *testing.T) {
-	var src string = "foo"
+	src := "foo"
 	ref := dyn.V(1234)
 	_, err := FromTyped(src, ref)
 	require.Error(t, err)
@@ -566,7 +566,7 @@ func TestFromTypedBoolEmptyOverwrite(t *testing.T) {
 }
 
 func TestFromTypedBoolNonEmpty(t *testing.T) {
-	var src bool = true
+	src := true
 	ref := dyn.NilValue
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -574,7 +574,7 @@ func TestFromTypedBoolNonEmpty(t *testing.T) {
 }
 
 func TestFromTypedBoolNonEmptyOverwrite(t *testing.T) {
-	var src bool = true
+	src := true
 	ref := dyn.V(false)
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -585,7 +585,7 @@ func TestFromTypedBoolRetainsLocations(t *testing.T) {
 	ref := dyn.NewValue(true, []dyn.Location{{File: "foo"}})
 
 	// case: value has not been changed
-	var src bool = true
+	src := true
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
 	assert.Equal(t, dyn.NewValue(true, []dyn.Location{{File: "foo"}}), nv)
@@ -598,7 +598,7 @@ func TestFromTypedBoolRetainsLocations(t *testing.T) {
 }
 
 func TestFromTypedBoolVariableReference(t *testing.T) {
-	var src bool = true
+	src := true
 	ref := dyn.V("${var.foo}")
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -606,7 +606,7 @@ func TestFromTypedBoolVariableReference(t *testing.T) {
 }
 
 func TestFromTypedBoolTypeError(t *testing.T) {
-	var src bool = true
+	src := true
 	ref := dyn.V("string")
 	_, err := FromTyped(src, ref)
 	require.Error(t, err)
@@ -629,7 +629,7 @@ func TestFromTypedIntEmptyOverwrite(t *testing.T) {
 }
 
 func TestFromTypedIntNonEmpty(t *testing.T) {
-	var src int = 1234
+	src := 1234
 	ref := dyn.NilValue
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -637,7 +637,7 @@ func TestFromTypedIntNonEmpty(t *testing.T) {
 }
 
 func TestFromTypedIntNonEmptyOverwrite(t *testing.T) {
-	var src int = 1234
+	src := 1234
 	ref := dyn.V(1233)
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -648,7 +648,7 @@ func TestFromTypedIntRetainsLocations(t *testing.T) {
 	ref := dyn.NewValue(1234, []dyn.Location{{File: "foo"}})
 
 	// case: value has not been changed
-	var src int = 1234
+	src := 1234
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
 	assert.Equal(t, dyn.NewValue(1234, []dyn.Location{{File: "foo"}}), nv)
@@ -661,7 +661,7 @@ func TestFromTypedIntRetainsLocations(t *testing.T) {
 }
 
 func TestFromTypedIntVariableReference(t *testing.T) {
-	var src int = 1234
+	src := 1234
 	ref := dyn.V("${var.foo}")
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -669,7 +669,7 @@ func TestFromTypedIntVariableReference(t *testing.T) {
 }
 
 func TestFromTypedIntTypeError(t *testing.T) {
-	var src int = 1234
+	src := 1234
 	ref := dyn.V("string")
 	_, err := FromTyped(src, ref)
 	require.Error(t, err)
@@ -692,7 +692,7 @@ func TestFromTypedFloatEmptyOverwrite(t *testing.T) {
 }
 
 func TestFromTypedFloatNonEmpty(t *testing.T) {
-	var src float64 = 1.23
+	src := 1.23
 	ref := dyn.NilValue
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -700,7 +700,7 @@ func TestFromTypedFloatNonEmpty(t *testing.T) {
 }
 
 func TestFromTypedFloatNonEmptyOverwrite(t *testing.T) {
-	var src float64 = 1.23
+	src := 1.23
 	ref := dyn.V(1.24)
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -725,7 +725,7 @@ func TestFromTypedFloatRetainsLocations(t *testing.T) {
 }
 
 func TestFromTypedFloatVariableReference(t *testing.T) {
-	var src float64 = 1.23
+	src := 1.23
 	ref := dyn.V("${var.foo}")
 	nv, err := FromTyped(src, ref)
 	require.NoError(t, err)
@@ -733,7 +733,7 @@ func TestFromTypedFloatVariableReference(t *testing.T) {
 }
 
 func TestFromTypedFloatTypeError(t *testing.T) {
-	var src float64 = 1.23
+	src := 1.23
 	ref := dyn.V("string")
 	_, err := FromTyped(src, ref)
 	require.Error(t, err)

--- a/libs/dyn/convert/struct_info.go
+++ b/libs/dyn/convert/struct_info.go
@@ -60,7 +60,7 @@ func buildStructInfo(typ reflect.Type) structInfo {
 
 	// Queue holds the indexes of the structs to visit.
 	// It is initialized with a single empty slice to visit the top level struct.
-	var queue [][]int = [][]int{{}}
+	queue := [][]int{{}}
 	for i := 0; i < len(queue); i++ {
 		prefix := queue[i]
 

--- a/libs/dyn/convert/to_typed_test.go
+++ b/libs/dyn/convert/to_typed_test.go
@@ -174,7 +174,7 @@ func TestToTypedStructAnonymousByValue(t *testing.T) {
 	err := ToTyped(&out, v)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", out.Foo.Foo)
-	assert.Equal(t, "baz", out.Foo.Bar.Bar)
+	assert.Equal(t, "baz", out.Bar.Bar)
 }
 
 func TestToTypedStructAnonymousByPointer(t *testing.T) {
@@ -200,7 +200,7 @@ func TestToTypedStructAnonymousByPointer(t *testing.T) {
 	err := ToTyped(&out, v)
 	require.NoError(t, err)
 	assert.Equal(t, "bar", out.Foo.Foo)
-	assert.Equal(t, "baz", out.Foo.Bar.Bar)
+	assert.Equal(t, "baz", out.Bar.Bar)
 }
 
 func TestToTypedStructNil(t *testing.T) {
@@ -367,7 +367,7 @@ func TestToTypedString(t *testing.T) {
 }
 
 func TestToTypedStringOverwrite(t *testing.T) {
-	var out string = "bar"
+	out := "bar"
 	err := ToTyped(&out, dyn.V("foo"))
 	require.NoError(t, err)
 	assert.Equal(t, "foo", out)
@@ -402,7 +402,7 @@ func TestToTypedBool(t *testing.T) {
 }
 
 func TestToTypedBoolOverwrite(t *testing.T) {
-	var out bool = true
+	out := true
 	err := ToTyped(&out, dyn.V(false))
 	require.NoError(t, err)
 	assert.False(t, out)
@@ -431,7 +431,7 @@ func TestToTypedBoolFromString(t *testing.T) {
 }
 
 func TestToTypedBoolFromStringVariableReference(t *testing.T) {
-	var out bool = true
+	out := true
 	err := ToTyped(&out, dyn.V("${var.foo}"))
 	require.NoError(t, err)
 	assert.False(t, out)
@@ -459,7 +459,7 @@ func TestToTypedInt64(t *testing.T) {
 }
 
 func TestToTypedIntOverwrite(t *testing.T) {
-	var out int = 123
+	out := 123
 	err := ToTyped(&out, dyn.V(1234))
 	require.NoError(t, err)
 	assert.Equal(t, int(1234), out)
@@ -493,7 +493,7 @@ func TestToTypedIntFromStringInt(t *testing.T) {
 }
 
 func TestToTypedIntFromStringVariableReference(t *testing.T) {
-	var out int = 123
+	out := 123
 	err := ToTyped(&out, dyn.V("${var.foo}"))
 	require.NoError(t, err)
 	assert.Equal(t, int(0), out)
@@ -534,7 +534,7 @@ func TestToTypedFloat32Overwrite(t *testing.T) {
 }
 
 func TestToTypedFloat64Overwrite(t *testing.T) {
-	var out float64 = 1.0
+	out := 1.0
 	err := ToTyped(&out, dyn.V(float64(2.0)))
 	require.NoError(t, err)
 	assert.Zero(t, 2.0-out)
@@ -574,7 +574,7 @@ func TestToTypedFloat32FromStringVariableReference(t *testing.T) {
 }
 
 func TestToTypedFloat64FromStringVariableReference(t *testing.T) {
-	var out float64 = 1.0
+	out := 1.0
 	err := ToTyped(&out, dyn.V("${var.foo}"))
 	require.NoError(t, err)
 	assert.Zero(t, out)

--- a/libs/dyn/dynassert/dump.go
+++ b/libs/dyn/dynassert/dump.go
@@ -22,7 +22,7 @@ func dump(v dyn.Value, sb *strings.Builder) {
 		sb.WriteString("map[string]dyn.Value{")
 		m := v.MustMap()
 		for _, p := range m.Pairs() {
-			sb.WriteString(fmt.Sprintf("\n%q: ", p.Key.MustString()))
+			fmt.Fprintf(sb, "\n%q: ", p.Key.MustString())
 			dump(p.Value, sb)
 			sb.WriteByte(',')
 		}
@@ -35,15 +35,15 @@ func dump(v dyn.Value, sb *strings.Builder) {
 		}
 		sb.WriteString("},\n")
 	case dyn.KindString:
-		sb.WriteString(fmt.Sprintf("%q,\n", v.MustString()))
+		fmt.Fprintf(sb, "%q,\n", v.MustString())
 	case dyn.KindBool:
-		sb.WriteString(fmt.Sprintf("%t,\n", v.MustBool()))
+		fmt.Fprintf(sb, "%t,\n", v.MustBool())
 	case dyn.KindInt:
-		sb.WriteString(fmt.Sprintf("%d,\n", v.MustInt()))
+		fmt.Fprintf(sb, "%d,\n", v.MustInt())
 	case dyn.KindFloat:
-		sb.WriteString(fmt.Sprintf("%f,\n", v.MustFloat()))
+		fmt.Fprintf(sb, "%f,\n", v.MustFloat())
 	case dyn.KindTime:
-		sb.WriteString(fmt.Sprintf("dyn.NewTime(%q),\n", v.MustTime().String()))
+		fmt.Fprintf(sb, "dyn.NewTime(%q),\n", v.MustTime().String())
 	case dyn.KindNil:
 		sb.WriteString("nil,\n")
 	default:
@@ -53,7 +53,7 @@ func dump(v dyn.Value, sb *strings.Builder) {
 	// Add location
 	sb.WriteString("[]dyn.Location{")
 	for _, l := range v.Locations() {
-		sb.WriteString(fmt.Sprintf("{File: %q, Line: %d, Column: %d},", l.File, l.Line, l.Column))
+		fmt.Fprintf(sb, "{File: %q, Line: %d, Column: %d},", l.File, l.Line, l.Column)
 	}
 	sb.WriteString("},\n")
 	sb.WriteString(")")

--- a/libs/dyn/jsonloader/json.go
+++ b/libs/dyn/jsonloader/json.go
@@ -46,7 +46,8 @@ func decodeValue(decoder *json.Decoder, o *Offset) (dyn.Value, error) {
 
 	switch tok := token.(type) {
 	case json.Delim:
-		if tok == '{' {
+		switch tok {
+		case '{':
 			location = o.GetPosition(offset - 1)
 			// Decode JSON object
 			obj := dyn.NewMapping()
@@ -78,7 +79,7 @@ func decodeValue(decoder *json.Decoder, o *Offset) (dyn.Value, error) {
 				return invalidValueWithLocation(decoder, o), err
 			}
 			return dyn.NewValue(obj, []dyn.Location{location}), nil
-		} else if tok == '[' {
+		case '[':
 			location = o.GetPosition(offset - 1)
 			// Decode JSON array
 			var arr []dyn.Value

--- a/libs/dyn/visit.go
+++ b/libs/dyn/visit.go
@@ -114,11 +114,11 @@ func visit(v Value, prefix Path, suffix Pattern, opts visitOptions) (Value, erro
 	return component.visit(v, prefix, suffix, opts)
 }
 
-func (component pathComponent) visit(v Value, prefix Path, suffix Pattern, opts visitOptions) (Value, error) {
-	path := append(prefix, component)
+func (c pathComponent) visit(v Value, prefix Path, suffix Pattern, opts visitOptions) (Value, error) {
+	path := append(prefix, c)
 
 	switch {
-	case component.isKey():
+	case c.isKey():
 		// Expect a map to be set if this is a key.
 		switch v.Kind() {
 		case KindMap:
@@ -132,7 +132,7 @@ func (component pathComponent) visit(v Value, prefix Path, suffix Pattern, opts 
 		m := v.MustMap()
 
 		// Lookup current value in the map.
-		ev, ok := m.GetByString(component.key)
+		ev, ok := m.GetByString(c.key)
 		if !ok {
 			return InvalidValue, noSuchKeyError{path}
 		}
@@ -150,14 +150,14 @@ func (component pathComponent) visit(v Value, prefix Path, suffix Pattern, opts 
 
 		// Return an updated map value.
 		m = m.Clone()
-		m.SetLoc(component.key, nil, nv)
+		m.SetLoc(c.key, nil, nv)
 		return Value{
 			v: m,
 			k: KindMap,
 			l: v.l,
 		}, nil
 
-	case component.isIndex():
+	case c.isIndex():
 		// Expect a sequence to be set if this is an index.
 		switch v.Kind() {
 		case KindSequence:
@@ -171,12 +171,12 @@ func (component pathComponent) visit(v Value, prefix Path, suffix Pattern, opts 
 		s := v.MustSequence()
 
 		// Lookup current value in the sequence.
-		if component.index < 0 || component.index >= len(s) {
+		if c.index < 0 || c.index >= len(s) {
 			return InvalidValue, indexOutOfBoundsError{path}
 		}
 
 		// Recursively transform the value.
-		ev := s[component.index]
+		ev := s[c.index]
 		nv, err := visit(ev, path, suffix, opts)
 		if err != nil {
 			return InvalidValue, err
@@ -189,7 +189,7 @@ func (component pathComponent) visit(v Value, prefix Path, suffix Pattern, opts 
 
 		// Return an updated sequence value.
 		s = slices.Clone(s)
-		s[component.index] = nv
+		s[c.index] = nv
 		return Value{
 			v: s,
 			k: KindSequence,

--- a/libs/filer/dbfs_client.go
+++ b/libs/filer/dbfs_client.go
@@ -205,10 +205,7 @@ func (w *DbfsClient) Delete(ctx context.Context, name string, mode ...DeleteMode
 		return err
 	}
 
-	recursive := false
-	if slices.Contains(mode, DeleteRecursively) {
-		recursive = true
-	}
+	recursive := slices.Contains(mode, DeleteRecursively)
 
 	err = w.workspaceClient.Dbfs.Delete(ctx, files.Delete{
 		Path:      absPath,

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -29,7 +29,7 @@ type wsfsDirEntry struct {
 }
 
 func (entry wsfsDirEntry) Type() fs.FileMode {
-	return entry.wsfsFileInfo.Mode()
+	return entry.Mode()
 }
 
 func (entry wsfsDirEntry) Info() (fs.FileInfo, error) {
@@ -56,7 +56,7 @@ type wsfsFileInfo struct {
 }
 
 func (info wsfsFileInfo) Name() string {
-	return path.Base(info.ObjectInfo.Path)
+	return path.Base(info.Path)
 }
 
 func (info wsfsFileInfo) Size() int64 {
@@ -64,7 +64,7 @@ func (info wsfsFileInfo) Size() int64 {
 }
 
 func (info wsfsFileInfo) Mode() fs.FileMode {
-	switch info.ObjectInfo.ObjectType {
+	switch info.ObjectType {
 	case workspace.ObjectTypeDirectory, workspace.ObjectTypeRepo:
 		return fs.ModeDir
 	default:
@@ -73,7 +73,7 @@ func (info wsfsFileInfo) Mode() fs.FileMode {
 }
 
 func (info wsfsFileInfo) ModTime() time.Time {
-	return time.UnixMilli(info.ObjectInfo.ModifiedAt)
+	return time.UnixMilli(info.ModifiedAt)
 }
 
 func (info wsfsFileInfo) IsDir() bool {
@@ -249,10 +249,7 @@ func (w *WorkspaceFilesClient) Delete(ctx context.Context, name string, mode ...
 		return CannotDeleteRootError{}
 	}
 
-	recursive := false
-	if slices.Contains(mode, DeleteRecursively) {
-		recursive = true
-	}
+	recursive := slices.Contains(mode, DeleteRecursively)
 
 	err = w.workspaceClient.Workspace.Delete(ctx, workspace.Delete{
 		Path:      absPath,

--- a/libs/flags/progress_format.go
+++ b/libs/flags/progress_format.go
@@ -54,7 +54,7 @@ func (p *ProgressLogFormat) Type() string {
 }
 
 // Complete is the Cobra compatible completion function for this flag.
-func (f *ProgressLogFormat) Complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func (p *ProgressLogFormat) Complete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return []string{
 		"append",
 		"inplace",

--- a/libs/git/ignore.go
+++ b/libs/git/ignore.go
@@ -82,7 +82,7 @@ func (f *ignoreFile) load() error {
 
 	// If the underlying file has not been modified
 	// it does not need to be reloaded.
-	if stat.ModTime() == f.modTime {
+	if stat.ModTime().Equal(f.modTime) {
 		return nil
 	}
 

--- a/libs/jsonschema/schema.go
+++ b/libs/jsonschema/schema.go
@@ -157,8 +157,8 @@ const (
 )
 
 // Validate property types are all valid JSON schema types.
-func (schema *Schema) validateSchemaPropertyTypes() error {
-	for _, v := range schema.Properties {
+func (s *Schema) validateSchemaPropertyTypes() error {
+	for _, v := range s.Properties {
 		switch v.Type {
 		case NumberType, BooleanType, StringType, IntegerType, ObjectType, ArrayType:
 			continue
@@ -176,8 +176,8 @@ func (schema *Schema) validateSchemaPropertyTypes() error {
 }
 
 // Validate default property values are consistent with types.
-func (schema *Schema) validateSchemaDefaultValueTypes() error {
-	for name, property := range schema.Properties {
+func (s *Schema) validateSchemaDefaultValueTypes() error {
+	for name, property := range s.Properties {
 		if property.Default == nil {
 			continue
 		}
@@ -188,8 +188,8 @@ func (schema *Schema) validateSchemaDefaultValueTypes() error {
 	return nil
 }
 
-func (schema *Schema) validateConstValueTypes() error {
-	for name, property := range schema.Properties {
+func (s *Schema) validateConstValueTypes() error {
+	for name, property := range s.Properties {
 		if property.Const == nil {
 			continue
 		}
@@ -201,8 +201,8 @@ func (schema *Schema) validateConstValueTypes() error {
 }
 
 // Validate enum field values for properties are consistent with types.
-func (schema *Schema) validateSchemaEnumValueTypes() error {
-	for name, property := range schema.Properties {
+func (s *Schema) validateSchemaEnumValueTypes() error {
+	for name, property := range s.Properties {
 		if property.Enum == nil {
 			continue
 		}
@@ -217,8 +217,8 @@ func (schema *Schema) validateSchemaEnumValueTypes() error {
 }
 
 // Validate default value is contained in the list of enums if both are defined.
-func (schema *Schema) validateSchemaDefaultValueIsInEnums() error {
-	for name, property := range schema.Properties {
+func (s *Schema) validateSchemaDefaultValueIsInEnums() error {
+	for name, property := range s.Properties {
 		if property.Default == nil || property.Enum == nil {
 			continue
 		}
@@ -232,8 +232,8 @@ func (schema *Schema) validateSchemaDefaultValueIsInEnums() error {
 }
 
 // Validate usage of "pattern" is consistent.
-func (schema *Schema) validateSchemaPattern() error {
-	for name, property := range schema.Properties {
+func (s *Schema) validateSchemaPattern() error {
+	for name, property := range s.Properties {
 		pattern := property.Pattern
 		if pattern == "" {
 			continue
@@ -261,9 +261,9 @@ func (schema *Schema) validateSchemaPattern() error {
 	return nil
 }
 
-func (schema *Schema) validateSchemaMinimumCliVersion(currentVersion string) func() error {
+func (s *Schema) validateSchemaMinimumCliVersion(currentVersion string) func() error {
 	return func() error {
-		if schema.MinDatabricksCliVersion == "" {
+		if s.MinDatabricksCliVersion == "" {
 			return nil
 		}
 
@@ -273,20 +273,20 @@ func (schema *Schema) validateSchemaMinimumCliVersion(currentVersion string) fun
 		}
 
 		// Confirm that MinDatabricksCliVersion is a valid semver.
-		if !semver.IsValid(schema.MinDatabricksCliVersion) {
-			return fmt.Errorf("invalid minimum CLI version %q specified. Please specify the version in the format v0.0.0", schema.MinDatabricksCliVersion)
+		if !semver.IsValid(s.MinDatabricksCliVersion) {
+			return fmt.Errorf("invalid minimum CLI version %q specified. Please specify the version in the format v0.0.0", s.MinDatabricksCliVersion)
 		}
 
 		// Confirm that MinDatabricksCliVersion is less than or equal to the current version.
-		if semver.Compare(schema.MinDatabricksCliVersion, currentVersion) > 0 {
-			return fmt.Errorf("minimum CLI version %q is greater than current CLI version %q. Please upgrade your current Databricks CLI", schema.MinDatabricksCliVersion, currentVersion)
+		if semver.Compare(s.MinDatabricksCliVersion, currentVersion) > 0 {
+			return fmt.Errorf("minimum CLI version %q is greater than current CLI version %q. Please upgrade your current Databricks CLI", s.MinDatabricksCliVersion, currentVersion)
 		}
 		return nil
 	}
 }
 
-func (schema *Schema) validateSchemaSkippedPropertiesHaveDefaults() error {
-	for name, property := range schema.Properties {
+func (s *Schema) validateSchemaSkippedPropertiesHaveDefaults() error {
+	for name, property := range s.Properties {
 		if property.SkipPromptIf != nil && property.Default == nil {
 			return fmt.Errorf("property %q has a skip_prompt_if clause but no default value", name)
 		}
@@ -294,16 +294,16 @@ func (schema *Schema) validateSchemaSkippedPropertiesHaveDefaults() error {
 	return nil
 }
 
-func (schema *Schema) validate() error {
+func (s *Schema) validate() error {
 	for _, fn := range []func() error{
-		schema.validateSchemaPropertyTypes,
-		schema.validateSchemaDefaultValueTypes,
-		schema.validateSchemaEnumValueTypes,
-		schema.validateConstValueTypes,
-		schema.validateSchemaDefaultValueIsInEnums,
-		schema.validateSchemaPattern,
-		schema.validateSchemaMinimumCliVersion("v" + build.GetInfo().Version),
-		schema.validateSchemaSkippedPropertiesHaveDefaults,
+		s.validateSchemaPropertyTypes,
+		s.validateSchemaDefaultValueTypes,
+		s.validateSchemaEnumValueTypes,
+		s.validateConstValueTypes,
+		s.validateSchemaDefaultValueIsInEnums,
+		s.validateSchemaPattern,
+		s.validateSchemaMinimumCliVersion("v" + build.GetInfo().Version),
+		s.validateSchemaSkippedPropertiesHaveDefaults,
 	} {
 		err := fn()
 		if err != nil {

--- a/libs/patchwheel/patch.go
+++ b/libs/patchwheel/patch.go
@@ -213,19 +213,20 @@ func PatchWheel(path, outputDir string) (string, bool, error) {
 			return "", false, err
 		}
 
-		if f.Name == metadataFile.Name {
+		switch f.Name {
+		case metadataFile.Name:
 			_, err = writer.Write(newMetadata)
 			if err != nil {
 				return "", false, err
 			}
 			metadataUpdated += 1
-		} else if f.Name == recordFile.Name {
+		case recordFile.Name:
 			_, err = writer.Write(newRecord)
 			if err != nil {
 				return "", false, err
 			}
 			recordUpdated += 1
-		} else {
+		default:
 			rc, err := f.Open()
 			if err != nil {
 				return "", false, err

--- a/libs/patchwheel/patch.go
+++ b/libs/patchwheel/patch.go
@@ -35,7 +35,7 @@ func patchMetadata(r io.Reader, oldVersion, newVersion string) ([]byte, error) {
 		if versionValue, ok := bytes.CutPrefix(line, versionKey); ok {
 			foundVersion := string(bytes.TrimSpace(versionValue))
 			if foundVersion != oldVersion {
-				return nil, fmt.Errorf("Unexpected version in METADATA: %s (expected %s)", strings.TrimSpace(string(line)), oldVersion)
+				return nil, fmt.Errorf("unexpected version in METADATA: %s (expected %s)", strings.TrimSpace(string(line)), oldVersion)
 			}
 			buf.WriteString(string(versionKey) + " " + newVersion + "\n")
 		} else {
@@ -249,11 +249,11 @@ func PatchWheel(path, outputDir string) (string, bool, error) {
 	outFile.Close()
 
 	if metadataUpdated != 1 {
-		return "", false, errors.New("Could not update METADATA")
+		return "", false, errors.New("could not update METADATA")
 	}
 
 	if recordUpdated != 1 {
-		return "", false, errors.New("Could not update RECORD")
+		return "", false, errors.New("could not update RECORD")
 	}
 
 	if err := os.Rename(tmpFilename, outpath); err != nil {

--- a/libs/process/stub.go
+++ b/libs/process/stub.go
@@ -41,12 +41,12 @@ type processStub struct {
 }
 
 func (s *processStub) WithStdout(output string) *processStub {
-	s.reponseStub.stdout = output
+	s.stdout = output
 	return s
 }
 
 func (s *processStub) WithFailure(err error) *processStub {
-	s.reponseStub.err = err
+	s.err = err
 	return s
 }
 
@@ -168,9 +168,9 @@ func (s *processStub) run(cmd *exec.Cmd) error {
 	if s.reponseStub == zeroStub {
 		return errors.New("no default process stub")
 	}
-	err := s.reponseStub.err
-	if s.reponseStub.stdout != "" {
-		_, err1 := cmd.Stdout.Write([]byte(s.reponseStub.stdout))
+	err := s.err
+	if s.stdout != "" {
+		_, err1 := cmd.Stdout.Write([]byte(s.stdout))
 		if err == nil {
 			err = err1
 		}

--- a/libs/python/pythontest/pythontest.go
+++ b/libs/python/pythontest/pythontest.go
@@ -85,12 +85,12 @@ func CreatePythonEnv(opts *VenvOpts) error {
 		cmd := exec.Command(opts.PythonExe, "--version")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Failed to run %s --version: %s", opts.PythonExe, err)
+			return fmt.Errorf("failed to run %s --version: %s", opts.PythonExe, err)
 		}
 		outString := string(out)
 		expectVersion := "Python " + opts.PythonVersion
 		if !strings.HasPrefix(outString, expectVersion) {
-			return fmt.Errorf("Unexpected output from %s --version: %v (expected %v)", opts.PythonExe, outString, expectVersion)
+			return fmt.Errorf("unexpected output from %s --version: %v (expected %v)", opts.PythonExe, outString, expectVersion)
 		}
 	}
 

--- a/libs/sync/snapshot.go
+++ b/libs/sync/snapshot.go
@@ -176,7 +176,7 @@ func loadOrNewSnapshot(ctx context.Context, opts *SyncOptions) (*Snapshot, error
 	// Ensure that all paths are slash-separated upon loading
 	// an existing snapshot file. If it was created by an older
 	// CLI version (<= v0.220.0), it may contain backslashes.
-	snapshot.SnapshotState = snapshot.SnapshotState.ToSlash()
+	snapshot.SnapshotState = snapshot.ToSlash()
 
 	snapshot.New = false
 	return snapshot, nil

--- a/libs/sync/snapshot_state.go
+++ b/libs/sync/snapshot_state.go
@@ -122,7 +122,7 @@ func (fs *SnapshotState) validate() error {
 
 // ToSlash ensures all local paths in the snapshot state
 // are slash-separated. Returns a new snapshot state.
-func (old SnapshotState) ToSlash() *SnapshotState {
+func (fs SnapshotState) ToSlash() *SnapshotState {
 	new := SnapshotState{
 		LastModifiedTimes:  make(map[string]time.Time),
 		LocalToRemoteNames: make(map[string]string),
@@ -130,17 +130,17 @@ func (old SnapshotState) ToSlash() *SnapshotState {
 	}
 
 	// Keys are local paths.
-	for k, v := range old.LastModifiedTimes {
+	for k, v := range fs.LastModifiedTimes {
 		new.LastModifiedTimes[filepath.ToSlash(k)] = v
 	}
 
 	// Keys are local paths.
-	for k, v := range old.LocalToRemoteNames {
+	for k, v := range fs.LocalToRemoteNames {
 		new.LocalToRemoteNames[filepath.ToSlash(k)] = v
 	}
 
 	// Values are remote paths.
-	for k, v := range old.RemoteToLocalNames {
+	for k, v := range fs.RemoteToLocalNames {
 		new.RemoteToLocalNames[k] = filepath.ToSlash(v)
 	}
 

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -78,12 +78,12 @@ type FakeWorkspace struct {
 	Repos      map[string]workspace.RepoInfo
 }
 
-func (w *FakeWorkspace) LockUnlock() func() {
-	if w == nil {
+func (s *FakeWorkspace) LockUnlock() func() {
+	if s == nil {
 		panic("LockUnlock called on nil FakeWorkspace")
 	}
-	w.mu.Lock()
-	return func() { w.mu.Unlock() }
+	s.mu.Lock()
+	return func() { s.mu.Unlock() }
 }
 
 // Generic functions to handle map operations

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -242,7 +242,7 @@ func (s *Server) getWorkspaceForToken(token string) *FakeWorkspace {
 	defer s.mu.Unlock()
 
 	if _, ok := s.fakeWorkspaces[token]; !ok {
-		s.fakeWorkspaces[token] = NewFakeWorkspace(s.Server.URL, token)
+		s.fakeWorkspaces[token] = NewFakeWorkspace(s.URL, token)
 	}
 
 	return s.fakeWorkspaces[token]

--- a/libs/textutil/case.go
+++ b/libs/textutil/case.go
@@ -3,7 +3,7 @@ package textutil
 import "unicode"
 
 func CamelToSnakeCase(name string) string {
-	var out []rune = make([]rune, 0, len(name)*2)
+	out := make([]rune, 0, len(name)*2)
 	for i, r := range name {
 		if i > 0 && unicode.IsUpper(r) {
 			out = append(out, '_')


### PR DESCRIPTION
## Changes
Enable all rules except one (ST1003) which produces too many changes so deserves its own PR. Some had autofix, some were fixed with cursor.

## Why
No reason to keep them disabled. I think they were disabled originally to minimize changes to original PR.

## Tests
Existing tests.
