### PR TITLE
acc: generate increasing UUID in testserver

### DIFF
--- a/libs/testserver/alerts.go
+++ b/libs/testserver/alerts.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/databricks/databricks-sdk-go/service/sql"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) AlertsUpsert(req Request, alertId string) Response {
@@ -29,7 +28,7 @@ func (s *FakeWorkspace) AlertsUpsert(req Request, alertId string) Response {
 			}
 		}
 	} else {
-		alertId = uuid.New().String()
+		alertId = nextUUID()
 	}
 
 	alert.Id = alertId

--- a/libs/testserver/catalogs.go
+++ b/libs/testserver/catalogs.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) CatalogsCreate(req Request) Response {
@@ -34,7 +33,7 @@ func (s *FakeWorkspace) CatalogsCreate(req Request) Response {
 		CreatedBy:    s.CurrentUser().UserName,
 		UpdatedAt:    time.Now().UnixMilli(),
 		UpdatedBy:    s.CurrentUser().UserName,
-		MetastoreId:  uuid.New().String(),
+		MetastoreId:  nextUUID(),
 		Owner:        s.CurrentUser().UserName,
 		CatalogType:  catalog.CatalogTypeManagedCatalog,
 	}

--- a/libs/testserver/clusters.go
+++ b/libs/testserver/clusters.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/databricks/databricks-sdk-go/service/compute"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) ClustersCreate(req Request) any {
@@ -19,7 +18,7 @@ func (s *FakeWorkspace) ClustersCreate(req Request) any {
 
 	defer s.LockUnlock()()
 
-	clusterId := uuid.New().String()
+	clusterId := nextUUID()
 	request.ClusterId = clusterId
 	s.Clusters[clusterId] = request
 

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) DashboardCreate(req Request) Response {
@@ -20,7 +19,7 @@ func (s *FakeWorkspace) DashboardCreate(req Request) Response {
 	}
 
 	// Lakeview API strips hyphens from a uuid for dashboards
-	dashboard.DashboardId = strings.ReplaceAll(uuid.New().String(), "-", "")
+	dashboard.DashboardId = strings.ReplaceAll(nextUUID(), "-", "")
 
 	// All dashboards are active by default:
 	dashboard.LifecycleState = dashboards.LifecycleStateActive
@@ -61,7 +60,7 @@ func (s *FakeWorkspace) DashboardCreate(req Request) Response {
 	return Response{
 		Body: dashboards.Dashboard{
 			DashboardId: dashboard.DashboardId,
-			Etag:        uuid.New().String(),
+			Etag:        nextUUID(),
 		},
 	}
 }
@@ -77,7 +76,7 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 	}
 
 	// Update the etag for the dashboard.
-	dashboard.Etag = uuid.New().String()
+	dashboard.Etag = nextUUID()
 
 	// All dashboards are active by default:
 	dashboard.LifecycleState = dashboards.LifecycleStateActive

--- a/libs/testserver/database_instances.go
+++ b/libs/testserver/database_instances.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/database"
-	"github.com/google/uuid"
 )
 
 var ForceSendFields []string = []string{
@@ -29,7 +28,7 @@ func (s *FakeWorkspace) DatabaseInstanceCreate(req Request) Response {
 	}
 
 	// set default fields:
-	databaseInstance.Uid = uuid.New().String()
+	databaseInstance.Uid = nextUUID()
 	databaseInstance.State = database.DatabaseInstanceStateAvailable
 	databaseInstance.PgVersion = "PG_VERSION_16"
 	databaseInstance.EffectiveNodeCount = 1

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -2,6 +2,7 @@ package testserver
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/service/compute"
 	"github.com/databricks/databricks-sdk-go/service/database"
+	"github.com/google/uuid"
 
 	"github.com/databricks/databricks-sdk-go/service/apps"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
@@ -61,6 +63,14 @@ func nextID() int64 {
 	}
 
 	return lastID
+}
+
+func nextUUID() string {
+	var b [16]byte
+	binary.BigEndian.PutUint64(b[0:8], uint64(nextID()))
+	binary.BigEndian.PutUint64(b[8:16], uint64(nextID()))
+	u := uuid.Must(uuid.FromBytes(b[:]))
+	return u.String()
 }
 
 type FileEntry struct {

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) PipelineGet(pipelineId string) Response {
@@ -39,7 +38,7 @@ func (s *FakeWorkspace) PipelineCreate(req Request) Response {
 	var r pipelines.GetPipelineResponse
 	r.Spec = &spec
 
-	pipelineId := uuid.New().String()
+	pipelineId := nextUUID()
 	r.PipelineId = pipelineId
 	r.CreatorUserName = "tester@databricks.com"
 	r.LastModified = time.Now().UnixMilli()
@@ -104,7 +103,7 @@ func (s *FakeWorkspace) PipelineStartUpdate(pipelineId string) Response {
 		}
 	}
 
-	updateId := uuid.New().String()
+	updateId := nextUUID()
 	s.PipelineUpdates[updateId] = true
 
 	return Response{

--- a/libs/testserver/registered_models.go
+++ b/libs/testserver/registered_models.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) RegisteredModelsCreate(req Request) Response {
@@ -35,7 +34,7 @@ func (s *FakeWorkspace) RegisteredModelsCreate(req Request) Response {
 		CreatedBy:       s.CurrentUser().UserName,
 		UpdatedAt:       time.Now().UnixMilli(),
 		UpdatedBy:       s.CurrentUser().UserName,
-		MetastoreId:     uuid.New().String(),
+		MetastoreId:     nextUUID(),
 		Owner:           s.CurrentUser().UserName,
 	}
 

--- a/libs/testserver/sql_warehouses.go
+++ b/libs/testserver/sql_warehouses.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/databricks/databricks-sdk-go/service/sql"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) SqlWarehousesUpsert(req Request, warehouseId string) Response {
@@ -29,7 +28,7 @@ func (s *FakeWorkspace) SqlWarehousesUpsert(req Request, warehouseId string) Res
 			}
 		}
 	} else {
-		warehouseId = uuid.New().String()
+		warehouseId = nextUUID()
 	}
 	warehouse.Id = warehouseId
 	warehouse.Name = warehouseId

--- a/libs/testserver/volumes.go
+++ b/libs/testserver/volumes.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
-	"github.com/google/uuid"
 )
 
 func (s *FakeWorkspace) VolumesCreate(req Request) Response {
@@ -31,7 +30,7 @@ func (s *FakeWorkspace) VolumesCreate(req Request) Response {
 		}
 	}
 	// QQQ first UUID should be constant per workspace?
-	volume.StorageLocation = fmt.Sprintf("s3://deco-uc-prod-isolated-aws-us-east-1/metastore/%s/volumes/%s", uuid.New().String(), uuid.New().String())
+	volume.StorageLocation = fmt.Sprintf("s3://deco-uc-prod-isolated-aws-us-east-1/metastore/%s/volumes/%s", nextUUID(), nextUUID())
 
 	defer s.LockUnlock()()
 


### PR DESCRIPTION
When sorting requests that have UUID in it (e.g. /pipelines) it helps if order of creation matches sort order of request path.
