### PR TITLE
Log to telemetry redacted $resources references

### DIFF
--- a/acceptance/bundle/debuglog/out.stderr.direct-exp.txt
+++ b/acceptance/bundle/debuglog/out.stderr.direct-exp.txt
@@ -45,6 +45,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=ConfigureWSFS
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=ResolveVariableReferences(resources)
+10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=LogResourceReferences
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=NormalizePaths
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=TranslatePathsDashboards
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load_resources)

--- a/acceptance/bundle/debuglog/out.stderr.terraform.txt
+++ b/acceptance/bundle/debuglog/out.stderr.terraform.txt
@@ -45,6 +45,7 @@
 10:07:59 Debug: Apply pid=12345 mutator=ConfigureWSFS
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=ResolveVariableReferences(resources)
+10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=LogResourceReferences
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=NormalizePaths
 10:07:59 Debug: Apply pid=12345 mutator=ProcessStaticResources mutator=TranslatePathsDashboards
 10:07:59 Debug: Apply pid=12345 mutator=PythonMutator(load_resources)

--- a/acceptance/bundle/resource_deps/job_tasks/databricks.yml
+++ b/acceptance/bundle/resource_deps/job_tasks/databricks.yml
@@ -1,0 +1,31 @@
+resources:
+  jobs:
+    test_job:
+      name: "My Wheel Job"
+      environments: []
+      tags:
+        my_own_tag_key: my_own_tag_value
+      tasks:
+        - task_key: TestTask
+          python_wheel_task:
+            package_name: "my_test_code"
+            entry_point: "run"
+          environment_key: test_env
+          libraries:
+            - whl: hello.whl
+    foo:
+      name: "My foo Job"
+      environments: []
+      tags:
+        my_other_tag: ${resources.jobs.test_job.tags.my_own_tag_key}
+      tasks:
+        - task_key: TestTask
+          python_wheel_task:
+            package_name: "my_test_code"
+            # for direct, the syntax follows SDK struct:
+            #entry_point: ${resources.jobs.test_job.tasks[0].python_wheel_task.entry_point}
+            # for terraform, the syntax follows TF model:
+            entry_point: ${resources.jobs.test_job.task[0].python_wheel_task[0].entry_point}
+          environment_key: test_env
+          libraries:
+            - whl: hello.whl

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_CLI_DEPLOYMENT = ["terraform"]

--- a/acceptance/bundle/resource_deps/job_tasks/output.txt
+++ b/acceptance/bundle/resource_deps/job_tasks/output.txt
@@ -22,7 +22,7 @@ has_classic_job_compute
 has_serverless_compute
 presets_name_prefix_is_set
 python_wheel_wrapper_is_set
-resref_jobs_tags_my_own_tag_key
-resref_jobs_task_python_wheel_task_cut_3
+resref__jobs__tags__mapkey
+resreferr__jobs__task
 run_as_set
 skip_artifact_cleanup

--- a/acceptance/bundle/resource_deps/job_tasks/output.txt
+++ b/acceptance/bundle/resource_deps/job_tasks/output.txt
@@ -1,0 +1,28 @@
+
+>>> [CLI] bundle validate
+Name: test-bundle
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Validation OK!
+
+>>> [CLI] bundle deploy
+Uploading hello.whl...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> print_telemetry_bool_values
+experimental.use_legacy_run_as
+has_classic_interactive_compute
+has_classic_job_compute
+has_serverless_compute
+presets_name_prefix_is_set
+python_wheel_wrapper_is_set
+resref_jobs_tags_my_own_tag_key
+resref_jobs_task_python_wheel_task_cut_3
+run_as_set
+skip_artifact_cleanup

--- a/acceptance/bundle/resource_deps/job_tasks/output.txt
+++ b/acceptance/bundle/resource_deps/job_tasks/output.txt
@@ -1,13 +1,4 @@
 
->>> [CLI] bundle validate
-Name: test-bundle
-Target: default
-Workspace:
-  User: [USERNAME]
-  Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
-
-Validation OK!
-
 >>> [CLI] bundle deploy
 Uploading hello.whl...
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -16,13 +7,13 @@ Updating deployment state...
 Deployment complete!
 
 >>> print_telemetry_bool_values
-experimental.use_legacy_run_as
-has_classic_interactive_compute
-has_classic_job_compute
-has_serverless_compute
-presets_name_prefix_is_set
-python_wheel_wrapper_is_set
-resref__jobs__tags__mapkey
-resreferr__jobs__task
-run_as_set
-skip_artifact_cleanup
+experimental.use_legacy_run_as false
+has_classic_interactive_compute false
+has_classic_job_compute false
+has_serverless_compute true
+presets_name_prefix_is_set false
+python_wheel_wrapper_is_set false
+resref__jobs__tags__mapkey true
+resreferr__jobs__task true
+run_as_set false
+skip_artifact_cleanup false

--- a/acceptance/bundle/resource_deps/job_tasks/output.txt
+++ b/acceptance/bundle/resource_deps/job_tasks/output.txt
@@ -13,7 +13,7 @@ has_classic_job_compute false
 has_serverless_compute true
 presets_name_prefix_is_set false
 python_wheel_wrapper_is_set false
-resref__jobs__tags__mapkey true
-resreferr__jobs__task true
+resref_jobs.tags.* true
+resreferr_jobs.task true
 run_as_set false
 skip_artifact_cleanup false

--- a/acceptance/bundle/resource_deps/job_tasks/script
+++ b/acceptance/bundle/resource_deps/job_tasks/script
@@ -1,5 +1,4 @@
 touch hello.whl
-trace $CLI bundle validate
 trace $CLI bundle deploy
 trace print_telemetry_bool_values
 rm out.requests.txt hello.whl

--- a/acceptance/bundle/resource_deps/job_tasks/script
+++ b/acceptance/bundle/resource_deps/job_tasks/script
@@ -1,0 +1,5 @@
+touch hello.whl
+trace $CLI bundle validate
+trace $CLI bundle deploy
+trace print_telemetry_bool_values
+rm out.requests.txt hello.whl

--- a/acceptance/bundle/resource_deps/job_tasks/test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/test.toml
@@ -1,0 +1,4 @@
+RecordRequests = true
+
+# direct fails with Error: schema mismatch for ${resources.jobs.test_job.task[0].python_wheel_task[0].entry_point}: task: field "task" not found in resources.Job
+EnvMatrix.DATABRICKS_CLI_DEPLOYMENT = ["terraform"]  # uses TF-specific syntax task[0].python_wheel_task[0]

--- a/acceptance/bundle/resource_deps/missing_map_key_tffix/output.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key_tffix/output.txt
@@ -42,3 +42,6 @@
     }
   }
 }
+
+=== Nothing is logged in telemetry because deploy has failed
+>>> print_telemetry_bool_values

--- a/acceptance/bundle/resource_deps/missing_map_key_tffix/script
+++ b/acceptance/bundle/resource_deps/missing_map_key_tffix/script
@@ -1,3 +1,7 @@
 trace $CLI bundle validate -o json | jq .resources
 musterr $CLI bundle plan &> out.plan.$DATABRICKS_CLI_DEPLOYMENT.txt
 musterr $CLI bundle deploy &> out.deploy.$DATABRICKS_CLI_DEPLOYMENT.txt
+
+title "Nothing is logged in telemetry because deploy has failed"
+trace print_telemetry_bool_values
+rm out.requests.txt

--- a/acceptance/bundle/resource_deps/missing_map_key_tffix/test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key_tffix/test.toml
@@ -1,2 +1,2 @@
 Badness = "Uploading files even though bundle is wrong; bundle validate does not detect the issue; direct fails but with wrong error message"
-RecordRequests = false
+RecordRequests = true

--- a/acceptance/bundle/resource_deps/resources_var/out.requests.txt
+++ b/acceptance/bundle/resource_deps/resources_var/out.requests.txt
@@ -1,3 +1,0 @@
-
->>> jq -s .[] | select(.path=="/api/2.0/pipelines") | .body.name out.requests.txt
-"[dev [USERNAME]] pipeline for mycatalog.myschema.myname"

--- a/acceptance/bundle/resource_deps/resources_var/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var/output.txt
@@ -43,8 +43,8 @@ has_classic_job_compute
 has_serverless_compute
 presets_name_prefix_is_set
 python_wheel_wrapper_is_set
-resref_volumes_catalog_name
-resref_volumes_name
-resref_volumes_schema_name
+resref__volumes__catalog_name
+resref__volumes__name
+resref__volumes__schema_name
 run_as_set
 skip_artifact_cleanup

--- a/acceptance/bundle/resource_deps/resources_var/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var/output.txt
@@ -37,14 +37,14 @@
 "[dev [USERNAME]] pipeline for mycatalog.myschema.myname"
 
 >>> print_telemetry_bool_values
-experimental.use_legacy_run_as
-has_classic_interactive_compute
-has_classic_job_compute
-has_serverless_compute
-presets_name_prefix_is_set
-python_wheel_wrapper_is_set
-resref__volumes__catalog_name
-resref__volumes__name
-resref__volumes__schema_name
-run_as_set
-skip_artifact_cleanup
+experimental.use_legacy_run_as false
+has_classic_interactive_compute false
+has_classic_job_compute false
+has_serverless_compute false
+presets_name_prefix_is_set true
+python_wheel_wrapper_is_set false
+resref__volumes__catalog_name true
+resref__volumes__name true
+resref__volumes__schema_name true
+run_as_set false
+skip_artifact_cleanup false

--- a/acceptance/bundle/resource_deps/resources_var/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var/output.txt
@@ -43,8 +43,8 @@ has_classic_job_compute false
 has_serverless_compute false
 presets_name_prefix_is_set true
 python_wheel_wrapper_is_set false
-resref__volumes__catalog_name true
-resref__volumes__name true
-resref__volumes__schema_name true
+resref_volumes.catalog_name true
+resref_volumes.name true
+resref_volumes.schema_name true
 run_as_set false
 skip_artifact_cleanup false

--- a/acceptance/bundle/resource_deps/resources_var/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var/output.txt
@@ -32,3 +32,19 @@
     }
   }
 }
+
+>>> jq -s .[] | select(.path=="/api/2.0/pipelines") | .body.name out.requests.txt
+"[dev [USERNAME]] pipeline for mycatalog.myschema.myname"
+
+>>> print_telemetry_bool_values
+experimental.use_legacy_run_as
+has_classic_interactive_compute
+has_classic_job_compute
+has_serverless_compute
+presets_name_prefix_is_set
+python_wheel_wrapper_is_set
+resref_volumes_catalog_name
+resref_volumes_name
+resref_volumes_schema_name
+run_as_set
+skip_artifact_cleanup

--- a/acceptance/bundle/resource_deps/resources_var/script
+++ b/acceptance/bundle/resource_deps/resources_var/script
@@ -1,5 +1,5 @@
 trace $CLI bundle validate -t dev -o json | jq .resources
 trace errcode $CLI bundle deploy -t dev &> out.deploy.txt
-trace jq -s '.[] | select(.path=="/api/2.0/pipelines") | .body.name' out.requests.txt &> tmp.requests.txt
+trace jq -s '.[] | select(.path=="/api/2.0/pipelines") | .body.name' out.requests.txt
+trace print_telemetry_bool_values
 rm out.requests.txt
-mv tmp.requests.txt out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-artifacts-variables/script
+++ b/acceptance/bundle/telemetry/deploy-artifacts-variables/script
@@ -6,6 +6,6 @@ trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext
 trace $CLI bundle deploy -t prod
 
 title "Artifact metrics expected"
-trace print_telemetry_bool_values | grep artifacts_reference_used
+trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values[] | select(.key == "artifacts_reference_used")'
 
 rm out.requests.txt

--- a/acceptance/bundle/telemetry/deploy-artifacts-variables/script
+++ b/acceptance/bundle/telemetry/deploy-artifacts-variables/script
@@ -6,6 +6,6 @@ trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext
 trace $CLI bundle deploy -t prod
 
 title "Artifact metrics expected"
-trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson | .entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values[] | select(.key == "artifacts_reference_used")'
+trace print_telemetry_bool_values | grep artifacts_reference_used
 
 rm out.requests.txt

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -95,5 +95,5 @@ envsubst() {
 }
 
 print_telemetry_bool_values() {
-    jq -r 'select(.path? == "/telemetry-ext") | (.body.protoLogs // [])[] | fromjson | ( (.entry // .) | (.databricks_cli_log.bundle_deploy_event.experimental.bool_values // []) ) | map(.key) | .[]' out.requests.txt | sort
+    jq -r 'select(.path? == "/telemetry-ext") | (.body.protoLogs // [])[] | fromjson | ( (.entry // .) | (.databricks_cli_log.bundle_deploy_event.experimental.bool_values // []) ) | map("\(.key) \(.value)") | .[]' out.requests.txt | sort
 }

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -93,3 +93,7 @@ envsubst() {
     # when MSYS_NO_PATHCONV is enabled.
     env -u MSYS_NO_PATHCONV envsubst.py
 }
+
+print_telemetry_bool_values() {
+    jq -r 'select(.path? == "/telemetry-ext") | (.body.protoLogs // [])[] | fromjson | ( (.entry // .) | (.databricks_cli_log.bundle_deploy_event.experimental.bool_values // []) ) | map(.key) | .[]' out.requests.txt | sort
+}

--- a/bundle/config/mutator/log_resource_references.go
+++ b/bundle/config/mutator/log_resource_references.go
@@ -56,9 +56,17 @@ func (m *logResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) dia
 			return dyn.InvalidValue, err
 		}
 
+		maxRefsLogged := 50
+
+		// map iteration is randomized, which works for this case
 		for key := range used {
 			b.Metrics.AddBoolValue(key, true)
+			maxRefsLogged--
+			if maxRefsLogged <= 0 {
+				break
+			}
 		}
+
 		return root, nil
 	})
 	if err != nil {

--- a/bundle/config/mutator/log_resource_references.go
+++ b/bundle/config/mutator/log_resource_references.go
@@ -22,12 +22,7 @@ func (m *logResourceReferences) Name() string {
 	return "LogResourceReferences"
 }
 
-func (m *logResourceReferences) Validate(ctx context.Context, b *bundle.Bundle) error {
-	return nil
-}
-
 func (m *logResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	// Walk only the resources subtree.
 	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
 		pattern := dyn.NewPattern(dyn.Key("resources"))
 		used := map[string]struct{}{}

--- a/bundle/config/mutator/log_resource_references.go
+++ b/bundle/config/mutator/log_resource_references.go
@@ -1,0 +1,110 @@
+package mutator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/dynvar"
+)
+
+// logResourceReferences scans resources for ${resources.*} references and logs them.
+func LogResourceReferences() bundle.Mutator {
+	return &logResourceReferences{}
+}
+
+type logResourceReferences struct{}
+
+func (m *logResourceReferences) Name() string {
+	return "LogResourceReferences"
+}
+
+func (m *logResourceReferences) Validate(ctx context.Context, b *bundle.Bundle) error {
+	return nil
+}
+
+func (m *logResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	// Walk only the resources subtree.
+	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+		pattern := dyn.NewPattern(dyn.Key("resources"))
+		used := map[string]struct{}{}
+		_, err := dyn.MapByPattern(root, pattern, func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+			_ = dyn.WalkReadOnly(v, func(path dyn.Path, val dyn.Value) error {
+				ref, ok := dynvar.NewRef(val)
+				if !ok {
+					return nil
+				}
+				for _, r := range ref.References() {
+					// Only track ${resources.*} references.
+					if !strings.HasPrefix(r, "resources.") {
+						continue
+					}
+
+					key := convertReferenceToMetric(r)
+					if key != "" {
+						used[key] = struct{}{}
+					}
+				}
+				return nil
+			})
+			return v, nil
+		})
+		if err != nil {
+			return dyn.InvalidValue, err
+		}
+
+		for key := range used {
+			b.Metrics.AddBoolValue(key, true)
+		}
+		return root, nil
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+// convertReferenceToMetric converts a reference like "resources.jobs.foo.id" to
+// a telemetry key like "jobs_id"; and deep paths like
+// "resources.pipelines.bar.my.som.field[3].key.bla" to "pipelines_my_som_cut_4".
+// It drops the resource key, keeps up to 2 key fields, truncates each to 15 chars,
+// and appends _cut_N when there are remaining components (indices count too).
+func convertReferenceToMetric(ref string) string {
+	p, err := dyn.NewPathFromString(ref)
+	if err != nil || len(p) < 3 || p[0].Key() != "resources" {
+		return ""
+	}
+
+	kept := []string{"resref", truncate(p[1].Key(), 20)}
+	remaining := 0
+	for i := 3; i < len(p); i++ {
+		c := p[i]
+		if c.Key() != "" {
+			if len(kept) < 4 {
+				// Longest field name:
+				// >>> len('hard_deletion_sync_min_interval_in_seconds') == 42
+				kept = append(kept, truncate(c.Key(), 42))
+				continue
+			}
+			remaining++
+			continue
+		}
+		// index
+		remaining++
+	}
+
+	if remaining > 0 {
+		kept = append(kept, fmt.Sprintf("cut_%d", remaining))
+	}
+	return strings.Join(kept, "_")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/bundle/config/mutator/log_resource_references.go
+++ b/bundle/config/mutator/log_resource_references.go
@@ -31,49 +31,43 @@ func (m *logResourceReferences) Name() string {
 }
 
 func (m *logResourceReferences) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
-		used := map[string]struct{}{}
-		resources := root.Get("resources")
-		if !resources.IsValid() {
-			// No resources section, nothing to do
-			return root, nil
-		}
-
-		_ = dyn.WalkReadOnly(resources, func(path dyn.Path, val dyn.Value) error {
-			ref, ok := dynvar.NewRef(val)
-			if !ok {
-				return nil
-			}
-			for _, r := range ref.References() {
-				// Only track ${resources.*} references.
-				if !strings.HasPrefix(r, "resources.") {
-					continue
-				}
-
-				key := convertReferenceToMetric(ctx, b.Config, r)
-				if key != "" {
-					used[key] = struct{}{}
-				}
-			}
-			return nil
-		})
-
-		maxRefsLogged := 50
-
-		// map iteration is randomized, which works for this case
-		for key := range used {
-			b.Metrics.AddBoolValue(key, true)
-			maxRefsLogged--
-			if maxRefsLogged <= 0 {
-				break
-			}
-		}
-
-		return root, nil
-	})
-	if err != nil {
-		return diag.FromErr(err)
+	used := map[string]struct{}{}
+	resources := b.Config.Value().Get("resources")
+	if !resources.IsValid() {
+		// No resources section, nothing to do
+		return nil
 	}
+
+	_ = dyn.WalkReadOnly(resources, func(path dyn.Path, val dyn.Value) error {
+		ref, ok := dynvar.NewRef(val)
+		if !ok {
+			return nil
+		}
+		for _, r := range ref.References() {
+			// Only track ${resources.*} references.
+			if !strings.HasPrefix(r, "resources.") {
+				continue
+			}
+
+			key := convertReferenceToMetric(ctx, b.Config, r)
+			if key != "" {
+				used[key] = struct{}{}
+			}
+		}
+		return nil
+	})
+
+	maxRefsLogged := 50
+
+	// map iteration is randomized, which works for this case
+	for key := range used {
+		b.Metrics.AddBoolValue(key, true)
+		maxRefsLogged--
+		if maxRefsLogged <= 0 {
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/bundle/config/mutator/log_resource_references.go
+++ b/bundle/config/mutator/log_resource_references.go
@@ -86,7 +86,9 @@ func convertReferenceToMetric(ctx context.Context, cfg any, ref string) string {
 		return ""
 	}
 
-	kept := []string{"resref", truncate(p[1].Key(), maxFieldLength, "")}
+	group := truncate(p[1].Key(), maxFieldLength, "")
+	kept := []string{"resref_" + group}
+
 	for i := 3; i < len(p); i++ {
 		c := p[i]
 		if c.Key() != "" {
@@ -94,7 +96,7 @@ func convertReferenceToMetric(ctx context.Context, cfg any, ref string) string {
 
 			repl, err := censorValue(ctx, cfg, p[:i])
 			if err != nil {
-				kept[0] = "resreferr"
+				kept[0] = "resreferr_" + group
 				break
 			}
 
@@ -108,7 +110,7 @@ func convertReferenceToMetric(ctx context.Context, cfg any, ref string) string {
 		}
 	}
 
-	result := strings.Join(kept, "__")
+	result := strings.Join(kept, ".")
 	return truncate(result, maxMetricLength, "__cut")
 }
 
@@ -136,7 +138,7 @@ func censorValue(ctx context.Context, v any, path dyn.Path) (string, error) {
 			rv = rv.Elem()
 		default:
 			if rv.Kind() == reflect.Map {
-				return "mapkey", nil
+				return "*", nil
 			}
 			return "", nil
 		}

--- a/bundle/config/mutator/log_resource_references_test.go
+++ b/bundle/config/mutator/log_resource_references_test.go
@@ -80,9 +80,14 @@ func TestConvertReferenceToMetric_Table(t *testing.T) {
 			want: "resreferr__jobs",
 		},
 		{
-			name: "array index task key",
+			name: "array index tasks key",
 			ref:  "resources.jobs.foo.tasks[0].task_key",
 			want: "resref__jobs__tasks__task_key",
+		},
+		{
+			name: "array index task key",
+			ref:  "resources.jobs.foo.task[0].task_key",
+			want: "resreferr__jobs__task",
 		},
 	}
 

--- a/bundle/config/mutator/log_resource_references_test.go
+++ b/bundle/config/mutator/log_resource_references_test.go
@@ -45,6 +45,11 @@ func TestConvertReferenceToMetric_Table(t *testing.T) {
 			want: "resref_jobs.id",
 		},
 		{
+			name: "basic job id with non-ascii key",
+			ref:  "resources.jobs.джоб.id",
+			want: "resreferr_jobs",
+		},
+		{
 			name: "invalid empty",
 			ref:  "",
 			want: "",

--- a/bundle/config/mutator/log_resource_references_test.go
+++ b/bundle/config/mutator/log_resource_references_test.go
@@ -1,0 +1,51 @@
+package mutator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	cres "github.com/databricks/cli/bundle/config/resources"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertReferenceToMetric_Table(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.Root{
+		Resources: config.Resources{
+			Jobs: map[string]*cres.Job{
+				"foo":    {},
+				"niljob": nil,
+			},
+			Apps: map[string]*cres.App{
+				"app1": {
+					Config: map[string]any{
+						"k": "v",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "basic job id", ref: "resources.jobs.foo.id", want: "resref__jobs__id"},
+		{name: "invalid empty", ref: "", want: ""},
+		{name: "invalid variables", ref: "variables.foo", want: ""},
+		{name: "invalid short resources", ref: "resources", want: ""},
+		{name: "invalid short group", ref: "resources.jobs", want: ""},
+		{name: "mapkey censor on app config", ref: "resources.apps.app1.config.foo", want: "resref__apps__config__mapkey"},
+		{name: "nil job pointer yields plain id", ref: "resources.jobs.niljob.id", want: "resref__jobs__id"},
+		{name: "err censor on missing job key", ref: "resources.jobs.missing.id", want: "resreferr__jobs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertReferenceToMetric(ctx, cfg, tt.ref)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/bundle/config/mutator/log_resource_references_test.go
+++ b/bundle/config/mutator/log_resource_references_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/cli/bundle/config"
 	cres "github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +15,13 @@ func TestConvertReferenceToMetric_Table(t *testing.T) {
 	cfg := config.Root{
 		Resources: config.Resources{
 			Jobs: map[string]*cres.Job{
-				"foo":    {},
+				"foo": {
+					JobSettings: jobs.JobSettings{
+						Tasks: []jobs.Task{
+							{TaskKey: "alpha"},
+						},
+					},
+				},
 				"niljob": nil,
 			},
 			Apps: map[string]*cres.App{
@@ -32,14 +39,51 @@ func TestConvertReferenceToMetric_Table(t *testing.T) {
 		ref  string
 		want string
 	}{
-		{name: "basic job id", ref: "resources.jobs.foo.id", want: "resref__jobs__id"},
-		{name: "invalid empty", ref: "", want: ""},
-		{name: "invalid variables", ref: "variables.foo", want: ""},
-		{name: "invalid short resources", ref: "resources", want: ""},
-		{name: "invalid short group", ref: "resources.jobs", want: ""},
-		{name: "mapkey censor on app config", ref: "resources.apps.app1.config.foo", want: "resref__apps__config__mapkey"},
-		{name: "nil job pointer yields plain id", ref: "resources.jobs.niljob.id", want: "resref__jobs__id"},
-		{name: "err censor on missing job key", ref: "resources.jobs.missing.id", want: "resreferr__jobs"},
+		{
+			name: "basic job id",
+			ref:  "resources.jobs.foo.id",
+			want: "resref__jobs__id",
+		},
+		{
+			name: "invalid empty",
+			ref:  "",
+			want: "",
+		},
+		{
+			name: "invalid variables",
+			ref:  "variables.foo",
+			want: "",
+		},
+		{
+			name: "invalid short resources",
+			ref:  "resources",
+			want: "",
+		},
+		{
+			name: "invalid short group",
+			ref:  "resources.jobs",
+			want: "",
+		},
+		{
+			name: "mapkey censor on app config",
+			ref:  "resources.apps.app1.config.foo",
+			want: "resref__apps__config__mapkey",
+		},
+		{
+			name: "nil job pointer yields plain id",
+			ref:  "resources.jobs.niljob.id",
+			want: "resref__jobs__id",
+		},
+		{
+			name: "err censor on missing job key",
+			ref:  "resources.jobs.missing.id",
+			want: "resreferr__jobs",
+		},
+		{
+			name: "array index task key",
+			ref:  "resources.jobs.foo.tasks[0].task_key",
+			want: "resref__jobs__tasks__task_key",
+		},
 	}
 
 	for _, tt := range tests {

--- a/bundle/config/mutator/log_resource_references_test.go
+++ b/bundle/config/mutator/log_resource_references_test.go
@@ -42,7 +42,7 @@ func TestConvertReferenceToMetric_Table(t *testing.T) {
 		{
 			name: "basic job id",
 			ref:  "resources.jobs.foo.id",
-			want: "resref__jobs__id",
+			want: "resref_jobs.id",
 		},
 		{
 			name: "invalid empty",
@@ -67,27 +67,27 @@ func TestConvertReferenceToMetric_Table(t *testing.T) {
 		{
 			name: "mapkey censor on app config",
 			ref:  "resources.apps.app1.config.foo",
-			want: "resref__apps__config__mapkey",
+			want: "resref_apps.config.*",
 		},
 		{
 			name: "nil job pointer yields plain id",
 			ref:  "resources.jobs.niljob.id",
-			want: "resref__jobs__id",
+			want: "resref_jobs.id",
 		},
 		{
 			name: "err censor on missing job key",
 			ref:  "resources.jobs.missing.id",
-			want: "resreferr__jobs",
+			want: "resreferr_jobs",
 		},
 		{
 			name: "array index tasks key",
 			ref:  "resources.jobs.foo.tasks[0].task_key",
-			want: "resref__jobs__tasks__task_key",
+			want: "resref_jobs.tasks.task_key",
 		},
 		{
 			name: "array index task key",
 			ref:  "resources.jobs.foo.task[0].task_key",
-			want: "resreferr__jobs__task",
+			want: "resreferr_jobs.task",
 		},
 	}
 

--- a/bundle/config/mutator/resourcemutator/process_static_resources.go
+++ b/bundle/config/mutator/resourcemutator/process_static_resources.go
@@ -45,6 +45,8 @@ func (p processStaticResources) Apply(ctx context.Context, b *bundle.Bundle) dia
 		// Updates (dynamic): resources.* (strings) (resolves variable references to their actual values)
 		// Resolves variable references in 'resources' using bundle, workspace, and variables prefixes
 		mutator.ResolveVariableReferencesOnlyResources(),
+		// After normal variable resolution, log all ${resources.*} references
+		mutator.LogResourceReferences(),
 		mutator.NormalizePaths(),
 
 		// Translate dashboard paths into paths in the workspace file system


### PR DESCRIPTION
## Changes
For every $resource.group.key.field1.field2 reference add resref_group_field1_field2 bool metric.

If we encounter map key, place "mapkey" in case of actual value.

If we encounter error during struct traversal, log what we can with resreferr_ prefix instead.

## Why
With remote state lookups added in https://github.com/databricks/cli/pull/3531 we use API / SDK struct schema for accessing remote fields, which is different from Terraform schema. Having telemetry allows to estimate number of customers using $resources references and estimate usage of incompatible references.

## Tests
Existing tests expanded to log telemetry.
New acceptance test which includes longer path.
New helper in tests to log boolean fields from telemetry request.
New unit tests.
