### PR TITLE
acc: Temporary disable app-with-job test to unblock nightlies

### DIFF
--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/run/app-with-job/test.toml
+++ b/acceptance/bundle/run/app-with-job/test.toml
@@ -18,3 +18,6 @@ Ignore = [
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI
 # Setting this environment variable prevents that conversion on windows.
 MSYS_NO_PATHCONV = "1"
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]


### PR DESCRIPTION
## Changes
 Temporary disable app-with-job test to unblock nightlies

## Why
The test fails for direct deployment only, disabling to unblock until I figure out what's causing the failure

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
