### PR TITLE
Fix bundle representation for experiments

### DIFF
--- a/bundle/config/mutator/initialize_urls_test.go
+++ b/bundle/config/mutator/initialize_urls_test.go
@@ -37,8 +37,8 @@ func TestInitializeURLs(t *testing.T) {
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
 					"experiment1": {
-						BaseResource: resources.BaseResource{ID: "4"},
-						Experiment:   ml.Experiment{Name: "experiment1"},
+						BaseResource:     resources.BaseResource{ID: "4"},
+						CreateExperiment: ml.CreateExperiment{Name: "experiment1"},
 					},
 				},
 				Models: map[string]*resources.MlflowModel{

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -96,8 +96,8 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 					"pipeline1": {CreatePipeline: pipelines.CreatePipeline{Name: "pipeline1", Continuous: true}},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
-					"experiment1": {Experiment: ml.Experiment{Name: "/Users/lennart.kats@databricks.com/experiment1"}},
-					"experiment2": {Experiment: ml.Experiment{Name: "experiment2"}},
+					"experiment1": {CreateExperiment: ml.CreateExperiment{Name: "/Users/lennart.kats@databricks.com/experiment1"}},
+					"experiment2": {CreateExperiment: ml.CreateExperiment{Name: "experiment2"}},
 				},
 				Models: map[string]*resources.MlflowModel{
 					"model1": {CreateModelRequest: ml.CreateModelRequest{Name: "model1"}},

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -232,7 +232,7 @@ func TestProcessTargetModeDevelopment(t *testing.T) {
 	// Experiment 1
 	assert.Equal(t, "/Users/lennart.kats@databricks.com/[dev lennart] experiment1", b.Config.Resources.Experiments["experiment1"].Name)
 	assert.Contains(t, b.Config.Resources.Experiments["experiment1"].Tags, ml.ExperimentTag{Key: "dev", Value: "lennart"})
-	assert.Equal(t, "dev", b.Config.Resources.Experiments["experiment1"].Experiment.Tags[0].Key)
+	assert.Equal(t, "dev", b.Config.Resources.Experiments["experiment1"].CreateExperiment.Tags[0].Key)
 
 	// Experiment 2
 	assert.Equal(t, "[dev lennart] experiment2", b.Config.Resources.Experiments["experiment2"].Name)

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -24,7 +24,7 @@ type MlflowExperimentPermission struct {
 
 type MlflowExperiment struct {
 	BaseResource
-	ml.Experiment
+	ml.CreateExperiment
 
 	Permissions []MlflowExperimentPermission `json:"permissions,omitempty"`
 }

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -131,7 +131,7 @@ func TestResourcesBindSupport(t *testing.T) {
 		},
 		Experiments: map[string]*resources.MlflowExperiment{
 			"my_experiment": {
-				Experiment: ml.Experiment{},
+				CreateExperiment: ml.CreateExperiment{},
 			},
 		},
 		RegisteredModels: map[string]*resources.RegisteredModel{

--- a/bundle/deploy/terraform/convert_test.go
+++ b/bundle/deploy/terraform/convert_test.go
@@ -360,7 +360,7 @@ func TestBundleToTerraformModelPermissions(t *testing.T) {
 
 func TestBundleToTerraformExperiment(t *testing.T) {
 	src := resources.MlflowExperiment{
-		Experiment: ml.Experiment{
+		CreateExperiment: ml.CreateExperiment{
 			Name: "name",
 		},
 	}
@@ -383,7 +383,7 @@ func TestBundleToTerraformExperiment(t *testing.T) {
 
 func TestBundleToTerraformExperimentPermissions(t *testing.T) {
 	src := resources.MlflowExperiment{
-		Experiment: ml.Experiment{
+		CreateExperiment: ml.CreateExperiment{
 			Name: "name",
 		},
 		Permissions: []resources.MlflowExperimentPermission{

--- a/bundle/deploy/terraform/tfdyn/convert_experiment_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_experiment_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestConvertExperiment(t *testing.T) {
 	src := resources.MlflowExperiment{
-		Experiment: ml.Experiment{
+		CreateExperiment: ml.CreateExperiment{
 			Name: "name",
 		},
 		Permissions: []resources.MlflowExperimentPermission{

--- a/bundle/internal/schema/testdata/pass/ml.yml
+++ b/bundle/internal/schema/testdata/pass/ml.yml
@@ -35,8 +35,8 @@ resources:
   experiments:
     myexperiment:
       artifact_location: /dbfs/myexperiment
-      last_update_time: ${var.complexvar.key2}
-      lifecycle_stage: ${var.simplevar}
+      name: ${var.simplevar}
+      tags: ${var.complexvar.key1}
       permissions:
         - service_principal_name: myserviceprincipal
           level: CAN_MANAGE

--- a/bundle/internal/validation/generated/required_fields.go
+++ b/bundle/internal/validation/generated/required_fields.go
@@ -45,6 +45,7 @@ var RequiredFields = map[string][]string{
 	"resources.database_instances.*":                {"name"},
 	"resources.database_instances.*.permissions[*]": {"level"},
 
+	"resources.experiments.*":                {"name"},
 	"resources.experiments.*.permissions[*]": {"level"},
 
 	"resources.jobs.*.deployment":                                                                                  {"kind"},

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -46,8 +46,8 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 					"model_2": {},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
-					"experiment_1": {Experiment: ml.Experiment{}},
-					"experiment_2": {Experiment: ml.Experiment{}},
+					"experiment_1": {CreateExperiment: ml.CreateExperiment{}},
+					"experiment_2": {CreateExperiment: ml.CreateExperiment{}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint_1": {CreateServingEndpoint: serving.CreateServingEndpoint{}},
@@ -106,8 +106,8 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 					"model_2": {},
 				},
 				Experiments: map[string]*resources.MlflowExperiment{
-					"experiment_1": {Experiment: ml.Experiment{}},
-					"experiment_2": {Experiment: ml.Experiment{}},
+					"experiment_1": {CreateExperiment: ml.CreateExperiment{}},
+					"experiment_2": {CreateExperiment: ml.CreateExperiment{}},
 				},
 				ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{
 					"endpoint_1": {CreateServingEndpoint: serving.CreateServingEndpoint{}},

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -961,25 +961,9 @@
                         "description": "Location where artifacts for the experiment are stored.",
                         "$ref": "#/$defs/string"
                       },
-                      "creation_time": {
-                        "description": "Creation time",
-                        "$ref": "#/$defs/int64"
-                      },
-                      "experiment_id": {
-                        "description": "Unique identifier for the experiment.",
-                        "$ref": "#/$defs/string"
-                      },
-                      "last_update_time": {
-                        "description": "Last update time",
-                        "$ref": "#/$defs/int64"
-                      },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
-                      },
-                      "lifecycle_stage": {
-                        "description": "Current life cycle stage of the experiment: \"active\" or \"deleted\".\nDeleted experiments are not returned by APIs.",
-                        "$ref": "#/$defs/string"
                       },
                       "name": {
                         "description": "Human readable name that identifies the experiment.",
@@ -994,6 +978,9 @@
                       }
                     },
                     "additionalProperties": false,
+                    "required": [
+                      "name"
+                    ],
                     "markdownDescription": "The experiment resource allows you to define [MLflow experiments](https://docs.databricks.com/api/workspace/experiments/createexperiment) in a bundle. For information about MLflow experiments, see [link](https://docs.databricks.com/mlflow/experiments.html)."
                   },
                   {

--- a/bundle/statemgmt/state_load_test.go
+++ b/bundle/statemgmt/state_load_test.go
@@ -162,7 +162,7 @@ func TestStateToBundleEmptyRemoteResources(t *testing.T) {
 			},
 			Experiments: map[string]*resources.MlflowExperiment{
 				"test_mlflow_experiment": {
-					Experiment: ml.Experiment{
+					CreateExperiment: ml.CreateExperiment{
 						Name: "test_mlflow_experiment",
 					},
 				},
@@ -369,12 +369,12 @@ func TestStateToBundleModifiedResources(t *testing.T) {
 			},
 			Experiments: map[string]*resources.MlflowExperiment{
 				"test_mlflow_experiment": {
-					Experiment: ml.Experiment{
+					CreateExperiment: ml.CreateExperiment{
 						Name: "test_mlflow_experiment",
 					},
 				},
 				"test_mlflow_experiment_new": {
-					Experiment: ml.Experiment{
+					CreateExperiment: ml.CreateExperiment{
 						Name: "test_mlflow_experiment_new",
 					},
 				},


### PR DESCRIPTION
## Changes
This PR changes the experiments resource definition to use `ml.CreateExperiment` instead of using `ml.Experiment`.

## Why
This removes output only fields from the resource schema. Those fields were never settable in the first place.

for reference, here are the structs:
```
type CreateExperiment struct {
	// Location where all artifacts for the experiment are stored. If not
	// provided, the remote server will select an appropriate default.
	ArtifactLocation string `json:"artifact_location,omitempty"`
	// Experiment name.
	Name string `json:"name"`
	// A collection of tags to set on the experiment. Maximum tag size and
	// number of tags per request depends on the storage backend. All storage
	// backends are guaranteed to support tag keys up to 250 bytes in size and
	// tag values up to 5000 bytes in size. All storage backends are also
	// guaranteed to support up to 20 tags per request.
	Tags []ExperimentTag `json:"tags,omitempty"`

	ForceSendFields []string `json:"-" url:"-"`
}
```

```
// An experiment and its metadata.
type Experiment struct {
	// Location where artifacts for the experiment are stored.
	ArtifactLocation string `json:"artifact_location,omitempty"`
	// Creation time
	CreationTime int64 `json:"creation_time,omitempty"`
	// Unique identifier for the experiment.
	ExperimentId string `json:"experiment_id,omitempty"`
	// Last update time
	LastUpdateTime int64 `json:"last_update_time,omitempty"`
	// Current life cycle stage of the experiment: "active" or "deleted".
	// Deleted experiments are not returned by APIs.
	LifecycleStage string `json:"lifecycle_stage,omitempty"`
	// Human readable name that identifies the experiment.
	Name string `json:"name,omitempty"`
	// Tags: Additional metadata key-value pairs.
	Tags []ExperimentTag `json:"tags,omitempty"`

	ForceSendFields []string `json:"-" url:"-"`
}

```


## Tests
New integration tests are being added in https://github.com/databricks/cli/pull/3669/files provide coverage. Just looking at the structs though is enough to confirm that no input fields are being lost. 
