### PR TITLE
direct: fix cycle message; simplify labels

### DIFF
--- a/acceptance/bundle/resource_deps/loop_jobs/out.deploy.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.deploy.direct-exp.txt
@@ -1,9 +1,5 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-<<<<<<< HEAD
-Error: cycle detected: jobs.bar refers to jobs.foo via ${resources.jobs.bar.id} which refers to jobs.bar via ${resources.jobs.foo.id}
-=======
 Error: cycle detected: jobs.bar refers to jobs.foo via "id" which refers to jobs.bar via "id"
->>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_jobs/out.deploy.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.deploy.direct-exp.txt
@@ -1,5 +1,5 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Error: cycle detected: jobs.bar refers to jobs.foo via "id" which refers to jobs.bar via "id"
+Error: cycle detected: jobs.bar -> jobs.foo -> jobs.bar (via "id", "id")
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_jobs/out.deploy.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.deploy.direct-exp.txt
@@ -1,5 +1,9 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+<<<<<<< HEAD
 Error: cycle detected: jobs.bar refers to jobs.foo via ${resources.jobs.bar.id} which refers to jobs.bar via ${resources.jobs.foo.id}
+=======
+Error: cycle detected: jobs.bar refers to jobs.foo via "id" which refers to jobs.bar via "id"
+>>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 Error: cycle detected: jobs.bar refers to jobs.foo via ${resources.jobs.bar.id} which refers to jobs.bar via ${resources.jobs.foo.id}
+=======
+Error: cycle detected: jobs.bar refers to jobs.foo via "id" which refers to jobs.bar via "id"
+>>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-Error: cycle detected: jobs.bar refers to jobs.foo via ${resources.jobs.bar.id} which refers to jobs.bar via ${resources.jobs.foo.id}
-=======
 Error: cycle detected: jobs.bar refers to jobs.foo via "id" which refers to jobs.bar via "id"
->>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
@@ -1,4 +1,4 @@
-Error: cycle detected: jobs.bar refers to jobs.foo via "id" which refers to jobs.bar via "id"
+Error: cycle detected: jobs.bar -> jobs.foo -> jobs.bar (via "id", "id")
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.deploy.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.deploy.direct-exp.txt
@@ -1,9 +1,5 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-<<<<<<< HEAD
-Error: cycle detected: jobs.foo refers to itself via ${resources.jobs.foo.id}
-=======
 Error: cycle detected: jobs.foo refers to itself via "id"
->>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.deploy.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.deploy.direct-exp.txt
@@ -1,5 +1,5 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Error: cycle detected: jobs.foo refers to itself via "id"
+Error: cycle detected: jobs.foo -> jobs.foo (via "id")
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.deploy.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.deploy.direct-exp.txt
@@ -1,5 +1,9 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+<<<<<<< HEAD
 Error: cycle detected: jobs.foo refers to itself via ${resources.jobs.foo.id}
+=======
+Error: cycle detected: jobs.foo refers to itself via "id"
+>>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-Error: cycle detected: jobs.foo refers to itself via ${resources.jobs.foo.id}
-=======
 Error: cycle detected: jobs.foo refers to itself via "id"
->>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
@@ -1,4 +1,4 @@
-Error: cycle detected: jobs.foo refers to itself via "id"
+Error: cycle detected: jobs.foo -> jobs.foo (via "id")
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 Error: cycle detected: jobs.foo refers to itself via ${resources.jobs.foo.id}
+=======
+Error: cycle detected: jobs.foo refers to itself via "id"
+>>>>>>> f5d1333e7 (update tests wrt label in quotes)
 
 
 Exit code (musterr): 1

--- a/bundle/terranova/graph.go
+++ b/bundle/terranova/graph.go
@@ -68,7 +68,7 @@ func makeResourceGraph(ctx context.Context, b *bundle.Bundle) (*dagrun.Graph[dep
 		for _, fieldRef := range fieldRefs {
 			for _, referencedNode := range fieldRef.referencedNodes {
 				// We're only supporting "id" field at the moment, so label is unambigous
-				label := "${resources." + referencedNode.Group + "." + referencedNode.Key + ".id}"
+				label := "id"
 				log.Debugf(ctx, "Adding resource edge: %s (via %#v)", label, fieldRef.ref.Str)
 				// TODO: this may add duplicate edges. Investigate if we need to prevent that
 				g.AddDirectedEdge(

--- a/libs/dagrun/dagrun.go
+++ b/libs/dagrun/dagrun.go
@@ -63,7 +63,7 @@ func (e *CycleError[N]) Error() string {
 
 	// Build cycle path: "A -> B -> ... -> A"
 	var pathParts []string
-	for i := 0; i < len(e.Nodes); i++ {
+	for i := range len(e.Nodes) {
 		pathParts = append(pathParts, fmt.Sprintf("%v", e.Nodes[i]))
 	}
 	// close back to the first node
@@ -72,7 +72,7 @@ func (e *CycleError[N]) Error() string {
 
 	// Build labels list: '"l1", "l2", ...'
 	var labelParts []string
-	for i := 0; i < len(e.Edges); i++ {
+	for i := range len(e.Edges) {
 		labelParts = append(labelParts, fmt.Sprintf("%q", e.Edges[i]))
 	}
 

--- a/libs/dagrun/dagrun.go
+++ b/libs/dagrun/dagrun.go
@@ -62,17 +62,17 @@ func (e *CycleError[N]) Error() string {
 	}
 
 	if len(e.Nodes) == 1 {
-		return fmt.Sprintf("cycle detected: %v refers to itself via %s", e.Nodes[0], e.Edges[0])
+		return fmt.Sprintf("cycle detected: %v refers to itself via %q", e.Nodes[0], e.Edges[0])
 	}
 
 	// Build "A refers to B via E1" pieces for every edge except the closing one.
 	var parts []string
 	for i := 1; i < len(e.Nodes); i++ {
-		parts = append(parts, fmt.Sprintf("%v refers to %v via %s", e.Nodes[i-1], e.Nodes[i], e.Edges[i-1]))
+		parts = append(parts, fmt.Sprintf("%v refers to %v via %q", e.Nodes[i-1], e.Nodes[i], e.Edges[i-1]))
 	}
 
 	return fmt.Sprintf(
-		"cycle detected: %s which refers to %v via %s",
+		"cycle detected: %s which refers to %v via %q",
 		strings.Join(parts, " "),
 		e.Nodes[0],
 		e.Edges[len(e.Edges)-1],

--- a/libs/dagrun/dagrun.go
+++ b/libs/dagrun/dagrun.go
@@ -61,22 +61,22 @@ func (e *CycleError[N]) Error() string {
 		return "cycle detected"
 	}
 
-	if len(e.Nodes) == 1 {
-		return fmt.Sprintf("cycle detected: %v refers to itself via %q", e.Nodes[0], e.Edges[0])
+	// Build cycle path: "A -> B -> ... -> A"
+	var pathParts []string
+	for i := 0; i < len(e.Nodes); i++ {
+		pathParts = append(pathParts, fmt.Sprintf("%v", e.Nodes[i]))
+	}
+	// close back to the first node
+	pathParts = append(pathParts, fmt.Sprintf("%v", e.Nodes[0]))
+	path := strings.Join(pathParts, " -> ")
+
+	// Build labels list: '"l1", "l2", ...'
+	var labelParts []string
+	for i := 0; i < len(e.Edges); i++ {
+		labelParts = append(labelParts, fmt.Sprintf("%q", e.Edges[i]))
 	}
 
-	// Build "A refers to B via E1" pieces for every edge except the closing one.
-	var parts []string
-	for i := 1; i < len(e.Nodes); i++ {
-		parts = append(parts, fmt.Sprintf("%v refers to %v via %q", e.Nodes[i-1], e.Nodes[i], e.Edges[i-1]))
-	}
-
-	return fmt.Sprintf(
-		"cycle detected: %s which refers to %v via %q",
-		strings.Join(parts, " "),
-		e.Nodes[0],
-		e.Edges[len(e.Edges)-1],
-	)
+	return fmt.Sprintf("cycle detected: %s (via %s)", path, strings.Join(labelParts, ", "))
 }
 
 func (g *Graph[N]) indegrees() map[N]int {

--- a/libs/dagrun/dagrun_test.go
+++ b/libs/dagrun/dagrun_test.go
@@ -69,7 +69,7 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 			edges: []edge{
 				{"A", "A", "${A.id}"},
 			},
-			cycle: "cycle detected: A refers to itself via \"${A.id}\"",
+			cycle: "cycle detected: A -> A (via \"${A.id}\")",
 		},
 		{
 			name: "two-node cycle",
@@ -77,7 +77,7 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 				{"A", "B", "${A.id}"},
 				{"B", "A", "${B.id}"},
 			},
-			cycle: "cycle detected: A refers to B via \"${A.id}\" which refers to A via \"${B.id}\"",
+			cycle: "cycle detected: A -> B -> A (via \"${A.id}\", \"${B.id}\")",
 		},
 		{
 			name: "three-node cycle",
@@ -86,7 +86,7 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 				{"Y", "Z", "e2"},
 				{"Z", "X", "e3"},
 			},
-			cycle: "cycle detected: X refers to Y via \"e1\" Y refers to Z via \"e2\" which refers to X via \"e3\"",
+			cycle: "cycle detected: X -> Y -> Z -> X (via \"e1\", \"e2\", \"e3\")",
 		},
 		{
 			name:         "downstream runs with failed dependency",

--- a/libs/dagrun/dagrun_test.go
+++ b/libs/dagrun/dagrun_test.go
@@ -69,7 +69,7 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 			edges: []edge{
 				{"A", "A", "${A.id}"},
 			},
-			cycle: "cycle detected: A refers to itself via ${A.id}",
+			cycle: "cycle detected: A refers to itself via \"${A.id}\"",
 		},
 		{
 			name: "two-node cycle",
@@ -77,7 +77,7 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 				{"A", "B", "${A.id}"},
 				{"B", "A", "${B.id}"},
 			},
-			cycle: "cycle detected: A refers to B via ${A.id} which refers to A via ${B.id}",
+			cycle: "cycle detected: A refers to B via \"${A.id}\" which refers to A via \"${B.id}\"",
 		},
 		{
 			name: "three-node cycle",
@@ -86,7 +86,7 @@ func TestRun_VariousGraphsAndPools(t *testing.T) {
 				{"Y", "Z", "e2"},
 				{"Z", "X", "e3"},
 			},
-			cycle: "cycle detected: X refers to Y via e1 Y refers to Z via e2 which refers to X via e3",
+			cycle: "cycle detected: X refers to Y via \"e1\" Y refers to Z via \"e2\" which refers to X via \"e3\"",
 		},
 		{
 			name:         "downstream runs with failed dependency",


### PR DESCRIPTION
## Changes
- Fix message to list nodes participating in a cycle, then list edges.
- Instead of using full reference, use just the variable name.

## Why
The old message was not correct, "X refers to Y" was reverted. The new is easier to read.

The variable reference can be long if we support arbitrary variables and full resource name is redundant as we already have the node information.

This also simplifies https://github.com/databricks/cli/pull/3466 where I use label as path to the field.