### PR TITLE
Homebrew tap action needs to depend on goreleaser-unix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
       group: databricks-deco-testing-runner-group
       labels: ubuntu-latest-deco
 
-    needs: upload-windows-to-release
+    needs: [goreleaser-unix, upload-windows-to-release]
 
     steps:
       - name: Set VERSION variable from tag


### PR DESCRIPTION
## Changes
Homebrew tap action needs to depend on goreleaser-unix

## Why
  This resolves the ReferenceError: Cannot access 'artifacts' before initialization error because the job now waits
  for goreleaser-unix to complete and can access its artifacts output at line 192.

