### PR TITLE
acc: cleanup debuglog test output

### DIFF
--- a/acceptance/bundle/debuglog/out.stderr.direct-exp.txt
+++ b/acceptance/bundle/debuglog/out.stderr.direct-exp.txt
@@ -24,11 +24,6 @@
 10:07:59 Debug: Apply pid=12345 mutator=SyncInferRoot
 10:07:59 Debug: Apply pid=12345 mutator=PopulateCurrentUser
 10:07:59 Debug: GET /api/2.0/preview/scim/v2/Me
-< HTTP/1.1 200 OK
-< {
-<   "id": "[USERID]",
-<   "userName": "[USERNAME]"
-< } pid=12345 mutator=PopulateCurrentUser sdk=true
 10:07:59 Debug: Apply pid=12345 mutator=LoadGitDetails
 10:07:59 Debug: Apply pid=12345 mutator=ApplySourceLinkedDeploymentPreset
 10:07:59 Debug: Apply pid=12345 mutator=DefineDefaultWorkspaceRoot
@@ -73,22 +68,9 @@
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_task_cluster_spec
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:artifact_paths
 10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
-< HTTP/1.1 404 Not Found
-< {
-<   "message": "Workspace path not found"
-< } pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: non-retriable error: Workspace path not found pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: POST /api/2.0/workspace/mkdirs
-> {
->   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-> }
-< HTTP/1.1 200 OK pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
-< HTTP/1.1 200 OK
-< {
-<   "object_type": "DIRECTORY",
-<   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-< } pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: Path /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files has type directory (ID: 0) pid=12345 mutator=validate:files_to_sync
 10:07:59 Info: completed execution pid=12345 exit_code=0
 10:07:59 Debug: no telemetry logs to upload pid=12345

--- a/acceptance/bundle/debuglog/out.stderr.terraform.txt
+++ b/acceptance/bundle/debuglog/out.stderr.terraform.txt
@@ -24,11 +24,6 @@
 10:07:59 Debug: Apply pid=12345 mutator=SyncInferRoot
 10:07:59 Debug: Apply pid=12345 mutator=PopulateCurrentUser
 10:07:59 Debug: GET /api/2.0/preview/scim/v2/Me
-< HTTP/1.1 200 OK
-< {
-<   "id": "[USERID]",
-<   "userName": "[USERNAME]"
-< } pid=12345 mutator=PopulateCurrentUser sdk=true
 10:07:59 Debug: Apply pid=12345 mutator=LoadGitDetails
 10:07:59 Debug: Apply pid=12345 mutator=ApplySourceLinkedDeploymentPreset
 10:07:59 Debug: Apply pid=12345 mutator=DefineDefaultWorkspaceRoot
@@ -77,22 +72,9 @@
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_task_cluster_spec
 10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:artifact_paths
 10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
-< HTTP/1.1 404 Not Found
-< {
-<   "message": "Workspace path not found"
-< } pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: non-retriable error: Workspace path not found pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: POST /api/2.0/workspace/mkdirs
-> {
->   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-> }
-< HTTP/1.1 200 OK pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
-< HTTP/1.1 200 OK
-< {
-<   "object_type": "DIRECTORY",
-<   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-< } pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Debug: Path /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files has type directory (ID: 0) pid=12345 mutator=validate:files_to_sync
 10:07:59 Info: completed execution pid=12345 exit_code=0
 10:07:59 Debug: no telemetry logs to upload pid=12345

--- a/acceptance/bundle/debuglog/script
+++ b/acceptance/bundle/debuglog/script
@@ -1,1 +1,4 @@
-$CLI bundle validate --debug 2> out.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt
+$CLI bundle validate --debug 2> tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt
+# filter out lines that can change the order
+grep -v '^<' tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt | grep -v '^>' | grep -v '^Debug: GET /api/2.0/workspace/get-status' > out.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt
+rm tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt


### PR DESCRIPTION
After rate limit was disabled in https://github.com/databricks/cli/pull/3581 this test became flaky.

The ApplyParallel lines are already logged in order but the output of those mutator appears as it comes.

This PR filters out the SDK request traces + request in question that can change order.

```
=== FAIL: acceptance TestAccept/bundle/debuglog/DATABRICKS_CLI_DEPLOYMENT=direct-exp (0.04s)
    acceptance_test.go:1336: Writing updated bundle config to databricks.yml. BundleConfig sections: default_name
    acceptance_test.go:803: Diff:
        --- bundle/debuglog/out.stderr.direct-exp.txt
        +++ /tmp/TestAcceptbundledebuglogDATABRICKS_CLI_DEPLOYMENT=direct-exp1521238718/001/out.stderr.direct-exp.txt
        @@ -70,8 +70,6 @@
         10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:folder_permissions
         10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:validate_sync_patterns
         10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_cluster_key_defined
        -10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_task_cluster_spec
        -10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:artifact_paths
         10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
         < HTTP/1.1 404 Not Found
         < {
        @@ -83,6 +81,8 @@
         >   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
         > }
         < HTTP/1.1 200 OK pid=12345 mutator=validate:files_to_sync sdk=true
        +10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:job_task_cluster_spec
        +10:07:59 Debug: ApplyParallel pid=12345 mutator=fast_validate(readonly) mutator=validate:artifact_paths
         10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
         < HTTP/1.1 200 OK
         < {
```
