### PR TITLE
Improve the output of bundle run when bundle is not deployed

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,5 +11,6 @@
 ### Bundles
 * Add new Lakeflow Pipelines support for bundle generate ([#3568](https://github.com/databricks/cli/pull/3568))
 * Introduce new bundle variable: `${workspace.current_user.domain_friendly_name}` ([#3623](https://github.com/databricks/cli/pull/3623))
+* Improve the output of bundle run when bundle is not deployed ([#3652](https://github.com/databricks/cli/pull/3652))
 
 ### API Changes

--- a/acceptance/bundle/run/no-state/output.txt
+++ b/acceptance/bundle/run/no-state/output.txt
@@ -1,4 +1,4 @@
-Error: no deployment state. Did you forget to run 'databricks bundle deploy'?
+Error: resource not found or not yet deployed. Did you forget to run 'databricks bundle deploy'?
 
 
 Exit code (musterr): 1

--- a/acceptance/bundle/run/state-wiped/output.txt
+++ b/acceptance/bundle/run/state-wiped/output.txt
@@ -1,6 +1,6 @@
 
 >>> musterr [CLI] bundle run foo
-Error: no deployment state. Did you forget to run 'databricks bundle deploy'?
+Error: resource not found or not yet deployed. Did you forget to run 'databricks bundle deploy'?
 
 
 Exit code (musterr): 1

--- a/bundle/statemgmt/state_load.go
+++ b/bundle/statemgmt/state_load.go
@@ -136,7 +136,7 @@ func StateToBundle(ctx context.Context, state ExportedResourcesMap, config *conf
 
 func (l *load) validateState(state ExportedResourcesMap) error {
 	if len(state) == 0 && slices.Contains(l.modes, ErrorOnEmptyState) {
-		return errors.New("no deployment state. Did you forget to run 'databricks bundle deploy'?")
+		return errors.New("resource not found or not yet deployed. Did you forget to run 'databricks bundle deploy'?")
 	}
 
 	return nil


### PR DESCRIPTION
## Changes
Improve the output of bundle run when the bundle is not deployed

## Why
Makes it a bit more user-friendly, why the error appears

## Tests
Acceptance tests

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
