### PR TITLE
Add hidden "bundle ref-schema" command

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -84,7 +84,7 @@ const (
 	EntryPointScript = "script"
 	CleanupScript    = "script.cleanup"
 	PrepareScript    = "script.prepare"
-	MaxFileSize      = 100_000
+	MaxFileSize      = 1_000_000
 	// Filename to save replacements to (used by diff.py)
 	ReplsFile = "repls.json"
 	// Filename for materialized config (used as golden file)

--- a/acceptance/bundle/refschema/out.fields.txt
+++ b/acceptance/bundle/refschema/out.fields.txt
@@ -1,0 +1,2540 @@
+resources.apps.*.active_deployment	*apps.AppDeployment	ALL
+resources.apps.*.active_deployment.create_time	string	ALL
+resources.apps.*.active_deployment.creator	string	ALL
+resources.apps.*.active_deployment.deployment_artifacts	*apps.AppDeploymentArtifacts	ALL
+resources.apps.*.active_deployment.deployment_artifacts.source_code_path	string	ALL
+resources.apps.*.active_deployment.deployment_id	string	ALL
+resources.apps.*.active_deployment.mode	apps.AppDeploymentMode	ALL
+resources.apps.*.active_deployment.source_code_path	string	ALL
+resources.apps.*.active_deployment.status	*apps.AppDeploymentStatus	ALL
+resources.apps.*.active_deployment.status.message	string	ALL
+resources.apps.*.active_deployment.status.state	apps.AppDeploymentState	ALL
+resources.apps.*.active_deployment.update_time	string	ALL
+resources.apps.*.app_status	*apps.ApplicationStatus	ALL
+resources.apps.*.app_status.message	string	ALL
+resources.apps.*.app_status.state	apps.ApplicationState	ALL
+resources.apps.*.budget_policy_id	string	ALL
+resources.apps.*.compute_status	*apps.ComputeStatus	ALL
+resources.apps.*.compute_status.message	string	ALL
+resources.apps.*.compute_status.state	apps.ComputeState	ALL
+resources.apps.*.config	map[string]interface {}	INPUT
+resources.apps.*.config[0]	interface {}	INPUT
+resources.apps.*.create_time	string	ALL
+resources.apps.*.creator	string	ALL
+resources.apps.*.default_source_code_path	string	ALL
+resources.apps.*.description	string	ALL
+resources.apps.*.effective_budget_policy_id	string	ALL
+resources.apps.*.effective_user_api_scopes	[]string	ALL
+resources.apps.*.effective_user_api_scopes[0]	string	ALL
+resources.apps.*.id	string	ALL
+resources.apps.*.modified_status	string	INPUT
+resources.apps.*.name	string	ALL
+resources.apps.*.oauth2_app_client_id	string	ALL
+resources.apps.*.oauth2_app_integration_id	string	ALL
+resources.apps.*.pending_deployment	*apps.AppDeployment	ALL
+resources.apps.*.pending_deployment.create_time	string	ALL
+resources.apps.*.pending_deployment.creator	string	ALL
+resources.apps.*.pending_deployment.deployment_artifacts	*apps.AppDeploymentArtifacts	ALL
+resources.apps.*.pending_deployment.deployment_artifacts.source_code_path	string	ALL
+resources.apps.*.pending_deployment.deployment_id	string	ALL
+resources.apps.*.pending_deployment.mode	apps.AppDeploymentMode	ALL
+resources.apps.*.pending_deployment.source_code_path	string	ALL
+resources.apps.*.pending_deployment.status	*apps.AppDeploymentStatus	ALL
+resources.apps.*.pending_deployment.status.message	string	ALL
+resources.apps.*.pending_deployment.status.state	apps.AppDeploymentState	ALL
+resources.apps.*.pending_deployment.update_time	string	ALL
+resources.apps.*.permissions	[]resources.AppPermission	INPUT
+resources.apps.*.permissions[0]	resources.AppPermission	INPUT
+resources.apps.*.permissions[0].group_name	string	INPUT
+resources.apps.*.permissions[0].level	resources.AppPermissionLevel	INPUT
+resources.apps.*.permissions[0].service_principal_name	string	INPUT
+resources.apps.*.permissions[0].user_name	string	INPUT
+resources.apps.*.resources	[]apps.AppResource	ALL
+resources.apps.*.resources[0]	apps.AppResource	ALL
+resources.apps.*.resources[0].database	*apps.AppResourceDatabase	ALL
+resources.apps.*.resources[0].database.database_name	string	ALL
+resources.apps.*.resources[0].database.instance_name	string	ALL
+resources.apps.*.resources[0].database.permission	apps.AppResourceDatabaseDatabasePermission	ALL
+resources.apps.*.resources[0].description	string	ALL
+resources.apps.*.resources[0].job	*apps.AppResourceJob	ALL
+resources.apps.*.resources[0].job.id	string	ALL
+resources.apps.*.resources[0].job.permission	apps.AppResourceJobJobPermission	ALL
+resources.apps.*.resources[0].name	string	ALL
+resources.apps.*.resources[0].secret	*apps.AppResourceSecret	ALL
+resources.apps.*.resources[0].secret.key	string	ALL
+resources.apps.*.resources[0].secret.permission	apps.AppResourceSecretSecretPermission	ALL
+resources.apps.*.resources[0].secret.scope	string	ALL
+resources.apps.*.resources[0].serving_endpoint	*apps.AppResourceServingEndpoint	ALL
+resources.apps.*.resources[0].serving_endpoint.name	string	ALL
+resources.apps.*.resources[0].serving_endpoint.permission	apps.AppResourceServingEndpointServingEndpointPermission	ALL
+resources.apps.*.resources[0].sql_warehouse	*apps.AppResourceSqlWarehouse	ALL
+resources.apps.*.resources[0].sql_warehouse.id	string	ALL
+resources.apps.*.resources[0].sql_warehouse.permission	apps.AppResourceSqlWarehouseSqlWarehousePermission	ALL
+resources.apps.*.resources[0].uc_securable	*apps.AppResourceUcSecurable	ALL
+resources.apps.*.resources[0].uc_securable.permission	apps.AppResourceUcSecurableUcSecurablePermission	ALL
+resources.apps.*.resources[0].uc_securable.securable_full_name	string	ALL
+resources.apps.*.resources[0].uc_securable.securable_type	apps.AppResourceUcSecurableUcSecurableType	ALL
+resources.apps.*.service_principal_client_id	string	ALL
+resources.apps.*.service_principal_id	int64	ALL
+resources.apps.*.service_principal_name	string	ALL
+resources.apps.*.source_code_path	string	INPUT
+resources.apps.*.update_time	string	ALL
+resources.apps.*.updater	string	ALL
+resources.apps.*.url	string	ALL
+resources.apps.*.user_api_scopes	[]string	ALL
+resources.apps.*.user_api_scopes[0]	string	ALL
+resources.database_catalogs.*.create_database_if_not_exists	bool	ALL
+resources.database_catalogs.*.database_instance_name	string	ALL
+resources.database_catalogs.*.database_name	string	ALL
+resources.database_catalogs.*.id	string	INPUT
+resources.database_catalogs.*.modified_status	string	INPUT
+resources.database_catalogs.*.name	string	ALL
+resources.database_catalogs.*.uid	string	ALL
+resources.database_catalogs.*.url	string	INPUT
+resources.database_instances.*.capacity	string	ALL
+resources.database_instances.*.child_instance_refs	[]database.DatabaseInstanceRef	ALL
+resources.database_instances.*.child_instance_refs[0]	database.DatabaseInstanceRef	ALL
+resources.database_instances.*.child_instance_refs[0].branch_time	string	ALL
+resources.database_instances.*.child_instance_refs[0].effective_lsn	string	ALL
+resources.database_instances.*.child_instance_refs[0].lsn	string	ALL
+resources.database_instances.*.child_instance_refs[0].name	string	ALL
+resources.database_instances.*.child_instance_refs[0].uid	string	ALL
+resources.database_instances.*.creation_time	string	ALL
+resources.database_instances.*.creator	string	ALL
+resources.database_instances.*.effective_enable_pg_native_login	bool	ALL
+resources.database_instances.*.effective_enable_readable_secondaries	bool	ALL
+resources.database_instances.*.effective_node_count	int	ALL
+resources.database_instances.*.effective_retention_window_in_days	int	ALL
+resources.database_instances.*.effective_stopped	bool	ALL
+resources.database_instances.*.enable_pg_native_login	bool	ALL
+resources.database_instances.*.enable_readable_secondaries	bool	ALL
+resources.database_instances.*.id	string	INPUT
+resources.database_instances.*.modified_status	string	INPUT
+resources.database_instances.*.name	string	ALL
+resources.database_instances.*.node_count	int	ALL
+resources.database_instances.*.parent_instance_ref	*database.DatabaseInstanceRef	ALL
+resources.database_instances.*.parent_instance_ref.branch_time	string	ALL
+resources.database_instances.*.parent_instance_ref.effective_lsn	string	ALL
+resources.database_instances.*.parent_instance_ref.lsn	string	ALL
+resources.database_instances.*.parent_instance_ref.name	string	ALL
+resources.database_instances.*.parent_instance_ref.uid	string	ALL
+resources.database_instances.*.permissions	[]resources.DatabaseInstancePermission	INPUT
+resources.database_instances.*.permissions[0]	resources.DatabaseInstancePermission	INPUT
+resources.database_instances.*.permissions[0].group_name	string	INPUT
+resources.database_instances.*.permissions[0].level	resources.DatabaseInstancePermissionLevel	INPUT
+resources.database_instances.*.permissions[0].service_principal_name	string	INPUT
+resources.database_instances.*.permissions[0].user_name	string	INPUT
+resources.database_instances.*.pg_version	string	ALL
+resources.database_instances.*.read_only_dns	string	ALL
+resources.database_instances.*.read_write_dns	string	ALL
+resources.database_instances.*.retention_window_in_days	int	ALL
+resources.database_instances.*.state	database.DatabaseInstanceState	ALL
+resources.database_instances.*.stopped	bool	ALL
+resources.database_instances.*.uid	string	ALL
+resources.database_instances.*.url	string	INPUT
+resources.jobs.*.budget_policy_id	string	INPUT	STATE
+resources.jobs.*.continuous	*jobs.Continuous	INPUT	STATE
+resources.jobs.*.continuous.pause_status	jobs.PauseStatus	INPUT	STATE
+resources.jobs.*.continuous.task_retry_mode	jobs.TaskRetryMode	INPUT	STATE
+resources.jobs.*.created_time	int64	REMOTE
+resources.jobs.*.creator_user_name	string	REMOTE
+resources.jobs.*.deployment	*jobs.JobDeployment	INPUT	STATE
+resources.jobs.*.deployment.kind	jobs.JobDeploymentKind	INPUT	STATE
+resources.jobs.*.deployment.metadata_file_path	string	INPUT	STATE
+resources.jobs.*.description	string	INPUT	STATE
+resources.jobs.*.edit_mode	jobs.JobEditMode	INPUT	STATE
+resources.jobs.*.effective_budget_policy_id	string	REMOTE
+resources.jobs.*.effective_usage_policy_id	string	REMOTE
+resources.jobs.*.email_notifications	*jobs.JobEmailNotifications	INPUT	STATE
+resources.jobs.*.email_notifications.no_alert_for_skipped_runs	bool	INPUT	STATE
+resources.jobs.*.email_notifications.on_duration_warning_threshold_exceeded	[]string	INPUT	STATE
+resources.jobs.*.email_notifications.on_duration_warning_threshold_exceeded[0]	string	INPUT	STATE
+resources.jobs.*.email_notifications.on_failure	[]string	INPUT	STATE
+resources.jobs.*.email_notifications.on_failure[0]	string	INPUT	STATE
+resources.jobs.*.email_notifications.on_start	[]string	INPUT	STATE
+resources.jobs.*.email_notifications.on_start[0]	string	INPUT	STATE
+resources.jobs.*.email_notifications.on_streaming_backlog_exceeded	[]string	INPUT	STATE
+resources.jobs.*.email_notifications.on_streaming_backlog_exceeded[0]	string	INPUT	STATE
+resources.jobs.*.email_notifications.on_success	[]string	INPUT	STATE
+resources.jobs.*.email_notifications.on_success[0]	string	INPUT	STATE
+resources.jobs.*.environments	[]jobs.JobEnvironment	INPUT	STATE
+resources.jobs.*.environments[0]	jobs.JobEnvironment	INPUT	STATE
+resources.jobs.*.environments[0].environment_key	string	INPUT	STATE
+resources.jobs.*.environments[0].spec	*compute.Environment	INPUT	STATE
+resources.jobs.*.environments[0].spec.client	string	INPUT	STATE
+resources.jobs.*.environments[0].spec.dependencies	[]string	INPUT	STATE
+resources.jobs.*.environments[0].spec.dependencies[0]	string	INPUT	STATE
+resources.jobs.*.environments[0].spec.environment_version	string	INPUT	STATE
+resources.jobs.*.environments[0].spec.jar_dependencies	[]string	INPUT	STATE
+resources.jobs.*.environments[0].spec.jar_dependencies[0]	string	INPUT	STATE
+resources.jobs.*.format	jobs.Format	INPUT	STATE
+resources.jobs.*.git_source	*jobs.GitSource	INPUT	STATE
+resources.jobs.*.git_source.git_branch	string	INPUT	STATE
+resources.jobs.*.git_source.git_commit	string	INPUT	STATE
+resources.jobs.*.git_source.git_provider	jobs.GitProvider	INPUT	STATE
+resources.jobs.*.git_source.git_snapshot	*jobs.GitSnapshot	INPUT	STATE
+resources.jobs.*.git_source.git_snapshot.used_commit	string	INPUT	STATE
+resources.jobs.*.git_source.git_tag	string	INPUT	STATE
+resources.jobs.*.git_source.git_url	string	INPUT	STATE
+resources.jobs.*.git_source.job_source	*jobs.JobSource	INPUT	STATE
+resources.jobs.*.git_source.job_source.dirty_state	jobs.JobSourceDirtyState	INPUT	STATE
+resources.jobs.*.git_source.job_source.import_from_git_branch	string	INPUT	STATE
+resources.jobs.*.git_source.job_source.job_config_path	string	INPUT	STATE
+resources.jobs.*.has_more	bool	REMOTE
+resources.jobs.*.health	*jobs.JobsHealthRules	INPUT	STATE
+resources.jobs.*.health.rules	[]jobs.JobsHealthRule	INPUT	STATE
+resources.jobs.*.health.rules[0]	jobs.JobsHealthRule	INPUT	STATE
+resources.jobs.*.health.rules[0].metric	jobs.JobsHealthMetric	INPUT	STATE
+resources.jobs.*.health.rules[0].op	jobs.JobsHealthOperator	INPUT	STATE
+resources.jobs.*.health.rules[0].value	int64	INPUT	STATE
+resources.jobs.*.id	string	INPUT
+resources.jobs.*.job_clusters	[]jobs.JobCluster	INPUT	STATE
+resources.jobs.*.job_clusters[0]	jobs.JobCluster	INPUT	STATE
+resources.jobs.*.job_clusters[0].job_cluster_key	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster	compute.ClusterSpec	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.apply_policy_default_values	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.autoscale	*compute.AutoScale	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.autoscale.max_workers	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.autoscale.min_workers	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.autotermination_minutes	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes	*compute.AwsAttributes	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.availability	compute.AwsAvailability	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.ebs_volume_count	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.ebs_volume_iops	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.ebs_volume_size	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.ebs_volume_throughput	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.ebs_volume_type	compute.EbsVolumeType	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.instance_profile_arn	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.spot_bid_price_percent	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.aws_attributes.zone_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes	*compute.AzureAttributes	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes.availability	compute.AzureAvailability	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_primary_key	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_workspace_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.azure_attributes.spot_bid_max_price	float64	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf	*compute.ClusterLogConf	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.dbfs.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3	*compute.S3StorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.canned_acl	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.enable_encryption	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.encryption_type	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.endpoint	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.kms_key	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.s3.region	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_log_conf.volumes.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.cluster_name	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.custom_tags	map[string]string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.custom_tags[0]	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.data_security_mode	compute.DataSecurityMode	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.docker_image	*compute.DockerImage	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.docker_image.basic_auth	*compute.DockerBasicAuth	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.docker_image.basic_auth.password	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.docker_image.basic_auth.username	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.docker_image.url	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.driver_instance_pool_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.driver_node_type_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.enable_elastic_disk	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.enable_local_disk_encryption	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes	*compute.GcpAttributes	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.availability	compute.GcpAvailability	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.boot_disk_size	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.google_service_account	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.local_ssd_count	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.use_preemptible_executors	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.gcp_attributes.zone_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts	[]compute.InitScriptInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0]	compute.InitScriptInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].abfss	*compute.Adlsgen2Info	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].abfss.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].dbfs.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].file	*compute.LocalFileInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].file.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].gcs	*compute.GcsStorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].gcs.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3	*compute.S3StorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.canned_acl	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.enable_encryption	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.encryption_type	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.endpoint	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.kms_key	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].s3.region	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].volumes.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].workspace	*compute.WorkspaceStorageInfo	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.init_scripts[0].workspace.destination	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.instance_pool_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.is_single_node	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.kind	compute.Kind	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.node_type_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.num_workers	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.policy_id	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.remote_disk_throughput	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.runtime_engine	compute.RuntimeEngine	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.single_user_name	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.spark_conf	map[string]string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.spark_conf[0]	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.spark_env_vars	map[string]string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.spark_env_vars[0]	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.spark_version	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.ssh_public_keys	[]string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.ssh_public_keys[0]	string	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.total_initial_remote_disk_size	int	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.use_ml_runtime	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.workload_type	*compute.WorkloadType	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.workload_type.clients	compute.ClientsTypes	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.workload_type.clients.jobs	bool	INPUT	STATE
+resources.jobs.*.job_clusters[0].new_cluster.workload_type.clients.notebooks	bool	INPUT	STATE
+resources.jobs.*.job_id	int64	REMOTE
+resources.jobs.*.max_concurrent_runs	int	INPUT	STATE
+resources.jobs.*.modified_status	string	INPUT
+resources.jobs.*.name	string	INPUT	STATE
+resources.jobs.*.next_page_token	string	REMOTE
+resources.jobs.*.notification_settings	*jobs.JobNotificationSettings	INPUT	STATE
+resources.jobs.*.notification_settings.no_alert_for_canceled_runs	bool	INPUT	STATE
+resources.jobs.*.notification_settings.no_alert_for_skipped_runs	bool	INPUT	STATE
+resources.jobs.*.parameters	[]jobs.JobParameterDefinition	INPUT	STATE
+resources.jobs.*.parameters[0]	jobs.JobParameterDefinition	INPUT	STATE
+resources.jobs.*.parameters[0].default	string	INPUT	STATE
+resources.jobs.*.parameters[0].name	string	INPUT	STATE
+resources.jobs.*.performance_target	jobs.PerformanceTarget	INPUT	STATE
+resources.jobs.*.permissions	[]resources.JobPermission	INPUT
+resources.jobs.*.permissions[0]	resources.JobPermission	INPUT
+resources.jobs.*.permissions[0].group_name	string	INPUT
+resources.jobs.*.permissions[0].level	resources.JobPermissionLevel	INPUT
+resources.jobs.*.permissions[0].service_principal_name	string	INPUT
+resources.jobs.*.permissions[0].user_name	string	INPUT
+resources.jobs.*.queue	*jobs.QueueSettings	INPUT	STATE
+resources.jobs.*.queue.enabled	bool	INPUT	STATE
+resources.jobs.*.run_as	*jobs.JobRunAs	INPUT	STATE
+resources.jobs.*.run_as.service_principal_name	string	INPUT	STATE
+resources.jobs.*.run_as.user_name	string	INPUT	STATE
+resources.jobs.*.run_as_user_name	string	REMOTE
+resources.jobs.*.schedule	*jobs.CronSchedule	INPUT	STATE
+resources.jobs.*.schedule.pause_status	jobs.PauseStatus	INPUT	STATE
+resources.jobs.*.schedule.quartz_cron_expression	string	INPUT	STATE
+resources.jobs.*.schedule.timezone_id	string	INPUT	STATE
+resources.jobs.*.settings	*jobs.JobSettings	REMOTE
+resources.jobs.*.settings.budget_policy_id	string	REMOTE
+resources.jobs.*.settings.continuous	*jobs.Continuous	REMOTE
+resources.jobs.*.settings.continuous.pause_status	jobs.PauseStatus	REMOTE
+resources.jobs.*.settings.continuous.task_retry_mode	jobs.TaskRetryMode	REMOTE
+resources.jobs.*.settings.deployment	*jobs.JobDeployment	REMOTE
+resources.jobs.*.settings.deployment.kind	jobs.JobDeploymentKind	REMOTE
+resources.jobs.*.settings.deployment.metadata_file_path	string	REMOTE
+resources.jobs.*.settings.description	string	REMOTE
+resources.jobs.*.settings.edit_mode	jobs.JobEditMode	REMOTE
+resources.jobs.*.settings.email_notifications	*jobs.JobEmailNotifications	REMOTE
+resources.jobs.*.settings.email_notifications.no_alert_for_skipped_runs	bool	REMOTE
+resources.jobs.*.settings.email_notifications.on_duration_warning_threshold_exceeded	[]string	REMOTE
+resources.jobs.*.settings.email_notifications.on_duration_warning_threshold_exceeded[0]	string	REMOTE
+resources.jobs.*.settings.email_notifications.on_failure	[]string	REMOTE
+resources.jobs.*.settings.email_notifications.on_failure[0]	string	REMOTE
+resources.jobs.*.settings.email_notifications.on_start	[]string	REMOTE
+resources.jobs.*.settings.email_notifications.on_start[0]	string	REMOTE
+resources.jobs.*.settings.email_notifications.on_streaming_backlog_exceeded	[]string	REMOTE
+resources.jobs.*.settings.email_notifications.on_streaming_backlog_exceeded[0]	string	REMOTE
+resources.jobs.*.settings.email_notifications.on_success	[]string	REMOTE
+resources.jobs.*.settings.email_notifications.on_success[0]	string	REMOTE
+resources.jobs.*.settings.environments	[]jobs.JobEnvironment	REMOTE
+resources.jobs.*.settings.environments[0]	jobs.JobEnvironment	REMOTE
+resources.jobs.*.settings.environments[0].environment_key	string	REMOTE
+resources.jobs.*.settings.environments[0].spec	*compute.Environment	REMOTE
+resources.jobs.*.settings.environments[0].spec.client	string	REMOTE
+resources.jobs.*.settings.environments[0].spec.dependencies	[]string	REMOTE
+resources.jobs.*.settings.environments[0].spec.dependencies[0]	string	REMOTE
+resources.jobs.*.settings.environments[0].spec.environment_version	string	REMOTE
+resources.jobs.*.settings.environments[0].spec.jar_dependencies	[]string	REMOTE
+resources.jobs.*.settings.environments[0].spec.jar_dependencies[0]	string	REMOTE
+resources.jobs.*.settings.format	jobs.Format	REMOTE
+resources.jobs.*.settings.git_source	*jobs.GitSource	REMOTE
+resources.jobs.*.settings.git_source.git_branch	string	REMOTE
+resources.jobs.*.settings.git_source.git_commit	string	REMOTE
+resources.jobs.*.settings.git_source.git_provider	jobs.GitProvider	REMOTE
+resources.jobs.*.settings.git_source.git_snapshot	*jobs.GitSnapshot	REMOTE
+resources.jobs.*.settings.git_source.git_snapshot.used_commit	string	REMOTE
+resources.jobs.*.settings.git_source.git_tag	string	REMOTE
+resources.jobs.*.settings.git_source.git_url	string	REMOTE
+resources.jobs.*.settings.git_source.job_source	*jobs.JobSource	REMOTE
+resources.jobs.*.settings.git_source.job_source.dirty_state	jobs.JobSourceDirtyState	REMOTE
+resources.jobs.*.settings.git_source.job_source.import_from_git_branch	string	REMOTE
+resources.jobs.*.settings.git_source.job_source.job_config_path	string	REMOTE
+resources.jobs.*.settings.health	*jobs.JobsHealthRules	REMOTE
+resources.jobs.*.settings.health.rules	[]jobs.JobsHealthRule	REMOTE
+resources.jobs.*.settings.health.rules[0]	jobs.JobsHealthRule	REMOTE
+resources.jobs.*.settings.health.rules[0].metric	jobs.JobsHealthMetric	REMOTE
+resources.jobs.*.settings.health.rules[0].op	jobs.JobsHealthOperator	REMOTE
+resources.jobs.*.settings.health.rules[0].value	int64	REMOTE
+resources.jobs.*.settings.job_clusters	[]jobs.JobCluster	REMOTE
+resources.jobs.*.settings.job_clusters[0]	jobs.JobCluster	REMOTE
+resources.jobs.*.settings.job_clusters[0].job_cluster_key	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster	compute.ClusterSpec	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.apply_policy_default_values	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.autoscale	*compute.AutoScale	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.autoscale.max_workers	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.autoscale.min_workers	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.autotermination_minutes	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes	*compute.AwsAttributes	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.availability	compute.AwsAvailability	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.ebs_volume_count	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.ebs_volume_iops	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.ebs_volume_size	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.ebs_volume_throughput	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.ebs_volume_type	compute.EbsVolumeType	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.instance_profile_arn	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.spot_bid_price_percent	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.aws_attributes.zone_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes	*compute.AzureAttributes	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes.availability	compute.AzureAvailability	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_primary_key	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_workspace_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.azure_attributes.spot_bid_max_price	float64	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf	*compute.ClusterLogConf	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.dbfs.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3	*compute.S3StorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.canned_acl	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.enable_encryption	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.encryption_type	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.endpoint	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.kms_key	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.s3.region	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.volumes	*compute.VolumesStorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_log_conf.volumes.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.cluster_name	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.custom_tags	map[string]string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.custom_tags[0]	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.data_security_mode	compute.DataSecurityMode	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.docker_image	*compute.DockerImage	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.docker_image.basic_auth	*compute.DockerBasicAuth	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.docker_image.basic_auth.password	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.docker_image.basic_auth.username	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.docker_image.url	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.driver_instance_pool_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.driver_node_type_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.enable_elastic_disk	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.enable_local_disk_encryption	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes	*compute.GcpAttributes	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.availability	compute.GcpAvailability	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.boot_disk_size	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.google_service_account	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.local_ssd_count	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.use_preemptible_executors	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.gcp_attributes.zone_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts	[]compute.InitScriptInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0]	compute.InitScriptInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].abfss	*compute.Adlsgen2Info	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].abfss.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].dbfs.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].file	*compute.LocalFileInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].file.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].gcs	*compute.GcsStorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].gcs.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3	*compute.S3StorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.canned_acl	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.enable_encryption	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.encryption_type	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.endpoint	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.kms_key	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].s3.region	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].volumes	*compute.VolumesStorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].volumes.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].workspace	*compute.WorkspaceStorageInfo	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.init_scripts[0].workspace.destination	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.instance_pool_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.is_single_node	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.kind	compute.Kind	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.node_type_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.num_workers	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.policy_id	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.remote_disk_throughput	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.runtime_engine	compute.RuntimeEngine	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.single_user_name	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.spark_conf	map[string]string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.spark_conf[0]	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.spark_env_vars	map[string]string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.spark_env_vars[0]	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.spark_version	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.ssh_public_keys	[]string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.ssh_public_keys[0]	string	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.total_initial_remote_disk_size	int	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.use_ml_runtime	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.workload_type	*compute.WorkloadType	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.workload_type.clients	compute.ClientsTypes	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.workload_type.clients.jobs	bool	REMOTE
+resources.jobs.*.settings.job_clusters[0].new_cluster.workload_type.clients.notebooks	bool	REMOTE
+resources.jobs.*.settings.max_concurrent_runs	int	REMOTE
+resources.jobs.*.settings.name	string	REMOTE
+resources.jobs.*.settings.notification_settings	*jobs.JobNotificationSettings	REMOTE
+resources.jobs.*.settings.notification_settings.no_alert_for_canceled_runs	bool	REMOTE
+resources.jobs.*.settings.notification_settings.no_alert_for_skipped_runs	bool	REMOTE
+resources.jobs.*.settings.parameters	[]jobs.JobParameterDefinition	REMOTE
+resources.jobs.*.settings.parameters[0]	jobs.JobParameterDefinition	REMOTE
+resources.jobs.*.settings.parameters[0].default	string	REMOTE
+resources.jobs.*.settings.parameters[0].name	string	REMOTE
+resources.jobs.*.settings.performance_target	jobs.PerformanceTarget	REMOTE
+resources.jobs.*.settings.queue	*jobs.QueueSettings	REMOTE
+resources.jobs.*.settings.queue.enabled	bool	REMOTE
+resources.jobs.*.settings.run_as	*jobs.JobRunAs	REMOTE
+resources.jobs.*.settings.run_as.service_principal_name	string	REMOTE
+resources.jobs.*.settings.run_as.user_name	string	REMOTE
+resources.jobs.*.settings.schedule	*jobs.CronSchedule	REMOTE
+resources.jobs.*.settings.schedule.pause_status	jobs.PauseStatus	REMOTE
+resources.jobs.*.settings.schedule.quartz_cron_expression	string	REMOTE
+resources.jobs.*.settings.schedule.timezone_id	string	REMOTE
+resources.jobs.*.settings.tags	map[string]string	REMOTE
+resources.jobs.*.settings.tags[0]	string	REMOTE
+resources.jobs.*.settings.tasks	[]jobs.Task	REMOTE
+resources.jobs.*.settings.tasks[0]	jobs.Task	REMOTE
+resources.jobs.*.settings.tasks[0].clean_rooms_notebook_task	*jobs.CleanRoomsNotebookTask	REMOTE
+resources.jobs.*.settings.tasks[0].clean_rooms_notebook_task.clean_room_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].clean_rooms_notebook_task.etag	string	REMOTE
+resources.jobs.*.settings.tasks[0].clean_rooms_notebook_task.notebook_base_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].clean_rooms_notebook_task.notebook_base_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].clean_rooms_notebook_task.notebook_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].condition_task	*jobs.ConditionTask	REMOTE
+resources.jobs.*.settings.tasks[0].condition_task.left	string	REMOTE
+resources.jobs.*.settings.tasks[0].condition_task.op	jobs.ConditionTaskOp	REMOTE
+resources.jobs.*.settings.tasks[0].condition_task.right	string	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task	*jobs.DashboardTask	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.dashboard_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription	*jobs.Subscription	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription.custom_subject	string	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription.paused	bool	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription.subscribers	[]jobs.SubscriptionSubscriber	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription.subscribers[0]	jobs.SubscriptionSubscriber	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription.subscribers[0].destination_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.subscription.subscribers[0].user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].dashboard_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_cloud_task	*jobs.DbtCloudTask	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_cloud_task.connection_resource_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_cloud_task.dbt_cloud_job_id	int64	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_platform_task	*jobs.DbtPlatformTask	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_platform_task.connection_resource_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_platform_task.dbt_platform_job_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task	*jobs.DbtTask	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.catalog	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.commands	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.commands[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.profiles_directory	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.project_directory	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.schema	string	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].dbt_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].depends_on	[]jobs.TaskDependency	REMOTE
+resources.jobs.*.settings.tasks[0].depends_on[0]	jobs.TaskDependency	REMOTE
+resources.jobs.*.settings.tasks[0].depends_on[0].outcome	string	REMOTE
+resources.jobs.*.settings.tasks[0].depends_on[0].task_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].description	string	REMOTE
+resources.jobs.*.settings.tasks[0].disable_auto_optimization	bool	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications	*jobs.TaskEmailNotifications	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.no_alert_for_skipped_runs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_duration_warning_threshold_exceeded	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_duration_warning_threshold_exceeded[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_failure	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_failure[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_start	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_start[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_streaming_backlog_exceeded	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_streaming_backlog_exceeded[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_success	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].email_notifications.on_success[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].environment_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].existing_cluster_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task	*jobs.ForEachTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.concurrency	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.inputs	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task	jobs.Task	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.clean_rooms_notebook_task	*jobs.CleanRoomsNotebookTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.clean_rooms_notebook_task.clean_room_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.clean_rooms_notebook_task.etag	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.clean_rooms_notebook_task.notebook_base_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.clean_rooms_notebook_task.notebook_base_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.clean_rooms_notebook_task.notebook_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.condition_task	*jobs.ConditionTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.condition_task.left	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.condition_task.op	jobs.ConditionTaskOp	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.condition_task.right	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task	*jobs.DashboardTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.dashboard_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription	*jobs.Subscription	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription.custom_subject	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription.paused	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers	[]jobs.SubscriptionSubscriber	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers[0]	jobs.SubscriptionSubscriber	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers[0].destination_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers[0].user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dashboard_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_cloud_task	*jobs.DbtCloudTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_cloud_task.connection_resource_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_cloud_task.dbt_cloud_job_id	int64	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_platform_task	*jobs.DbtPlatformTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_platform_task.connection_resource_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_platform_task.dbt_platform_job_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task	*jobs.DbtTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.catalog	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.commands	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.commands[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.profiles_directory	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.project_directory	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.schema	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.dbt_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.depends_on	[]jobs.TaskDependency	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.depends_on[0]	jobs.TaskDependency	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.depends_on[0].outcome	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.depends_on[0].task_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.description	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.disable_auto_optimization	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications	*jobs.TaskEmailNotifications	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.no_alert_for_skipped_runs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_duration_warning_threshold_exceeded	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_duration_warning_threshold_exceeded[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_failure	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_failure[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_start	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_start[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_streaming_backlog_exceeded	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_streaming_backlog_exceeded[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_success	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.email_notifications.on_success[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.environment_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.existing_cluster_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.for_each_task	*jobs.ForEachTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.for_each_task.concurrency	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.for_each_task.inputs	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.for_each_task.task	jobs.Task	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task	*jobs.GenAiComputeTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.command	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.compute	*jobs.ComputeConfig	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.compute.gpu_node_pool_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.compute.gpu_type	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.compute.num_gpus	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.dl_runtime_image	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.mlflow_experiment_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.training_script_path	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.yaml_parameters	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.gen_ai_compute_task.yaml_parameters_file_path	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.health	*jobs.JobsHealthRules	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.health.rules	[]jobs.JobsHealthRule	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.health.rules[0]	jobs.JobsHealthRule	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.health.rules[0].metric	jobs.JobsHealthMetric	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.health.rules[0].op	jobs.JobsHealthOperator	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.health.rules[0].value	int64	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.job_cluster_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries	[]compute.Library	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0]	compute.Library	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].cran	*compute.RCranLibrary	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].cran.package	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].cran.repo	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].egg	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].jar	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].maven	*compute.MavenLibrary	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].maven.coordinates	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].maven.exclusions	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].maven.exclusions[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].maven.repo	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].pypi	*compute.PythonPyPiLibrary	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].pypi.package	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].pypi.repo	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].requirements	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.libraries[0].whl	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.max_retries	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.min_retry_interval_millis	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster	*compute.ClusterSpec	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.apply_policy_default_values	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.autoscale	*compute.AutoScale	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.autoscale.max_workers	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.autoscale.min_workers	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.autotermination_minutes	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes	*compute.AwsAttributes	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.availability	compute.AwsAvailability	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_count	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_iops	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_size	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_throughput	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_type	compute.EbsVolumeType	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.instance_profile_arn	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.spot_bid_price_percent	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.aws_attributes.zone_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes	*compute.AzureAttributes	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes.availability	compute.AzureAvailability	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes.log_analytics_info.log_analytics_primary_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes.log_analytics_info.log_analytics_workspace_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.azure_attributes.spot_bid_max_price	float64	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf	*compute.ClusterLogConf	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.dbfs.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3	*compute.S3StorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.canned_acl	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.enable_encryption	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.encryption_type	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.endpoint	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.kms_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.region	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.volumes	*compute.VolumesStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.volumes.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.cluster_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.custom_tags	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.custom_tags[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.data_security_mode	compute.DataSecurityMode	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.docker_image	*compute.DockerImage	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.docker_image.basic_auth	*compute.DockerBasicAuth	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.docker_image.basic_auth.password	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.docker_image.basic_auth.username	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.docker_image.url	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.driver_instance_pool_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.driver_node_type_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.enable_elastic_disk	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.enable_local_disk_encryption	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes	*compute.GcpAttributes	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.availability	compute.GcpAvailability	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.boot_disk_size	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.google_service_account	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.local_ssd_count	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.use_preemptible_executors	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.gcp_attributes.zone_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts	[]compute.InitScriptInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0]	compute.InitScriptInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].abfss	*compute.Adlsgen2Info	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].abfss.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].dbfs.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].file	*compute.LocalFileInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].file.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].gcs	*compute.GcsStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].gcs.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3	*compute.S3StorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.canned_acl	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.enable_encryption	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.encryption_type	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.endpoint	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.kms_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.region	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].volumes	*compute.VolumesStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].volumes.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].workspace	*compute.WorkspaceStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.init_scripts[0].workspace.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.instance_pool_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.is_single_node	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.kind	compute.Kind	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.node_type_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.num_workers	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.policy_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.remote_disk_throughput	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.runtime_engine	compute.RuntimeEngine	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.single_user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.spark_conf	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.spark_conf[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.spark_env_vars	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.spark_env_vars[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.spark_version	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.ssh_public_keys	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.ssh_public_keys[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.total_initial_remote_disk_size	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.use_ml_runtime	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.workload_type	*compute.WorkloadType	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.workload_type.clients	compute.ClientsTypes	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.workload_type.clients.jobs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.new_cluster.workload_type.clients.notebooks	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notebook_task	*jobs.NotebookTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notebook_task.base_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notebook_task.base_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notebook_task.notebook_path	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notebook_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notebook_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notification_settings	*jobs.TaskNotificationSettings	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notification_settings.alert_on_last_attempt	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notification_settings.no_alert_for_canceled_runs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.notification_settings.no_alert_for_skipped_runs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.pipeline_task	*jobs.PipelineTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.pipeline_task.full_refresh	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.pipeline_task.pipeline_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task	*jobs.PowerBiTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.connection_resource_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.power_bi_model	*jobs.PowerBiModel	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.power_bi_model.authentication_method	jobs.AuthenticationMethod	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.power_bi_model.model_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.power_bi_model.overwrite_existing	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.power_bi_model.storage_mode	jobs.StorageMode	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.power_bi_model.workspace_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.refresh_after_update	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.tables	[]jobs.PowerBiTable	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.tables[0]	jobs.PowerBiTable	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.tables[0].catalog	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.tables[0].name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.tables[0].schema	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.tables[0].storage_mode	jobs.StorageMode	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.power_bi_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task	*jobs.PythonWheelTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task.entry_point	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task.named_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task.named_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task.package_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.python_wheel_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.retry_on_timeout	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_if	jobs.RunIf	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task	*jobs.RunJobTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.dbt_commands	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.dbt_commands[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.jar_params	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.jar_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.job_id	int64	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.job_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.job_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.notebook_params	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.notebook_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.pipeline_params	*jobs.PipelineParams	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.pipeline_params.full_refresh	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.python_named_params	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.python_named_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.python_params	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.python_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.spark_submit_params	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.spark_submit_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.sql_params	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.run_job_task.sql_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_jar_task	*jobs.SparkJarTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_jar_task.jar_uri	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_jar_task.main_class_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_jar_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_jar_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_jar_task.run_as_repl	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_python_task	*jobs.SparkPythonTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_python_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_python_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_python_task.python_file	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_python_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_submit_task	*jobs.SparkSubmitTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_submit_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.spark_submit_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task	*jobs.SqlTask	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert	*jobs.SqlTaskAlert	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert.alert_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert.pause_subscriptions	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert.subscriptions	[]jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert.subscriptions[0]	jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert.subscriptions[0].destination_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.alert.subscriptions[0].user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard	*jobs.SqlTaskDashboard	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.custom_subject	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.dashboard_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.pause_subscriptions	bool	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions	[]jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions[0]	jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions[0].destination_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions[0].user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.file	*jobs.SqlTaskFile	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.file.path	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.file.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.query	*jobs.SqlTaskQuery	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.query.query_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.sql_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.task_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.timeout_seconds	int	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications	*jobs.WebhookNotifications	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_duration_warning_threshold_exceeded	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_duration_warning_threshold_exceeded[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_duration_warning_threshold_exceeded[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_failure	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_failure[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_failure[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_start	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_start[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_start[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_streaming_backlog_exceeded	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_streaming_backlog_exceeded[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_streaming_backlog_exceeded[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_success	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_success[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].for_each_task.task.webhook_notifications.on_success[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task	*jobs.GenAiComputeTask	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.command	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.compute	*jobs.ComputeConfig	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.compute.gpu_node_pool_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.compute.gpu_type	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.compute.num_gpus	int	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.dl_runtime_image	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.mlflow_experiment_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.training_script_path	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.yaml_parameters	string	REMOTE
+resources.jobs.*.settings.tasks[0].gen_ai_compute_task.yaml_parameters_file_path	string	REMOTE
+resources.jobs.*.settings.tasks[0].health	*jobs.JobsHealthRules	REMOTE
+resources.jobs.*.settings.tasks[0].health.rules	[]jobs.JobsHealthRule	REMOTE
+resources.jobs.*.settings.tasks[0].health.rules[0]	jobs.JobsHealthRule	REMOTE
+resources.jobs.*.settings.tasks[0].health.rules[0].metric	jobs.JobsHealthMetric	REMOTE
+resources.jobs.*.settings.tasks[0].health.rules[0].op	jobs.JobsHealthOperator	REMOTE
+resources.jobs.*.settings.tasks[0].health.rules[0].value	int64	REMOTE
+resources.jobs.*.settings.tasks[0].job_cluster_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries	[]compute.Library	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0]	compute.Library	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].cran	*compute.RCranLibrary	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].cran.package	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].cran.repo	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].egg	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].jar	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].maven	*compute.MavenLibrary	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].maven.coordinates	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].maven.exclusions	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].maven.exclusions[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].maven.repo	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].pypi	*compute.PythonPyPiLibrary	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].pypi.package	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].pypi.repo	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].requirements	string	REMOTE
+resources.jobs.*.settings.tasks[0].libraries[0].whl	string	REMOTE
+resources.jobs.*.settings.tasks[0].max_retries	int	REMOTE
+resources.jobs.*.settings.tasks[0].min_retry_interval_millis	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster	*compute.ClusterSpec	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.apply_policy_default_values	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.autoscale	*compute.AutoScale	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.autoscale.max_workers	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.autoscale.min_workers	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.autotermination_minutes	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes	*compute.AwsAttributes	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.availability	compute.AwsAvailability	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.ebs_volume_count	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.ebs_volume_iops	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.ebs_volume_size	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.ebs_volume_throughput	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.ebs_volume_type	compute.EbsVolumeType	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.instance_profile_arn	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.spot_bid_price_percent	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.aws_attributes.zone_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes	*compute.AzureAttributes	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes.availability	compute.AzureAvailability	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_primary_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_workspace_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.azure_attributes.spot_bid_max_price	float64	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf	*compute.ClusterLogConf	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.dbfs.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3	*compute.S3StorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.canned_acl	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.enable_encryption	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.encryption_type	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.endpoint	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.kms_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.s3.region	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.volumes	*compute.VolumesStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_log_conf.volumes.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.cluster_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.custom_tags	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.custom_tags[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.data_security_mode	compute.DataSecurityMode	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.docker_image	*compute.DockerImage	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.docker_image.basic_auth	*compute.DockerBasicAuth	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.docker_image.basic_auth.password	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.docker_image.basic_auth.username	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.docker_image.url	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.driver_instance_pool_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.driver_node_type_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.enable_elastic_disk	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.enable_local_disk_encryption	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes	*compute.GcpAttributes	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.availability	compute.GcpAvailability	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.boot_disk_size	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.first_on_demand	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.google_service_account	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.local_ssd_count	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.use_preemptible_executors	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.gcp_attributes.zone_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts	[]compute.InitScriptInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0]	compute.InitScriptInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].abfss	*compute.Adlsgen2Info	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].abfss.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].dbfs.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].file	*compute.LocalFileInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].file.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].gcs	*compute.GcsStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].gcs.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3	*compute.S3StorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.canned_acl	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.enable_encryption	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.encryption_type	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.endpoint	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.kms_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].s3.region	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].volumes	*compute.VolumesStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].volumes.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].workspace	*compute.WorkspaceStorageInfo	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.init_scripts[0].workspace.destination	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.instance_pool_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.is_single_node	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.kind	compute.Kind	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.node_type_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.num_workers	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.policy_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.remote_disk_throughput	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.runtime_engine	compute.RuntimeEngine	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.single_user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.spark_conf	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.spark_conf[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.spark_env_vars	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.spark_env_vars[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.spark_version	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.ssh_public_keys	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.ssh_public_keys[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.total_initial_remote_disk_size	int	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.use_ml_runtime	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.workload_type	*compute.WorkloadType	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.workload_type.clients	compute.ClientsTypes	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.workload_type.clients.jobs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].new_cluster.workload_type.clients.notebooks	bool	REMOTE
+resources.jobs.*.settings.tasks[0].notebook_task	*jobs.NotebookTask	REMOTE
+resources.jobs.*.settings.tasks[0].notebook_task.base_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].notebook_task.base_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].notebook_task.notebook_path	string	REMOTE
+resources.jobs.*.settings.tasks[0].notebook_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].notebook_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].notification_settings	*jobs.TaskNotificationSettings	REMOTE
+resources.jobs.*.settings.tasks[0].notification_settings.alert_on_last_attempt	bool	REMOTE
+resources.jobs.*.settings.tasks[0].notification_settings.no_alert_for_canceled_runs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].notification_settings.no_alert_for_skipped_runs	bool	REMOTE
+resources.jobs.*.settings.tasks[0].pipeline_task	*jobs.PipelineTask	REMOTE
+resources.jobs.*.settings.tasks[0].pipeline_task.full_refresh	bool	REMOTE
+resources.jobs.*.settings.tasks[0].pipeline_task.pipeline_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task	*jobs.PowerBiTask	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.connection_resource_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.power_bi_model	*jobs.PowerBiModel	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.power_bi_model.authentication_method	jobs.AuthenticationMethod	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.power_bi_model.model_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.power_bi_model.overwrite_existing	bool	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.power_bi_model.storage_mode	jobs.StorageMode	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.power_bi_model.workspace_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.refresh_after_update	bool	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.tables	[]jobs.PowerBiTable	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.tables[0]	jobs.PowerBiTable	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.tables[0].catalog	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.tables[0].name	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.tables[0].schema	string	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.tables[0].storage_mode	jobs.StorageMode	REMOTE
+resources.jobs.*.settings.tasks[0].power_bi_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task	*jobs.PythonWheelTask	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task.entry_point	string	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task.named_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task.named_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task.package_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].python_wheel_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].retry_on_timeout	bool	REMOTE
+resources.jobs.*.settings.tasks[0].run_if	jobs.RunIf	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task	*jobs.RunJobTask	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.dbt_commands	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.dbt_commands[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.jar_params	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.jar_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.job_id	int64	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.job_parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.job_parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.notebook_params	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.notebook_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.pipeline_params	*jobs.PipelineParams	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.pipeline_params.full_refresh	bool	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.python_named_params	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.python_named_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.python_params	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.python_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.spark_submit_params	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.spark_submit_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.sql_params	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].run_job_task.sql_params[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_jar_task	*jobs.SparkJarTask	REMOTE
+resources.jobs.*.settings.tasks[0].spark_jar_task.jar_uri	string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_jar_task.main_class_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_jar_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_jar_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_jar_task.run_as_repl	bool	REMOTE
+resources.jobs.*.settings.tasks[0].spark_python_task	*jobs.SparkPythonTask	REMOTE
+resources.jobs.*.settings.tasks[0].spark_python_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_python_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_python_task.python_file	string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_python_task.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].spark_submit_task	*jobs.SparkSubmitTask	REMOTE
+resources.jobs.*.settings.tasks[0].spark_submit_task.parameters	[]string	REMOTE
+resources.jobs.*.settings.tasks[0].spark_submit_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task	*jobs.SqlTask	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert	*jobs.SqlTaskAlert	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert.alert_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert.pause_subscriptions	bool	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert.subscriptions	[]jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert.subscriptions[0]	jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert.subscriptions[0].destination_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.alert.subscriptions[0].user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard	*jobs.SqlTaskDashboard	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.custom_subject	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.dashboard_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.pause_subscriptions	bool	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.subscriptions	[]jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.subscriptions[0]	jobs.SqlTaskSubscription	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.subscriptions[0].destination_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.dashboard.subscriptions[0].user_name	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.file	*jobs.SqlTaskFile	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.file.path	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.file.source	jobs.Source	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.parameters	map[string]string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.parameters[0]	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.query	*jobs.SqlTaskQuery	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.query.query_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].sql_task.warehouse_id	string	REMOTE
+resources.jobs.*.settings.tasks[0].task_key	string	REMOTE
+resources.jobs.*.settings.tasks[0].timeout_seconds	int	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications	*jobs.WebhookNotifications	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_duration_warning_threshold_exceeded	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_duration_warning_threshold_exceeded[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_duration_warning_threshold_exceeded[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_failure	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_failure[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_failure[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_start	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_start[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_start[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_streaming_backlog_exceeded	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_streaming_backlog_exceeded[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_streaming_backlog_exceeded[0].id	string	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_success	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_success[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.tasks[0].webhook_notifications.on_success[0].id	string	REMOTE
+resources.jobs.*.settings.timeout_seconds	int	REMOTE
+resources.jobs.*.settings.trigger	*jobs.TriggerSettings	REMOTE
+resources.jobs.*.settings.trigger.file_arrival	*jobs.FileArrivalTriggerConfiguration	REMOTE
+resources.jobs.*.settings.trigger.file_arrival.min_time_between_triggers_seconds	int	REMOTE
+resources.jobs.*.settings.trigger.file_arrival.url	string	REMOTE
+resources.jobs.*.settings.trigger.file_arrival.wait_after_last_change_seconds	int	REMOTE
+resources.jobs.*.settings.trigger.pause_status	jobs.PauseStatus	REMOTE
+resources.jobs.*.settings.trigger.periodic	*jobs.PeriodicTriggerConfiguration	REMOTE
+resources.jobs.*.settings.trigger.periodic.interval	int	REMOTE
+resources.jobs.*.settings.trigger.periodic.unit	jobs.PeriodicTriggerConfigurationTimeUnit	REMOTE
+resources.jobs.*.settings.trigger.table	*jobs.TableUpdateTriggerConfiguration	REMOTE
+resources.jobs.*.settings.trigger.table.condition	jobs.Condition	REMOTE
+resources.jobs.*.settings.trigger.table.min_time_between_triggers_seconds	int	REMOTE
+resources.jobs.*.settings.trigger.table.table_names	[]string	REMOTE
+resources.jobs.*.settings.trigger.table.table_names[0]	string	REMOTE
+resources.jobs.*.settings.trigger.table.wait_after_last_change_seconds	int	REMOTE
+resources.jobs.*.settings.trigger.table_update	*jobs.TableUpdateTriggerConfiguration	REMOTE
+resources.jobs.*.settings.trigger.table_update.condition	jobs.Condition	REMOTE
+resources.jobs.*.settings.trigger.table_update.min_time_between_triggers_seconds	int	REMOTE
+resources.jobs.*.settings.trigger.table_update.table_names	[]string	REMOTE
+resources.jobs.*.settings.trigger.table_update.table_names[0]	string	REMOTE
+resources.jobs.*.settings.trigger.table_update.wait_after_last_change_seconds	int	REMOTE
+resources.jobs.*.settings.usage_policy_id	string	REMOTE
+resources.jobs.*.settings.webhook_notifications	*jobs.WebhookNotifications	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_duration_warning_threshold_exceeded	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_duration_warning_threshold_exceeded[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_duration_warning_threshold_exceeded[0].id	string	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_failure	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_failure[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_failure[0].id	string	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_start	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_start[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_start[0].id	string	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_streaming_backlog_exceeded	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_streaming_backlog_exceeded[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_streaming_backlog_exceeded[0].id	string	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_success	[]jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_success[0]	jobs.Webhook	REMOTE
+resources.jobs.*.settings.webhook_notifications.on_success[0].id	string	REMOTE
+resources.jobs.*.tags	map[string]string	INPUT	STATE
+resources.jobs.*.tags[0]	string	INPUT	STATE
+resources.jobs.*.tasks	[]jobs.Task	INPUT	STATE
+resources.jobs.*.tasks[0]	jobs.Task	INPUT	STATE
+resources.jobs.*.tasks[0].clean_rooms_notebook_task	*jobs.CleanRoomsNotebookTask	INPUT	STATE
+resources.jobs.*.tasks[0].clean_rooms_notebook_task.clean_room_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].clean_rooms_notebook_task.etag	string	INPUT	STATE
+resources.jobs.*.tasks[0].clean_rooms_notebook_task.notebook_base_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].clean_rooms_notebook_task.notebook_base_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].clean_rooms_notebook_task.notebook_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].condition_task	*jobs.ConditionTask	INPUT	STATE
+resources.jobs.*.tasks[0].condition_task.left	string	INPUT	STATE
+resources.jobs.*.tasks[0].condition_task.op	jobs.ConditionTaskOp	INPUT	STATE
+resources.jobs.*.tasks[0].condition_task.right	string	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task	*jobs.DashboardTask	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.dashboard_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription	*jobs.Subscription	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription.custom_subject	string	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription.paused	bool	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription.subscribers	[]jobs.SubscriptionSubscriber	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription.subscribers[0]	jobs.SubscriptionSubscriber	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription.subscribers[0].destination_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.subscription.subscribers[0].user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].dashboard_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_cloud_task	*jobs.DbtCloudTask	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_cloud_task.connection_resource_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_cloud_task.dbt_cloud_job_id	int64	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_platform_task	*jobs.DbtPlatformTask	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_platform_task.connection_resource_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_platform_task.dbt_platform_job_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task	*jobs.DbtTask	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.catalog	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.commands	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.commands[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.profiles_directory	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.project_directory	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.schema	string	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].dbt_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].depends_on	[]jobs.TaskDependency	INPUT	STATE
+resources.jobs.*.tasks[0].depends_on[0]	jobs.TaskDependency	INPUT	STATE
+resources.jobs.*.tasks[0].depends_on[0].outcome	string	INPUT	STATE
+resources.jobs.*.tasks[0].depends_on[0].task_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].description	string	INPUT	STATE
+resources.jobs.*.tasks[0].disable_auto_optimization	bool	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications	*jobs.TaskEmailNotifications	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.no_alert_for_skipped_runs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_duration_warning_threshold_exceeded	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_duration_warning_threshold_exceeded[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_failure	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_failure[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_start	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_start[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_streaming_backlog_exceeded	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_streaming_backlog_exceeded[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_success	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].email_notifications.on_success[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].environment_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].existing_cluster_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task	*jobs.ForEachTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.concurrency	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.inputs	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task	jobs.Task	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.clean_rooms_notebook_task	*jobs.CleanRoomsNotebookTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.clean_rooms_notebook_task.clean_room_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.clean_rooms_notebook_task.etag	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.clean_rooms_notebook_task.notebook_base_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.clean_rooms_notebook_task.notebook_base_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.clean_rooms_notebook_task.notebook_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.condition_task	*jobs.ConditionTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.condition_task.left	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.condition_task.op	jobs.ConditionTaskOp	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.condition_task.right	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task	*jobs.DashboardTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.dashboard_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription	*jobs.Subscription	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription.custom_subject	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription.paused	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers	[]jobs.SubscriptionSubscriber	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers[0]	jobs.SubscriptionSubscriber	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers[0].destination_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.subscription.subscribers[0].user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dashboard_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_cloud_task	*jobs.DbtCloudTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_cloud_task.connection_resource_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_cloud_task.dbt_cloud_job_id	int64	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_platform_task	*jobs.DbtPlatformTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_platform_task.connection_resource_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_platform_task.dbt_platform_job_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task	*jobs.DbtTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.catalog	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.commands	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.commands[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.profiles_directory	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.project_directory	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.schema	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.dbt_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.depends_on	[]jobs.TaskDependency	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.depends_on[0]	jobs.TaskDependency	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.depends_on[0].outcome	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.depends_on[0].task_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.description	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.disable_auto_optimization	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications	*jobs.TaskEmailNotifications	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.no_alert_for_skipped_runs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_duration_warning_threshold_exceeded	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_duration_warning_threshold_exceeded[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_failure	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_failure[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_start	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_start[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_streaming_backlog_exceeded	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_streaming_backlog_exceeded[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_success	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.email_notifications.on_success[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.environment_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.existing_cluster_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.for_each_task	*jobs.ForEachTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.for_each_task.concurrency	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.for_each_task.inputs	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.for_each_task.task	jobs.Task	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task	*jobs.GenAiComputeTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.command	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.compute	*jobs.ComputeConfig	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.compute.gpu_node_pool_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.compute.gpu_type	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.compute.num_gpus	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.dl_runtime_image	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.mlflow_experiment_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.training_script_path	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.yaml_parameters	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.gen_ai_compute_task.yaml_parameters_file_path	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.health	*jobs.JobsHealthRules	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.health.rules	[]jobs.JobsHealthRule	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.health.rules[0]	jobs.JobsHealthRule	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.health.rules[0].metric	jobs.JobsHealthMetric	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.health.rules[0].op	jobs.JobsHealthOperator	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.health.rules[0].value	int64	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.job_cluster_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries	[]compute.Library	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0]	compute.Library	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].cran	*compute.RCranLibrary	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].cran.package	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].cran.repo	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].egg	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].jar	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].maven	*compute.MavenLibrary	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].maven.coordinates	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].maven.exclusions	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].maven.exclusions[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].maven.repo	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].pypi	*compute.PythonPyPiLibrary	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].pypi.package	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].pypi.repo	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].requirements	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.libraries[0].whl	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.max_retries	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.min_retry_interval_millis	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster	*compute.ClusterSpec	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.apply_policy_default_values	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.autoscale	*compute.AutoScale	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.autoscale.max_workers	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.autoscale.min_workers	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.autotermination_minutes	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes	*compute.AwsAttributes	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.availability	compute.AwsAvailability	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_count	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_iops	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_size	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_throughput	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.ebs_volume_type	compute.EbsVolumeType	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.instance_profile_arn	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.spot_bid_price_percent	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.aws_attributes.zone_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes	*compute.AzureAttributes	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes.availability	compute.AzureAvailability	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes.log_analytics_info.log_analytics_primary_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes.log_analytics_info.log_analytics_workspace_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.azure_attributes.spot_bid_max_price	float64	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf	*compute.ClusterLogConf	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.dbfs.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3	*compute.S3StorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.canned_acl	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.enable_encryption	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.encryption_type	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.endpoint	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.kms_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.s3.region	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_log_conf.volumes.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.cluster_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.custom_tags	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.custom_tags[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.data_security_mode	compute.DataSecurityMode	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.docker_image	*compute.DockerImage	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.docker_image.basic_auth	*compute.DockerBasicAuth	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.docker_image.basic_auth.password	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.docker_image.basic_auth.username	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.docker_image.url	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.driver_instance_pool_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.driver_node_type_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.enable_elastic_disk	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.enable_local_disk_encryption	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes	*compute.GcpAttributes	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.availability	compute.GcpAvailability	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.boot_disk_size	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.google_service_account	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.local_ssd_count	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.use_preemptible_executors	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.gcp_attributes.zone_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts	[]compute.InitScriptInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0]	compute.InitScriptInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].abfss	*compute.Adlsgen2Info	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].abfss.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].dbfs.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].file	*compute.LocalFileInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].file.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].gcs	*compute.GcsStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].gcs.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3	*compute.S3StorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.canned_acl	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.enable_encryption	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.encryption_type	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.endpoint	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.kms_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].s3.region	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].volumes.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].workspace	*compute.WorkspaceStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.init_scripts[0].workspace.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.instance_pool_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.is_single_node	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.kind	compute.Kind	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.node_type_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.num_workers	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.policy_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.remote_disk_throughput	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.runtime_engine	compute.RuntimeEngine	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.single_user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.spark_conf	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.spark_conf[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.spark_env_vars	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.spark_env_vars[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.spark_version	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.ssh_public_keys	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.ssh_public_keys[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.total_initial_remote_disk_size	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.use_ml_runtime	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.workload_type	*compute.WorkloadType	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.workload_type.clients	compute.ClientsTypes	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.workload_type.clients.jobs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.new_cluster.workload_type.clients.notebooks	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notebook_task	*jobs.NotebookTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notebook_task.base_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notebook_task.base_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notebook_task.notebook_path	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notebook_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notebook_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notification_settings	*jobs.TaskNotificationSettings	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notification_settings.alert_on_last_attempt	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notification_settings.no_alert_for_canceled_runs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.notification_settings.no_alert_for_skipped_runs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.pipeline_task	*jobs.PipelineTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.pipeline_task.full_refresh	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.pipeline_task.pipeline_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task	*jobs.PowerBiTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.connection_resource_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.power_bi_model	*jobs.PowerBiModel	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.power_bi_model.authentication_method	jobs.AuthenticationMethod	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.power_bi_model.model_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.power_bi_model.overwrite_existing	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.power_bi_model.storage_mode	jobs.StorageMode	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.power_bi_model.workspace_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.refresh_after_update	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.tables	[]jobs.PowerBiTable	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.tables[0]	jobs.PowerBiTable	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.tables[0].catalog	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.tables[0].name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.tables[0].schema	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.tables[0].storage_mode	jobs.StorageMode	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.power_bi_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task	*jobs.PythonWheelTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task.entry_point	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task.named_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task.named_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task.package_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.python_wheel_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.retry_on_timeout	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_if	jobs.RunIf	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task	*jobs.RunJobTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.dbt_commands	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.dbt_commands[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.jar_params	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.jar_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.job_id	int64	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.job_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.job_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.notebook_params	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.notebook_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.pipeline_params	*jobs.PipelineParams	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.pipeline_params.full_refresh	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.python_named_params	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.python_named_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.python_params	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.python_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.spark_submit_params	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.spark_submit_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.sql_params	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.run_job_task.sql_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_jar_task	*jobs.SparkJarTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_jar_task.jar_uri	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_jar_task.main_class_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_jar_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_jar_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_jar_task.run_as_repl	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_python_task	*jobs.SparkPythonTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_python_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_python_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_python_task.python_file	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_python_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_submit_task	*jobs.SparkSubmitTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_submit_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.spark_submit_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task	*jobs.SqlTask	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert	*jobs.SqlTaskAlert	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert.alert_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert.pause_subscriptions	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert.subscriptions	[]jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert.subscriptions[0]	jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert.subscriptions[0].destination_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.alert.subscriptions[0].user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard	*jobs.SqlTaskDashboard	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.custom_subject	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.dashboard_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.pause_subscriptions	bool	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions	[]jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions[0]	jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions[0].destination_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.dashboard.subscriptions[0].user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.file	*jobs.SqlTaskFile	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.file.path	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.file.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.query	*jobs.SqlTaskQuery	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.query.query_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.sql_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.task_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.timeout_seconds	int	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications	*jobs.WebhookNotifications	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_duration_warning_threshold_exceeded	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_duration_warning_threshold_exceeded[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_duration_warning_threshold_exceeded[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_failure	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_failure[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_failure[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_start	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_start[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_start[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_streaming_backlog_exceeded	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_streaming_backlog_exceeded[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_streaming_backlog_exceeded[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_success	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_success[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].for_each_task.task.webhook_notifications.on_success[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task	*jobs.GenAiComputeTask	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.command	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.compute	*jobs.ComputeConfig	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.compute.gpu_node_pool_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.compute.gpu_type	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.compute.num_gpus	int	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.dl_runtime_image	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.mlflow_experiment_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.training_script_path	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.yaml_parameters	string	INPUT	STATE
+resources.jobs.*.tasks[0].gen_ai_compute_task.yaml_parameters_file_path	string	INPUT	STATE
+resources.jobs.*.tasks[0].health	*jobs.JobsHealthRules	INPUT	STATE
+resources.jobs.*.tasks[0].health.rules	[]jobs.JobsHealthRule	INPUT	STATE
+resources.jobs.*.tasks[0].health.rules[0]	jobs.JobsHealthRule	INPUT	STATE
+resources.jobs.*.tasks[0].health.rules[0].metric	jobs.JobsHealthMetric	INPUT	STATE
+resources.jobs.*.tasks[0].health.rules[0].op	jobs.JobsHealthOperator	INPUT	STATE
+resources.jobs.*.tasks[0].health.rules[0].value	int64	INPUT	STATE
+resources.jobs.*.tasks[0].job_cluster_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries	[]compute.Library	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0]	compute.Library	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].cran	*compute.RCranLibrary	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].cran.package	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].cran.repo	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].egg	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].jar	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].maven	*compute.MavenLibrary	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].maven.coordinates	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].maven.exclusions	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].maven.exclusions[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].maven.repo	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].pypi	*compute.PythonPyPiLibrary	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].pypi.package	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].pypi.repo	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].requirements	string	INPUT	STATE
+resources.jobs.*.tasks[0].libraries[0].whl	string	INPUT	STATE
+resources.jobs.*.tasks[0].max_retries	int	INPUT	STATE
+resources.jobs.*.tasks[0].min_retry_interval_millis	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster	*compute.ClusterSpec	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.apply_policy_default_values	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.autoscale	*compute.AutoScale	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.autoscale.max_workers	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.autoscale.min_workers	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.autotermination_minutes	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes	*compute.AwsAttributes	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.availability	compute.AwsAvailability	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.ebs_volume_count	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.ebs_volume_iops	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.ebs_volume_size	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.ebs_volume_throughput	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.ebs_volume_type	compute.EbsVolumeType	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.instance_profile_arn	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.spot_bid_price_percent	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.aws_attributes.zone_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes	*compute.AzureAttributes	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes.availability	compute.AzureAvailability	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_primary_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes.log_analytics_info.log_analytics_workspace_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.azure_attributes.spot_bid_max_price	float64	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf	*compute.ClusterLogConf	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.dbfs.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3	*compute.S3StorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.canned_acl	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.enable_encryption	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.encryption_type	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.endpoint	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.kms_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.s3.region	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_log_conf.volumes.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.cluster_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.custom_tags	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.custom_tags[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.data_security_mode	compute.DataSecurityMode	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.docker_image	*compute.DockerImage	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.docker_image.basic_auth	*compute.DockerBasicAuth	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.docker_image.basic_auth.password	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.docker_image.basic_auth.username	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.docker_image.url	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.driver_instance_pool_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.driver_node_type_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.enable_elastic_disk	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.enable_local_disk_encryption	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes	*compute.GcpAttributes	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.availability	compute.GcpAvailability	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.boot_disk_size	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.first_on_demand	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.google_service_account	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.local_ssd_count	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.use_preemptible_executors	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.gcp_attributes.zone_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts	[]compute.InitScriptInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0]	compute.InitScriptInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].abfss	*compute.Adlsgen2Info	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].abfss.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].dbfs.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].file	*compute.LocalFileInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].file.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].gcs	*compute.GcsStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].gcs.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3	*compute.S3StorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.canned_acl	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.enable_encryption	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.encryption_type	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.endpoint	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.kms_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].s3.region	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].volumes.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].workspace	*compute.WorkspaceStorageInfo	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.init_scripts[0].workspace.destination	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.instance_pool_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.is_single_node	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.kind	compute.Kind	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.node_type_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.num_workers	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.policy_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.remote_disk_throughput	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.runtime_engine	compute.RuntimeEngine	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.single_user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.spark_conf	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.spark_conf[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.spark_env_vars	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.spark_env_vars[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.spark_version	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.ssh_public_keys	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.ssh_public_keys[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.total_initial_remote_disk_size	int	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.use_ml_runtime	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.workload_type	*compute.WorkloadType	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.workload_type.clients	compute.ClientsTypes	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.workload_type.clients.jobs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].new_cluster.workload_type.clients.notebooks	bool	INPUT	STATE
+resources.jobs.*.tasks[0].notebook_task	*jobs.NotebookTask	INPUT	STATE
+resources.jobs.*.tasks[0].notebook_task.base_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].notebook_task.base_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].notebook_task.notebook_path	string	INPUT	STATE
+resources.jobs.*.tasks[0].notebook_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].notebook_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].notification_settings	*jobs.TaskNotificationSettings	INPUT	STATE
+resources.jobs.*.tasks[0].notification_settings.alert_on_last_attempt	bool	INPUT	STATE
+resources.jobs.*.tasks[0].notification_settings.no_alert_for_canceled_runs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].notification_settings.no_alert_for_skipped_runs	bool	INPUT	STATE
+resources.jobs.*.tasks[0].pipeline_task	*jobs.PipelineTask	INPUT	STATE
+resources.jobs.*.tasks[0].pipeline_task.full_refresh	bool	INPUT	STATE
+resources.jobs.*.tasks[0].pipeline_task.pipeline_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task	*jobs.PowerBiTask	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.connection_resource_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.power_bi_model	*jobs.PowerBiModel	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.power_bi_model.authentication_method	jobs.AuthenticationMethod	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.power_bi_model.model_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.power_bi_model.overwrite_existing	bool	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.power_bi_model.storage_mode	jobs.StorageMode	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.power_bi_model.workspace_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.refresh_after_update	bool	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.tables	[]jobs.PowerBiTable	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.tables[0]	jobs.PowerBiTable	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.tables[0].catalog	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.tables[0].name	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.tables[0].schema	string	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.tables[0].storage_mode	jobs.StorageMode	INPUT	STATE
+resources.jobs.*.tasks[0].power_bi_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task	*jobs.PythonWheelTask	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task.entry_point	string	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task.named_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task.named_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task.package_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].python_wheel_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].retry_on_timeout	bool	INPUT	STATE
+resources.jobs.*.tasks[0].run_if	jobs.RunIf	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task	*jobs.RunJobTask	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.dbt_commands	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.dbt_commands[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.jar_params	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.jar_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.job_id	int64	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.job_parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.job_parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.notebook_params	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.notebook_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.pipeline_params	*jobs.PipelineParams	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.pipeline_params.full_refresh	bool	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.python_named_params	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.python_named_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.python_params	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.python_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.spark_submit_params	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.spark_submit_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.sql_params	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].run_job_task.sql_params[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_jar_task	*jobs.SparkJarTask	INPUT	STATE
+resources.jobs.*.tasks[0].spark_jar_task.jar_uri	string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_jar_task.main_class_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_jar_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_jar_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_jar_task.run_as_repl	bool	INPUT	STATE
+resources.jobs.*.tasks[0].spark_python_task	*jobs.SparkPythonTask	INPUT	STATE
+resources.jobs.*.tasks[0].spark_python_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_python_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_python_task.python_file	string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_python_task.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].spark_submit_task	*jobs.SparkSubmitTask	INPUT	STATE
+resources.jobs.*.tasks[0].spark_submit_task.parameters	[]string	INPUT	STATE
+resources.jobs.*.tasks[0].spark_submit_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task	*jobs.SqlTask	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert	*jobs.SqlTaskAlert	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert.alert_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert.pause_subscriptions	bool	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert.subscriptions	[]jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert.subscriptions[0]	jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert.subscriptions[0].destination_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.alert.subscriptions[0].user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard	*jobs.SqlTaskDashboard	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.custom_subject	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.dashboard_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.pause_subscriptions	bool	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.subscriptions	[]jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.subscriptions[0]	jobs.SqlTaskSubscription	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.subscriptions[0].destination_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.dashboard.subscriptions[0].user_name	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.file	*jobs.SqlTaskFile	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.file.path	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.file.source	jobs.Source	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.parameters	map[string]string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.parameters[0]	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.query	*jobs.SqlTaskQuery	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.query.query_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].sql_task.warehouse_id	string	INPUT	STATE
+resources.jobs.*.tasks[0].task_key	string	INPUT	STATE
+resources.jobs.*.tasks[0].timeout_seconds	int	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications	*jobs.WebhookNotifications	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_duration_warning_threshold_exceeded	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_duration_warning_threshold_exceeded[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_duration_warning_threshold_exceeded[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_failure	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_failure[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_failure[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_start	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_start[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_start[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_streaming_backlog_exceeded	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_streaming_backlog_exceeded[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_streaming_backlog_exceeded[0].id	string	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_success	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_success[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.tasks[0].webhook_notifications.on_success[0].id	string	INPUT	STATE
+resources.jobs.*.timeout_seconds	int	INPUT	STATE
+resources.jobs.*.trigger	*jobs.TriggerSettings	INPUT	STATE
+resources.jobs.*.trigger.file_arrival	*jobs.FileArrivalTriggerConfiguration	INPUT	STATE
+resources.jobs.*.trigger.file_arrival.min_time_between_triggers_seconds	int	INPUT	STATE
+resources.jobs.*.trigger.file_arrival.url	string	INPUT	STATE
+resources.jobs.*.trigger.file_arrival.wait_after_last_change_seconds	int	INPUT	STATE
+resources.jobs.*.trigger.pause_status	jobs.PauseStatus	INPUT	STATE
+resources.jobs.*.trigger.periodic	*jobs.PeriodicTriggerConfiguration	INPUT	STATE
+resources.jobs.*.trigger.periodic.interval	int	INPUT	STATE
+resources.jobs.*.trigger.periodic.unit	jobs.PeriodicTriggerConfigurationTimeUnit	INPUT	STATE
+resources.jobs.*.trigger.table	*jobs.TableUpdateTriggerConfiguration	INPUT	STATE
+resources.jobs.*.trigger.table.condition	jobs.Condition	INPUT	STATE
+resources.jobs.*.trigger.table.min_time_between_triggers_seconds	int	INPUT	STATE
+resources.jobs.*.trigger.table.table_names	[]string	INPUT	STATE
+resources.jobs.*.trigger.table.table_names[0]	string	INPUT	STATE
+resources.jobs.*.trigger.table.wait_after_last_change_seconds	int	INPUT	STATE
+resources.jobs.*.trigger.table_update	*jobs.TableUpdateTriggerConfiguration	INPUT	STATE
+resources.jobs.*.trigger.table_update.condition	jobs.Condition	INPUT	STATE
+resources.jobs.*.trigger.table_update.min_time_between_triggers_seconds	int	INPUT	STATE
+resources.jobs.*.trigger.table_update.table_names	[]string	INPUT	STATE
+resources.jobs.*.trigger.table_update.table_names[0]	string	INPUT	STATE
+resources.jobs.*.trigger.table_update.wait_after_last_change_seconds	int	INPUT	STATE
+resources.jobs.*.trigger_state	*jobs.TriggerStateProto	REMOTE
+resources.jobs.*.trigger_state.file_arrival	*jobs.FileArrivalTriggerState	REMOTE
+resources.jobs.*.trigger_state.file_arrival.using_file_events	bool	REMOTE
+resources.jobs.*.trigger_state.table	*jobs.TableTriggerState	REMOTE
+resources.jobs.*.trigger_state.table.last_seen_table_states	[]jobs.TableState	REMOTE
+resources.jobs.*.trigger_state.table.last_seen_table_states[0]	jobs.TableState	REMOTE
+resources.jobs.*.trigger_state.table.last_seen_table_states[0].has_seen_updates	bool	REMOTE
+resources.jobs.*.trigger_state.table.last_seen_table_states[0].table_name	string	REMOTE
+resources.jobs.*.trigger_state.table.using_scalable_monitoring	bool	REMOTE
+resources.jobs.*.url	string	INPUT
+resources.jobs.*.usage_policy_id	string	INPUT	STATE
+resources.jobs.*.webhook_notifications	*jobs.WebhookNotifications	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_duration_warning_threshold_exceeded	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_duration_warning_threshold_exceeded[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_duration_warning_threshold_exceeded[0].id	string	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_failure	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_failure[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_failure[0].id	string	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_start	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_start[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_start[0].id	string	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_streaming_backlog_exceeded	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_streaming_backlog_exceeded[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_streaming_backlog_exceeded[0].id	string	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_success	[]jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_success[0]	jobs.Webhook	INPUT	STATE
+resources.jobs.*.webhook_notifications.on_success[0].id	string	INPUT	STATE
+resources.pipelines.*.allow_duplicate_names	bool	INPUT	STATE
+resources.pipelines.*.budget_policy_id	string	INPUT	STATE
+resources.pipelines.*.catalog	string	INPUT	STATE
+resources.pipelines.*.cause	string	REMOTE
+resources.pipelines.*.channel	string	INPUT	STATE
+resources.pipelines.*.cluster_id	string	REMOTE
+resources.pipelines.*.clusters	[]pipelines.PipelineCluster	INPUT	STATE
+resources.pipelines.*.clusters[0]	pipelines.PipelineCluster	INPUT	STATE
+resources.pipelines.*.clusters[0].apply_policy_default_values	bool	INPUT	STATE
+resources.pipelines.*.clusters[0].autoscale	*pipelines.PipelineClusterAutoscale	INPUT	STATE
+resources.pipelines.*.clusters[0].autoscale.max_workers	int	INPUT	STATE
+resources.pipelines.*.clusters[0].autoscale.min_workers	int	INPUT	STATE
+resources.pipelines.*.clusters[0].autoscale.mode	pipelines.PipelineClusterAutoscaleMode	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes	*compute.AwsAttributes	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.availability	compute.AwsAvailability	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.ebs_volume_count	int	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.ebs_volume_iops	int	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.ebs_volume_size	int	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.ebs_volume_throughput	int	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.ebs_volume_type	compute.EbsVolumeType	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.first_on_demand	int	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.instance_profile_arn	string	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.spot_bid_price_percent	int	INPUT	STATE
+resources.pipelines.*.clusters[0].aws_attributes.zone_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes	*compute.AzureAttributes	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes.availability	compute.AzureAvailability	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes.first_on_demand	int	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes.log_analytics_info.log_analytics_primary_key	string	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes.log_analytics_info.log_analytics_workspace_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].azure_attributes.spot_bid_max_price	float64	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf	*compute.ClusterLogConf	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.dbfs.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3	*compute.S3StorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.canned_acl	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.enable_encryption	bool	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.encryption_type	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.endpoint	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.kms_key	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.s3.region	string	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].cluster_log_conf.volumes.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].custom_tags	map[string]string	INPUT	STATE
+resources.pipelines.*.clusters[0].custom_tags[0]	string	INPUT	STATE
+resources.pipelines.*.clusters[0].driver_instance_pool_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].driver_node_type_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].enable_local_disk_encryption	bool	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes	*compute.GcpAttributes	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.availability	compute.GcpAvailability	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.boot_disk_size	int	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.first_on_demand	int	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.google_service_account	string	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.local_ssd_count	int	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.use_preemptible_executors	bool	INPUT	STATE
+resources.pipelines.*.clusters[0].gcp_attributes.zone_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts	[]compute.InitScriptInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0]	compute.InitScriptInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].abfss	*compute.Adlsgen2Info	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].abfss.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].dbfs	*compute.DbfsStorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].dbfs.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].file	*compute.LocalFileInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].file.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].gcs	*compute.GcsStorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].gcs.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3	*compute.S3StorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.canned_acl	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.enable_encryption	bool	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.encryption_type	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.endpoint	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.kms_key	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].s3.region	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].volumes	*compute.VolumesStorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].volumes.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].workspace	*compute.WorkspaceStorageInfo	INPUT	STATE
+resources.pipelines.*.clusters[0].init_scripts[0].workspace.destination	string	INPUT	STATE
+resources.pipelines.*.clusters[0].instance_pool_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].label	string	INPUT	STATE
+resources.pipelines.*.clusters[0].node_type_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].num_workers	int	INPUT	STATE
+resources.pipelines.*.clusters[0].policy_id	string	INPUT	STATE
+resources.pipelines.*.clusters[0].spark_conf	map[string]string	INPUT	STATE
+resources.pipelines.*.clusters[0].spark_conf[0]	string	INPUT	STATE
+resources.pipelines.*.clusters[0].spark_env_vars	map[string]string	INPUT	STATE
+resources.pipelines.*.clusters[0].spark_env_vars[0]	string	INPUT	STATE
+resources.pipelines.*.clusters[0].ssh_public_keys	[]string	INPUT	STATE
+resources.pipelines.*.clusters[0].ssh_public_keys[0]	string	INPUT	STATE
+resources.pipelines.*.configuration	map[string]string	INPUT	STATE
+resources.pipelines.*.configuration[0]	string	INPUT	STATE
+resources.pipelines.*.continuous	bool	INPUT	STATE
+resources.pipelines.*.creator_user_name	string	REMOTE
+resources.pipelines.*.deployment	*pipelines.PipelineDeployment	INPUT	STATE
+resources.pipelines.*.deployment.kind	pipelines.DeploymentKind	INPUT	STATE
+resources.pipelines.*.deployment.metadata_file_path	string	INPUT	STATE
+resources.pipelines.*.development	bool	INPUT	STATE
+resources.pipelines.*.dry_run	bool	INPUT	STATE
+resources.pipelines.*.edition	string	INPUT	STATE
+resources.pipelines.*.effective_budget_policy_id	string	REMOTE
+resources.pipelines.*.environment	*pipelines.PipelinesEnvironment	INPUT	STATE
+resources.pipelines.*.environment.dependencies	[]string	INPUT	STATE
+resources.pipelines.*.environment.dependencies[0]	string	INPUT	STATE
+resources.pipelines.*.event_log	*pipelines.EventLogSpec	INPUT	STATE
+resources.pipelines.*.event_log.catalog	string	INPUT	STATE
+resources.pipelines.*.event_log.name	string	INPUT	STATE
+resources.pipelines.*.event_log.schema	string	INPUT	STATE
+resources.pipelines.*.filters	*pipelines.Filters	INPUT	STATE
+resources.pipelines.*.filters.exclude	[]string	INPUT	STATE
+resources.pipelines.*.filters.exclude[0]	string	INPUT	STATE
+resources.pipelines.*.filters.include	[]string	INPUT	STATE
+resources.pipelines.*.filters.include[0]	string	INPUT	STATE
+resources.pipelines.*.gateway_definition	*pipelines.IngestionGatewayPipelineDefinition	INPUT	STATE
+resources.pipelines.*.gateway_definition.connection_id	string	INPUT	STATE
+resources.pipelines.*.gateway_definition.connection_name	string	INPUT	STATE
+resources.pipelines.*.gateway_definition.gateway_storage_catalog	string	INPUT	STATE
+resources.pipelines.*.gateway_definition.gateway_storage_name	string	INPUT	STATE
+resources.pipelines.*.gateway_definition.gateway_storage_schema	string	INPUT	STATE
+resources.pipelines.*.health	pipelines.GetPipelineResponseHealth	REMOTE
+resources.pipelines.*.id	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition	*pipelines.IngestionPipelineDefinition	INPUT	STATE
+resources.pipelines.*.ingestion_definition.connection_name	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.ingestion_gateway_id	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects	[]pipelines.IngestionConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0]	pipelines.IngestionConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report	*pipelines.ReportSpec	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.destination_catalog	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.destination_schema	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.destination_table	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.source_url	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration	*pipelines.TableSpecificConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.exclude_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.exclude_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.include_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.include_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.primary_keys	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.primary_keys[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.cursor_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.cursor_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.deletion_condition	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.salesforce_include_formula_fields	bool	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.sequence_by	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].report.table_configuration.sequence_by[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema	*pipelines.SchemaSpec	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.destination_catalog	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.destination_schema	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.source_catalog	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.source_schema	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration	*pipelines.TableSpecificConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.exclude_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.exclude_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.include_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.include_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.primary_keys	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.primary_keys[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.cursor_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.cursor_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.deletion_condition	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.salesforce_include_formula_fields	bool	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.sequence_by	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].schema.table_configuration.sequence_by[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table	*pipelines.TableSpec	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.destination_catalog	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.destination_schema	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.destination_table	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.source_catalog	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.source_schema	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.source_table	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration	*pipelines.TableSpecificConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.exclude_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.exclude_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.include_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.include_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.primary_keys	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.primary_keys[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.cursor_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.cursor_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.deletion_condition	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.salesforce_include_formula_fields	bool	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.sequence_by	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.objects[0].table.table_configuration.sequence_by[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations	[]pipelines.SourceConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0]	pipelines.SourceConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0].catalog	*pipelines.SourceCatalogConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0].catalog.postgres	*pipelines.PostgresCatalogConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0].catalog.postgres.slot_config	*pipelines.PostgresSlotConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0].catalog.postgres.slot_config.publication_name	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0].catalog.postgres.slot_config.slot_name	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_configurations[0].catalog.source_catalog	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.source_type	pipelines.IngestionSourceType	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration	*pipelines.TableSpecificConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.exclude_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.exclude_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.include_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.include_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.primary_keys	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.primary_keys[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.query_based_connector_config.cursor_columns	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.query_based_connector_config.cursor_columns[0]	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.query_based_connector_config.deletion_condition	string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.salesforce_include_formula_fields	bool	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.sequence_by	[]string	INPUT	STATE
+resources.pipelines.*.ingestion_definition.table_configuration.sequence_by[0]	string	INPUT	STATE
+resources.pipelines.*.last_modified	int64	REMOTE
+resources.pipelines.*.latest_updates	[]pipelines.UpdateStateInfo	REMOTE
+resources.pipelines.*.latest_updates[0]	pipelines.UpdateStateInfo	REMOTE
+resources.pipelines.*.latest_updates[0].creation_time	string	REMOTE
+resources.pipelines.*.latest_updates[0].state	pipelines.UpdateStateInfoState	REMOTE
+resources.pipelines.*.latest_updates[0].update_id	string	REMOTE
+resources.pipelines.*.libraries	[]pipelines.PipelineLibrary	INPUT	STATE
+resources.pipelines.*.libraries[0]	pipelines.PipelineLibrary	INPUT	STATE
+resources.pipelines.*.libraries[0].file	*pipelines.FileLibrary	INPUT	STATE
+resources.pipelines.*.libraries[0].file.path	string	INPUT	STATE
+resources.pipelines.*.libraries[0].glob	*pipelines.PathPattern	INPUT	STATE
+resources.pipelines.*.libraries[0].glob.include	string	INPUT	STATE
+resources.pipelines.*.libraries[0].jar	string	INPUT	STATE
+resources.pipelines.*.libraries[0].maven	*compute.MavenLibrary	INPUT	STATE
+resources.pipelines.*.libraries[0].maven.coordinates	string	INPUT	STATE
+resources.pipelines.*.libraries[0].maven.exclusions	[]string	INPUT	STATE
+resources.pipelines.*.libraries[0].maven.exclusions[0]	string	INPUT	STATE
+resources.pipelines.*.libraries[0].maven.repo	string	INPUT	STATE
+resources.pipelines.*.libraries[0].notebook	*pipelines.NotebookLibrary	INPUT	STATE
+resources.pipelines.*.libraries[0].notebook.path	string	INPUT	STATE
+resources.pipelines.*.libraries[0].whl	string	INPUT	STATE
+resources.pipelines.*.modified_status	string	INPUT
+resources.pipelines.*.name	string	ALL
+resources.pipelines.*.notifications	[]pipelines.Notifications	INPUT	STATE
+resources.pipelines.*.notifications[0]	pipelines.Notifications	INPUT	STATE
+resources.pipelines.*.notifications[0].alerts	[]string	INPUT	STATE
+resources.pipelines.*.notifications[0].alerts[0]	string	INPUT	STATE
+resources.pipelines.*.notifications[0].email_recipients	[]string	INPUT	STATE
+resources.pipelines.*.notifications[0].email_recipients[0]	string	INPUT	STATE
+resources.pipelines.*.permissions	[]resources.PipelinePermission	INPUT
+resources.pipelines.*.permissions[0]	resources.PipelinePermission	INPUT
+resources.pipelines.*.permissions[0].group_name	string	INPUT
+resources.pipelines.*.permissions[0].level	resources.PipelinePermissionLevel	INPUT
+resources.pipelines.*.permissions[0].service_principal_name	string	INPUT
+resources.pipelines.*.permissions[0].user_name	string	INPUT
+resources.pipelines.*.photon	bool	INPUT	STATE
+resources.pipelines.*.pipeline_id	string	REMOTE
+resources.pipelines.*.restart_window	*pipelines.RestartWindow	INPUT	STATE
+resources.pipelines.*.restart_window.days_of_week	[]pipelines.DayOfWeek	INPUT	STATE
+resources.pipelines.*.restart_window.days_of_week[0]	pipelines.DayOfWeek	INPUT	STATE
+resources.pipelines.*.restart_window.start_hour	int	INPUT	STATE
+resources.pipelines.*.restart_window.time_zone_id	string	INPUT	STATE
+resources.pipelines.*.root_path	string	INPUT	STATE
+resources.pipelines.*.run_as	*pipelines.RunAs	ALL
+resources.pipelines.*.run_as.service_principal_name	string	ALL
+resources.pipelines.*.run_as.user_name	string	ALL
+resources.pipelines.*.run_as_user_name	string	REMOTE
+resources.pipelines.*.schema	string	INPUT	STATE
+resources.pipelines.*.serverless	bool	INPUT	STATE
+resources.pipelines.*.spec	*pipelines.PipelineSpec	REMOTE
+resources.pipelines.*.spec.budget_policy_id	string	REMOTE
+resources.pipelines.*.spec.catalog	string	REMOTE
+resources.pipelines.*.spec.channel	string	REMOTE
+resources.pipelines.*.spec.clusters	[]pipelines.PipelineCluster	REMOTE
+resources.pipelines.*.spec.clusters[0]	pipelines.PipelineCluster	REMOTE
+resources.pipelines.*.spec.clusters[0].apply_policy_default_values	bool	REMOTE
+resources.pipelines.*.spec.clusters[0].autoscale	*pipelines.PipelineClusterAutoscale	REMOTE
+resources.pipelines.*.spec.clusters[0].autoscale.max_workers	int	REMOTE
+resources.pipelines.*.spec.clusters[0].autoscale.min_workers	int	REMOTE
+resources.pipelines.*.spec.clusters[0].autoscale.mode	pipelines.PipelineClusterAutoscaleMode	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes	*compute.AwsAttributes	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.availability	compute.AwsAvailability	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.ebs_volume_count	int	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.ebs_volume_iops	int	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.ebs_volume_size	int	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.ebs_volume_throughput	int	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.ebs_volume_type	compute.EbsVolumeType	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.first_on_demand	int	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.instance_profile_arn	string	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.spot_bid_price_percent	int	REMOTE
+resources.pipelines.*.spec.clusters[0].aws_attributes.zone_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes	*compute.AzureAttributes	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes.availability	compute.AzureAvailability	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes.first_on_demand	int	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes.log_analytics_info	*compute.LogAnalyticsInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes.log_analytics_info.log_analytics_primary_key	string	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes.log_analytics_info.log_analytics_workspace_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].azure_attributes.spot_bid_max_price	float64	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf	*compute.ClusterLogConf	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.dbfs.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3	*compute.S3StorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.canned_acl	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.enable_encryption	bool	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.encryption_type	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.endpoint	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.kms_key	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.s3.region	string	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.volumes	*compute.VolumesStorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].cluster_log_conf.volumes.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].custom_tags	map[string]string	REMOTE
+resources.pipelines.*.spec.clusters[0].custom_tags[0]	string	REMOTE
+resources.pipelines.*.spec.clusters[0].driver_instance_pool_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].driver_node_type_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].enable_local_disk_encryption	bool	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes	*compute.GcpAttributes	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.availability	compute.GcpAvailability	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.boot_disk_size	int	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.first_on_demand	int	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.google_service_account	string	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.local_ssd_count	int	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.use_preemptible_executors	bool	REMOTE
+resources.pipelines.*.spec.clusters[0].gcp_attributes.zone_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts	[]compute.InitScriptInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0]	compute.InitScriptInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].abfss	*compute.Adlsgen2Info	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].abfss.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].dbfs	*compute.DbfsStorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].dbfs.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].file	*compute.LocalFileInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].file.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].gcs	*compute.GcsStorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].gcs.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3	*compute.S3StorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.canned_acl	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.enable_encryption	bool	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.encryption_type	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.endpoint	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.kms_key	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].s3.region	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].volumes	*compute.VolumesStorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].volumes.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].workspace	*compute.WorkspaceStorageInfo	REMOTE
+resources.pipelines.*.spec.clusters[0].init_scripts[0].workspace.destination	string	REMOTE
+resources.pipelines.*.spec.clusters[0].instance_pool_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].label	string	REMOTE
+resources.pipelines.*.spec.clusters[0].node_type_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].num_workers	int	REMOTE
+resources.pipelines.*.spec.clusters[0].policy_id	string	REMOTE
+resources.pipelines.*.spec.clusters[0].spark_conf	map[string]string	REMOTE
+resources.pipelines.*.spec.clusters[0].spark_conf[0]	string	REMOTE
+resources.pipelines.*.spec.clusters[0].spark_env_vars	map[string]string	REMOTE
+resources.pipelines.*.spec.clusters[0].spark_env_vars[0]	string	REMOTE
+resources.pipelines.*.spec.clusters[0].ssh_public_keys	[]string	REMOTE
+resources.pipelines.*.spec.clusters[0].ssh_public_keys[0]	string	REMOTE
+resources.pipelines.*.spec.configuration	map[string]string	REMOTE
+resources.pipelines.*.spec.configuration[0]	string	REMOTE
+resources.pipelines.*.spec.continuous	bool	REMOTE
+resources.pipelines.*.spec.deployment	*pipelines.PipelineDeployment	REMOTE
+resources.pipelines.*.spec.deployment.kind	pipelines.DeploymentKind	REMOTE
+resources.pipelines.*.spec.deployment.metadata_file_path	string	REMOTE
+resources.pipelines.*.spec.development	bool	REMOTE
+resources.pipelines.*.spec.edition	string	REMOTE
+resources.pipelines.*.spec.environment	*pipelines.PipelinesEnvironment	REMOTE
+resources.pipelines.*.spec.environment.dependencies	[]string	REMOTE
+resources.pipelines.*.spec.environment.dependencies[0]	string	REMOTE
+resources.pipelines.*.spec.event_log	*pipelines.EventLogSpec	REMOTE
+resources.pipelines.*.spec.event_log.catalog	string	REMOTE
+resources.pipelines.*.spec.event_log.name	string	REMOTE
+resources.pipelines.*.spec.event_log.schema	string	REMOTE
+resources.pipelines.*.spec.filters	*pipelines.Filters	REMOTE
+resources.pipelines.*.spec.filters.exclude	[]string	REMOTE
+resources.pipelines.*.spec.filters.exclude[0]	string	REMOTE
+resources.pipelines.*.spec.filters.include	[]string	REMOTE
+resources.pipelines.*.spec.filters.include[0]	string	REMOTE
+resources.pipelines.*.spec.gateway_definition	*pipelines.IngestionGatewayPipelineDefinition	REMOTE
+resources.pipelines.*.spec.gateway_definition.connection_id	string	REMOTE
+resources.pipelines.*.spec.gateway_definition.connection_name	string	REMOTE
+resources.pipelines.*.spec.gateway_definition.gateway_storage_catalog	string	REMOTE
+resources.pipelines.*.spec.gateway_definition.gateway_storage_name	string	REMOTE
+resources.pipelines.*.spec.gateway_definition.gateway_storage_schema	string	REMOTE
+resources.pipelines.*.spec.id	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition	*pipelines.IngestionPipelineDefinition	REMOTE
+resources.pipelines.*.spec.ingestion_definition.connection_name	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.ingestion_gateway_id	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects	[]pipelines.IngestionConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0]	pipelines.IngestionConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report	*pipelines.ReportSpec	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.destination_catalog	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.destination_schema	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.destination_table	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.source_url	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration	*pipelines.TableSpecificConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.exclude_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.exclude_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.include_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.include_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.primary_keys	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.primary_keys[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.cursor_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.cursor_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.deletion_condition	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.salesforce_include_formula_fields	bool	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.sequence_by	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].report.table_configuration.sequence_by[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema	*pipelines.SchemaSpec	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.destination_catalog	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.destination_schema	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.source_catalog	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.source_schema	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration	*pipelines.TableSpecificConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.exclude_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.exclude_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.include_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.include_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.primary_keys	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.primary_keys[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.cursor_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.cursor_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.deletion_condition	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.salesforce_include_formula_fields	bool	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.sequence_by	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].schema.table_configuration.sequence_by[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table	*pipelines.TableSpec	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.destination_catalog	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.destination_schema	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.destination_table	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.source_catalog	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.source_schema	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.source_table	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration	*pipelines.TableSpecificConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.exclude_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.exclude_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.include_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.include_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.primary_keys	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.primary_keys[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.cursor_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.cursor_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.deletion_condition	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.salesforce_include_formula_fields	bool	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.sequence_by	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.objects[0].table.table_configuration.sequence_by[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations	[]pipelines.SourceConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0]	pipelines.SourceConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0].catalog	*pipelines.SourceCatalogConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0].catalog.postgres	*pipelines.PostgresCatalogConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0].catalog.postgres.slot_config	*pipelines.PostgresSlotConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0].catalog.postgres.slot_config.publication_name	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0].catalog.postgres.slot_config.slot_name	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_configurations[0].catalog.source_catalog	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.source_type	pipelines.IngestionSourceType	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration	*pipelines.TableSpecificConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.exclude_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.exclude_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.include_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.include_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.primary_keys	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.primary_keys[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.query_based_connector_config	*pipelines.IngestionPipelineDefinitionTableSpecificConfigQueryBasedConnectorConfig	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.query_based_connector_config.cursor_columns	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.query_based_connector_config.cursor_columns[0]	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.query_based_connector_config.deletion_condition	string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.query_based_connector_config.hard_deletion_sync_min_interval_in_seconds	int64	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.salesforce_include_formula_fields	bool	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.scd_type	pipelines.TableSpecificConfigScdType	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.sequence_by	[]string	REMOTE
+resources.pipelines.*.spec.ingestion_definition.table_configuration.sequence_by[0]	string	REMOTE
+resources.pipelines.*.spec.libraries	[]pipelines.PipelineLibrary	REMOTE
+resources.pipelines.*.spec.libraries[0]	pipelines.PipelineLibrary	REMOTE
+resources.pipelines.*.spec.libraries[0].file	*pipelines.FileLibrary	REMOTE
+resources.pipelines.*.spec.libraries[0].file.path	string	REMOTE
+resources.pipelines.*.spec.libraries[0].glob	*pipelines.PathPattern	REMOTE
+resources.pipelines.*.spec.libraries[0].glob.include	string	REMOTE
+resources.pipelines.*.spec.libraries[0].jar	string	REMOTE
+resources.pipelines.*.spec.libraries[0].maven	*compute.MavenLibrary	REMOTE
+resources.pipelines.*.spec.libraries[0].maven.coordinates	string	REMOTE
+resources.pipelines.*.spec.libraries[0].maven.exclusions	[]string	REMOTE
+resources.pipelines.*.spec.libraries[0].maven.exclusions[0]	string	REMOTE
+resources.pipelines.*.spec.libraries[0].maven.repo	string	REMOTE
+resources.pipelines.*.spec.libraries[0].notebook	*pipelines.NotebookLibrary	REMOTE
+resources.pipelines.*.spec.libraries[0].notebook.path	string	REMOTE
+resources.pipelines.*.spec.libraries[0].whl	string	REMOTE
+resources.pipelines.*.spec.name	string	REMOTE
+resources.pipelines.*.spec.notifications	[]pipelines.Notifications	REMOTE
+resources.pipelines.*.spec.notifications[0]	pipelines.Notifications	REMOTE
+resources.pipelines.*.spec.notifications[0].alerts	[]string	REMOTE
+resources.pipelines.*.spec.notifications[0].alerts[0]	string	REMOTE
+resources.pipelines.*.spec.notifications[0].email_recipients	[]string	REMOTE
+resources.pipelines.*.spec.notifications[0].email_recipients[0]	string	REMOTE
+resources.pipelines.*.spec.photon	bool	REMOTE
+resources.pipelines.*.spec.restart_window	*pipelines.RestartWindow	REMOTE
+resources.pipelines.*.spec.restart_window.days_of_week	[]pipelines.DayOfWeek	REMOTE
+resources.pipelines.*.spec.restart_window.days_of_week[0]	pipelines.DayOfWeek	REMOTE
+resources.pipelines.*.spec.restart_window.start_hour	int	REMOTE
+resources.pipelines.*.spec.restart_window.time_zone_id	string	REMOTE
+resources.pipelines.*.spec.root_path	string	REMOTE
+resources.pipelines.*.spec.schema	string	REMOTE
+resources.pipelines.*.spec.serverless	bool	REMOTE
+resources.pipelines.*.spec.storage	string	REMOTE
+resources.pipelines.*.spec.tags	map[string]string	REMOTE
+resources.pipelines.*.spec.tags[0]	string	REMOTE
+resources.pipelines.*.spec.target	string	REMOTE
+resources.pipelines.*.spec.trigger	*pipelines.PipelineTrigger	REMOTE
+resources.pipelines.*.spec.trigger.cron	*pipelines.CronTrigger	REMOTE
+resources.pipelines.*.spec.trigger.cron.quartz_cron_schedule	string	REMOTE
+resources.pipelines.*.spec.trigger.cron.timezone_id	string	REMOTE
+resources.pipelines.*.spec.trigger.manual	*pipelines.ManualTrigger	REMOTE
+resources.pipelines.*.state	pipelines.PipelineState	REMOTE
+resources.pipelines.*.storage	string	INPUT	STATE
+resources.pipelines.*.tags	map[string]string	INPUT	STATE
+resources.pipelines.*.tags[0]	string	INPUT	STATE
+resources.pipelines.*.target	string	INPUT	STATE
+resources.pipelines.*.trigger	*pipelines.PipelineTrigger	INPUT	STATE
+resources.pipelines.*.trigger.cron	*pipelines.CronTrigger	INPUT	STATE
+resources.pipelines.*.trigger.cron.quartz_cron_schedule	string	INPUT	STATE
+resources.pipelines.*.trigger.cron.timezone_id	string	INPUT	STATE
+resources.pipelines.*.trigger.manual	*pipelines.ManualTrigger	INPUT	STATE
+resources.pipelines.*.url	string	INPUT
+resources.schemas.*.browse_only	bool	REMOTE
+resources.schemas.*.catalog_name	string	ALL
+resources.schemas.*.catalog_type	catalog.CatalogType	REMOTE
+resources.schemas.*.comment	string	ALL
+resources.schemas.*.created_at	int64	REMOTE
+resources.schemas.*.created_by	string	REMOTE
+resources.schemas.*.effective_predictive_optimization_flag	*catalog.EffectivePredictiveOptimizationFlag	REMOTE
+resources.schemas.*.effective_predictive_optimization_flag.inherited_from_name	string	REMOTE
+resources.schemas.*.effective_predictive_optimization_flag.inherited_from_type	catalog.EffectivePredictiveOptimizationFlagInheritedFromType	REMOTE
+resources.schemas.*.effective_predictive_optimization_flag.value	catalog.EnablePredictiveOptimization	REMOTE
+resources.schemas.*.enable_predictive_optimization	catalog.EnablePredictiveOptimization	REMOTE
+resources.schemas.*.full_name	string	REMOTE
+resources.schemas.*.grants	[]resources.SchemaGrant	INPUT
+resources.schemas.*.grants[0]	resources.SchemaGrant	INPUT
+resources.schemas.*.grants[0].principal	string	INPUT
+resources.schemas.*.grants[0].privileges	[]resources.SchemaGrantPrivilege	INPUT
+resources.schemas.*.grants[0].privileges[0]	resources.SchemaGrantPrivilege	INPUT
+resources.schemas.*.id	string	INPUT
+resources.schemas.*.metastore_id	string	REMOTE
+resources.schemas.*.modified_status	string	INPUT
+resources.schemas.*.name	string	ALL
+resources.schemas.*.owner	string	REMOTE
+resources.schemas.*.properties	map[string]string	ALL
+resources.schemas.*.properties[0]	string	ALL
+resources.schemas.*.schema_id	string	REMOTE
+resources.schemas.*.storage_location	string	REMOTE
+resources.schemas.*.storage_root	string	ALL
+resources.schemas.*.updated_at	int64	REMOTE
+resources.schemas.*.updated_by	string	REMOTE
+resources.schemas.*.url	string	INPUT
+resources.sql_warehouses.*.auto_stop_mins	int	ALL
+resources.sql_warehouses.*.channel	*sql.Channel	ALL
+resources.sql_warehouses.*.channel.dbsql_version	string	ALL
+resources.sql_warehouses.*.channel.name	sql.ChannelName	ALL
+resources.sql_warehouses.*.cluster_size	string	ALL
+resources.sql_warehouses.*.creator_name	string	ALL
+resources.sql_warehouses.*.enable_photon	bool	ALL
+resources.sql_warehouses.*.enable_serverless_compute	bool	ALL
+resources.sql_warehouses.*.health	*sql.EndpointHealth	REMOTE
+resources.sql_warehouses.*.health.details	string	REMOTE
+resources.sql_warehouses.*.health.failure_reason	*sql.TerminationReason	REMOTE
+resources.sql_warehouses.*.health.failure_reason.code	sql.TerminationReasonCode	REMOTE
+resources.sql_warehouses.*.health.failure_reason.parameters	map[string]string	REMOTE
+resources.sql_warehouses.*.health.failure_reason.parameters[0]	string	REMOTE
+resources.sql_warehouses.*.health.failure_reason.type	sql.TerminationReasonType	REMOTE
+resources.sql_warehouses.*.health.message	string	REMOTE
+resources.sql_warehouses.*.health.status	sql.Status	REMOTE
+resources.sql_warehouses.*.health.summary	string	REMOTE
+resources.sql_warehouses.*.id	string	INPUT	REMOTE
+resources.sql_warehouses.*.instance_profile_arn	string	ALL
+resources.sql_warehouses.*.jdbc_url	string	REMOTE
+resources.sql_warehouses.*.max_num_clusters	int	ALL
+resources.sql_warehouses.*.min_num_clusters	int	ALL
+resources.sql_warehouses.*.modified_status	string	INPUT
+resources.sql_warehouses.*.name	string	ALL
+resources.sql_warehouses.*.num_active_sessions	int64	REMOTE
+resources.sql_warehouses.*.num_clusters	int	REMOTE
+resources.sql_warehouses.*.odbc_params	*sql.OdbcParams	REMOTE
+resources.sql_warehouses.*.odbc_params.hostname	string	REMOTE
+resources.sql_warehouses.*.odbc_params.path	string	REMOTE
+resources.sql_warehouses.*.odbc_params.port	int	REMOTE
+resources.sql_warehouses.*.odbc_params.protocol	string	REMOTE
+resources.sql_warehouses.*.permissions	[]resources.SqlWarehousePermission	INPUT
+resources.sql_warehouses.*.permissions[0]	resources.SqlWarehousePermission	INPUT
+resources.sql_warehouses.*.permissions[0].group_name	string	INPUT
+resources.sql_warehouses.*.permissions[0].level	resources.SqlWarehousePermissionLevel	INPUT
+resources.sql_warehouses.*.permissions[0].service_principal_name	string	INPUT
+resources.sql_warehouses.*.permissions[0].user_name	string	INPUT
+resources.sql_warehouses.*.spot_instance_policy	sql.SpotInstancePolicy	ALL
+resources.sql_warehouses.*.state	sql.State	REMOTE
+resources.sql_warehouses.*.tags	*sql.EndpointTags	ALL
+resources.sql_warehouses.*.tags.custom_tags	[]sql.EndpointTagPair	ALL
+resources.sql_warehouses.*.tags.custom_tags[0]	sql.EndpointTagPair	ALL
+resources.sql_warehouses.*.tags.custom_tags[0].key	string	ALL
+resources.sql_warehouses.*.tags.custom_tags[0].value	string	ALL
+resources.sql_warehouses.*.url	string	INPUT
+resources.sql_warehouses.*.warehouse_type	sql.CreateWarehouseRequestWarehouseType	INPUT	STATE
+resources.sql_warehouses.*.warehouse_type	sql.GetWarehouseResponseWarehouseType	REMOTE
+resources.synced_database_tables.*.data_synchronization_status	*database.SyncedTableStatus	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status	*database.SyncedTableContinuousUpdateStatus	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress	*database.SyncedTablePipelineProgress	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress.estimated_completion_time_seconds	float64	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress.latest_version_currently_processing	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress.provisioning_phase	database.ProvisioningPhase	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress.sync_progress_completion	float64	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress.synced_row_count	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.initial_pipeline_sync_progress.total_row_count	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.last_processed_commit_version	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.continuous_update_status.timestamp	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.detailed_state	database.SyncedTableState	ALL
+resources.synced_database_tables.*.data_synchronization_status.failed_status	*database.SyncedTableFailedStatus	ALL
+resources.synced_database_tables.*.data_synchronization_status.failed_status.last_processed_commit_version	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.failed_status.timestamp	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.last_sync	*database.SyncedTablePosition	ALL
+resources.synced_database_tables.*.data_synchronization_status.last_sync.delta_table_sync_info	*database.DeltaTableSyncInfo	ALL
+resources.synced_database_tables.*.data_synchronization_status.last_sync.delta_table_sync_info.delta_commit_timestamp	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.last_sync.delta_table_sync_info.delta_commit_version	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.last_sync.sync_end_timestamp	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.last_sync.sync_start_timestamp	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.message	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.pipeline_id	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status	*database.SyncedTableProvisioningStatus	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress	*database.SyncedTablePipelineProgress	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress.estimated_completion_time_seconds	float64	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress.latest_version_currently_processing	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress.provisioning_phase	database.ProvisioningPhase	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress.sync_progress_completion	float64	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress.synced_row_count	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.provisioning_status.initial_pipeline_sync_progress.total_row_count	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status	*database.SyncedTableTriggeredUpdateStatus	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.last_processed_commit_version	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.timestamp	string	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress	*database.SyncedTablePipelineProgress	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress.estimated_completion_time_seconds	float64	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress.latest_version_currently_processing	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress.provisioning_phase	database.ProvisioningPhase	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress.sync_progress_completion	float64	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress.synced_row_count	int64	ALL
+resources.synced_database_tables.*.data_synchronization_status.triggered_update_status.triggered_update_progress.total_row_count	int64	ALL
+resources.synced_database_tables.*.database_instance_name	string	ALL
+resources.synced_database_tables.*.effective_database_instance_name	string	ALL
+resources.synced_database_tables.*.effective_logical_database_name	string	ALL
+resources.synced_database_tables.*.id	string	INPUT
+resources.synced_database_tables.*.logical_database_name	string	ALL
+resources.synced_database_tables.*.modified_status	string	INPUT
+resources.synced_database_tables.*.name	string	ALL
+resources.synced_database_tables.*.spec	*database.SyncedTableSpec	ALL
+resources.synced_database_tables.*.spec.create_database_objects_if_missing	bool	ALL
+resources.synced_database_tables.*.spec.existing_pipeline_id	string	ALL
+resources.synced_database_tables.*.spec.new_pipeline_spec	*database.NewPipelineSpec	ALL
+resources.synced_database_tables.*.spec.new_pipeline_spec.storage_catalog	string	ALL
+resources.synced_database_tables.*.spec.new_pipeline_spec.storage_schema	string	ALL
+resources.synced_database_tables.*.spec.primary_key_columns	[]string	ALL
+resources.synced_database_tables.*.spec.primary_key_columns[0]	string	ALL
+resources.synced_database_tables.*.spec.scheduling_policy	database.SyncedTableSchedulingPolicy	ALL
+resources.synced_database_tables.*.spec.source_table_full_name	string	ALL
+resources.synced_database_tables.*.spec.timeseries_key	string	ALL
+resources.synced_database_tables.*.unity_catalog_provisioning_state	database.ProvisioningInfoState	ALL
+resources.synced_database_tables.*.url	string	INPUT
+resources.volumes.*.access_point	string	REMOTE
+resources.volumes.*.browse_only	bool	REMOTE
+resources.volumes.*.catalog_name	string	ALL
+resources.volumes.*.comment	string	ALL
+resources.volumes.*.created_at	int64	REMOTE
+resources.volumes.*.created_by	string	REMOTE
+resources.volumes.*.encryption_details	*catalog.EncryptionDetails	REMOTE
+resources.volumes.*.encryption_details.sse_encryption_details	*catalog.SseEncryptionDetails	REMOTE
+resources.volumes.*.encryption_details.sse_encryption_details.algorithm	catalog.SseEncryptionDetailsAlgorithm	REMOTE
+resources.volumes.*.encryption_details.sse_encryption_details.aws_kms_key_arn	string	REMOTE
+resources.volumes.*.full_name	string	REMOTE
+resources.volumes.*.grants	[]resources.VolumeGrant	INPUT
+resources.volumes.*.grants[0]	resources.VolumeGrant	INPUT
+resources.volumes.*.grants[0].principal	string	INPUT
+resources.volumes.*.grants[0].privileges	[]resources.VolumeGrantPrivilege	INPUT
+resources.volumes.*.grants[0].privileges[0]	resources.VolumeGrantPrivilege	INPUT
+resources.volumes.*.id	string	INPUT
+resources.volumes.*.metastore_id	string	REMOTE
+resources.volumes.*.modified_status	string	INPUT
+resources.volumes.*.name	string	ALL
+resources.volumes.*.owner	string	REMOTE
+resources.volumes.*.schema_name	string	ALL
+resources.volumes.*.storage_location	string	ALL
+resources.volumes.*.updated_at	int64	REMOTE
+resources.volumes.*.updated_by	string	REMOTE
+resources.volumes.*.url	string	INPUT
+resources.volumes.*.volume_id	string	REMOTE
+resources.volumes.*.volume_type	catalog.VolumeType	ALL

--- a/acceptance/bundle/refschema/out.test.toml
+++ b/acceptance/bundle/refschema/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]

--- a/acceptance/bundle/refschema/output.txt
+++ b/acceptance/bundle/refschema/output.txt
@@ -1,0 +1,22 @@
+
+>>> [CLI] bundle ref-schema --help
+Dumps all available fields for each resource type by walking the relevant types. Each line is a path to a field, type and set of tags:
+- INPUT: field is present in bundle config.
+- STATE: field is present in the state of the resource (direct deployment only).
+- REMOTE: field is present in the remote state of the resource (direct deployment only).
+- ALL: shortcut for all three.
+
+Usage:
+  databricks bundle ref-schema [flags]
+
+Flags:
+  -h, --help   help for ref-schema
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+      --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"
+
+>>> [CLI] bundle ref-schema

--- a/acceptance/bundle/refschema/script
+++ b/acceptance/bundle/refschema/script
@@ -1,0 +1,2 @@
+trace $CLI bundle ref-schema --help
+trace $CLI bundle ref-schema > out.fields.txt

--- a/acceptance/bundle/refschema/test.toml
+++ b/acceptance/bundle/refschema/test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+Local = true

--- a/cmd/bundle/bundle.go
+++ b/cmd/bundle/bundle.go
@@ -41,5 +41,6 @@ Online documentation: https://docs.databricks.com/en/dev-tools/bundles/index.htm
 	cmd.AddCommand(deployment.NewDeploymentCommand())
 	cmd.AddCommand(newOpenCommand())
 	cmd.AddCommand(newPlanCommand())
+	cmd.AddCommand(newRefSchemaCommand())
 	return cmd
 }

--- a/cmd/bundle/refschema.go
+++ b/cmd/bundle/refschema.go
@@ -1,0 +1,114 @@
+package bundle
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/databricks/cli/bundle/terranova/tnresources"
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/structdiff/structpath"
+	"github.com/databricks/cli/libs/structwalk"
+	"github.com/databricks/cli/libs/utils"
+	"github.com/spf13/cobra"
+)
+
+func newRefSchemaCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ref-schema",
+		Short: "Dump all relevant fields all bundle resources",
+		Long: `Dumps all available fields for each resource type by walking the relevant types. Each line is a path to a field, type and set of tags:
+- INPUT: field is present in bundle config.
+- STATE: field is present in the state of the resource (direct deployment only).
+- REMOTE: field is present in the remote state of the resource (direct deployment only).
+- ALL: shortcut for all three.
+`,
+		Args:   root.NoArgs,
+		Hidden: true,
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return dumpRemoteSchemas()
+	}
+
+	return cmd
+}
+
+// dumpRemoteSchemas walks through all supported resources and dumps their schema fields.
+func dumpRemoteSchemas() error {
+	adapters, err := tnresources.InitAll(nil)
+	if err != nil {
+		return fmt.Errorf("failed to initialize adapters: %w", err)
+	}
+
+	for _, resourceName := range utils.SortedKeys(adapters) {
+		adapter := adapters[resourceName]
+
+		// path -> typeLabel -> set of sources
+		pathTypes := make(map[string]map[string]map[string]struct{})
+
+		collect := func(root reflect.Type, source string) error {
+			return structwalk.WalkType(root, func(path *structpath.PathNode, typ reflect.Type) bool {
+				if path == nil {
+					return true
+				}
+				p := convertArraysToIndexed(path.String())
+				p = strings.TrimPrefix(p, ".")
+				t := fmt.Sprint(typ)
+				byType, ok := pathTypes[p]
+				if !ok {
+					byType = make(map[string]map[string]struct{})
+					pathTypes[p] = byType
+				}
+				sources, ok := byType[t]
+				if !ok {
+					sources = make(map[string]struct{})
+					byType[t] = sources
+				}
+				sources[source] = struct{}{}
+				return true
+			})
+		}
+
+		if err := collect(adapter.InputConfigType(), "INPUT"); err != nil {
+			return fmt.Errorf("failed to walk input type for %s: %w", resourceName, err)
+		}
+		if err := collect(adapter.ConfigType(), "STATE"); err != nil {
+			return fmt.Errorf("failed to walk config type for %s: %w", resourceName, err)
+		}
+		if err := collect(adapter.RemoteType(), "REMOTE"); err != nil {
+			return fmt.Errorf("failed to walk remote type for %s: %w", resourceName, err)
+		}
+
+		var lines []string
+		for _, p := range utils.SortedKeys(pathTypes) {
+			byType := pathTypes[p]
+			for _, t := range utils.SortedKeys(byType) {
+				info := formatTags(byType[t])
+				lines = append(lines, fmt.Sprintf("resources.%s.*.%s\t%s\t%s", resourceName, p, t, info))
+			}
+		}
+
+		sort.Strings(lines)
+		for _, l := range lines {
+			fmt.Println(l)
+		}
+	}
+
+	return nil
+}
+
+func formatTags(sources map[string]struct{}) string {
+	if len(sources) == 3 {
+		return "ALL"
+	}
+	return strings.Join(utils.SortedKeys(sources), "\t")
+}
+
+// convertArraysToIndexed converts array patterns like "tasks[*]" to "tasks[0]" format.
+func convertArraysToIndexed(path string) string {
+	// Replace patterns like "field[*]" with "field[0]"
+	result := strings.ReplaceAll(path, "[*]", "[0]")
+	return result
+}


### PR DESCRIPTION
## Changes

- New hidden command "bundle ref-schema".
- Acceptance test that records full output of it.

## Why
Track bundle schema changes. Unlike jsonschema, this includes not just input yaml but stored state and remote resource types. This will help us notice when something disappears or changes type in the state or remote, as this has potential of breaking existing deployments.

It is also in greppable format, could be useful for debugging complex $resources.jobs.foo.tasks[0].something.something else references.