### PR TITLE
Enable gocritic offBy1 and fix import warning slicing (codex)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
       disable-all: true
       enabled-checks:
         - ruleguard
+        - offBy1
       settings:
         ruleguard:
           failOn: all

--- a/bundle/deploy/terraform/import.go
+++ b/bundle/deploy/terraform/import.go
@@ -70,10 +70,12 @@ func (m *importResource) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	defer os.RemoveAll(tmpDir)
 
 	if changed && !m.opts.AutoApprove {
-		output := buf.String()
-		// Remove output starting from Warning until end of output
-		output = output[:strings.Index(output, "Warning:")]
-		cmdio.LogString(ctx, output)
+                output := buf.String()
+                // Remove output starting from Warning until end of output, if present.
+                if idx := strings.Index(output, "Warning:"); idx != -1 {
+                        output = output[:idx]
+                }
+                cmdio.LogString(ctx, output)
 
 		if !cmdio.IsPromptSupported(ctx) {
 			return diag.Errorf("This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed.")

--- a/bundle/deploy/terraform/import.go
+++ b/bundle/deploy/terraform/import.go
@@ -70,12 +70,12 @@ func (m *importResource) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	defer os.RemoveAll(tmpDir)
 
 	if changed && !m.opts.AutoApprove {
-                output := buf.String()
-                // Remove output starting from Warning until end of output, if present.
-                if idx := strings.Index(output, "Warning:"); idx != -1 {
-                        output = output[:idx]
-                }
-                cmdio.LogString(ctx, output)
+		output := buf.String()
+		// Remove output starting from Warning until end of output, if present.
+		if idx := strings.Index(output, "Warning:"); idx != -1 {
+			output = output[:idx]
+		}
+		cmdio.LogString(ctx, output)
 
 		if !cmdio.IsPromptSupported(ctx) {
 			return diag.Errorf("This bind operation requires user confirmation, but the current console does not support prompting. Please specify --auto-approve if you would like to skip prompts and proceed.")


### PR DESCRIPTION
## Changes
- enable the gocritic offBy1 check in golangci-lint so we catch missing Index() bounds handling
- guard the Terraform import warning truncation against missing "Warning:" blocks to avoid slice panics

------
https://chatgpt.com/s/cd_68df8308cdf081918babe8e111fb5dce