### PR TITLE
testserver: add locking for secret ACLs

### DIFF
--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -445,6 +445,8 @@ func AddDefaultHandlers(server *Server) {
 	})
 
 	server.Handle("GET", "/api/2.0/secrets/acls/get", func(req Request) any {
+		defer req.Workspace.LockUnlock()()
+
 		scope := req.URL.Query().Get("scope")
 		principal := req.URL.Query().Get("principal")
 		scopeAcls := req.Workspace.Acls[scope]
@@ -461,6 +463,8 @@ func AddDefaultHandlers(server *Server) {
 	})
 
 	server.Handle("POST", "/api/2.0/secrets/acls/put", func(req Request) any {
+		defer req.Workspace.LockUnlock()()
+
 		var request workspace.PutAcl
 		if err := json.Unmarshal(req.Body, &request); err != nil {
 			return Response{
@@ -476,6 +480,8 @@ func AddDefaultHandlers(server *Server) {
 	})
 
 	server.Handle("POST", "/api/2.0/secrets/acls/delete", func(req Request) any {
+		defer req.Workspace.LockUnlock()()
+
 		var request workspace.DeleteAcl
 		if err := json.Unmarshal(req.Body, &request); err != nil {
 			return Response{


### PR DESCRIPTION
Fixes this:

```
fatal error: concurrent map writes

goroutine 2662 [running]:
internal/runtime/maps.fatal({0x102f562ed?, 0x103479c40?})
	/Users/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.darwin-arm64/src/runtime/panic.go:1058 +0x20
github.com/databricks/cli/libs/testserver.AddDefaultHandlers.func70({{0x14002c811a0, 0x4}, 0x14002356c60, 0x140020961b0, {0x14001842800, 0x50, 0x200}, 0x14002096300, 0x1400088e1a0, {0x103740b80, ...}})
	/Users/runner/work/cli/cli/libs/testserver/handlers.go:489 +0x264
github.com/databricks/cli/libs/testserver.(*Server).Handle.func1({0x10373d1e0, 0x14000def500}, 0x14001e09540)
	/Users/runner/work/cli/cli/libs/testserver/server.go:276 +0x228
```

https://github.com/databricks/cli/actions/runs/17618351931/job/50057421389?pr=3586