### PR TITLE
Rename ResolveResourceReferences to mutator.ResolveLookupVariables

### DIFF
--- a/acceptance/bundle/debug/direct/out.stderr.txt
+++ b/acceptance/bundle/debug/direct/out.stderr.txt
@@ -40,7 +40,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=RewriteWorkspacePrefix
 10:07:59 Debug: Apply pid=12345 mutator=SetVariables
 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
-10:07:59 Debug: Apply pid=12345 mutator=ResolveResourceReferences
+10:07:59 Debug: Apply pid=12345 mutator=ResolveLookupVariables
 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
 10:07:59 Debug: Apply pid=12345 mutator=validate:volume-path
 10:07:59 Debug: Apply pid=12345 mutator=ApplyTargetMode

--- a/acceptance/bundle/debug/direct/output.txt
+++ b/acceptance/bundle/debug/direct/output.txt
@@ -14,7 +14,18 @@ Validation OK!
 +>>> [CLI] bundle validate --debug
  10:07:59 Info: start pid=12345 version=[DEV_VERSION] args="[CLI], bundle, validate, --debug"
  10:07:59 Debug: Found bundle root at [TEST_TMP_DIR] (file [TEST_TMP_DIR]/databricks.yml) pid=12345
+<<<<<<< HEAD
 @@ -62,8 +64,4 @@
+=======
+@@ -38,5 +40,5 @@
+ 10:07:59 Debug: Apply pid=12345 mutator=SetVariables
+ 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
+-10:07:59 Debug: Apply pid=12345 mutator=ResolveResourceReferences
++10:07:59 Debug: Apply pid=12345 mutator=ResolveLookupVariables
+ 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
+ 10:07:59 Debug: Apply pid=12345 mutator=validate:volume-path
+@@ -61,8 +63,4 @@
+>>>>>>> b23c33d23 (debug output)
  10:07:59 Debug: Apply pid=12345 mutator=metadata.AnnotateJobs
  10:07:59 Debug: Apply pid=12345 mutator=metadata.AnnotatePipelines
 -10:07:59 Debug: Apply pid=12345 mutator=terraform.Initialize

--- a/acceptance/bundle/debug/direct/output.txt
+++ b/acceptance/bundle/debug/direct/output.txt
@@ -14,18 +14,7 @@ Validation OK!
 +>>> [CLI] bundle validate --debug
  10:07:59 Info: start pid=12345 version=[DEV_VERSION] args="[CLI], bundle, validate, --debug"
  10:07:59 Debug: Found bundle root at [TEST_TMP_DIR] (file [TEST_TMP_DIR]/databricks.yml) pid=12345
-<<<<<<< HEAD
 @@ -62,8 +64,4 @@
-=======
-@@ -38,5 +40,5 @@
- 10:07:59 Debug: Apply pid=12345 mutator=SetVariables
- 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
--10:07:59 Debug: Apply pid=12345 mutator=ResolveResourceReferences
-+10:07:59 Debug: Apply pid=12345 mutator=ResolveLookupVariables
- 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
- 10:07:59 Debug: Apply pid=12345 mutator=validate:volume-path
-@@ -61,8 +63,4 @@
->>>>>>> b23c33d23 (debug output)
  10:07:59 Debug: Apply pid=12345 mutator=metadata.AnnotateJobs
  10:07:59 Debug: Apply pid=12345 mutator=metadata.AnnotatePipelines
 -10:07:59 Debug: Apply pid=12345 mutator=terraform.Initialize

--- a/acceptance/bundle/debug/tf/out.stderr.txt
+++ b/acceptance/bundle/debug/tf/out.stderr.txt
@@ -38,7 +38,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=RewriteWorkspacePrefix
 10:07:59 Debug: Apply pid=12345 mutator=SetVariables
 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
-10:07:59 Debug: Apply pid=12345 mutator=ResolveResourceReferences
+10:07:59 Debug: Apply pid=12345 mutator=ResolveLookupVariables
 10:07:59 Debug: Apply pid=12345 mutator=ResolveVariableReferences
 10:07:59 Debug: Apply pid=12345 mutator=validate:volume-path
 10:07:59 Debug: Apply pid=12345 mutator=ApplyTargetMode

--- a/bundle/config/mutator/resolve_lookup_variables.go
+++ b/bundle/config/mutator/resolve_lookup_variables.go
@@ -10,13 +10,13 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type resolveResourceReferences struct{}
+type resolveLookupVariables struct{}
 
-func ResolveResourceReferences() bundle.Mutator {
-	return &resolveResourceReferences{}
+func ResolveLookupVariables() bundle.Mutator {
+	return &resolveLookupVariables{}
 }
 
-func (m *resolveResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+func (m *resolveLookupVariables) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	errs, errCtx := errgroup.WithContext(ctx)
 
 	for k := range b.Config.Variables {
@@ -44,6 +44,6 @@ func (m *resolveResourceReferences) Apply(ctx context.Context, b *bundle.Bundle)
 	return diag.FromErr(errs.Wait())
 }
 
-func (*resolveResourceReferences) Name() string {
-	return "ResolveResourceReferences"
+func (*resolveLookupVariables) Name() string {
+	return "ResolveLookupVariables"
 }

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -113,7 +113,7 @@ func Initialize(ctx context.Context, b *bundle.Bundle) {
 
 		// Reads (dynamic): variables.*.lookup (checks for variables with lookup fields)
 		// Updates (dynamic): variables.*.value (sets values based on resolved lookups)
-		mutator.ResolveResourceReferences(),
+		mutator.ResolveLookupVariables(),
 
 		// Reads (dynamic): * (strings) (searches for variable references in string values)
 		// Updates (dynamic): * (except 'resources') (strings) (resolves variable references to their actual values)


### PR DESCRIPTION
## Why

ResourceResourceReferences sounds like it would be resolving ${resources...} like references which is also something we do.