### PR TITLE
Fixed panic in bundle generate command when multiple profiles matched

### DIFF
--- a/cmd/bundle/generate/app.go
+++ b/cmd/bundle/generate/app.go
@@ -59,7 +59,7 @@ per target environment.`,
 		cmd.SetContext(ctx)
 
 		b := root.MustConfigureBundle(cmd)
-		if b == nil {
+		if b == nil || logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
 		}
 

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -389,7 +389,7 @@ func (d *dashboard) RunE(cmd *cobra.Command, args []string) error {
 	cmd.SetContext(ctx)
 
 	b := root.MustConfigureBundle(cmd)
-	if b == nil {
+	if b == nil || logdiag.HasError(ctx) {
 		return root.ErrAlreadyPrinted
 	}
 

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -62,7 +62,7 @@ After generation, you can deploy this job to other targets using:
 		cmd.SetContext(ctx)
 
 		b := root.MustConfigureBundle(cmd)
-		if b == nil {
+		if b == nil || logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
 		}
 

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -62,7 +62,7 @@ like catalogs, schemas, and compute configurations per target.`,
 		cmd.SetContext(ctx)
 
 		b := root.MustConfigureBundle(cmd)
-		if b == nil {
+		if b == nil || logdiag.HasError(ctx) {
 			return root.ErrAlreadyPrinted
 		}
 


### PR DESCRIPTION
## Changes
Fixed panic in bundle generate command when multiple profiles matched

## Why
Previously it would fail with 

```
Error: cannot resolve bundle auth configuration: resolve: https://foobar.com: multiple profiles matched: deco-staging, deco-staging-2, deco-staging-sp: please set DATABRICKS_CONFIG_PROFILE or provide --profile flag to specify one. Config: host=https://foobar.com

The Databricks CLI unexpectedly had a fatal error.
Please report this issue to Databricks in the form of a GitHub issue at:
https://github.com/databricks/cli

CLI Version: 0.0.0-dev+5c95e650cc33

Panic Payload: cannot resolve bundle auth configuration: resolve: https://foobar.com: multiple profiles matched: deco-staging, deco-staging-2, deco-staging-sp: please set DATABRICKS_CONFIG_PROFILE or provide --profile flag to specify one. Config: host=https://foobar.com

Stack Trace:
goroutine 1 [running]:
runtime/debug.Stack()
        /Users/andrew.nester/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.darwin-arm64/src/runtime/debug/stack.go:26 +0x64
github.com/databricks/cli/cmd/root.Execute.func1()
        /Users/andrew.nester/cli/cmd/root/root.go:112 +0x9c
panic({0x105bd2da0?, 0x1400061fe80?})
        /Users/andrew.nester/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.1.darwin-arm64/src/runtime/panic.go:783 +0x120
github.com/databricks/cli/bundle.(*Bundle).WorkspaceClient(...)
        /Users/andrew.nester/cli/bundle/bundle.go:221
github.com/databricks/cli/cmd/bundle/generate.NewGenerateAppCommand.func1(0x140005b7b08, {0x1056fb433?, 0x4?, 0x1056fb437?})
        /Users/andrew.nester/cli/cmd/bundle/generate/app.go:66 +0x590
github.com/spf13/cobra.(*Command).execute(0x140005b7b08, {0x140001248c0, 0x2, 0x2})
        /Users/andrew.nester/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015 +0x7d4
github.com/spf13/cobra.(*Command).ExecuteC(0x1400019ec08)
        /Users/andrew.nester/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).ExecuteContextC(...)
        /Users/andrew.nester/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1080
github.com/databricks/cli/cmd/root.Execute({0x105ee2ce0, 0x106af60a0}, 0x1400019ec08)
        /Users/andrew.nester/cli/cmd/root/root.go:141 +0x108
main.main()
        /Users/andrew.nester/cli/main.go:29 +0x44
```

Now with
```
Error: cannot resolve bundle auth configuration: resolve: foobar.com multiple profiles matched: deco-staging, deco-staging-2, deco-staging-sp: please set DATABRICKS_CONFIG_PROFILE or provide --profile flag to specify one. Config: host=foobar.com
```

## Tests
Manually tested

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
