### PR TITLE
Document prerequisites for running tests on Windows

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -91,12 +91,19 @@ If you're not an administrator user, enable this by following these steps:
 
 ### Enable long path support (up to ~32,767 characters)
 
-Modern Windows (10 Anniversary Update and newer) supports longer paths if you enable it.
-
-Some acceptance tests fail if this is not enabled because their paths exceed the
-default maximum total length of 260 characters.
+Some acceptance tests fail if this is not enabled because their paths
+exceed the default maximum total length of 260 characters.
 
 * Run "Edit group policy".
 * Go to Local Computer Policy → Computer Configuration → Administrative Templates → System → Filesystem → Enable Win32 long paths.
 * Enable the setting.
 * Reboot.
+
+
+
+
+⚠️ Last resort: Group Policy full disable
+
+If you’re on Windows Pro/Enterprise, and you’ve disabled Tamper Protection, you can permanently disable Defender via Group Policy Editor (gpedit.msc) →
+Computer Configuration → Administrative Templates → Windows Components → Microsoft Defender Antivirus → Turn off Microsoft Defender Antivirus → Enabled.
+Reboot afterwards.

--- a/acceptance/bundle/artifacts/whl_dynamic/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_dynamic/databricks.yml
@@ -2,7 +2,7 @@ artifacts:
   my_test_code:
     type: whl
     path: "./my_test_code"
-    # using 'python' there because 'python3' does not exist in virtualenv on windows
+    # Use 'python' because 'python3' does not exist in Windows virtualenvs.
     build: python setup.py bdist_wheel
     dynamic_version: true
   my_prebuilt_whl:

--- a/acceptance/bundle/artifacts/whl_explicit/databricks.yml
+++ b/acceptance/bundle/artifacts/whl_explicit/databricks.yml
@@ -2,7 +2,7 @@ artifacts:
   my_test_code:
     type: whl
     path: "./my_test_code"
-    # using 'python' there because 'python3' does not exist in virtualenv on windows
+    # Use 'python' because 'python3' does not exist in Windows virtualenvs.
     build: python setup.py bdist_wheel
 
 resources:

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/databricks.yml
@@ -23,7 +23,8 @@ targets:
       test:
         type: whl
         path: ./my_test_code
+        # Use 'python' because 'python3' does not exist in Windows virtualenvs.
+        build: python setup.py bdist_wheel
         dynamic_version: true
-        build: "python3 setup.py bdist_wheel"
         files:
           - source: "./my_test_code/dist/*.whl"

--- a/acceptance/bundle/templates/default-python/integration_classic/script
+++ b/acceptance/bundle/templates/default-python/integration_classic/script
@@ -3,11 +3,6 @@ venv_activate
 trace python -c 'import sys; print("%s.%s" % sys.version_info[:2])'
 uv pip install -q setuptools
 
-# Note(@pietern): without installing hatchling directly,
-# this test fails with Python 3.13 on Windows.
-# I cannot reproduce with `-keeptmp` and then manually running `uv build --wheel`...
-uv pip install -q hatchling
-
 envsubst < input.json.tmpl > input.json
 trace $CLI bundle init default-python --config-file ./input.json --output-dir .
 rm input.json

--- a/acceptance/bundle/templates/default-python/integration_classic/script
+++ b/acceptance/bundle/templates/default-python/integration_classic/script
@@ -3,6 +3,11 @@ venv_activate
 trace python -c 'import sys; print("%s.%s" % sys.version_info[:2])'
 uv pip install -q setuptools
 
+# Note(@pietern): without installing hatchling directly,
+# this test fails with Python 3.13 on Windows.
+# I cannot reproduce with `-keeptmp` and then manually running `uv build --wheel`...
+uv pip install -q hatchling
+
 envsubst < input.json.tmpl > input.json
 trace $CLI bundle init default-python --config-file ./input.json --output-dir .
 rm input.json


### PR DESCRIPTION
## Changes

Document steps to make the acceptance tests pass on a fresh Windows VM.

## Why

The test runners use a different edition from the one you can install with Parallels.

Reproducing Windows-specific issues is easier interactively on a VM.