### PR TITLE
testserver: use proper test user if IsServicePrincipal is enabled

### DIFF
--- a/libs/testserver/experiments.go
+++ b/libs/testserver/experiments.go
@@ -20,12 +20,14 @@ func (s *FakeWorkspace) ExperimentCreate(req Request) Response {
 		}
 	}
 
+	testUser := s.CurrentUser()
+
 	// Server appends these tags automatically to experiments.
 	// We replicate that behaviour in the test server as well.
 	appendTags := []ml.ExperimentTag{
 		{
 			Key:   "mlflow.ownerId",
-			Value: TestUser.Id,
+			Value: testUser.Id,
 		},
 		{
 			Key:   "mlflow.experiment.sourceName",
@@ -33,11 +35,11 @@ func (s *FakeWorkspace) ExperimentCreate(req Request) Response {
 		},
 		{
 			Key:   "mlflow.ownerId",
-			Value: TestUser.Id,
+			Value: testUser.Id,
 		},
 		{
 			Key:   "mlflow.ownerEmail",
-			Value: TestUser.UserName,
+			Value: testUser.UserName,
 		},
 		{
 			Key:   "mlflow.experimentType",

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -32,7 +32,11 @@ func (s *FakeWorkspace) JobsCreate(req Request) Response {
 
 	// CreatorUserName field is used by TF to check if the resource exists or not. CreatorUserName should be non-empty for the resource to be considered as "exists"
 	// https://github.com/databricks/terraform-provider-databricks/blob/main/permissions/permission_definitions.go#L108
-	s.Jobs[jobId] = jobs.Job{JobId: jobId, Settings: &jobSettings, CreatorUserName: TestUser.UserName}
+	s.Jobs[jobId] = jobs.Job{
+		JobId:           jobId,
+		Settings:        &jobSettings,
+		CreatorUserName: s.CurrentUser().UserName,
+	}
 	return Response{Body: jobs.CreateResponse{JobId: jobId}}
 }
 


### PR DESCRIPTION
## Why
Testserver support both regular user and service principal, we need to use SP consistently.

Found out when working on permissions that terraform pull incorrect user from a job. 
