### PR TITLE
Rename action "noop" to "skip"

### DIFF
--- a/bundle/deployplan/action.go
+++ b/bundle/deployplan/action.go
@@ -31,7 +31,7 @@ type ActionType int
 // Note, Create/Delete are handled explicitly and never compared.
 const (
 	ActionTypeUnset ActionType = iota
-	ActionTypeNoop
+	ActionTypeSkip
 	ActionTypeResize
 	ActionTypeUpdate
 	ActionTypeUpdateWithID
@@ -41,7 +41,7 @@ const (
 )
 
 var actionName = map[ActionType]string{
-	ActionTypeNoop:         "noop",
+	ActionTypeSkip:         "skip",
 	ActionTypeResize:       "resize",
 	ActionTypeUpdate:       "update",
 	ActionTypeUpdateWithID: "update_id",
@@ -62,7 +62,7 @@ func init() {
 }
 
 func (a ActionType) IsNoop() bool {
-	return a == ActionTypeNoop
+	return a == ActionTypeSkip
 }
 
 func (a ActionType) KeepsID() bool {

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -121,7 +121,7 @@ func (b *DeploymentBundle) CalculatePlanForDeploy(ctx context.Context, client *d
 			}
 		}
 
-		if actionType == deployplan.ActionTypeNoop {
+		if actionType == deployplan.ActionTypeSkip {
 			if hasDelayedResolutions {
 				logdiag.LogError(ctx, fmt.Errorf("%s: internal error, action noop must not have delayed resolutions", errorPrefix))
 				return false

--- a/bundle/direct/dresources/adapter.go
+++ b/bundle/direct/dresources/adapter.go
@@ -449,10 +449,10 @@ func (a *Adapter) DoUpdateWithID(ctx context.Context, oldID string, newState any
 
 // ClassifyByTriggers classifies a set of changes using FieldTriggers.
 // Unspecified changed fields default to ActionTypeUpdate. Final action is the
-// maximum by precedence. No changes yield ActionTypeNoop.
+// maximum by precedence. No changes yield ActionTypeSkip.
 func (a *Adapter) ClassifyByTriggers(changes []structdiff.Change) deployplan.ActionType {
 	if len(changes) == 0 {
-		return deployplan.ActionTypeNoop
+		return deployplan.ActionTypeSkip
 	}
 
 	// Default when there are changes but no explicit trigger is update.

--- a/bundle/direct/plan.go
+++ b/bundle/direct/plan.go
@@ -20,7 +20,7 @@ import (
 func (d *DeploymentUnit) Plan(ctx context.Context, client *databricks.WorkspaceClient, db *dstate.DeploymentState, inputConfig any, localOnly, refresh bool) (deployplan.ActionType, error) {
 	result, err := d.plan(ctx, client, db, inputConfig, localOnly, refresh)
 	if err != nil {
-		return deployplan.ActionTypeNoop, fmt.Errorf("planning: %s: %w", d.ResourceKey, err)
+		return deployplan.ActionTypeSkip, fmt.Errorf("planning: %s: %w", d.ResourceKey, err)
 	}
 	return result, err
 }
@@ -197,7 +197,7 @@ func calcDiff(adapter *dresources.Adapter, savedState, config any) (deployplan.A
 	}
 
 	if len(localDiff) == 0 {
-		return deployplan.ActionTypeNoop, nil
+		return deployplan.ActionTypeSkip, nil
 	}
 
 	result := adapter.ClassifyByTriggers(localDiff)

--- a/cmd/bundle/plan.go
+++ b/cmd/bundle/plan.go
@@ -86,7 +86,7 @@ It is useful for previewing changes before running 'bundle deploy'.`,
 				// A recreate counts as both a delete and a create
 				deleteCount++
 				createCount++
-			case deployplan.ActionTypeNoop, deployplan.ActionTypeUnset:
+			case deployplan.ActionTypeSkip, deployplan.ActionTypeUnset:
 				// Noop
 			}
 		}


### PR DESCRIPTION
All other actions are verbs, so some messages look odd with "noop"

> cannot noop resources.jobs.foo: failed to resolve ...