### PR TITLE
Enable tests for testarchive; enable parallel tool downloads

### DIFF
--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +10,10 @@ import (
 )
 
 func TestArchive(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "" {
+		t.Skip("Skipping test in local environment")
+	}
+
 	t.Parallel()
 
 	archiveDir := t.TempDir()

--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -1,5 +1,3 @@
-//go:build dbr_only
-
 package main
 
 import (
@@ -11,6 +9,8 @@ import (
 )
 
 func TestArchive(t *testing.T) {
+	t.Parallel()
+
 	archiveDir := t.TempDir()
 	binDir := t.TempDir()
 	repoRoot := "../.."
@@ -24,12 +24,19 @@ func TestArchive(t *testing.T) {
 
 	// Go installation is a directory because it includes the
 	// standard library source code along with the Go binary.
-	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "go", "bin", "go"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "go", "bin", "go"))
-	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "uv"))
-	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "jq"))
+
+	// TODO: Uncomment these when we have arm64 support
+	// in serverless clusters. Before that point we do not need
+	// to download the arm64 binaries.
+	// assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "go", "bin", "go"))
+	// assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
+	// assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
+	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "go"))
+	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
+	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
 
 	assert.FileExists(t, filepath.Join(assertDir, "cli", "go.mod"))
 	assert.FileExists(t, filepath.Join(assertDir, "cli", "go.sum"))

--- a/internal/testarchive/downloader_test.go
+++ b/internal/testarchive/downloader_test.go
@@ -1,5 +1,3 @@
-//go:build dbr_only
-
 package main
 
 import (
@@ -12,6 +10,7 @@ import (
 )
 
 func TestUvDownloader(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -27,6 +26,7 @@ func TestUvDownloader(t *testing.T) {
 }
 
 func TestJqDownloader(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -42,6 +42,7 @@ func TestJqDownloader(t *testing.T) {
 }
 
 func TestGoDownloader(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {

--- a/internal/testarchive/downloader_test.go
+++ b/internal/testarchive/downloader_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestUvDownloader(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "" {
+		t.Skip("Skipping test in local environment")
+	}
+
 	t.Parallel()
 	tmpDir := t.TempDir()
 
@@ -26,6 +30,10 @@ func TestUvDownloader(t *testing.T) {
 }
 
 func TestJqDownloader(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "" {
+		t.Skip("Skipping test in local environment")
+	}
+
 	t.Parallel()
 	tmpDir := t.TempDir()
 
@@ -42,6 +50,10 @@ func TestJqDownloader(t *testing.T) {
 }
 
 func TestGoDownloader(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "" {
+		t.Skip("Skipping test in local environment")
+	}
+
 	t.Parallel()
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Changes
Feedback in https://github.com/databricks/cli/pull/3453#discussion_r2297493314 recommended not using build tags. In consistent with that theme, we remove the build flags here as well.

Seperately:
1. This PR downloads the tools in parallel to make that operation faster.
2. Skips downloading the arm64 tools for now.
3. Always run the unit tests on CI.

## Why
While the tests are relatively ok in speed (22 seconds for the slowest one, TestArchive), this PR opts to only run the tests on CI environments to keep the runtime for unit tests small.

These functions will be anyways only used in CI environments since they are meant for DBR testing.

## Tests
Existing tests
