### PR TITLE
Add changelog entry for PR #3307

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,5 +16,6 @@
 * Update default-python template to make DB Connect work out of the box for unit tests, using uv to install dependencies ([#3254](https://github.com/databricks/cli/pull/3254))
 * Add support for `TaskRetryMode` for continuous jobs ([#3529](https://github.com/databricks/cli/pull/3529))
 * Add support for specifying database instance as an application resource ([#3529](https://github.com/databricks/cli/pull/3529))
+* Add top level `run_as` support for DLT pipelines ([#3307](https://github.com/databricks/cli/pull/3307))
 
 ### API Changes


### PR DESCRIPTION
## Summary

This PR adds a changelog entry for PR #3307 which implemented top level `run_as` support for DLT pipelines in Databricks Asset Bundles (DABs).

## Changes

- Added entry to `NEXT_CHANGELOG.md` under the Bundles section documenting the new top level `run_as` support for DLT pipelines

## Context

PR #3307 enabled DABs to support the `run_as` field at the top level for DLT pipelines. Previously, DABs would error if pipelines were used with the `run_as` field set. Now the CLI transparently reads the `run_as` value and applies it to all pipelines in the bundle.

🤖 Generated with [Claude Code](https://claude.ai/code)