### PR TITLE
acc: Fix `artifact_path_with_volume` tests after musterr change

### DIFF
--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
@@ -28,6 +28,4 @@ Error: volume main.schema-[UNIQUE_NAME].doesnotexist does not exist
   in databricks.yml:6:18
 
 
-Exit code (musterr): 1
-
 >>> [CLI] schemas delete main.schema-[UNIQUE_NAME]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/output.txt
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/output.txt
@@ -35,6 +35,4 @@ the volume using 'bundle deploy' and then switch over to using it in
 the artifact_path.
 
 
-Exit code (musterr): 1
-
 >>> [CLI] schemas delete main.schema-[UNIQUE_NAME]


### PR DESCRIPTION
## Changes

Update test outputs to remove 'Exit code (musterr): 1'.

This is no longer printed after the musterr function was modified to not log exit codes.

Needed after #3345.