### PR TITLE
internal: update GetResourceConfig to use dyn/convert rather than JSON roundtrip

### DIFF
--- a/bundle/config/root.go
+++ b/bundle/config/root.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -609,14 +608,10 @@ func (r *Root) GetResourceConfig(path string) (any, bool) {
 		return nil, false
 	}
 
-	// json-round-trip into a value of the concrete resource type to ensure proper handling of ForceSendFields
-	bytes, err := json.Marshal(v.AsAny())
-	if err != nil {
-		return nil, false
-	}
-
 	typedConfigPtr := reflect.New(typ)
-	if err := json.Unmarshal(bytes, typedConfigPtr.Interface()); err != nil {
+
+	err = convert.ToTyped(typedConfigPtr.Interface(), v)
+	if err != nil {
 		return nil, false
 	}
 


### PR DESCRIPTION
## Why
For direct, we fetch configs as struct instances via GetResourceConfig, which is using json roundtrip between dyn value and struct. That, however, does not work well when there references in the config, see https://github.com/databricks/cli/pull/3645 for details.

This switches to converting dyn.Value with dyn/convert ToTyped function. The function was not used previously because it did not handle ForceSendFields correctly for embedded structs which caused JSON marshaller in Go SDK to return error. This was fixed in https://github.com/databricks/cli/pull/3650 and https://github.com/databricks/cli/pull/3649

## Tests
Existing tests.