### PR TITLE
Fix `bundle plan` to not create workspace objects or upload the files

### DIFF
--- a/acceptance/bundle/plan/no_upload/.gitignore
+++ b/acceptance/bundle/plan/no_upload/.gitignore
@@ -1,0 +1,1 @@
+.databricks

--- a/acceptance/bundle/plan/no_upload/databricks.yml
+++ b/acceptance/bundle/plan/no_upload/databricks.yml
@@ -1,0 +1,20 @@
+bundle:
+  name: plan-no-upload
+
+resources:
+  jobs:
+    my_job:
+      name: my-job
+      tasks:
+        - task_key: task1
+          spark_python_task:
+            python_file: "./my_script.py"
+          new_cluster:
+            num_workers: 1
+            spark_version: 13.3.x-scala2.12
+            node_type_id: i3.xlarge
+            driver_node_type_id: i3.xlarge
+            custom_tags:
+              "ResourceClass": "SingleNode"
+          libraries:
+            - whl: "*.whl"

--- a/acceptance/bundle/plan/no_upload/my_script.py
+++ b/acceptance/bundle/plan/no_upload/my_script.py
@@ -1,0 +1,1 @@
+print("Hello, World!")

--- a/acceptance/bundle/plan/no_upload/out.test.toml
+++ b/acceptance/bundle/plan/no_upload/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/plan/no_upload/output.txt
+++ b/acceptance/bundle/plan/no_upload/output.txt
@@ -1,0 +1,7 @@
+
+>>> [CLI] bundle plan
+create jobs.my_job
+
+>>> jq -s .[] | select(.path=="/api/2.0/workspace/delete") | select(.body.path | test(".*/artifacts/.internal")) out.requests.txt
+
+>>> jq -s .[] | select(.path | contains("/api/2.0/workspace-files/import-file")) out.requests.txt

--- a/acceptance/bundle/plan/no_upload/script
+++ b/acceptance/bundle/plan/no_upload/script
@@ -1,0 +1,9 @@
+trace $CLI bundle plan
+
+# Expect no clean up requests
+trace jq -s '.[] | select(.path=="/api/2.0/workspace/delete") | select(.body.path | test(".*/artifacts/.internal"))' out.requests.txt
+
+# Expect no upload requests
+trace jq -s '.[] | select(.path | contains("/api/2.0/workspace-files/import-file"))' out.requests.txt
+
+rm out.requests.txt

--- a/acceptance/bundle/plan/no_upload/test.toml
+++ b/acceptance/bundle/plan/no_upload/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+RecordRequests = true


### PR DESCRIPTION
## Changes
Refactored `deployPrepare` to make it non-mutative. Moved artifact folder cleanup and libraries upload to `uploadLibraries`, which is only used by deploy.

## Why
This makes `bundle plan` non-mutative and safe to use to preview bundle changes.

## Tests
Added acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
