### PR TITLE
Skip fields generation for resource_quality_monitor in tf codegen

### DIFF
--- a/bundle/internal/tf/codegen/generator/generator.go
+++ b/bundle/internal/tf/codegen/generator/generator.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,9 +68,16 @@ func Run(ctx context.Context, schema *tfjson.ProviderSchema, path string) error 
 			name:           k,
 			block:          v.Block,
 		}
-		err := b.Generate(path)
-		if err != nil {
-			return err
+
+		// Skip fields generation for resource_quality_monitor to avoid unwanted changes,
+		// as of August 2025 the generator turns pointer fields into slices, which breaks the resource behaviour
+		if k == "databricks_quality_monitor" {
+			log.Printf("Warning: Skipping file generation for %s to avoid known unwanted changes", k)
+		} else {
+			err := b.Generate(path)
+			if err != nil {
+				return err
+			}
 		}
 		resources = append(resources, b)
 	}


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

When running codegen, a developer who is not aware of the issue with fields of the quality monitor can get confused / spend a lot of time trying to understand the issue with it. Skipping this generation helps to avoid this confusion. The downside of this change is that new changes to the quality monitor will not be automatically picked up by the codegen. To mitigate that a warning line in the log is added, so that if you are looking for changes specifically in the quality monitor, you will get alerted by the message.