### PR TITLE
Do not add 'development' in generated pipeline configuration

### DIFF
--- a/acceptance/bundle/generate/pipeline/test.toml
+++ b/acceptance/bundle/generate/pipeline/test.toml
@@ -5,6 +5,7 @@ Response.Body = '''
     "pipeline_id": 1234,
     "spec": {
         "name": "generate-pipeline",
+        "development": true,
         "clusters": [
             {
                 "custom_tags": {

--- a/bundle/generate/pipeline.go
+++ b/bundle/generate/pipeline.go
@@ -29,5 +29,6 @@ func ConvertPipelineToValue(pipeline *pipelines.PipelineSpec, rootPath, remoteRo
 	// - id: this is a read-only field
 	// - storage: changes to this field are rare because changing the storage recreates pipeline-related resources
 	// - edition: this field is rarely changed
-	return yamlsaver.ConvertToMapValue(pipeline, pipelineOrder, []string{"id", "storage", "edition"}, value)
+	// - development: this field is specific to the mode where it's used and does not need to be saved to the bundle configuration.
+	return yamlsaver.ConvertToMapValue(pipeline, pipelineOrder, []string{"id", "storage", "edition", "development"}, value)
 }


### PR DESCRIPTION
## Changes
Do not add 'development' in the generated pipeline configuration

## Why
This field is specific to the mode in which the pipeline is running and can be irrelevant for the generated config.
Otherwise it is possible to run into the issues like
```
Error: target with 'mode: production' cannot include a pipeline with 'development: true'
```

## Tests
Exisiting acceptance test pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
