### PR TITLE
Fix "cache: token not found" for auth token command

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### CLI
 
+* Fix "cache: token not found" for auth token command ([#3447](https://github.com/databricks/cli/pull/3447))
+
 ### Bundles
 * Add support for Lakebase database instances in DABs ([#3283](https://github.com/databricks/cli/pull/3283))
 * Improve error message for SDK/API errors ([#3379](https://github.com/databricks/cli/pull/3379))

--- a/acceptance/cmd/auth/token/out.test.toml
+++ b/acceptance/cmd/auth/token/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/cmd/auth/token/output.txt
+++ b/acceptance/cmd/auth/token/output.txt
@@ -1,0 +1,5 @@
+
+>>> [CLI] auth token --host [DATABRICKS_URL]
+Error: cache: databricks OAuth is not configured for this host. Try logging in again with `databricks auth login --host [DATABRICKS_URL]` before retrying. If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new
+
+Exit code: 1

--- a/acceptance/cmd/auth/token/script
+++ b/acceptance/cmd/auth/token/script
@@ -1,0 +1,13 @@
+mkdir -p home
+export HOME="$PWD/home"
+
+export DATABRICKS_HOST_ORIG="$DATABRICKS_HOST"
+export DATABRICKS_TOKEN_ORIG="$DATABRICKS_TOKEN"
+
+unset DATABRICKS_HOST
+unset DATABRICKS_TOKEN
+
+# This is expected to fail because there is no token cache.
+# We need to assert that the returned error message does not change,
+# because older SDK versions check for a particular substring.
+trace $CLI auth token --host $DATABRICKS_HOST_ORIG

--- a/acceptance/cmd/auth/token/test.toml
+++ b/acceptance/cmd/auth/token/test.toml
@@ -1,0 +1,3 @@
+Ignore = [
+    "home"
+]


### PR DESCRIPTION
## Changes

Update the "auth token" command to return the same error as CLI v0.263.0.

## Why

Older versions of Databricks SDKs call this command to retrieve an OAuth token. They perform a substring match on the returned error to determine if the CLI experienced a real error or if OAuth is not an applicable authentication mechanism in the user's context. By changing the error message (see databricks/databricks-sdk-go#1250), these older SDKs no longer fall through but return an error `cache: no token found` when checking if they can use OAuth to authenticate.

## Tests

Adds an acceptance test. It passes with the previous version of the CLI and passes with this commit.