### PR TITLE
Reject use of fmt.Printf under cmd/

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - unused
     - exhaustruct
     - copyloopvar
+    - forbidigo
   settings:
     copyloopvar:
       check-alias: true
@@ -72,6 +73,9 @@ linters:
       - path: bundle/terranova/tnresources/all_test.go
         linters:
           - exhaustruct
+      - path-except: ^cmd
+        linters:
+          - forbidigo
 issues:
   max-issues-per-linter: 1000
   max-same-issues: 1000


### PR DESCRIPTION
## Changes

Reject directly writing to global stdout/stderr.

The "forbidigo" linter includes this rule by default.

Also see https://golangci-lint.run/docs/linters/configuration/#forbidigo

## Why

The CLI uses Cobra and should therefore use `cmd.OutOrStdout()` and friends.

Saw this here: https://github.com/databricks/cli/pull/3546#discussion_r2330073899