### PR TITLE
Mark apps/run-local-node as slow

### DIFF
--- a/acceptance/cmd/workspace/apps/run-local-node/test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/test.toml
@@ -1,5 +1,6 @@
 Cloud = false
 Local = true
+Slow = true
 RecordRequests = false
 Timeout = '2m'
 TimeoutWindows = '10m'


### PR DESCRIPTION
## Why
Prevent 'make test' and PRs from failing.

The test is currently failing on PRs. Historically it's has been very flaky.