### PR TITLE
Use bigger runner for linux

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
         os:
           - macos-latest
           - group: databricks-protected-runner-group-large
-            label: linux-ubuntu-latest-large
+            labels: linux-ubuntu-latest-large
           - windows-latest
         deployment:
           - "terraform"


### PR DESCRIPTION
## Changes
Use new 8 core runners for ubuntu tests.

On this PR
- direct tests took 1m38s. Previous times from most recent closed PRs:  2m 36s, 2m 30s,  2m 29s.
- terraform tests took  6m10s. Previous times: 10m 51s, 10m 59s, 10m 47s.
