### PR TITLE
Fix panic in auto-completion handler for pipelines run/open

### DIFF
--- a/acceptance/pipelines/open/output.txt
+++ b/acceptance/pipelines/open/output.txt
@@ -26,3 +26,9 @@ Opening browser at [DATABRICKS_URL]/pipelines/[UUID]?o=[NUMID]
 Error: exec: "open": cannot run executable found relative to current directory
 
 Exit code (musterr): 1
+
+=== test auto-completion handler
+>>> [PIPELINES] __complete open ,
+test-pipelines-open
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/acceptance/pipelines/open/script
+++ b/acceptance/pipelines/open/script
@@ -11,3 +11,6 @@ musterr trace $PIPELINES open
 
 title "open with KEY, expect same output as opening without KEY"
 musterr trace $PIPELINES open test-pipelines-open
+
+title "test auto-completion handler"
+trace $PIPELINES __complete open ,

--- a/acceptance/pipelines/run/run-pipeline/output.txt
+++ b/acceptance/pipelines/run/run-pipeline/output.txt
@@ -23,3 +23,9 @@ Update ID: [UUID]
 Update for pipeline completed successfully.
 Pipeline configurations for this update:
 • All tables are refreshed
+
+=== completion handler
+>>> [PIPELINES] __complete run ,
+my_pipeline
+:4
+Completion ended with directive: ShellCompDirectiveNoFileComp

--- a/acceptance/pipelines/run/run-pipeline/script
+++ b/acceptance/pipelines/run/run-pipeline/script
@@ -4,3 +4,6 @@ trace $PIPELINES run
 
 title "Run pipeline with KEY, expect same output as without KEY"
 trace $PIPELINES run my_pipeline
+
+title "completion handler"
+trace $PIPELINES __complete run ,

--- a/cmd/pipelines/open.go
+++ b/cmd/pipelines/open.go
@@ -141,6 +141,9 @@ If there is only one pipeline in the project, KEY is optional and the pipeline w
 	}
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := logdiag.InitContext(cmd.Context())
+		cmd.SetContext(ctx)
+
 		b := root.MustConfigureBundle(cmd)
 		if logdiag.HasError(cmd.Context()) {
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/pipelines/run.go
+++ b/cmd/pipelines/run.go
@@ -231,6 +231,9 @@ Refreshes all tables in the pipeline unless otherwise specified.`,
 	}
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := logdiag.InitContext(cmd.Context())
+		cmd.SetContext(ctx)
+
 		b := root.MustConfigureBundle(cmd)
 		if logdiag.HasError(cmd.Context()) {
 			return nil, cobra.ShellCompDirectiveError


### PR DESCRIPTION
## Changes
Copying fix applied to autocompletion in bundle to pipelines run/open: https://github.com/databricks/cli/pull/3358

## Why
Before, cmd.ValidArgsFunction is not working properly, as in the terminal, Tab does not autocomplete the resource key.

databricks pipelines run ... 

Now autocompletes with
databricks pipelines run resource-name

## Tests
New acceptance tests that trigger completion handler for pipelines run/open.