### PR TITLE
acc: Separate test output for direct and terraform for interactive_single_user test

### DIFF
--- a/acceptance/bundle/integration_whl/interactive_single_user/out.direct-exp.txt
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.direct-exp.txt
@@ -1,0 +1,6 @@
+Hello from my func
+Got arguments:
+['my_test_code', 'one', 'two']
+Hello from my func
+Got arguments:
+['my_test_code', 'one', 'two']

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.terraform.txt
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.terraform.txt
@@ -1,0 +1,6 @@
+Hello from my func
+Got arguments:
+['my_test_code', 'one', 'two']
+UPDATED MY FUNC
+Got arguments:
+['my_test_code', 'one', 'two']

--- a/acceptance/bundle/integration_whl/interactive_single_user/output.txt
+++ b/acceptance/bundle/integration_whl/interactive_single_user/output.txt
@@ -43,9 +43,6 @@ Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS
-Hello from my func
-Got arguments:
-['my_test_code', 'one', 'two']
 
 === Make a change to code without version change and run the job again
 >>> [CLI] bundle deploy
@@ -61,9 +58,6 @@ Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS
-UPDATED MY FUNC
-Got arguments:
-['my_test_code', 'one', 'two']
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:

--- a/acceptance/bundle/integration_whl/interactive_single_user/script
+++ b/acceptance/bundle/integration_whl/interactive_single_user/script
@@ -4,9 +4,9 @@ trace cat databricks.yml
 cp -r $TESTDIR/../interactive_cluster/{setup.py,my_test_code} .
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
-trace $CLI bundle run some_other_job
+trace $CLI bundle run some_other_job > out.$DATABRICKS_BUNDLE_ENGINE.txt
 
 title "Make a change to code without version change and run the job again"
 update_file.py my_test_code/__main__.py 'Hello from my func' 'UPDATED MY FUNC'
 trace $CLI bundle deploy
-trace $CLI bundle run some_other_job
+trace $CLI bundle run some_other_job >> out.$DATABRICKS_BUNDLE_ENGINE.txt


### PR DESCRIPTION
## Changes
Separate test output for direct and terraform for interactive_single_user test

## Why
TF test behaviour for wheel jobs on single-user interactive clusters is technically incorrect because TF in such a setup produces permanent drift (incorrect), which leads to cluster restart on each bundle deploy, and therefore wheel changes are picked up
```
  # databricks_cluster.shared_autoscaling will be updated in-place
  ~ resource "databricks_cluster" "shared_autoscaling" {
        id                             = "1015-102652-xxxxxxx"
      - single_user_name               = "aaaaaaaabbbb-bbbb-cccc-dddd-bb6ce382668a" -> null
        # (19 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```
Direct does not update/restart the cluster on subsequent deploys (correct), and changes for the wheel are not picked, which is expected.

I separated the test output into 2 separate files for now, to unlock the test.

## Tests
Existing tests pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
