### PR TITLE
Add Makefile target and agent guidance for updating template acceptance tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,50 @@ test case in your responses. I am just interested in the tests.
 - Each test directory contains `databricks.yml`, `script`, and `output.txt`
 - Run with `go test ./acceptance -run TestAccept/bundle/<path>/<to>/<folder> -tail -test.v`
 - Use `-update` flag to regenerate expected output files
-- When you see the test fails because it has an old output, just run it one more time with an `-update` flag instead of changing the `output.txt` directly
+- When a test fails because it has an old output, just run it one more time with an `-update` flag instead of changing the `output.txt` directly
+
+**When asked to update acceptance tests, follow this workflow**:
+
+1. **Run the update command**:
+   - For all acceptance tests: `make test-update`
+   - When asked to update acceptance tests for templates specifically: `make test-update-templates`
+
+2. **Verify code quality**:
+   - Run `make fmt` and `make lint`
+   - **Critical**: If these commands modify any files in `acceptance/`, this indicates an issue in the source files (e.g., in `libs/template/templates/` for template tests)!
+
+3. **Fix the root cause**:
+   - **Never manually edit files in `acceptance/`** - they are auto-generated outputs
+   - Find and fix the corresponding source file that generated the problematic acceptance test output
+   - For template tests: fix files in `libs/template/templates/`
+   - Common issues: trailing whitespace, missing/extra newlines, formatting problems
+
+4. **Regenerate after fixing**:
+   - After fixing the source files, run the update command again (e.g., `make test-update-templates`)
+   - This regenerates the acceptance test outputs from the corrected sources
+   - Now `make fmt` and `make lint` should pass with no changes
+
+**Example workflow**:
+```bash
+# Update acceptance tests
+make test-update  # or make test-update-templates for templates only
+
+# Check for issues - if these modify files in acceptance/, you have a source file problem
+make fmt
+make lint
+
+# If there are modifications in acceptance/:
+# 1. Find the corresponding source file (e.g., in libs/template/templates/ for templates)
+# 2. Fix the issue there (e.g., whitespace, newlines)
+# 3. Regenerate from the fixed source
+make test-update  # or make test-update-templates
+
+# Verify everything is clean
+make fmt    # Should show no changes now
+make lint   # Should show no issues now
+```
+
+**Key principle**: Files in `acceptance/` are outputs, not sources. Always fix the source files and regenerate.
 
 # Logging
 

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,12 @@ test-update:
 	@# at the moment second pass is required because some tests show diff against output of another test for easier review
 	-go test ./acceptance -run '^TestAccept$$' -update -timeout=${LOCAL_TIMEOUT}
 
+# Updates acceptance test output for template tests only
+test-update-templates:
+	-go test ./acceptance -run '^TestAccept/bundle/templates' -update -timeout=${LOCAL_TIMEOUT}
+	@# at the moment second pass is required because some tests show diff against output of another test for easier review
+	-go test ./acceptance -run '^TestAccept/bundle/templates' -update -timeout=${LOCAL_TIMEOUT}
+
 # Updates acceptance test output (integration tests, requires access)
 test-update-aws:
 	deco env run -i -n aws-prod-ucws -- go test ./acceptance -run ^TestAccept$$ -update -timeout=1h -skiplocal -v
@@ -142,4 +148,4 @@ generate:
 	$(GENKIT_BINARY) update-sdk
 
 
-.PHONY: lint lintfull tidy lintcheck fmt fmtfull test cover showcover build snapshot snapshot-release schema integration integration-short acc-cover acc-showcover docs ws links checks test-update test-update-aws test-update-all generate-validation
+.PHONY: lint lintfull tidy lintcheck fmt fmtfull test cover showcover build snapshot snapshot-release schema integration integration-short acc-cover acc-showcover docs ws links checks test-update test-update-templates test-update-aws test-update-all generate-validation


### PR DESCRIPTION
 ## Changes

  Adds a new `make test-update-templates` target for faster template acceptance test updates, and adds guidance to AGENTS.md on the proper workflow for
  updating acceptance tests.

  ## Tests

  Exercised with PRs like https://github.com/databricks/cli/pull/3712.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)