### PR TITLE
refactor: Extract common resource fields into a separate embedded struct

### DIFF
--- a/bundle/apps/interpolate_variables_test.go
+++ b/bundle/apps/interpolate_variables_test.go
@@ -35,7 +35,7 @@ func TestAppInterpolateVariables(t *testing.T) {
 				},
 				Jobs: map[string]*resources.Job{
 					"my_job": {
-						ID: "123",
+						BaseResource: resources.BaseResource{ID: "123"},
 					},
 				},
 			},

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -25,8 +25,8 @@ func TestInitializeURLs(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						ID:          "1",
-						JobSettings: jobs.JobSettings{Name: "job1"},
+						BaseResource: resources.BaseResource{ID: "1"},
+						JobSettings:  jobs.JobSettings{Name: "job1"},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
@@ -37,19 +37,19 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment1": {
-						ID:         "4",
-						Experiment: ml.Experiment{Name: "experiment1"},
+						BaseResource: resources.BaseResource{ID: "4"},
+						Experiment:   ml.Experiment{Name: "experiment1"},
 					},
 				},
 				Models: map[string]*resources.MlflowModel{
 					"model1": {
-						ID:                 "a model uses its name for identifier",
+						BaseResource:       resources.BaseResource{ID: "a model uses its name for identifier"},
 						CreateModelRequest: ml.CreateModelRequest{Name: "a model uses its name for identifier"},
 					},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"servingendpoint1": {
-						ID: "my_serving_endpoint",
+						BaseResource: resources.BaseResource{ID: "my_serving_endpoint"},
 						CreateServingEndpoint: serving.CreateServingEndpoint{
 							Name: "my_serving_endpoint",
 						},
@@ -57,7 +57,7 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				RegisteredModels: map[string]*resources.RegisteredModel{
 					"registeredmodel1": {
-						ID: "8",
+						BaseResource: resources.BaseResource{ID: "8"},
 						CreateRegisteredModelRequest: catalog.CreateRegisteredModelRequest{
 							Name: "my_registered_model",
 						},
@@ -71,7 +71,7 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
-						ID: "catalog.schema",
+						BaseResource: resources.BaseResource{ID: "catalog.schema"},
 						CreateSchema: catalog.CreateSchema{
 							Name: "schema",
 						},
@@ -79,7 +79,7 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				Clusters: map[string]*resources.Cluster{
 					"cluster1": {
-						ID: "1017-103929-vlr7jzcf",
+						BaseResource: resources.BaseResource{ID: "1017-103929-vlr7jzcf"},
 						ClusterSpec: compute.ClusterSpec{
 							ClusterName: "cluster1",
 						},
@@ -87,7 +87,7 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				Dashboards: map[string]*resources.Dashboard{
 					"dashboard1": {
-						ID: "01ef8d56871e1d50ae30ce7375e42478",
+						BaseResource: resources.BaseResource{ID: "01ef8d56871e1d50ae30ce7375e42478"},
 						DashboardConfig: resources.DashboardConfig{
 							Dashboard: dashboards.Dashboard{
 								DisplayName: "My special dashboard",
@@ -128,8 +128,8 @@ func TestInitializeURLsWithoutOrgId(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						ID:          "1",
-						JobSettings: jobs.JobSettings{Name: "job1"},
+						BaseResource: resources.BaseResource{ID: "1"},
+						JobSettings:  jobs.JobSettings{Name: "job1"},
 					},
 				},
 			},

--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -31,7 +31,7 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline1": {
-						ID:             "3",
+						BaseResource:   resources.BaseResource{ID: "3"},
 						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1"},
 					},
 				},

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -23,11 +23,7 @@ type AppPermission struct {
 }
 
 type App struct {
-	// We cannot embed BaseResource here because apps.App has its own Id field
-	// that conflicts with BaseResource.ID
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	BaseResource
 
 	// SourceCodePath is a required field used by DABs to point to Databricks app source code
 	// on local disk and to the corresponding workspace path during app deployment.
@@ -41,7 +37,7 @@ type App struct {
 
 	Permissions []AppPermission `json:"permissions,omitempty"`
 
-	apps.App
+	apps.App // nolint App struct also defines Id and URL field with the same json tag "id" and "url"
 }
 
 func (a *App) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -23,9 +23,11 @@ type AppPermission struct {
 }
 
 type App struct {
-	// This is app's name pulled from the state. Usually the same as Name but may be different if Name in the config
-	// was changed but the app was not re-deployed yet.
-	ID string `json:"id,omitempty" bundle:"readonly"`
+	// We cannot embed BaseResource here because apps.App has its own Id field
+	// that conflicts with BaseResource.ID
+	ID             string         `json:"id,omitempty" bundle:"readonly"`
+	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string         `json:"url,omitempty" bundle:"internal"`
 
 	// SourceCodePath is a required field used by DABs to point to Databricks app source code
 	// on local disk and to the corresponding workspace path during app deployment.
@@ -34,12 +36,10 @@ type App struct {
 	// Config is an optional field which allows configuring the app following Databricks app configuration format like in app.yml.
 	// When this field is set, DABs read the configuration set in this field and write
 	// it to app.yml in the root of the source code folder in Databricks workspace.
-	// If there’s app.yml defined locally, DABs will raise an error.
+	// If there's app.yml defined locally, DABs will raise an error.
 	Config map[string]any `json:"config,omitempty"`
 
-	Permissions    []AppPermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string          `json:"url,omitempty" bundle:"internal"`
+	Permissions []AppPermission `json:"permissions,omitempty"`
 
 	apps.App
 }

--- a/bundle/config/resources/base.go
+++ b/bundle/config/resources/base.go
@@ -1,0 +1,8 @@
+package resources
+
+// BaseResource is a struct that contains the base settings for a resource.
+type BaseResource struct {
+	ID             string         `json:"id,omitempty" bundle:"readonly"`
+	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
+	URL            string         `json:"url,omitempty" bundle:"internal"`
+}

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -23,10 +23,9 @@ type ClusterPermission struct {
 }
 
 type Cluster struct {
-	ID             string              `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []ClusterPermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus      `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string              `json:"url,omitempty" bundle:"internal"`
+	BaseResource
+
+	Permissions []ClusterPermission `json:"permissions,omitempty"`
 
 	compute.ClusterSpec
 }

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -45,10 +45,8 @@ type DashboardConfig struct {
 }
 
 type Dashboard struct {
-	ID             string                `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []DashboardPermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus        `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string                `json:"url,omitempty" bundle:"internal"`
+	BaseResource
+	Permissions []DashboardPermission `json:"permissions,omitempty"`
 
 	DashboardConfig
 

--- a/bundle/config/resources/database_catalog.go
+++ b/bundle/config/resources/database_catalog.go
@@ -11,9 +11,7 @@ import (
 )
 
 type DatabaseCatalog struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
+	BaseResource
 
 	database.DatabaseCatalog
 }

--- a/bundle/config/resources/database_instance.go
+++ b/bundle/config/resources/database_instance.go
@@ -23,10 +23,9 @@ type DatabaseInstancePermission struct {
 }
 
 type DatabaseInstance struct {
-	ID             string                       `json:"id,omitempty" bundle:"readonly"`
-	URL            string                       `json:"url,omitempty" bundle:"internal"`
-	Permissions    []DatabaseInstancePermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus               `json:"modified_status,omitempty" bundle:"internal"`
+	BaseResource
+
+	Permissions []DatabaseInstancePermission `json:"permissions,omitempty"`
 
 	database.DatabaseInstance
 }

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -24,10 +24,9 @@ type JobPermission struct {
 }
 
 type Job struct {
-	ID             string          `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []JobPermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus  `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string          `json:"url,omitempty" bundle:"internal"`
+	BaseResource
+
+	Permissions []JobPermission `json:"permissions,omitempty"`
 
 	jobs.JobSettings
 }

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -23,10 +23,9 @@ type MlflowExperimentPermission struct {
 }
 
 type MlflowExperiment struct {
-	ID             string                       `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []MlflowExperimentPermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus               `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string                       `json:"url,omitempty" bundle:"internal"`
+	BaseResource
+
+	Permissions []MlflowExperimentPermission `json:"permissions,omitempty"`
 
 	ml.Experiment
 }

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -23,10 +23,9 @@ type MlflowModelPermission struct {
 }
 
 type MlflowModel struct {
-	ID             string                  `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []MlflowModelPermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus          `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string                  `json:"url,omitempty" bundle:"internal"`
+	BaseResource
+
+	Permissions []MlflowModelPermission `json:"permissions,omitempty"`
 
 	ml.CreateModelRequest
 }

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -23,20 +23,15 @@ type ModelServingEndpointPermission struct {
 }
 
 type ModelServingEndpoint struct {
-	// This represents the input args for terraform, and will get converted
-	// to a HCL representation for CRUD
-	serving.CreateServingEndpoint
-
-	// This represents the id (ie serving_endpoint_id) that can be used
-	// as a reference in other resources. This value is returned by terraform.
-	ID string `json:"id,omitempty" bundle:"readonly"`
+	BaseResource
 
 	// This is a resource agnostic implementation of permissions for ACLs.
 	// Implementation could be different based on the resource type.
 	Permissions []ModelServingEndpointPermission `json:"permissions,omitempty"`
 
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	// This represents the input args for terraform, and will get converted
+	// to a HCL representation for CRUD
+	serving.CreateServingEndpoint
 }
 
 func (s *ModelServingEndpoint) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -23,14 +23,10 @@ type PipelinePermission struct {
 }
 
 type Pipeline struct {
-	// We cannot embed BaseResource here because pipelines.CreatePipeline has its own Id field
-	// that conflicts with BaseResource.ID
-	ID             string               `json:"id,omitempty" bundle:"readonly"`
-	Permissions    []PipelinePermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus       `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string               `json:"url,omitempty" bundle:"internal"`
+	BaseResource
+	Permissions []PipelinePermission `json:"permissions,omitempty"`
 
-	pipelines.CreatePipeline
+	pipelines.CreatePipeline //nolint CreatePipeline also defines Id field with the same json tag "id"
 }
 
 func (p *Pipeline) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -23,6 +23,8 @@ type PipelinePermission struct {
 }
 
 type Pipeline struct {
+	// We cannot embed BaseResource here because pipelines.CreatePipeline has its own Id field
+	// that conflicts with BaseResource.ID
 	ID             string               `json:"id,omitempty" bundle:"readonly"`
 	Permissions    []PipelinePermission `json:"permissions,omitempty"`
 	ModifiedStatus ModifiedStatus       `json:"modified_status,omitempty" bundle:"internal"`

--- a/bundle/config/resources/quality_monitor.go
+++ b/bundle/config/resources/quality_monitor.go
@@ -12,9 +12,7 @@ import (
 )
 
 type QualityMonitor struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
+	BaseResource
 
 	// The table name is a required field but not included as a JSON field in [catalog.CreateMonitor].
 	TableName string `json:"table_name"`

--- a/bundle/config/resources/registered_model.go
+++ b/bundle/config/resources/registered_model.go
@@ -12,21 +12,15 @@ import (
 )
 
 type RegisteredModel struct {
+	BaseResource
+
 	// This is a resource agnostic implementation of grants.
 	// Implementation could be different based on the resource type.
 	Grants []Grant `json:"grants,omitempty"`
 
-	// This represents the id which is the full name of the model
-	// (catalog_name.schema_name.model_name) that can be used
-	// as a reference in other resources. This value is returned by terraform.
-	ID string `json:"id,omitempty" bundle:"readonly"`
-
 	// This represents the input args for terraform, and will get converted
 	// to a HCL representation for CRUD
 	catalog.CreateRegisteredModelRequest
-
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
 }
 
 func (s *RegisteredModel) UnmarshalJSON(b []byte) error {

--- a/bundle/config/resources/schema.go
+++ b/bundle/config/resources/schema.go
@@ -60,17 +60,12 @@ type SchemaGrant struct {
 }
 
 type Schema struct {
+	BaseResource
+
 	// List of grants to apply on this schema.
 	Grants []SchemaGrant `json:"grants,omitempty"`
 
-	// Full name of the schema (catalog_name.schema_name). This value is read from
-	// the terraform state after deployment succeeds.
-	ID string `json:"id,omitempty" bundle:"readonly"`
-
 	catalog.CreateSchema
-
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
 }
 
 func (s *Schema) Exists(ctx context.Context, w *databricks.WorkspaceClient, fullName string) (bool, error) {

--- a/bundle/config/resources/secret_scope.go
+++ b/bundle/config/resources/secret_scope.go
@@ -23,14 +23,12 @@ type SecretScopePermission struct {
 }
 
 type SecretScope struct {
-	// ID is Name that is stored in resources state, usually the same as Name unless re-deployment is pending.
-	ID string `json:"id,omitempty" bundle:"readonly"`
+	BaseResource
 
 	// A unique name to identify the secret scope.
 	Name string `json:"name"`
 
-	Permissions    []SecretScopePermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus          `json:"modified_status,omitempty" bundle:"internal"`
+	Permissions []SecretScopePermission `json:"permissions,omitempty"`
 
 	// Secret scope configuration is explicitly defined here with individual fields
 	// to maintain API stability and prevent unintended configuration changes.

--- a/bundle/config/resources/sql_warehouses.go
+++ b/bundle/config/resources/sql_warehouses.go
@@ -21,11 +21,9 @@ type SqlWarehousePermission struct {
 }
 
 type SqlWarehouse struct {
-	ID string `json:"id,omitempty" bundle:"readonly"`
+	BaseResource
 
-	Permissions    []SqlWarehousePermission `json:"permissions,omitempty"`
-	ModifiedStatus ModifiedStatus           `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string                   `json:"url,omitempty" bundle:"internal"`
+	Permissions []SqlWarehousePermission `json:"permissions,omitempty"`
 
 	sql.CreateWarehouseRequest
 }

--- a/bundle/config/resources/synced_database_table.go
+++ b/bundle/config/resources/synced_database_table.go
@@ -11,9 +11,7 @@ import (
 )
 
 type SyncedDatabaseTable struct {
-	ID             string         `json:"id,omitempty" bundle:"readonly"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
+	BaseResource
 
 	database.SyncedDatabaseTable
 }

--- a/bundle/config/resources/volume.go
+++ b/bundle/config/resources/volume.go
@@ -41,17 +41,12 @@ type VolumeGrant struct {
 }
 
 type Volume struct {
+	BaseResource
+
 	// List of grants to apply on this volume.
 	Grants []VolumeGrant `json:"grants,omitempty"`
 
-	// Full name of the volume (catalog_name.schema_name.volume_name). This value is read from
-	// the terraform state after deployment succeeds.
-	ID string `json:"id,omitempty" bundle:"readonly"`
-
 	catalog.CreateVolumeRequestContent
-
-	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
-	URL            string         `json:"url,omitempty" bundle:"internal"`
 }
 
 func (v *Volume) UnmarshalJSON(b []byte) error {

--- a/bundle/deploy/metadata/compute_test.go
+++ b/bundle/deploy/metadata/compute_test.go
@@ -36,13 +36,13 @@ func TestComputeMetadataMutator(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"my-job-1": {
-						ID: "1111",
+						BaseResource: resources.BaseResource{ID: "1111"},
 						JobSettings: jobs.JobSettings{
 							Name: "My Job One",
 						},
 					},
 					"my-job-2": {
-						ID: "2222",
+						BaseResource: resources.BaseResource{ID: "2222"},
 						JobSettings: jobs.JobSettings{
 							Name: "My Job Two",
 						},

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -575,8 +575,8 @@ func TestBundleToTerraformDeletedResources(t *testing.T) {
 		JobSettings: jobs.JobSettings{},
 	}
 	job2 := resources.Job{
-		ModifiedStatus: resources.ModifiedStatusDeleted,
-		JobSettings:    jobs.JobSettings{},
+		BaseResource: resources.BaseResource{ModifiedStatus: resources.ModifiedStatusDeleted},
+		JobSettings:  jobs.JobSettings{},
 	}
 	config := config.Root{
 		Resources: config.Resources{

--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -329,31 +329,28 @@ func TestRenderSummary(t *testing.T) {
 			Resources: config.Resources{
 				Jobs: map[string]*resources.Job{
 					"job1": {
-						ID:          "1",
-						URL:         "https://url1",
-						JobSettings: jobs.JobSettings{Name: "job1-name"},
+						BaseResource: resources.BaseResource{ID: "1", URL: "https://url1"},
+						JobSettings:  jobs.JobSettings{Name: "job1-name"},
 					},
 					"job2": {
-						ID:          "2",
-						URL:         "https://url2",
-						JobSettings: jobs.JobSettings{Name: "job2-name"},
+						BaseResource: resources.BaseResource{ID: "2", URL: "https://url2"},
+						JobSettings:  jobs.JobSettings{Name: "job2-name"},
 					},
 				},
 				Pipelines: map[string]*resources.Pipeline{
 					"pipeline2": {
-						ID: "4",
+						BaseResource: resources.BaseResource{ID: "4"},
 						// no URL
 						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline2-name"},
 					},
 					"pipeline1": {
-						ID:             "3",
-						URL:            "https://url3",
+						BaseResource:   resources.BaseResource{ID: "3", URL: "https://url3"},
 						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1-name"},
 					},
 				},
 				Schemas: map[string]*resources.Schema{
 					"schema1": {
-						ID: "catalog.schema",
+						BaseResource: resources.BaseResource{ID: "catalog.schema"},
 						CreateSchema: catalog.CreateSchema{
 							Name: "schema",
 						},
@@ -362,11 +359,10 @@ func TestRenderSummary(t *testing.T) {
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint1": {
-						ID: "7",
+						BaseResource: resources.BaseResource{ID: "7", URL: "https://url4"},
 						CreateServingEndpoint: serving.CreateServingEndpoint{
 							Name: "my_serving_endpoint",
 						},
-						URL: "https://url4",
 					},
 				},
 			},

--- a/bundle/run/job_test.go
+++ b/bundle/run/job_test.go
@@ -58,7 +58,7 @@ func TestConvertPythonParams(t *testing.T) {
 
 func TestJobRunnerCancel(t *testing.T) {
 	job := &resources.Job{
-		ID: "123",
+		BaseResource: resources.BaseResource{ID: "123"},
 	}
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -102,7 +102,7 @@ func TestJobRunnerCancel(t *testing.T) {
 
 func TestJobRunnerCancelWithNoActiveRuns(t *testing.T) {
 	job := &resources.Job{
-		ID: "123",
+		BaseResource: resources.BaseResource{ID: "123"},
 	}
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -141,8 +141,8 @@ func TestJobRunnerRestart(t *testing.T) {
 		},
 	} {
 		job := &resources.Job{
-			ID:          "123",
-			JobSettings: jobSettings,
+			BaseResource: resources.BaseResource{ID: "123"},
+			JobSettings:  jobSettings,
 		}
 		b := &bundle.Bundle{
 			Config: config.Root{
@@ -208,7 +208,7 @@ func TestJobRunnerRestart(t *testing.T) {
 
 func TestJobRunnerRestartForContinuousUnpausedJobs(t *testing.T) {
 	job := &resources.Job{
-		ID: "123",
+		BaseResource: resources.BaseResource{ID: "123"},
 		JobSettings: jobs.JobSettings{
 			Continuous: &jobs.Continuous{
 				PauseStatus: jobs.PauseStatusUnpaused,

--- a/bundle/run/pipeline_test.go
+++ b/bundle/run/pipeline_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestPipelineRunnerCancel(t *testing.T) {
 	pipeline := &resources.Pipeline{
-		ID: "123",
+		BaseResource: resources.BaseResource{ID: "123"},
 	}
 
 	b := &bundle.Bundle{
@@ -54,7 +54,7 @@ func TestPipelineRunnerCancel(t *testing.T) {
 
 func TestPipelineRunnerRestart(t *testing.T) {
 	pipeline := &resources.Pipeline{
-		ID: "123",
+		BaseResource: resources.BaseResource{ID: "123"},
 	}
 
 	b := &bundle.Bundle{

--- a/libs/structaccess/bundle_test.go
+++ b/libs/structaccess/bundle_test.go
@@ -16,8 +16,7 @@ func TestGet_ConfigRoot_JobTagsAccess(t *testing.T) {
 		Resources: config.Resources{
 			Jobs: map[string]*resources.Job{
 				"my_job": {
-					ID:  "jobid",
-					URL: "joburl",
+					BaseResource: resources.BaseResource{ID: "jobid", URL: "joburl"},
 					JobSettings: jobs.JobSettings{
 						Name: "example",
 						Tasks: []jobs.Task{

--- a/libs/structaccess/bundle_test.go
+++ b/libs/structaccess/bundle_test.go
@@ -34,7 +34,7 @@ func TestGet_ConfigRoot_JobTagsAccess(t *testing.T) {
 			},
 			Apps: map[string]*resources.App{
 				"my_app": {
-					URL: "app_outer_url",
+					BaseResource: resources.BaseResource{URL: "app_outer_url"},
 					App: apps.App{
 						Url: "app_inner_url",
 					},

--- a/libs/structwalk/walktype_test.go
+++ b/libs/structwalk/walktype_test.go
@@ -123,7 +123,7 @@ func TestTypeJobSettings(t *testing.T) {
 func TestTypeRoot(t *testing.T) {
 	testStruct(t,
 		reflect.TypeOf(config.Root{}),
-		3600, 4000, // 3980 at the time of the update
+		3800, 4200, // 4001 at the time of the update
 		map[string]any{
 			".bundle.target":                 "",
 			`.variables[*].lookup.dashboard`: "",


### PR DESCRIPTION
## Changes
Extract common resource fields into a separate embedded struct `BaseResource`

## Why
Based on feedback from https://github.com/databricks/cli/pull/3448#discussion_r2330023305

## Tests
Existing tests pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
