### PR TITLE
direct: Added support for ClassifyChanges

### DIFF
--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -169,7 +169,7 @@ func (b *DeploymentBundle) CalculatePlanForDeploy(ctx context.Context, client *d
 				return false
 			}
 
-			remoteAction, remoteChangeMap = interpretOldStateVsRemoteState(adapter, remoteDiff)
+			remoteAction, remoteChangeMap = interpretOldStateVsRemoteState(ctx, adapter, remoteDiff, remoteState)
 		}
 
 		entry.Action = max(localAction, remoteAction).String()
@@ -237,7 +237,7 @@ func convertChangesToTriggersMap(adapter *dresources.Adapter, diff []structdiff.
 	return action, m
 }
 
-func interpretOldStateVsRemoteState(adapter *dresources.Adapter, diff []structdiff.Change) (deployplan.ActionType, map[string]deployplan.Trigger) {
+func interpretOldStateVsRemoteState(ctx context.Context, adapter *dresources.Adapter, diff []structdiff.Change, remoteState any) (deployplan.ActionType, map[string]deployplan.Trigger) {
 	action := deployplan.ActionTypeSkip
 	m := make(map[string]deployplan.Trigger)
 
@@ -252,7 +252,17 @@ func interpretOldStateVsRemoteState(adapter *dresources.Adapter, diff []structdi
 			}
 			continue
 		}
-		fieldAction := adapter.ClassifyByTriggers(ch)
+		var fieldAction deployplan.ActionType
+		if adapter.HasClassifyChange() {
+			var err error
+			fieldAction, _, err = adapter.ClassifyChange(ch, remoteState)
+			if err != nil {
+				logdiag.LogError(ctx, fmt.Errorf("internal error: failed to classify changes: %w", err))
+				continue
+			}
+		} else {
+			fieldAction = adapter.ClassifyByTriggers(ch)
+		}
 		if fieldAction > action {
 			action = fieldAction
 		}


### PR DESCRIPTION
## Changes
Added support for ClassifyChanges

## Why
Needed for 

Some resources might have different types of changes based on their remote state. For example, the cluster's resize action becomes an update if the cluster is stopped. In order to do such classification, we need access to the remote state, so we are introducing a new ClassifyChange method.

Either ClassifyChange or ClassifyByTriggers is called

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
