### PR TITLE
Fix ssh tunnel on windows

### DIFF
--- a/experimental/ssh/internal/client/releases.go
+++ b/experimental/ssh/internal/client/releases.go
@@ -42,8 +42,8 @@ func uploadReleases(ctx context.Context, workspaceFiler filer.Filer, getRelease 
 	for _, arch := range architectures {
 		fileName := getReleaseName(arch, version)
 		remoteSubFolder := strings.TrimSuffix(fileName, ".zip")
-		remoteBinaryPath := filepath.Join(remoteSubFolder, "databricks")
-		remoteArchivePath := filepath.Join(remoteSubFolder, "databricks.zip")
+		remoteBinaryPath := filepath.ToSlash(filepath.Join(remoteSubFolder, "databricks"))
+		remoteArchivePath := filepath.ToSlash(filepath.Join(remoteSubFolder, "databricks.zip"))
 
 		_, err := workspaceFiler.Stat(ctx, remoteBinaryPath)
 		if err == nil {


### PR DESCRIPTION
## Changes
We were using incorrect paths when uploading the releases to workspace.

## Why
Because I always forget to properly test on windows!

## Tests
Would really help, looking into quick integration tests now
