### PR TITLE
Fixed panic when provide a CLI command with an incorrect JSON input

### DIFF
--- a/acceptance/cmd/workspace/create-scope/out.test.toml
+++ b/acceptance/cmd/workspace/create-scope/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/cmd/workspace/create-scope/output.txt
+++ b/acceptance/cmd/workspace/create-scope/output.txt
@@ -1,0 +1,23 @@
+
+>>> musterr [CLI] secrets create-scope --scope-backend-type AZURE_KEYVAULT --json 
+"scope": "xxxxxxxx-xxx",
+"scope_backend_type": "AZURE_KEYVAULT",
+"keyvault_metadata": {
+  "dns_name": "test",
+  "resource_id": "123456"
+}
+Error: expected input of type *workspace.CreateScope, received string
+
+Exit code (musterr): 1
+
+>>> [CLI] secrets create-scope --scope-backend-type AZURE_KEYVAULT --json {
+"scope": "xxxxxxxx-xxx",
+"scope_backend_type": "AZURE_KEYVAULT",
+"keyvault_metadata": {
+  "dns_name": "test",
+  "resource_id": "123456"
+}
+}
+Warning: unknown field: keyvault_metadata
+  in (inline):4:2
+

--- a/acceptance/cmd/workspace/create-scope/script
+++ b/acceptance/cmd/workspace/create-scope/script
@@ -1,0 +1,16 @@
+trace musterr $CLI secrets create-scope --scope-backend-type AZURE_KEYVAULT --json '
+"scope": "xxxxxxxx-xxx",
+"scope_backend_type": "AZURE_KEYVAULT",
+"keyvault_metadata": {
+  "dns_name": "test",
+  "resource_id": "123456"
+}'
+
+trace $CLI secrets create-scope --scope-backend-type AZURE_KEYVAULT --json '{
+"scope": "xxxxxxxx-xxx",
+"scope_backend_type": "AZURE_KEYVAULT",
+"keyvault_metadata": {
+  "dns_name": "test",
+  "resource_id": "123456"
+}
+}'

--- a/acceptance/cmd/workspace/create-scope/test.toml
+++ b/acceptance/cmd/workspace/create-scope/test.toml
@@ -1,0 +1,10 @@
+Local = true
+Cloud = false
+
+[[Server]]
+Pattern = "POST /api/2.0/secrets/scopes/create"
+Response.Body = '''
+{
+    "scope": "xxxxxxxx-xxx"
+}
+'''

--- a/libs/flags/json_flag.go
+++ b/libs/flags/json_flag.go
@@ -57,6 +57,14 @@ func (j *JsonFlag) Unmarshal(v any) diag.Diagnostics {
 		return diags
 	}
 
+	if !nv.IsValid() {
+		return diags.Append(diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Invalid command input",
+			Detail:   fmt.Sprintf("expected input of type %s, received %s", reflect.TypeOf(v), dv.Kind()),
+		})
+	}
+
 	// Then marshal the normalized data to the output.
 	// It will serialize all set data with the correct types.
 	data, err := json.Marshal(nv.AsAny())


### PR DESCRIPTION
## Changes
Fixed panic when providing a CLI command with an incorrect JSON input

## Why
CLI should not panic but show a nicer, more actionable error instead.
Fixes #3393

## Tests
Added an acceptance test
