### PR TITLE
Enable source-linked deployments for apps

### DIFF
--- a/bundle/config/mutator/apply_source_linked_deployment_preset.go
+++ b/bundle/config/mutator/apply_source_linked_deployment_preset.go
@@ -72,22 +72,6 @@ func (m *applySourceLinkedDeploymentPreset) Apply(ctx context.Context, b *bundle
 		b.Config.Presets.SourceLinkedDeployment = &enabled
 	}
 
-	if len(b.Config.Resources.Apps) > 0 && config.IsExplicitlyEnabled(b.Config.Presets.SourceLinkedDeployment) {
-		path := dyn.NewPath(dyn.Key("targets"), dyn.Key(target), dyn.Key("presets"), dyn.Key("source_linked_deployment"))
-		diags = diags.Append(
-			diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "source-linked deployment is not supported for apps",
-				Paths: []dyn.Path{
-					path,
-				},
-				Locations: b.Config.GetLocations(path[2:].String()),
-			},
-		)
-
-		return diags
-	}
-
 	// This mutator runs before workspace paths are defaulted so it's safe to check for the user-defined value
 	if b.Config.Workspace.FilePath != "" && config.IsExplicitlyEnabled(b.Config.Presets.SourceLinkedDeployment) {
 		path := dyn.NewPath(dyn.Key("workspace"), dyn.Key("file_path"))

--- a/bundle/config/mutator/apply_source_linked_deployment_preset_test.go
+++ b/bundle/config/mutator/apply_source_linked_deployment_preset_test.go
@@ -100,7 +100,6 @@ func TestApplyPresetsSourceLinkedDeployment(t *testing.T) {
 			},
 			initialValue:  &enabled,
 			expectedValue: &enabled,
-			expectedError: "source-linked deployment is not supported for apps",
 		},
 		{
 			name: "preset enabled, production mode, bundle in Workspace, databricks runtime",


### PR DESCRIPTION
## Changes
Enable source-linked deployments for apps

## Why
We no longer write the app.yml file from DABs, meaning the entire app source code can be "source-linked" in DABs within the workspace.
