### PR TITLE
dyn: Allow resolution for non-integer variables

### DIFF
--- a/acceptance/bundle/variables/int/databricks.yml
+++ b/acceptance/bundle/variables/int/databricks.yml
@@ -1,0 +1,5 @@
+variables:
+  foo:
+    default: 25
+  bar:
+    default: "${var.foo}+${var.foo}"

--- a/acceptance/bundle/variables/int/out.test.toml
+++ b/acceptance/bundle/variables/int/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/variables/int/output.txt
+++ b/acceptance/bundle/variables/int/output.txt
@@ -1,0 +1,10 @@
+{
+  "bar": {
+    "default": "25+25",
+    "value": "25+25"
+  },
+  "foo": {
+    "default": 25,
+    "value": 25
+  }
+}

--- a/acceptance/bundle/variables/int/script
+++ b/acceptance/bundle/variables/int/script
@@ -1,0 +1,1 @@
+$CLI bundle validate -o json | jq .variables

--- a/libs/dyn/dynvar/resolve.go
+++ b/libs/dyn/dynvar/resolve.go
@@ -167,10 +167,7 @@ func (r *resolver) resolveRef(ref Ref, seen []string) (dyn.Value, error) {
 		// Try to turn the resolved value into a string.
 		s, ok := resolved[j].AsString()
 		if !ok {
-			return dyn.InvalidValue, fmt.Errorf(
-				"cannot interpolate non-string value: %s",
-				ref.Matches[j][0],
-			)
+			s = fmt.Sprint(resolved[j].AsAny())
 		}
 
 		ref.Str = strings.Replace(ref.Str, ref.Matches[j][0], s, 1)

--- a/libs/dyn/dynvar/resolve_test.go
+++ b/libs/dyn/dynvar/resolve_test.go
@@ -114,8 +114,9 @@ func TestResolveWithTypeRetentionFailure(t *testing.T) {
 		"c": dyn.V("${a} ${b}"),
 	})
 
-	_, err := dynvar.Resolve(in, dynvar.DefaultLookup(in))
-	require.ErrorContains(t, err, "cannot interpolate non-string value: ${a}")
+	out, err := dynvar.Resolve(in, dynvar.DefaultLookup(in))
+	require.NoError(t, err)
+	assert.EqualValues(t, "1 2", getByPath(t, out, "c").MustString())
 }
 
 func TestResolveWithTypeRetention(t *testing.T) {


### PR DESCRIPTION
## Why
Terraform supports that, so to match $resources resolution we need to support it as well. Also, it's natural for interpolation to support types that have string representation.

## Tests
Existing unit test, new acceptance test for $var case. In my remote state PR, I have acc test for $resources case as well.