### PR TITLE
Add `latest_stable_environment_version` template helper

### DIFF
--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -52,6 +52,10 @@ var metastoreDisabledErrorCodes = []string{
 // is run and can be used to attribute DBU revenue to bundle templates.
 var bundleUuid = uuid.New().String()
 
+// latestStableEnvironmentVersion is the latest stable version for serverless environment.
+// This constant can be updated when a new environment version becomes the recommended default.
+const latestStableEnvironmentVersion = 2
+
 func loadHelpers(ctx context.Context) template.FuncMap {
 	w := cmdctx.WorkspaceClient(ctx)
 	return template.FuncMap{
@@ -180,6 +184,11 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		},
 		"upper": func(s string) string {
 			return strings.ToUpper(s)
+		},
+		// Returns the latest stable recommended version for serverless environment.
+		// This can be updated in a single place when new environment versions roll out.
+		"latest_stable_environment_version": func() int {
+			return latestStableEnvironmentVersion
 		},
 	}
 }

--- a/libs/template/helpers_test.go
+++ b/libs/template/helpers_test.go
@@ -178,3 +178,20 @@ func TestWorkspaceHostNotConfigured(t *testing.T) {
 	err = r.walk()
 	require.ErrorContains(t, err, "cannot determine target workspace")
 }
+
+func TestTemplateLatestStableEnvironmentVersionFunction(t *testing.T) {
+	ctx := context.Background()
+
+	ctx = cmdctx.SetWorkspaceClient(ctx, nil)
+	helpers := loadHelpers(ctx)
+	r, err := newRenderer(ctx, nil, helpers, os.DirFS("."), "./testdata/latest-stable-environment-version/template", "./testdata/latest-stable-environment-version/library")
+	require.NoError(t, err)
+
+	err = r.walk()
+	assert.NoError(t, err)
+
+	assert.Len(t, r.files, 1)
+	envVersion, err := strconv.Atoi(strings.TrimSpace(string(r.files[0].(*inMemoryFile).content)))
+	require.NoError(t, err)
+	assert.Equal(t, latestStableEnvironmentVersion, envVersion)
+}

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -60,7 +60,7 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "2"
+            environment_version: "{{latest_stable_environment_version}}"
             dependencies:
               - dbt-databricks>=1.8.0,<2.0.0
       {{- end }}

--- a/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/default-python/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -74,7 +74,7 @@ resources:
           # Full documentation of this spec can be found at:
           # https://docs.databricks.com/api/workspace/jobs/create#environments-spec
           spec:
-            environment_version: "2"
+            environment_version: "{{latest_stable_environment_version}}"
             dependencies:
               - ../dist/*.whl
 {{end}}{{ else }}

--- a/libs/template/testdata/latest-stable-environment-version/template/hello.tmpl
+++ b/libs/template/testdata/latest-stable-environment-version/template/hello.tmpl
@@ -1,0 +1,1 @@
+{{ latest_stable_environment_version }}


### PR DESCRIPTION
## Changes

This change introduces a new template helper function that returns the latest stable environment version for serverless compute. By using this helper in bundle templates, both built-in and external templates can automatically track the recommended environment version.

## Why

The ds-env team can update the environment version in a single place (the `latestStableEnvironmentVersion` constant in `libs/template/helpers.go`) when a new version becomes the recommended default. All templates using `{{latest_stable_environment_version}}` will pick up the new version after the next CLI release.

This eliminates the need to manually update multiple templates and reduces the coordination overhead when new environment versions roll out.

## Tests

The materialized environment version doesn't change in this PR.