### PR TITLE
Disable rate limit in tnresources unit tests

### DIFF
--- a/bundle/terranova/tnresources/all_test.go
+++ b/bundle/terranova/tnresources/all_test.go
@@ -187,8 +187,6 @@ func TestRecreateFields(t *testing.T) {
 func setupTestServerClient(t *testing.T) (*testserver.Server, *databricks.WorkspaceClient) {
 	server := testserver.New(t)
 	testserver.AddDefaultHandlers(server)
-	t.Setenv("DATABRICKS_HOST", server.URL)
-	t.Setenv("DATABRICKS_TOKEN", "testtoken")
 	client, err := databricks.NewWorkspaceClient(&databricks.Config{
 		Host:               server.URL,
 		Token:              "testtoken",

--- a/bundle/terranova/tnresources/all_test.go
+++ b/bundle/terranova/tnresources/all_test.go
@@ -2,6 +2,7 @@ package tnresources
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"testing"
 
@@ -188,7 +189,11 @@ func setupTestServerClient(t *testing.T) (*testserver.Server, *databricks.Worksp
 	testserver.AddDefaultHandlers(server)
 	t.Setenv("DATABRICKS_HOST", server.URL)
 	t.Setenv("DATABRICKS_TOKEN", "testtoken")
-	client, err := databricks.NewWorkspaceClient()
+	client, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:               server.URL,
+		Token:              "testtoken",
+		RateLimitPerSecond: math.MaxInt,
+	})
 	require.NoError(t, err)
 	return server, client
 }


### PR DESCRIPTION
## Why
This is running against local testserver.

Before:
```
--- PASS: TestAll (3.74s)
    --- PASS: TestAll/pipelines (0.34s)
    --- PASS: TestAll/schemas (0.40s)
    --- PASS: TestAll/volumes (0.40s)
    --- PASS: TestAll/apps (0.47s)
    --- PASS: TestAll/sql_warehouses (0.40s)
    --- PASS: TestAll/database_instances (0.47s)
    --- PASS: TestAll/database_catalogs (0.47s)
    --- PASS: TestAll/synced_database_tables (0.40s)
    --- PASS: TestAll/jobs (0.40s)
```

After:
```
--- PASS: TestAll (0.01s)
    --- PASS: TestAll/schemas (0.00s)
    --- PASS: TestAll/database_instances (0.00s)
    --- PASS: TestAll/synced_database_tables (0.00s)
    --- PASS: TestAll/jobs (0.00s)
    --- PASS: TestAll/pipelines (0.00s)
    --- PASS: TestAll/volumes (0.00s)
    --- PASS: TestAll/apps (0.00s)
    --- PASS: TestAll/sql_warehouses (0.00s)
    --- PASS: TestAll/database_catalogs (0.00s)
```
