### PR TITLE
Move libs/apps code into libs/apps/runlocal subdirectory

### DIFF
--- a/libs/apps/runlocal/apps.go
+++ b/libs/apps/runlocal/apps.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"

--- a/libs/apps/runlocal/cfg.go
+++ b/libs/apps/runlocal/cfg.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import "fmt"
 

--- a/libs/apps/runlocal/env.go
+++ b/libs/apps/runlocal/env.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"strconv"

--- a/libs/apps/runlocal/headers.go
+++ b/libs/apps/runlocal/headers.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"github.com/databricks/databricks-sdk-go/service/iam"

--- a/libs/apps/runlocal/node.go
+++ b/libs/apps/runlocal/node.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"

--- a/libs/apps/runlocal/python.go
+++ b/libs/apps/runlocal/python.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"

--- a/libs/apps/runlocal/python_test.go
+++ b/libs/apps/runlocal/python_test.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"

--- a/libs/apps/runlocal/run.go
+++ b/libs/apps/runlocal/run.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"

--- a/libs/apps/runlocal/spec.go
+++ b/libs/apps/runlocal/spec.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"

--- a/libs/apps/runlocal/spec_test.go
+++ b/libs/apps/runlocal/spec_test.go
@@ -1,4 +1,4 @@
-package apps
+package runlocal
 
 import (
 	"context"


### PR DESCRIPTION
## Changes

The code in `libs/apps` was specific to the `apps run-local` command.

This moves it to `libs/apps/runlocal` to make `libs/apps` a collection of packages rather than a single package.

## Why

Make space for other libraries under `libs/apps`.

## Tests

n/a