### PR TITLE
Add a `build-vm` command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ acc-showcover:
 build: tidy
 	go build
 
+# builds the binary in a VM environment (such as Parallels Desktop) where your files are mirrored from the host os
+build-vm: tidy
+	go build -buildvcs=false
+
 snapshot:
 	go build -o .databricks/databricks
 


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

New command allows to build a binary in a VM environment that has the source files but can't properly read git stamps. I test the CLI on Windows using Parallels Desktop where my files are mirrored from the hosted Mac OS to a separate virtual disk, this set up somehow confuses go/git to properly stamp the binary with the VCS info.

## Tests
<!-- How have you tested the changes? -->
Manual runs of `make build` and `make build-vm`

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
