### PR TITLE
Fix indentation issue in dbt-sql template

### DIFF
--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_profiles/profiles.yml
@@ -4,35 +4,35 @@ my_dbt_sql:
   target: dev # default target
   outputs:
 
-  # Doing local development with the dbt CLI?
-  # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
-  # (See README.md)
+    # Doing local development with the dbt CLI?
+    # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
+    # (See README.md)
 
-  # The default target when deployed with the Databricks CLI
-  # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
-  dev:
-    type: databricks
-    method: http
-    catalog: main
-    schema: "{{ var('dev_schema') }}"
+    # The default target when deployed with the Databricks CLI
+    # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
+    dev:
+      type: databricks
+      method: http
+      catalog: main
+      schema: "{{ var('dev_schema') }}"
 
-    http_path: /sql/2.0/warehouses/f00dcafe
+      http_path: /sql/2.0/warehouses/f00dcafe
 
-    # The workspace host / token are provided by Databricks
-    # see databricks.yml for the workspace host used for 'dev'
-    host: "{{ env_var('DBT_HOST') }}"
-    token: "{{ env_var('DBT_ACCESS_TOKEN') }}"
+      # The workspace host / token are provided by Databricks
+      # see databricks.yml for the workspace host used for 'dev'
+      host: "{{ env_var('DBT_HOST') }}"
+      token: "{{ env_var('DBT_ACCESS_TOKEN') }}"
 
-  # The production target when deployed with the Databricks CLI
-  prod:
-    type: databricks
-    method: http
-    catalog: main
-    schema: default
+    # The production target when deployed with the Databricks CLI
+    prod:
+      type: databricks
+      method: http
+      catalog: main
+      schema: default
 
-    http_path: /sql/2.0/warehouses/f00dcafe
+      http_path: /sql/2.0/warehouses/f00dcafe
 
-    # The workspace host / token are provided by Databricks
-    # see databricks.yml for the workspace host used for 'prod'
-    host: "{{ env_var('DBT_HOST') }}"
-    token: "{{ env_var('DBT_ACCESS_TOKEN') }}"
+      # The workspace host / token are provided by Databricks
+      # see databricks.yml for the workspace host used for 'prod'
+      host: "{{ env_var('DBT_HOST') }}"
+      token: "{{ env_var('DBT_ACCESS_TOKEN') }}"

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_profiles/profiles.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_profiles/profiles.yml.tmpl
@@ -7,39 +7,39 @@
   target: dev # default target
   outputs:
 
-  # Doing local development with the dbt CLI?
-  # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
-  # (See README.md)
+    # Doing local development with the dbt CLI?
+    # Then you should create your own profile in your .dbt/profiles.yml using 'dbt init'
+    # (See README.md)
 
-  # The default target when deployed with the Databricks CLI
-  # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
-  dev:
-    type: databricks
-    method: http
-    catalog: {{$catalog}}
+    # The default target when deployed with the Databricks CLI
+    # N.B. when you use dbt from the command line, it uses the profile from .dbt/profiles.yml
+    dev:
+      type: databricks
+      method: http
+      catalog: {{$catalog}}
 {{- if (regexp "^yes").MatchString .personal_schemas}}
-    schema: "{{"{{"}} var('dev_schema') {{"}}"}}"
+      schema: "{{"{{"}} var('dev_schema') {{"}}"}}"
 {{- else}}
-    schema: "{{.shared_schema}}"
+      schema: "{{.shared_schema}}"
 {{- end}}
 
-    http_path: {{.http_path}}
+      http_path: {{.http_path}}
 
-    # The workspace host / token are provided by Databricks
-    # see databricks.yml for the workspace host used for 'dev'
-    host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
-    token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"
+      # The workspace host / token are provided by Databricks
+      # see databricks.yml for the workspace host used for 'dev'
+      host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
+      token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"
 
-  # The production target when deployed with the Databricks CLI
-  prod:
-    type: databricks
-    method: http
-    catalog: {{$catalog}}
-    schema: {{.shared_schema}}
+    # The production target when deployed with the Databricks CLI
+    prod:
+      type: databricks
+      method: http
+      catalog: {{$catalog}}
+      schema: {{.shared_schema}}
 
-    http_path: {{.http_path}}
+      http_path: {{.http_path}}
 
-    # The workspace host / token are provided by Databricks
-    # see databricks.yml for the workspace host used for 'prod'
-    host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
-    token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"
+      # The workspace host / token are provided by Databricks
+      # see databricks.yml for the workspace host used for 'prod'
+      host: "{{"{{"}} env_var('DBT_HOST') {{"}}"}}"
+      token: "{{"{{"}} env_var('DBT_ACCESS_TOKEN') {{"}}"}}"


### PR DESCRIPTION
## Why

The profiles file was incorrectly indented and made the example job run fail.

The indentation change happened in #3026.

Fixes #3596.

## Tests

Initialized the template and successfully ran the job.