### PR TITLE
Add development entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ tools/golangci-lint
 
 # Release artifacts
 dist/
+
+# Local development notes, tmp
+/pr-*
+/tmp/


### PR DESCRIPTION
## Changes
Add /pr-* and /tmp/ to .gitignore to prevent local development notes and temporary files from being tracked.

## Why

- Adding `/tmp/` gives agents a scratch space inside the current directory that is safe from accidental commits
- Adding `/pr-*` allows for tracking descriptions of pending pull requests in markdown files, again safe from accidental commits

Accidental commits of files that aren't git-ignored are more prone to happening with agents, so I previously had to manually revert commits of files like the above. Having them listed in .gitignore makes it easier for agents to do the right thing.