### PR TITLE
Revert "Acc: disable app-with-job on direct-exp (#3776)"

### DIFF
--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -3,4 +3,4 @@ Cloud = true
 CloudSlow = true
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct-exp"]

--- a/acceptance/bundle/run/app-with-job/test.toml
+++ b/acceptance/bundle/run/app-with-job/test.toml
@@ -13,9 +13,6 @@ Ignore = [
     'databricks.yml',
 ]
 
-# As of Oct 16 2025 this test is failing on direct-exp engine - timing out on trying to stop the app
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]
-
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI


### PR DESCRIPTION


## Changes
<!-- Brief summary of your changes that is easy to understand -->

This reverts commit 538ac7774c36fee7f0bf7559587f33d0b381497f (PR #3776)

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

1) the test fails on both engines
2) I will add this test to known_failures instead - this way the test will keep running and we will see if/when it recovers
