### PR TITLE
Acc: disable app-with-job on direct-exp

### DIFF
--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct-exp"]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/run/app-with-job/test.toml
+++ b/acceptance/bundle/run/app-with-job/test.toml
@@ -13,6 +13,9 @@ Ignore = [
     'databricks.yml',
 ]
 
+# As of Oct 16 2025 this test is failing on direct-exp engine - timing out on trying to stop the app
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
The test is currently failing in the nightly workflow and direct-exp engine is not released yet.
