### PR TITLE
Downgrade load git info failure to info logs

### DIFF
--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -86,7 +86,7 @@ func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.Work
 		result.CurrentBranch = gi.Branch
 		result.WorktreeRoot = fixedPath
 	} else {
-		log.Debugf(ctx, "Failed to load git info from %s", apiEndpoint)
+		log.Infof(ctx, "Failed to load git info from %s", apiEndpoint)
 	}
 
 	return result, nil


### PR DESCRIPTION
## Why
The warnings leak into the acceptance tests' output when the tests are run on the workspace file system. This warning is not expected to show up if the tests were run on Git folders instead.

While some integration tests will need to be run on Git Folders, the plan is to run integration tests on the workspace file system by default. This is because Git folders are:
1. Slightly complex and time-consuming to set up (they need to be backed by a real repository).
2. Historically, the repos API has been a source of flakiness.
3. Repos functionality is unnecessary for most integration test assertions we perform in our acceptance tests. The only place it is relevant is when loading Git metadata. I plan to create a separate test for that.