### PR TITLE
acc: use really non existing subdomain

### DIFF
--- a/acceptance/auth/bundle_and_profile/.databrickscfg
+++ b/acceptance/auth/bundle_and_profile/.databrickscfg
@@ -2,4 +2,4 @@
 host = $DATABRICKS_HOST
 
 [profile_name]
-host = https://test@non-existing-subdomain.databricks.com
+host = https://test@non.existing.subdomain.databricks.com

--- a/acceptance/auth/bundle_and_profile/output.txt
+++ b/acceptance/auth/bundle_and_profile/output.txt
@@ -13,13 +13,13 @@
 
 === Inside the bundle, profile flag not matching bundle host. Should use profile from the flag and not the bundle.
 >>> errcode [CLI] current-user me -p profile_name
-Error: Credential was not sent or was of an unsupported type for this API. [ReqId: [UUID]]
+Error: Get "https://non.existing.subdomain.databricks.com/api/2.0/preview/scim/v2/Me": (redacted)
 
 Exit code: 1
 
 === Inside the bundle, target and not matching profile
 >>> errcode [CLI] current-user me -t dev -p profile_name
-Error: cannot resolve bundle auth configuration: the host in the profile (https://non-existing-subdomain.databricks.com) doesn’t match the host configured in the bundle ([DATABRICKS_TARGET]). The profile "DEFAULT" has host="[DATABRICKS_TARGET]" that matches host in the bundle. To select it, pass "-p DEFAULT"
+Error: cannot resolve bundle auth configuration: the host in the profile (https://non.existing.subdomain.databricks.com) doesn’t match the host configured in the bundle ([DATABRICKS_TARGET]). The profile "DEFAULT" has host="[DATABRICKS_TARGET]" that matches host in the bundle. To select it, pass "-p DEFAULT"
 
 
 Exit code: 1
@@ -48,7 +48,7 @@ Validation OK!
 
 === Bundle commands load bundle configuration with -p flag, validation not OK (profile host don't match bundle host)
 >>> errcode [CLI] bundle validate -p profile_name
-Error: cannot resolve bundle auth configuration: the host in the profile (https://non-existing-subdomain.databricks.com) doesn’t match the host configured in the bundle ([DATABRICKS_TARGET]). The profile "DEFAULT" has host="[DATABRICKS_TARGET]" that matches host in the bundle. To select it, pass "-p DEFAULT"
+Error: cannot resolve bundle auth configuration: the host in the profile (https://non.existing.subdomain.databricks.com) doesn’t match the host configured in the bundle ([DATABRICKS_TARGET]). The profile "DEFAULT" has host="[DATABRICKS_TARGET]" that matches host in the bundle. To select it, pass "-p DEFAULT"
 
 Name: test-auth
 Target: dev

--- a/acceptance/auth/bundle_and_profile/test.toml
+++ b/acceptance/auth/bundle_and_profile/test.toml
@@ -10,5 +10,5 @@ Old='DATABRICKS_URL'
 New='DATABRICKS_TARGET'
 
 [[Repls]]
-Old='Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": .*'
-New='Get "https://non-existing-subdomain.databricks.com/api/2.0/preview/scim/v2/Me": (redacted)'
+Old='Get "https://non.existing.subdomain.databricks.com/api/2.0/preview/scim/v2/Me": .*'
+New='Get "https://non.existing.subdomain.databricks.com/api/2.0/preview/scim/v2/Me": (redacted)'


### PR DESCRIPTION
https://non-existing-subdomain.databricks.com/ works now, that was not the intention.