### PR TITLE
[Python] Fix cleanup in codegen script

### DIFF
--- a/experimental/python/Makefile
+++ b/experimental/python/Makefile
@@ -17,7 +17,10 @@ lint:
 	uv run ruff format --diff
 
 codegen:
-	find databricks -name _models | xargs rm -rf
+	find databricks/bundles -type d -mindepth 1 -maxdepth 1 \
+	  ! -path databricks/bundles/core \
+	  ! -path databricks/bundles/resources \
+	  -exec rm -rf {} \;
 
 	cd codegen; uv run -m pytest codegen_tests
 	cd codegen; uv run -m codegen.main --output ..


### PR DESCRIPTION
## Changes
Fix the cleanup stage in the codegen script to remove unnecessary `__init__` files.

## Why
We have unnescessary `compute/__init__.py` that shouldn't have existed in the first place.

## Tests
Codegen script is executed on every commit in CI