### PR TITLE
Update annotation test to check properties instead of root types

### DIFF
--- a/bundle/internal/schema/main_test.go
+++ b/bundle/internal/schema/main_test.go
@@ -132,15 +132,18 @@ func TestNoDuplicatedAnnotations(t *testing.T) {
 		"annotations.yml",
 	}
 
-	annotations := map[string]bool{}
+	annotations := map[string]string{}
 	for _, file := range files {
 		annotationsFile, err := getAnnotations(file)
 		assert.NoError(t, err)
-		for k := range annotationsFile {
-			if _, ok := annotations[k]; ok {
-				t.Errorf("Annotation `%s` is duplicated in %s", k, file)
+		for typ, props := range annotationsFile {
+			for prop := range props {
+				key := typ + "_" + prop
+				if prevFile, ok := annotations[key]; ok {
+					t.Errorf("Annotation `%s` is duplicated in %s and %s", key, prevFile, file)
+				}
+				annotations[key] = file
 			}
-			annotations[k] = true
 		}
 	}
 }


### PR DESCRIPTION
## Changes
Previously, it was checking only the root type, so it wasn't possible to have different properties in openapi_overrides and custom overrides of the same root type

Also updated message to make it more clear:
<img width="982" height="86" alt="image" src="https://github.com/user-attachments/assets/49493c88-da6e-4e2f-b61f-dfe8141e6170" />


## Why
Tests were unexpectedly failing in this PR https://github.com/databricks/cli/pull/3635

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
