### PR TITLE
Add centralized prompt template system

### DIFF
--- a/experimental/aitools/tools/prompts/auth_error.tmpl
+++ b/experimental/aitools/tools/prompts/auth_error.tmpl
@@ -10,7 +10,16 @@ To authenticate, please run:
 
 Replace <your-workspace-url> with your Databricks workspace URL (e.g., mycompany.cloud.databricks.com).
 
+Alternatives:
+
+1. Run `databricks auth profiles` to list available profiles and set the `DATABRICKS_CONFIG_PROFILE` to the profile you want to use.
+2. Set the `DATABRICKS_CONFIG_HOST` to the host of the workspace you want to use.
+
+You might have to leave the coding agent to set these environment variables and then come back to it.
+
 Don't have a Databricks account? You can set up a fully free account for experimentation at:
 https://docs.databricks.com/getting-started/free-edition
+
+Do not run anything else before authenticating successfully.
 
 Once authenticated, you can use this tool again

--- a/experimental/apps-mcp/lib/prompts/auth_error.tmpl
+++ b/experimental/apps-mcp/lib/prompts/auth_error.tmpl
@@ -1,0 +1,15 @@
+{{- /*
+     * Actionable rror message shown when user is not authenticated to Databricks.
+     *
+     */ -}}
+
+Not authenticated to Databricks
+
+I need to know either the Databricks workspace URL or the Databricks profile name.
+You can list the available profiles by running `databricks auth profiles`.
+
+ASK the user which of the configured profiles or databricks workspace URL they want to use.
+Only then call the `databricks_configure_auth` tool to configure the authentication.
+
+Do not run anything else before authenticating successfully.
+Once authenticated, you can use this tool again

--- a/experimental/apps-mcp/lib/prompts/auth_u2m.tmpl
+++ b/experimental/apps-mcp/lib/prompts/auth_u2m.tmpl
@@ -1,0 +1,17 @@
+{{- /*
+     * Message shown when user knows the workspace URL but is not authenticated to Databricks.
+     *
+     */ -}}
+
+You are not authenticated to Databricks.
+
+To authenticate, please run:
+  databricks auth login --profile <profile_name> --host {{.WorkspaceURL}}
+
+Ask for a profile name or use `DEFAULT`.
+
+Don't have a Databricks account? You can set up a fully free account for experimentation at:
+https://docs.databricks.com/getting-started/free-edition
+
+Do not run anything else before authenticating successfully.
+Once authenticated, you can use this tool again

--- a/experimental/apps-mcp/lib/prompts/initialization_message.tmpl
+++ b/experimental/apps-mcp/lib/prompts/initialization_message.tmpl
@@ -1,0 +1,18 @@
+Your session in Databricks MCP has been successfully initialized. Here are the guidelines to follow while working on projects using databricks_mcp tools:
+
+## Project State Management:
+This project uses a state file (`.edda_state`) managed by edda MCP to enforce the correct workflow order:
+1. **Scaffolded**: `scaffold_data_app` creates project structure from template (starts in this state)
+2. **Validated**: `validate_data_app` runs build + tests in sandbox, computes BLAKE3 checksum of package.json and all core source files
+3. **Deployed**: `deploy_databricks_app` deploys to Databricks Apps, but ONLY if checksum hasn't changed since validation
+
+Re-validation is allowed (Deployed → Validated) to update the checksum after intentional changes. The databricks_mcp tools enforce these state transitions and prevent invalid state changes.
+
+## Workflow:
+- Projects MUST end with validate_project to verify build + tests pass
+- Bias towards backend code when the task allows implementation in multiple places
+- Always add tests for what you're implementing, put them next to the code (e.g. src/*.test.ts)
+- When working with Databricks or other services, use real API calls in tests (no mocks) to verify end-to-end functionality, unless explicitly instructed otherwise. It can be done on subset of data if applicable.
+- Do NOT create summary files, reports, or README unless explicitly requested
+- When not sure about the user's intent, ask clarifying questions before proceeding. For example, if user asks for "a data app to analyze sales data", ask for more details on data sources and analysis goals. Do not make assumptions regarding their needs and data sources.
+- However, stick to the technical stack initialized by the `scaffold_data_app` as it has been approved by the management and battle-tested in production.

--- a/experimental/apps-mcp/lib/prompts/prompts.go
+++ b/experimental/apps-mcp/lib/prompts/prompts.go
@@ -1,0 +1,60 @@
+package prompts
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed *.tmpl
+var promptTemplates embed.FS
+
+// ExecuteTemplate loads and executes a template with the given name and data.
+func ExecuteTemplate(name string, data any) (string, error) {
+	tmplContent, err := promptTemplates.ReadFile(name)
+	if err != nil {
+		return "", fmt.Errorf("failed to read template %s: %w", name, err)
+	}
+
+	tmpl, err := template.New(name).Parse(string(tmplContent))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse template %s: %w", name, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute template %s: %w", name, err)
+	}
+
+	return buf.String(), nil
+}
+
+// MustExecuteTemplate is like ExecuteTemplate but panics on error.
+// Use this only when template execution errors are programming errors.
+func MustExecuteTemplate(name string, data any) string {
+	result, err := ExecuteTemplate(name, data)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// LoadTemplate loads a template without executing it.
+// Returns the raw template content as a string.
+func LoadTemplate(name string) (string, error) {
+	tmplContent, err := promptTemplates.ReadFile(name)
+	if err != nil {
+		return "", fmt.Errorf("failed to read template %s: %w", name, err)
+	}
+	return string(tmplContent), nil
+}
+
+// MustLoadTemplate is like LoadTemplate but panics on error.
+func MustLoadTemplate(name string) string {
+	result, err := LoadTemplate(name)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}


### PR DESCRIPTION
Creates reusable prompt template system with Go text/template.

## Changes
- Add ExecuteTemplate() and MustExecuteTemplate() helpers
- Embed templates using //go:embed
- Add auth error, U2M, and initialization message templates
- Enhance aitools auth error with profile selection guidance

## Dependencies
None - standalone system

## Testing
- Compiles successfully
- Templates properly embedded