### PR TITLE
Implement database_catalog in direct deployment

### DIFF
--- a/acceptance/bundle/deploy/lakebase/database-catalog/out.test.toml
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/out.test.toml
@@ -6,4 +6,4 @@ RequiresUnityCatalog = true
   gcp = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["direct-exp"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/deploy/lakebase/database-catalog/out.test.toml
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/out.test.toml
@@ -6,4 +6,4 @@ RequiresUnityCatalog = true
   gcp = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["direct-exp"]

--- a/acceptance/bundle/deploy/lakebase/database-catalog/output.txt
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/output.txt
@@ -24,7 +24,7 @@ Resources:
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default/files...
-Error: reading config: reading config: unsupported resource: database_catalogs
+Error: reading config: failed to read references from config for database_catalogs.my_catalog: parsing refs: cannot process reference resources.database_instances.my_instance.name: only ${resources.<group>.<key>.id} references are supported
 
 
 >>> [CLI] bundle destroy --auto-approve

--- a/acceptance/bundle/deploy/lakebase/database-catalog/output.txt
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/output.txt
@@ -24,13 +24,45 @@ Resources:
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default/files...
-Error: reading config: failed to read references from config for database_catalogs.my_catalog: parsing refs: cannot process reference resources.database_instances.my_instance.name: only ${resources.<group>.<key>.id} references are supported
+Deploying resources...
+Updating deployment state...
+Deployment complete!
 
+>>> [CLI] database get-database-instance test-database-instance-[UNIQUE_NAME]
+{
+  "capacity": "CU_1",
+  "creation_time": "[TIMESTAMP]Z",
+  "creator": "[USERNAME]",
+  "effective_enable_readable_secondaries": false,
+  "effective_node_count": 1,
+  "effective_retention_window_in_days": 7,
+  "effective_stopped": false,
+  "name": "test-database-instance-[UNIQUE_NAME]",
+  "pg_version": "PG_VERSION_16",
+  "state": "AVAILABLE",
+  "uid": "[UUID]"
+}
+
+>>> [CLI] bundle summary
+Name: deploy-lakebase-catalog-[UNIQUE_NAME]
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default
+Resources:
+  Database catalogs:
+    my_catalog:
+      Name: my_catalog_[UNIQUE_NAME]
+  Database instances:
+    my_instance:
+      Name: test-database-instance-[UNIQUE_NAME]
 
 >>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete database_catalog my_catalog
+  delete database_instance my_instance
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!
-
-Exit code: 1

--- a/acceptance/bundle/deploy/lakebase/database-catalog/output.txt
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/output.txt
@@ -24,45 +24,13 @@ Resources:
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default/files...
-Deploying resources...
-Updating deployment state...
-Deployment complete!
+Error: reading config: reading config: unsupported resource: database_catalogs
 
->>> [CLI] database get-database-instance test-database-instance-[UNIQUE_NAME]
-{
-  "capacity": "CU_1",
-  "creation_time": "[TIMESTAMP]Z",
-  "creator": "[USERNAME]",
-  "effective_enable_readable_secondaries": false,
-  "effective_node_count": 1,
-  "effective_retention_window_in_days": 7,
-  "effective_stopped": false,
-  "name": "test-database-instance-[UNIQUE_NAME]",
-  "pg_version": "PG_VERSION_16",
-  "state": "AVAILABLE",
-  "uid": "[UUID]"
-}
-
->>> [CLI] bundle summary
-Name: deploy-lakebase-catalog-[UNIQUE_NAME]
-Target: default
-Workspace:
-  User: [USERNAME]
-  Path: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default
-Resources:
-  Database catalogs:
-    my_catalog:
-      Name: my_catalog_[UNIQUE_NAME]
-  Database instances:
-    my_instance:
-      Name: test-database-instance-[UNIQUE_NAME]
 
 >>> [CLI] bundle destroy --auto-approve
-The following resources will be deleted:
-  delete database_catalog my_catalog
-  delete database_instance my_instance
-
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!
+
+Exit code: 1

--- a/acceptance/bundle/deploy/lakebase/database-catalog/test.toml
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/test.toml
@@ -4,4 +4,4 @@ Cloud = true
 RecordRequests = false
 
 [EnvMatrix]
-DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+DATABRICKS_CLI_DEPLOYMENT = ["direct-exp"]

--- a/acceptance/bundle/deploy/lakebase/database-catalog/test.toml
+++ b/acceptance/bundle/deploy/lakebase/database-catalog/test.toml
@@ -2,6 +2,3 @@ Local = true
 Cloud = true
 
 RecordRequests = false
-
-[EnvMatrix]
-DATABRICKS_CLI_DEPLOYMENT = ["direct-exp"]

--- a/bundle/terranova/resource.go
+++ b/bundle/terranova/resource.go
@@ -114,6 +114,11 @@ var SupportedResources = map[string]ResourceSettings{
 		ConfigType: TypeOfConfig(&tnresources.ResourceDatabaseInstance{}),
 		DeleteFN:   tnresources.DeleteDatabaseInstance,
 	},
+	"database_catalogs": {
+		New:        reflect.ValueOf(tnresources.NewResourceDatabaseCatalog),
+		ConfigType: TypeOfConfig(&tnresources.ResourceDatabaseCatalog{}),
+		DeleteFN:   tnresources.DeleteDatabaseCatalog,
+	},
 }
 
 type IResource interface {

--- a/bundle/terranova/tnresources/database_catalog.go
+++ b/bundle/terranova/tnresources/database_catalog.go
@@ -1,0 +1,60 @@
+package tnresources
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/database"
+)
+
+type ResourceDatabaseCatalog struct {
+	client *databricks.WorkspaceClient
+	config database.DatabaseCatalog
+}
+
+func (d ResourceDatabaseCatalog) Config() any {
+	return d.config
+}
+
+func (d *ResourceDatabaseCatalog) DoCreate(ctx context.Context) (string, error) {
+	result, err := d.client.Database.CreateDatabaseCatalog(ctx, database.CreateDatabaseCatalogRequest{
+		Catalog: d.config,
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.Name, nil
+}
+
+func (d ResourceDatabaseCatalog) DoUpdate(ctx context.Context, id string) error {
+	request := database.UpdateDatabaseCatalogRequest{
+		DatabaseCatalog: d.config,
+		Name:            d.config.Name,
+		UpdateMask:      "*",
+	}
+
+	_, err := d.client.Database.UpdateDatabaseCatalog(ctx, request)
+	return err
+}
+
+func (d ResourceDatabaseCatalog) WaitAfterCreate(_ context.Context) error {
+	return nil
+}
+
+func (d ResourceDatabaseCatalog) WaitAfterUpdate(_ context.Context) error {
+	return nil
+}
+
+func NewResourceDatabaseCatalog(client *databricks.WorkspaceClient, resource *resources.DatabaseCatalog) (*ResourceDatabaseCatalog, error) {
+	return &ResourceDatabaseCatalog{
+		client: client,
+		config: resource.DatabaseCatalog,
+	}, nil
+}
+
+func DeleteDatabaseCatalog(ctx context.Context, client *databricks.WorkspaceClient, name string) error {
+	return client.Database.DeleteDatabaseCatalog(ctx, database.DeleteDatabaseCatalogRequest{
+		Name: name,
+	})
+}


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
This change allows to deploy database catalogs when using `direct-exp` deployment method

## Tests
<!-- How have you tested the changes? -->
Existing test is expanded to run using `direct-exp`

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
