### PR TITLE
gh_report: include icon per test

### DIFF
--- a/tools/gh_parse.py
+++ b/tools/gh_parse.py
@@ -520,9 +520,15 @@ def print_report(filenames, filter, filter_env, show_output, markdown=False, omi
     table = []
     for test_key, items in simplified_results.items():
         package_name, testname = test_key
+        status = "??"
+        for action in ACTIONS_WITH_ICON:
+            if action in items.values():
+                status = action[:2]
+                break
         items_proc = dict((k, short_action(v)) for (k, v) in items.items())
         table.append(
             {
+                " ": status,
                 "Test Name": testname,
                 **items_proc,
             }


### PR DESCRIPTION
The top left column in test case includes most interesting action from the row.

This allows quickly seeing flaky vs failing vs known failures.

Same logic in how we summarize env status with a single icon.

Example how it looks: https://github.com/databricks/cli/pull/3980#issuecomment-3562653722
Actual look: https://github.com/databricks/cli/pull/3961#issuecomment-3558345456