### PR TITLE
Show a warning for source-linked deployment without mode development

### DIFF
--- a/bundle/config/mutator/apply_source_linked_deployment_preset.go
+++ b/bundle/config/mutator/apply_source_linked_deployment_preset.go
@@ -49,6 +49,20 @@ func (m *applySourceLinkedDeploymentPreset) Apply(ctx context.Context, b *bundle
 			b.Config.Presets.SourceLinkedDeployment = &disabled
 			return diags
 		}
+
+		if b.Config.Bundle.Mode != config.Development {
+			path := dyn.NewPath(dyn.Key("targets"), dyn.Key(target), dyn.Key("presets"), dyn.Key("source_linked_deployment"))
+			diags = diags.Append(
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "source-linked deployment in non-development mode is deprecated and will not be supported in a future release",
+					Paths: []dyn.Path{
+						path,
+					},
+					Locations: b.Config.GetLocations(path[2:].String()),
+				},
+			)
+		}
 	}
 
 	if isDatabricksWorkspace && b.Config.Bundle.Mode == config.Development {

--- a/bundle/config/mutator/apply_source_linked_deployment_preset_test.go
+++ b/bundle/config/mutator/apply_source_linked_deployment_preset_test.go
@@ -83,6 +83,7 @@ func TestApplyPresetsSourceLinkedDeployment(t *testing.T) {
 			ctx:  dbr.MockRuntime(testContext, dbr.Environment{IsDbr: true, Version: "15.4"}),
 			mutateBundle: func(b *bundle.Bundle) {
 				b.Config.Workspace.FilePath = "file_path"
+				b.Config.Bundle.Mode = config.Development
 			},
 			initialValue:    &enabled,
 			expectedValue:   &enabled,
@@ -95,10 +96,21 @@ func TestApplyPresetsSourceLinkedDeployment(t *testing.T) {
 				b.Config.Resources.Apps = map[string]*resources.App{
 					"app": {},
 				}
+				b.Config.Bundle.Mode = config.Development
 			},
 			initialValue:  &enabled,
 			expectedValue: &enabled,
 			expectedError: "source-linked deployment is not supported for apps",
+		},
+		{
+			name: "preset enabled, production mode, bundle in Workspace, databricks runtime",
+			ctx:  dbr.MockRuntime(testContext, dbr.Environment{IsDbr: true, Version: "15.4"}),
+			mutateBundle: func(b *bundle.Bundle) {
+				b.Config.Bundle.Mode = config.Production
+			},
+			initialValue:    &enabled,
+			expectedValue:   &enabled,
+			expectedWarning: "source-linked deployment in non-development mode is deprecated and will not be supported in a future release",
 		},
 	}
 


### PR DESCRIPTION
## Changes

Show a deprecation warning for source-linked deployments in non-development mode. Further plan is to stop supporting these deployments and raise an error

## Why

From @lennartkats-db:

> Resource-linked deployments should likely not be supported without mode: development. That’s potentially a trap: they will link to one source first and then to a different source (maybe from a different user) later

## Tests
Updated unit test, making proper acceptance test is tricky as we need to run it on DBR
