### PR TITLE
Run testarchive unit tests on PRs

### DIFF
--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -1,5 +1,3 @@
-//go:build dbr_only
-
 package main
 
 import (
@@ -11,6 +9,10 @@ import (
 )
 
 func TestArchive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	archiveDir := t.TempDir()
 	binDir := t.TempDir()
 	repoRoot := "../.."

--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -13,6 +13,8 @@ func TestArchive(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
+	t.Parallel()
+
 	archiveDir := t.TempDir()
 	binDir := t.TempDir()
 	repoRoot := "../.."

--- a/internal/testarchive/downloader_test.go
+++ b/internal/testarchive/downloader_test.go
@@ -14,6 +14,8 @@ func TestUvDownloader(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -33,6 +35,8 @@ func TestJqDownloader(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -51,6 +55,8 @@ func TestGoDownloader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
 	}
+
+	t.Parallel()
 
 	tmpDir := t.TempDir()
 

--- a/internal/testarchive/downloader_test.go
+++ b/internal/testarchive/downloader_test.go
@@ -1,5 +1,3 @@
-//go:build dbr_only
-
 package main
 
 import (
@@ -12,6 +10,10 @@ import (
 )
 
 func TestUvDownloader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -27,6 +29,10 @@ func TestUvDownloader(t *testing.T) {
 }
 
 func TestJqDownloader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -42,6 +48,10 @@ func TestJqDownloader(t *testing.T) {
 }
 
 func TestGoDownloader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {


### PR DESCRIPTION
## Why
Feedback in https://github.com/databricks/cli/pull/3453#discussion_r2297493314 recommended not using build tags. This PR enables these tests by default. 

These tests will be skipped when `-short` flag is provided. Note: We do not specify the `-short` flag in CI so these tests will run by default.