### PR TITLE
Use `cmdio.IsPromptSupported()` more widely

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -35,7 +35,7 @@ GCP: https://docs.gcp.databricks.com/dev-tools/auth/index.html`,
 }
 
 func promptForHost(ctx context.Context) (string, error) {
-	if !cmdio.IsInTTY(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return "", errors.New("the command is being run in a non-interactive environment, please specify a host using --host")
 	}
 
@@ -45,7 +45,7 @@ func promptForHost(ctx context.Context) (string, error) {
 }
 
 func promptForAccountID(ctx context.Context) (string, error) {
-	if !cmdio.IsInTTY(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return "", errors.New("the command is being run in a non-interactive environment, please specify an account ID using --account-id")
 	}
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -24,7 +24,7 @@ import (
 )
 
 func promptForProfile(ctx context.Context, defaultValue string) (string, error) {
-	if !cmdio.IsInTTY(ctx) {
+	if !cmdio.IsPromptSupported(ctx) {
 		return "", nil
 	}
 

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -33,7 +33,7 @@ func TestSetHostDoesNotFailWithNoDatabrickscfg(t *testing.T) {
 func TestSetHost(t *testing.T) {
 	var authArguments auth.AuthArguments
 	t.Setenv("DATABRICKS_CONFIG_FILE", "./testdata/.databrickscfg")
-	ctx, _ := cmdio.SetupTest(context.Background())
+	ctx, _ := cmdio.SetupTest(context.Background(), cmdio.TestOptions{})
 
 	profile1 := loadTestProfile(t, ctx, "profile-1")
 	profile2 := loadTestProfile(t, ctx, "profile-2")
@@ -76,7 +76,7 @@ func TestSetHost(t *testing.T) {
 func TestSetAccountId(t *testing.T) {
 	var authArguments auth.AuthArguments
 	t.Setenv("DATABRICKS_CONFIG_FILE", "./testdata/.databrickscfg")
-	ctx, _ := cmdio.SetupTest(context.Background())
+	ctx, _ := cmdio.SetupTest(context.Background(), cmdio.TestOptions{})
 
 	accountProfile := loadTestProfile(t, ctx, "account-profile")
 

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -128,7 +128,7 @@ The host must be specified with the --host flag or the DATABRICKS_HOST environme
 		}
 
 		ctx := cmd.Context()
-		if cmdio.IsInTTY(ctx) && cmdio.IsOutTTY(ctx) {
+		if cmdio.IsPromptSupported(ctx) {
 			err = configureInteractive(cmd, &flags, &cfg)
 		} else {
 			err = configureNonInteractive(cmd, &flags, &cfg)

--- a/cmd/root/auth_test.go
+++ b/cmd/root/auth_test.go
@@ -39,7 +39,7 @@ func expectPrompts(t *testing.T, fn promptFn, config *config.Config) {
 	// Channel to pass errors from the prompting function back to the test.
 	errch := make(chan error, 1)
 
-	ctx, io := cmdio.SetupTest(ctx)
+	ctx, io := cmdio.SetupTest(ctx, cmdio.TestOptions{PromptSupported: true})
 	go func() {
 		defer close(errch)
 		defer cancel()
@@ -61,7 +61,7 @@ func expectReturns(t *testing.T, fn promptFn, config *config.Config) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	ctx, _ = cmdio.SetupTest(ctx)
+	ctx, _ = cmdio.SetupTest(ctx, cmdio.TestOptions{PromptSupported: true})
 	client, err := fn(ctx, config, true)
 	require.NoError(t, err)
 	require.NotNil(t, client)
@@ -224,7 +224,7 @@ func TestMustAccountClientWorksWithDatabricksCfg(t *testing.T) {
 func TestMustAccountClientWorksWithNoDatabricksCfgButEnvironmentVariables(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
-	ctx, tt := cmdio.SetupTest(context.Background())
+	ctx, tt := cmdio.SetupTest(context.Background(), cmdio.TestOptions{PromptSupported: true})
 	t.Cleanup(tt.Done)
 	cmd := New(ctx)
 	t.Setenv("DATABRICKS_HOST", "https://accounts.azuredatabricks.net/")
@@ -238,7 +238,7 @@ func TestMustAccountClientWorksWithNoDatabricksCfgButEnvironmentVariables(t *tes
 func TestMustAccountClientErrorsWithNoDatabricksCfg(t *testing.T) {
 	testutil.CleanupEnvironment(t)
 
-	ctx, tt := cmdio.SetupTest(context.Background())
+	ctx, tt := cmdio.SetupTest(context.Background(), cmdio.TestOptions{PromptSupported: true})
 	t.Cleanup(tt.Done)
 	cmd := New(ctx)
 
@@ -261,7 +261,7 @@ func TestMustAnyClientCanCreateWorkspaceClient(t *testing.T) {
 		0o755)
 	require.NoError(t, err)
 
-	ctx, tt := cmdio.SetupTest(context.Background())
+	ctx, tt := cmdio.SetupTest(context.Background(), cmdio.TestOptions{PromptSupported: true})
 	t.Cleanup(tt.Done)
 	cmd := New(ctx)
 
@@ -290,7 +290,7 @@ func TestMustAnyClientCanCreateAccountClient(t *testing.T) {
 		0o755)
 	require.NoError(t, err)
 
-	ctx, tt := cmdio.SetupTest(context.Background())
+	ctx, tt := cmdio.SetupTest(context.Background(), cmdio.TestOptions{PromptSupported: true})
 	t.Cleanup(tt.Done)
 	cmd := New(ctx)
 
@@ -314,7 +314,7 @@ func TestMustAnyClientWithEmptyDatabricksCfg(t *testing.T) {
 		0o755)
 	require.NoError(t, err)
 
-	ctx, tt := cmdio.SetupTest(context.Background())
+	ctx, tt := cmdio.SetupTest(context.Background(), cmdio.TestOptions{PromptSupported: true})
 	t.Cleanup(tt.Done)
 	cmd := New(ctx)
 

--- a/cmd/workspace/secrets/put_secret.go
+++ b/cmd/workspace/secrets/put_secret.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-	"os"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
@@ -117,9 +116,9 @@ func newPutSecret() *cobra.Command {
 }
 
 func promptSecret(cmd *cobra.Command) ([]byte, error) {
-	// If stdin is a TTY, prompt for the secret.
-	if !cmdio.IsInTTY(cmd.Context()) {
-		return io.ReadAll(os.Stdin)
+	// If prompting is not supported, read secret from stdin.
+	if !cmdio.IsPromptSupported(cmd.Context()) {
+		return io.ReadAll(cmd.InOrStdin())
 	}
 
 	value, err := cmdio.Secret(cmd.Context(), "Please enter your secret value")

--- a/libs/cmdio/io_test.go
+++ b/libs/cmdio/io_test.go
@@ -8,14 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsPromptSupportedFalseForGitBash(t *testing.T) {
+func TestIsGitBash(t *testing.T) {
 	ctx := context.Background()
-	ctx, _ = SetupTest(ctx)
-
-	assert.True(t, IsPromptSupported(ctx))
+	assert.False(t, isGitBash(ctx))
 
 	ctx = env.Set(ctx, "MSYSTEM", "MINGW64")
 	ctx = env.Set(ctx, "TERM", "xterm")
 	ctx = env.Set(ctx, "PS1", "\\[\033]0;$TITLEPREFIX:$PWD\007\\]\n\\[\033[32m\\]\\u@\\h \\[\033[35m\\]$MSYSTEM \\[\033[33m\\]\\w\\[\033[36m\\]`__git_ps1`\\[\033[0m\\]\n$")
-	assert.False(t, IsPromptSupported(ctx))
+	assert.True(t, isGitBash(ctx))
 }

--- a/libs/cmdio/testing.go
+++ b/libs/cmdio/testing.go
@@ -14,13 +14,26 @@ type Test struct {
 	Stderr *bufio.Reader
 }
 
-func SetupTest(ctx context.Context) (context.Context, *Test) {
+type TestOptions struct {
+	// PromptSupported indicates whether IsPromptSupported should return true
+	// for the test context. If false (default), prompting will fail as it would
+	// in a non-interactive environment (e.g., CI).
+	PromptSupported bool
+}
+
+// SetupTest creates a cmdio context with pipes for stdin/stdout/stderr.
+// This is useful for testing interactive I/O operations.
+//
+// By default, IsPromptSupported returns false for the test context because
+// pipes are not TTYs. To test prompt logic, pass TestOptions{PromptSupported: true}.
+func SetupTest(ctx context.Context, opts TestOptions) (context.Context, *Test) {
 	rin, win := io.Pipe()
 	rout, wout := io.Pipe()
 	rerr, werr := io.Pipe()
 
 	cmdio := &cmdIO{
 		interactive: true,
+		prompt:      opts.PromptSupported,
 		in:          rin,
 		out:         wout,
 		err:         werr,

--- a/libs/template/config.go
+++ b/libs/template/config.go
@@ -259,8 +259,7 @@ func (c *config) promptForValues(r *renderer) error {
 // Prompt user for any missing config values. Assign default values if
 // terminal is not TTY
 func (c *config) promptOrAssignDefaultValues(r *renderer) error {
-	// TODO: replace with IsPromptSupported call (requires fixing TestAccBundleInitErrorOnUnknownFields test)
-	if cmdio.IsOutTTY(c.ctx) && cmdio.IsInTTY(c.ctx) && !cmdio.IsGitBash(c.ctx) {
+	if cmdio.IsPromptSupported(c.ctx) {
 		return c.promptForValues(r)
 	}
 	log.Debugf(c.ctx, "Terminal is not TTY. Assigning default values to template input parameters")


### PR DESCRIPTION
## Changes

All prompting logic under `cmd/` now uses a single `IsPromptSupported()` function instead of ad-hoc TTY checks:

### Before
Callers checked various combinations:
- `IsInTTY(ctx) && IsOutTTY(ctx)` 
- `!IsInTTY(ctx)`
- `IsOutTTY(ctx) && IsInTTY(ctx) && !IsGitBash(ctx)`

### After
All callers use:
```go
if cmdio.IsPromptSupported(ctx) {
    // prompt user
} else {
    // return error or use non-interactive fallback
}
```

### Behavior Changes
Prompting now requires ALL of:
- Interactive mode (no dumb terminal, no NO_COLOR)
- stdin to be a TTY (for reading input)
- stdout to be a TTY (for showing prompts)
- Not running in Git Bash on Windows

This prevents prompting in edge cases that weren't properly handled before (e.g., TTY stdin with piped stdout).

## Why

Higher level capability checks mean we can more easily swap out what we do for terminal I/O.

## Tests

Existing tests pass.

Manually ran `configure` and `auth login` commands.