### PR TITLE
Fix proxy server for CurrentWorkspaceId method

### DIFF
--- a/libs/testproxy/server.go
+++ b/libs/testproxy/server.go
@@ -157,17 +157,11 @@ func (s *ProxyServer) proxyToCloud(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	formattedHeaders := http.Header{}
-	for k, v := range responseHeaders {
-		formattedHeaders[k] = []string{*v}
-	}
-
 	// Successful response
 	if encodedResponse == nil {
 		encodedResponse = &testserver.EncodedResponse{
 			StatusCode: 200,
 			Body:       respBody.Bytes(),
-			Headers:    formattedHeaders,
 		}
 	}
 


### PR DESCRIPTION
## Changes
This PR modifies the proxy server to use the new API client from the Go SDK and then pass through the `X-Databricks-Org-Id`

## Why
To make the `w.CurrentWorkspaceId()` SDK call work, which relies on this header.

## Tests
Existing tests pass. `bundle summary` which failed before with `RecordRequests = true` passes now.