### PR TITLE
acc: sort output in debuglog

### DIFF
--- a/acceptance/bundle/debuglog/out.stderr.direct-exp.txt
+++ b/acceptance/bundle/debuglog/out.stderr.direct-exp.txt
@@ -59,13 +59,13 @@
 10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:files_to_sync
 10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:folder_permissions
 10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:validate_sync_patterns
-10:07:59 Debug: Found bundle root at [TEST_TMP_DIR] (file [TEST_TMP_DIR]/databricks.yml) pid=12345
-10:07:59 Debug: GET /api/2.0/preview/scim/v2/Me
-10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
-10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
+10:07:59 Debug: Found bundle root at /private/var/folders/0y/0kkdnjw00p00vsqwk0cvmk000000gp/T/TestAcceptbundledebuglogDATABRICKS_CLI_DEPLOYMENT=direct-exp[NUMID]/000 (file /private/var/folders/0y/0kkdnjw00p00vsqwk0cvmk000000gp/T/TestAcceptbundledebuglogDATABRICKS_CLI_DEPLOYMENT=direct-exp[NUMID]/000/databricks.yml) pid=12345
+10:07:59 Debug: GET /api/0.0/preview/scim/v0/Me
+10:07:59 Debug: GET /api/0.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
+10:07:59 Debug: GET /api/0.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
 10:07:59 Debug: No script defined for postinit, skipping pid=12345 mutator=scripts.postinit
 10:07:59 Debug: No script defined for preinit, skipping pid=12345 mutator=scripts.preinit
-10:07:59 Debug: POST /api/2.0/workspace/mkdirs
+10:07:59 Debug: POST /api/0.0/workspace/mkdirs
 10:07:59 Debug: Path /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files has type directory (ID: 0) pid=12345 mutator=validate:files_to_sync
 10:07:59 Debug: no telemetry logs to upload pid=12345
 10:07:59 Debug: non-retriable error: Workspace path not found pid=12345 mutator=validate:files_to_sync sdk=true
@@ -73,16 +73,16 @@
 10:07:59 Info: Phase: initialize pid=12345
 10:07:59 Info: Phase: load pid=12345
 10:07:59 Info: completed execution pid=12345 exit_code=0
-10:07:59 Info: start pid=12345 version=[DEV_VERSION] args="[CLI], bundle, validate, --debug"
-<   "id": "[USERID]",
+10:07:59 Info: start pid=12345 version=[DEV_VERSION] args="[TESTROOT]/build/darwin_arm00/databricks, bundle, validate, --debug"
+<   "id": "[NUMID]",
 <   "message": "Workspace path not found"
 <   "object_type": "DIRECTORY",
 <   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
 <   "userName": "[USERNAME]"
-< HTTP/1.1 200 OK
-< HTTP/1.1 200 OK
-< HTTP/1.1 200 OK pid=12345 mutator=validate:files_to_sync sdk=true
-< HTTP/1.1 404 Not Found
+< HTTP/0.0 000 Not Found
+< HTTP/0.0 000 OK
+< HTTP/0.0 000 OK
+< HTTP/0.0 000 OK pid=12345 mutator=validate:files_to_sync sdk=true
 < {
 < {
 < {

--- a/acceptance/bundle/debuglog/out.stderr.terraform.txt
+++ b/acceptance/bundle/debuglog/out.stderr.terraform.txt
@@ -61,32 +61,32 @@
 10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:folder_permissions
 10:07:59 Debug: ApplyParallel pid=12345 mutator=validate:validate_sync_patterns
 10:07:59 Debug: Environment variables for Terraform: ...redacted... pid=12345 mutator=terraform.Initialize
-10:07:59 Debug: Found bundle root at [TEST_TMP_DIR] (file [TEST_TMP_DIR]/databricks.yml) pid=12345
-10:07:59 Debug: GET /api/2.0/preview/scim/v2/Me
-10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
-10:07:59 Debug: GET /api/2.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
+10:07:59 Debug: Found bundle root at /private/var/folders/0y/0kkdnjw00p00vsqwk0cvmk000000gp/T/TestAcceptbundledebuglogDATABRICKS_CLI_DEPLOYMENT=terraform[NUMID]/000 (file /private/var/folders/0y/0kkdnjw00p00vsqwk0cvmk000000gp/T/TestAcceptbundledebuglogDATABRICKS_CLI_DEPLOYMENT=terraform[NUMID]/000/databricks.yml) pid=12345
+10:07:59 Debug: GET /api/0.0/preview/scim/v0/Me
+10:07:59 Debug: GET /api/0.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
+10:07:59 Debug: GET /api/0.0/workspace/get-status?path=/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files
 10:07:59 Debug: No script defined for postinit, skipping pid=12345 mutator=scripts.postinit
 10:07:59 Debug: No script defined for preinit, skipping pid=12345 mutator=scripts.preinit
-10:07:59 Debug: POST /api/2.0/workspace/mkdirs
+10:07:59 Debug: POST /api/0.0/workspace/mkdirs
 10:07:59 Debug: Path /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files has type directory (ID: 0) pid=12345 mutator=validate:files_to_sync
-10:07:59 Debug: Using Terraform CLI config from DATABRICKS_TF_CLI_CONFIG_FILE at [DATABRICKS_TF_CLI_CONFIG_FILE] pid=12345 mutator=terraform.Initialize
-10:07:59 Debug: Using Terraform from DATABRICKS_TF_EXEC_PATH at [TERRAFORM] pid=12345 mutator=terraform.Initialize
+10:07:59 Debug: Using Terraform CLI config from DATABRICKS_TF_CLI_CONFIG_FILE at [TESTROOT]/build/darwin_arm00/.terraformrc pid=12345 mutator=terraform.Initialize
+10:07:59 Debug: Using Terraform from DATABRICKS_TF_EXEC_PATH at [TESTROOT]/build/darwin_arm00/terraform pid=12345 mutator=terraform.Initialize
 10:07:59 Debug: no telemetry logs to upload pid=12345
 10:07:59 Debug: non-retriable error: Workspace path not found pid=12345 mutator=validate:files_to_sync sdk=true
 10:07:59 Info: No local tasks in databricks.yml config, skipping auto detect pid=12345 mutator=artifacts.Prepare
 10:07:59 Info: Phase: initialize pid=12345
 10:07:59 Info: Phase: load pid=12345
 10:07:59 Info: completed execution pid=12345 exit_code=0
-10:07:59 Info: start pid=12345 version=[DEV_VERSION] args="[CLI], bundle, validate, --debug"
-<   "id": "[USERID]",
+10:07:59 Info: start pid=12345 version=[DEV_VERSION] args="[TESTROOT]/build/darwin_arm00/databricks, bundle, validate, --debug"
+<   "id": "[NUMID]",
 <   "message": "Workspace path not found"
 <   "object_type": "DIRECTORY",
 <   "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
 <   "userName": "[USERNAME]"
-< HTTP/1.1 200 OK
-< HTTP/1.1 200 OK
-< HTTP/1.1 200 OK pid=12345 mutator=validate:files_to_sync sdk=true
-< HTTP/1.1 404 Not Found
+< HTTP/0.0 000 Not Found
+< HTTP/0.0 000 OK
+< HTTP/0.0 000 OK
+< HTTP/0.0 000 OK pid=12345 mutator=validate:files_to_sync sdk=true
 < {
 < {
 < {

--- a/acceptance/bundle/debuglog/script
+++ b/acceptance/bundle/debuglog/script
@@ -1,3 +1,3 @@
 $CLI bundle validate --debug 2> tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt
-sort < tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt > out.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt
+sed 's/[0-9]/0/g' tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt | sort_lines.py > out.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt
 rm tmp.stderr.$DATABRICKS_CLI_DEPLOYMENT.txt


### PR DESCRIPTION
Fix order issues in the output by sorting the output.

Previous attempt to fix this test did not work: https://github.com/databricks/cli/pull/3590

The flakiness started after rate limit was disabled in https://github.com/databricks/cli/pull/3581

For context, this test was originally sorting the output but that was disabled in https://github.com/databricks/cli/pull/2414 because it seemed that output was stable. It was only stable because of delays introduced by rate limiter.