### PR TITLE
Remove empty permissions from json output

### DIFF
--- a/acceptance/bundle/bundle_tag/id/output.txt
+++ b/acceptance/bundle/bundle_tag/id/output.txt
@@ -21,7 +21,6 @@ Validation OK!
       "id": "123",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       }

--- a/acceptance/bundle/bundle_tag/url/output.txt
+++ b/acceptance/bundle/bundle_tag/url/output.txt
@@ -20,7 +20,6 @@ Validation OK!
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       },

--- a/acceptance/bundle/bundle_tag/url_ref/output.txt
+++ b/acceptance/bundle/bundle_tag/url_ref/output.txt
@@ -20,7 +20,6 @@ Validation OK!
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       },
@@ -35,7 +34,6 @@ Validation OK!
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       },

--- a/acceptance/bundle/deploy/dashboard/detect-change/output.txt
+++ b/acceptance/bundle/deploy/dashboard/detect-change/output.txt
@@ -7,7 +7,6 @@
   "file_path": "dashboard.lvdash.json",
   "modified_status": "created",
   "parent_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources",
-  "permissions": [],
   "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
 }
 
@@ -34,7 +33,6 @@ Deployment complete!
   "file_path": "dashboard.lvdash.json",
   "id": "[ALPHANUMID]",
   "parent_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources",
-  "permissions": [],
   "url": "[DATABRICKS_URL]/dashboardsv3/[ALPHANUMID]/published",
   "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
 }

--- a/acceptance/bundle/deploy/sql_warehouse/output.txt
+++ b/acceptance/bundle/deploy/sql_warehouse/output.txt
@@ -18,7 +18,6 @@ Validation OK!
     "max_num_clusters": 1,
     "min_num_clusters": 1,
     "name": "sql_warehouse_name",
-    "permissions": [],
     "spot_instance_policy": "COST_OPTIMIZED"
   }
 }

--- a/acceptance/bundle/includes/yml_outside_root/output.txt
+++ b/acceptance/bundle/includes/yml_outside_root/output.txt
@@ -18,7 +18,6 @@ Validation OK!
   "format": "MULTI_TASK",
   "max_concurrent_runs": 1,
   "name": "include_outside_root",
-  "permissions": [],
   "queue": {
     "enabled": true
   },

--- a/acceptance/bundle/override/job_cluster/output.txt
+++ b/acceptance/bundle/override/job_cluster/output.txt
@@ -20,7 +20,6 @@
     ],
     "max_concurrent_runs": 1,
     "name": "job",
-    "permissions": [],
     "queue": {
       "enabled": true
     }
@@ -48,7 +47,6 @@
     ],
     "max_concurrent_runs": 1,
     "name": "job",
-    "permissions": [],
     "queue": {
       "enabled": true
     }

--- a/acceptance/bundle/override/job_cluster_var/output.txt
+++ b/acceptance/bundle/override/job_cluster_var/output.txt
@@ -20,7 +20,6 @@
     ],
     "max_concurrent_runs": 1,
     "name": "job",
-    "permissions": [],
     "queue": {
       "enabled": true
     }
@@ -57,7 +56,6 @@ Validation OK!
     ],
     "max_concurrent_runs": 1,
     "name": "job",
-    "permissions": [],
     "queue": {
       "enabled": true
     }

--- a/acceptance/bundle/override/job_tasks/output.txt
+++ b/acceptance/bundle/override/job_tasks/output.txt
@@ -1,7 +1,6 @@
 {
   "max_concurrent_runs": 1,
   "name": "job",
-  "permissions": [],
   "queue": {
     "enabled": true
   },
@@ -37,7 +36,6 @@ Exit code: 1
 {
   "max_concurrent_runs": 1,
   "name": "job",
-  "permissions": [],
   "queue": {
     "enabled": true
   },

--- a/acceptance/bundle/override/pipeline_cluster/output.txt
+++ b/acceptance/bundle/override/pipeline_cluster/output.txt
@@ -18,8 +18,7 @@
       "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/development/state/metadata.json"
     },
     "edition": "ADVANCED",
-    "name": "job",
-    "permissions": []
+    "name": "job"
   }
 }
 
@@ -42,7 +41,6 @@
       "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/staging/state/metadata.json"
     },
     "edition": "ADVANCED",
-    "name": "job",
-    "permissions": []
+    "name": "job"
   }
 }

--- a/acceptance/bundle/paths/git_source_jobs/output.txt
+++ b/acceptance/bundle/paths/git_source_jobs/output.txt
@@ -15,7 +15,6 @@
         },
         "max_concurrent_runs": 1,
         "name": "my_job",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/paths/invalid_pipeline_globs/output.txt
+++ b/acceptance/bundle/paths/invalid_pipeline_globs/output.txt
@@ -16,8 +16,7 @@ Exit code: 1
               "path": "non-existent/*.ipynb"
             }
           }
-        ],
-        "permissions": []
+        ]
       }
     }
   }

--- a/acceptance/bundle/paths/outside_root_no_sync/output.txt
+++ b/acceptance/bundle/paths/outside_root_no_sync/output.txt
@@ -8,7 +8,6 @@ Error: path [TEST_TMP_DIR]/src/notebook.py is not contained in sync root path
       "my_job": {
         "max_concurrent_runs": 1,
         "name": "include_outside_root",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/paths/pipeline_expected_file_got_notebook/output.txt
+++ b/acceptance/bundle/paths/pipeline_expected_file_got_notebook/output.txt
@@ -16,8 +16,7 @@ Exit code: 1
               "path": "notebooks/nyc_taxi_loader.py"
             }
           }
-        ],
-        "permissions": []
+        ]
       }
     }
   }

--- a/acceptance/bundle/paths/pipeline_globs/output.txt
+++ b/acceptance/bundle/paths/pipeline_globs/output.txt
@@ -54,8 +54,7 @@
               "path": "s3://notebooks/*.ipynb"
             }
           }
-        ],
-        "permissions": []
+        ]
       }
     }
   }

--- a/acceptance/bundle/paths/relative_path_outside_root/output.txt
+++ b/acceptance/bundle/paths/relative_path_outside_root/output.txt
@@ -12,7 +12,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "include_outside_root",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/python/mutator-ordering/output.txt
+++ b/acceptance/bundle/python/mutator-ordering/output.txt
@@ -20,7 +20,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "Untitled",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/python/pipelines-support/output.txt
+++ b/acceptance/bundle/python/pipelines-support/output.txt
@@ -20,8 +20,7 @@
           "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/my_project/default/state/metadata.json"
         },
         "edition": "ADVANCED",
-        "name": "My Pipeline 1 (updated)",
-        "permissions": []
+        "name": "My Pipeline 1 (updated)"
       },
       "my_pipeline_2": {
         "channel": "CURRENT",
@@ -30,8 +29,7 @@
           "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/my_project/default/state/metadata.json"
         },
         "edition": "ADVANCED",
-        "name": "My Pipeline 2 (updated)",
-        "permissions": []
+        "name": "My Pipeline 2 (updated)"
       }
     }
   }

--- a/acceptance/bundle/python/resolve-variable/output.txt
+++ b/acceptance/bundle/python/resolve-variable/output.txt
@@ -19,7 +19,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "abc",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/python/resource-loading/output.txt
+++ b/acceptance/bundle/python/resource-loading/output.txt
@@ -20,7 +20,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "Job 1",
-        "permissions": [],
         "queue": {
           "enabled": true
         }
@@ -34,7 +33,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "Job 2",
-        "permissions": [],
         "queue": {
           "enabled": true
         }
@@ -48,7 +46,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "Job 3",
-        "permissions": [],
         "queue": {
           "enabled": true
         }

--- a/acceptance/bundle/python/unicode-support/output.txt
+++ b/acceptance/bundle/python/unicode-support/output.txt
@@ -21,7 +21,6 @@ Warning: This is a warning message with unicode characters: 🔥🔥🔥
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "🔥🔥🔥",
-        "permissions": [],
         "queue": {
           "enabled": true
         }
@@ -35,7 +34,6 @@ Warning: This is a warning message with unicode characters: 🔥🔥🔥
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "🔥🔥🔥",
-        "permissions": [],
         "queue": {
           "enabled": true
         }

--- a/acceptance/bundle/resource_deps/missing_map_key/output.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key/output.txt
@@ -11,7 +11,6 @@
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "test ${resources.jobs.test.tasks[0].new_cluster.custom_tags.missing_tag}",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -25,7 +24,6 @@
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "test",
-      "permissions": [],
       "queue": {
         "enabled": true
       },

--- a/acceptance/bundle/resource_deps/missing_map_key_tffix/output.txt
+++ b/acceptance/bundle/resource_deps/missing_map_key_tffix/output.txt
@@ -11,7 +11,6 @@
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "test ${resources.jobs.test.task[0].new_cluster[0].custom_tags.missing_tag}",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -25,7 +24,6 @@
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "test",
-      "permissions": [],
       "queue": {
         "enabled": true
       },

--- a/acceptance/bundle/resource_deps/missing_string_field/output.txt
+++ b/acceptance/bundle/resource_deps/missing_string_field/output.txt
@@ -10,8 +10,7 @@
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/metadata.json"
       },
       "edition": "ADVANCED",
-      "name": "pbar",
-      "permissions": []
+      "name": "pbar"
     },
     "foo": {
       "channel": "CURRENT",
@@ -20,8 +19,7 @@
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/metadata.json"
       },
       "edition": "ADVANCED",
-      "name": "pfoo",
-      "permissions": []
+      "name": "pfoo"
     }
   }
 }

--- a/acceptance/bundle/resource_deps/resources_var/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var/output.txt
@@ -11,7 +11,6 @@
       "development": true,
       "edition": "ADVANCED",
       "name": "[dev [USERNAME]] pipeline for ${resources.volumes.foo.catalog_name}.${resources.volumes.foo.schema_name}.${resources.volumes.foo.name}",
-      "permissions": [],
       "tags": {
         "dev": "[USERNAME]"
       }

--- a/acceptance/bundle/resource_deps/resources_var_presets/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var_presets/output.txt
@@ -11,7 +11,6 @@
       "development": true,
       "edition": "ADVANCED",
       "name": "[dev [USERNAME]] pipeline for ${resources.schemas.foo.catalog_name}.${resources.schemas.foo.name}",
-      "permissions": [],
       "tags": {
         "dev": "[USERNAME]"
       }

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/output.txt
@@ -11,7 +11,6 @@
       "development": true,
       "edition": "ADVANCED",
       "name": "[dev [USERNAME]] pipeline for ${resources.volumes.foo.catalog_name}.${resources.volumes.foo.schema_name}.${resources.volumes.foo.name}",
-      "permissions": [],
       "tags": {
         "dev": "[USERNAME]"
       }

--- a/acceptance/bundle/run_as/allowed/regular_user/output.txt
+++ b/acceptance/bundle/run_as/allowed/regular_user/output.txt
@@ -34,16 +34,14 @@ Warning: required field "schema_name" is not set
 >>> jq .resources.experiments
 {
   "experiment_one": {
-    "name": "experiment_one",
-    "permissions": []
+    "name": "experiment_one"
   }
 }
 
 >>> jq .resources.models
 {
   "model_one": {
-    "name": "skynet",
-    "permissions": []
+    "name": "skynet"
   }
 }
 
@@ -83,7 +81,6 @@ Warning: required field "schema_name" is not set
 {
   "experiment_one": {
     "name": "[dev [USERNAME]] experiment_one",
-    "permissions": [],
     "tags": [
       {
         "key": "dev",
@@ -97,7 +94,6 @@ Warning: required field "schema_name" is not set
 {
   "model_one": {
     "name": "[dev [USERNAME]] skynet",
-    "permissions": [],
     "tags": [
       {
         "key": "dev",

--- a/acceptance/bundle/run_as/allowed/service_principal/output.txt
+++ b/acceptance/bundle/run_as/allowed/service_principal/output.txt
@@ -34,16 +34,14 @@ Warning: required field "schema_name" is not set
 >>> jq .resources.experiments
 {
   "experiment_one": {
-    "name": "experiment_one",
-    "permissions": []
+    "name": "experiment_one"
   }
 }
 
 >>> jq .resources.models
 {
   "model_one": {
-    "name": "skynet",
-    "permissions": []
+    "name": "skynet"
   }
 }
 
@@ -83,7 +81,6 @@ Warning: required field "schema_name" is not set
 {
   "experiment_one": {
     "name": "[dev [USERNAME]] experiment_one",
-    "permissions": [],
     "tags": [
       {
         "key": "dev",
@@ -97,7 +94,6 @@ Warning: required field "schema_name" is not set
 {
   "model_one": {
     "name": "[dev [USERNAME]] skynet",
-    "permissions": [],
     "tags": [
       {
         "key": "dev",

--- a/acceptance/bundle/run_as/pipelines_legacy/output.txt
+++ b/acceptance/bundle/run_as/pipelines_legacy/output.txt
@@ -51,15 +51,13 @@ Warning: required field "schema_name" is not set
 >>> jq .resources.experiments
 {
   "experiment_one": {
-    "name": "experiment_one",
-    "permissions": []
+    "name": "experiment_one"
   }
 }
 
 >>> jq .resources.models
 {
   "model_one": {
-    "name": "skynet",
-    "permissions": []
+    "name": "skynet"
   }
 }

--- a/acceptance/bundle/summary/modified_status/output.txt
+++ b/acceptance/bundle/summary/modified_status/output.txt
@@ -22,8 +22,7 @@ Warning: unknown field: alerts
         }
       ],
       "modified_status": "created",
-      "name": "test-pipeline",
-      "permissions": []
+      "name": "test-pipeline"
     }
   },
   "schemas": {
@@ -43,7 +42,6 @@ Warning: unknown field: alerts
       "max_num_clusters": 1,
       "modified_status": "created",
       "name": "test-sql-warehouse",
-      "permissions": [],
       "spot_instance_policy": "COST_OPTIMIZED"
     }
   }
@@ -83,7 +81,6 @@ Warning: unknown field: alerts
         }
       ],
       "name": "test-pipeline",
-      "permissions": [],
       "url": "[DATABRICKS_URL]/pipelines/[UUID]?o=[NUMID]"
     }
   },
@@ -105,7 +102,6 @@ Warning: unknown field: alerts
       "id": "[UUID]",
       "max_num_clusters": 1,
       "name": "test-sql-warehouse",
-      "permissions": [],
       "spot_instance_policy": "COST_OPTIMIZED",
       "url": "[DATABRICKS_URL]/sql/warehouses/[UUID]?o=[NUMID]"
     }

--- a/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
@@ -67,7 +67,6 @@
         ],
         "max_concurrent_runs": 4,
         "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_job",
-        "permissions": [],
         "queue": {
           "enabled": true
         },
@@ -141,7 +140,6 @@
           }
         ],
         "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_pipeline",
-        "permissions": [],
         "schema": "project_name_[UNIQUE_NAME]_dev",
         "tags": {
           "dev": "[USERNAME]"

--- a/acceptance/bundle/templates/default-python/integration_classic/output.txt
+++ b/acceptance/bundle/templates/default-python/integration_classic/output.txt
@@ -60,7 +60,7 @@ Resources:
 +        "id": "[NUMID]",
          "job_clusters": [
            {
-@@ -119,5 +120,6 @@
+@@ -118,5 +119,6 @@
              "unit": "DAYS"
            }
 -        }
@@ -68,13 +68,13 @@ Resources:
 +        "url": "[DATABRICKS_URL]/jobs/[NUMID]"
        }
      },
-@@ -134,4 +136,5 @@
+@@ -133,4 +135,5 @@
          "development": true,
          "edition": "ADVANCED",
 +        "id": "[UUID]",
          "libraries": [
            {
-@@ -146,5 +149,6 @@
+@@ -144,5 +147,6 @@
          "tags": {
            "dev": "[USERNAME]"
 -        }
@@ -166,14 +166,14 @@ Validation OK!
 +          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/state/metadata.json"
          },
          "edit_mode": "UI_LOCKED",
-@@ -66,12 +56,9 @@
+@@ -66,11 +56,9 @@
            }
          ],
 -        "max_concurrent_runs": 4,
 -        "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_job",
 +        "max_concurrent_runs": 1,
 +        "name": "project_name_[UNIQUE_NAME]_job",
-         "permissions": [],
++        "permissions": [],
          "queue": {
            "enabled": true
 -        },
@@ -181,21 +181,21 @@ Validation OK!
 -          "dev": "[USERNAME]"
          },
          "tasks": [
-@@ -97,5 +84,5 @@
+@@ -96,5 +84,5 @@
              "job_cluster_key": "job_cluster",
              "notebook_task": {
 -              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook"
 +              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook"
              },
              "task_key": "notebook_task"
-@@ -114,5 +101,5 @@
+@@ -113,5 +101,5 @@
          ],
          "trigger": {
 -          "pause_status": "PAUSED",
 +          "pause_status": "UNPAUSED",
            "periodic": {
              "interval": 1,
-@@ -126,25 +113,21 @@
+@@ -125,24 +113,21 @@
          "channel": "CURRENT",
          "configuration": {
 -          "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src"
@@ -217,16 +217,16 @@ Validation OK!
            }
          ],
 -        "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_pipeline",
-+        "name": "project_name_[UNIQUE_NAME]_pipeline",
-         "permissions": [],
 -        "schema": "project_name_[UNIQUE_NAME]_dev",
 -        "tags": {
 -          "dev": "[USERNAME]"
 -        }
++        "name": "project_name_[UNIQUE_NAME]_pipeline",
++        "permissions": [],
 +        "schema": "project_name_[UNIQUE_NAME]_prod"
        }
      }
-@@ -156,10 +139,10 @@
+@@ -154,10 +139,10 @@
    },
    "workspace": {
 -    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",
@@ -327,14 +327,14 @@ Resources:
 +          "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/state/metadata.json"
          },
          "edit_mode": "UI_LOCKED",
-@@ -67,12 +57,9 @@
+@@ -67,11 +57,9 @@
            }
          ],
 -        "max_concurrent_runs": 4,
 -        "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_job",
 +        "max_concurrent_runs": 1,
 +        "name": "project_name_[UNIQUE_NAME]_job",
-         "permissions": [],
++        "permissions": [],
          "queue": {
            "enabled": true
 -        },
@@ -342,21 +342,21 @@ Resources:
 -          "dev": "[USERNAME]"
          },
          "tasks": [
-@@ -98,5 +85,5 @@
+@@ -97,5 +85,5 @@
              "job_cluster_key": "job_cluster",
              "notebook_task": {
 -              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/notebook"
 +              "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/prod/files/src/notebook"
              },
              "task_key": "notebook_task"
-@@ -115,5 +102,5 @@
+@@ -114,5 +102,5 @@
          ],
          "trigger": {
 -          "pause_status": "PAUSED",
 +          "pause_status": "UNPAUSED",
            "periodic": {
              "interval": 1,
-@@ -128,11 +115,10 @@
+@@ -127,11 +115,10 @@
          "channel": "CURRENT",
          "configuration": {
 -          "bundle.sourcePath": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src"
@@ -370,7 +370,7 @@ Resources:
 -        "development": true,
          "edition": "ADVANCED",
          "id": "[UUID]",
-@@ -140,14 +126,11 @@
+@@ -139,13 +126,11 @@
            {
              "notebook": {
 -              "path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files/src/pipeline"
@@ -379,16 +379,16 @@ Resources:
            }
          ],
 -        "name": "[dev [USERNAME]] project_name_[UNIQUE_NAME]_pipeline",
-+        "name": "project_name_[UNIQUE_NAME]_pipeline",
-         "permissions": [],
 -        "schema": "project_name_[UNIQUE_NAME]_dev",
 -        "tags": {
 -          "dev": "[USERNAME]"
 -        },
++        "name": "project_name_[UNIQUE_NAME]_pipeline",
++        "permissions": [],
 +        "schema": "project_name_[UNIQUE_NAME]_prod",
          "url": "[DATABRICKS_URL]/pipelines/[UUID]"
        }
-@@ -160,10 +143,10 @@
+@@ -158,10 +143,10 @@
    },
    "workspace": {
 -    "artifact_path": "/Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/artifacts",

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output.txt
@@ -38,7 +38,6 @@ Warning: Ignoring Databricks CLI version constraint for development build. Requi
       ],
       "max_concurrent_runs": 4,
       "name": "[dev [USERNAME]] my_jobs_as_code_job",
-      "permissions": [],
       "queue": {
         "enabled": true
       },
@@ -102,7 +101,6 @@ Warning: Ignoring Databricks CLI version constraint for development build. Requi
         }
       ],
       "name": "[dev [USERNAME]] my_jobs_as_code_pipeline",
-      "permissions": [],
       "tags": {
         "dev": "[USERNAME]"
       },

--- a/acceptance/bundle/validate/dashboard_defaults/output.txt
+++ b/acceptance/bundle/validate/dashboard_defaults/output.txt
@@ -1,28 +1,23 @@
 {
   "completely_empty": {
     "embed_credentials": false,
-    "parent_path": "/Workspace/foo/bar",
-    "permissions": []
+    "parent_path": "/Workspace/foo/bar"
   },
   "empty_string": {
     "embed_credentials": false,
-    "parent_path": "",
-    "permissions": []
+    "parent_path": ""
   },
   "non_empty_string": {
     "embed_credentials": false,
-    "parent_path": "already-set",
-    "permissions": []
+    "parent_path": "already-set"
   },
   "other_fields": {
     "display_name": "hello",
     "embed_credentials": false,
-    "parent_path": "/Workspace/foo/bar",
-    "permissions": []
+    "parent_path": "/Workspace/foo/bar"
   },
   "set_to_true": {
     "embed_credentials": true,
-    "parent_path": "/Workspace/foo/bar",
-    "permissions": []
+    "parent_path": "/Workspace/foo/bar"
   }
 }

--- a/acceptance/bundle/validate/empty_resources/empty_dict/output.txt
+++ b/acceptance/bundle/validate/empty_resources/empty_dict/output.txt
@@ -11,7 +11,6 @@
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -28,8 +27,7 @@
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/state/metadata.json"
       },
-      "edition": "ADVANCED",
-      "permissions": []
+      "edition": "ADVANCED"
     }
   }
 }
@@ -41,9 +39,7 @@ Warning: required field "name" is not set
 
 {
   "models": {
-    "rname": {
-      "permissions": []
-    }
+    "rname": {}
   }
 }
 
@@ -51,8 +47,7 @@ Warning: required field "name" is not set
 {
   "experiments": {
     "rname": {
-      "name": ".",
-      "permissions": []
+      "name": "."
     }
   }
 }
@@ -143,8 +138,7 @@ Warning: required field "schema_name" is not set
   "dashboards": {
     "rname": {
       "embed_credentials": false,
-      "parent_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/resources",
-      "permissions": []
+      "parent_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/resources"
     }
   }
 }
@@ -166,8 +160,7 @@ app resource 'rname' is missing required source_code_path field
 {
   "apps": {
     "rname": {
-      "description": "",
-      "permissions": []
+      "description": ""
     }
   }
 }
@@ -179,7 +172,6 @@ app resource 'rname' is missing required source_code_path field
       "auto_stop_mins": 120,
       "enable_photon": true,
       "max_num_clusters": 1,
-      "permissions": [],
       "spot_instance_policy": "COST_OPTIMIZED"
     }
   }
@@ -192,9 +184,7 @@ Warning: required field "name" is not set
 
 {
   "secret_scopes": {
-    "rname": {
-      "permissions": []
-    }
+    "rname": {}
   }
 }
 

--- a/acceptance/bundle/validate/empty_resources/with_grants/output.txt
+++ b/acceptance/bundle/validate/empty_resources/with_grants/output.txt
@@ -15,7 +15,6 @@ Warning: unknown field: grants
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -36,8 +35,7 @@ Warning: unknown field: grants
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/state/metadata.json"
       },
-      "edition": "ADVANCED",
-      "permissions": []
+      "edition": "ADVANCED"
     }
   }
 }
@@ -53,9 +51,7 @@ Warning: required field "name" is not set
 
 {
   "models": {
-    "rname": {
-      "permissions": []
-    }
+    "rname": {}
   }
 }
 
@@ -67,8 +63,7 @@ Warning: unknown field: grants
 {
   "experiments": {
     "rname": {
-      "name": ".",
-      "permissions": []
+      "name": "."
     }
   }
 }
@@ -176,8 +171,7 @@ Warning: unknown field: grants
   "dashboards": {
     "rname": {
       "embed_credentials": false,
-      "parent_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/resources",
-      "permissions": []
+      "parent_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/resources"
     }
   }
 }
@@ -203,8 +197,7 @@ app resource 'rname' is missing required source_code_path field
 {
   "apps": {
     "rname": {
-      "description": "",
-      "permissions": []
+      "description": ""
     }
   }
 }
@@ -220,7 +213,6 @@ Warning: unknown field: grants
       "auto_stop_mins": 120,
       "enable_photon": true,
       "max_num_clusters": 1,
-      "permissions": [],
       "spot_instance_policy": "COST_OPTIMIZED"
     }
   }
@@ -237,9 +229,7 @@ Warning: required field "name" is not set
 
 {
   "secret_scopes": {
-    "rname": {
-      "permissions": []
-    }
+    "rname": {}
   }
 }
 

--- a/acceptance/bundle/validate/empty_resources/with_permissions/output.txt
+++ b/acceptance/bundle/validate/empty_resources/with_permissions/output.txt
@@ -11,7 +11,6 @@
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "Untitled",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -28,8 +27,7 @@
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/state/metadata.json"
       },
-      "edition": "ADVANCED",
-      "permissions": []
+      "edition": "ADVANCED"
     }
   }
 }
@@ -41,9 +39,7 @@ Warning: required field "name" is not set
 
 {
   "models": {
-    "rname": {
-      "permissions": []
-    }
+    "rname": {}
   }
 }
 
@@ -51,8 +47,7 @@ Warning: required field "name" is not set
 {
   "experiments": {
     "rname": {
-      "name": ".",
-      "permissions": []
+      "name": "."
     }
   }
 }
@@ -161,8 +156,7 @@ Warning: required field "schema_name" is not set
   "dashboards": {
     "rname": {
       "embed_credentials": false,
-      "parent_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/resources",
-      "permissions": []
+      "parent_path": "/Workspace/Users/[USERNAME]/.bundle/BUNDLE/default/resources"
     }
   }
 }
@@ -184,8 +178,7 @@ app resource 'rname' is missing required source_code_path field
 {
   "apps": {
     "rname": {
-      "description": "",
-      "permissions": []
+      "description": ""
     }
   }
 }
@@ -197,7 +190,6 @@ app resource 'rname' is missing required source_code_path field
       "auto_stop_mins": 120,
       "enable_photon": true,
       "max_num_clusters": 1,
-      "permissions": [],
       "spot_instance_policy": "COST_OPTIMIZED"
     }
   }
@@ -210,9 +202,7 @@ Warning: required field "name" is not set
 
 {
   "secret_scopes": {
-    "rname": {
-      "permissions": []
-    }
+    "rname": {}
   }
 }
 

--- a/acceptance/bundle/validate/job-references/output.txt
+++ b/acceptance/bundle/validate/job-references/output.txt
@@ -20,7 +20,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "inner loop",
-        "permissions": [],
         "queue": {
           "enabled": true
         }
@@ -34,7 +33,6 @@
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "outer loop",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/validate/presets_max_concurrent_runs/output.txt
+++ b/acceptance/bundle/validate/presets_max_concurrent_runs/output.txt
@@ -8,7 +8,6 @@
     "format": "MULTI_TASK",
     "max_concurrent_runs": 5,
     "name": "job1",
-    "permissions": [],
     "queue": {
       "enabled": true
     }
@@ -22,7 +21,6 @@
     "format": "MULTI_TASK",
     "max_concurrent_runs": 3,
     "name": "job2",
-    "permissions": [],
     "queue": {
       "enabled": true
     }

--- a/acceptance/bundle/validate/presets_name_prefix/output.txt
+++ b/acceptance/bundle/validate/presets_name_prefix/output.txt
@@ -22,7 +22,6 @@ Warning: required field "catalog_name" is not set
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "prefix-job1",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -66,7 +65,6 @@ Warning: required field "catalog_name" is not set
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "[prefix]job1",
-      "permissions": [],
       "queue": {
         "enabled": true
       }
@@ -110,7 +108,6 @@ Warning: required field "catalog_name" is not set
       "format": "MULTI_TASK",
       "max_concurrent_runs": 1,
       "name": "job1",
-      "permissions": [],
       "queue": {
         "enabled": true
       }

--- a/acceptance/bundle/variables/complex/out.default.json
+++ b/acceptance/bundle/variables/complex/out.default.json
@@ -26,7 +26,6 @@
         ],
         "max_concurrent_runs": 1,
         "name": "Untitled",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/variables/complex/out.dev.json
+++ b/acceptance/bundle/variables/complex/out.dev.json
@@ -24,7 +24,6 @@
         ],
         "max_concurrent_runs": 1,
         "name": "Untitled",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/variables/complex_multiple_files/output.txt
+++ b/acceptance/bundle/variables/complex_multiple_files/output.txt
@@ -60,7 +60,6 @@
         ],
         "max_concurrent_runs": 1,
         "name": "Untitled",
-        "permissions": [],
         "queue": {
           "enabled": true
         }

--- a/acceptance/bundle/variables/prepend-workspace-var/output.txt
+++ b/acceptance/bundle/variables/prepend-workspace-var/output.txt
@@ -29,7 +29,6 @@ Warning: required field "package_name" is not set
         "format": "MULTI_TASK",
         "max_concurrent_runs": 1,
         "name": "Untitled",
-        "permissions": [],
         "queue": {
           "enabled": true
         },

--- a/acceptance/bundle/variables/resolve-nonstrings/output.txt
+++ b/acceptance/bundle/variables/resolve-nonstrings/output.txt
@@ -30,7 +30,6 @@
         "no_alert_for_canceled_runs": true,
         "no_alert_for_skipped_runs": false
       },
-      "permissions": [],
       "queue": {
         "enabled": true
       },

--- a/acceptance/bundle/variables/resolve-resources-fields/output.txt
+++ b/acceptance/bundle/variables/resolve-resources-fields/output.txt
@@ -13,7 +13,6 @@
     "baz": {
       "description": "",
       "name": "myapp",
-      "permissions": [],
       "source_code_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
     }
   },

--- a/acceptance/bundle/variables/variable_overrides_in_target/output.txt
+++ b/acceptance/bundle/variables/variable_overrides_in_target/output.txt
@@ -16,8 +16,7 @@
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/foobar/use-default-variable-values/state/metadata.json"
       },
       "edition": "ADVANCED",
-      "name": "a_string",
-      "permissions": []
+      "name": "a_string"
     }
   }
 }
@@ -39,8 +38,7 @@
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/foobar/override-string-variable/state/metadata.json"
       },
       "edition": "ADVANCED",
-      "name": "overridden_string",
-      "permissions": []
+      "name": "overridden_string"
     }
   }
 }
@@ -62,8 +60,7 @@
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/foobar/override-int-variable/state/metadata.json"
       },
       "edition": "ADVANCED",
-      "name": "a_string",
-      "permissions": []
+      "name": "a_string"
     }
   }
 }
@@ -85,8 +82,7 @@
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/foobar/override-both-bool-and-string-variables/state/metadata.json"
       },
       "edition": "ADVANCED",
-      "name": "overridden_string",
-      "permissions": []
+      "name": "overridden_string"
     }
   }
 }

--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions.go
@@ -116,6 +116,10 @@ func (m *bundlePermissions) Apply(ctx context.Context, b *bundle.Bundle) diag.Di
 					levelsMap[key],
 				)...)
 
+				if len(permissions) == 0 {
+					permissions = nil
+				}
+
 				pv, err = convert.FromTyped(permissions, dyn.NilValue)
 				if err != nil {
 					return dyn.InvalidValue, fmt.Errorf("failed to convert permissions: %w", err)


### PR DESCRIPTION
## Changes
When processing permissions, do not convert nils to empty slice in dyn value.

## Why
Without this '"permissions: []"' shows up in JSON output. Given that permissions are not present in the config, this is confusing.

In addition, permissions are also marked as "omitempty" so even if they are present, they should be cleaned up. 

Related: https://github.com/databricks/cli/pull/2756#pullrequestreview-2790052042

## Tests
Existing tests.