### PR TITLE
Add ssh command group and setup sub-command

### DIFF
--- a/cmd/ssh/README.md
+++ b/cmd/ssh/README.md
@@ -1,0 +1,119 @@
+## SSH Tunnel for Databricks
+SSH tunnel lets customers connect any IDE to Databricks clusters to run and debug all code - including non-Spark/ML- with environment parity, and simple setup.
+
+## Cluster Requirements
+- Dedicated (single user) access mode if you want to use Remote Development tools in IDEs
+- Dedicated or Standard access mode for terminal ssh connections
+
+## Usage
+A. With local ssh config setup:
+```shell
+databricks ssh setup --name=hello --cluster=id # one time only
+ssh hello # use system SSH client to create a session
+```
+B. Spawn an ssh session directly:
+```shell
+databricks ssh connect --cluster=id
+```
+
+## Development
+```shell
+make build snapshot-release
+./cli ssh connect --cluster=<id> --releases-dir=./dist --debug # or modify ssh config accordingly
+```
+
+## Design
+
+High level:
+```mermaid
+---
+config:
+  theme: redux
+  layout: dagre
+---
+flowchart TD
+ n1(["Client A"])
+ subgraph s1["Control Plane"]
+        n3["Jobs API"]
+        n2["Driver Proxy API"]
+        n11["Workspace API"]
+  end
+ subgraph s3["Spark User A (or root)"]
+        n4["SSH Server A"]
+  end
+ subgraph s4["Spark User B"]
+        n6["SSH Server B"]
+  end
+ subgraph s2["Cluster"]
+        s3
+        s4
+        n12["WSFS/DBFS/Volumes"]
+  end
+    n1 -. "1 - start an ssh server job" .-> n3
+    n3 -. "2 - start ssh server" .-> n4
+    n4 <-. "3 - save the port number" .-> n12
+    n1 <-. "4 - get ssh server port" .-> n11
+    n1 <-. "6 - websocket connection" .-> n2
+    n2 <-. "7 - websocket connection" .-> n4
+    n6 <-.-> n12
+    style s2 stroke:#757575
+    style s1 stroke:#757575
+```
+
+Connection flow:
+```mermaid
+---
+config:
+  theme: base
+---
+sequenceDiagram
+  autonumber
+  participant P1 as databricks ssh connect
+  participant P2 as ssh client
+  participant P3 as databricks ssh connect --proxy
+  participant P4 as wsfs
+  participant P6 as databricks ssh server
+  participant P7 as sshd
+  Note over P1,P6: Try to get a port and a remote user name of an existing server<br/> ($v is databricks CLI version, $cluster is supplied by the user)
+  activate P1
+  P1 ->> P4: GET ~/.ssh/$v/$cluster/metadata.json
+  P4 -->> P1: {port: xxxx} or error
+  P1 ->> P6: GET /dirver-proxy-api/$cluster/$port/metadata
+  P6 -->> P1: {user: spark-xxxx} or {user: root} or error
+  Note over P1,P6: Start the new server in the case of an error
+  opt
+    P1 -->> P1: generate<br/>key pair
+    P1 -->> P4: PUT ~/.ssh/$v/bin/databricks, unless it's already there
+    P1 ->> P4: PUT ~/.ssh/$v/$cluster/start-server-with-pub-key.ipynb
+    P1 ->> P6: jobs/runs/submit start-server-with-pub-key.ipynb $cluster
+    activate P6
+    P6 ->> P6: start self-kill-timeout<br/>generate server key pair<br/>create custom sshd config<br/>listen for /ssh and /metadata on a free port
+    P6 ->> P4: PUT ~/.ssh/$v/$cluster/metadata.json<br/>{port: xxxx}
+    loop unil successful or timed out
+      P1 -> P6: Get port and remote user name of the server (sequence 1 - 4 above)
+    end
+  end
+  Note over P1,P7: We know the port and the user, spawn "ssh"
+  P1 ->> P2: ssh -l $user -i $key<br/> -o ProxyCommand="databricks ssh connect --proxy $cluster $user $port"
+  activate P2
+  P2 ->> P3: exec ProxyCommand
+  activate P3
+  P3 ->> P6: wss:/dirver-proxy-api/$cluster/$port/ssh
+  P6 ->> P6: stop self-kill-timeout
+  P6 ->> P7: /usr/sbin/sshd -i -f config
+  activate P7
+  P2 -> P7: pubkey auth
+  loop until the connection is closed<br/>by ssh client, sshd, or driver-proxy
+    P2 -> P7: stdin and stdout
+    P1 -> P2: stdin, stdout, and stderr
+    deactivate P7
+    deactivate P3
+    deactivate P2
+    deactivate P1
+  end
+  break when the last ws connection drops
+    P6 ->> P6: start self-kill-timeout
+    P6 ->> P4: DELETE  ~/.ssh/$v/$cluster/metadata.json
+    deactivate P6
+  end
+```

--- a/cmd/ssh/setup.go
+++ b/cmd/ssh/setup.go
@@ -1,0 +1,51 @@
+package ssh
+
+import (
+	"time"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/ssh"
+	"github.com/spf13/cobra"
+)
+
+func newSetupCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Setup SSH configuration for a Databricks cluster",
+		Long: `Setup SSH configuration for a Databricks cluster.
+
+This command configures SSH to connect to a Databricks cluster by adding
+an SSH host configuration to your SSH config file.
+
+` + disclaimer,
+	}
+
+	var hostName string
+	var clusterID string
+	var sshConfigPath string
+	var shutdownDelay time.Duration
+
+	cmd.Flags().StringVar(&hostName, "name", "", "Host name to use in SSH config")
+	cmd.MarkFlagRequired("name")
+	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks cluster ID")
+	cmd.MarkFlagRequired("cluster")
+	cmd.Flags().StringVar(&sshConfigPath, "ssh-config", "", "Path to SSH config file (default ~/.ssh/config)")
+	cmd.Flags().DurationVar(&shutdownDelay, "shutdown-delay", 10*time.Minute, "SSH server will terminate after this delay if there are no active connections")
+
+	cmd.PreRunE = root.MustWorkspaceClient
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		client := cmdctx.WorkspaceClient(ctx)
+		opts := ssh.SetupOptions{
+			HostName:      hostName,
+			ClusterID:     clusterID,
+			SSHConfigPath: sshConfigPath,
+			ShutdownDelay: shutdownDelay,
+			Profile:       client.Config.Profile,
+		}
+		return ssh.Setup(ctx, client, opts)
+	}
+
+	return cmd
+}

--- a/cmd/ssh/ssh.go
+++ b/cmd/ssh/ssh.go
@@ -1,0 +1,35 @@
+package ssh
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const disclaimer = `WARNING! This is an experimental feature:
+- The product is in preview and not intended to be used in production;
+- The product may change or may never be released;
+- While we will not charge separately for this product right now, we may charge for it in the future. You will still incur charges for DBUs.
+- There's no formal support or SLAs for the preview - so please reach out to your account or other contact with any questions or feedback.
+- We may terminate the preview or your access at any time;
+- Non-public information about the preview (including the fact that there is a preview for the feature/product itself) is confidential;`
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "ssh",
+		Short:  "Connect to Databricks clusters with ssh",
+		Hidden: true,
+		Long: `Connect to Databricks clusters with ssh.
+
+SSH commands let you setup and establish ssh connections to Databricks clusters.
+
+Common workflows:
+  databricks ssh connect --cluster=<cluster-id> --profile=<profile-name>  # connect to a cluster without any setup
+  databricks ssh setup --name=my-cluster --cluster=<cluster-id>           # update local ssh config
+  ssh my-cluster                                                          # connect to the cluster using ssh client
+
+` + disclaimer,
+	}
+
+	cmd.AddCommand(newSetupCommand())
+
+	return cmd
+}

--- a/libs/ssh/keys.go
+++ b/libs/ssh/keys.go
@@ -1,0 +1,18 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func getLocalSSHKeyPath(clusterID, keysDir string) (string, error) {
+	if keysDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		keysDir = filepath.Join(homeDir, ".databricks", "ssh-tunnel-keys")
+	}
+	return filepath.Join(keysDir, clusterID), nil
+}

--- a/libs/ssh/setup.go
+++ b/libs/ssh/setup.go
@@ -1,0 +1,187 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+)
+
+type SetupOptions struct {
+	HostName      string
+	ClusterID     string
+	SSHConfigPath string
+	SSHKeysDir    string
+	ShutdownDelay time.Duration
+	Profile       string
+}
+
+func validateClusterAccess(ctx context.Context, client *databricks.WorkspaceClient, clusterID string) error {
+	clusterInfo, err := client.Clusters.Get(ctx, compute.GetClusterRequest{ClusterId: clusterID})
+	if err != nil {
+		return fmt.Errorf("failed to get cluster information for cluster ID '%s': %w", clusterID, err)
+	}
+	if clusterInfo.DataSecurityMode != compute.DataSecurityModeSingleUser {
+		return fmt.Errorf("cluster '%s' does not have dedicated access mode. Current access mode: %s. Please ensure the cluster is configured with dedicated access mode (single user)", clusterID, clusterInfo.DataSecurityMode)
+	}
+	return nil
+}
+
+func resolveConfigPath(configPath string) (string, error) {
+	if configPath != "" {
+		return configPath, nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".ssh", "config"), nil
+}
+
+func generateHostConfig(opts SetupOptions) (string, error) {
+	identityFilePath, err := getLocalSSHKeyPath(opts.ClusterID, opts.SSHKeysDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to get local keys folder: %w", err)
+	}
+	escapedIdentityFilePath := strings.ReplaceAll(identityFilePath, `"`, `\"`)
+
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %w", err)
+	}
+	escapedExecPath := strings.ReplaceAll(execPath, `"`, `\"`)
+
+	profileOption := ""
+	if opts.Profile != "" {
+		profileOption = "--profile=" + opts.Profile
+	}
+
+	hostConfig := fmt.Sprintf(`
+Host %s
+    User root
+    ConnectTimeout 360
+    StrictHostKeyChecking accept-new
+    IdentityFile "%s"
+    ProxyCommand "%s" ssh connect --proxy --cluster=%s --shutdown-delay=%s %s
+`, opts.HostName, escapedIdentityFilePath, escapedExecPath, opts.ClusterID, opts.ShutdownDelay, profileOption)
+
+	return hostConfig, nil
+}
+
+func ensureSSHConfigExists(configPath string) error {
+	_, err := os.Stat(configPath)
+	if os.IsNotExist(err) {
+		sshDir := filepath.Dir(configPath)
+		err = os.MkdirAll(sshDir, 0o700)
+		if err != nil {
+			return fmt.Errorf("failed to create SSH directory: %w", err)
+		}
+		err = os.WriteFile(configPath, []byte(""), 0o600)
+		if err != nil {
+			return fmt.Errorf("failed to create SSH config file: %w", err)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check SSH config file: %w", err)
+	}
+	return nil
+}
+
+func checkExistingHosts(content []byte, hostName string) error {
+	existingContent := string(content)
+	pattern := fmt.Sprintf(`(?m)^\s*Host\s+%s\s*$`, regexp.QuoteMeta(hostName))
+	matched, err := regexp.MatchString(pattern, existingContent)
+	if err != nil {
+		return fmt.Errorf("failed to check for existing host: %w", err)
+	}
+	if matched {
+		return fmt.Errorf("host '%s' already exists in the SSH config", hostName)
+	}
+	return nil
+}
+
+func createBackup(content []byte, configPath string) (string, error) {
+	backupPath := configPath + ".bak"
+	err := os.WriteFile(backupPath, content, 0o600)
+	if err != nil {
+		return backupPath, fmt.Errorf("failed to create backup of SSH config file: %w", err)
+	}
+	return backupPath, nil
+}
+
+func updateSSHConfigFile(configPath, hostConfig, hostName string) error {
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read SSH config file: %w", err)
+	}
+
+	existingContent := string(content)
+	if !strings.HasSuffix(existingContent, "\n") && existingContent != "" {
+		existingContent += "\n"
+	}
+	newContent := existingContent + hostConfig
+
+	err = os.WriteFile(configPath, []byte(newContent), 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to update SSH config file: %w", err)
+	}
+
+	return nil
+}
+
+func Setup(ctx context.Context, client *databricks.WorkspaceClient, opts SetupOptions) error {
+	err := validateClusterAccess(ctx, client, opts.ClusterID)
+	if err != nil {
+		return err
+	}
+
+	configPath, err := resolveConfigPath(opts.SSHConfigPath)
+	if err != nil {
+		return err
+	}
+
+	hostConfig, err := generateHostConfig(opts)
+	if err != nil {
+		return err
+	}
+
+	cmdio.LogString(ctx, fmt.Sprintf("Adding new entry to the SSH config:\n%s", hostConfig))
+
+	err = ensureSSHConfigExists(configPath)
+	if err != nil {
+		return err
+	}
+
+	existingContent, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read SSH config file: %w", err)
+	}
+
+	if len(existingContent) > 0 {
+		err = checkExistingHosts(existingContent, opts.HostName)
+		if err != nil {
+			return err
+		}
+		backupPath, err := createBackup(existingContent, configPath)
+		if err != nil {
+			return err
+		}
+		cmdio.LogString(ctx, fmt.Sprintf("Created backup of existing SSH config at %s", backupPath))
+	}
+
+	err = updateSSHConfigFile(configPath, hostConfig, opts.HostName)
+	if err != nil {
+		return err
+	}
+
+	cmdio.LogString(ctx, fmt.Sprintf("Updated SSH config file at %s with '%s' host", configPath, opts.HostName))
+	cmdio.LogString(ctx, fmt.Sprintf("You can now connect to the cluster using 'ssh %s' terminal command, or use remote capabilities of your IDE", opts.HostName))
+	return nil
+}

--- a/libs/ssh/setup_test.go
+++ b/libs/ssh/setup_test.go
@@ -1,0 +1,417 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateClusterAccess(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("valid cluster with single user mode", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		clustersAPI := m.GetMockClustersAPI()
+
+		clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "cluster-123"}).Return(&compute.ClusterDetails{
+			DataSecurityMode: compute.DataSecurityModeSingleUser,
+		}, nil)
+
+		err := validateClusterAccess(ctx, m.WorkspaceClient, "cluster-123")
+		assert.NoError(t, err)
+	})
+
+	t.Run("cluster with invalid access mode", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		clustersAPI := m.GetMockClustersAPI()
+
+		clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "cluster-123"}).Return(&compute.ClusterDetails{
+			DataSecurityMode: compute.DataSecurityModeUserIsolation,
+		}, nil)
+
+		err := validateClusterAccess(ctx, m.WorkspaceClient, "cluster-123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not have dedicated access mode")
+	})
+
+	t.Run("cluster not found", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		clustersAPI := m.GetMockClustersAPI()
+
+		clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "nonexistent"}).Return(nil, fmt.Errorf("cluster not found"))
+
+		err := validateClusterAccess(ctx, m.WorkspaceClient, "nonexistent")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get cluster information for cluster ID 'nonexistent'")
+	})
+}
+
+func TestGenerateHostConfig(t *testing.T) {
+	// Create a temporary directory for testing
+	tmpDir := t.TempDir()
+
+	t.Run("valid host config generation", func(t *testing.T) {
+		opts := SetupOptions{
+			HostName:      "test-host",
+			ClusterID:     "cluster-123",
+			SSHKeysDir:    tmpDir,
+			ShutdownDelay: 30 * time.Second,
+			Profile:       "test-profile",
+		}
+
+		result, err := generateHostConfig(opts)
+		assert.NoError(t, err)
+
+		assert.Contains(t, result, "Host test-host")
+		assert.Contains(t, result, "User root")
+		assert.Contains(t, result, "StrictHostKeyChecking accept-new")
+		assert.Contains(t, result, "--cluster=cluster-123")
+		assert.Contains(t, result, "--shutdown-delay=30s")
+		assert.Contains(t, result, "--profile=test-profile")
+
+		// Check that identity file path is included
+		expectedKeyPath := filepath.Join(tmpDir, "cluster-123")
+		assert.Contains(t, result, fmt.Sprintf(`IdentityFile "%s"`, expectedKeyPath))
+	})
+
+	t.Run("host config without profile", func(t *testing.T) {
+		opts := SetupOptions{
+			HostName:      "test-host",
+			ClusterID:     "cluster-123",
+			SSHKeysDir:    tmpDir,
+			ShutdownDelay: 30 * time.Second,
+			Profile:       "", // No profile
+		}
+
+		result, err := generateHostConfig(opts)
+		assert.NoError(t, err)
+
+		// Should not contain profile option
+		assert.NotContains(t, result, "--profile=")
+		// But should contain other elements
+		assert.Contains(t, result, "Host test-host")
+		assert.Contains(t, result, "--cluster=cluster-123")
+	})
+
+	t.Run("path escaping with quotes", func(t *testing.T) {
+		// Create a directory with quotes in the name for testing escaping
+		specialDir := filepath.Join(tmpDir, `path"with"quotes`)
+		err := os.MkdirAll(specialDir, 0o755)
+		require.NoError(t, err)
+
+		opts := SetupOptions{
+			HostName:      "test-host",
+			ClusterID:     "cluster-123",
+			SSHKeysDir:    specialDir,
+			ShutdownDelay: 30 * time.Second,
+		}
+
+		result, err := generateHostConfig(opts)
+		assert.NoError(t, err)
+
+		// Check that quotes are properly escaped
+		expectedEscapedPath := strings.ReplaceAll(filepath.Join(specialDir, "cluster-123"), `"`, `\"`)
+		assert.Contains(t, result, fmt.Sprintf(`IdentityFile "%s"`, expectedEscapedPath))
+	})
+}
+
+func TestEnsureSSHConfigExists(t *testing.T) {
+	t.Run("creates config file when it doesn't exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, ".ssh", "config")
+
+		err := ensureSSHConfigExists(configPath)
+		assert.NoError(t, err)
+
+		// Check that directory was created
+		_, err = os.Stat(filepath.Dir(configPath))
+		assert.NoError(t, err)
+
+		// Check that file was created
+		info, err := os.Stat(configPath)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode())
+
+		// Check that file is empty
+		content, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		assert.Empty(t, content)
+	})
+}
+
+func TestCheckExistingHosts(t *testing.T) {
+	t.Run("no existing host with same name", func(t *testing.T) {
+		content := []byte(`Host other-host
+    User root
+    HostName example.com
+
+Host another-host
+    User admin
+`)
+		err := checkExistingHosts(content, "test-host")
+		assert.NoError(t, err)
+	})
+
+	t.Run("host already exists", func(t *testing.T) {
+		content := []byte(`Host test-host
+    User root
+    HostName example.com
+
+Host another-host
+    User admin
+`)
+		err := checkExistingHosts(content, "another-host")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "host 'another-host' already exists in the SSH config")
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		content := []byte("")
+		err := checkExistingHosts(content, "test-host")
+		assert.NoError(t, err)
+	})
+
+	t.Run("Host name with whitespaces around it", func(t *testing.T) {
+		content := []byte(` Host  test-host  `)
+		err := checkExistingHosts(content, "test-host")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "host 'test-host' already exists in the SSH config")
+	})
+
+	t.Run("partial name match", func(t *testing.T) {
+		content := []byte(`Host test-host-long`)
+		err := checkExistingHosts(content, "test-host")
+		assert.NoError(t, err)
+	})
+}
+
+func TestCreateBackup(t *testing.T) {
+	t.Run("creates backup file successfully", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config")
+		content := []byte("original content")
+
+		backupPath, err := createBackup(content, configPath)
+		assert.NoError(t, err)
+		assert.Equal(t, configPath+".bak", backupPath)
+
+		// Check that backup file was created with correct content
+		backupContent, err := os.ReadFile(backupPath)
+		assert.NoError(t, err)
+		assert.Equal(t, content, backupContent)
+
+		// Check file permissions
+		info, err := os.Stat(backupPath)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode())
+	})
+
+	t.Run("overwrites existing backup", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config")
+		backupPath := configPath + ".bak"
+
+		// Create existing backup
+		oldContent := []byte("old backup")
+		err := os.WriteFile(backupPath, oldContent, 0o644)
+		require.NoError(t, err)
+
+		// Create new backup
+		newContent := []byte("new content")
+		resultPath, err := createBackup(newContent, configPath)
+		assert.NoError(t, err)
+		assert.Equal(t, backupPath, resultPath)
+
+		// Check that backup was overwritten
+		backupContent, err := os.ReadFile(backupPath)
+		assert.NoError(t, err)
+		assert.Equal(t, newContent, backupContent)
+	})
+}
+
+func TestUpdateSSHConfigFile(t *testing.T) {
+	t.Run("updates config file successfully", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config")
+
+		// Create initial config file
+		initialContent := "# SSH Config\nHost existing\n    User root\n"
+		err := os.WriteFile(configPath, []byte(initialContent), 0o600)
+		require.NoError(t, err)
+
+		hostConfig := "\nHost new-host\n    User root\n    HostName example.com\n"
+		err = updateSSHConfigFile(configPath, hostConfig, "new-host")
+		assert.NoError(t, err)
+
+		// Check that content was appended
+		finalContent, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		expected := initialContent + hostConfig
+		assert.Equal(t, expected, string(finalContent))
+	})
+
+	t.Run("adds newline if file doesn't end with newline", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config")
+
+		// Create config file without trailing newline
+		initialContent := "Host existing\n    User root"
+		err := os.WriteFile(configPath, []byte(initialContent), 0o600)
+		require.NoError(t, err)
+
+		hostConfig := "\nHost new-host\n    User root\n"
+		err = updateSSHConfigFile(configPath, hostConfig, "new-host")
+		assert.NoError(t, err)
+
+		// Check that newline was added before the new content
+		finalContent, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		expected := initialContent + "\n" + hostConfig
+		assert.Equal(t, expected, string(finalContent))
+	})
+
+	t.Run("handles empty file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config")
+
+		// Create empty config file
+		err := os.WriteFile(configPath, []byte(""), 0o600)
+		require.NoError(t, err)
+
+		hostConfig := "Host new-host\n    User root\n"
+		err = updateSSHConfigFile(configPath, hostConfig, "new-host")
+		assert.NoError(t, err)
+
+		// Check that content was added without extra newlines
+		finalContent, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+		assert.Equal(t, hostConfig, string(finalContent))
+	})
+
+	t.Run("handles read error", func(t *testing.T) {
+		configPath := "/nonexistent/file"
+		hostConfig := "Host new-host\n"
+
+		err := updateSSHConfigFile(configPath, hostConfig, "new-host")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read SSH config file")
+	})
+}
+
+func TestSetup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("successful setup with new config file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "ssh_config")
+
+		m := mocks.NewMockWorkspaceClient(t)
+		clustersAPI := m.GetMockClustersAPI()
+
+		clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "cluster-123"}).Return(&compute.ClusterDetails{
+			DataSecurityMode: compute.DataSecurityModeSingleUser,
+		}, nil)
+
+		opts := SetupOptions{
+			HostName:      "test-host",
+			ClusterID:     "cluster-123",
+			SSHConfigPath: configPath,
+			SSHKeysDir:    tmpDir,
+			ShutdownDelay: 30 * time.Second,
+			Profile:       "test-profile",
+		}
+
+		err := Setup(ctx, m.WorkspaceClient, opts)
+		assert.NoError(t, err)
+
+		// Check that config file was created
+		content, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+
+		configStr := string(content)
+		assert.Contains(t, configStr, "Host test-host")
+		assert.Contains(t, configStr, "--cluster=cluster-123")
+		assert.Contains(t, configStr, "--profile=test-profile")
+	})
+
+	t.Run("successful setup with existing config file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "ssh_config")
+
+		// Create existing config file
+		existingContent := "# Existing SSH Config\nHost existing-host\n    User root\n"
+		err := os.WriteFile(configPath, []byte(existingContent), 0o600)
+		require.NoError(t, err)
+
+		m := mocks.NewMockWorkspaceClient(t)
+		clustersAPI := m.GetMockClustersAPI()
+
+		clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "cluster-456"}).Return(&compute.ClusterDetails{
+			DataSecurityMode: compute.DataSecurityModeSingleUser,
+		}, nil)
+
+		opts := SetupOptions{
+			HostName:      "new-host",
+			ClusterID:     "cluster-456",
+			SSHConfigPath: configPath,
+			SSHKeysDir:    tmpDir,
+			ShutdownDelay: 60 * time.Second,
+		}
+
+		err = Setup(ctx, m.WorkspaceClient, opts)
+		assert.NoError(t, err)
+
+		// Check that config file was updated and backup was created
+		content, err := os.ReadFile(configPath)
+		assert.NoError(t, err)
+
+		configStr := string(content)
+		assert.Contains(t, configStr, "# Existing SSH Config") // Original content preserved
+		assert.Contains(t, configStr, "Host new-host")         // New content added
+		assert.Contains(t, configStr, "--cluster=cluster-456")
+
+		// Check backup was created
+		backupPath := configPath + ".bak"
+		backupContent, err := os.ReadFile(backupPath)
+		assert.NoError(t, err)
+		assert.Equal(t, existingContent, string(backupContent))
+	})
+
+	t.Run("fails when host already exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "ssh_config")
+
+		// Create config file with existing host
+		existingContent := "Host duplicate-host\n    User root\n"
+		err := os.WriteFile(configPath, []byte(existingContent), 0o600)
+		require.NoError(t, err)
+
+		m := mocks.NewMockWorkspaceClient(t)
+		clustersAPI := m.GetMockClustersAPI()
+
+		clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "cluster-123"}).Return(&compute.ClusterDetails{
+			DataSecurityMode: compute.DataSecurityModeSingleUser,
+		}, nil)
+
+		opts := SetupOptions{
+			HostName:      "duplicate-host", // Same as existing
+			ClusterID:     "cluster-123",
+			SSHConfigPath: configPath,
+			SSHKeysDir:    tmpDir,
+			ShutdownDelay: 30 * time.Second,
+		}
+
+		err = Setup(ctx, m.WorkspaceClient, opts)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "host 'duplicate-host' already exists in the SSH config")
+	})
+}


### PR DESCRIPTION
## Changes

This is the first PR that introduces the ssh-tunnel functionality into the CLI

See README for an overview of the SSH tunnel feature and its usage. 

This PR only adds `ssh setup` command, `connect` and `server` will be in separate PRs (WIP, will add links to them when the PRs are ready).

The whole `ssh` command group is hidden (not available in `--help` output), and the usage text has private preview disclaimer. Hidden flag will be removed when we move to public preview phase (no timeline yet).

For the full picture check this repo: https://github.com/databricks/ssh-tunnel

## Why
We've agreed to move the implementation in the separate CLI to the main databricks CLI

## Tests
Manually and unit tests. 
