### PR TITLE
[Python] Test support for unknown resources

### DIFF
--- a/acceptance/bundle/python/unknown-resource-for-cli/databricks.yml
+++ b/acceptance/bundle/python/unknown-resource-for-cli/databricks.yml
@@ -1,0 +1,9 @@
+bundle:
+  name: my_project
+
+sync: {paths: []} # don't need to copy files
+
+experimental:
+  python:
+    resources:
+      - "resources:load_resources"

--- a/acceptance/bundle/python/unknown-resource-for-cli/databricks/bundles/build.py
+++ b/acceptance/bundle/python/unknown-resource-for-cli/databricks/bundles/build.py
@@ -1,0 +1,29 @@
+import argparse
+import json
+import sys
+import pathlib
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", default=None)
+    parser.add_argument("--output", default=None)
+    parser.add_argument("--diagnostics", default=None)
+
+    args = sys.argv[1:]
+    parsed, _ = parser.parse_known_args(args)
+
+    with open(parsed.input, "r") as f:
+        input = json.load(f)
+
+    input["resources"] = input.get("resources", {})
+    input["resources"]["unknown_resource"] = {"my_resource": {"name": "My Resource"}}
+
+    pathlib.Path(parsed.diagnostics).touch()
+
+    with open(parsed.output, "w") as f:
+        json.dump(input, f, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/acceptance/bundle/python/unknown-resource-for-cli/out.test.toml
+++ b/acceptance/bundle/python/unknown-resource-for-cli/out.test.toml
@@ -1,0 +1,6 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  UV_ARGS = []

--- a/acceptance/bundle/python/unknown-resource-for-cli/output.txt
+++ b/acceptance/bundle/python/unknown-resource-for-cli/output.txt
@@ -1,0 +1,16 @@
+Error: unknown field: unknown_resource
+  at resources
+  in __generated_by_python__.yml:1:792
+
+{
+  "experimental": {
+    "python": {
+      "resources": [
+        "resources:load_resources"
+      ]
+    }
+  },
+  "resources": null
+}
+
+Exit code: 1

--- a/acceptance/bundle/python/unknown-resource-for-cli/script
+++ b/acceptance/bundle/python/unknown-resource-for-cli/script
@@ -1,0 +1,4 @@
+$CLI bundle validate --output json | \
+  jq "pick(.experimental.python, .resources)"
+
+rm -fr .databricks __pycache__

--- a/acceptance/bundle/python/unknown-resource-for-cli/test.toml
+++ b/acceptance/bundle/python/unknown-resource-for-cli/test.toml
@@ -1,0 +1,2 @@
+[EnvMatrix]
+UV_ARGS = [] # don't use UV, we provide our own "fake" implementation

--- a/acceptance/bundle/python/unknown-resource-for-python/databricks.yml
+++ b/acceptance/bundle/python/unknown-resource-for-python/databricks.yml
@@ -1,0 +1,17 @@
+bundle:
+  name: my_project
+
+sync: {paths: []} # don't need to copy files
+
+experimental:
+  python:
+    resources:
+      - "resources:load_resources"
+    mutators:
+      - "mutators:update_job"
+
+resources:
+  apps:
+    my_app:
+      name: "My App"
+      source_code_path: ""

--- a/acceptance/bundle/python/unknown-resource-for-python/mutators.py
+++ b/acceptance/bundle/python/unknown-resource-for-python/mutators.py
@@ -1,0 +1,8 @@
+from dataclasses import replace
+from databricks.bundles.jobs import Job
+from databricks.bundles.core import job_mutator
+
+
+@job_mutator
+def update_job(job: Job) -> Job:
+    return replace(job, name="Updated Job Name")

--- a/acceptance/bundle/python/unknown-resource-for-python/out.test.toml
+++ b/acceptance/bundle/python/unknown-resource-for-python/out.test.toml
@@ -1,0 +1,6 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform", "direct-exp"]
+  UV_ARGS = ["--with databricks-bundles==0.7.3", "--with-requirements requirements-latest.txt --no-cache"]

--- a/acceptance/bundle/python/unknown-resource-for-python/output.txt
+++ b/acceptance/bundle/python/unknown-resource-for-python/output.txt
@@ -1,0 +1,30 @@
+
+>>> uv run [UV_ARGS] -q [CLI] bundle validate --output json
+{
+  "resources": {
+    "apps": {
+      "my_app": {
+        "description": "",
+        "name": "My App",
+        "permissions": [],
+        "source_code_path": "/Workspace/Users/[USERNAME]/.bundle/my_project/default/files"
+      }
+    },
+    "jobs": {
+      "my_job_1": {
+        "deployment": {
+          "kind": "BUNDLE",
+          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/my_project/default/state/metadata.json"
+        },
+        "edit_mode": "UI_LOCKED",
+        "format": "MULTI_TASK",
+        "max_concurrent_runs": 1,
+        "name": "Updated Job Name",
+        "permissions": [],
+        "queue": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}

--- a/acceptance/bundle/python/unknown-resource-for-python/resources.py
+++ b/acceptance/bundle/python/unknown-resource-for-python/resources.py
@@ -1,0 +1,11 @@
+from databricks.bundles.core import Resources
+
+
+def load_resources() -> Resources:
+    resources = Resources()
+    resources.add_job(
+        resource_name="my_job_1",
+        job={"name": "Job 1"},
+    )
+
+    return resources

--- a/acceptance/bundle/python/unknown-resource-for-python/script
+++ b/acceptance/bundle/python/unknown-resource-for-python/script
@@ -1,0 +1,6 @@
+echo "$DATABRICKS_BUNDLES_WHEEL" > "requirements-latest.txt"
+
+trace uv run $UV_ARGS -q $CLI bundle validate --output json | \
+  jq "pick(.resources)"
+
+rm -fr .databricks __pycache__


### PR DESCRIPTION
## Changes
Test support for unknown resources between CLI/Python:
- CLI supports a resource that is not known to Python code
- Python code supports a resource type that is not known to the CLI

## Why
We don't enforce a 1-1 match between versions, which can potentially create compatibility problems that we need to test.