### PR TITLE
acc: set CloudSlow=true for lakebase/database-instance

### DIFF
--- a/acceptance/bundle/deploy/lakebase/database-instance/single-instance/out.test.toml
+++ b/acceptance/bundle/deploy/lakebase/database-instance/single-instance/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+CloudSlow = true
 RequiresUnityCatalog = true
 
 [CloudEnvs]

--- a/acceptance/bundle/deploy/lakebase/database-instance/single-instance/test.toml
+++ b/acceptance/bundle/deploy/lakebase/database-instance/single-instance/test.toml
@@ -1,6 +1,9 @@
 Local = true
 Cloud = true
 
+# Mitigates running into quota limits in workspaces
+CloudSlow = true
+
 Ignore = [
     "databricks.yml",
 ]


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

Reduces the number of tests that spin up a database instance that spin up thus mitigating running into quota limits in workspaces