### PR TITLE
Use correct zero-width space character

### DIFF
--- a/tools/gh_parse.py
+++ b/tools/gh_parse.py
@@ -15,20 +15,20 @@ from pathlib import Path
 # Total number of environments expected
 TOTAL_ENVS = 10
 
-# \u200c is zero-width space. It is added so that len of the string corresponds to real width.
+# \u200b is zero-width space. It is added so that len of the string corresponds to real width.
 # ❌, ✅, 🔄 each take space of 2 characters.
-FLAKY = "🔄\u200cflaky"
-FAIL = "❌\u200cFAIL"
-PASS = "✅\u200cpass"
-SKIP = "🙈\u200cskip"
+FLAKY = "🔄\u200bflaky"
+FAIL = "❌\u200bFAIL"
+PASS = "✅\u200bpass"
+SKIP = "🙈\u200bskip"
 
 # FAIL is replaced with BUG when test fails in all environments (and when we have >=TOTAL_ENVS-1 environments)
 # This indicate that it's very likely that PR did broke this test rather than environment being flaky.
-BUG = "🪲\u200cBUG"
+BUG = "🪲\u200bBUG"
 
 # This happens when Eventually is used - there is output for the test but no result.
-MISSING = "🤯\u200cMISS"
-PANIC = "💥\u200cPANIC"
+MISSING = "🤯\u200bMISS"
+PANIC = "💥\u200bPANIC"
 
 INTERESTING_ACTIONS = (FAIL, BUG, FLAKY, PANIC, MISSING)
 ACTIONS_WITH_ICON = INTERESTING_ACTIONS + (PASS, SKIP)


### PR DESCRIPTION
## Changes

The previous character (\u200c) is a zero-width non-joiner and renders incorrectly in some terminals.

Also see:
* https://en.wikipedia.org/wiki/Zero-width_space
* https://en.wikipedia.org/wiki/Zero-width_non-joiner
