### PR TITLE
github: update Python from 3.9 to 3.13

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.9'
+          python-version: '3.13'
 
       - name: Install uv
         uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3


### PR DESCRIPTION
3.9 is legacy / unsupported anymore.

Some of our scripts already require 3.12.