### PR TITLE
Add summary for 'bundle plan' output and print to stdout

### DIFF
--- a/acceptance/bundle/apps/app_yaml/output.txt
+++ b/acceptance/bundle/apps/app_yaml/output.txt
@@ -9,7 +9,8 @@ Workspace:
 Validation OK!
 
 >>> [CLI] bundle plan
-create apps.myapp
+Plan: 1 to add, 0 to change, 0 to delete
+  create apps.myapp
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/bundle_tag/id/output.txt
+++ b/acceptance/bundle/bundle_tag/id/output.txt
@@ -30,7 +30,8 @@ Validation OK!
 }
 
 >>> [CLI] bundle plan
-create jobs.foo
+Plan: 1 to add, 0 to change, 0 to delete
+  create jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/bundle_tag/url/output.txt
+++ b/acceptance/bundle/bundle_tag/url/output.txt
@@ -30,7 +30,8 @@ Validation OK!
 }
 
 >>> [CLI] bundle plan
-create jobs.foo
+Plan: 1 to add, 0 to change, 0 to delete
+  create jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/bundle_tag/url_ref/out.plan.direct-exp.txt
+++ b/acceptance/bundle/bundle_tag/url_ref/out.plan.direct-exp.txt
@@ -4,5 +4,6 @@ Error: cannot plan jobs.bar: dependency failed: jobs.foo
 
 Error: planning failed
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code: 1

--- a/acceptance/bundle/bundle_tag/url_ref/out.plan.terraform.txt
+++ b/acceptance/bundle/bundle_tag/url_ref/out.plan.terraform.txt
@@ -1,2 +1,3 @@
-create jobs.bar
-create jobs.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create jobs.bar
+  create jobs.foo

--- a/acceptance/bundle/debug/out.stderr.terraform.txt
+++ b/acceptance/bundle/debug/out.stderr.terraform.txt
@@ -64,7 +64,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=metadata.AnnotatePipelines
 10:07:59 Debug: Apply pid=12345 mutator=terraform.Initialize
 10:07:59 Debug: Using Terraform from DATABRICKS_TF_EXEC_PATH at [TERRAFORM] pid=12345 mutator=terraform.Initialize
-10:07:59 Debug: Using Terraform CLI config from DATABRICKS_TF_CLI_CONFIG_FILE at [DATABRICKS_TF_CLI_CONFIG_FILE] pid=12345 mutator=terraform.Initialize
+10:07:59 Debug: DATABRICKS_TF_PROVIDER_VERSION as 1.84.0 does not match the current version 1.88.0, ignoring DATABRICKS_TF_CLI_CONFIG_FILE pid=12345 mutator=terraform.Initialize
 10:07:59 Debug: Environment variables for Terraform: ...redacted... pid=12345 mutator=terraform.Initialize
 10:07:59 Debug: Apply pid=12345 mutator=scripts.postinit
 10:07:59 Debug: No script defined for postinit, skipping pid=12345 mutator=scripts.postinit

--- a/acceptance/bundle/deploy/jobs/task-source/output.txt
+++ b/acceptance/bundle/deploy/jobs/task-source/output.txt
@@ -14,7 +14,8 @@ Deployment complete!
 >>> jq -s .[] | select(.path=="/api/2.2/jobs/create") | select(.body.name=="workspace_job") | .body out.requests.txt
 
 >>> [CLI] bundle plan
-update jobs.git_job
+Plan: 0 to add, 1 to change, 0 to delete
+  update jobs.git_job
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/task-source/default/files...

--- a/acceptance/bundle/deploy/pipeline/auto-approve/output.txt
+++ b/acceptance/bundle/deploy/pipeline/auto-approve/output.txt
@@ -36,8 +36,9 @@ Deployment complete!
 >>> rm resources.yml
 
 >>> [CLI] bundle plan
-delete jobs.foo
-delete pipelines.bar
+Plan: 0 to add, 0 to change, 2 to delete
+  delete jobs.foo
+  delete pipelines.bar
 
 === Try to redeploy the bundle - should fail without --auto-approve
 >>> errcode [CLI] bundle deploy

--- a/acceptance/bundle/deploy/pipeline/recreate/output.txt
+++ b/acceptance/bundle/deploy/pipeline/recreate/output.txt
@@ -30,9 +30,10 @@ Deployment complete!
   }
 }
 
+  recreate pipelines.foo
+  recreate schemas.bar
 >>> [CLI] bundle plan --var=catalog=another_catalog
-recreate pipelines.foo
-recreate schemas.bar
+Plan: 2 to add, 0 to change, 2 to delete
 
 === Try to redeploy the bundle, pointing the DLT pipeline to a different UC catalog
 >>> errcode [CLI] bundle deploy --force-lock --var=catalog=another_catalog

--- a/acceptance/bundle/plan/no_upload/output.txt
+++ b/acceptance/bundle/plan/no_upload/output.txt
@@ -1,5 +1,6 @@
 
 >>> [CLI] bundle plan
-create jobs.my_job
+Plan: 1 to add, 0 to change, 0 to delete
+  create jobs.my_job
 
 >>> jq -s .[] | select(.method != "GET") out.requests.txt

--- a/acceptance/bundle/resource_deps/bad_syntax/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.plan.direct-exp.txt
@@ -1,2 +1,3 @@
-create volumes.bar
-create volumes.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create volumes.bar
+  create volumes.foo

--- a/acceptance/bundle/resource_deps/bad_syntax/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.plan.terraform.txt
@@ -8,3 +8,4 @@ Error: Invalid attribute name
 An attribute name is required after a dot.
 
 
+No changes. Your infrastructure matches the configuration.

--- a/acceptance/bundle/resource_deps/create_error/output.txt
+++ b/acceptance/bundle/resource_deps/create_error/output.txt
@@ -1,9 +1,10 @@
 
 >>> [CLI] bundle plan
-create jobs.bar
-create jobs.baz
-create jobs.foo
-create jobs.independent
+Plan: 4 to add, 0 to change, 0 to delete
+  create jobs.bar
+  create jobs.baz
+  create jobs.foo
+  create jobs.independent
 
 >>> print_sorted_requests
 {
@@ -66,9 +67,10 @@ Resources:
 
 === Plan should still contain foo and bar
 >>> [CLI] bundle plan
-create jobs.bar
-create jobs.baz
-create jobs.foo
+Plan: 3 to add, 0 to change, 0 to delete
+  create jobs.bar
+  create jobs.baz
+  create jobs.foo
 
 === Expecting no difference in the output between first and second deploy
 >>> print_requests

--- a/acceptance/bundle/resource_deps/id_chain/output.txt
+++ b/acceptance/bundle/resource_deps/id_chain/output.txt
@@ -1,10 +1,11 @@
 
 >>> [CLI] bundle plan
-create jobs.a
-create jobs.b
-create jobs.c
-create jobs.d
-create jobs.e
+Plan: 5 to add, 0 to change, 0 to delete
+  create jobs.a
+  create jobs.b
+  create jobs.c
+  create jobs.d
+  create jobs.e
 
 >>> print_requests
 
@@ -26,11 +27,12 @@ Deployment complete!
 >>> update_file.py databricks.yml prefix new_prefix
 
 >>> [CLI] bundle plan
-update jobs.a
-update jobs.b
-update jobs.c
-update jobs.d
-update jobs.e
+Plan: 0 to add, 5 to change, 0 to delete
+  update jobs.a
+  update jobs.b
+  update jobs.c
+  update jobs.d
+  update jobs.e
 
 >>> print_requests
 

--- a/acceptance/bundle/resource_deps/job_id/output.txt
+++ b/acceptance/bundle/resource_deps/job_id/output.txt
@@ -1,7 +1,8 @@
 
 >>> [CLI] bundle plan
-create jobs.bar
-create jobs.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create jobs.bar
+  create jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/resource_deps/jobs_update/output.txt
+++ b/acceptance/bundle/resource_deps/jobs_update/output.txt
@@ -1,7 +1,8 @@
 
 >>> [CLI] bundle plan
-create jobs.bar
-create jobs.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create jobs.bar
+  create jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -63,12 +64,14 @@ Deployment complete!
 }
 
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 === Update trigger.periodic.unit and re-deploy; jobs.bar is unchanged
 >>> update_file.py databricks.yml DAYS HOURS
 
 >>> [CLI] bundle plan
-update jobs.foo
+Plan: 0 to add, 1 to change, 0 to delete
+  update jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -115,6 +118,7 @@ Deployment complete!
 }
 
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 === Fetch job ID and verify remote state
 >>> [CLI] jobs get [FOO_ID]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.plan.direct-exp.txt
@@ -1,4 +1,5 @@
 Error: cycle detected: jobs.foo refers to jobs.bar via ${resources.jobs.bar.id} which refers to jobs.foo via ${resources.jobs.foo.id}
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_jobs/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.plan.terraform.txt
@@ -4,5 +4,6 @@ Error: Cycle: databricks_job.foo, databricks_job.bar
 
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.plan.direct-exp.txt
@@ -1,4 +1,5 @@
 Error: cycle detected: jobs.foo refers to itself via ${resources.jobs.foo.id}
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/loop_self/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/loop_self/out.plan.terraform.txt
@@ -15,5 +15,6 @@ Error: Self-referential block
 Configuration for databricks_job.foo may not refer to itself.
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.plan.direct-exp.txt
@@ -4,5 +4,6 @@ Error: cannot plan pipelines.bar: dependency failed: pipelines.foo
 
 Error: planning failed
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.plan.terraform.txt
@@ -9,5 +9,6 @@ Block type "ingestion_definition" is represented by a list of objects, so it
 must be indexed using a numeric key, like .ingestion_definition[0].
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_map_key/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.plan.direct-exp.txt
@@ -4,5 +4,6 @@ Error: cannot plan jobs.bar: dependency failed: jobs.test
 
 Error: planning failed
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_map_key/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.plan.terraform.txt
@@ -9,5 +9,6 @@ This object has no argument, nested block, or exported attribute named
 "tasks". Did you mean "tags"?
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_map_key_tffix/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key_tffix/out.plan.direct-exp.txt
@@ -4,5 +4,6 @@ Error: cannot plan jobs.bar: dependency failed: jobs.test
 
 Error: planning failed
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_map_key_tffix/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key_tffix/out.plan.terraform.txt
@@ -10,5 +10,6 @@ Error: Missing map element
 This map does not have an element with the key "missing_tag".
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/missing_string_field/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.plan.direct-exp.txt
@@ -2,5 +2,6 @@ Warning: expected a string value, found null
   at resources.pipelines.bar.catalog
   in databricks.yml:6:16
 
-create pipelines.bar
-create pipelines.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create pipelines.bar
+  create pipelines.foo

--- a/acceptance/bundle/resource_deps/missing_string_field/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.plan.terraform.txt
@@ -1,2 +1,3 @@
-create pipelines.bar
-create pipelines.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create pipelines.bar
+  create pipelines.foo

--- a/acceptance/bundle/resource_deps/non_existent_field/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.plan.direct-exp.txt
@@ -4,5 +4,6 @@ Error: cannot plan volumes.foo: dependency failed: volumes.bar
 
 Error: planning failed
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/non_existent_field/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.plan.terraform.txt
@@ -9,5 +9,6 @@ This object has no argument, nested block, or exported attribute named
 "non_existent".
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code (musterr): 1

--- a/acceptance/bundle/resource_deps/pipelines_recreate/output.txt
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/output.txt
@@ -1,7 +1,8 @@
 
 >>> [CLI] bundle plan
-create jobs.bar
-create pipelines.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create jobs.bar
+  create pipelines.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -44,13 +45,15 @@ Deployment complete!
 }
 
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 === Update catalog, triggering recreate for pipeline; this means updating downstream deps
 >>> update_file.py databricks.yml mycatalog mynewcatalog
 
 >>> [CLI] bundle plan
-update jobs.bar
-recreate pipelines.foo
+Plan: 1 to add, 1 to change, 1 to delete
+  update jobs.bar
+  recreate pipelines.foo
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -153,6 +156,7 @@ Exit code (musterr): 1
 
 === Follow up plan & deploy do nothing
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.plan.direct-exp.txt
@@ -1,2 +1,3 @@
-create pipelines.bar
-create pipelines.foo
+Plan: 2 to add, 0 to change, 0 to delete
+  create pipelines.bar
+  create pipelines.foo

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.plan.terraform.txt
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.plan.terraform.txt
@@ -9,5 +9,6 @@ Block type "ingestion_definition" is represented by a list of objects, so it
 must be indexed using a numeric key, like .ingestion_definition[0].
 
 
+No changes. Your infrastructure matches the configuration.
 
 Exit code: 1

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/output.txt
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/output.txt
@@ -25,9 +25,10 @@
 }
 
 >>> [CLI] bundle plan
-create schemas.my
-create volumes.bar
-create volumes.foo
+Plan: 3 to add, 0 to change, 0 to delete
+  create schemas.my
+  create volumes.bar
+  create volumes.foo
 
 >>> print_requests
 

--- a/acceptance/bundle/resources/apps/update/output.txt
+++ b/acceptance/bundle/resources/apps/update/output.txt
@@ -1,6 +1,7 @@
 
 >>> [CLI] bundle plan
-create apps.mykey
+Plan: 1 to add, 0 to change, 0 to delete
+  create apps.mykey
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -34,7 +35,8 @@ Resources:
 >>> update_file.py databricks.yml my_app_description MY_APP_DESCRIPTION
 
 >>> [CLI] bundle plan
-update apps.mykey
+Plan: 0 to add, 1 to change, 0 to delete
+  update apps.mykey
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -68,7 +70,8 @@ Resources:
 >>> update_file.py databricks.yml myappname mynewappname
 
 >>> [CLI] bundle plan
-recreate apps.mykey
+Plan: 1 to add, 0 to change, 1 to delete
+  recreate apps.mykey
 
 >>> [CLI] bundle summary
 Name: test-bundle
@@ -104,6 +107,7 @@ Deployment complete!
 }
 
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 >>> [CLI] bundle summary
 Name: test-bundle

--- a/acceptance/bundle/resources/jobs/update/output.txt
+++ b/acceptance/bundle/resources/jobs/update/output.txt
@@ -1,6 +1,7 @@
 
 >>> [CLI] bundle plan
-create jobs.foo
+Plan: 1 to add, 0 to change, 0 to delete
+  create jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -9,6 +10,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 >>> print_requests
 {
@@ -50,7 +52,8 @@ jobs foo id='[JOB_ID]' name='foo'
 >>> update_file.py databricks.yml DAYS HOURS
 
 >>> [CLI] bundle plan
-update jobs.foo
+Plan: 0 to add, 1 to change, 0 to delete
+  update jobs.foo
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -59,6 +62,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle plan
+No changes. Your infrastructure matches the configuration.
 
 >>> print_requests
 {

--- a/acceptance/bundle/resources/pipelines/recreate/change-catalog/output.txt
+++ b/acceptance/bundle/resources/pipelines/recreate/change-catalog/output.txt
@@ -15,7 +15,8 @@ resources:
             path: "./foo.py"
 
 >>> [CLI] bundle plan
-create pipelines.my
+Plan: 1 to add, 0 to change, 0 to delete
+  create pipelines.my
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...
@@ -49,7 +50,8 @@ Deployment complete!
 >>> update_file.py databricks.yml catalog1 catalog2
 
 >>> [CLI] bundle plan
-recreate pipelines.my
+Plan: 1 to add, 0 to change, 1 to delete
+  recreate pipelines.my
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...

--- a/acceptance/bundle/resources/pipelines/recreate/change-ingestion-definition/output.txt
+++ b/acceptance/bundle/resources/pipelines/recreate/change-ingestion-definition/output.txt
@@ -15,7 +15,8 @@ resources:
             path: "./foo.py"
 
 >>> [CLI] bundle plan
-create pipelines.my
+Plan: 1 to add, 0 to change, 0 to delete
+  create pipelines.my
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...
@@ -54,7 +55,8 @@ Deployment complete!
 >>> update_file.py databricks.yml my_connection my_new_connection
 
 >>> [CLI] bundle plan
-recreate pipelines.my
+Plan: 1 to add, 0 to change, 1 to delete
+  recreate pipelines.my
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...

--- a/acceptance/bundle/resources/pipelines/recreate/change-storage/output.txt
+++ b/acceptance/bundle/resources/pipelines/recreate/change-storage/output.txt
@@ -15,7 +15,8 @@ resources:
             path: "./foo.py"
 
 >>> [CLI] bundle plan
-create pipelines.my
+Plan: 1 to add, 0 to change, 0 to delete
+  create pipelines.my
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...
@@ -49,7 +50,8 @@ Deployment complete!
 >>> update_file.py databricks.yml pipelines/custom pipelines/newcustom
 
 >>> [CLI] bundle plan
-recreate pipelines.my
+Plan: 1 to add, 0 to change, 1 to delete
+  recreate pipelines.my
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/acc-[UNIQUE_NAME]/default/files...

--- a/acceptance/bundle/resources/schemas/recreate/output.txt
+++ b/acceptance/bundle/resources/schemas/recreate/output.txt
@@ -31,7 +31,8 @@ Deployment complete!
 >>> update_file.py databricks.yml catalog_name: main catalog_name: newmain
 
 >>> [CLI] bundle plan
-recreate schemas.schema1
+Plan: 1 to add, 0 to change, 1 to delete
+  recreate schemas.schema1
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/resources/volumes/change-name/output.txt
+++ b/acceptance/bundle/resources/volumes/change-name/output.txt
@@ -37,7 +37,8 @@ Deployment complete!
 >>> update_file.py databricks.yml myvolume mynewvolume
 
 >>> [CLI] bundle plan
-update volumes.volume1
+Plan: 0 to add, 1 to change, 0 to delete
+  update volumes.volume1
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/resources/volumes/change-schema-name/output.txt
+++ b/acceptance/bundle/resources/volumes/change-schema-name/output.txt
@@ -37,7 +37,8 @@ Deployment complete!
 >>> update_file.py databricks.yml myschema mynewschema
 
 >>> [CLI] bundle plan
-recreate volumes.volume1
+Plan: 1 to add, 0 to change, 1 to delete
+  recreate volumes.volume1
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...

--- a/acceptance/bundle/resources/volumes/set-storage-location/output.txt
+++ b/acceptance/bundle/resources/volumes/set-storage-location/output.txt
@@ -1,7 +1,8 @@
 
 >>> [CLI] bundle plan
-create schemas.myschema
-create volumes.volume1
+Plan: 2 to add, 0 to change, 0 to delete
+  create schemas.myschema
+  create volumes.volume1
 
 >>> print_requests
 


### PR DESCRIPTION
## Changes
1. Changed plan output to be printed from stderr (cmdio.LogString) to stdout (fmt.Printf/fmt.Println)
2. Added summary line with counts: Plan: X to add, Y to change, Z to delete

Example output:
  ```
  Plan: 2 to add, 0 to change, 2 to delete
    create job.my_project_job
    delete job.sample_job
    create pipeline.my_project_pipeline
    delete pipeline.sample_etl
```

## Why
Improving the output before making the command publicly available

## Tests
Updated acceptance test output
Existing acceptance test updated and passing

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
