### PR TITLE
Better error message in case of conversion error

### DIFF
--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -76,7 +76,7 @@ func fromTyped(src any, ref dyn.Value, options ...fromTypedOptions) (dyn.Value, 
 		// If the value is untyped and not set (e.g. any type with nil value), we return nil.
 		v, err = dyn.NilValue, nil
 	default:
-		return dyn.InvalidValue, fmt.Errorf("cannot convert %s field to dynamic type %#v: src=%#v ref=%#v", srcv.Kind(), ref.Kind().String(), src, ref.AsAny())
+		return dyn.InvalidValue, fmt.Errorf("unsupported type: %s", srcv.Kind())
 	}
 
 	// Ensure the location metadata is retained.


### PR DESCRIPTION
## Changes
Improve error message when converting typed struct to dynamic.

## Why
Currently different functions share the message body, so you don't know which field failed to convert.

Real example when working on https://github.com/databricks/cli/pull/3390 test acceptance/bundle/deploy/jobs/double-underscore-keys triggers this error condition:

Before this change "bundle deploy" fails with:

```
Warn: unable to convert typed configuration to dynamic configuration: unhandled type: string
Error: exit error: unhandled type: string
```

After:

```
Warn: unable to convert typed configuration to dynamic configuration: cannot convert int field to dynamic type "string": src=4611686018427387911 ref="4611686018427387911"
Error: exit error: cannot convert int field to dynamic type "string": src=4611686018427387911 ref="4611686018427387911"
```

## Tests
Manually, by applying this commit on https://github.com/databricks/cli/pull/3390
