### PR TITLE
acc: fix install_terraform.py on aarch64

### DIFF
--- a/acceptance/install_terraform.py
+++ b/acceptance/install_terraform.py
@@ -19,7 +19,10 @@ from urllib.request import urlretrieve
 os_name = platform.system().lower()
 
 arch = platform.machine().lower()
-arch = {"x86_64": "amd64"}.get(arch, arch)
+arch = {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+}.get(arch, arch)
 if os_name == "windows" and arch not in ("386", "amd64"):
     # terraform 1.5.5 only has builds for these two.
     arch = "amd64"


### PR DESCRIPTION
Noticed it does not work on Linux clusters.