### PR TITLE
Fix: Update field trigger unit test to validate on state type.

### DIFF
--- a/bundle/direct/dresources/all_test.go
+++ b/bundle/direct/dresources/all_test.go
@@ -540,7 +540,7 @@ func TestFieldTriggers(t *testing.T) {
 			validateFields(t, adapter.StateType(), adapter.fieldTriggersLocal)
 		})
 		t.Run(resourceName+"_remote", func(t *testing.T) {
-			validateFields(t, adapter.InputConfigType(), adapter.fieldTriggersRemote)
+			validateFields(t, adapter.StateType(), adapter.fieldTriggersRemote)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Field triggers apply to the state type, since they are applied after `PrepareState`. They do not apply on the input config schema. This was not a problem until now because both state and config were the same.

That's not the case, however, for secret scopes. Created a separate PR because of the prompt in: https://github.com/databricks/cli/pull/3886#discussion_r2527568637