### PR TITLE
[Python] Sort __all__

### DIFF
--- a/experimental/python/databricks/bundles/core/_load.py
+++ b/experimental/python/databricks/bundles/core/_load.py
@@ -14,9 +14,9 @@ from databricks.bundles.core._resources import Resources
 
 __all__ = [
     "load_resources_from_current_package_module",
-    "load_resources_from_package_module",
-    "load_resources_from_modules",
     "load_resources_from_module",
+    "load_resources_from_modules",
+    "load_resources_from_package_module",
 ]
 
 """

--- a/experimental/python/databricks/bundles/core/_variable.py
+++ b/experimental/python/databricks/bundles/core/_variable.py
@@ -11,9 +11,9 @@ from typing import (
 __all__ = [
     "Variable",
     "VariableOr",
-    "VariableOrOptional",
     "VariableOrDict",
     "VariableOrList",
+    "VariableOrOptional",
     "variables",
 ]
 

--- a/experimental/python/pyproject.toml
+++ b/experimental/python/pyproject.toml
@@ -68,4 +68,5 @@ lint.select = [
     "N", # pep8-naming
     "F", # flake8
     "I", # isort
+    "RUF022", # sort __all__, see: https://docs.astral.sh/ruff/rules/unsorted-dunder-all/
 ]


### PR DESCRIPTION
## Changes
Ensure that `__all__` is sorted through ruff. See https://docs.astral.sh/ruff/rules/unsorted-dunder-all/

## Why
Use a common convention for `__all__` to make code more readable and idiomatic.