### PR TITLE
Revert "Resolves $resources as regular variables if set by user (#3370)"

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,8 +1,9 @@
 # NEXT CHANGELOG
 
-## Release v0.265.0
+## Release v0.264.2
 
 ### Notable Changes
+* Revert ([#3370](https://github.com/databricks/cli/pull/3370)) "Resolve $resources as regular variables if set by user". This breaks deployments due to swapping the order of resolution and preset application.
 
 ### Dependency updates
 

--- a/acceptance/bundle/variables/resolve-resources-fields/output.txt
+++ b/acceptance/bundle/variables/resolve-resources-fields/output.txt
@@ -19,13 +19,13 @@
   "schemas": {
     "bar": {
       "catalog_name": "main",
-      "comment": "var.b=this is var.b unresolved? apps.baz.id=\"${resources.apps.baz.id}\" apps.baz.url=\"${resources.apps.baz.url}\" schemas.bar.name=unresolved? apps.baz.id=\"${resources.apps.baz.id}\" apps.baz.url=\"${resources.apps.baz.url}\" schemas.foo.name=unresolved? apps.baz.id=\"${resources.apps.baz.id}\" apps.baz.url=\"${resources.apps.baz.url}\"",
+      "comment": "var.b=this is var.b ${resources.schemas.foo.name} schemas.bar.name=${resources.schemas.bar.name} schemas.foo.name=${resources.schemas.foo.name}",
       "name": "unresolved? apps.baz.id=\"${resources.apps.baz.id}\" apps.baz.url=\"${resources.apps.baz.url}\""
     },
     "foo": {
       "catalog_name": "main",
       "comment": "unresolved? schemas.bar.non_existing:\"${resources.schemas.bar.non_existing}\"  schemas.bar.id:\"${resources.schemas.bar.id}\"",
-      "name": "unresolved? apps.baz.id=\"${resources.apps.baz.id}\" apps.baz.url=\"${resources.apps.baz.url}\""
+      "name": "${resources.schemas.bar.name}"
     }
   }
 }

--- a/bundle/config/mutator/resolve_variable_references.go
+++ b/bundle/config/mutator/resolve_variable_references.go
@@ -41,14 +41,6 @@ var defaultPrefixes = []string{
 	"bundle",
 	"workspace",
 	"variables",
-	"resources",
-}
-
-var optionalResolution = map[string]bool{
-	// Enables different mode for resolution:
-	//  - normalization is not done, if field is not set by user it's missing
-	//  - if field is missing (either it's a valid field but not set or invalid field), it remains unresolved, no error
-	"resources": true,
 }
 
 var artifactPath = dyn.MustPathFromString("artifacts")
@@ -237,24 +229,8 @@ func (m *resolveVariableReferences) resolveOnce(b *bundle.Bundle, prefixes []dyn
 				// Perform resolution only if the path starts with one of the specified prefixes.
 				for _, prefix := range prefixes {
 					if path.HasPrefix(prefix) {
-						isOpt := optionalResolution[prefix[0].Key()]
-						var value dyn.Value
-						var err error
-						if isOpt {
-							// We don't want injected zero value when resolving $resources.
-							// We only want entries that are explicitly provided by users, so we're using root not normalized here.
-							value, err = m.lookupFn(root, path, b)
-							if !value.IsValid() {
-								// Not having a value is not an error in this case, it might be resolved at deploy time.
-								// TODO: we still could check whether it's part of the schema or not. If latter, we can reject it right away.
-								// TODO: This might be better done after we got rid of TF.
-								return dyn.InvalidValue, dynvar.ErrSkipResolution
-							}
-						} else {
-							value, err = m.lookupFn(normalized, path, b)
-						}
-						hasUpdates = hasUpdates || (err == nil && value.IsValid())
-						return value, err
+						hasUpdates = true
+						return m.lookupFn(normalized, path, b)
 					}
 				}
 


### PR DESCRIPTION
This reverts commit 9681b7f323eb760f551a2914fb9110db79e6747f.

This breaks deployments due to swapping the order of resolution and preset application.