### PR TITLE
acc: Temporarily disable run-local-node test

### DIFF
--- a/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
@@ -1,4 +1,4 @@
-Local = true
+Local = false
 Cloud = false
 
 [EnvMatrix]

--- a/acceptance/cmd/workspace/apps/run-local-node/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/test.toml
@@ -1,3 +1,6 @@
+# Temporarily disabled due to the flakiness like here https://github.com/databricks/cli/actions/runs/17234131593/job/48894892423
+Cloud = false
+Local = false
 RecordRequests = false
 Timeout = '2m'
 TimeoutWindows = '10m'


### PR DESCRIPTION
## Changes
Temporarily disable the run-local-node test

## Why
Currently it's flaky, the reason is unknown

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
