### PR TITLE
Update lakeflow template project_name validation message

### DIFF
--- a/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
+++ b/libs/template/templates/lakeflow-pipelines/databricks_template_schema.json
@@ -17,7 +17,7 @@
             "description": "\nUnique name for this project",
             "order": 1,
             "pattern": "^[a-z0-9_]+$",
-            "pattern_match_failure_message": "Name must consist of letters, numbers, and underscores."
+            "pattern_match_failure_message": "Name must consist of lower case letters, numbers, and underscores."
         },
         "project_name_short": {
             "//": "This is a derived property based on project_name (it replaces lakeflow_project with lakeflow and strips _project|_app|_service)",


### PR DESCRIPTION
## Changes
Updated to align with the pattern
## Why

Why not change the pattern to allow uppercase? It is lowercase because this name is used for certain Python modules and functions. So we'd need to accept that we're breaking the Python conventions if we allow upper case

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
