### PR TITLE
Fix test creating `terraform.tfstate` in source directory

### DIFF
--- a/bundle/deploy/terraform/util_test.go
+++ b/bundle/deploy/terraform/util_test.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/bundle"
@@ -86,10 +87,12 @@ func TestParseResourcesStateWithExistingStateFile(t *testing.T) {
 		  }
 		]
 	}`)
-	name, _ := b.StateFilenameTerraform(ctx)
-	err := os.WriteFile(name, data, os.ModePerm)
+	_, localPath := b.StateFilenameTerraform(ctx)
+	err := os.MkdirAll(filepath.Dir(localPath), 0o700)
 	assert.NoError(t, err)
-	state, err := parseResourcesState(ctx, name)
+	err = os.WriteFile(localPath, data, 0o600)
+	assert.NoError(t, err)
+	state, err := parseResourcesState(ctx, localPath)
 	assert.NoError(t, err)
 	expected := ExportedResourcesMap{
 		"pipelines": map[string]ResourceState{


### PR DESCRIPTION
## Changes

PR #3797 replaced a function that returns a state file path with one that returns both a filename and a path. The test used only the filename, causing the state file to be created in the wrong directory.

In the current state, it creates the file in `$PWD`, equal to the directory where the test file is located. The path in `localPath` is located inside the bundle cache directory, which is initialized to somewhere inside `t.TempDir()` above.