### PR TITLE
Fix race condition in `cmdio.LogString`

### DIFF
--- a/libs/cmdio/compat.go
+++ b/libs/cmdio/compat.go
@@ -23,8 +23,7 @@ func Log(ctx context.Context, str fmt.Stringer) {
 // It writes the string to the error writer.
 func LogString(ctx context.Context, str string) {
 	c := fromContext(ctx)
-	_, _ = io.WriteString(c.err, str)
-	_, _ = io.WriteString(c.err, "\n")
+	_, _ = io.WriteString(c.err, str+"\n")
 }
 
 // readLine reads a line from the reader and returns it without the trailing newline characters.


### PR DESCRIPTION
## Changes

Make `LogString` write the string and newline in a single call to reduce the likelihood of interleaved output when called concurrently. This was atomic until #3818 where I removed the lock, assuming it wasn't necessary.

Note: This fix assumes `io.WriteString` provides atomic writes for small messages, which is not guaranteed.

## Why

Fixes flaky test from: https://github.com/databricks/cli/actions/runs/18995883239/job/54255615389