### PR TITLE
Added support for running specified job tasks instead of all job tasks

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,6 @@
 * Changed logic for resolving `${resources...}` references. Previously this would be done by terraform at deploy time. Now if it references a field that is present in the config, it will be done by DABs during bundle loading ([#3370](https://github.com/databricks/cli/pull/3370))
 * Add support for tagging pipelines ([#3086](https://github.com/databricks/cli/pull/3086))
 * Add warning for when an invalid value is specified for an enum field ([#3050](https://github.com/databricks/cli/pull/3050))
-* Added support for running specified job tasks instead of all job tasks ([#3388](https://github.com/databricks/cli/pull/3388))
+* Add support for running specified job tasks instead of all job tasks ([#3388](https://github.com/databricks/cli/pull/3388))
 
 ### API Changes

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,5 +14,6 @@
 * Changed logic for resolving `${resources...}` references. Previously this would be done by terraform at deploy time. Now if it references a field that is present in the config, it will be done by DABs during bundle loading ([#3370](https://github.com/databricks/cli/pull/3370))
 * Add support for tagging pipelines ([#3086](https://github.com/databricks/cli/pull/3086))
 * Add warning for when an invalid value is specified for an enum field ([#3050](https://github.com/databricks/cli/pull/3050))
+* Added support for running specified job tasks instead of all job tasks ([#3388](https://github.com/databricks/cli/pull/3388))
 
 ### API Changes

--- a/acceptance/bundle/help/bundle-run/output.txt
+++ b/acceptance/bundle/help/bundle-run/output.txt
@@ -39,6 +39,7 @@ Usage:
 
 Job Flags:
       --params stringToString   comma separated k=v pairs for job parameters (default [])
+      --tasks strings           comma separated list of task keys to run
 
 Job Task Flags:
   Note: please prefer use of job-level parameters (--param) over task-level parameters.

--- a/acceptance/bundle/help/bundle-run/output.txt
+++ b/acceptance/bundle/help/bundle-run/output.txt
@@ -38,8 +38,8 @@ Usage:
   databricks bundle run [flags] [KEY]
 
 Job Flags:
+      --only strings            comma separated list of task keys to run
       --params stringToString   comma separated k=v pairs for job parameters (default [])
-      --tasks strings           comma separated list of task keys to run
 
 Job Task Flags:
   Note: please prefer use of job-level parameters (--param) over task-level parameters.

--- a/acceptance/bundle/run/jobs/partial_run/databricks.yml
+++ b/acceptance/bundle/run/jobs/partial_run/databricks.yml
@@ -5,21 +5,10 @@ resources:
   jobs:
     my_job:
       name: my_job
-      job_clusters:
-        - job_cluster_key: job_cluster
-          new_cluster:
-            num_workers: 2
-            autoscale:
-              min_workers: 1
-              max_workers: 2
-            spark_version: "13.3.x-scala2.12"
-            node_type_id: "Standard_DS3_v2"
       tasks:
         - task_key: task_1
-          job_cluster_key: job_cluster
           notebook_task:
             notebook_path: "./notebook1.py"
         - task_key: task_2
-          job_cluster_key: job_cluster
           notebook_task:
             notebook_path: "./notebook2.py"

--- a/acceptance/bundle/run/jobs/partial_run/databricks.yml
+++ b/acceptance/bundle/run/jobs/partial_run/databricks.yml
@@ -1,0 +1,25 @@
+bundle:
+  name: partial_run
+
+resources:
+  jobs:
+    my_job:
+      name: my_job
+      job_clusters:
+        - job_cluster_key: job_cluster
+          new_cluster:
+            num_workers: 2
+            autoscale:
+              min_workers: 1
+              max_workers: 2
+            spark_version: "13.3.x-scala2.12"
+            node_type_id: "Standard_DS3_v2"
+      tasks:
+        - task_key: task_1
+          job_cluster_key: job_cluster
+          notebook_task:
+            notebook_path: "./notebook1.py"
+        - task_key: task_2
+          job_cluster_key: job_cluster
+          notebook_task:
+            notebook_path: "./notebook2.py"

--- a/acceptance/bundle/run/jobs/partial_run/notebook1.py
+++ b/acceptance/bundle/run/jobs/partial_run/notebook1.py
@@ -1,0 +1,3 @@
+# Databricks notebook source
+
+print("Hello from notebook1!")

--- a/acceptance/bundle/run/jobs/partial_run/notebook2.py
+++ b/acceptance/bundle/run/jobs/partial_run/notebook2.py
@@ -1,0 +1,3 @@
+# Databricks notebook source
+
+print("Hello from notebook2!")

--- a/acceptance/bundle/run/jobs/partial_run/out.test.toml
+++ b/acceptance/bundle/run/jobs/partial_run/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -10,47 +10,56 @@ Run URL: [DATABRICKS_URL]/job/run/[NUMID]
 
 [TIMESTAMP] "run-name" TERMINATED
 
->>> [CLI] bundle run my_job --tasks task_1,task_2
-Run URL: [DATABRICKS_URL]/job/run/[NUMID]
-
-[TIMESTAMP] "run-name" TERMINATED
-
->>> [CLI] bundle run my_job
-Run URL: [DATABRICKS_URL]/job/run/[NUMID]
-
-[TIMESTAMP] "run-name" TERMINATED
-
->>> jq -s .[] | select(.path=="/api/2.2/jobs/run-now") out.requests.txt
+>>> print_requests
 {
-  "method": "POST",
-  "path": "/api/2.2/jobs/run-now",
   "body": {
     "job_id": [NUMID],
     "only": [
       "task_1"
     ]
-  }
-}
-{
+  },
   "method": "POST",
-  "path": "/api/2.2/jobs/run-now",
+  "path": "/api/2.2/jobs/run-now"
+}
+
+>>> [CLI] bundle run my_job --tasks task_1,task_2
+Run URL: [DATABRICKS_URL]/job/run/[NUMID]
+
+[TIMESTAMP] "run-name" TERMINATED
+
+>>> print_requests
+{
   "body": {
     "job_id": [NUMID],
     "only": [
       "task_1",
       "task_2"
     ]
-  }
-}
-{
+  },
   "method": "POST",
-  "path": "/api/2.2/jobs/run-now",
+  "path": "/api/2.2/jobs/run-now"
+}
+
+>>> [CLI] bundle run my_job
+Run URL: [DATABRICKS_URL]/job/run/[NUMID]
+
+[TIMESTAMP] "run-name" TERMINATED
+
+>>> print_requests
+{
   "body": {
     "job_id": [NUMID]
-  }
+  },
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now"
 }
 
 >>> errcode [CLI] bundle run my_job --tasks non_existent_task
-Error: task [non_existent_task] not found in job my_job
+Error: task non_existent_task not found in job my_job
+
+Exit code: 1
+
+>>> errcode [CLI] bundle run my_job --tasks non_existent_task,task_1
+Error: task non_existent_task not found in job my_job
 
 Exit code: 1

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -55,11 +55,11 @@ Run URL: [DATABRICKS_URL]/job/run/[NUMID]
 }
 
 >>> musterr [CLI] bundle run my_job --only non_existent_task
-Error: task non_existent_task not found in job my_job
+Error: task "non_existent_task" not found in job "my_job"
 
 Exit code (musterr): 1
 
 >>> musterr [CLI] bundle run my_job --only non_existent_task,task_1
-Error: task non_existent_task not found in job my_job
+Error: task "non_existent_task" not found in job "my_job"
 
 Exit code (musterr): 1

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] bundle run my_job --tasks task_1
+>>> [CLI] bundle run my_job --only task_1
 Run URL: [DATABRICKS_URL]/job/run/[NUMID]
 
 [TIMESTAMP] "run-name" TERMINATED
@@ -22,7 +22,7 @@ Run URL: [DATABRICKS_URL]/job/run/[NUMID]
   "path": "/api/2.2/jobs/run-now"
 }
 
->>> [CLI] bundle run my_job --tasks task_1,task_2
+>>> [CLI] bundle run my_job --only task_1,task_2
 Run URL: [DATABRICKS_URL]/job/run/[NUMID]
 
 [TIMESTAMP] "run-name" TERMINATED
@@ -54,12 +54,12 @@ Run URL: [DATABRICKS_URL]/job/run/[NUMID]
   "path": "/api/2.2/jobs/run-now"
 }
 
->>> musterr [CLI] bundle run my_job --tasks non_existent_task
+>>> musterr [CLI] bundle run my_job --only non_existent_task
 Error: task non_existent_task not found in job my_job
 
 Exit code (musterr): 1
 
->>> musterr [CLI] bundle run my_job --tasks non_existent_task,task_1
+>>> musterr [CLI] bundle run my_job --only non_existent_task,task_1
 Error: task non_existent_task not found in job my_job
 
 Exit code (musterr): 1

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -1,0 +1,56 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/partial_run/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle run my_job --tasks task_1
+Run URL: [DATABRICKS_URL]/job/run/[NUMID]
+
+[TIMESTAMP] "run-name" TERMINATED
+
+>>> [CLI] bundle run my_job --tasks task_1,task_2
+Run URL: [DATABRICKS_URL]/job/run/[NUMID]
+
+[TIMESTAMP] "run-name" TERMINATED
+
+>>> [CLI] bundle run my_job
+Run URL: [DATABRICKS_URL]/job/run/[NUMID]
+
+[TIMESTAMP] "run-name" TERMINATED
+
+>>> jq -s .[] | select(.path=="/api/2.2/jobs/run-now") out.requests.txt
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [NUMID],
+    "only": [
+      "task_1"
+    ]
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [NUMID],
+    "only": [
+      "task_1",
+      "task_2"
+    ]
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [NUMID]
+  }
+}
+
+>>> errcode [CLI] bundle run my_job --tasks non_existent_task
+Error: task [non_existent_task] not found in job my_job
+
+Exit code: 1

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -54,12 +54,12 @@ Run URL: [DATABRICKS_URL]/job/run/[NUMID]
   "path": "/api/2.2/jobs/run-now"
 }
 
->>> errcode [CLI] bundle run my_job --tasks non_existent_task
+>>> musterr [CLI] bundle run my_job --tasks non_existent_task
 Error: task non_existent_task not found in job my_job
 
-Exit code: 1
+Exit code (musterr): 1
 
->>> errcode [CLI] bundle run my_job --tasks non_existent_task,task_1
+>>> musterr [CLI] bundle run my_job --tasks non_existent_task,task_1
 Error: task non_existent_task not found in job my_job
 
-Exit code: 1
+Exit code (musterr): 1

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -63,3 +63,22 @@ Exit code (musterr): 1
 Error: task "non_existent_task" not found in job "my_job"
 
 Exit code (musterr): 1
+
+>>> [CLI] bundle run my_job --only task1.table1,task2>,task3>table3
+Run URL: [DATABRICKS_URL]/job/run/[NUMID]
+
+[TIMESTAMP] "run-name" TERMINATED
+
+>>> print_requests
+{
+  "body": {
+    "job_id": [NUMID],
+    "only": [
+      "task1.table1",
+      "task2>",
+      "task3>table3"
+    ]
+  },
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now"
+}

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -1,5 +1,5 @@
 print_requests() {
-    jq --sort-keys 'select(.path=="/api/2.2/jobs/run-now")' < out.requests.txt
+    jq --sort-keys 'select(.path | contains("/jobs/run-now"))' < out.requests.txt
     rm out.requests.txt
 }
 

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -1,0 +1,16 @@
+trace $CLI bundle deploy
+
+trace $CLI bundle run my_job --tasks task_1
+trace $CLI bundle run my_job --tasks task_1,task_2
+trace $CLI bundle run my_job
+
+# We expect 3 requests:
+# 1. Run the job with all tasks
+# 2. Run the job with task_1
+# 3. Run the job with task_1 and task_2
+trace jq -s '.[] | select(.path=="/api/2.2/jobs/run-now")' out.requests.txt
+
+# We expect an error because the task does not exist
+trace errcode $CLI bundle run my_job --tasks non_existent_task
+
+rm out.requests.txt

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -20,4 +20,6 @@ trace musterr $CLI bundle run my_job --only non_existent_task
 # We expect an error because one of the tasks does not exist
 trace musterr $CLI bundle run my_job --only non_existent_task,task_1
 
-rm out.requests.txt
+# We expect these values to be send through
+trace $CLI bundle run my_job --only "task1.table1,task2>,task3>table3"
+trace print_requests

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -15,9 +15,9 @@ trace $CLI bundle run my_job
 trace print_requests
 
 # We expect an error because the task does not exist
-trace errcode $CLI bundle run my_job --tasks non_existent_task
+trace musterr $CLI bundle run my_job --tasks non_existent_task
 
 # We expect an error because one of the tasks does not exist
-trace errcode $CLI bundle run my_job --tasks non_existent_task,task_1
+trace musterr $CLI bundle run my_job --tasks non_existent_task,task_1
 
 rm out.requests.txt

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -5,19 +5,19 @@ print_requests() {
 
 trace $CLI bundle deploy
 
-trace $CLI bundle run my_job --tasks task_1
+trace $CLI bundle run my_job --only task_1
 trace print_requests
 
-trace $CLI bundle run my_job --tasks task_1,task_2
+trace $CLI bundle run my_job --only task_1,task_2
 trace print_requests
 
 trace $CLI bundle run my_job
 trace print_requests
 
 # We expect an error because the task does not exist
-trace musterr $CLI bundle run my_job --tasks non_existent_task
+trace musterr $CLI bundle run my_job --only non_existent_task
 
 # We expect an error because one of the tasks does not exist
-trace musterr $CLI bundle run my_job --tasks non_existent_task,task_1
+trace musterr $CLI bundle run my_job --only non_existent_task,task_1
 
 rm out.requests.txt

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -1,16 +1,23 @@
+print_requests() {
+    jq --sort-keys 'select(.path=="/api/2.2/jobs/run-now")' < out.requests.txt
+    rm out.requests.txt
+}
+
 trace $CLI bundle deploy
 
 trace $CLI bundle run my_job --tasks task_1
-trace $CLI bundle run my_job --tasks task_1,task_2
-trace $CLI bundle run my_job
+trace print_requests
 
-# We expect 3 requests:
-# 1. Run the job with all tasks
-# 2. Run the job with task_1
-# 3. Run the job with task_1 and task_2
-trace jq -s '.[] | select(.path=="/api/2.2/jobs/run-now")' out.requests.txt
+trace $CLI bundle run my_job --tasks task_1,task_2
+trace print_requests
+
+trace $CLI bundle run my_job
+trace print_requests
 
 # We expect an error because the task does not exist
 trace errcode $CLI bundle run my_job --tasks non_existent_task
+
+# We expect an error because one of the tasks does not exist
+trace errcode $CLI bundle run my_job --tasks non_existent_task,task_1
 
 rm out.requests.txt

--- a/acceptance/bundle/run/jobs/partial_run/test.toml
+++ b/acceptance/bundle/run/jobs/partial_run/test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+
+RecordRequests = true

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -78,17 +78,17 @@ func (o *JobOptions) Validate(job *resources.Job) error {
 	}
 
 	if len(o.tasks) > 0 {
-		found := false
 		for _, task := range o.tasks {
+			found := false
 			for _, t := range job.Tasks {
 				if t.TaskKey == task {
 					found = true
 					break
 				}
 			}
-		}
-		if !found {
-			return fmt.Errorf("task %s not found in job %s", o.tasks, job.Name)
+			if !found {
+				return fmt.Errorf("task %s not found in job %s", task, job.Name)
+			}
 		}
 	}
 
@@ -141,10 +141,7 @@ func (o *JobOptions) toPayload(job *resources.Job, jobID int64) (*jobs.RunNow, e
 		SqlParams:         o.sqlParams,
 
 		JobParameters: o.jobParams,
-	}
-
-	if len(o.tasks) > 0 {
-		payload.Only = o.tasks
+		Only:          o.tasks,
 	}
 
 	return payload, nil

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -27,13 +27,13 @@ type JobOptions struct {
 	// Also see https://docs.databricks.com/en/workflows/jobs/settings.html#add-parameters-for-all-job-tasks.
 	jobParams map[string]string
 
-	// tasks is a list of task keys to run. If not specified, all tasks are run.
-	tasks []string
+	// only is a list of task keys to run. If not specified, all only are run.
+	only []string
 }
 
 func (o *JobOptions) DefineJobOptions(fs *flag.FlagSet) {
 	fs.StringToStringVar(&o.jobParams, "params", nil, "comma separated k=v pairs for job parameters")
-	fs.StringSliceVar(&o.tasks, "tasks", nil, "comma separated list of task keys to run")
+	fs.StringSliceVar(&o.only, "only", nil, "comma separated list of task keys to run")
 }
 
 func (o *JobOptions) DefineTaskOptions(fs *flag.FlagSet) {
@@ -77,8 +77,8 @@ func (o *JobOptions) Validate(job *resources.Job) error {
 		return errors.New("the job to run does not define job parameters; specifying job parameters is not allowed")
 	}
 
-	if len(o.tasks) > 0 {
-		for _, task := range o.tasks {
+	if len(o.only) > 0 {
+		for _, task := range o.only {
 			found := false
 			for _, t := range job.Tasks {
 				if t.TaskKey == task {
@@ -141,7 +141,7 @@ func (o *JobOptions) toPayload(job *resources.Job, jobID int64) (*jobs.RunNow, e
 		SqlParams:         o.sqlParams,
 
 		JobParameters: o.jobParams,
-		Only:          o.tasks,
+		Only:          o.only,
 	}
 
 	return payload, nil

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -27,7 +27,7 @@ type JobOptions struct {
 	// Also see https://docs.databricks.com/en/workflows/jobs/settings.html#add-parameters-for-all-job-tasks.
 	jobParams map[string]string
 
-	// only is a list of task keys to run. If not specified, all only are run.
+	// only is a list of task keys to run. If not specified, the full job is run.
 	only []string
 }
 

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -87,7 +87,7 @@ func (o *JobOptions) Validate(job *resources.Job) error {
 				}
 			}
 			if !found {
-				return fmt.Errorf("task %v not found in job %v", task, job.Name)
+				return fmt.Errorf("task %#v not found in job %#v", task, job.Name)
 			}
 		}
 	}

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -3,6 +3,7 @@ package run
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/databricks/cli/bundle/config/resources"
@@ -62,6 +63,8 @@ func (o *JobOptions) hasJobParametersConfigured() bool {
 	return len(o.jobParams) > 0
 }
 
+var taskKeyRegex = regexp.MustCompile(`^[\w\-\_]+$`)
+
 // Validate returns if the combination of options is valid.
 func (o *JobOptions) Validate(job *resources.Job) error {
 	if job == nil {
@@ -79,6 +82,11 @@ func (o *JobOptions) Validate(job *resources.Job) error {
 
 	if len(o.only) > 0 {
 		for _, task := range o.only {
+			// Skip if did not match the regex. It can mean that the more complex syntax like "task1.table1" is used.
+			if !taskKeyRegex.MatchString(task) {
+				continue
+			}
+
 			found := false
 			for _, t := range job.Tasks {
 				if t.TaskKey == task {

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -63,6 +63,7 @@ func (o *JobOptions) hasJobParametersConfigured() bool {
 	return len(o.jobParams) > 0
 }
 
+// regex to match valid task keys as defined in https://docs.databricks.com/api/workspace/jobs/create#tasks-task_key
 var taskKeyRegex = regexp.MustCompile(`^[\w\-\_]+$`)
 
 // Validate returns if the combination of options is valid.

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -87,7 +87,7 @@ func (o *JobOptions) Validate(job *resources.Job) error {
 				}
 			}
 			if !found {
-				return fmt.Errorf("task %s not found in job %s", task, job.Name)
+				return fmt.Errorf("task %v not found in job %v", task, job.Name)
 			}
 		}
 	}


### PR DESCRIPTION
## Changes
Added support for running specified job tasks instead of all job tasks.

This change introduces a new flag `--only` for the `bundle run` command when executed on a job.
It allows specifying which specific tasks out of all in the jobs to run.

Usage
```
databricks bundle run my_job --only task_1,task_2
```

## Why
The feature was relatively recently added to Jobs API
https://docs.databricks.com/api/workspace/jobs/runnow#only

## Tests
Added an acceptance tests.
Skipped running on Cloud because the test is really slow but verified manually it works as expected too.

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
