### PR TITLE
Remove unused `SimplePrompt` and `DefaultPrompt` functions

### DIFF
--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -203,35 +203,6 @@ func RunSelect(ctx context.Context, prompt *promptui.Select) (int, string, error
 	return prompt.Run()
 }
 
-func (c *cmdIO) simplePrompt(label string) *promptui.Prompt {
-	return &promptui.Prompt{
-		Label:  label,
-		Stdin:  io.NopCloser(c.in),
-		Stdout: nopWriteCloser{c.out},
-	}
-}
-
-func (c *cmdIO) SimplePrompt(label string) (value string, err error) {
-	return c.simplePrompt(label).Run()
-}
-
-func SimplePrompt(ctx context.Context, label string) (value string, err error) {
-	c := fromContext(ctx)
-	return c.SimplePrompt(label)
-}
-
-func (c *cmdIO) DefaultPrompt(label, defaultValue string) (value string, err error) {
-	prompt := c.simplePrompt(label)
-	prompt.Default = defaultValue
-	prompt.AllowEdit = true
-	return prompt.Run()
-}
-
-func DefaultPrompt(ctx context.Context, label, defaultValue string) (value string, err error) {
-	c := fromContext(ctx)
-	return c.DefaultPrompt(label, defaultValue)
-}
-
 func (c *cmdIO) Spinner(ctx context.Context) chan string {
 	var sp *spinner.Spinner
 	if c.interactive {


### PR DESCRIPTION
## Why

These functions were added in 5ed635a24 (Aug 2023) for the OAuth enrollment feature but became orphaned in c3ced68c6 (Nov 2023) when the Databricks SDK removed OAuth enrollment.

They have been unused for nearly 2 years.