### PR TITLE
Refine known_failures cache update handling

### DIFF
--- a/tools/gh_report.py
+++ b/tools/gh_report.py
@@ -137,7 +137,6 @@ def download_known_failures():
             content = response.read().decode("utf-8")
     except Exception as e:
         print(f"Failed to download known_failures.txt: {e}", file=sys.stderr)
-        temp_path.unlink(missing_ok=True)
         return
 
     temp_path.write_text(content)


### PR DESCRIPTION
## Changes
- separate downloading of known_failures.txt from writing it to disk
- maintain atomic replacement of the cached known_failures file

------
https://chatgpt.com/codex/tasks/task_e_68e7c56a98d88325aae2335e5f37e6b0

Original PR: https://github.com/denik/cli/pull/4