### PR TITLE
Hardcode TF version to v1.13.4 for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN /build/docker/setup.sh
 # Start from a fresh base image, to remove any build artifacts and scripts.
 FROM alpine:3.19
 
+ENV DATABRICKS_TF_VERSION "1.13.4"
 ENV DATABRICKS_TF_EXEC_PATH "/app/bin/terraform"
 ENV DATABRICKS_TF_CLI_CONFIG_FILE "/app/config/config.tfrc"
 ENV PATH="/app:${PATH}"


### PR DESCRIPTION
# Example how to use a later TF version in a Docker build.

## Prerequisites
- Go 1.25+ installed
- Docker installed

## Steps

### 1. Build the CLI binary
Build a static binary that can run in Alpine Linux:

```bash
CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o databricks
```

### 2. Build the Docker image

Build the Docker image with the desired architecture:

```
# For amd64
docker build -t databricks-cli --build-arg ARCH=amd64 .

# For arm64
docker build -t databricks-cli --build-arg ARCH=arm64 .
```

### 3. Verify the build

Test that the image works:

```
docker run --rm databricks-cli version
```

Notes

- The static binary (CGO_ENABLED=0) is required because the Docker image uses Alpine Linux with musl libc
- The Docker image includes Terraform v1.13.4 and the Databricks Terraform provider
- Environment variables are pre-configured in the image:
  - DATABRICKS_TF_VERSION=1.13.4
  - DATABRICKS_TF_EXEC_PATH=/app/bin/terraform