### PR TITLE
internal: Convert deployplan.ActionType to int-based enum

### DIFF
--- a/bundle/terranova/tnresources/adapter.go
+++ b/bundle/terranova/tnresources/adapter.go
@@ -428,11 +428,11 @@ func (a *Adapter) MustRecreate(changes []structdiff.Change) bool {
 // ClassifyChanges calls the resource's ClassifyChanges method if implemented.
 func (a *Adapter) ClassifyChanges(changes []structdiff.Change) (deployplan.ActionType, error) {
 	if a.classifyChanges == nil {
-		return "", errors.New("internal error: ClassifyChanges not implemented")
+		return deployplan.ActionTypeUnset, errors.New("internal error: ClassifyChanges not implemented")
 	}
 	outs, err := a.classifyChanges.Call(changes)
 	if err != nil {
-		return "", err
+		return deployplan.ActionTypeUnset, err
 	}
 	result := outs[0].(deployplan.ActionType)
 	return result, nil

--- a/cmd/bundle/plan.go
+++ b/cmd/bundle/plan.go
@@ -75,7 +75,7 @@ func newPlanCommand() *cobra.Command {
 		changes := phases.Diff(ctx, b)
 
 		for _, change := range changes {
-			cmdio.LogString(ctx, fmt.Sprintf("%s %s.%s", change.ActionType, change.Group, change.Key))
+			cmdio.LogString(ctx, fmt.Sprintf("%s %s.%s", change.ActionType.String(), change.Group, change.Key))
 		}
 
 		if logdiag.HasError(ctx) {


### PR DESCRIPTION
## Changes
- The order defines severity of action which will be used to decide final action for resource.
- Add a new 'resize' action, will be useful when we add clusters.

## Why
We will be able to decide on final action for the given resource as max(actions...), where actions come from local and remote comparison of individual fields.

## Tests
Existing tests.