### PR TITLE
Remove colons after field labels in template schema for LDP

### DIFF
--- a/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
+++ b/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
@@ -14,7 +14,7 @@
             "default": "{{default_catalog}}",
             "pattern": "^\\w*$",
             "pattern_match_failure_message": "Invalid catalog name.",
-            "description": "\nInitial catalog:\ndefault_catalog",
+            "description": "\nInitial catalog\ndefault_catalog",
             "order": 3
         },
         "personal_schemas": {
@@ -39,13 +39,13 @@
             "default": "default",
             "pattern": "^\\w+$",
             "pattern_match_failure_message": "Invalid schema name.",
-            "description": "\nInitial schema during development:\ndefault_schema",
+            "description": "\nInitial schema during development\ndefault_schema",
             "order": 5
         },
         "language": {
             "type": "string",
             "default": "python",
-            "description": "\nInitial language for this project:\nlanguage",
+            "description": "\nInitial language for this project\nlanguage",
             "enum": [
                 "python",
                 "sql"


### PR DESCRIPTION
## Changes
Remove colons after field labels in the template schema for Lakelow Declarative Pipelines. 

## Why
This follows Databricks guidelines for input labels. 

## Tests
Not sure if there are any existing tests for this but this is a very low risk change and was validated with a local databricks webapp build 
