### PR TITLE
Remove terraform.Write/Interpolate calls from various commands

### DIFF
--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/generate"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/bundle/resources"
@@ -362,8 +361,6 @@ func (d *dashboard) runForResource(ctx context.Context, b *bundle.Bundle) {
 	}
 
 	bundle.ApplySeqContext(ctx, b,
-		terraform.Interpolate(),
-		terraform.Write(),
 		statemgmt.StatePull(),
 		statemgmt.Load(),
 	)

--- a/cmd/bundle/open.go
+++ b/cmd/bundle/open.go
@@ -104,17 +104,6 @@ Use after deployment to quickly navigate to your resources in the workspace.`,
 			if logdiag.HasError(ctx) {
 				return root.ErrAlreadyPrinted
 			}
-
-			if !b.DirectDeployment {
-				bundle.ApplySeqContext(ctx, b,
-					terraform.Interpolate(),
-					terraform.Write(),
-				)
-			}
-
-			if logdiag.HasError(ctx) {
-				return root.ErrAlreadyPrinted
-			}
 		}
 
 		bundle.ApplySeqContext(ctx, b,

--- a/cmd/pipelines/dry_run.go
+++ b/cmd/pipelines/dry_run.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/databricks/cli/bundle"
-	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/bundle/resources"
 	"github.com/databricks/cli/bundle/run"
@@ -52,16 +51,6 @@ If there is only one pipeline in the project, KEY is optional and the pipeline w
 		key, _, err := resolveRunArgument(ctx, b, args)
 		if err != nil {
 			return err
-		}
-
-		if !b.DirectDeployment {
-			bundle.ApplySeqContext(ctx, b,
-				terraform.Interpolate(),
-				terraform.Write(),
-			)
-			if logdiag.HasError(ctx) {
-				return root.ErrAlreadyPrinted
-			}
 		}
 
 		bundle.ApplySeqContext(ctx, b,

--- a/cmd/pipelines/open.go
+++ b/cmd/pipelines/open.go
@@ -88,17 +88,6 @@ If there is only one pipeline in the project, KEY is optional and the pipeline w
 			if logdiag.HasError(ctx) {
 				return root.ErrAlreadyPrinted
 			}
-
-			if !b.DirectDeployment {
-				bundle.ApplySeqContext(ctx, b,
-					terraform.Interpolate(),
-					terraform.Write(),
-				)
-			}
-
-			if logdiag.HasError(ctx) {
-				return root.ErrAlreadyPrinted
-			}
 		}
 
 		bundle.ApplySeqContext(ctx, b,

--- a/cmd/pipelines/run.go
+++ b/cmd/pipelines/run.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/resources"
-	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/phases"
 	bundleresources "github.com/databricks/cli/bundle/resources"
 	"github.com/databricks/cli/bundle/run"
@@ -272,16 +271,6 @@ Refreshes all tables in the pipeline unless otherwise specified.`,
 		key, _, err := resolveRunArgument(ctx, b, args)
 		if err != nil {
 			return err
-		}
-
-		if !b.DirectDeployment {
-			bundle.ApplySeqContext(ctx, b,
-				terraform.Interpolate(),
-				terraform.Write(),
-			)
-			if logdiag.HasError(ctx) {
-				return root.ErrAlreadyPrinted
-			}
 		}
 
 		bundle.ApplySeqContext(ctx, b,

--- a/cmd/pipelines/stop.go
+++ b/cmd/pipelines/stop.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/databricks/cli/bundle"
 
-	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/phases"
 	"github.com/databricks/cli/bundle/resources"
 	"github.com/databricks/cli/bundle/run"
@@ -66,16 +65,6 @@ If there is only one pipeline in the project, KEY is optional and the pipeline w
 		key, err := resolveStopArgument(ctx, b, args)
 		if err != nil {
 			return err
-		}
-
-		if !b.DirectDeployment {
-			bundle.ApplySeqContext(ctx, b,
-				terraform.Interpolate(),
-				terraform.Write(),
-			)
-			if logdiag.HasError(ctx) {
-				return root.ErrAlreadyPrinted
-			}
 		}
 
 		bundle.ApplySeqContext(ctx, b,


### PR DESCRIPTION
## Changes

Remove terraform.Write/Interpolate calls from various commands
- bundle generate dashboard
- bundle open
- pipelines open / run / stop / dry_run

## Why
Follow up to https://github.com/databricks/cli/pull/3803 and https://github.com/databricks/cli/pull/3169

There used to be 'terraform show' call that needed it, but it's no longer used.

## Tests
Existing tests.