### PR TITLE
dyn/convert: Fix ForceSendFields handling for embedded structs

### DIFF
--- a/acceptance/bundle/resources/jobs/update_single_node/databricks.yml
+++ b/acceptance/bundle/resources/jobs/update_single_node/databricks.yml
@@ -1,0 +1,22 @@
+resources:
+  jobs:
+    foo:
+      name: foo
+
+      trigger:
+        periodic:
+          interval: 1
+          unit: DAYS
+
+      job_clusters:
+        - job_cluster_key: key
+          new_cluster:
+            # main intention is to test this "num_workers: 0" as there were issues with zero conversion
+            # ../update also tests this but there num_workers is implicitly set
+            num_workers: 0
+            spark_version: 13.3.x-scala2.12
+            spark_conf:
+              spark.databricks.cluster.profile: singleNode
+              spark.master: local[*]
+            custom_tags:
+              ResourceClass: SingleNode

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct-exp"]

--- a/acceptance/bundle/resources/jobs/update_single_node/output.txt
+++ b/acceptance/bundle/resources/jobs/update_single_node/output.txt
@@ -1,0 +1,207 @@
+
+>>> [CLI] bundle plan
+create jobs.foo
+
+Plan: 1 to add, 0 to change, 0 to delete, 0 unchanged
+
+>>> [CLI] bundle plan -o json
+{
+  "plan": {
+    "resources.jobs.foo": {
+      "action": "create"
+    }
+  }
+}
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] bundle plan -o json
+{
+  "plan": {}
+}
+
+>>> print_requests
+{
+  "body": {
+    "deployment": {
+      "kind": "BUNDLE",
+      "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/metadata.json"
+    },
+    "edit_mode": "UI_LOCKED",
+    "format": "MULTI_TASK",
+    "job_clusters": [
+      {
+        "job_cluster_key": "key",
+        "new_cluster": {
+          "custom_tags": {
+            "ResourceClass": "SingleNode"
+          },
+          "num_workers": 0,
+          "spark_conf": {
+            "spark.databricks.cluster.profile": "singleNode",
+            "spark.master": "local[*]"
+          },
+          "spark_version": "13.3.x-scala2.12"
+        }
+      }
+    ],
+    "max_concurrent_runs": 1,
+    "name": "foo",
+    "queue": {
+      "enabled": true
+    },
+    "trigger": {
+      "pause_status": "UNPAUSED",
+      "periodic": {
+        "interval": 1,
+        "unit": "DAYS"
+      }
+    }
+  },
+  "method": "POST",
+  "path": "/api/2.2/jobs/create"
+}
+jobs foo id='[JOB_ID]' name='foo'
+
+=== Update trigger.periodic.unit and re-deploy
+>>> update_file.py databricks.yml DAYS HOURS
+
+>>> [CLI] bundle plan
+update jobs.foo
+
+Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
+
+>>> [CLI] bundle plan -o json
+{
+  "plan": {
+    "resources.jobs.foo": {
+      "action": "update(id_stable)"
+    }
+  }
+}
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> print_requests
+{
+  "body": {
+    "job_id": [JOB_ID],
+    "new_settings": {
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "job_clusters": [
+        {
+          "job_cluster_key": "key",
+          "new_cluster": {
+            "custom_tags": {
+              "ResourceClass": "SingleNode"
+            },
+            "num_workers": 0,
+            "spark_conf": {
+              "spark.databricks.cluster.profile": "singleNode",
+              "spark.master": "local[*]"
+            },
+            "spark_version": "13.3.x-scala2.12"
+          }
+        }
+      ],
+      "max_concurrent_runs": 1,
+      "name": "foo",
+      "queue": {
+        "enabled": true
+      },
+      "trigger": {
+        "pause_status": "UNPAUSED",
+        "periodic": {
+          "interval": 1,
+          "unit": "HOURS"
+        }
+      }
+    }
+  },
+  "method": "POST",
+  "path": "/api/2.2/jobs/reset"
+}
+jobs foo id='[JOB_ID]' name='foo'
+
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
+
+=== Fetch job ID and verify remote state
+>>> [CLI] jobs get [JOB_ID]
+{
+  "job_id":[JOB_ID],
+  "settings": {
+    "deployment": {
+      "kind":"BUNDLE",
+      "metadata_file_path":"/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/metadata.json"
+    },
+    "edit_mode":"UI_LOCKED",
+    "format":"MULTI_TASK",
+    "job_clusters": [
+      {
+        "job_cluster_key":"key",
+        "new_cluster": {
+          "custom_tags": {
+            "ResourceClass":"SingleNode"
+          },
+          "num_workers":0,
+          "spark_conf": {
+            "spark.databricks.cluster.profile":"singleNode",
+            "spark.master":"local[*]"
+          },
+          "spark_version":"13.3.x-scala2.12"
+        }
+      }
+    ],
+    "max_concurrent_runs":1,
+    "name":"foo",
+    "queue": {
+      "enabled":true
+    },
+    "trigger": {
+      "pause_status":"UNPAUSED",
+      "periodic": {
+        "interval":1,
+        "unit":"HOURS"
+      }
+    }
+  }
+}
+
+=== Destroy the job and verify that it's removed from the state and from remote
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete job foo
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Deleting files...
+Destroy complete!
+
+>>> print_requests
+{
+  "body": {
+    "job_id": [JOB_ID]
+  },
+  "method": "POST",
+  "path": "/api/2.2/jobs/delete"
+}
+State not found for jobs.foo
+
+>>> musterr [CLI] jobs get [JOB_ID]
+Error: Not Found
+
+Exit code (musterr): 1

--- a/acceptance/bundle/resources/jobs/update_single_node/output.txt
+++ b/acceptance/bundle/resources/jobs/update_single_node/output.txt
@@ -21,7 +21,11 @@ Deployment complete!
 
 >>> [CLI] bundle debug plan
 {
-  "plan": {}
+  "plan": {
+    "resources.jobs.foo": {
+      "action": "skip"
+    }
+  }
 }
 
 >>> print_requests
@@ -79,7 +83,7 @@ Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
 {
   "plan": {
     "resources.jobs.foo": {
-      "action": "update(id_stable)"
+      "action": "update"
     }
   }
 }

--- a/acceptance/bundle/resources/jobs/update_single_node/output.txt
+++ b/acceptance/bundle/resources/jobs/update_single_node/output.txt
@@ -4,7 +4,7 @@ create jobs.foo
 
 Plan: 1 to add, 0 to change, 0 to delete, 0 unchanged
 
->>> [CLI] bundle plan -o json
+>>> [CLI] bundle debug plan
 {
   "plan": {
     "resources.jobs.foo": {
@@ -19,7 +19,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] bundle plan -o json
+>>> [CLI] bundle debug plan
 {
   "plan": {}
 }
@@ -75,7 +75,7 @@ update jobs.foo
 
 Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
 
->>> [CLI] bundle plan -o json
+>>> [CLI] bundle debug plan
 {
   "plan": {
     "resources.jobs.foo": {

--- a/acceptance/bundle/resources/jobs/update_single_node/script
+++ b/acceptance/bundle/resources/jobs/update_single_node/script
@@ -1,8 +1,8 @@
 echo "*" > .gitignore
 trace $CLI bundle plan
-trace $CLI bundle plan -o json
+trace $CLI bundle debug plan
 trace $CLI bundle deploy
-trace $CLI bundle plan -o json
+trace $CLI bundle debug plan
 
 print_requests() {
     jq --sort-keys 'select(.method != "GET" and (.path | contains("/jobs")))' < out.requests.txt
@@ -15,7 +15,7 @@ trace print_requests
 title "Update trigger.periodic.unit and re-deploy"
 trace update_file.py databricks.yml DAYS HOURS
 trace $CLI bundle plan
-trace $CLI bundle plan -o json
+trace $CLI bundle debug plan
 trace $CLI bundle deploy
 trace print_requests
 

--- a/acceptance/bundle/resources/jobs/update_single_node/script
+++ b/acceptance/bundle/resources/jobs/update_single_node/script
@@ -1,0 +1,37 @@
+echo "*" > .gitignore
+trace $CLI bundle plan
+trace $CLI bundle plan -o json
+trace $CLI bundle deploy
+trace $CLI bundle plan -o json
+
+print_requests() {
+    jq --sort-keys 'select(.method != "GET" and (.path | contains("/jobs")))' < out.requests.txt
+    rm out.requests.txt
+    read_state.py jobs foo id name
+}
+
+trace print_requests
+
+title "Update trigger.periodic.unit and re-deploy"
+trace update_file.py databricks.yml DAYS HOURS
+trace $CLI bundle plan
+trace $CLI bundle plan -o json
+trace $CLI bundle deploy
+trace print_requests
+
+trace $CLI bundle plan
+
+title "Fetch job ID and verify remote state"
+
+ppid=`read_id.py jobs foo`
+echo "$ppid:JOB_ID" >> ACC_REPLS
+
+trace $CLI jobs get $ppid
+rm out.requests.txt
+
+title "Destroy the job and verify that it's removed from the state and from remote"
+trace $CLI bundle destroy --auto-approve
+trace print_requests
+
+trace musterr $CLI jobs get $ppid
+rm out.requests.txt

--- a/libs/dyn/convert/end_to_end_test.go
+++ b/libs/dyn/convert/end_to_end_test.go
@@ -113,3 +113,59 @@ func TestAdditional(t *testing.T) {
 		})
 	})
 }
+
+func TestEndToEndForceSendFields(t *testing.T) {
+	type Inner struct {
+		InnerField      string   `json:"inner_field"`
+		ForceSendFields []string `json:"-"`
+	}
+	type Outer struct {
+		OuterField string `json:"outer_field"`
+		Inner
+	}
+
+	// Test with zero value in embedded struct
+	src := Outer{
+		OuterField: "outer_value",
+		Inner: Inner{
+			InnerField:      "",                     // Zero value
+			ForceSendFields: []string{"InnerField"}, // Should be preserved
+		},
+	}
+
+	assertFromTypedToTypedEqual(t, src)
+}
+
+func TestEndToEndPointerForceSendFields(t *testing.T) {
+	type NewCluster struct {
+		NumWorkers      int      `json:"num_workers"`
+		SparkVersion    string   `json:"spark_version"`
+		ForceSendFields []string `json:"-"`
+	}
+	type JobCluster struct {
+		JobClusterKey string      `json:"job_cluster_key"`
+		NewCluster    *NewCluster `json:"new_cluster"`
+	}
+	type JobSettings struct {
+		JobClusters     []JobCluster `json:"job_clusters"`
+		Name            string       `json:"name"`
+		ForceSendFields []string     `json:"-"`
+	}
+
+	// Test with zero value in pointer embedded struct (like acceptance test)
+	src := JobSettings{
+		Name: "test-job",
+		JobClusters: []JobCluster{
+			{
+				JobClusterKey: "key",
+				NewCluster: &NewCluster{
+					NumWorkers:      0, // Zero value
+					SparkVersion:    "13.3.x-scala2.12",
+					ForceSendFields: []string{"NumWorkers"}, // Should be preserved
+				},
+			},
+		},
+	}
+
+	assertFromTypedToTypedEqual(t, src)
+}

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -355,4 +355,3 @@ func fromTypedFloat(src reflect.Value, ref dyn.Value, options ...fromTypedOption
 
 	return dyn.InvalidValue, fmt.Errorf("cannot convert float field to dynamic type %#v: src=%#v ref=%#v", ref.Kind().String(), src, ref.AsAny())
 }
-

--- a/libs/dyn/convert/from_typed.go
+++ b/libs/dyn/convert/from_typed.go
@@ -388,14 +388,14 @@ func getForceSendFieldsForFromTyped(v reflect.Value) map[int][]string {
 
 		if field.Name == "ForceSendFields" && !field.Anonymous {
 			// Direct ForceSendFields (structKey = -1)
-			if fields := extractForceSendFieldsSlice(fieldValue); len(fields) > 0 {
+			if fields, ok := fieldValue.Interface().([]string); ok {
 				result[-1] = fields
 			}
 		} else if field.Anonymous {
 			// Embedded struct - check for ForceSendFields inside it
 			if embeddedStruct := getEmbeddedStructForReading(fieldValue); embeddedStruct.IsValid() {
 				if forceSendField := embeddedStruct.FieldByName("ForceSendFields"); forceSendField.IsValid() {
-					if fields := extractForceSendFieldsSlice(forceSendField); len(fields) > 0 {
+					if fields, ok := forceSendField.Interface().([]string); ok {
 						result[i] = fields
 					}
 				}
@@ -404,16 +404,6 @@ func getForceSendFieldsForFromTyped(v reflect.Value) map[int][]string {
 	}
 
 	return result
-}
-
-// Helper function to extract []string from a ForceSendFields field
-func extractForceSendFieldsSlice(fieldValue reflect.Value) []string {
-	if fieldValue.IsValid() && fieldValue.Kind() == reflect.Slice {
-		if fields, ok := fieldValue.Interface().([]string); ok {
-			return fields
-		}
-	}
-	return nil
 }
 
 // Helper function for reading - doesn't create nil pointers

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -923,6 +923,6 @@ func TestFromTypedForceSendFieldsEmbedded(t *testing.T) {
 	field := nv.Get("field")
 	other := nv.Get("other")
 	assert.True(t, field.IsValid(), "embedded field should be present due to ForceSendFields")
-	assert.Equal(t, field.Kind(), dyn.KindNil, "embedded field should be present due to ForceSendFields")
+	assert.Equal(t, dyn.KindNil, field.Kind(), "embedded field should be present due to ForceSendFields")
 	assert.Equal(t, dyn.V("value"), other)
 }

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -923,6 +923,6 @@ func TestFromTypedForceSendFieldsEmbedded(t *testing.T) {
 	field := nv.Get("field")
 	other := nv.Get("other")
 	assert.True(t, field.IsValid(), "embedded field should be present due to ForceSendFields")
-	assert.True(t, field.Kind() == dyn.KindNil, "embedded field should be present due to ForceSendFields")
+	assert.Equal(t, field.Kind(), dyn.KindNil, "embedded field should be present due to ForceSendFields")
 	assert.Equal(t, dyn.V("value"), other)
 }

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -839,9 +839,6 @@ func TestFromTypedNilSliceRetainsLocation(t *testing.T) {
 	assert.Equal(t, dyn.NewValue(nil, []dyn.Location{{File: "foobar"}}), nv)
 }
 
-// Regression test for ForceSendFields with complex types causing panics.
-// Bug: when a field is in ForceSendFields but fromTyped() returns dyn.NilValue,
-// the code calls dyn.V() directly on complex types, causing "not handled" panics.
 func TestFromTypedForceSendFieldsComplexTypes(t *testing.T) {
 	type Inner struct {
 		Value string `json:"value"`
@@ -890,7 +887,6 @@ func TestFromTypedForceSendFieldsComplexTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// This should not panic once the bug is fixed
 			nv, err := FromTyped(tt.src, dyn.NilValue)
 			require.NoError(t, err)
 

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -838,3 +838,94 @@ func TestFromTypedNilSliceRetainsLocation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, dyn.NewValue(nil, []dyn.Location{{File: "foobar"}}), nv)
 }
+
+// Regression test for ForceSendFields with complex types causing panics.
+// Bug: when a field is in ForceSendFields but fromTyped() returns dyn.NilValue,
+// the code calls dyn.V() directly on complex types, causing "not handled" panics.
+func TestFromTypedForceSendFieldsComplexTypes(t *testing.T) {
+	type Inner struct {
+		Value string `json:"value"`
+	}
+
+	tests := []struct {
+		name string
+		src  any
+	}{
+		{
+			name: "struct_pointer",
+			src: struct {
+				Field           *Inner   `json:"field"`
+				ForceSendFields []string `json:"-"`
+			}{Field: nil, ForceSendFields: []string{"Field"}},
+		},
+		{
+			name: "struct_value",
+			src: struct {
+				Field           Inner    `json:"field"`
+				ForceSendFields []string `json:"-"`
+			}{Field: Inner{}, ForceSendFields: []string{"Field"}},
+		},
+		{
+			name: "slice",
+			src: struct {
+				Field           []string `json:"field"`
+				ForceSendFields []string `json:"-"`
+			}{Field: nil, ForceSendFields: []string{"Field"}},
+		},
+		{
+			name: "map",
+			src: struct {
+				Field           map[string]string `json:"field"`
+				ForceSendFields []string          `json:"-"`
+			}{Field: nil, ForceSendFields: []string{"Field"}},
+		},
+		{
+			name: "interface",
+			src: struct {
+				Field           any      `json:"field"`
+				ForceSendFields []string `json:"-"`
+			}{Field: (*string)(nil), ForceSendFields: []string{"Field"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This should not panic once the bug is fixed
+			nv, err := FromTyped(tt.src, dyn.NilValue)
+			require.NoError(t, err)
+
+			// All should include the field because it's in ForceSendFields
+			field := nv.Get("field")
+			assert.True(t, field.IsValid(), "field should be present due to ForceSendFields")
+		})
+	}
+}
+
+// Test embedded structs with ForceSendFields (separate test due to different structure)
+func TestFromTypedForceSendFieldsEmbedded(t *testing.T) {
+	type Inner struct {
+		Field           *string  `json:"field"`
+		ForceSendFields []string `json:"-"`
+	}
+	type Outer struct {
+		Inner
+		Other string `json:"other"`
+	}
+
+	src := Outer{
+		Inner: Inner{
+			Field:           nil,
+			ForceSendFields: []string{"Field"},
+		},
+		Other: "value",
+	}
+
+	nv, err := FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	// Both fields should be present
+	field := nv.Get("field")
+	other := nv.Get("other")
+	assert.True(t, field.IsValid(), "embedded field should be present due to ForceSendFields")
+	assert.Equal(t, dyn.V("value"), other)
+}

--- a/libs/dyn/convert/from_typed_test.go
+++ b/libs/dyn/convert/from_typed_test.go
@@ -923,5 +923,6 @@ func TestFromTypedForceSendFieldsEmbedded(t *testing.T) {
 	field := nv.Get("field")
 	other := nv.Get("other")
 	assert.True(t, field.IsValid(), "embedded field should be present due to ForceSendFields")
+	assert.True(t, field.Kind() == dyn.KindNil, "embedded field should be present due to ForceSendFields")
 	assert.Equal(t, dyn.V("value"), other)
 }

--- a/libs/dyn/convert/struct_info.go
+++ b/libs/dyn/convert/struct_info.go
@@ -210,7 +210,7 @@ func getForceSendFieldsValues(v reflect.Value) map[int]reflect.Value {
 			result[-1] = fieldValue
 		} else if field.Anonymous {
 			// Embedded struct - check for ForceSendFields inside it
-			if embeddedStruct := getEmbeddedStruct(fieldValue); embeddedStruct.IsValid() {
+			if embeddedStruct := deref(fieldValue); embeddedStruct.IsValid() {
 				if forceSendField := embeddedStruct.FieldByName("ForceSendFields"); forceSendField.IsValid() {
 					result[i] = forceSendField
 				}
@@ -221,16 +221,13 @@ func getForceSendFieldsValues(v reflect.Value) map[int]reflect.Value {
 	return result
 }
 
-// getEmbeddedStruct handles embedded struct access - never creates nil pointers
-func getEmbeddedStruct(fieldValue reflect.Value) reflect.Value {
-	if fieldValue.Kind() == reflect.Pointer {
-		if fieldValue.IsNil() {
-			return reflect.Value{} // Don't create, just return invalid
+// deref dereferences a pointer, returning invalid value if nil
+func deref(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return reflect.Value{}
 		}
-		fieldValue = fieldValue.Elem()
+		return v.Elem()
 	}
-	if fieldValue.Kind() == reflect.Struct {
-		return fieldValue
-	}
-	return reflect.Value{}
+	return v
 }

--- a/libs/dyn/convert/struct_info.go
+++ b/libs/dyn/convert/struct_info.go
@@ -164,18 +164,15 @@ func (s *structInfo) FieldValues(v reflect.Value) []FieldValue {
 		}
 
 		if fv.IsValid() {
-			var inForceSendFields bool
+			isForced := true
 
-			// Check ForceSendFields if the field value is zero
+			// TODO: we should use isEmptyForOmitEmpty instead of IsZero()
 			if fv.IsZero() {
 				goName := s.GolangNames[k]
 				structKey := s.ForceSendFieldsStructKey[k]
 				forceSendFields := forceSendFieldsMap[structKey]
-				inForceSendFields = slices.Contains(forceSendFields, goName)
+				isForced = slices.Contains(forceSendFields, goName)
 			}
-
-			// IsForced is true if field is not zero OR if it's in ForceSendFields
-			isForced := !fv.IsZero() || inForceSendFields
 
 			out = append(out, FieldValue{
 				Key:      k,

--- a/libs/dyn/convert/struct_info.go
+++ b/libs/dyn/convert/struct_info.go
@@ -188,7 +188,6 @@ func (s *structInfo) FieldValues(v reflect.Value) []FieldValue {
 	return out
 }
 
-
 // Type of [dyn.Value].
 var configValueType = reflect.TypeOf((*dyn.Value)(nil)).Elem()
 

--- a/libs/dyn/convert/to_typed.go
+++ b/libs/dyn/convert/to_typed.go
@@ -68,9 +68,10 @@ func toTypedStruct(dst reflect.Value, src dyn.Value) error {
 		// that aren't present in [src] are cleared.
 		dst.SetZero()
 
-		var forceSendFields []string
-
 		info := getStructInfo(dst.Type())
+
+		forceSendFieldLocations := getForceSendFieldLocationsForToTyped(dst)
+		forceSendFieldsMap := make(map[int][]string)
 
 		for _, pair := range src.MustMap().Pairs() {
 			pk := pair.Key
@@ -105,14 +106,22 @@ func toTypedStruct(dst reflect.Value, src dyn.Value) error {
 			}
 
 			if pv.IsZero() {
-				forceSendFields = append(forceSendFields, info.GolangNames[jsonKey])
+				// Use first index as key: -1 for direct fields, struct index for embedded fields
+				var structKey int
+				if len(index) == 1 {
+					structKey = -1 // Direct field
+				} else {
+					structKey = index[0] // Embedded struct index
+				}
+
+				forceSendFieldsMap[structKey] = append(forceSendFieldsMap[structKey], info.GolangNames[jsonKey])
 			}
 		}
 
-		if forceSendFields != nil {
-			f := dst.FieldByName("ForceSendFields")
-			if f.IsValid() {
-				f.Set(reflect.ValueOf(forceSendFields))
+		// Set ForceSendFields using precalculated locations
+		for structKey, fields := range forceSendFieldsMap {
+			if forceSendFieldLocation, exists := forceSendFieldLocations[structKey]; exists {
+				forceSendFieldLocation.Set(reflect.ValueOf(fields))
 			}
 		}
 
@@ -140,6 +149,54 @@ func toTypedStruct(dst reflect.Value, src dyn.Value) error {
 		value: src,
 		msg:   fmt.Sprintf("expected a map, found a %s", src.Kind()),
 	}
+}
+
+// getForceSendFieldLocationsForToTyped collects ForceSendFields locations for ToTyped operations
+// Returns map[structKey]reflect.Value for setting ForceSendFields slices
+func getForceSendFieldLocationsForToTyped(v reflect.Value) map[int]reflect.Value {
+	if !v.IsValid() || v.Type().Kind() != reflect.Struct {
+		return make(map[int]reflect.Value)
+	}
+
+	locations := make(map[int]reflect.Value)
+
+	for i := range v.Type().NumField() {
+		field := v.Type().Field(i)
+		fieldValue := v.Field(i)
+
+		if field.Name == "ForceSendFields" && !field.Anonymous {
+			// Direct ForceSendFields (structKey = -1)
+			locations[-1] = fieldValue
+		} else if field.Anonymous {
+			// Embedded struct - check for ForceSendFields inside it
+			if embeddedStruct := getEmbeddedStructForWriting(fieldValue); embeddedStruct.IsValid() {
+				if forceSendField := embeddedStruct.FieldByName("ForceSendFields"); forceSendField.IsValid() {
+					locations[i] = forceSendField
+				}
+			}
+		}
+	}
+
+	return locations
+}
+
+// Helper function for writing - creates nil pointers when needed for ToTyped
+func getEmbeddedStructForWriting(fieldValue reflect.Value) reflect.Value {
+	if fieldValue.Kind() == reflect.Pointer {
+		if fieldValue.IsNil() {
+			// For ToTyped, we need to create the embedded struct to get the location
+			if fieldValue.CanSet() {
+				fieldValue.Set(reflect.New(fieldValue.Type().Elem()))
+			} else {
+				return reflect.Value{} // Can't set, return invalid
+			}
+		}
+		fieldValue = fieldValue.Elem()
+	}
+	if fieldValue.Kind() == reflect.Struct {
+		return fieldValue
+	}
+	return reflect.Value{}
 }
 
 func toTypedMap(dst reflect.Value, src dyn.Value) error {


### PR DESCRIPTION
## Changes
Fix ToTyped / FromTyped wrt ForceSendFields when there are (multiple) embedded structs.

## Why
Incorrect conversion between typed & dynamic value can result in subtle bugs. In direct engine it is even more important, as we rely on typed structs more here. Enables https://github.com/databricks/cli/pull/3646

## Tests
New unit tests.