### PR TITLE
[Python] Fix missing compute.Kind

### DIFF
--- a/bundle/internal/schema/annotations_openapi_overrides.yml
+++ b/bundle/internal/schema/annotations_openapi_overrides.yml
@@ -803,6 +803,11 @@ github.com/databricks/databricks-sdk-go/service/compute.InitScriptInfo:
   "abfss":
     "description": |-
       Contains the Azure Data Lake Storage destination path
+github.com/databricks/databricks-sdk-go/service/compute.Kind:
+  "_":
+    "enum":
+      - |-
+        CLASSIC_PREVIEW
 github.com/databricks/databricks-sdk-go/service/compute.LogAnalyticsInfo:
   "log_analytics_primary_key":
     "description": |-

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -4167,7 +4167,18 @@
               ]
             },
             "compute.Kind": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "CLASSIC_PREVIEW"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "\\$\\{(var(\\.[a-zA-Z]+([-_]?[a-zA-Z0-9]+)*(\\[[0-9]+\\])*)+)\\}"
+                }
+              ]
             },
             "compute.Library": {
               "oneOf": [

--- a/experimental/python/codegen/codegen/jsonschema_patch.py
+++ b/experimental/python/codegen/codegen/jsonschema_patch.py
@@ -3,10 +3,6 @@ from dataclasses import replace
 from codegen.jsonschema import Schema
 
 REMOVED_FIELDS = {
-    "compute.ClusterSpec": {
-        # doesn't work, openapi schema needs to be updated to be enum
-        "kind",
-    },
     # fields that were deprecated a long time ago
     "resources.Pipeline": {
         # 'trigger' is deprecated, use 'continuous' or schedule pipeline refresh using job instead

--- a/experimental/python/codegen/codegen/packages.py
+++ b/experimental/python/codegen/codegen/packages.py
@@ -57,10 +57,6 @@ def is_resource(ref: str) -> bool:
 def should_load_ref(ref: str) -> bool:
     name = ref.split("/")[-1]
 
-    # FIXME doesn't work, looks like enum, but doesn't have any values specified
-    if name == "compute.Kind":
-        return False
-
     for namespace in LOADED_NAMESPACES:
         if name.startswith(f"{namespace}."):
             return True

--- a/experimental/python/databricks/bundles/jobs/__init__.py
+++ b/experimental/python/databricks/bundles/jobs/__init__.py
@@ -131,6 +131,8 @@ __all__ = [
     "JobsHealthRules",
     "JobsHealthRulesDict",
     "JobsHealthRulesParam",
+    "Kind",
+    "KindParam",
     "Library",
     "LibraryDict",
     "LibraryParam",
@@ -484,6 +486,7 @@ from databricks.bundles.jobs._models.jobs_health_rules import (
     JobsHealthRulesDict,
     JobsHealthRulesParam,
 )
+from databricks.bundles.jobs._models.kind import Kind, KindParam
 from databricks.bundles.jobs._models.library import Library, LibraryDict, LibraryParam
 from databricks.bundles.jobs._models.lifecycle import (
     Lifecycle,

--- a/experimental/python/databricks/bundles/jobs/_models/cluster_spec.py
+++ b/experimental/python/databricks/bundles/jobs/_models/cluster_spec.py
@@ -37,6 +37,7 @@ from databricks.bundles.jobs._models.init_script_info import (
     InitScriptInfo,
     InitScriptInfoParam,
 )
+from databricks.bundles.jobs._models.kind import Kind, KindParam
 from databricks.bundles.jobs._models.runtime_engine import (
     RuntimeEngine,
     RuntimeEngineParam,
@@ -170,6 +171,8 @@ class ClusterSpec:
     
     When set to true, Databricks will automatically set single node related `custom_tags`, `spark_conf`, and `num_workers`
     """
+
+    kind: VariableOrOptional[Kind] = None
 
     node_type_id: VariableOrOptional[str] = None
     """
@@ -383,6 +386,8 @@ class ClusterSpecDict(TypedDict, total=False):
     
     When set to true, Databricks will automatically set single node related `custom_tags`, `spark_conf`, and `num_workers`
     """
+
+    kind: VariableOrOptional[KindParam]
 
     node_type_id: VariableOrOptional[str]
     """

--- a/experimental/python/databricks/bundles/jobs/_models/kind.py
+++ b/experimental/python/databricks/bundles/jobs/_models/kind.py
@@ -1,0 +1,9 @@
+from enum import Enum
+from typing import Literal
+
+
+class Kind(Enum):
+    CLASSIC_PREVIEW = "CLASSIC_PREVIEW"
+
+
+KindParam = Literal["CLASSIC_PREVIEW"] | Kind


### PR DESCRIPTION
## Changes
Fix missing `compute.Kind`. There is a single documented value that applies a behaviour different from the absent value.

Add an enum annotation because it's missing in the OpenAPI spec.

## Why
Fixes https://github.com/databricks/cli/issues/3622

## Tests
Looking at the diff for the generated code