### PR TITLE
testrunner: automatically allow parent testcase failure

### DIFF
--- a/tools/testrunner/main_test.go
+++ b/tools/testrunner/main_test.go
@@ -42,6 +42,18 @@ func TestConfigRuleMatches(t *testing.T) {
 		// Empty values cases
 		{"* TestDeploy", "", "TestDeploy", true},
 		{"bundle *", "bundle", "", true},
+
+		// Subtest failure results in parent test failure as well. So we allow strict prefixes to fail as well
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic", "acceptance", "TestAccept", true},
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic", "acceptance", "TestAnother", false},
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic/x", false},
+
+		// pattern version
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept", true},
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAnother", false},
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic/x", true},
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic", true},
+		{"acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes
- Include logs when test is passed on retry so that it's clear it does not cause the failure.
- Automatically match parent tests cases.

## Why
If you have a subtest failure, parent test fails as well. Rather than requiring to specify all parent tests, we automatically allow them. Inspired by this output:

```
acceptance TestAccept/bundle/templates/default-python/combinations/classic/DATABRICKS_BUNDLE_ENGINE=direct-exp/DLT=no/NBOOK=no/PY=no failure is not allowed
acceptance TestAccept/bundle/templates/default-python/combinations/classic/DATABRICKS_BUNDLE_ENGINE=direct-exp/DLT=no/NBOOK=no/PY=yes failure is not allowed
acceptance TestAccept/bundle/templates/default-python/combinations/classic failure is not allowed
acceptance TestAccept failure is not allowed
```

Here parent tests are 'TestAccept/bundle/templates/default-python/combinations/classic' and 'TestAccept'. So if known_failures.txt specifies "acceptance TestAccept/bundle/templates/default-python/combinations/classic/" then TestAccept would not match without this PR.

If users specify "acceptance TestAccept/bundle/templates/default-python/combinations/classic/DATABRICKS_BUNDLE_ENGINE=direct-exp/DLT=no/NBOOK=no/PY=no" then neither "TestAccept" nor "TestAccept/bundle/templates/default-python/combinations/classic" would match without this PR.

## Tests
Unit tests.
