### PR TITLE
Include API error message in cluster update retry

### DIFF
--- a/bundle/direct/dresources/cluster.go
+++ b/bundle/direct/dresources/cluster.go
@@ -98,7 +98,7 @@ func (r *ResourceCluster) DoUpdate(ctx context.Context, id string, config *compu
 		// Only Running and Terminated clusters can be modified. In particular, autoscaling clusters cannot be modified
 		// while the resizing is ongoing. We retry in this case. Scaling can take several minutes.
 		if errors.As(err, &apiErr) && apiErr.ErrorCode == "INVALID_STATE" {
-			return nil, retries.Continues(fmt.Sprintf("cluster %s cannot be modified in its current state", id))
+			return nil, retries.Continues(fmt.Sprintf("cluster %s cannot be modified in its current state: %s", id, apiErr.Message))
 		}
 		return nil, retries.Halt(err)
 	})


### PR DESCRIPTION
## Why

I saw this error in an integration test and the underlying cause was missing.

## Tests

We don't have an existing acceptance test for this and need to capture the set of possible errors first.