### PR TITLE
acc: add test for variable in variable

### DIFF
--- a/acceptance/bundle/variables/var_in_var/databricks.yml
+++ b/acceptance/bundle/variables/var_in_var/databricks.yml
@@ -1,0 +1,19 @@
+variables:
+  foo_x:
+    default: hello from foo x
+  foo_y:
+    default: hi from foo y
+  tail:
+    default: x
+  final:
+    # This works but it's not officially supported, please do not rely on it.\
+    # We might start to reject this config in the future.
+    default: ${var.foo_${var.tail}}
+
+targets:
+  target_x:
+    variables:
+      tail: x
+  target_y:
+    variables:
+      tail: y

--- a/acceptance/bundle/variables/var_in_var/databricks.yml
+++ b/acceptance/bundle/variables/var_in_var/databricks.yml
@@ -1,3 +1,6 @@
+bundle:
+  name: test-bundle
+
 variables:
   foo_x:
     default: hello from foo x

--- a/acceptance/bundle/variables/var_in_var/output.txt
+++ b/acceptance/bundle/variables/var_in_var/output.txt
@@ -1,0 +1,40 @@
+
+>>> [CLI] bundle validate -o json -t target_x
+{
+  "final": {
+    "default": "hello from foo x",
+    "value": "hello from foo x"
+  },
+  "foo_x": {
+    "default": "hello from foo x",
+    "value": "hello from foo x"
+  },
+  "foo_y": {
+    "default": "hi from foo y",
+    "value": "hi from foo y"
+  },
+  "tail": {
+    "default": "x",
+    "value": "x"
+  }
+}
+
+>>> [CLI] bundle validate -o json -t target_y
+{
+  "final": {
+    "default": "hi from foo y",
+    "value": "hi from foo y"
+  },
+  "foo_x": {
+    "default": "hello from foo x",
+    "value": "hello from foo x"
+  },
+  "foo_y": {
+    "default": "hi from foo y",
+    "value": "hi from foo y"
+  },
+  "tail": {
+    "default": "y",
+    "value": "y"
+  }
+}

--- a/acceptance/bundle/variables/var_in_var/script
+++ b/acceptance/bundle/variables/var_in_var/script
@@ -1,0 +1,2 @@
+trace $CLI bundle validate -o json -t target_x | jq .variables
+trace $CLI bundle validate -o json -t target_y | jq .variables


### PR DESCRIPTION
This is a surprising feature.

Up to version 0.239.0 there was a resolution but due to one round it would leave config in a broken state:

```
~/work/cli/acceptance/bundle/variables/var_in_var % ./databricks-238 bundle validate -o json -t target_x | jq .variables.final
{
  "default": "${var.foo_x}",
  "value": "${var.foo_x}"
}
```

After 0.239 thanks to multiple rounds of evaluation it is not now resolved fully, but we're not sure if we want to support this.

```
~/work/cli/acceptance/bundle/variables/var_in_var % ./databricks-239 bundle validate -o json -t target_x | jq .variables.final
{
  "default": "hello from foo x",
  "value": "hello from foo x"
}
```
