### PR TITLE
Add small UX improvements for `databricks configure`

### DIFF
--- a/cmd/configure/host.go
+++ b/cmd/configure/host.go
@@ -3,7 +3,26 @@ package configure
 import (
 	"errors"
 	"net/url"
+	"strings"
 )
+
+// NormalizeHost normalizes host input to prevent double https:// prefixes.
+// If the input already starts with https://, it returns it as-is.
+// If the input doesn't start with https://, it prepends https://.
+func NormalizeHost(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "https://"
+	}
+
+	// If it already starts with https://, return as-is
+	if strings.HasPrefix(strings.ToLower(input), "https://") {
+		return input
+	}
+
+	// Otherwise, prepend https://
+	return "https://" + input
+}
 
 func validateHost(s string) error {
 	u, err := url.Parse(s)

--- a/cmd/configure/host_test.go
+++ b/cmd/configure/host_test.go
@@ -6,6 +6,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Empty input
+		{"", "https://"},
+		{"   ", "https://"},
+
+		// Already has https://
+		{"https://example.databricks.com", "https://example.databricks.com"},
+		{"HTTPS://EXAMPLE.DATABRICKS.COM", "HTTPS://EXAMPLE.DATABRICKS.COM"},
+		{"https://example.databricks.com/", "https://example.databricks.com/"},
+
+		// Missing protocol (should add https://)
+		{"example.databricks.com", "https://example.databricks.com"},
+		{"  example.databricks.com  ", "https://example.databricks.com"},
+		{"subdomain.example.databricks.com", "https://subdomain.example.databricks.com"},
+
+		// Edge cases
+		{"https://", "https://"},
+		{"example.com", "https://example.com"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := NormalizeHost(test.input)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
 func TestValidateHost(t *testing.T) {
 	var err error
 

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -115,6 +115,46 @@ func IsGitBash(ctx context.Context) bool {
 	return false
 }
 
+// IsHyperlinkSupported detects if the terminal supports hyperlinks (OSC 8 escape sequences).
+func IsHyperlinkSupported(ctx context.Context) bool {
+	// Check if we're in a terminal that supports hyperlinks
+	if !IsOutTTY(ctx) {
+		return false
+	}
+
+	// Check for terminals that don't support hyperlinks
+	term := env.Get(ctx, "TERM")
+	if term == "dumb" || term == "linux" {
+		return false
+	}
+
+	// Check for NO_COLOR environment variable
+	if env.Get(ctx, "NO_COLOR") != "" {
+		return false
+	}
+
+	// Git Bash doesn't support hyperlinks well
+	if IsGitBash(ctx) {
+		return false
+	}
+
+	// Default to true for modern terminals, let them handle unsupported sequences gracefully
+	return true
+}
+
+// Hyperlink creates a clickable hyperlink in terminals that support it.
+// Falls back to displaying the URL in parentheses for unsupported terminals.
+func Hyperlink(ctx context.Context, text, url string) string {
+	if !IsHyperlinkSupported(ctx) {
+		return fmt.Sprintf("%s (%s)", text, url)
+	}
+
+	// Use OSC 8 escape sequence for hyperlinks
+	// \033]8;;URL\033\\ starts the hyperlink
+	// \033]8;;\033\\ ends the hyperlink
+	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", url, text)
+}
+
 type Tuple struct{ Name, Id string }
 
 func (c *cmdIO) Select(items []Tuple, label string) (id string, err error) {


### PR DESCRIPTION
## Changes
1. Added a link to where to find PAT token. It works with a custom label in modern terminals but fallbacks to just printing the URL in the old ones.
2. Removed the default `https://` prefix in the Host input and always prefixed it if the host input passed with the https://

<img width="370" height="70" alt="Screenshot 2025-09-15 at 15 40 54" src="https://github.com/user-attachments/assets/2ec91a33-0a4d-4996-9606-b6391f373ce7" />

## Why
Small UX improvements/tweaks

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
