### PR TITLE
Show a warning message if a resource is not in GroupToTerraformName

### DIFF
--- a/bundle/deploy/terraform/showplanfile.go
+++ b/bundle/deploy/terraform/showplanfile.go
@@ -11,7 +11,7 @@ import (
 
 func isSilentlyUpdated(resourceType string) bool {
 	// These types are automatically created by DABs, no need to show them in the plan
-	var silentlyUpdatedResources = []string{
+	silentlyUpdatedResources := []string{
 		"databricks_grant",
 		"databricks_permissions",
 		"databricks_secret_acl",

--- a/bundle/deploy/terraform/showplanfile.go
+++ b/bundle/deploy/terraform/showplanfile.go
@@ -9,20 +9,12 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func isSilentlyUpdated(resourceType string) bool {
-	// These types are automatically created by DABs, no need to show them in the plan
-	silentlyUpdatedResources := []string{
-		"databricks_grant",
-		"databricks_permissions",
-		"databricks_secret_acl",
-	}
-
-	for _, s := range silentlyUpdatedResources {
-		if s == resourceType {
-			return true
-		}
-	}
-	return false
+// silentlyUpdatedResources contains resource types that are automatically created by DABs,
+// no need to show them in the plan
+var silentlyUpdatedResources = map[string]bool{
+	"databricks_grants":      true,
+	"databricks_permissions": true,
+	"databricks_secret_acl":  true,
 }
 
 // GetActions converts Terraform resource changes into deployplan.Action values.
@@ -51,7 +43,7 @@ func GetActions(ctx context.Context, changes []*tfjson.ResourceChange) []deployp
 
 		group, ok := TerraformToGroupName[rc.Type]
 		if !ok {
-			if !isSilentlyUpdated(rc.Type) {
+			if !silentlyUpdatedResources[rc.Type] {
 				log.Warnf(ctx, "unknown resource type '%s'", rc.Type)
 			}
 			continue

--- a/bundle/phases/deploy_test.go
+++ b/bundle/phases/deploy_test.go
@@ -41,7 +41,7 @@ func TestParseTerraformActions(t *testing.T) {
 		},
 	}
 
-	actions := terraform.GetActions(changes)
+	actions := terraform.GetActions(t.Context(), changes)
 	res := deployplan.FilterGroup(actions, "pipelines", deployplan.ActionTypeDelete, deployplan.ActionTypeRecreate)
 
 	assert.Equal(t, []deployplan.Action{


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

When introducing a new resource to the system it does not get a mention in the plan automatically. Instead, developer must know that the new resource has to be added to the GroupToTerraformName map for it. The warning message is a good indicator for the developer of the new resource that an extra step is needed for the resource support. I opted for the warning message instead of panicking because apparently there are resources that do not need to be in the plan, but there is no comprehensive list of such resources provided and I am not sure that the test suite covers every such resource, it is not a great experience for the bundle operation to be blocked just because the resource is in neither of the lists.

## Tests
<!-- How have you tested the changes? -->
Existing tests are green

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
