### PR TITLE
Fix flaky TestHandover by increasing timeout to 500ms

### DIFF
--- a/experimental/ssh/internal/proxy/client_server_test.go
+++ b/experimental/ssh/internal/proxy/client_server_test.go
@@ -144,7 +144,7 @@ func TestHandover(t *testing.T) {
 	defer server.Close()
 
 	maxHandoverCount := 3
-	handoverTimeout := 10 * time.Millisecond
+	handoverTimeout := 500 * time.Millisecond
 	createConnChan := make(chan error, 1)
 	clientInputWriter, clientOutput := createTestClient(t, server.URL, handoverTimeout, nil, createConnChan)
 	defer clientInputWriter.Close()


### PR DESCRIPTION
## Changes

The 10ms handover timeout was too aggressive for the connection handover process, which involves creating new WebSocket connections, closing old ones, and waiting for acknowledgments. Changed to 500ms to allow reliable completion.

## Why

Failure: https://github.com/databricks/cli/actions/runs/18462066531/job/52595573781