### PR TITLE
Include skip actions in JSON plan

### DIFF
--- a/acceptance/bundle/resources/jobs/update/output.txt
+++ b/acceptance/bundle/resources/jobs/update/output.txt
@@ -24,7 +24,11 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
 
 >>> [CLI] bundle debug plan
 {
-  "plan": {}
+  "plan": {
+    "resources.jobs.foo": {
+      "action": "skip"
+    }
+  }
 }
 
 >>> print_requests
@@ -91,7 +95,11 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
 
 >>> [CLI] bundle debug plan
 {
-  "plan": {}
+  "plan": {
+    "resources.jobs.foo": {
+      "action": "skip"
+    }
+  }
 }
 
 >>> print_requests

--- a/bundle/direct/apply.go
+++ b/bundle/direct/apply.go
@@ -33,6 +33,10 @@ func (d *DeploymentUnit) Destroy(ctx context.Context, db *dstate.DeploymentState
 }
 
 func (d *DeploymentUnit) Deploy(ctx context.Context, db *dstate.DeploymentState, inputConfig any, actionType deployplan.ActionType) error {
+	if actionType == deployplan.ActionTypeSkip {
+		return nil
+	}
+
 	// Note, newState may be different between plan and deploy due to resolved $resource references
 	newState, err := d.Adapter.PrepareState(inputConfig)
 	if err != nil {

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -121,16 +121,15 @@ func (b *DeploymentBundle) CalculatePlanForDeploy(ctx context.Context, client *d
 			}
 		}
 
+		plan.Plan[resourceKey] = deployplan.PlanEntry{
+			Action: actionType.String(),
+		}
+
 		if actionType == deployplan.ActionTypeSkip {
 			if hasDelayedResolutions {
 				logdiag.LogError(ctx, fmt.Errorf("%s: internal error, action noop must not have delayed resolutions", errorPrefix))
 				return false
 			}
-			return true
-		}
-
-		plan.Plan[resourceKey] = deployplan.PlanEntry{
-			Action: actionType.String(),
 		}
 
 		return true

--- a/cmd/bundle/plan.go
+++ b/cmd/bundle/plan.go
@@ -71,10 +71,9 @@ It is useful for previewing changes before running 'bundle deploy'.`,
 		createCount := 0
 		updateCount := 0
 		deleteCount := 0
-		changed := make(map[string]bool)
+		unchangedCount := 0
 
 		for _, change := range plan.GetActions() {
-			changed[change.ResourceKey] = true
 			switch change.ActionType {
 			case deployplan.ActionTypeCreate:
 				createCount++
@@ -87,18 +86,7 @@ It is useful for previewing changes before running 'bundle deploy'.`,
 				deleteCount++
 				createCount++
 			case deployplan.ActionTypeSkip, deployplan.ActionTypeUnset:
-				// Noop
-			}
-		}
-
-		// Calculate number of all unchanged resources
-		unchanged := 0
-		for _, group := range b.Config.Resources.AllResources() {
-			for rKey := range group.Resources {
-				resourceKey := "resources." + group.Description.PluralName + "." + rKey
-				if _, ok := changed[resourceKey]; !ok {
-					unchanged++
-				}
+				unchangedCount++
 			}
 		}
 
@@ -116,7 +104,7 @@ It is useful for previewing changes before running 'bundle deploy'.`,
 				}
 				fmt.Fprintln(out)
 			}
-			fmt.Fprintf(out, "Plan: %d to add, %d to change, %d to delete, %d unchanged\n", createCount, updateCount, deleteCount, unchanged)
+			fmt.Fprintf(out, "Plan: %d to add, %d to change, %d to delete, %d unchanged\n", createCount, updateCount, deleteCount, unchangedCount)
 		case flags.OutputJSON:
 			buf, err := json.MarshalIndent(plan, "", "  ")
 			if err != nil {

--- a/cmd/bundle/plan.go
+++ b/cmd/bundle/plan.go
@@ -99,6 +99,9 @@ It is useful for previewing changes before running 'bundle deploy'.`,
 			if totalChanges > 0 {
 				// Print all actions in the order they were processed
 				for _, action := range plan.GetActions() {
+					if action.ActionType == deployplan.ActionTypeSkip {
+						continue
+					}
 					key := strings.TrimPrefix(action.ResourceKey, "resources.")
 					fmt.Fprintf(out, "%s %s\n", action.ActionType.StringShort(), key)
 				}

--- a/cmd/bundle/utils/utils.go
+++ b/cmd/bundle/utils/utils.go
@@ -69,8 +69,8 @@ func GetPlan(ctx context.Context, b *bundle.Bundle) (*deployplan.Plan, error) {
 			for rKey := range group.Resources {
 				resourceKey := "resources." + group.Description.PluralName + "." + rKey
 				if _, ok := plan.Plan[resourceKey]; !ok {
-					plan.Plan[resourceKey] = &deployplan.PlanEntry{
-						Action: deployplan.ActionTypeNoop.StringFull(),
+					plan.Plan[resourceKey] = deployplan.PlanEntry{
+						Action: deployplan.ActionTypeSkip.String(),
 					}
 				}
 			}

--- a/cmd/bundle/utils/utils.go
+++ b/cmd/bundle/utils/utils.go
@@ -63,5 +63,19 @@ func GetPlan(ctx context.Context, b *bundle.Bundle) (*deployplan.Plan, error) {
 		return nil, root.ErrAlreadyPrinted
 	}
 
+	// Direct engine includes noop actions, TF does not. This adds no-op actions for consistency:
+	if !b.DirectDeployment {
+		for _, group := range b.Config.Resources.AllResources() {
+			for rKey := range group.Resources {
+				resourceKey := "resources." + group.Description.PluralName + "." + rKey
+				if _, ok := plan.Plan[resourceKey]; !ok {
+					plan.Plan[resourceKey] = &deployplan.PlanEntry{
+						Action: deployplan.ActionTypeNoop.StringFull(),
+					}
+				}
+			}
+		}
+	}
+
 	return plan, nil
 }


### PR DESCRIPTION
## Changes
Include 'skip' nodes in JSON plan.

## Why
We need to process 'skip' resources as well (e.g. to resolve references). Today, we have these nodes in the graph but not in the plan. Once we move to serialized plan https://github.com/databricks/cli/pull/3636 we will build graph from the plan so they must match. This prepares for that (and minimizes that PR).

This also gives more information to users of JSON plan, e.g. they can count unchanged count. 

## Tests
Existing tests.