### PR TITLE
internal: move GetResourceConfig from /bundle to /bundle/config

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -8,12 +8,10 @@ package bundle
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 
 	"github.com/databricks/cli/bundle/config"
@@ -23,7 +21,6 @@ import (
 	"github.com/databricks/cli/bundle/terranova/tnstate"
 	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/dagrun"
-	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/fileset"
 	"github.com/databricks/cli/libs/locker"
 	"github.com/databricks/cli/libs/log"
@@ -326,39 +323,6 @@ func (b *Bundle) AuthEnv() (map[string]string, error) {
 
 	cfg := b.client.Config
 	return auth.Env(cfg), nil
-}
-
-// GetResourceConfig returns the configuration object for a given resource group/name pair.
-// The returned value is a pointer to the concrete struct that represents that resource type.
-// When the group or name is not found the second return value is false.
-func (b *Bundle) GetResourceConfig(group, name string) (any, bool) {
-	// Resolve the Go type that represents a single resource in this group.
-	typ, ok := config.ResourcesTypes[group]
-	if !ok {
-		return nil, false
-	}
-
-	// Fetch the raw value from the dynamic representation of the bundle config.
-	v, err := dyn.GetByPath(
-		b.Config.Value(),
-		dyn.NewPath(dyn.Key("resources"), dyn.Key(group), dyn.Key(name)),
-	)
-	if err != nil {
-		return nil, false
-	}
-
-	// json-round-trip into a value of the concrete resource type to ensure proper handling of ForceSendFields
-	bytes, err := json.Marshal(v.AsAny())
-	if err != nil {
-		return nil, false
-	}
-
-	typedConfigPtr := reflect.New(typ)
-	if err := json.Unmarshal(bytes, typedConfigPtr.Interface()); err != nil {
-		return nil, false
-	}
-
-	return typedConfigPtr.Interface(), true
 }
 
 func (b *Bundle) StateFilename() string {

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -165,17 +165,17 @@ func TestBundleGetResourceConfigJobsPointer(t *testing.T) {
 
 	b := &Bundle{Config: rootCfg}
 
-	res, ok := b.GetResourceConfig("jobs", "my_job")
+	res, ok := b.Config.GetResourceConfig("jobs", "my_job")
 	require.True(t, ok, "expected to find jobs.my_job in config")
 
 	_, isJob := res.(*resources.Job)
 	assert.True(t, isJob, "expected *resources.Job, got %T", res)
 
-	res, ok = b.GetResourceConfig("jobs", "not_found")
+	res, ok = b.Config.GetResourceConfig("jobs", "not_found")
 	require.False(t, ok)
 	require.Nil(t, res)
 
-	res, ok = b.GetResourceConfig("not_found", "my_job")
+	res, ok = b.Config.GetResourceConfig("not_found", "my_job")
 	require.False(t, ok)
 	require.Nil(t, res)
 }

--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -3,8 +3,10 @@ package config
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/databricks/cli/bundle/config/resources"
@@ -565,6 +567,39 @@ func (r Root) GetLocations(path string) []dyn.Location {
 		return nil
 	}
 	return v.Locations()
+}
+
+// GetResourceConfig returns the configuration object for a given resource group/name pair.
+// The returned value is a pointer to the concrete struct that represents that resource type.
+// When the group or name is not found the second return value is false.
+func (r *Root) GetResourceConfig(group, name string) (any, bool) {
+	// Resolve the Go type that represents a single resource in this group.
+	typ, ok := ResourcesTypes[group]
+	if !ok {
+		return nil, false
+	}
+
+	// Fetch the raw value from the dynamic representation of the bundle config.
+	v, err := dyn.GetByPath(
+		r.Value(),
+		dyn.NewPath(dyn.Key("resources"), dyn.Key(group), dyn.Key(name)),
+	)
+	if err != nil {
+		return nil, false
+	}
+
+	// json-round-trip into a value of the concrete resource type to ensure proper handling of ForceSendFields
+	bytes, err := json.Marshal(v.AsAny())
+	if err != nil {
+		return nil, false
+	}
+
+	typedConfigPtr := reflect.New(typ)
+	if err := json.Unmarshal(bytes, typedConfigPtr.Interface()); err != nil {
+		return nil, false
+	}
+
+	return typedConfigPtr.Interface(), true
 }
 
 // Value returns the dynamic configuration value of the root object. This value

--- a/bundle/terranova/apply.go
+++ b/bundle/terranova/apply.go
@@ -100,7 +100,7 @@ func (m *terranovaApplyMutator) Apply(ctx context.Context, b *bundle.Bundle) dia
 			return false
 		}
 
-		config, ok := b.GetResourceConfig(node.Group, node.Key)
+		config, ok := b.Config.GetResourceConfig(node.Group, node.Key)
 		if !ok {
 			logdiag.LogError(ctx, fmt.Errorf("%s: internal error when reading config", errorPrefix))
 			return false

--- a/bundle/terranova/plan.go
+++ b/bundle/terranova/plan.go
@@ -141,7 +141,7 @@ func CalculatePlanForDeploy(ctx context.Context, b *bundle.Bundle) error {
 			settings:     settings,
 		}
 
-		config, ok := b.GetResourceConfig(pl.group, pl.resourceName)
+		config, ok := b.Config.GetResourceConfig(pl.group, pl.resourceName)
 		if !ok {
 			logdiag.LogError(ctx, fmt.Errorf("%s: internal error: cannot read config", errorPrefix))
 			return false


### PR DESCRIPTION
## Why
- Passing whole bundle is overkill of only config root is needed.
- I want to break dependency of terranova package on /bundle so that I can embed terranova struct in the bundle.