### PR TITLE
Remove check for interactive mode in labs installer

### DIFF
--- a/cmd/labs/project/installer.go
+++ b/cmd/labs/project/installer.go
@@ -168,10 +168,6 @@ func (i *installer) recordVersion(ctx context.Context) error {
 }
 
 func (i *installer) login(ctx context.Context) (*databricks.WorkspaceClient, error) {
-	if !cmdio.IsPromptSupported(ctx) {
-		log.Debugf(ctx, "Skipping workspace profile prompts in non-interactive mode")
-		return nil, nil
-	}
 	cfg, err := i.metaEntrypoint(ctx).validLogin(i.cmd)
 	if errors.Is(err, ErrNoLoginConfig) {
 		cfg, err = i.Installer.envAwareConfig(ctx)


### PR DESCRIPTION
## Changes

If this condition evaluates to true, it returns `(nil, nil)` and leads to a panic further along in the code. The check for an interactive terminal is done earlier than necessary and can be removed altogether. The `askWorkspaceProfile` function also checks for an interactive terminal and returns an error if there isn't one.

We mark Git Bash as a terminal where prompting is not supported (see #1069).

Fixes #3597.

## Tests

Manually confirmed the installer no longer panics in Git Bash on Windows.