### PR TITLE
Revert "acc: Use fixed ports instead of dynamically allocated ones for run-local tests"

### DIFF
--- a/acceptance/bin/allocate_ports.py
+++ b/acceptance/bin/allocate_ports.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python3
+import socket
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: allocate_ports.py <number_of_ports>", file=sys.stderr)
+    sys.exit(1)
+
+num_ports = int(sys.argv[1])
+
+ports = []
+sockets = []
+for _ in range(num_ports):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    ports.append(str(port))
+    sockets.append(s)
+for s in sockets:
+    s.close()
+sys.stdout.write("\n".join(ports))
+sys.stdout.flush()

--- a/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
@@ -1,5 +1,5 @@
-Local = true
+Local = false
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/cmd/workspace/apps/run-local-node/script
+++ b/acceptance/cmd/workspace/apps/run-local-node/script
@@ -4,9 +4,14 @@ cd app
 # so we don't need to start it in background. It will install the dependencies as part of the command
 trace $CLI apps run-local --prepare-environment --entry-point test.yml 2>&1 | grep -w "Hello, world"
 
-PORT=8080
-DEBUG_PORT=5252
-PROXY_PORT=8081
+# Get 3 unique ports sequentially to avoid conflicts
+PORTS=$(allocate_ports.py 3 | tr -d '\r')
+
+# Read ports into array
+PORTS_ARR=($(echo "$PORTS"))
+PORT="${PORTS_ARR[0]}"
+DEBUG_PORT="${PORTS_ARR[1]}"
+PROXY_PORT="${PORTS_ARR[2]}"
 
 title "Starting the app in background..."
 trace $CLI apps run-local --prepare-environment --debug --port "$PROXY_PORT" --debug-port "$DEBUG_PORT" --app-port "$PORT" > ../out.run.txt 2>&1 &
@@ -20,11 +25,6 @@ title Waiting for the app to start...
 # due to file locking, buffering issues, and different text processing behavior across Windows versions.
 # A simple grep loop is more robust across platforms.
 while [ -z "$(grep -o "Server is running on port " out.run.txt 2>/dev/null)" ]; do
-    sleep 1
-done
-
-# Make sure the proxy is ready to serve requests
-while [ -z "$(grep -o "To access your app go to " out.run.txt 2>/dev/null)" ]; do
     sleep 1
 done
 

--- a/acceptance/cmd/workspace/apps/run-local-node/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/test.toml
@@ -1,5 +1,6 @@
+# Temporarily disabled due to the flakiness like here https://github.com/databricks/cli/actions/runs/17234131593/job/48894892423
 Cloud = false
-Local = true
+Local = false
 RecordRequests = false
 Timeout = '2m'
 TimeoutWindows = '10m'
@@ -20,6 +21,3 @@ New='127.0.0.1:$(port)'
 [[Repls]]
 Old='To debug your app, attach a debugger to port [0-9]+'
 New='To debug your app, attach a debugger to port $(debug_port)'
-
-[EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/cmd/workspace/apps/run-local/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/out.test.toml
@@ -1,5 +1,5 @@
-Local = true
+Local = false
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/cmd/workspace/apps/run-local/script
+++ b/acceptance/cmd/workspace/apps/run-local/script
@@ -6,9 +6,14 @@ trace errcode $CLI apps run-local --entry-point value-from.yml 2>&1
 # so we don't need to start it in background. It will install the dependencies as part of the command
 trace $CLI apps run-local --prepare-environment --entry-point test.yml 2>&1 | grep -w "Hello, world"
 
-PORT=8080
-DEBUG_PORT=5252
-PROXY_PORT=8081
+# Get 3 unique ports sequentially to avoid conflicts
+PORTS=$(allocate_ports.py 3 | tr -d '\r')
+
+# Read ports into array
+PORTS_ARR=($(echo "$PORTS"))
+PORT="${PORTS_ARR[0]}"
+DEBUG_PORT="${PORTS_ARR[1]}"
+PROXY_PORT="${PORTS_ARR[2]}"
 
 title "Starting the app in background..."
 trace $CLI apps run-local --prepare-environment --debug --port "$PROXY_PORT" --debug-port "$DEBUG_PORT" --app-port "$PORT" > ../out.run.txt 2>&1 &
@@ -22,11 +27,6 @@ title Waiting for the app to start...
 # due to file locking, buffering issues, and different text processing behavior across Windows versions.
 # A simple grep loop is more robust across platforms.
 while [ -z "$(grep -o "Python Flask app has started with" out.run.txt 2>/dev/null)" ]; do
-    sleep 1
-done
-
-# Make sure the proxy is ready to serve requests
-while [ -z "$(grep -o "To access your app go to " out.run.txt 2>/dev/null)" ]; do
     sleep 1
 done
 

--- a/acceptance/cmd/workspace/apps/run-local/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/test.toml
@@ -1,5 +1,5 @@
 Cloud = false
-Local = true
+Local = false
 RecordRequests = false
 Timeout = '2m'
 TimeoutWindows = '10m'
@@ -20,6 +20,3 @@ New='127.0.0.1:$(port)'
 [[Repls]]
 Old='To debug your app, attach a debugger to port [0-9]+'
 New='To debug your app, attach a debugger to port $(debug_port)'
-
-[EnvMatrix]
-  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]


### PR DESCRIPTION
Reverts databricks/cli#3490

The tests still failing https://github.com/databricks/cli/actions/runs/17289620395/job/49073700178

```
+++ /var/folders/x7/ch5v91h56_zbvbd1y2f600dm0000gn/T/TestAcceptcmdworkspaceappsrun-local1357262386/001/output.txt
        @@ -10,25 +10,6 @@
         === Waiting
         === Checking app is running...
         >>> curl -s -o - http://127.0.0.1:$(port)/
        -{
        -  "Accept": "*/*",
        -  "Accept-Encoding": "gzip",
        -  "Host": "127.0.0.1:$(port)",
        -  "User-Agent": "curl/(version)",
        -  "X-Forwarded-Email": "[USERNAME]",
        -  "X-Forwarded-Host": "localhost",
        -  "X-Forwarded-Preferred-Username": "",
        -  "X-Forwarded-User": "[USERNAME]",
        -  "X-Real-Ip": "127.0.0.1",
        -  "X-Request-Id": "[UUID]"
        -}
        +jq: parse error: Invalid numeric literal at line 1, column 6
  ```