### PR TITLE
Update to go 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli
 
 go 1.24.0
 
-toolchain go1.24.2
+toolchain go1.24.6
 
 require (
 	dario.cat/mergo v1.0.2 // BSD 3-Clause


### PR DESCRIPTION
## Why
Release notes: https://go.dev/doc/devel/release#go1.24.minor. The patch only includes minor bug and security fixes.

## Tests
Existing tests.
