### PR TITLE
internal: Rename DoRefresh to DoRead

### DIFF
--- a/bundle/direct/apply.go
+++ b/bundle/direct/apply.go
@@ -234,7 +234,7 @@ func (d *DeploymentUnit) refreshRemoteState(ctx context.Context, id string) erro
 	if d.RemoteState != nil {
 		return nil
 	}
-	remoteState, err := d.Adapter.DoRefresh(ctx, id)
+	remoteState, err := d.Adapter.DoRead(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to refresh remote state id=%s: %w", id, err)
 	}

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -99,7 +99,7 @@ func (b *DeploymentBundle) CalculatePlan(ctx context.Context, client *databricks
 				return false
 			}
 
-			remoteState, err := adapter.DoRefresh(ctx, dbentry.ID)
+			remoteState, err := adapter.DoRead(ctx, dbentry.ID)
 			if err != nil {
 				if isResourceGone(err) {
 					// no such resource
@@ -150,7 +150,7 @@ func (b *DeploymentBundle) CalculatePlan(ctx context.Context, client *databricks
 			return false
 		}
 
-		remoteState, err := adapter.DoRefresh(ctx, dbentry.ID)
+		remoteState, err := adapter.DoRead(ctx, dbentry.ID)
 		if err != nil {
 			if isResourceGone(err) {
 				remoteState = nil

--- a/bundle/direct/dresources/README.md
+++ b/bundle/direct/dresources/README.md
@@ -9,7 +9,7 @@
  - Each Create/Update/Delete method should correspond to one API call. We persist state right after, so there is minimum chance of having orphaned resources.
  - The logic what kind of update it is should be in FieldTriggers / ClassifyChange methods. The methods performing update should not have logic in them on what method to call.
  - Create/Update/Delete methods should not need to read any state. (We can implement support for passing remoteState we already to these methods if such need arises though).
- - Prefer “with refresh” variants of methods if resource API supports that. That avoids explicit DoRefresh() call.
+ - Prefer “with refresh” variants of methods if resource API supports that. That avoids explicit DoRead() call.
 
 Nice to have
  - Add link to corresponding API documentation before each method.

--- a/bundle/direct/dresources/adapter.go
+++ b/bundle/direct/dresources/adapter.go
@@ -33,9 +33,9 @@ type IResource interface {
 	// Example: func (*ResourceJob) RemapState(jobs *jobs.Job) *jobs.JobSettings
 	RemapState(input any) any
 
-	// DoRefresh reads and returns remote state from the backend. The return type defines schema for remote field resolution.
-	// Example: func (r *ResourceJob) DoRefresh(ctx context.Context, id string) (*jobs.Job, error)
-	DoRefresh(ctx context.Context, id string) (remoteState any, e error)
+	// DoRead reads and returns remote state from the backend. The return type defines schema for remote field resolution.
+	// Example: func (r *ResourceJob) DoRead(ctx context.Context, id string) (*jobs.Job, error)
+	DoRead(ctx context.Context, id string) (remoteState any, e error)
 
 	// DoDelete deletes the resource.
 	// Example: func (r *ResourceJob) DoDelete(ctx context.Context, id string) error
@@ -210,7 +210,7 @@ func (a *Adapter) initMethods(resource any) error {
 		return err
 	}
 
-	a.doRefresh, err = prepareCallRequired(resource, "DoRefresh")
+	a.doRefresh, err = prepareCallRequired(resource, "DoRead")
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (a *Adapter) RemapState(remoteState any) (any, error) {
 	return outs[0], nil
 }
 
-func (a *Adapter) DoRefresh(ctx context.Context, id string) (any, error) {
+func (a *Adapter) DoRead(ctx context.Context, id string) (any, error) {
 	outs, err := a.doRefresh.Call(ctx, id)
 	if err != nil {
 		return nil, err

--- a/bundle/direct/dresources/alert.go
+++ b/bundle/direct/dresources/alert.go
@@ -22,8 +22,8 @@ func (*ResourceAlert) PrepareState(input *resources.Alert) *sql.AlertV2 {
 	return &input.AlertV2
 }
 
-// DoRefresh reads the alert by id.
-func (r *ResourceAlert) DoRefresh(ctx context.Context, id string) (*sql.AlertV2, error) {
+// DoRead reads the alert by id.
+func (r *ResourceAlert) DoRead(ctx context.Context, id string) (*sql.AlertV2, error) {
 	return r.client.AlertsV2.GetAlertById(ctx, id)
 }
 

--- a/bundle/direct/dresources/all_test.go
+++ b/bundle/direct/dresources/all_test.go
@@ -404,8 +404,8 @@ func testCRUD(t *testing.T, group string, adapter *Adapter, client *databricks.W
 
 	ctx := context.Background()
 
-	// initial DoRefresh() cannot find the resource
-	remote, err := adapter.DoRefresh(ctx, "1234")
+	// initial DoRead() cannot find the resource
+	remote, err := adapter.DoRead(ctx, "1234")
 	require.Nil(t, remote)
 	require.Error(t, err)
 	// TODO: if errors.Is(err, databricks.ErrResourceDoesNotExist) {... }
@@ -414,7 +414,7 @@ func testCRUD(t *testing.T, group string, adapter *Adapter, client *databricks.W
 	require.NoError(t, err, "DoCreate failed state=%v", newState)
 	require.NotEmpty(t, createdID, "ID returned from DoCreate was empty")
 
-	remote, err = adapter.DoRefresh(ctx, createdID)
+	remote, err = adapter.DoRead(ctx, createdID)
 	require.NoError(t, err)
 	require.NotNil(t, remote)
 
@@ -503,7 +503,7 @@ func testCRUD(t *testing.T, group string, adapter *Adapter, client *databricks.W
 
 	deleteIsNoop := strings.HasSuffix(group, "permissions") || strings.HasSuffix(group, "grants")
 
-	remoteAfterDelete, err := adapter.DoRefresh(ctx, createdID)
+	remoteAfterDelete, err := adapter.DoRead(ctx, createdID)
 	if deleteIsNoop {
 		require.NoError(t, err)
 	} else {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -24,7 +24,7 @@ func (*ResourceApp) PrepareState(input *resources.App) *apps.App {
 	return &input.App
 }
 
-func (r *ResourceApp) DoRefresh(ctx context.Context, id string) (*apps.App, error) {
+func (r *ResourceApp) DoRead(ctx context.Context, id string) (*apps.App, error) {
 	return r.client.Apps.GetByName(ctx, id)
 }
 

--- a/bundle/direct/dresources/cluster.go
+++ b/bundle/direct/dresources/cluster.go
@@ -73,7 +73,7 @@ func (r *ResourceCluster) RemapState(input *compute.ClusterDetails) *compute.Clu
 	return spec
 }
 
-func (r *ResourceCluster) DoRefresh(ctx context.Context, id string) (*compute.ClusterDetails, error) {
+func (r *ResourceCluster) DoRead(ctx context.Context, id string) (*compute.ClusterDetails, error) {
 	return r.client.Clusters.GetByClusterId(ctx, id)
 }
 

--- a/bundle/direct/dresources/dashboard.go
+++ b/bundle/direct/dresources/dashboard.go
@@ -85,7 +85,7 @@ func (r *ResourceDashboard) RemapState(state *resources.DashboardConfig) *resour
 	}
 }
 
-func (r *ResourceDashboard) DoRefresh(ctx context.Context, id string) (*resources.DashboardConfig, error) {
+func (r *ResourceDashboard) DoRead(ctx context.Context, id string) (*resources.DashboardConfig, error) {
 	var dashboard *dashboards.Dashboard
 	var publishedDashboard *dashboards.PublishedDashboard
 

--- a/bundle/direct/dresources/database_catalog.go
+++ b/bundle/direct/dresources/database_catalog.go
@@ -20,7 +20,7 @@ func (*ResourceDatabaseCatalog) PrepareState(input *resources.DatabaseCatalog) *
 	return &input.DatabaseCatalog
 }
 
-func (r *ResourceDatabaseCatalog) DoRefresh(ctx context.Context, id string) (*database.DatabaseCatalog, error) {
+func (r *ResourceDatabaseCatalog) DoRead(ctx context.Context, id string) (*database.DatabaseCatalog, error) {
 	return r.client.Database.GetDatabaseCatalogByName(ctx, id)
 }
 

--- a/bundle/direct/dresources/database_instance.go
+++ b/bundle/direct/dresources/database_instance.go
@@ -21,7 +21,7 @@ func (*ResourceDatabaseInstance) PrepareState(input *resources.DatabaseInstance)
 	return &input.DatabaseInstance
 }
 
-func (d *ResourceDatabaseInstance) DoRefresh(ctx context.Context, id string) (*database.DatabaseInstance, error) {
+func (d *ResourceDatabaseInstance) DoRead(ctx context.Context, id string) (*database.DatabaseInstance, error) {
 	return d.client.Database.GetDatabaseInstanceByName(ctx, id)
 }
 

--- a/bundle/direct/dresources/experiment.go
+++ b/bundle/direct/dresources/experiment.go
@@ -38,7 +38,7 @@ func (*ResourceExperiment) RemapState(experiment *ml.Experiment) *ml.CreateExper
 	}
 }
 
-func (r *ResourceExperiment) DoRefresh(ctx context.Context, id string) (*ml.Experiment, error) {
+func (r *ResourceExperiment) DoRead(ctx context.Context, id string) (*ml.Experiment, error) {
 	result, err := r.client.Experiments.GetExperiment(ctx, ml.GetExperimentRequest{
 		ExperimentId: id,
 	})

--- a/bundle/direct/dresources/grants.go
+++ b/bundle/direct/dresources/grants.go
@@ -118,7 +118,7 @@ func (*ResourceGrants) PrepareState(state *GrantsState) *GrantsState {
 	return state
 }
 
-func (r *ResourceGrants) DoRefresh(ctx context.Context, id string) (*GrantsState, error) {
+func (r *ResourceGrants) DoRead(ctx context.Context, id string) (*GrantsState, error) {
 	securableType, fullName, err := parseGrantsID(id)
 	if err != nil {
 		return nil, err

--- a/bundle/direct/dresources/job.go
+++ b/bundle/direct/dresources/job.go
@@ -29,7 +29,7 @@ func (*ResourceJob) RemapState(jobs *jobs.Job) *jobs.JobSettings {
 	return jobs.Settings
 }
 
-func (r *ResourceJob) DoRefresh(ctx context.Context, id string) (*jobs.Job, error) {
+func (r *ResourceJob) DoRead(ctx context.Context, id string) (*jobs.Job, error) {
 	idInt, err := parseJobID(id)
 	if err != nil {
 		return nil, err

--- a/bundle/direct/dresources/model.go
+++ b/bundle/direct/dresources/model.go
@@ -31,7 +31,7 @@ func (*ResourceMlflowModel) RemapState(model *ml.ModelDatabricks) *ml.CreateMode
 	}
 }
 
-func (r *ResourceMlflowModel) DoRefresh(ctx context.Context, id string) (*ml.ModelDatabricks, error) {
+func (r *ResourceMlflowModel) DoRead(ctx context.Context, id string) (*ml.ModelDatabricks, error) {
 	response, err := r.client.ModelRegistry.GetModel(ctx, ml.GetModelRequest{
 		Name: id,
 	})
@@ -46,7 +46,7 @@ func (r *ResourceMlflowModel) DoCreate(ctx context.Context, config *ml.CreateMod
 	if err != nil {
 		return "", nil, err
 	}
-	// Create API call returns [ml.Model] while DoRefresh returns [ml.ModelDatabricks].
+	// Create API call returns [ml.Model] while DoRead returns [ml.ModelDatabricks].
 	// Thus we need to convert the response to the expected type.
 	modelDatabricks := &ml.ModelDatabricks{
 		Name:            response.RegisteredModel.Name,
@@ -80,7 +80,7 @@ func (r *ResourceMlflowModel) DoUpdate(ctx context.Context, id string, config *m
 		return nil, err
 	}
 
-	// Update API call returns [ml.Model] while DoRefresh returns [ml.ModelDatabricks].
+	// Update API call returns [ml.Model] while DoRead returns [ml.ModelDatabricks].
 	// Thus we need to convert the response to the expected type.
 	modelDatabricks := &ml.ModelDatabricks{
 		Name:            response.RegisteredModel.Name,

--- a/bundle/direct/dresources/model_serving_endpoint.go
+++ b/bundle/direct/dresources/model_serving_endpoint.go
@@ -104,7 +104,7 @@ type RefreshOutput struct {
 	EndpointId      string                           `json:"endpoint_id"`
 }
 
-func (r *ResourceModelServingEndpoint) DoRefresh(ctx context.Context, id string) (*RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) DoRead(ctx context.Context, id string) (*RefreshOutput, error) {
 	endpoint, err := r.client.ServingEndpoints.GetByName(ctx, id)
 	if err != nil {
 		return nil, err

--- a/bundle/direct/dresources/permissions.go
+++ b/bundle/direct/dresources/permissions.go
@@ -106,7 +106,7 @@ func parsePermissionsID(id string) (extractedType, extractedID string, err error
 	return extractedType, extractedID, nil
 }
 
-func (r *ResourcePermissions) DoRefresh(ctx context.Context, id string) (*PermissionsState, error) {
+func (r *ResourcePermissions) DoRead(ctx context.Context, id string) (*PermissionsState, error) {
 	extractedType, extractedID, err := parsePermissionsID(id)
 	if err != nil {
 		return nil, err

--- a/bundle/direct/dresources/pipeline.go
+++ b/bundle/direct/dresources/pipeline.go
@@ -64,7 +64,7 @@ func (*ResourcePipeline) RemapState(p *pipelines.GetPipelineResponse) *pipelines
 	}
 }
 
-func (r *ResourcePipeline) DoRefresh(ctx context.Context, id string) (*pipelines.GetPipelineResponse, error) {
+func (r *ResourcePipeline) DoRead(ctx context.Context, id string) (*pipelines.GetPipelineResponse, error) {
 	return r.client.Pipelines.GetByPipelineId(ctx, id)
 }
 

--- a/bundle/direct/dresources/registered_model.go
+++ b/bundle/direct/dresources/registered_model.go
@@ -45,7 +45,7 @@ func (*ResourceRegisteredModel) RemapState(model *catalog.RegisteredModelInfo) *
 	}
 }
 
-func (r *ResourceRegisteredModel) DoRefresh(ctx context.Context, id string) (*catalog.RegisteredModelInfo, error) {
+func (r *ResourceRegisteredModel) DoRead(ctx context.Context, id string) (*catalog.RegisteredModelInfo, error) {
 	return r.client.RegisteredModels.Get(ctx, catalog.GetRegisteredModelRequest{
 		FullName:        id,
 		IncludeAliases:  false,

--- a/bundle/direct/dresources/schema.go
+++ b/bundle/direct/dresources/schema.go
@@ -34,7 +34,7 @@ func (*ResourceSchema) RemapState(info *catalog.SchemaInfo) *catalog.CreateSchem
 	}
 }
 
-func (r *ResourceSchema) DoRefresh(ctx context.Context, id string) (*catalog.SchemaInfo, error) {
+func (r *ResourceSchema) DoRead(ctx context.Context, id string) (*catalog.SchemaInfo, error) {
 	return r.client.Schemas.GetByFullName(ctx, id)
 }
 

--- a/bundle/direct/dresources/schema_test.go
+++ b/bundle/direct/dresources/schema_test.go
@@ -41,7 +41,7 @@ func TestResourceSchema_DoUpdate_WithUnsupportedForceSendFields(t *testing.T) {
 	_, err = adapter.DoUpdate(ctx, id, config)
 	require.NoError(t, err)
 
-	result, err := adapter.DoRefresh(ctx, id)
+	result, err := adapter.DoRead(ctx, id)
 	require.NoError(t, err)
 
 	result.CreatedAt = 0

--- a/bundle/direct/dresources/sql_warehouse.go
+++ b/bundle/direct/dresources/sql_warehouse.go
@@ -43,8 +43,8 @@ func (*ResourceSqlWarehouse) RemapState(warehouse *sql.GetWarehouseResponse) *sq
 	}
 }
 
-// DoRefresh reads the warehouse by id.
-func (r *ResourceSqlWarehouse) DoRefresh(ctx context.Context, id string) (*sql.GetWarehouseResponse, error) {
+// DoRead reads the warehouse by id.
+func (r *ResourceSqlWarehouse) DoRead(ctx context.Context, id string) (*sql.GetWarehouseResponse, error) {
 	return r.client.Warehouses.GetById(ctx, id)
 }
 

--- a/bundle/direct/dresources/synced_database_table.go
+++ b/bundle/direct/dresources/synced_database_table.go
@@ -20,7 +20,7 @@ func (*ResourceSyncedDatabaseTable) PrepareState(input *resources.SyncedDatabase
 	return &input.SyncedDatabaseTable
 }
 
-func (r *ResourceSyncedDatabaseTable) DoRefresh(ctx context.Context, name string) (*database.SyncedDatabaseTable, error) {
+func (r *ResourceSyncedDatabaseTable) DoRead(ctx context.Context, name string) (*database.SyncedDatabaseTable, error) {
 	return r.client.Database.GetSyncedDatabaseTableByName(ctx, name)
 }
 

--- a/bundle/direct/dresources/volume.go
+++ b/bundle/direct/dresources/volume.go
@@ -37,7 +37,7 @@ func (*ResourceVolume) RemapState(info *catalog.VolumeInfo) *catalog.CreateVolum
 	}
 }
 
-func (r *ResourceVolume) DoRefresh(ctx context.Context, id string) (*catalog.VolumeInfo, error) {
+func (r *ResourceVolume) DoRead(ctx context.Context, id string) (*catalog.VolumeInfo, error) {
 	return r.client.Volumes.ReadByName(ctx, id)
 }
 

--- a/bundle/direct/pkg.go
+++ b/bundle/direct/pkg.go
@@ -29,7 +29,7 @@ type DeploymentUnit struct {
 	// Remote state (pointer to adapter.RemoteType()) or nil if remote state was not fetched yet.
 	// Remote state will be eagerly populated by (withRefresh) DoCreate/DoUpdate/WaitForCreate/WaitForUpdate.
 	// If the resource does not implement withRefresh variants of those methods, remoteState remains nil and
-	// will be populated lazily by calling DoRefresh().
+	// will be populated lazily by calling DoRead().
 	RemoteState any
 }
 


### PR DESCRIPTION
## Why
"Refresh" has more meaning in terraform, which is not just read but update local state with new information. We don't do that and this method is simply a wrapper for read/get.

Calling it "DoRead" completes CRUD, given that we already have DoCreate, DoUpdate, DoDelete.