### PR TITLE
Re-enable copyloopvar linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - unconvert
     - unused
     - exhaustruct
+    - copyloopvar
   settings:
     copyloopvar:
       check-alias: true

--- a/integration/bundle/spark_jar_test.go
+++ b/integration/bundle/spark_jar_test.go
@@ -40,7 +40,6 @@ func runSparkJarTests(t *testing.T, testCases []sparkJarTestCase, testRunner fun
 
 	// Run the tests that can run
 	for _, tc := range testCases {
-		tc := tc // Capture range variable for goroutine
 		canRun := testCanRun[tc.name]
 
 		t.Run(tc.name, func(t *testing.T) {

--- a/libs/dagrun/dagrun_test.go
+++ b/libs/dagrun/dagrun_test.go
@@ -77,7 +77,6 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		for _, p := range pools {
 			t.Run(tc.name+fmt.Sprintf(" pool=%d", p), func(t *testing.T) {
 				g := NewGraph[stringWrapper]()


### PR DESCRIPTION
## Changes
Add copyloopvar linter to list of enabled linters. Fix found issues.

## Why
This was supposed to be enabled https://github.com/databricks/cli/pull/2160 but it seems I just ran it once at that time.