### PR TITLE
acc: add Slow setting; change "make test" no longer run slow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ links:
 checks: tidy ws links
 
 test:
+	${GOTESTSUM_CMD} -- ${PACKAGES} -timeout=${LOCAL_TIMEOUT} -short
+
+test-slow:
 	${GOTESTSUM_CMD} -- ${PACKAGES} -timeout=${LOCAL_TIMEOUT}
 
 # Updates acceptance test output (local tests)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -419,6 +419,10 @@ func getSkipReason(config *internal.TestConfig, configPath string) string {
 		return ""
 	}
 
+	if isTruePtr(config.Slow) && testing.Short() {
+		return "Disabled via Slow setting in " + configPath
+	}
+
 	isEnabled, isPresent := config.GOOS[runtime.GOOS]
 	if isPresent && !isEnabled {
 		return fmt.Sprintf("Disabled via GOOS.%s setting in %s", runtime.GOOS, configPath)

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -36,6 +36,9 @@ type TestConfig struct {
 	// If true, run this test when running locally with a testserver
 	Local *bool
 
+	// If true, this test will not be run in -short mode (which is default for make test / PR but not for main and merge checks)
+	Slow *bool
+
 	// If true, run this test when running with cloud env configured
 	Cloud *bool
 

--- a/acceptance/selftest/slow/out.test.toml
+++ b/acceptance/selftest/slow/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/selftest/slow/output.txt
+++ b/acceptance/selftest/slow/output.txt
@@ -1,0 +1,1 @@
+Skipped in -short mode

--- a/acceptance/selftest/slow/script
+++ b/acceptance/selftest/slow/script
@@ -1,0 +1,1 @@
+echo "Skipped in -short mode"

--- a/acceptance/selftest/slow/test.toml
+++ b/acceptance/selftest/slow/test.toml
@@ -1,0 +1,1 @@
+Slow = true


### PR DESCRIPTION
## Changes
- Add Slow settings to acceptance tests; when set test will be skipped in -short mode.
- Add -short option to "make test".

## Why
I'd like to add some tests that record output in case of real timeout, but don't want to run them every time.

## Tests
New self test.