### PR TITLE
Use the new environment_version property

### DIFF
--- a/acceptance/bundle/integration_whl/serverless/databricks.yml.tmpl
+++ b/acceptance/bundle/integration_whl/serverless/databricks.yml.tmpl
@@ -22,6 +22,6 @@ resources:
       environments:
         - environment_key:  "test_env"
           spec:
-            client: "1"
+            environment_version: "2"
             dependencies:
               - ./dist/*.whl

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/databricks.yml.tmpl
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/databricks.yml.tmpl
@@ -23,6 +23,6 @@ resources:
       environments:
         - environment_key:  "test_env"
           spec:
-            client: "1"
+            environment_version: "2"
             dependencies:
               - ./dist/*.whl

--- a/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
+++ b/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
@@ -41,7 +41,7 @@
 -          # Full documentation of this spec can be found at:
 -          # https://docs.databricks.com/api/workspace/jobs/create#environments-spec
 -          spec:
--            client: "2"
+-            environment_version: "2"
 -            dependencies:
 -              - ../dist/*.whl
 +      job_clusters:

--- a/acceptance/bundle/templates/default-python/serverless/output/my_default_python/resources/my_default_python.job.yml
+++ b/acceptance/bundle/templates/default-python/serverless/output/my_default_python/resources/my_default_python.job.yml
@@ -40,6 +40,6 @@ resources:
           # Full documentation of this spec can be found at:
           # https://docs.databricks.com/api/workspace/jobs/create#environments-spec
           spec:
-            client: "2"
+            environment_version: "2"
             dependencies:
               - ../dist/*.whl

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -74,7 +74,7 @@ resources:
           # Full documentation of this spec can be found at:
           # https://docs.databricks.com/api/workspace/jobs/create#environments-spec
           spec:
-            client: "2"
+            environment_version: "2"
             dependencies:
               - ../dist/*.whl
 {{end}}{{ else }}


### PR DESCRIPTION
## Changes
This updates the DABs serverless example to use the new environment_version property instead of the deprecated client property. See https://docs.databricks.com/api/workspace/jobs/create.

## Tests
* Tests were updated, functionality was manually validated