### PR TITLE
direct: internal: move all graph construction to planning phase

### DIFF
--- a/bundle/terranova/apply.go
+++ b/bundle/terranova/apply.go
@@ -40,18 +40,6 @@ func (m *terranovaApplyMutator) Apply(ctx context.Context, b *bundle.Bundle) dia
 		return nil
 	}
 
-	for node, action := range b.PlannedActions {
-		if !b.Graph.HasNode(node) {
-			if action == deployplan.ActionTypeDelete {
-				// it is expected that this node is not seen by makeResourceGraph because it is not in config
-				b.Graph.AddNode(node)
-			} else {
-				// it's internal error today because plan cannot be outdated. In the future when we load serialized plan, this will become user error
-				logdiag.LogError(ctx, fmt.Errorf("cannot %s %s.%s: internal error, plan is outdated", action, node.Group, node.Key))
-			}
-		}
-	}
-
 	if logdiag.HasError(ctx) {
 		return nil
 	}

--- a/bundle/terranova/plan.go
+++ b/bundle/terranova/plan.go
@@ -211,6 +211,7 @@ func CalculatePlanForDeploy(ctx context.Context, b *bundle.Bundle) error {
 				continue
 			}
 			b.PlannedActions[n] = deployplan.ActionTypeDelete
+			b.Graph.AddNode(n)
 		}
 	}
 


### PR DESCRIPTION
## Why

Previously we did one fix-up in apply phase for removed resources. Conceptually it's nice that graph is ready in plan stage and it requires less code.