### PR TITLE
Don't run coverage build on Windows runners

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -80,14 +80,14 @@ jobs:
         # We run tests without coverage on PR because we don't make use of coverage information
         # and would like to run the tests as fast as possible. We run it on schedule as well, because that is what
         # populates the cache and cache may include test results.
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || runner.os == 'Windows' }}
         env:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}
         run: make test
 
       - name: Run tests with coverage
         # Still run 'make cover' on push to main and merge checks to make sure it does not get broken.
-        if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' }}
+        if: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' && runner.os != 'Windows' }}
         env:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}
         run: make cover


### PR DESCRIPTION
## Why

The PR to upgrade to Go v1.25.1 (#3575) cannot be merged because it reliably fails the coverage step on Windows from the merge queue. Cleanup of `TestAccept` fails to remove a temporary directory with the following error message:
```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestAccept4228456929\001\AppData\Local\Microsoft\Windows\INetCache\Content.IE5: is a directory
```

I haven't been able to reproduce this, nor figure out how this directory is created. I expect this issue can be hidden by adding a custom temporary directory routine and making it log, not error, during cleanup.