### PR TITLE
Fix labs installer to work in non-interactive mode with env var auth

### DIFF
--- a/cmd/labs/project/installer_test.go
+++ b/cmd/labs/project/installer_test.go
@@ -371,6 +371,13 @@ func TestInstallerWorksForDevelopment(t *testing.T) {
 
 	// development installer assumes it's in the active virtualenv
 	ctx = env.Set(ctx, "PYTHON_BIN", py)
+
+	// Set up authentication via environment variables to avoid prompting in non-interactive mode
+	ctx = env.Set(ctx, "DATABRICKS_HOST", server.URL)
+	ctx = env.Set(ctx, "DATABRICKS_TOKEN", "...")
+	ctx = env.Set(ctx, "DATABRICKS_CLUSTER_ID", "abc-id")
+	ctx = env.Set(ctx, "DATABRICKS_WAREHOUSE_ID", "efg-id")
+
 	home, _ := env.UserHomeDir(ctx)
 	err = os.WriteFile(filepath.Join(home, ".databrickscfg"), []byte(fmt.Sprintf(`
 [profile-one]

--- a/cmd/labs/project/login.go
+++ b/cmd/labs/project/login.go
@@ -50,6 +50,12 @@ func (lc *loginConfig) askWorkspaceProfile(ctx context.Context, cfg *config.Conf
 		lc.WorkspaceProfile = cfg.Profile
 		return err
 	}
+	// Check if authentication is already configured (e.g., via environment variables).
+	// This is consistent with askCluster() and askWarehouse() which check if their
+	// values are already set before prompting.
+	if lc.isAuthConfigured(cfg) {
+		return err
+	}
 	if !cmdio.IsPromptSupported(ctx) {
 		return ErrNotInTTY
 	}


### PR DESCRIPTION
## Changes

When authentication is configured via environment variables, `askWorkspaceProfile()` was failing because it checked for a profile name instead of checking if auth is actually configured. This made labs installers fail when running from non-interactive terminals (Cursor, specifically).

The fix makes `askWorkspaceProfile()` consistent with `askCluster()` and `askWarehouse()`, which both check if their values are already set before prompting.

## Why

When running tests from Cursor, I saw the following failures after #3709:

Failing Tests:
* TestInstallerWorksForReleases
* TestInstallerWorksForDevelopment

Both tests fail with the error:
```
login: ask for workspace: profile: not in an interactive terminal
```

## Tests

The tests that previously failed on a non-interactive terminal now pass.