### PR TITLE
acc: always include 'inherited' field in permissions

### DIFF
--- a/acceptance/bundle/deployment/unbind/permissions/output.txt
+++ b/acceptance/bundle/deployment/unbind/permissions/output.txt
@@ -11,6 +11,7 @@ Deployment complete!
 {
   "all_permissions": [
     {
+      "inherited": false,
       "permission_level": "CAN_MANAGE"
     }
   ],
@@ -31,6 +32,7 @@ Deployment complete!
 {
   "all_permissions": [
     {
+      "inherited": false,
       "permission_level": "CAN_MANAGE"
     }
   ],

--- a/libs/testserver/permissions.go
+++ b/libs/testserver/permissions.go
@@ -141,7 +141,9 @@ func (s *FakeWorkspace) SetPermissions(req Request) any {
 		// Convert PermissionLevel to Permission
 		if acl.PermissionLevel != "" {
 			response.AllPermissions = append(response.AllPermissions, iam.Permission{
+				Inherited:       false,
 				PermissionLevel: acl.PermissionLevel,
+				ForceSendFields: []string{"Inherited"},
 			})
 		}
 


### PR DESCRIPTION
## Why
This matches real backend behaviour.

## Tests
Restores acceptance/bundle/deployment/unbind/permissions which is broken on cloud since https://github.com/databricks/cli/pull/3730