### PR TITLE
Simplify action name "update(id_stable)" -> "update"

### DIFF
--- a/acceptance/bundle/resources/jobs/update/output.txt
+++ b/acceptance/bundle/resources/jobs/update/output.txt
@@ -75,7 +75,7 @@ Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
 {
   "plan": {
     "resources.jobs.foo": {
-      "action": "update(id_stable)"
+      "action": "update"
     }
   }
 }

--- a/acceptance/bundle/resources/volumes/change-name/out.plan.direct-exp.txt
+++ b/acceptance/bundle/resources/volumes/change-name/out.plan.direct-exp.txt
@@ -1,7 +1,7 @@
 {
   "plan": {
     "resources.volumes.volume1": {
-      "action": "update(id_changes)"
+      "action": "update_id"
     }
   }
 }

--- a/acceptance/bundle/resources/volumes/change-name/out.plan.terraform.txt
+++ b/acceptance/bundle/resources/volumes/change-name/out.plan.terraform.txt
@@ -1,7 +1,7 @@
 {
   "plan": {
     "resources.volumes.volume1": {
-      "action": "update(id_stable)"
+      "action": "update"
     }
   }
 }

--- a/bundle/deploy/terraform/showplanfile.go
+++ b/bundle/deploy/terraform/showplanfile.go
@@ -47,7 +47,7 @@ func populatePlan(ctx context.Context, plan *deployplan.Plan, changes []*tfjson.
 		}
 
 		key := "resources." + group + "." + rc.Name
-		plan.Plan[key] = deployplan.PlanEntry{Action: actionType.StringFull()}
+		plan.Plan[key] = deployplan.PlanEntry{Action: actionType.String()}
 	}
 }
 

--- a/bundle/deployplan/action.go
+++ b/bundle/deployplan/action.go
@@ -43,8 +43,8 @@ const (
 var actionName = map[ActionType]string{
 	ActionTypeNoop:         "noop",
 	ActionTypeResize:       "resize",
-	ActionTypeUpdate:       "update(id_stable)",
-	ActionTypeUpdateWithID: "update(id_changes)",
+	ActionTypeUpdate:       "update",
+	ActionTypeUpdateWithID: "update_id",
 	ActionTypeCreate:       "create",
 	ActionTypeRecreate:     "recreate",
 	ActionTypeDelete:       "delete",
@@ -74,14 +74,14 @@ func (a ActionType) KeepsID() bool {
 	}
 }
 
-// StringShort short version of action string, without part in parens.
+// StringShort short version of action string, without suffix
 func (a ActionType) StringShort() string {
-	items := strings.SplitN(actionName[a], "(", 2)
+	items := strings.SplitN(actionName[a], "_", 2)
 	return items[0]
 }
 
-// StringFull returns the string representation of the action type.
-func (a ActionType) StringFull() string {
+// String returns the string representation of the action type.
+func (a ActionType) String() string {
 	return actionName[a]
 }
 

--- a/bundle/deployplan/action_test.go
+++ b/bundle/deployplan/action_test.go
@@ -1,7 +1,6 @@
 package deployplan
 
 import (
-	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -18,7 +17,7 @@ func TestStringShort(t *testing.T) {
 
 	for _, a := range keys {
 		s := actionName[a]
-		require.Equal(t, a.StringFull(), s)
+		require.Equal(t, a.String(), s)
 		short := a.StringShort()
 		require.NotEmpty(t, short)
 		require.True(t, strings.HasPrefix(s, short), "%q %q", s, short)
@@ -29,14 +28,7 @@ func TestStringShort(t *testing.T) {
 
 	require.Equal(t, map[string][]string{
 		"update": {
-			"update(id_stable)",
-			"update(id_changes)",
+			"update_id",
 		},
 	}, shortMap)
-}
-
-func TestNoStringer(t *testing.T) {
-	// Users should explicitly choose between full and short name, no default String()
-	_, hasStringer := any(ActionTypeNoop).(fmt.Stringer)
-	require.False(t, hasStringer)
 }

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -130,7 +130,7 @@ func (b *DeploymentBundle) CalculatePlanForDeploy(ctx context.Context, client *d
 		}
 
 		plan.Plan[resourceKey] = deployplan.PlanEntry{
-			Action: actionType.StringFull(),
+			Action: actionType.String(),
 		}
 
 		return true
@@ -156,7 +156,7 @@ func (b *DeploymentBundle) CalculatePlanForDeploy(ctx context.Context, client *d
 				continue
 			}
 			b.Graph.AddNode(n)
-			plan.Plan[n] = deployplan.PlanEntry{Action: deployplan.ActionTypeDelete.StringFull()}
+			plan.Plan[n] = deployplan.PlanEntry{Action: deployplan.ActionTypeDelete.String()}
 		}
 	}
 
@@ -184,7 +184,7 @@ func (b *DeploymentBundle) CalculatePlanForDestroy(ctx context.Context, client *
 		for key := range groupData {
 			n := "resources." + group + "." + key
 			b.Graph.AddNode(n)
-			plan.Plan[n] = deployplan.PlanEntry{Action: deployplan.ActionTypeDelete.StringFull()}
+			plan.Plan[n] = deployplan.PlanEntry{Action: deployplan.ActionTypeDelete.String()}
 		}
 	}
 


### PR DESCRIPTION
## Changes
- "update(id_stable)" becomes "update"
- "update(id_changes)" becomes "update_id"
- StringFull() becomes String()

## Why 

This names show up in JSON plan and "update" is most common action, so seeing "update(id_stable)" feels like unnecessary noise.

