### PR TITLE
Merge unix and windows SHA files into one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,43 @@ jobs:
           name: windows-artifacts
           path: dist
 
+      - name: Download Unix checksum file from release
+        run: |
+          VERSION=${{ github.ref_name }}
+          VERSION_NO_V=${VERSION:1}
+
+          echo "Downloading Unix checksum file..."
+          gh release download ${{ github.ref_name }} \
+            --pattern "databricks_cli_${VERSION_NO_V}_SHA256SUMS_unix" \
+            --dir dist \
+            --repo ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge checksum files
+        run: |
+          VERSION=${{ github.ref_name }}
+          VERSION_NO_V=${VERSION:1}
+
+          echo "Merging Unix and Windows checksum files..."
+          cat dist/databricks_cli_${VERSION_NO_V}_SHA256SUMS_unix > dist/databricks_cli_${VERSION_NO_V}_SHA256SUMS
+          cat dist/databricks_cli_${VERSION_NO_V}_SHA256SUMS_windows >> dist/databricks_cli_${VERSION_NO_V}_SHA256SUMS
+
+          echo "Merged SHA256SUMS file contents:"
+          cat dist/databricks_cli_${VERSION_NO_V}_SHA256SUMS
+
+      - name: Verify checksums after download
+        run: |
+          echo "Verifying Windows artifact checksums after download..."
+          for file in dist/*.zip; do
+            if [ -f "$file" ]; then
+              sha256sum "$file"
+            fi
+          done
+
       - name: Upload to GitHub release
         run: |
-          for file in dist/*.zip dist/*SHA256SUMS*; do
+          for file in dist/*.zip dist/*SHA256SUMS; do
             if [ -f "$file" ]; then
               echo "Uploading $(basename $file)"
               gh release upload ${{ github.ref_name }} "$file" --repo ${{ github.repository }}


### PR DESCRIPTION
## Changes
Merge unix and windows SHA files into one

## Why
The Komac tool (and any other tools expecting a unified checksum file) will now find the correct checksums in the standard databricks_cli_{{ .Version }}_SHA256SUMS file that contains entries for all platforms.
