### PR TITLE
Make Apps DevEx team code owners for the  command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 /acceptance/pipelines/    @jefferycheng1 @kanterov @lennartkats-db
 /cmd/pipelines/           @jefferycheng1 @kanterov @lennartkats-db
 /cmd/labs/                @alexott @nfx
-/cmd/workspace/apps/      @fjakobs @arsenyinfo @keugenek @igrekun @MarioCadenas @ditadi @pkosiec
-/libs/apps/               @fjakobs @arsenyinfo @keugenek @igrekun @MarioCadenas @ditadi @pkosiec
-/acceptance/apps/         @fjakobs @arsenyinfo @keugenek @igrekun @MarioCadenas @ditadi @pkosiec
+/cmd/workspace/apps/      @databricks/eng-app-devex
+/libs/apps/               @databricks/eng-app-devex
+/acceptance/apps/         @databricks/eng-app-devex


### PR DESCRIPTION
## Changes

Add the App DevEx team to the code owners of the `apps` command
