### PR TITLE
dyn: fix zero values conversion / IsZero() method

### DIFF
--- a/libs/dyn/convert/to_typed_test.go
+++ b/libs/dyn/convert/to_typed_test.go
@@ -130,6 +130,7 @@ func TestToTypedStructZeroFieldsForceSend(t *testing.T) {
 	type Tmp struct {
 		Foo             string   `json:"foo"`
 		Bar             string   `json:"bar,omitempty"`
+		NumWorkers      int      `json:"num_workers,omitempty"`
 		ForceSendFields []string `json:"-"`
 	}
 
@@ -143,12 +144,13 @@ func TestToTypedStructZeroFieldsForceSend(t *testing.T) {
 	m := dyn.Mapping{}
 	m.SetLoc("foo", nil, dyn.V(""))
 	m.SetLoc("bar", nil, dyn.V(""))
+	m.SetLoc("num_workers", nil, dyn.V(int64(0)))
 	v := dyn.V(m)
 
 	// The previously set fields should be cleared.
 	err := ToTyped(&out, v)
 	require.NoError(t, err)
-	assert.Equal(t, Tmp{ForceSendFields: []string{"Foo", "Bar"}}, out)
+	assert.Equal(t, Tmp{ForceSendFields: []string{"Foo", "Bar", "NumWorkers"}}, out)
 }
 
 func TestToTypedStructAnonymousByValue(t *testing.T) {

--- a/libs/dyn/kind.go
+++ b/libs/dyn/kind.go
@@ -29,7 +29,9 @@ func kindOf(v any) Kind {
 		return KindString
 	case bool:
 		return KindBool
-	case int, int32, int64:
+	case int, int8, int16, int32, int64:
+		return KindInt
+	case uint, uint8, uint16, uint32, uint64:
 		return KindInt
 	case float32, float64:
 		return KindFloat
@@ -38,7 +40,7 @@ func kindOf(v any) Kind {
 	case nil:
 		return KindNil
 	default:
-		panic("not handled")
+		panic(fmt.Sprintf("not handled: %T", v))
 	}
 }
 

--- a/libs/dyn/value.go
+++ b/libs/dyn/value.go
@@ -147,7 +147,7 @@ func (v Value) IsZero() bool {
 	case []Value:
 		return len(x) == 0
 	default:
-		return reflect.ValueOf(v.v).IsZero()
+		return reflect.ValueOf(x).IsZero()
 	}
 }
 

--- a/libs/dyn/value.go
+++ b/libs/dyn/value.go
@@ -2,6 +2,7 @@ package dyn
 
 import (
 	"fmt"
+	"reflect"
 	"slices"
 )
 
@@ -147,19 +148,11 @@ func (v Value) IsZero() bool {
 		return len(vv) == 0
 	case KindNil:
 		return true
-	case KindString:
-		return v.v == ""
-	case KindBool:
-		return v.v == false
-	case KindInt:
-		return v.v == 0
-	case KindFloat:
-		return v.v == 0.0
 	case KindTime:
 		t := v.v.(Time)
 		return t.IsZero()
 	default:
-		return false
+		return reflect.ValueOf(v.v).IsZero()
 	}
 }
 

--- a/libs/dyn/value.go
+++ b/libs/dyn/value.go
@@ -137,20 +137,15 @@ func (v Value) AsAny() any {
 }
 
 func (v Value) IsZero() bool {
-	switch v.k {
-	case KindInvalid:
+	if v.v == nil {
 		return true
-	case KindMap:
-		m := v.v.(Mapping)
-		return m.Len() == 0
-	case KindSequence:
-		vv := v.v.([]Value)
-		return len(vv) == 0
-	case KindNil:
-		return true
-	case KindTime:
-		t := v.v.(Time)
-		return t.IsZero()
+	}
+
+	switch x := v.v.(type) {
+	case Mapping:
+		return x.Len() == 0
+	case []Value:
+		return len(x) == 0
 	default:
 		return reflect.ValueOf(v.v).IsZero()
 	}

--- a/libs/dyn/value_test.go
+++ b/libs/dyn/value_test.go
@@ -51,6 +51,7 @@ func TestValueIsValid(t *testing.T) {
 }
 
 func TestIsZero(t *testing.T) {
+	assert.True(t, dyn.V(0).IsZero(), "int")
 	assert.True(t, dyn.V(int(0)).IsZero(), "int")
 	assert.False(t, dyn.V(int(1)).IsZero(), "int")
 	assert.True(t, dyn.V(uint(0)).IsZero(), "uint")
@@ -84,4 +85,7 @@ func TestIsZero(t *testing.T) {
 	assert.False(t, dyn.V(float64(0.01)).IsZero(), "float64")
 
 	assert.True(t, dyn.V(dyn.Time{}).IsZero(), "time")
+	assert.True(t, dyn.V(dyn.Mapping{}).IsZero(), "Mapping")
+	assert.True(t, dyn.V([]dyn.Value{}).IsZero(), "Sequence")
+	assert.False(t, dyn.V([]dyn.Value{dyn.V(0)}).IsZero(), "Sequence")
 }

--- a/libs/dyn/value_test.go
+++ b/libs/dyn/value_test.go
@@ -49,3 +49,37 @@ func TestValueIsValid(t *testing.T) {
 	intValue := dyn.V(1)
 	assert.True(t, intValue.IsValid())
 }
+
+func TestIsZero(t *testing.T) {
+	assert.True(t, dyn.V(int(0)).IsZero(), "int")
+	assert.False(t, dyn.V(int(1)).IsZero(), "int")
+	// assert.True(t, dyn.V(uint(0)).IsZero(), "uint") // panics
+
+	// assert.True(t, dyn.V(int8(0)).IsZero(), "int8") // panics
+	// assert.True(t, dyn.V(uint8(0)).IsZero(), "uint8") // panics
+
+	// assert.True(t, dyn.V(int16(0)).IsZero(), "int16") // panics
+	// assert.True(t, dyn.V(uint16(0)).IsZero(), "uint16") // panics
+
+	assert.True(t, dyn.V(int32(0)).IsZero(), "int32")
+	assert.False(t, dyn.V(int32(1)).IsZero(), "int32")
+	// assert.True(t, dyn.V(uint32(0)).IsZero(), "uint32") // panics
+
+	assert.True(t, dyn.V(int64(0)).IsZero(), "int64")
+	assert.False(t, dyn.V(int64(-1)).IsZero(), "int64")
+
+	// assert.True(t, dyn.V(uint64(0)).IsZero(), "uint64") // panics
+	// assert.False(t, dyn.V(uint64(2)).IsZero(), "uint64") // panics
+
+	assert.True(t, dyn.V("").IsZero(), "string")
+	assert.False(t, dyn.V("x").IsZero(), "string")
+
+	assert.True(t, dyn.V(false).IsZero(), "bool")
+	assert.False(t, dyn.V(true).IsZero(), "bool")
+
+	assert.True(t, dyn.V(float32(0.0)).IsZero(), "float32")
+	assert.False(t, dyn.V(float32(0.01)).IsZero(), "float32")
+
+	assert.True(t, dyn.V(float64(0.0)).IsZero(), "float64")
+	assert.False(t, dyn.V(float64(0.01)).IsZero(), "float64")
+}

--- a/libs/dyn/value_test.go
+++ b/libs/dyn/value_test.go
@@ -53,23 +53,23 @@ func TestValueIsValid(t *testing.T) {
 func TestIsZero(t *testing.T) {
 	assert.True(t, dyn.V(int(0)).IsZero(), "int")
 	assert.False(t, dyn.V(int(1)).IsZero(), "int")
-	// assert.True(t, dyn.V(uint(0)).IsZero(), "uint") // panics
+	assert.True(t, dyn.V(uint(0)).IsZero(), "uint")
 
-	// assert.True(t, dyn.V(int8(0)).IsZero(), "int8") // panics
-	// assert.True(t, dyn.V(uint8(0)).IsZero(), "uint8") // panics
+	assert.True(t, dyn.V(int8(0)).IsZero(), "int8")
+	assert.True(t, dyn.V(uint8(0)).IsZero(), "uint8")
 
-	// assert.True(t, dyn.V(int16(0)).IsZero(), "int16") // panics
-	// assert.True(t, dyn.V(uint16(0)).IsZero(), "uint16") // panics
+	assert.True(t, dyn.V(int16(0)).IsZero(), "int16")
+	assert.True(t, dyn.V(uint16(0)).IsZero(), "uint16")
 
 	assert.True(t, dyn.V(int32(0)).IsZero(), "int32")
 	assert.False(t, dyn.V(int32(1)).IsZero(), "int32")
-	// assert.True(t, dyn.V(uint32(0)).IsZero(), "uint32") // panics
+	assert.True(t, dyn.V(uint32(0)).IsZero(), "uint32")
 
 	assert.True(t, dyn.V(int64(0)).IsZero(), "int64")
 	assert.False(t, dyn.V(int64(-1)).IsZero(), "int64")
 
-	// assert.True(t, dyn.V(uint64(0)).IsZero(), "uint64") // panics
-	// assert.False(t, dyn.V(uint64(2)).IsZero(), "uint64") // panics
+	assert.True(t, dyn.V(uint64(0)).IsZero(), "uint64")
+	assert.False(t, dyn.V(uint64(2)).IsZero(), "uint64")
 
 	assert.True(t, dyn.V("").IsZero(), "string")
 	assert.False(t, dyn.V("x").IsZero(), "string")
@@ -82,4 +82,6 @@ func TestIsZero(t *testing.T) {
 
 	assert.True(t, dyn.V(float64(0.0)).IsZero(), "float64")
 	assert.False(t, dyn.V(float64(0.01)).IsZero(), "float64")
+
+	assert.True(t, dyn.V(dyn.Time{}).IsZero(), "time")
 }


### PR DESCRIPTION
## Changes
- Fix IsZero() method for types like int64. This fixes ToConvert for NumWorkers field in ClusterSpec.
- Do not panic in dyn.V() if other int types are encountered.
- If panic does happen, include type name.

## Why
ToConvert() depends on it and is broken. This unblocks https://github.com/databricks/cli/pull/3650 https://github.com/databricks/cli/pull/3646

## Tests
New unit tests.
