### PR TITLE
Do not download ARM binaries in testarchive

### DIFF
--- a/internal/testarchive/archive.go
+++ b/internal/testarchive/archive.go
@@ -107,11 +107,14 @@ func createArchive(archiveDir, binDir, repoRoot string) error {
 	// the CPU architecture to keep the door open for future optimizations.
 	downloaders := []downloader{
 		goDownloader{arch: "amd64", binDir: binDir},
-		goDownloader{arch: "arm64", binDir: binDir},
 		uvDownloader{arch: "amd64", binDir: binDir},
-		uvDownloader{arch: "arm64", binDir: binDir},
 		jqDownloader{arch: "amd64", binDir: binDir},
-		jqDownloader{arch: "arm64", binDir: binDir},
+
+		// TODO: Serverless clusters do not support arm64 yet.
+		// Enable ARM64 once serverless clusters support it.
+		// goDownloader{arch: "arm64", binDir: binDir},
+		// uvDownloader{arch: "arm64", binDir: binDir},
+		// jqDownloader{arch: "arm64", binDir: binDir},
 	}
 
 	for _, downloader := range downloaders {

--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -28,12 +28,15 @@ func TestArchive(t *testing.T) {
 
 	// Go installation is a directory because it includes the
 	// standard library source code along with the Go binary.
-	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "go", "bin", "go"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "go", "bin", "go"))
-	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "uv"))
-	assert.FileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
 	assert.FileExists(t, filepath.Join(assertDir, "bin", "amd64", "jq"))
+
+	// TODO: Serverless clusters do not support arm64 yet.
+	// Assert these files exist after we support arm64.
+	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "go", "bin", "go"))
+	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "uv"))
+	assert.NoFileExists(t, filepath.Join(assertDir, "bin", "arm64", "jq"))
 
 	assert.FileExists(t, filepath.Join(assertDir, "cli", "go.mod"))
 	assert.FileExists(t, filepath.Join(assertDir, "cli", "go.sum"))

--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -1,5 +1,3 @@
-//go:build dbr_only
-
 package main
 
 import (
@@ -11,6 +9,10 @@ import (
 )
 
 func TestArchive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	archiveDir := t.TempDir()
 	binDir := t.TempDir()
 	repoRoot := "../.."

--- a/internal/testarchive/archive_test.go
+++ b/internal/testarchive/archive_test.go
@@ -13,6 +13,8 @@ func TestArchive(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
+	t.Parallel()
+
 	archiveDir := t.TempDir()
 	binDir := t.TempDir()
 	repoRoot := "../.."

--- a/internal/testarchive/downloader_test.go
+++ b/internal/testarchive/downloader_test.go
@@ -14,6 +14,8 @@ func TestUvDownloader(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -33,6 +35,8 @@ func TestJqDownloader(t *testing.T) {
 		t.Skip("Skipping test in short mode")
 	}
 
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -51,6 +55,8 @@ func TestGoDownloader(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
 	}
+
+	t.Parallel()
 
 	tmpDir := t.TempDir()
 

--- a/internal/testarchive/downloader_test.go
+++ b/internal/testarchive/downloader_test.go
@@ -1,5 +1,3 @@
-//go:build dbr_only
-
 package main
 
 import (
@@ -12,6 +10,10 @@ import (
 )
 
 func TestUvDownloader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -27,6 +29,10 @@ func TestUvDownloader(t *testing.T) {
 }
 
 func TestJqDownloader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {
@@ -42,6 +48,10 @@ func TestJqDownloader(t *testing.T) {
 }
 
 func TestGoDownloader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	tmpDir := t.TempDir()
 
 	for _, arch := range []string{"arm64", "amd64"} {


### PR DESCRIPTION
## Why
We do not need ARM binaries right now, so skip downloads for them.

Builds on top of: https://github.com/databricks/cli/pull/3500

## Tests
Modified unit tests.
