### PR TITLE
acc: Add SkipOnDbr flag

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -411,6 +411,10 @@ func getSkipReason(config *internal.TestConfig, configPath string) string {
 		return "Disabled via SkipLocal setting in " + configPath
 	}
 
+	if isTruePtr(config.SkipOnDbr) && WorkspaceTmpDir {
+		return "Disabled via SkipOnDbr setting in " + configPath
+	}
+
 	if Forcerun {
 		return ""
 	}

--- a/acceptance/bundle/artifacts/test.toml
+++ b/acceptance/bundle/artifacts/test.toml
@@ -1,4 +1,18 @@
 RecordRequests = true
+
+# Workspace file system does not allow initializing python envs on it.
+# I suspect something about the default python env on DBR interferes with it.
+# We'll likely need a first class venv abstraction in acceptance tests to fix this.
+# script:
+#   uv venv -q .venv
+#   source .venv/bin/activate
+#   uv pip install -q setuptools
+# error:
+#   Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+#   Caused by: Failed to query Python interpreter
+#   Caused by: failed to canonicalize path `/Workspace/abcd/.venv/bin/python3`: Invalid cross-device link (os error 18)
+SkipOnDbr = true
+
 Ignore = [
     '.venv',
     'dist',
@@ -15,16 +29,3 @@ Response.Body = '''
   "spark_version": "13.3.x-scala2.12"
 }
 '''
-
-# Workspace file system does not allow initializing python envs on it.
-# I suspect something about the default python env on DBR interferes with it.
-# We'll likely need a first class venv abstraction in acceptance tests to fix this.
-# script:
-#   uv venv -q .venv
-#   source .venv/bin/activate
-#   uv pip install -q setuptools
-# error:
-#   Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
-#   Caused by: Failed to query Python interpreter
-#   Caused by: failed to canonicalize path `/Workspace/abcd/.venv/bin/python3`: Invalid cross-device link (os error 18)
-SkipOnDbr = true

--- a/acceptance/bundle/artifacts/test.toml
+++ b/acceptance/bundle/artifacts/test.toml
@@ -15,3 +15,16 @@ Response.Body = '''
   "spark_version": "13.3.x-scala2.12"
 }
 '''
+
+# Workspace file system does not allow initializing python envs on it.
+# I suspect something about the default python env on DBR interferes with it.
+# We'll likely need a first class venv abstraction in acceptance tests to fix this.
+# script:
+#   uv venv -q .venv
+#   source .venv/bin/activate
+#   uv pip install -q setuptools
+# error:
+#   Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+#   Caused by: Failed to query Python interpreter
+#   Caused by: failed to canonicalize path `/Workspace/abcd/.venv/bin/python3`: Invalid cross-device link (os error 18)
+SkipOnDbr = true

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,19 +1,6 @@
 Local = false
 CloudSlow = true
 
-Ignore = [
-    ".databricks",
-    ".venv",
-    "build",
-    "dist",
-    "my_test_code",
-    "my_test_code.egg-info",
-    "setup.py",
-    "databricks.yml",
-    "python_wheel_wrapper.yml",
-    "empty.yml",
-]
-
 # Workspace file system does not allow initializing python envs on it.
 # I suspect something about the default python env on DBR interferes with it.
 # We'll likely need a first class venv abstraction in acceptance tests to fix this.
@@ -26,3 +13,16 @@ Ignore = [
 #   Caused by: Failed to query Python interpreter
 #   Caused by: failed to canonicalize path `/Workspace/abcd/.venv/bin/python3`: Invalid cross-device link (os error 18)
 SkipOnDbr = true
+
+Ignore = [
+    ".databricks",
+    ".venv",
+    "build",
+    "dist",
+    "my_test_code",
+    "my_test_code.egg-info",
+    "setup.py",
+    "databricks.yml",
+    "python_wheel_wrapper.yml",
+    "empty.yml",
+]

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -13,3 +13,16 @@ Ignore = [
     "python_wheel_wrapper.yml",
     "empty.yml",
 ]
+
+# Workspace file system does not allow initializing python envs on it.
+# I suspect something about the default python env on DBR interferes with it.
+# We'll likely need a first class venv abstraction in acceptance tests to fix this.
+# script:
+#   uv venv -q .venv
+#   source .venv/bin/activate
+#   uv pip install -q setuptools
+# error:
+#   Failed to inspect Python interpreter from active virtual environment at `.venv/bin/python3`
+#   Caused by: Failed to query Python interpreter
+#   Caused by: failed to canonicalize path `/Workspace/abcd/.venv/bin/python3`: Invalid cross-device link (os error 18)
+SkipOnDbr = true

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -131,6 +131,9 @@ type TestConfig struct {
 	// Null means "databricks.yml"
 	BundleConfigTarget *string
 
+	// If true, skip this test when running on DBR / workspace file system.
+	SkipOnDbr *bool
+
 	// To be added:
 	// BundleConfigMatrix is to BundleConfig what EnvMatrix is to Env
 	// It creates different tests for each possible configuration update.


### PR DESCRIPTION
## Changes
Certain tests would need to be skipped on DBR because of quirks in the workspace file system. This PR adds a flag to do so and disables artfic-related acceptance tests for now.

## Tests
Manually, these tests were indeed skipped on runs.