### PR TITLE
Add enum for volume grant privileges

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,5 +9,6 @@
 ### CLI
 
 ### Bundles
+* Add supported enum values to JSON schema for volume grant privileges ([#3395](https://github.com/databricks/cli/pull/3395))
 
 ### API Changes

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -13,9 +13,24 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
 
+type VolumeGrantPrivilege string
+
+const (
+	VolumeGrantPrivilegeAllPrivileges VolumeGrantPrivilege = "ALL_PRIVILEGES"
+	VolumeGrantPrivilegeManage        VolumeGrantPrivilege = "MANAGE"
+	VolumeGrantPrivilegeReadVolume    VolumeGrantPrivilege = "READ_VOLUME"
+	VolumeGrantPrivilegeWriteVolume   VolumeGrantPrivilege = "WRITE_VOLUME"
+)
+
+type VolumeGrant struct {
+	Privileges []VolumeGrantPrivilege `json:"privileges"`
+
+	Principal string `json:"principal"`
+}
+
 type Volume struct {
 	// List of grants to apply on this volume.
-	Grants []Grant `json:"grants,omitempty"`
+	Grants []VolumeGrant `json:"grants,omitempty"`
 
 	// Full name of the volume (catalog_name.schema_name.volume_name). This value is read from
 	// the terraform state after deployment succeeds.

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -23,6 +23,17 @@ const (
 	VolumeGrantPrivilegeWriteVolume   VolumeGrantPrivilege = "WRITE_VOLUME"
 )
 
+// Values returns all valid VolumeGrantPrivilege values
+func (VolumeGrantPrivilege) Values() []VolumeGrantPrivilege {
+	return []VolumeGrantPrivilege{
+		VolumeGrantPrivilegeAllPrivileges,
+		VolumeGrantPrivilegeApplyTag,
+		VolumeGrantPrivilegeManage,
+		VolumeGrantPrivilegeReadVolume,
+		VolumeGrantPrivilegeWriteVolume,
+	}
+}
+
 type VolumeGrant struct {
 	Privileges []VolumeGrantPrivilege `json:"privileges"`
 

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -17,6 +17,7 @@ type VolumeGrantPrivilege string
 
 const (
 	VolumeGrantPrivilegeAllPrivileges VolumeGrantPrivilege = "ALL_PRIVILEGES"
+	VolumeGrantPrivilegeApplyTag      VolumeGrantPrivilege = "APPLY_TAG"
 	VolumeGrantPrivilegeManage        VolumeGrantPrivilege = "MANAGE"
 	VolumeGrantPrivilegeReadVolume    VolumeGrantPrivilege = "READ_VOLUME"
 	VolumeGrantPrivilegeWriteVolume   VolumeGrantPrivilege = "WRITE_VOLUME"

--- a/bundle/deploy/terraform/tfdyn/convert_volume_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_volume_test.go
@@ -23,14 +23,18 @@ func TestConvertVolume(t *testing.T) {
 			StorageLocation: "s3://bucket/path",
 			VolumeType:      "EXTERNAL",
 		},
-		Grants: []resources.Grant{
+		Grants: []resources.VolumeGrant{
 			{
-				Privileges: []string{"READ_VOLUME"},
-				Principal:  "jack@gmail.com",
+				Privileges: []resources.VolumeGrantPrivilege{
+					resources.VolumeGrantPrivilegeReadVolume,
+				},
+				Principal: "jack@gmail.com",
 			},
 			{
-				Privileges: []string{"WRITE_VOLUME"},
-				Principal:  "jane@gmail.com",
+				Privileges: []resources.VolumeGrantPrivilege{
+					resources.VolumeGrantPrivilegeWriteVolume,
+				},
+				Principal: "jane@gmail.com",
 			},
 		},
 	}

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -598,6 +598,13 @@ github.com/databricks/cli/bundle/config/resources.SqlWarehousePermission:
   "user_name":
     "description": |-
       PLACEHOLDER
+github.com/databricks/cli/bundle/config/resources.VolumeGrant:
+  "principal":
+    "description": |-
+      PLACEHOLDER
+  "privileges":
+    "description": |-
+      PLACEHOLDER
 github.com/databricks/cli/bundle/config/variable.Lookup:
   "alert":
     "description": |-

--- a/bundle/internal/schema/annotations_openapi_overrides.yml
+++ b/bundle/internal/schema/annotations_openapi_overrides.yml
@@ -503,6 +503,17 @@ github.com/databricks/cli/bundle/config/resources.SqlWarehousePermissionLevel:
         CAN_MONITOR
       - |-
         CAN_VIEW
+github.com/databricks/cli/bundle/config/resources.VolumeGrantPrivilege:
+  "_":
+    "enum":
+      - |-
+        ALL_PRIVILEGES
+      - |-
+        MANAGE
+      - |-
+        READ_VOLUME
+      - |-
+        WRITE_VOLUME
 github.com/databricks/cli/bundle/config/resources.Volume:
   "_":
     "markdown_description": |-

--- a/bundle/internal/schema/annotations_openapi_overrides.yml
+++ b/bundle/internal/schema/annotations_openapi_overrides.yml
@@ -509,6 +509,8 @@ github.com/databricks/cli/bundle/config/resources.VolumeGrantPrivilege:
       - |-
         ALL_PRIVILEGES
       - |-
+        APPLY_TAG
+      - |-
         MANAGE
       - |-
         READ_VOLUME

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1549,7 +1549,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Grant"
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.VolumeGrant"
                       },
                       "name": {
                         "description": "The name of the volume",
@@ -1574,6 +1574,47 @@
                       "schema_name"
                     ],
                     "markdownDescription": "The volume resource type allows you to define and create Unity Catalog [volumes](https://docs.databricks.com/api/workspace/volumes/create) as part of a bundle. When deploying a bundle with a volume defined, note that:\n\n- A volume cannot be referenced in the `artifact_path` for the bundle until it exists in the workspace. Hence, if you want to use Databricks Asset Bundles to create the volume, you must first define the volume in the bundle, deploy it to create the volume, then reference it in the `artifact_path` in subsequent deployments.\n\n- Volumes in the bundle are not prepended with the `dev_${workspace.current_user.short_name}` prefix when the deployment target has `mode: development` configured. However, you can manually configure this prefix. See [custom-presets](https://docs.databricks.com/dev-tools/bundles/deployment-modes.html#custom-presets)."
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.VolumeGrant": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "principal": {
+                        "$ref": "#/$defs/string"
+                      },
+                      "privileges": {
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.VolumeGrantPrivilege"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "privileges",
+                      "principal"
+                    ]
+                  },
+                  {
+                    "type": "string",
+                    "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                  }
+                ]
+              },
+              "resources.VolumeGrantPrivilege": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "ALL_PRIVILEGES",
+                      "MANAGE",
+                      "READ_VOLUME",
+                      "WRITE_VOLUME"
+                    ]
                   },
                   {
                     "type": "string",
@@ -8653,6 +8694,34 @@
                       "type": "array",
                       "items": {
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.SqlWarehousePermission"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.VolumeGrant": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.VolumeGrant"
+                      }
+                    },
+                    {
+                      "type": "string",
+                      "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                    }
+                  ]
+                },
+                "resources.VolumeGrantPrivilege": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.VolumeGrantPrivilege"
                       }
                     },
                     {

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1611,6 +1611,7 @@
                     "type": "string",
                     "enum": [
                       "ALL_PRIVILEGES",
+                      "APPLY_TAG",
                       "MANAGE",
                       "READ_VOLUME",
                       "WRITE_VOLUME"


### PR DESCRIPTION
## Changes
Add an enum for volume grant privileges.

Possible values are:
- `ALL_PRIVILEGES`
- `APPLY_TAG` (missing in Terraform docs but supported)
- `MANAGE`
- `READ_VOLUME`
- `WRITE_VOLUME`

It follows documented privileges in Terraform documentation: https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/grants#volume-grants

I will add `APPLY_TAG` to Terraform as a follow-up.

## Why
Using enums gives better typing in JSON schema and allows generating enums in Python code

## Tests
By inspecting the resulting JSON schema