### PR TITLE
Fix timing-related flakiness in telemetry acceptance test

### DIFF
--- a/acceptance/bundle/telemetry/deploy/output.txt
+++ b/acceptance/bundle/telemetry/deploy/output.txt
@@ -7,6 +7,6 @@ Deployment complete!
 
 >>> cat out.requests.txt
 
-=== Assert that there are atleast 5 mutators for which the execution time is recorded
+=== Assert that mutator execution times are being recorded
 >>> cat telemetry.json
 true

--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -2,10 +2,11 @@ trace $CLI bundle deploy
 
 trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext") | .body.protoLogs[] | fromjson' > telemetry.json
 
-# Note that the number 5 here is arbitrary. In practice I saw 16 mutators be recorded in acceptance test runs so 5 seems
-# like a reasonably safe number to assert that mutator execution times are being recorded.
-title "Assert that there are atleast 5 mutators for which the execution time is recorded"
-trace cat telemetry.json | jq ' .entry.databricks_cli_log.bundle_deploy_event.experimental.bundle_mutator_execution_time_ms | length > 5'
+# Assert that the telemetry mechanism is working and recording mutator execution times.
+# We only check that at least one mutator execution time is recorded to avoid flakiness on fast machines
+# where many mutators may complete in less than 1ms (the threshold for recording in bundle/mutator.go).
+title "Assert that mutator execution times are being recorded"
+trace cat telemetry.json | jq ' .entry.databricks_cli_log.bundle_deploy_event.experimental.bundle_mutator_execution_time_ms | length > 0'
 
 # bundle_mutator_execution_time_ms can have variable number of entries depending upon the runtime of the mutators. Thus we omit it from
 # being asserted here.


### PR DESCRIPTION
## Why

The test checks that at least 5 mutators recorded execution times, but on fast machines, many mutators complete in under 1ms and are not recorded (per the threshold in bundle/mutator.go). This caused intermittent failures when exactly 5 mutators were recorded.

The test's purpose is to verify that the telemetry mechanism works, not to enforce a specific count. We changed the assertion to check for at least one recorded mutator execution time, making the test robust across all machine speeds.

## Tests

This failed here https://github.com/databricks/cli/actions/runs/18225329786/job/51894965321