### PR TITLE
acc: Generate out.test.toml before skipping the tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -905,8 +905,7 @@ func CopyDir(src, dst string, inputs, outputs map[string]bool) error {
 			return err
 		}
 
-		_, isInput := inputs[relPath]
-		if strings.HasPrefix(relPath, "out") && !isInput {
+		if strings.HasPrefix(relPath, "out") {
 			if !info.IsDir() {
 				outputs[relPath] = true
 			}


### PR DESCRIPTION
## Changes
Generate out.test.toml before skipping the tests

## Why
Allows to generate out.test.toml for all settings locally, including Cloud = true 

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
