### PR TITLE
Rename bundle/terranova to bundle/direct

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,10 +67,10 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      - path-except: bundle/terranova/tnresources
+      - path-except: bundle/direct/dresources
         linters:
           - exhaustruct
-      - path: bundle/terranova/tnresources/all_test.go
+      - path: bundle/direct/dresources/all_test.go
         linters:
           - exhaustruct
       - path-except: ^cmd

--- a/acceptance/bin/read_id.py
+++ b/acceptance/bin/read_id.py
@@ -29,7 +29,7 @@ def print_resource_terraform(group, name):
             return
 
 
-def print_resource_terranova(group, name):
+def print_resource_direct(group, name):
     filename = ".databricks/bundle/default/resources.json"
     raw = open(filename).read()
     data = json.loads(raw)
@@ -42,6 +42,6 @@ def print_resource_terranova(group, name):
 
 
 if os.environ.get("DATABRICKS_CLI_DEPLOYMENT", "").startswith("direct"):
-    print_resource_terranova(*sys.argv[1:])
+    print_resource_direct(*sys.argv[1:])
 else:
     print_resource_terraform(*sys.argv[1:])

--- a/acceptance/bin/read_state.py
+++ b/acceptance/bin/read_state.py
@@ -33,7 +33,7 @@ def print_resource_terraform(group, name, *attrs):
         print(f"State not found for {group}.{name}")
 
 
-def print_resource_terranova(group, name, *attrs):
+def print_resource_direct(group, name, *attrs):
     filename = ".databricks/bundle/default/resources.json"
     raw = open(filename).read()
     data = json.loads(raw)
@@ -49,6 +49,6 @@ def print_resource_terranova(group, name, *attrs):
 
 
 if os.environ.get("DATABRICKS_CLI_DEPLOYMENT", "").startswith("direct"):
-    print_resource_terranova(*sys.argv[1:])
+    print_resource_direct(*sys.argv[1:])
 else:
     print_resource_terraform(*sys.argv[1:])

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/direct"
 	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/bundle/metadata"
-	"github.com/databricks/cli/bundle/terranova"
 	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/fileset"
 	"github.com/databricks/cli/libs/locker"
@@ -130,7 +130,7 @@ type Bundle struct {
 	TerraformPlanIsEmpty bool
 
 	// (direct only) deployment implementation and state
-	DeploymentBundle terranova.DeploymentBundle
+	DeploymentBundle direct.DeploymentBundle
 
 	// if true, we skip approval checks for deploy, destroy resources and delete
 	// files

--- a/bundle/direct/apply.go
+++ b/bundle/direct/apply.go
@@ -1,4 +1,4 @@
-package terranova
+package direct
 
 import (
 	"bytes"
@@ -9,11 +9,11 @@ import (
 	"reflect"
 
 	"github.com/databricks/cli/bundle/deployplan"
-	"github.com/databricks/cli/bundle/terranova/tnstate"
+	"github.com/databricks/cli/bundle/direct/dstate"
 	"github.com/databricks/cli/libs/log"
 )
 
-func (d *DeploymentUnit) Destroy(ctx context.Context, db *tnstate.TerranovaState) error {
+func (d *DeploymentUnit) Destroy(ctx context.Context, db *dstate.DeploymentState) error {
 	entry, hasEntry := db.GetResourceEntry(d.Group, d.Key)
 	if !hasEntry {
 		log.Infof(ctx, "Cannot delete %s.%s: missing from state", d.Group, d.Key)
@@ -32,7 +32,7 @@ func (d *DeploymentUnit) Destroy(ctx context.Context, db *tnstate.TerranovaState
 	return nil
 }
 
-func (d *DeploymentUnit) Deploy(ctx context.Context, db *tnstate.TerranovaState, inputConfig any, actionType deployplan.ActionType) error {
+func (d *DeploymentUnit) Deploy(ctx context.Context, db *dstate.DeploymentState, inputConfig any, actionType deployplan.ActionType) error {
 	// Note, newState may be different between plan and deploy due to resolved $resource references
 	newState, err := d.Adapter.PrepareState(inputConfig)
 	if err != nil {
@@ -65,7 +65,7 @@ func (d *DeploymentUnit) Deploy(ctx context.Context, db *tnstate.TerranovaState,
 	}
 }
 
-func (d *DeploymentUnit) Create(ctx context.Context, db *tnstate.TerranovaState, newState any) error {
+func (d *DeploymentUnit) Create(ctx context.Context, db *dstate.DeploymentState, newState any) error {
 	newID, remoteState, err := d.Adapter.DoCreate(ctx, newState)
 	if err != nil {
 		// No need to prefix error, there is no ambiguity (only one operation - DoCreate) and no additional context (like id)
@@ -97,7 +97,7 @@ func (d *DeploymentUnit) Create(ctx context.Context, db *tnstate.TerranovaState,
 	return nil
 }
 
-func (d *DeploymentUnit) Recreate(ctx context.Context, db *tnstate.TerranovaState, oldID string, newState any) error {
+func (d *DeploymentUnit) Recreate(ctx context.Context, db *dstate.DeploymentState, oldID string, newState any) error {
 	err := d.Adapter.DoDelete(ctx, oldID)
 	if err != nil {
 		return fmt.Errorf("deleting old id=%s: %w", oldID, err)
@@ -111,7 +111,7 @@ func (d *DeploymentUnit) Recreate(ctx context.Context, db *tnstate.TerranovaStat
 	return d.Create(ctx, db, newState)
 }
 
-func (d *DeploymentUnit) Update(ctx context.Context, db *tnstate.TerranovaState, id string, newState any) error {
+func (d *DeploymentUnit) Update(ctx context.Context, db *dstate.DeploymentState, id string, newState any) error {
 	remoteState, err := d.Adapter.DoUpdate(ctx, id, newState)
 	if err != nil {
 		return fmt.Errorf("updating id=%s: %w", id, err)
@@ -141,7 +141,7 @@ func (d *DeploymentUnit) Update(ctx context.Context, db *tnstate.TerranovaState,
 	return nil
 }
 
-func (d *DeploymentUnit) UpdateWithID(ctx context.Context, db *tnstate.TerranovaState, oldID string, newState any) error {
+func (d *DeploymentUnit) UpdateWithID(ctx context.Context, db *dstate.DeploymentState, oldID string, newState any) error {
 	newID, remoteState, err := d.Adapter.DoUpdateWithID(ctx, oldID, newState)
 	if err != nil {
 		return fmt.Errorf("updating id=%s: %w", oldID, err)
@@ -177,7 +177,7 @@ func (d *DeploymentUnit) UpdateWithID(ctx context.Context, db *tnstate.Terranova
 	return nil
 }
 
-func (d *DeploymentUnit) Delete(ctx context.Context, db *tnstate.TerranovaState, oldID string) error {
+func (d *DeploymentUnit) Delete(ctx context.Context, db *dstate.DeploymentState, oldID string) error {
 	// TODO: recognize 404 and 403 as "deleted" and proceed to removing state
 	err := d.Adapter.DoDelete(ctx, oldID)
 	if err != nil {

--- a/bundle/direct/bundle_apply.go
+++ b/bundle/direct/bundle_apply.go
@@ -1,4 +1,4 @@
-package terranova
+package direct
 
 import (
 	"context"

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -1,4 +1,4 @@
-package terranova
+package direct
 
 import (
 	"cmp"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/deployplan"
-	"github.com/databricks/cli/bundle/terranova/tnresources"
+	"github.com/databricks/cli/bundle/direct/dresources"
 	"github.com/databricks/cli/libs/dagrun"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/logdiag"
@@ -31,7 +31,7 @@ func (b *DeploymentBundle) Init(client *databricks.WorkspaceClient) error {
 		return nil
 	}
 	var err error
-	b.Adapters, err = tnresources.InitAll(client)
+	b.Adapters, err = dresources.InitAll(client)
 	return err
 }
 

--- a/bundle/direct/dresources/adapter.go
+++ b/bundle/direct/dresources/adapter.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/alert.go
+++ b/bundle/direct/dresources/alert.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/all.go
+++ b/bundle/direct/dresources/all.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"fmt"

--- a/bundle/direct/dresources/all_test.go
+++ b/bundle/direct/dresources/all_test.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/database_catalog.go
+++ b/bundle/direct/dresources/database_catalog.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/database_instance.go
+++ b/bundle/direct/dresources/database_instance.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/job.go
+++ b/bundle/direct/dresources/job.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/pipeline.go
+++ b/bundle/direct/dresources/pipeline.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/schema.go
+++ b/bundle/direct/dresources/schema.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/schema_test.go
+++ b/bundle/direct/dresources/schema_test.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/sql_warehouse.go
+++ b/bundle/direct/dresources/sql_warehouse.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/synced_database_table.go
+++ b/bundle/direct/dresources/synced_database_table.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dresources/util.go
+++ b/bundle/direct/dresources/util.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"reflect"

--- a/bundle/direct/dresources/util_test.go
+++ b/bundle/direct/dresources/util_test.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"testing"

--- a/bundle/direct/dresources/volume.go
+++ b/bundle/direct/dresources/volume.go
@@ -1,4 +1,4 @@
-package tnresources
+package dresources
 
 import (
 	"context"

--- a/bundle/direct/dstate/state.go
+++ b/bundle/direct/dstate/state.go
@@ -1,4 +1,4 @@
-package tnstate
+package dstate
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type TerranovaState struct {
+type DeploymentState struct {
 	Path string
 	Data Database
 	mu   sync.Mutex
@@ -28,7 +28,7 @@ type ResourceEntry struct {
 	State any    `json:"state"`
 }
 
-func (db *TerranovaState) SaveState(group, resourceName, newID string, state any) error {
+func (db *DeploymentState) SaveState(group, resourceName, newID string, state any) error {
 	db.AssertOpened()
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -47,7 +47,7 @@ func (db *TerranovaState) SaveState(group, resourceName, newID string, state any
 	return nil
 }
 
-func (db *TerranovaState) DeleteState(group, resourceName string) error {
+func (db *DeploymentState) DeleteState(group, resourceName string) error {
 	db.AssertOpened()
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -65,7 +65,7 @@ func (db *TerranovaState) DeleteState(group, resourceName string) error {
 	return nil
 }
 
-func (db *TerranovaState) GetResourceEntry(group, resourceName string) (ResourceEntry, bool) {
+func (db *DeploymentState) GetResourceEntry(group, resourceName string) (ResourceEntry, bool) {
 	db.AssertOpened()
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -79,7 +79,7 @@ func (db *TerranovaState) GetResourceEntry(group, resourceName string) (Resource
 	return result, ok
 }
 
-func (db *TerranovaState) Open(path string) error {
+func (db *DeploymentState) Open(path string) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
@@ -113,20 +113,20 @@ func (db *TerranovaState) Open(path string) error {
 	return nil
 }
 
-func (db *TerranovaState) Finalize() error {
+func (db *DeploymentState) Finalize() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
 	return db.unlockedSave()
 }
 
-func (db *TerranovaState) AssertOpened() {
+func (db *DeploymentState) AssertOpened() {
 	if db.Path == "" {
-		panic("internal error: TerranovaState must be opened first")
+		panic("internal error: DeploymentState must be opened first")
 	}
 }
 
-func (db *TerranovaState) ExportState(ctx context.Context) resourcestate.ExportedResourcesMap {
+func (db *DeploymentState) ExportState(ctx context.Context) resourcestate.ExportedResourcesMap {
 	result := make(resourcestate.ExportedResourcesMap, len(db.Data.DeploymentUnits))
 	for groupName, group := range db.Data.DeploymentUnits {
 		resultGroup := make(map[string]resourcestate.ResourceState, len(group))
@@ -141,7 +141,7 @@ func (db *TerranovaState) ExportState(ctx context.Context) resourcestate.Exporte
 	return result
 }
 
-func (db *TerranovaState) unlockedSave() error {
+func (db *DeploymentState) unlockedSave() error {
 	db.AssertOpened()
 	data, err := json.MarshalIndent(db.Data, "", " ")
 	if err != nil {

--- a/bundle/direct/graph.go
+++ b/bundle/direct/graph.go
@@ -1,4 +1,4 @@
-package terranova
+package direct
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 
 	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/deployplan"
-	"github.com/databricks/cli/bundle/terranova/tnresources"
+	"github.com/databricks/cli/bundle/direct/dresources"
 	"github.com/databricks/cli/libs/dagrun"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/dyn/convert"
@@ -38,7 +38,7 @@ func makeResourceGraph(ctx context.Context, configRoot dyn.Value) (*dagrun.Graph
 			group := p[1].Key()
 			name := p[2].Key()
 
-			_, ok := tnresources.SupportedResources[group]
+			_, ok := dresources.SupportedResources[group]
 			if !ok {
 				return v, fmt.Errorf("unsupported resource: %s", group)
 			}

--- a/bundle/direct/pkg.go
+++ b/bundle/direct/pkg.go
@@ -1,12 +1,12 @@
-package terranova
+package direct
 
 import (
 	"fmt"
 	"reflect"
 
 	"github.com/databricks/cli/bundle/deployplan"
-	"github.com/databricks/cli/bundle/terranova/tnresources"
-	"github.com/databricks/cli/bundle/terranova/tnstate"
+	"github.com/databricks/cli/bundle/direct/dresources"
+	"github.com/databricks/cli/bundle/direct/dstate"
 	"github.com/databricks/cli/libs/dagrun"
 )
 
@@ -22,7 +22,7 @@ type DeploymentUnit struct {
 	Key string
 
 	// Implementation for this resource; all deployments from the same group share the adapter
-	Adapter *tnresources.Adapter
+	Adapter *dresources.Adapter
 
 	// Planned ActionType
 	ActionType deployplan.ActionType
@@ -36,10 +36,10 @@ type DeploymentUnit struct {
 
 // DeploymentBundle holds everything needed to deploy a bundle
 type DeploymentBundle struct {
-	StateDB         tnstate.TerranovaState
+	StateDB         dstate.DeploymentState
 	Graph           *dagrun.Graph[deployplan.ResourceNode]
 	DeploymentUnits map[deployplan.ResourceNode]*DeploymentUnit
-	Adapters        map[string]*tnresources.Adapter
+	Adapters        map[string]*dresources.Adapter
 }
 
 // SetRemoteState updates the remote state with type validation and marks as fresh.

--- a/bundle/statemgmt/resourcestate/resourcestate.go
+++ b/bundle/statemgmt/resourcestate/resourcestate.go
@@ -1,7 +1,7 @@
 // This is in a separate package to avoid import cycles because it is imported by both terraform and statemgmt.
 package resourcestate
 
-// ResourceState stores relevant from terraform/terranova state for one resoruce
+// ResourceState stores relevant from terraform/direct state for one resoruce
 type ResourceState struct {
 	ID string
 
@@ -9,6 +9,6 @@ type ResourceState struct {
 	ETag string
 }
 
-// ExportedResourcesMap stores relevant attributes from terraform/terranova state for all resources
+// ExportedResourcesMap stores relevant attributes from terraform/direct state for all resources
 // Maps group (e.g. "jobs") -> resource name -> ResourceState
 type ExportedResourcesMap map[string]map[string]ResourceState

--- a/cmd/bundle/debug/refschema.go
+++ b/cmd/bundle/debug/refschema.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/databricks/cli/bundle/terranova/tnresources"
+	"github.com/databricks/cli/bundle/direct/dresources"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/databricks/cli/libs/structs/structwalk"
@@ -37,7 +37,7 @@ func NewRefSchemaCommand() *cobra.Command {
 
 // dumpRemoteSchemas walks through all supported resources and dumps their schema fields.
 func dumpRemoteSchemas(out io.Writer) error {
-	adapters, err := tnresources.InitAll(nil)
+	adapters, err := dresources.InitAll(nil)
 	if err != nil {
 		return fmt.Errorf("failed to initialize adapters: %w", err)
 	}


### PR DESCRIPTION
## Changes
Pure renames, no other changes.

## Why
We use "direct" name everywhere, makes sense to align the package names.