### PR TITLE
internal: Fixes for IsLocalPathInPipFlag and IsLibraryLocal

### DIFF
--- a/bundle/libraries/local_path.go
+++ b/bundle/libraries/local_path.go
@@ -81,10 +81,10 @@ var PipFlagsWithLocalPaths = []string{
 
 func IsLocalPathInPipFlag(dep string) (string, string, bool) {
 	for _, flag := range PipFlagsWithLocalPaths {
-		dep, ok := strings.CutPrefix(dep, flag+" ")
+		depWithoutFlag, ok := strings.CutPrefix(dep, flag+" ")
 		if ok {
-			dep = strings.TrimSpace(dep)
-			return dep, flag, IsLocalPath(dep)
+			depWithoutFlag = strings.TrimSpace(depWithoutFlag)
+			return depWithoutFlag, flag, IsLocalPath(depWithoutFlag)
 		}
 	}
 
@@ -95,7 +95,7 @@ func containsPipFlag(input string) bool {
 	// Trailing space means the the flag takes an argument or there's multiple arguments in input
 	// Alternatively it could be a flag with no argument and no space after it
 	// For example: -r myfile.txt or --index-url http://myindexurl.com or -i
-	re := regexp.MustCompile(`--?[a-zA-Z0-9-]+(\s|$)`)
+	re := regexp.MustCompile(`^\s*--?[a-zA-Z0-9-]+(\s|$)`)
 	return re.MatchString(input)
 }
 

--- a/bundle/libraries/local_path_test.go
+++ b/bundle/libraries/local_path_test.go
@@ -48,8 +48,11 @@ func TestIsLibraryLocal(t *testing.T) {
 		{path: "../../local/*.whl", expected: true},
 		{path: "..\\..\\local\\*.whl", expected: true},
 		{path: "file://path/to/package/whl.whl", expected: true},
+		{path: "local/foo-bar.whl", expected: true},
+
 		{path: "", expected: false},
 		{path: "pypipackage", expected: false},
+		{path: "foo-bar", expected: false},
 		{path: "/Volumes/catalog/schema/volume/path.whl", expected: false},
 		{path: "/Workspace/my_project/dist.whl", expected: false},
 		{path: "-r ../requirements.txt", expected: false},


### PR DESCRIPTION
## Changes
Added ^\s* for pip flag regexp so we don't match `foo-bar` as a flag
Renamed variable to avoid shadowing

## Why
Followups for https://github.com/databricks/cli/pull/3708

