### PR TITLE
Add CLI command for MCP tool-find-tables with schema name filtering

### DIFF
--- a/experimental/apps-mcp/cmd/apps_mcp.go
+++ b/experimental/apps-mcp/cmd/apps_mcp.go
@@ -82,5 +82,8 @@ The server communicates via stdio using the Model Context Protocol.`,
 	cmd.Flags().BoolVar(&allowDeployment, "allow-deployment", false, "Enable deployment tools")
 	cmd.Flags().BoolVar(&withWorkspaceTools, "with-workspace-tools", false, "Enable workspace tools (file operations, bash, grep, glob)")
 
+	// Add tool subcommands
+	cmd.AddCommand(newToolFindTablesCmd())
+
 	return cmd
 }

--- a/experimental/apps-mcp/cmd/tool_find_tables.go
+++ b/experimental/apps-mcp/cmd/tool_find_tables.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/databricks/cli/cmd/root"
+	mcplib "github.com/databricks/cli/experimental/apps-mcp/lib"
+	"github.com/databricks/cli/experimental/apps-mcp/lib/providers/databricks"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/spf13/cobra"
+)
+
+func newToolFindTablesCmd() *cobra.Command {
+	var catalogName string
+	var schemaName string
+	var filter string
+	var limit int
+	var offset int
+
+	cmd := &cobra.Command{
+		Use:   "tool-find-tables",
+		Short: "Find tables in Databricks Unity Catalog",
+		Long: `Find tables in Databricks Unity Catalog. Supports searching within a specific catalog and schema,
+across all schemas in a catalog, or across all catalogs. Supports wildcard patterns (* for multiple
+characters, ? for single character) in table name and schema name filtering.`,
+		PreRunE: root.MustWorkspaceClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := cmdctx.WorkspaceClient(ctx)
+
+			warehouseID := os.Getenv("DATABRICKS_WAREHOUSE_ID")
+			if warehouseID == "" {
+				return fmt.Errorf("DATABRICKS_WAREHOUSE_ID environment variable is required")
+			}
+
+			cfg := &mcplib.Config{
+				WarehouseID:    warehouseID,
+				DatabricksHost: w.Config.Host,
+			}
+
+			client, err := databricks.NewDatabricksRestClient(ctx, cfg)
+			if err != nil {
+				return err
+			}
+
+			// Build request using FindTablesInput structure
+			var catalogPtr *string
+			if catalogName != "" {
+				catalogPtr = &catalogName
+			}
+
+			var schemaPtr *string
+			if schemaName != "" {
+				schemaPtr = &schemaName
+			}
+
+			var filterPtr *string
+			if filter != "" {
+				filterPtr = &filter
+			}
+
+			// Set default limit
+			if limit == 0 {
+				limit = 1000
+			}
+
+			request := &databricks.ListTablesRequest{
+				CatalogName: catalogPtr,
+				SchemaName:  schemaPtr,
+				Filter:      filterPtr,
+				Limit:       limit,
+				Offset:      offset,
+			}
+
+			result, err := client.ListTables(ctx, request)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(result.Display())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&catalogName, "catalog-name", "", "Name of the catalog (optional - searches all catalogs if not provided)")
+	cmd.Flags().StringVar(&schemaName, "schema-name", "", "Name of the schema (optional - searches all schemas if not provided)")
+	cmd.Flags().StringVar(&filter, "filter", "", "Filter pattern for table names (supports * and ? wildcards)")
+	cmd.Flags().IntVar(&limit, "limit", 1000, "Maximum number of tables to return")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Offset for pagination")
+
+	return cmd
+}

--- a/experimental/apps-mcp/lib/providers/databricks/databricks.go
+++ b/experimental/apps-mcp/lib/providers/databricks/databricks.go
@@ -635,7 +635,9 @@ func (c *DatabricksRestClient) ListTables(ctx context.Context, request *ListTabl
 			filterLower := strings.ToLower(*request.Filter)
 			var filtered []TableInfoResponse
 			for _, t := range tables {
-				if strings.Contains(strings.ToLower(t.Name), filterLower) {
+				// Match against both table name and schema name
+				if strings.Contains(strings.ToLower(t.Name), filterLower) ||
+					strings.Contains(strings.ToLower(t.SchemaName), filterLower) {
 					filtered = append(filtered, t)
 				}
 			}
@@ -712,7 +714,8 @@ func (c *DatabricksRestClient) listTablesViaInformationSchema(ctx context.Contex
 			pattern = "%" + pattern + "%"
 		}
 
-		conditions = append(conditions, "table_name LIKE :pattern ESCAPE '\\\\'")
+		// Match against both table name and schema name
+		conditions = append(conditions, "(table_name LIKE :pattern ESCAPE '\\\\' OR table_schema LIKE :pattern ESCAPE '\\\\')")
 		parameters = append(parameters, sql.StatementParameterListItem{
 			Name:  "pattern",
 			Value: pattern,

--- a/experimental/apps-mcp/lib/providers/databricks/provider.go
+++ b/experimental/apps-mcp/lib/providers/databricks/provider.go
@@ -112,7 +112,7 @@ func (p *Provider) RegisterTools(server *mcpsdk.Server) error {
 	mcpsdk.AddTool(server,
 		&mcpsdk.Tool{
 			Name:        "databricks_find_tables",
-			Description: "Find tables in Databricks Unity Catalog. Supports searching within a specific catalog and schema, across all schemas in a catalog, or across all catalogs. Supports wildcard patterns (* for multiple characters, ? for single character) in table name filtering.",
+			Description: "Find tables in Databricks Unity Catalog. Supports searching within a specific catalog and schema, across all schemas in a catalog, or across all catalogs. Supports wildcard patterns (* for multiple characters, ? for single character) in table name and schema name filtering.",
 		},
 		session.WrapToolHandler(p.session, func(ctx context.Context, req *mcpsdk.CallToolRequest, args FindTablesInput) (*mcpsdk.CallToolResult, any, error) {
 			log.Debugf(ctx, "databricks_find_tables called: catalog=%s, schema=%s", *args.CatalogName, *args.SchemaName)


### PR DESCRIPTION
## Summary

This PR adds a new CLI subcommand `databricks experimental apps-mcp tool-find-tables` that exposes the MCP `databricks_find_tables` tool functionality directly via CLI.

Additionally, the filter functionality has been enhanced to match both table names AND schema names, making it easier to find tables when you know the schema name but not the exact table name.

## Key Features

- **New CLI Command**: `databricks experimental apps-mcp tool-find-tables`
- **Enhanced Filtering**: Filter now matches both table names and schema names
- **Flexible Search**: Supports searching within a specific catalog and schema, across all schemas in a catalog, or across all catalogs
- **Wildcard Support**: Pattern matching with `*` (multiple characters) and `?` (single character)
- **Pagination**: Built-in support with `--limit` and `--offset` parameters

## Changes

1. **New file**: `experimental/apps-mcp/cmd/tool_find_tables.go`
   - Implements the CLI command wrapper
   - Uses `FindTablesInput` structure to call `ListTables` method
   - Supports all filtering and pagination options

2. **Updated**: `experimental/apps-mcp/lib/providers/databricks/databricks.go`
   - Modified filter logic to match both table names and schema names
   - Updated both the fast path (specific catalog/schema) and information_schema query path
   - Added `OR` condition in SQL: `(table_name LIKE :pattern OR table_schema LIKE :pattern)`

3. **Updated**: `experimental/apps-mcp/lib/providers/databricks/provider.go`
   - Updated MCP tool description to reflect schema name filtering capability

4. **Updated**: `experimental/apps-mcp/cmd/apps_mcp.go`
   - Registered the new tool subcommand

## Example Usage

```bash
# Find tables with "taxi" in table name or schema name
DATABRICKS_CONFIG_PROFILE=googfood DATABRICKS_WAREHOUSE_ID=d4c59fdf4e7a13cc \
  ./databricks experimental apps-mcp tool-find-tables \
  --catalog-name samples --filter '*taxi*'

# Output:
# Showing 1 of 1 tables (offset: 0, limit: 1000):
# • samples.nyctaxi.trips (MANAGED)

# Find tables in a specific schema
./databricks experimental apps-mcp tool-find-tables \
  --catalog-name samples --schema-name nyctaxi

# Search across all catalogs
./databricks experimental apps-mcp tool-find-tables --filter '*trips*' --limit 10
```

## Test Plan

- [x] Built successfully with `make build`
- [x] Tested filtering by table name
- [x] Tested filtering by schema name
- [x] Tested filtering across catalogs
- [x] Verified help text displays correctly
- [x] Verified pagination parameters work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)