### PR TITLE
[Python] Support non-experimental conf in Python code

### DIFF
--- a/experimental/python/databricks/bundles/core/_diagnostics.py
+++ b/experimental/python/databricks/bundles/core/_diagnostics.py
@@ -134,6 +134,17 @@ class Diagnostics:
 
         return False
 
+    def has_warning(self) -> bool:
+        """
+        Returns True if there is at least one warning in diagnostics.
+        """
+
+        for item in self.items:
+            if item.severity == Severity.WARNING:
+                return True
+
+        return False
+
     @classmethod
     def create_error(
         cls,

--- a/experimental/python/databricks_tests/core/test_diagnostics.py
+++ b/experimental/python/databricks_tests/core/test_diagnostics.py
@@ -85,3 +85,17 @@ def test_location_from_weird_callable():
     location = Location.from_callable(print)
 
     assert location is None
+
+
+def test_has_error():
+    diagnostics = Diagnostics.create_error("foo is deprecated")
+
+    assert diagnostics.has_error()
+    assert not diagnostics.has_warning()
+
+
+def test_has_warning():
+    diagnostics = Diagnostics.create_warning("foo is deprecated")
+
+    assert not diagnostics.has_error()
+    assert diagnostics.has_warning()


### PR DESCRIPTION
## Changes
Support reading both `python` and `experimental.python` configs. If both are set, their value should be equivalent.

After we introduce the `python` section into the CLI, it has to keep setting both `python` and `experimental.python` into the payload for backward compatibility. After that, Python code can start erroring out if `experimental/python` is set but not `python` because it means that users have an outdated CLI version.

See also https://github.com/databricks/cli/pull/3540

## Why
It's a step toward graduating `python` outside the `experimental` section.

## Tests
Unit tests and existing acceptance tests