### PR TITLE
Highlight known failures in PR tests summary

### DIFF
--- a/tools/gh_parse.py
+++ b/tools/gh_parse.py
@@ -137,43 +137,76 @@ def _test_parse_known_failures():
         ("bundle TestDeploy", "bundle", "TestDeploy", True),
         ("bundle TestDeploy", "libs", "TestDeploy", False),
         ("bundle TestDeploy", "bundle", "TestSomethingElse", False),
-
         # Package prefix matches
         ("libs/ TestSomething", "libs/auth", "TestSomething", True),
         ("libs/ TestSomething", "libs", "TestSomething", True),
         ("libs/ TestSomething", "libsother", "TestSomething", False),
-
         # Test prefix matches
         ("bundle TestAccept/", "bundle", "TestAcceptDeploy", False),
         ("bundle TestAccept/", "bundle", "TestAccept", True),
         ("bundle TestAccept/", "bundle", "TestAccept/Deploy", True),
-
         # Wildcard matches
         ("* *", "any/package", "AnyTest", True),
         ("* TestAccept/", "any/package", "TestAcceptDeploy", False),
         ("* TestAccept/", "any/package", "TestAccept/Deploy", True),
         ("libs/ *", "libs/auth", "AnyTest", True),
-
         # Path prefix edge cases
         ("TestAccept/ TestAccept/", "TestAccept", "TestAccept", True),
         ("TestAccept/ TestAccept/", "TestAccept/bundle", "TestAccept/deploy", True),
         ("TestAccept/ TestAccept/", "TestAcceptSomething", "TestAcceptSomething", False),
-
         # Empty values cases
         ("* TestDeploy", "", "TestDeploy", True),
         ("bundle *", "bundle", "", True),
-
         # Subtest failure results in parent test failure as well
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic", "acceptance", "TestAccept", True),
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic", "acceptance", "TestAnother", False),
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic/x", False),
-
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic",
+            "acceptance",
+            "TestAccept",
+            True,
+        ),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic",
+            "acceptance",
+            "TestAnother",
+            False,
+        ),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic",
+            "acceptance",
+            "TestAccept/bundle/templates/default-python/combinations/classic/x",
+            False,
+        ),
         # Pattern version
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept", True),
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAnother", False),
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic/x", True),
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations/classic", True),
-        ("acceptance TestAccept/bundle/templates/default-python/combinations/classic/", "acceptance", "TestAccept/bundle/templates/default-python/combinations", True),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic/",
+            "acceptance",
+            "TestAccept",
+            True,
+        ),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic/",
+            "acceptance",
+            "TestAnother",
+            False,
+        ),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic/",
+            "acceptance",
+            "TestAccept/bundle/templates/default-python/combinations/classic/x",
+            True,
+        ),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic/",
+            "acceptance",
+            "TestAccept/bundle/templates/default-python/combinations/classic",
+            True,
+        ),
+        (
+            "acceptance TestAccept/bundle/templates/default-python/combinations/classic/",
+            "acceptance",
+            "TestAccept/bundle/templates/default-python/combinations",
+            True,
+        ),
     ]
 
     for input_str, package_name, testcase, expected_match in test_cases:
@@ -184,8 +217,10 @@ def _test_parse_known_failures():
         actual_match = bool(result)
 
         if actual_match != expected_match:
-            raise AssertionError(f"Test failed for input='{input_str}', package='{package_name}', test='{testcase}': "
-                               f"expected {expected_match}, got {actual_match} (result: '{result}')")
+            raise AssertionError(
+                f"Test failed for input='{input_str}', package='{package_name}', test='{testcase}': "
+                f"expected {expected_match}, got {actual_match} (result: '{result}')"
+            )
 
 
 def load_known_failures():


### PR DESCRIPTION
## Changes
The gh_parse.py / gh_report.py scripts now download and parse known_failures.txt and highlight matching tests https://github.com/databricks/cli/blob/ciconfig/known_failures.txt

See https://github.com/databricks/cli/pull/3733

## Why
Additional context on test status.

## Tests
Manually:

`~/work/cli-main % ./tools/gh_report.py --run 18343557422 --markdown`

|    | Env                | ✅pass | 💚RECOVERED | 🙈skip | 🟨KNOWN |
| -- | ------------------ | ------ | ----------- | ------ | ------- |
| 🟨 | aws linux          | 321    |             | 543    | 1       |
| 🟨 | aws windows        | 322    |             | 542    | 1       |
| 🟨 | aws-ucws linux     | 437    |             | 439    | 1       |
| 🟨 | aws-ucws windows   | 438    |             | 438    | 1       |
| 🟨 | azure linux        | 319    | 2           | 542    | 1       |
| 🟨 | azure windows      | 320    | 2           | 541    | 1       |
| 🟨 | azure-ucws linux   | 435    | 2           | 438    | 1       |
| 🟨 | azure-ucws windows | 436    | 2           | 437    | 1       |
| 🟨 | gcp linux          | 320    |             | 544    | 1       |
| 🟨 | gcp windows        | 321    |             | 543    | 1       |

| Test Name             | aws linux | aws windows | aws-ucws linux | aws-ucws windows | azure linux | azure windows | azure-ucws linux | azure-ucws windows | gcp linux | gcp windows |
| --------------------- | --------- | ----------- | -------------- | ---------------- | ----------- | ------------- | ---------------- | ------------------ | --------- | ----------- |
| TestTagKeyAzure       | 🙈skip    | 🙈skip      | 🙈skip         | 🙈skip           | 💚RECOVERED | 💚RECOVERED   | 💚RECOVERED      | 💚RECOVERED        | 🙈skip    | 🙈skip      |
| TestTagKeyAzure/empty |           |             |                |                  | 💚RECOVERED | 💚RECOVERED   | 💚RECOVERED      | 💚RECOVERED        |           |             |
| TestTelemetryEndpoint | 🟨KNOWN   | 🟨KNOWN     | 🟨KNOWN        | 🟨KNOWN          | 🟨KNOWN     | 🟨KNOWN       | 🟨KNOWN          | 🟨KNOWN            | 🟨KNOWN   | 🟨KNOWN     |