### PR TITLE
Do not run windows tests on merge_group

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,10 +42,12 @@ jobs:
           - macos-latest
           - group: databricks-protected-runner-group-large
             labels: linux-ubuntu-latest-large
-          - windows-latest
+          - ${{ github.event_name != 'merge_group' && 'windows-latest' || null }}
         deployment:
           - "terraform"
           - "direct"
+        exclude:
+          - os: null
 
     steps:
       - name: Checkout repository and submodules


### PR DESCRIPTION
## Why
It takes a lot of time and we already run tests on PR and on push to main.

## Tests
This PR if automerges, then it works.