### PR TITLE
Add "ssh server" command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/cmd/psql"
+	"github.com/databricks/cli/cmd/ssh"
 
 	"github.com/databricks/cli/cmd/account"
 	"github.com/databricks/cli/cmd/api"
@@ -77,6 +78,7 @@ func New(ctx context.Context) *cobra.Command {
 	cli.AddCommand(version.New())
 	cli.AddCommand(selftest.New())
 	cli.AddCommand(pipelines.InstallPipelinesCLI())
+	cli.AddCommand(ssh.New())
 
 	// Add workspace command groups, filtering out empty groups or groups with only hidden commands.
 	allGroups := workspace.Groups()

--- a/cmd/ssh/server.go
+++ b/cmd/ssh/server.go
@@ -1,0 +1,60 @@
+package ssh
+
+import (
+	"time"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/ssh"
+	"github.com/spf13/cobra"
+)
+
+func newServerCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Run SSH tunnel server",
+		Long: `Run SSH tunnel server.
+
+This command starts an SSH tunnel server that accepts WebSocket connections
+and proxies them to local SSH daemon processes.
+
+` + disclaimer,
+		// This is an internal command spawned by the SSH client running the "ssh-server-bootstrap.py" job
+		Hidden: true,
+	}
+
+	var maxClients int
+	var shutdownDelay time.Duration
+	var clusterID string
+	var version string
+
+	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks cluster ID")
+	cmd.MarkFlagRequired("cluster")
+	cmd.Flags().IntVar(&maxClients, "max-clients", 10, "Maximum number of SSH clients")
+	cmd.Flags().DurationVar(&shutdownDelay, "shutdown-delay", 10*time.Minute, "Delay before shutting down after no pings from clients")
+	cmd.Flags().StringVar(&version, "version", "", "Client version of the Databricks CLI")
+
+	cmd.PreRunE = root.MustWorkspaceClient
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		client := cmdctx.WorkspaceClient(ctx)
+		opts := ssh.ServerOptions{
+			ClusterID:            clusterID,
+			MaxClients:           maxClients,
+			ShutdownDelay:        shutdownDelay,
+			Version:              version,
+			ConfigDir:            ".ssh-tunnel",
+			ServerPrivateKeyName: "server-private-key",
+			ServerPublicKeyName:  "server-public-key",
+			DefaultPort:          7772,
+			PortRange:            100,
+		}
+		err := ssh.RunServer(ctx, client, opts)
+		if err != nil && ssh.IsNormalClosure(err) {
+			return nil
+		}
+		return err
+	}
+
+	return cmd
+}

--- a/cmd/ssh/ssh.go
+++ b/cmd/ssh/ssh.go
@@ -29,6 +29,7 @@ Common workflows:
 
 	cmd.AddCommand(newSetupCommand())
 	cmd.AddCommand(newConnectCommand())
+	cmd.AddCommand(newServerCommand())
 
 	return cmd
 }

--- a/libs/ssh/jupyter-init.py
+++ b/libs/ssh/jupyter-init.py
@@ -1,0 +1,185 @@
+from typing import List, Optional
+from IPython.core.getipython import get_ipython
+from IPython.display import display as ip_display
+from dbruntime import UserNamespaceInitializer
+
+
+def _log_exceptions(func):
+    from functools import wraps
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            print(f"Executing {func.__name__}")
+            return func(*args, **kwargs)
+        except Exception as e:
+            print(f"Error in {func.__name__}: {e}")
+
+    return wrapper
+
+
+_user_namespace_initializer = UserNamespaceInitializer.getOrCreate()
+_entry_point = _user_namespace_initializer.get_spark_entry_point()
+_globals = _user_namespace_initializer.get_namespace_globals()
+for name, value in _globals.items():
+    print(f"Registering global: {name} = {value}")
+    if name not in globals():
+        globals()[name] = value
+
+
+# 'display' from the runtime uses custom widgets that don't work in Jupyter.
+# We use the IPython display instead (in combination with the html formatter for DataFrames).
+globals()["display"] = ip_display
+
+
+@_log_exceptions
+def _register_runtime_hooks():
+    from dbruntime.monkey_patches import apply_dataframe_display_patch
+    from dbruntime.IPythonShellHooks import load_ipython_hooks, IPythonShellHook
+    from IPython.core.interactiveshell import ExecutionInfo
+
+    # Setting executing_raw_cell before cell execution is required to make dbutils.library.restartPython() work
+    class PreRunHook(IPythonShellHook):
+        def pre_run_cell(self, info: ExecutionInfo) -> None:
+            get_ipython().executing_raw_cell = info.raw_cell
+
+    load_ipython_hooks(get_ipython(), PreRunHook())
+    apply_dataframe_display_patch(ip_display)
+
+
+def _warn_for_dbr_alternative(magic: str):
+    import warnings
+
+    """Warn users about magics that have Databricks alternatives."""
+    local_magic_dbr_alternative = {"%%sh": "%sh"}
+    if magic in local_magic_dbr_alternative:
+        warnings.warn(
+            f"\\n{magic} is not supported on Databricks. This notebook might fail when running on a Databricks cluster.\\n"
+            f"Consider using %{local_magic_dbr_alternative[magic]} instead."
+        )
+
+
+def _throw_if_not_supported(magic: str):
+    """Throw an error for magics that are not supported locally."""
+    unsupported_dbr_magics = ["%r", "%scala"]
+    if magic in unsupported_dbr_magics:
+        raise NotImplementedError(f"{magic} is not supported for local Databricks Notebooks.")
+
+
+def _get_cell_magic(lines: List[str]) -> Optional[str]:
+    """Extract cell magic from the first line if it exists."""
+    if len(lines) == 0:
+        return None
+    if lines[0].strip().startswith("%%"):
+        return lines[0].split(" ")[0].strip()
+    return None
+
+
+def _get_line_magic(lines: List[str]) -> Optional[str]:
+    """Extract line magic from the first line if it exists."""
+    if len(lines) == 0:
+        return None
+    if lines[0].strip().startswith("%"):
+        return lines[0].split(" ")[0].strip().strip("%")
+    return None
+
+
+def _handle_cell_magic(lines: List[str]) -> List[str]:
+    """Process cell magic commands."""
+    cell_magic = _get_cell_magic(lines)
+    if cell_magic is None:
+        return lines
+
+    _warn_for_dbr_alternative(cell_magic)
+    _throw_if_not_supported(cell_magic)
+    return lines
+
+
+def _handle_line_magic(lines: List[str]) -> List[str]:
+    """Process line magic commands and transform them appropriately."""
+    lmagic = _get_line_magic(lines)
+    if lmagic is None:
+        return lines
+
+    _warn_for_dbr_alternative(lmagic)
+    _throw_if_not_supported(lmagic)
+
+    if lmagic in ["md", "md-sandbox"]:
+        lines[0] = "%%markdown" + lines[0].partition("%" + lmagic)[2]
+        return lines
+
+    if lmagic == "sh":
+        lines[0] = "%%sh" + lines[0].partition("%" + lmagic)[2]
+        return lines
+
+    if lmagic == "sql":
+        lines = lines[1:]
+        spark_string = "global _sqldf\n" + "_sqldf = spark.sql('''" + "".join(lines).replace("'", "\\'") + "''')\n" + "display(_sqldf)\n"
+        return spark_string.splitlines(keepends=True)
+
+    if lmagic == "python":
+        return lines[1:]
+
+    return lines
+
+
+def _strip_hash_magic(lines: List[str]) -> List[str]:
+    if len(lines) == 0:
+        return lines
+    if lines[0].startswith("# MAGIC"):
+        return [line.partition("# MAGIC ")[2] for line in lines]
+    return lines
+
+
+def _parse_line_for_databricks_magics(lines: List[str]) -> List[str]:
+    """Main parser function for Databricks magic commands."""
+    if len(lines) == 0:
+        return lines
+
+    lines_to_ignore = ("# Databricks notebook source", "# COMMAND ----------", "# DBTITLE")
+    lines = [line for line in lines if not line.strip().startswith(lines_to_ignore)]
+    lines = "".join(lines).strip().splitlines(keepends=True)
+    lines = _strip_hash_magic(lines)
+
+    if _get_cell_magic(lines):
+        return _handle_cell_magic(lines)
+
+    if _get_line_magic(lines):
+        return _handle_line_magic(lines)
+
+    return lines
+
+
+@_log_exceptions
+def _register_magics():
+    """Register the magic command parser with IPython."""
+    from dbruntime.DatasetInfo import UserNamespaceDict
+    from dbruntime.PipMagicOverrides import PipMagicOverrides
+
+    user_ns = UserNamespaceDict(
+        _user_namespace_initializer.get_namespace_globals(),
+        _entry_point.getDriverConf(),
+        _entry_point,
+    )
+    ip = get_ipython()
+    ip.input_transformers_cleanup.append(_parse_line_for_databricks_magics)
+    ip.register_magics(PipMagicOverrides(_entry_point, _globals["sc"]._conf, user_ns))
+
+
+@_log_exceptions
+def _register_formatters():
+    from pyspark.sql import DataFrame
+    from pyspark.sql.connect.dataframe import DataFrame as SparkConnectDataframe
+
+    def df_html(df: DataFrame) -> str:
+        return df.toPandas().to_html()
+
+    ip = get_ipython()
+    html_formatter = ip.display_formatter.formatters["text/html"]
+    html_formatter.for_type(SparkConnectDataframe, df_html)
+    html_formatter.for_type(DataFrame, df_html)
+
+
+_register_magics()
+_register_formatters()
+_register_runtime_hooks()

--- a/libs/ssh/proxy.go
+++ b/libs/ssh/proxy.go
@@ -180,7 +180,7 @@ func (pc *proxyConnection) Close() error {
 	// Keep in mind that pc.sendMessage blocks during handover
 	err := pc.sendMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	if err != nil {
-		if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+		if IsNormalClosure(err) {
 			return nil
 		} else {
 			return fmt.Errorf("failed to send close message: %w", err)

--- a/libs/ssh/secrets.go
+++ b/libs/ssh/secrets.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -22,6 +23,22 @@ func createSecretsScope(ctx context.Context, client *databricks.WorkspaceClient,
 		return "", fmt.Errorf("failed to create secrets scope: %w", err)
 	}
 	return secretsScope, nil
+}
+
+func getSecret(ctx context.Context, client *databricks.WorkspaceClient, scope, key string) ([]byte, error) {
+	resp, err := client.Secrets.GetSecret(ctx, workspace.GetSecretRequest{
+		Scope: scope,
+		Key:   key,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret %s from scope %s: %w", key, scope, err)
+	}
+
+	value, err := base64.StdEncoding.DecodeString(resp.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode secret key from base64: %w", err)
+	}
+	return value, nil
 }
 
 func putSecret(ctx context.Context, client *databricks.WorkspaceClient, scope, key, value string) error {

--- a/libs/ssh/server.go
+++ b/libs/ssh/server.go
@@ -1,0 +1,328 @@
+package ssh
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/databricks-sdk-go"
+	"golang.org/x/sync/errgroup"
+)
+
+//go:embed jupyter-init.py
+var jupyterInitScript string
+
+// connectionsManager manages concurrent websocket clients and sends a shutdown signal if no
+// clients are connected for a specified duration.
+type connectionsManager struct {
+	maxClients      int
+	shutdownDelay   time.Duration
+	shutdownTimer   *time.Timer
+	shutdownTimerMu sync.Mutex
+	connections     map[string]*proxyConnection
+	connectionsMu   sync.Mutex
+	TimedOut        chan bool
+}
+
+func newConnectionsManager(maxClients int, shutdownDelay time.Duration) *connectionsManager {
+	cm := &connectionsManager{
+		maxClients:    maxClients,
+		shutdownDelay: shutdownDelay,
+		connections:   make(map[string]*proxyConnection),
+		TimedOut:      make(chan bool),
+	}
+	cm.startShutdownTimer()
+	return cm
+}
+
+func (cm *connectionsManager) Count() int {
+	cm.connectionsMu.Lock()
+	defer cm.connectionsMu.Unlock()
+	return len(cm.connections)
+}
+
+func (cm *connectionsManager) TryAdd(id string, conn *proxyConnection) bool {
+	count := cm.Count()
+	if count >= cm.maxClients {
+		return false
+	}
+	cm.addConnection(id, conn)
+	cm.cancelShutdownTimer()
+	return true
+}
+
+func (cm *connectionsManager) addConnection(id string, conn *proxyConnection) {
+	cm.connectionsMu.Lock()
+	defer cm.connectionsMu.Unlock()
+	cm.connections[id] = conn
+}
+
+func (cm *connectionsManager) Get(id string) (*proxyConnection, bool) {
+	cm.connectionsMu.Lock()
+	defer cm.connectionsMu.Unlock()
+	conn, exists := cm.connections[id]
+	return conn, exists
+}
+
+func (cm *connectionsManager) Remove(id string) {
+	cm.removeConnection(id)
+	count := cm.Count()
+	if count <= 0 {
+		cm.startShutdownTimer()
+	}
+}
+
+func (cm *connectionsManager) removeConnection(id string) {
+	cm.connectionsMu.Lock()
+	defer cm.connectionsMu.Unlock()
+	delete(cm.connections, id)
+}
+
+func (cm *connectionsManager) startShutdownTimer() {
+	cm.shutdownTimerMu.Lock()
+	defer cm.shutdownTimerMu.Unlock()
+	if cm.shutdownTimer != nil {
+		cm.shutdownTimer.Stop()
+	}
+	cm.shutdownTimer = time.AfterFunc(cm.shutdownDelay, func() {
+		cm.TimedOut <- true
+	})
+}
+
+func (cm *connectionsManager) cancelShutdownTimer() {
+	cm.shutdownTimerMu.Lock()
+	defer cm.shutdownTimerMu.Unlock()
+	if cm.shutdownTimer != nil {
+		cm.shutdownTimer.Stop()
+	}
+}
+
+type sshHandler struct {
+	Connections    *connectionsManager
+	SSHDConfigPath string
+}
+
+func newSSHHandler(connections *connectionsManager, sshDConfigPath string) *sshHandler {
+	return &sshHandler{
+		Connections:    connections,
+		SSHDConfigPath: sshDConfigPath,
+	}
+}
+
+func (handler *sshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "Missing 'id' query parameter", http.StatusBadRequest)
+		return
+	}
+
+	if conn, exists := handler.Connections.Get(id); exists && conn != nil {
+		log.Info(ctx, fmt.Sprintf("Client with id %s is already connected", id))
+		err := conn.AcceptHandover(r.Context(), w, r)
+		if err != nil {
+			log.Error(ctx, fmt.Sprintf("failed to accept handover: %v", err))
+			http.Error(w, "Handover failed", http.StatusInternalServerError)
+		} else {
+			log.Info(ctx, "Handover accepted for client with id "+id)
+		}
+		return
+	}
+
+	proxy := newProxyConnection(nil)
+	err := proxy.Accept(w, r)
+	if err != nil {
+		log.Error(ctx, fmt.Sprintf("failed to upgrade to websockets: %v", err))
+		return
+	}
+	if handler.Connections.TryAdd(id, proxy) {
+		log.Info(ctx, fmt.Sprintf("Client connected, current count: %d", handler.Connections.Count()))
+	} else {
+		err = proxy.Close()
+		if err != nil {
+			log.Error(ctx, fmt.Sprintf("failed to close websocket: %v", err))
+		}
+		return
+	}
+	defer func() {
+		log.Info(ctx, "Closing WebSocket connection")
+		handler.Connections.Remove(id)
+		log.Info(ctx, fmt.Sprintf("Client disconnected, current count: %d", handler.Connections.Count()))
+		err := proxy.Close()
+		if err != nil {
+			log.Error(ctx, fmt.Sprintf("failed to close websocket: %v", err))
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	log.Info(ctx, "New WebSocket connection, starting sshd process")
+
+	sshdCmd := createSSHDProcess(gCtx, handler.SSHDConfigPath)
+
+	sshdCmd.Stderr = os.Stderr
+
+	sshdStdin, err := sshdCmd.StdinPipe()
+	if err != nil {
+		log.Error(ctx, fmt.Sprintf("failed to get stdin pipe: %v", err))
+		return
+	}
+	defer sshdStdin.Close()
+
+	sshdStdout, err := sshdCmd.StdoutPipe()
+	if err != nil {
+		log.Error(ctx, fmt.Sprintf("failed to get stdout pipe: %v", err))
+		return
+	}
+	defer sshdStdout.Close()
+
+	g.Go(func() error {
+		return sshdCmd.Run()
+	})
+
+	g.Go(func() error {
+		return proxy.Start(gCtx, sshdStdout, sshdStdin)
+	})
+
+	if err := g.Wait(); err != nil {
+		log.Error(ctx, fmt.Sprintf("SSHHandler error: %v", err))
+	}
+}
+
+func handleTimeout(ctx context.Context, timedOutChannel chan bool, shutdownDelay time.Duration) {
+	<-timedOutChannel
+	log.Info(ctx, fmt.Sprintf("No SSH clients for %v, shutting down...", shutdownDelay))
+	os.Exit(0)
+}
+
+func findAvailablePort(startPort, maxAttempts int) (int, error) {
+	for i := range maxAttempts {
+		port := startPort + i
+		addr := fmt.Sprintf(":%d", port)
+
+		listener, err := net.Listen("tcp", addr)
+		if err == nil {
+			listener.Close()
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available port found after %d attempts starting from port %d", maxAttempts, startPort)
+}
+
+func saveWorkspaceMetadata(ctx context.Context, client *databricks.WorkspaceClient, version, clusterID string, port int) error {
+	metadataBytes, err := json.Marshal(PortMetadata{Port: port})
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	contentDir, err := getWorkspaceContentDir(ctx, client, version, clusterID)
+	if err != nil {
+		return fmt.Errorf("failed to get workspace content directory: %w", err)
+	}
+
+	metadataPath := filepath.Join(contentDir, "metadata.json")
+	err = os.MkdirAll(filepath.Dir(metadataPath), 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", metadataPath, err)
+	}
+
+	err = os.WriteFile(metadataPath, metadataBytes, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write metadata file: %w", err)
+	}
+
+	log.Info(ctx, fmt.Sprintf("Saved port %d to metadata file: %s", port, metadataPath))
+	return nil
+}
+
+func saveJupyterInitScript(ctx context.Context) error {
+	ipythonStartupDir := os.ExpandEnv("$HOME/.ipython/profile_default/startup")
+
+	err := os.MkdirAll(ipythonStartupDir, 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create IPython startup directory %s: %w", ipythonStartupDir, err)
+	}
+
+	initScriptPath := filepath.Join(ipythonStartupDir, "init_script.py")
+	err = os.WriteFile(initScriptPath, []byte(jupyterInitScript), 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write Jupyter init script to %s: %w", initScriptPath, err)
+	}
+
+	log.Info(ctx, "Saved Jupyter init script to: "+initScriptPath)
+	return nil
+}
+
+type ServerOptions struct {
+	Version              string
+	MaxClients           int
+	ShutdownDelay        time.Duration
+	ClusterID            string
+	ConfigDir            string
+	ServerPrivateKeyName string
+	ServerPublicKeyName  string
+	DefaultPort          int
+	PortRange            int
+}
+
+func RunServer(ctx context.Context, client *databricks.WorkspaceClient, opts ServerOptions) error {
+	port, err := findAvailablePort(opts.DefaultPort, opts.PortRange)
+	if err != nil {
+		return fmt.Errorf("failed to find available port: %w", err)
+	}
+
+	listenAddr := fmt.Sprintf("0.0.0.0:%d", port)
+	log.Info(ctx, "Starting server on "+listenAddr)
+
+	err = saveWorkspaceMetadata(ctx, client, opts.Version, opts.ClusterID, port)
+	if err != nil {
+		return fmt.Errorf("failed to save metadata to the workspace: %w", err)
+	}
+
+	clientPublicKey := os.Getenv("PUBLIC_SSH_KEY")
+	if clientPublicKey == "" {
+		return errors.New("PUBLIC_SSH_KEY environment variable is not set")
+	}
+
+	sshdConfigPath, err := prepareSSHDConfig(ctx, client, clientPublicKey, opts)
+	if err != nil {
+		return fmt.Errorf("failed to setup SSH configuration: %w", err)
+	}
+
+	err = saveJupyterInitScript(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to save Jupyter init script: %w", err)
+	}
+
+	connections := newConnectionsManager(opts.MaxClients, opts.ShutdownDelay)
+	http.Handle("/ssh", newSSHHandler(connections, sshdConfigPath))
+	go handleTimeout(ctx, connections.TimedOut, opts.ShutdownDelay)
+
+	http.HandleFunc("/metadata", func(w http.ResponseWriter, r *http.Request) {
+		currentUser, err := user.Current()
+		if err != nil {
+			http.Error(w, "Failed to get current user", http.StatusInternalServerError)
+			return
+		}
+		_, err = io.WriteString(w, currentUser.Username)
+		if err != nil {
+			http.Error(w, "Failed to write current user", http.StatusInternalServerError)
+		}
+	})
+
+	return http.ListenAndServe(listenAddr, nil)
+}

--- a/libs/ssh/ssh-server-bootstrap.py
+++ b/libs/ssh/ssh-server-bootstrap.py
@@ -1,1 +1,142 @@
-# See implementation in the follow up PR
+from dbruntime.databricks_repl_context import get_context
+from databricks.sdk import WorkspaceClient
+import os
+import sys
+import subprocess
+import ctypes
+import ctypes.util
+import signal
+import atexit
+import platform
+import time
+
+SSH_TUNNEL_BASENAME = "databricks_cli_linux"
+
+dbutils.widgets.text("version", "")
+dbutils.widgets.text("secretsScope", "")
+dbutils.widgets.text("publicKeySecretName", "")
+dbutils.widgets.text("maxClients", "10")
+dbutils.widgets.text("shutdownDelay", "10m")
+
+
+def cleanup():
+    subprocess.run(["pkill", "-f", SSH_TUNNEL_BASENAME], check=False)
+
+
+def setup_subreaper():
+    # Mark itself as a child subreaper to handle orphaned processes,
+    # preventing them from re-parenting to PID 1 and losing access to wsfs and dbfs.
+    libc = ctypes.CDLL(ctypes.util.find_library("c"))
+    PR_SET_CHILD_SUBREAPER = 36
+    libc.prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+
+    def sigchld_handler(signum, frame):
+        try:
+            while True:
+                # -1 means any child, WNOHANG means don't block
+                pid, status = os.waitpid(-1, os.WNOHANG)
+                if pid == 0:
+                    break
+                print(f"Reaped child {pid} with status {status}")
+        except ChildProcessError:
+            pass
+
+    # Reap all dead children to prevent zombie processes.
+    # We have to do it manually now, since we are a child subreaper.
+    signal.signal(signal.SIGCHLD, sigchld_handler)
+
+
+def kill_all_children():
+    try:
+        current_pid = os.getpid()
+        while True:
+            result = subprocess.run(["pgrep", "-P", str(current_pid)], capture_output=True, text=True, check=False)
+            if result.returncode != 0 or not result.stdout.strip():
+                break
+            subprocess.run(["pkill", "-P", str(current_pid)], check=False)
+            time.sleep(0.1)
+        print("All descendant processes terminated")
+    except Exception as e:
+        print(f"Error while killing child processes: {e}")
+
+
+def setup_exit_handler():
+    # Register the cleanup function to be called when the script exits
+    atexit.register(kill_all_children)
+
+
+def run_ssh_server():
+    # Start the SSH tunnel
+    ctx = get_context()
+    client = WorkspaceClient()
+    workspace_url = ctx.workspaceUrl or client.config.host or spark.conf.get("spark.databricks.workspaceUrl")
+    user_name = client.current_user.me().user_name
+
+    os.environ["DATABRICKS_HOST"] = workspace_url if workspace_url.startswith("https://") else f"https://{workspace_url}"
+    os.environ["DATABRICKS_TOKEN"] = ctx.apiToken
+    os.environ["DATABRICKS_CLUSTER_ID"] = ctx.clusterId
+    os.environ["DATABRICKS_VIRTUAL_ENV"] = sys.executable
+    python_path = os.path.dirname(sys.executable)
+    os.environ["PATH"] = f"{python_path}:{os.environ['PATH']}"
+    if os.environ.get("VIRTUAL_ENV") is None:
+        os.environ["VIRTUAL_ENV"] = sys.executable
+
+    secrets_scope = dbutils.widgets.get("secretsScope")
+    if not secrets_scope:
+        raise RuntimeError("Secrets scope is required. Please provide it using the 'secretsScope' widget.")
+
+    public_key_secret_name = dbutils.widgets.get("publicKeySecretName")
+    if not public_key_secret_name:
+        raise RuntimeError("Public key secret name is required. Please provide it using the 'publicKeySecretName' widget.")
+
+    public_key = dbutils.secrets.get(scope=secrets_scope, key=public_key_secret_name)
+    if not public_key:
+        raise RuntimeError(f"Public key secret '{public_key_secret_name}' in scope '{secrets_scope}' is empty.")
+
+    os.environ["PUBLIC_SSH_KEY"] = public_key
+
+    version = dbutils.widgets.get("version")
+    if not version:
+        raise RuntimeError("Version is required. Please provide it using the 'version' widget.")
+
+    shutdown_delay = dbutils.widgets.get("shutdownDelay")
+    max_clients = dbutils.widgets.get("maxClients")
+
+    arch = platform.machine()
+    if arch == "x86_64":
+        cli_arch = "amd64"
+    elif arch == "aarch64" or arch == "arm64":
+        cli_arch = "arm64"
+    else:
+        raise RuntimeError(f"Unsupported architecture: {arch}")
+
+    binary_path = f"/Workspace/Users/{user_name}/.databricks/ssh-tunnel/{version}/{SSH_TUNNEL_BASENAME}_{cli_arch}/databricks"
+    try:
+        subprocess.run(
+            [
+                binary_path,
+                "ssh",
+                "server",
+                f"--cluster={ctx.clusterId}",
+                f"--max-clients={max_clients}",
+                f"--shutdown-delay={shutdown_delay}",
+                f"--version={version}",
+                # "info" has enough verbosity for debugging purposes, and "debug" log level prints too much (including secrets)
+                "--log-level=info",
+                # To get the server logs:
+                # 1. Get a job run id from the "databricks ssh connect" output
+                # 2. Run "databricks jobs get-run <id>" and open a run_page_url
+                # TODO: file with log rotation
+                "--log-file=stdout",
+            ],
+            check=True,
+        )
+    finally:
+        kill_all_children()
+
+
+if __name__ == "__main__":
+    cleanup()
+    setup_subreaper()
+    setup_exit_handler()
+    run_ssh_server()

--- a/libs/ssh/sshd.go
+++ b/libs/ssh/sshd.go
@@ -1,0 +1,90 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go"
+)
+
+func prepareSSHDConfig(ctx context.Context, client *databricks.WorkspaceClient, clientPublicKey string, opts ServerOptions) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	sshDir := path.Join(homeDir, opts.ConfigDir)
+
+	err = os.RemoveAll(sshDir)
+	if err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to remove existing SSH directory: %w", err)
+	}
+
+	err = os.MkdirAll(sshDir, 0o700)
+	if err != nil {
+		return "", fmt.Errorf("failed to create SSH directory: %w", err)
+	}
+
+	privateKeyBytes, publicKeyBytes, err := checkAndGenerateSSHKeyPairFromSecrets(ctx, client, opts.ClusterID, opts.ServerPrivateKeyName, opts.ServerPublicKeyName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get SSH key pair from secrets: %w", err)
+	}
+
+	keyPath := filepath.Join(sshDir, "keys", opts.ServerPrivateKeyName)
+	if err := saveSSHKeyPair(keyPath, privateKeyBytes, publicKeyBytes); err != nil {
+		return "", fmt.Errorf("failed to save SSH key pair: %w", err)
+	}
+
+	sshdConfig := filepath.Join(sshDir, "sshd_config")
+	authKeys := filepath.Join(sshDir, "authorized_keys")
+	if err := os.WriteFile(authKeys, []byte(clientPublicKey), 0o600); err != nil {
+		return "", err
+	}
+
+	// Set all available env vars, wrapping values in quotes and escaping quotes inside values
+	setEnv := "SetEnv"
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		valEscaped := strings.ReplaceAll(parts[1], "\"", "\\\"")
+		setEnv += " " + parts[0] + "=\"" + valEscaped + "\""
+	}
+	setEnv += " DATABRICKS_CLI_UPSTREAM=databricks_ssh_tunnel"
+	setEnv += " DATABRICKS_CLI_UPSTREAM_VERSION=" + opts.Version
+	setEnv += " DATABRICKS_SDK_UPSTREAM=databricks_ssh_tunnel"
+	setEnv += " DATABRICKS_SDK_UPSTREAM_VERSION=" + opts.Version
+	setEnv += " GIT_CONFIG_GLOBAL=/Workspace/.proc/self/git/config"
+	setEnv += " ENABLE_DATABRICKS_CLI=true"
+	setEnv += " PYTHONPYCACHEPREFIX=/tmp/pycache"
+
+	sshdConfigContent := "PubkeyAuthentication yes\n" +
+		"PasswordAuthentication no\n" +
+		"ChallengeResponseAuthentication no\n" +
+		"Subsystem sftp internal-sftp\n" +
+		"HostKey " + keyPath + "\n" +
+		"AuthorizedKeysFile " + authKeys + "\n" +
+		setEnv + "\n"
+
+	if err := os.WriteFile(sshdConfig, []byte(sshdConfigContent), 0o600); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll("/run/sshd", 0o755); err != nil {
+		// On shared clusters this will fail, but there it's not needed, as we execute it as a non-root user
+		// TODO: fail if this happens on dedicated clusters
+		cmdio.LogString(ctx, "Failed to create /run/sshd directory, SSHD may not work properly")
+	}
+
+	return sshdConfig, nil
+}
+
+func createSSHDProcess(ctx context.Context, configPath string) *exec.Cmd {
+	return exec.CommandContext(ctx, "/usr/sbin/sshd", "-f", configPath, "-i")
+}


### PR DESCRIPTION
## Changes
1. "ssh" and "ssh setup" commands PR: https://github.com/databricks/cli/pull/3470
2. "ssh connect" PR: https://github.com/databricks/cli/pull/3471

This PR is based on the above, it adds "ssh server" command and related logic and finishes the "ssh" implementation by adding `ssh` command group to the root `cmd` (it's still hidden from the --help output).

Server overview:
- The server itself is started by the client running the `ssh-server-bootsrap.py` job
  - The client passes inputs to this file as jobs API args, and the python logic gets the values using dbutils widgets 
  - One interesting part is `setup_subreaper` method, which ensures no child process leave the parent process group. This is necessary in order to prevent background processes being reparented to pid 1 when their parent ssh server session terminates, after which they loose access to wsfs and dbfs fuse mounts (as access is based on process groups). All major IDEs usually try to spawn their server processes as a background processes (by double forking for example).
- Server creates one sshd config for all future sshd processes in the home folder
- It spawns sshd with `-i` flag, making it run as in non-daemon mode and communicating with it through stdin and our (and so sshd doesn't listen on any ports)
- Separate sshd process is spawned for each new websocket connection (but the sshd config is re-used), there are limit of 10 connections (for no particular reason)
- The server start a shutdown timer when there are not active connections, after which it terminates itself, which terminates the job, and the cluster idle timeout can start ticking after that
- The server also places jupyter-init.py file to the `$HOME/.ipython/profile_default/startup`. This file makes jupyter kernels a bit more similar to webapp notebooks - it provides spark and dbutils globals, plus handles %sql and %pip magic commands 

WIP: unit tests

## Tests
Manual and unit

