### PR TITLE
Use unified timeout values in integration tests

### DIFF
--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -11,6 +11,11 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/iam"
 )
 
+const (
+	WorkspaceClientHTTPTimeoutSeconds = 90
+	WorkspaceRetryTimeoutSeconds      = 15 * 60
+)
+
 // Workspace defines configurables at the workspace level.
 type Workspace struct {
 	// Unified authentication attributes.
@@ -89,10 +94,10 @@ func (w *Workspace) Config() *config.Config {
 		// Having client-side timeouts that kill the deployment seems counter-productive. We should just keep on
 		// trying and the user should be the one interrupting it if they decide so.
 		// Default is 30s
-		HTTPTimeoutSeconds: 90,
+		HTTPTimeoutSeconds: WorkspaceClientHTTPTimeoutSeconds,
 
 		// Default is 5min
-		RetryTimeoutSeconds: 15 * 60,
+		RetryTimeoutSeconds: WorkspaceRetryTimeoutSeconds,
 
 		// Generic
 		Host:               w.Host,

--- a/integration/internal/acc/workspace.go
+++ b/integration/internal/acc/workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/compute"
@@ -26,7 +27,10 @@ func WorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 
 	t.Logf("CLOUD_ENV=%s", testutil.GetEnvOrSkipTest(t, "CLOUD_ENV"))
 
-	w, err := databricks.NewWorkspaceClient()
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		HTTPTimeoutSeconds:  config.WorkspaceClientHTTPTimeoutSeconds,
+		RetryTimeoutSeconds: config.WorkspaceRetryTimeoutSeconds,
+	})
 	require.NoError(t, err)
 
 	wt := &WorkspaceT{
@@ -54,7 +58,10 @@ func UcWorkspaceTest(t testutil.TestingT) (context.Context, *WorkspaceT) {
 		t.Skipf("Skipping on accounts")
 	}
 
-	w, err := databricks.NewWorkspaceClient()
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		HTTPTimeoutSeconds:  config.WorkspaceClientHTTPTimeoutSeconds,
+		RetryTimeoutSeconds: config.WorkspaceRetryTimeoutSeconds,
+	})
 	require.NoError(t, err)
 
 	wt := &WorkspaceT{


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->

Set the same timeout values in workspace clients used in production and integration tests

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
Timeout values were recently updated for workspace client, but integration tests were still using the default values. This change makes sure that changing timeout values in the prod client would also update the timeout values used in integration tests

## Tests
<!-- How have you tested the changes? -->
`make test`

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
