### PR TITLE
direct: Add waiting for the app after create same as in TF implementation

### DIFF
--- a/bundle/terranova/tnresources/app.go
+++ b/bundle/terranova/tnresources/app.go
@@ -101,16 +101,3 @@ func (r *ResourceApp) waitForApp(ctx context.Context, w *databricks.WorkspaceCli
 		}
 	})
 }
-
-// This is copied from the retries package of the databricks-sdk-go. It should be made public,
-// but for now, I'm copying it here.
-func shouldRetry(err error) bool {
-	if err == nil {
-		return false
-	}
-	e := err.(*retries.Err)
-	if e == nil {
-		return false
-	}
-	return !e.Halt
-}

--- a/bundle/terranova/tnresources/app.go
+++ b/bundle/terranova/tnresources/app.go
@@ -38,8 +38,6 @@ func (r *ResourceApp) DoCreate(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	// TODO: Store waiter for Wait method
-
 	return waiter.Response.Name, nil
 }
 
@@ -80,6 +78,9 @@ func (r *ResourceApp) WaitAfterUpdate(ctx context.Context) error {
 
 // waitForApp waits for the app to reach the target state. The target state is either ACTIVE or STOPPED.
 // Apps with no_compute set to true will reach the STOPPED state, otherwise they will reach the ACTIVE state.
+// We can't use the default waiter from SDK because it only waits on ACTIVE state but we need also STOPPED state.
+// Ideally this should be done in Go SDK but currently only ACTIVE is marked as terminal state
+// so this would need to be addressed by Apps service team first in their proto.
 func (r *ResourceApp) waitForApp(ctx context.Context, w *databricks.WorkspaceClient, name string) (*apps.App, error) {
 	retrier := retries.New[apps.App](retries.WithTimeout(-1), retries.WithRetryFunc(shouldRetry))
 	return retrier.Run(ctx, func(ctx context.Context) (*apps.App, error) {

--- a/bundle/terranova/tnresources/util.go
+++ b/bundle/terranova/tnresources/util.go
@@ -2,6 +2,8 @@ package tnresources
 
 import (
 	"reflect"
+
+	"github.com/databricks/databricks-sdk-go/retries"
 )
 
 // filterFields creates a new slice with fields present only in the provided type.
@@ -17,4 +19,17 @@ func filterFields[T any](fields []string) []string {
 	}
 
 	return result
+}
+
+// This is copied from the retries package of the databricks-sdk-go. It should be made public,
+// but for now, I'm copying it here.
+func shouldRetry(err error) bool {
+	if err == nil {
+		return false
+	}
+	e := err.(*retries.Err)
+	if e == nil {
+		return false
+	}
+	return !e.Halt
 }


### PR DESCRIPTION
## Changes
Copied an implementation from TF so both behaviours are in line
https://github.com/databricks/terraform-provider-databricks/blob/9346a78bde642b3ee4e8caec80439a71fa681a9b/internal/providers/pluginfw/products/app/resource_app.go#L161

## Why
Behaviour in TF and direct should be same, currently difference causing app related acceptance test to fail

## Tests
Existing acceptance/bundle/run/app-with-job should pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
