### PR TITLE
Remove the "package" annotation from command groups

### DIFF
--- a/cmd/account/access-control/access-control.go
+++ b/cmd/account/access-control/access-control.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   grant rules are supported. A grant rule specifies a role assigned to a set of
   principals. A list of rules attached to a resource is called a rule set.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/billable-usage/billable-usage.go
+++ b/cmd/account/billable-usage/billable-usage.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Long: `This API allows you to download billable usage logs for the specified account
   and date range. This feature works with all account types.`,
 		GroupID: "billing",
-		Annotations: map[string]string{
-			"package": "billing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/budget-policy/budget-policy.go
+++ b/cmd/account/budget-policy/budget-policy.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `A service serves REST API about Budget policies.`,
 		Long:    `A service serves REST API about Budget policies`,
 		GroupID: "billing",
-		Annotations: map[string]string{
-			"package": "billing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/budgets/budgets.go
+++ b/cmd/account/budgets/budgets.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   account-wide spending, or apply filters to track the spending of specific
   teams, projects, or workspaces.`,
 		GroupID: "billing",
-		Annotations: map[string]string{
-			"package": "billing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/credentials/credentials.go
+++ b/cmd/account/credentials/credentials.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   credential configuration encapsulates this role information, and its ID is
   used when creating a new workspace.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/custom-app-integration/custom-app-integration.go
+++ b/cmd/account/custom-app-integration/custom-app-integration.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
   which is required for adding/using Custom OAuth App Integration like Tableau
   Cloud for Databricks in AWS cloud.`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/encryption-keys/encryption-keys.go
+++ b/cmd/account/encryption-keys/encryption-keys.go
@@ -38,10 +38,7 @@ func New() *cobra.Command {
   If you have an older workspace, it might not be on the E2 version of the
   platform. If you are not sure, contact your Databricks representative.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/federation-policy/federation-policy.go
+++ b/cmd/account/federation-policy/federation-policy.go
@@ -69,10 +69,7 @@ func New() *cobra.Command {
 
   [SCIM]: https://docs.databricks.com/admin/users-groups/scim/index.html`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/groups-v2/groups-v2.go
+++ b/cmd/account/groups-v2/groups-v2.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   account identities can be assigned as members of groups, and members inherit
   permissions that are assigned to their group.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/iam-v2/iam-v2.go
+++ b/cmd/account/iam-v2/iam-v2.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `These APIs are used to manage identities and the workspace access of these
   identities in <Databricks>.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iamv2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/ip-access-lists/ip-access-lists.go
+++ b/cmd/account/ip-access-lists/ip-access-lists.go
@@ -44,10 +44,7 @@ func New() *cobra.Command {
   After changes to the account-level IP access lists, it can take a few minutes
   for changes to take effect.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/log-delivery/log-delivery.go
+++ b/cmd/account/log-delivery/log-delivery.go
@@ -86,10 +86,7 @@ func New() *cobra.Command {
   [Usage page]: https://docs.databricks.com/administration-guide/account-settings/usage.html
   [create a new AWS S3 bucket]: https://docs.databricks.com/administration-guide/account-api/aws-storage.html`,
 		GroupID: "billing",
-		Annotations: map[string]string{
-			"package": "billing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/metastore-assignments/metastore-assignments.go
+++ b/cmd/account/metastore-assignments/metastore-assignments.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Short:   `These APIs manage metastore assignments to a workspace.`,
 		Long:    `These APIs manage metastore assignments to a workspace.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/metastores/metastores.go
+++ b/cmd/account/metastores/metastores.go
@@ -22,10 +22,7 @@ func New() *cobra.Command {
 		Long: `These APIs manage Unity Catalog metastores for an account. A metastore
   contains catalogs that can be associated with workspaces`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/network-connectivity/network-connectivity.go
+++ b/cmd/account/network-connectivity/network-connectivity.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
 
   [configure serverless secure connectivity]: https://learn.microsoft.com/azure/databricks/security/network/serverless-network-security`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/network-policies/network-policies.go
+++ b/cmd/account/network-policies/network-policies.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   workspace. 'default-policy' is reserved and cannot be deleted, but it can be
   updated to customize the default network access rules for your account.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/networks/networks.go
+++ b/cmd/account/networks/networks.go
@@ -22,10 +22,7 @@ func New() *cobra.Command {
 		Long: `These APIs manage network configurations for customer-managed VPCs (optional).
   Its ID is used when creating a new workspace if you use customer-managed VPCs.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/o-auth-published-apps/o-auth-published-apps.go
+++ b/cmd/account/o-auth-published-apps/o-auth-published-apps.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
   applications to their account through the OAuth Published App Integration
   APIs.`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/private-access/private-access.go
+++ b/cmd/account/private-access/private-access.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `These APIs manage private access settings for this account.`,
 		Long:    `These APIs manage private access settings for this account.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/published-app-integration/published-app-integration.go
+++ b/cmd/account/published-app-integration/published-app-integration.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
   which is required for adding/using Published OAuth App Integration like
   Tableau Desktop for Databricks in AWS cloud.`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/service-principal-federation-policy/service-principal-federation-policy.go
+++ b/cmd/account/service-principal-federation-policy/service-principal-federation-policy.go
@@ -76,10 +76,7 @@ func New() *cobra.Command {
   You do not need to configure an OAuth application in Databricks to use token
   federation.`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/service-principal-secrets/service-principal-secrets.go
+++ b/cmd/account/service-principal-secrets/service-principal-secrets.go
@@ -33,10 +33,7 @@ func New() *cobra.Command {
   [Authentication using OAuth tokens for service principals]: https://docs.databricks.com/dev-tools/authentication-oauth.html
   [Databricks Terraform Provider]: https://github.com/databricks/terraform-provider-databricks/blob/master/docs/index.md#authenticating-with-service-principal`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/service-principals-v2/service-principals-v2.go
+++ b/cmd/account/service-principals-v2/service-principals-v2.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   write, delete, or modify privileges in production. This eliminates the risk of
   a user overwriting production data by accident.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/settings-v2/settings-v2.go
+++ b/cmd/account/settings-v2/settings-v2.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `APIs to manage account level settings.`,
 		Long:    `APIs to manage account level settings`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settingsv2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/settings/settings.go
+++ b/cmd/account/settings/settings.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
 		Short:   `Accounts Settings API allows users to manage settings at the account level.`,
 		Long:    `Accounts Settings API allows users to manage settings at the account level.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add subservices

--- a/cmd/account/storage-credentials/storage-credentials.go
+++ b/cmd/account/storage-credentials/storage-credentials.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `These APIs manage storage credentials for a particular metastore.`,
 		Long:    `These APIs manage storage credentials for a particular metastore.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/storage/storage.go
+++ b/cmd/account/storage/storage.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
   encapsulates this bucket information, and its ID is used when creating a new
   workspace.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/usage-dashboards/usage-dashboards.go
+++ b/cmd/account/usage-dashboards/usage-dashboards.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
   you to gain insights into your usage with pre-built dashboards: visualize
   breakdowns, analyze tag attributions, and identify cost drivers.`,
 		GroupID: "billing",
-		Annotations: map[string]string{
-			"package": "billing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/users-v2/users-v2.go
+++ b/cmd/account/users-v2/users-v2.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   account. This ensures a consistent offboarding process and prevents
   unauthorized users from accessing sensitive data.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/vpc-endpoints/vpc-endpoints.go
+++ b/cmd/account/vpc-endpoints/vpc-endpoints.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `These APIs manage VPC endpoint configurations for this account.`,
 		Long:    `These APIs manage VPC endpoint configurations for this account.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/workspace-assignment/workspace-assignment.go
+++ b/cmd/account/workspace-assignment/workspace-assignment.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `The Workspace Permission Assignment API allows you to manage workspace
   permissions for principals in your account.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/workspace-network-configuration/workspace-network-configuration.go
+++ b/cmd/account/workspace-network-configuration/workspace-network-configuration.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
   You cannot create or delete a workspace's network option, only update it to
   associate the workspace with a different policy`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/account/workspaces/workspaces.go
+++ b/cmd/account/workspaces/workspaces.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   platform or on a select custom plan that allows multiple workspaces per
   account.`,
 		GroupID: "provisioning",
-		Annotations: map[string]string{
-			"package": "provisioning",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/access-control/access-control.go
+++ b/cmd/workspace/access-control/access-control.go
@@ -23,9 +23,6 @@ func New() *cobra.Command {
 		Short:   `Rule based Access Control for Databricks Resources.`,
 		Long:    `Rule based Access Control for Databricks Resources.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/agent-bricks/agent-bricks.go
+++ b/cmd/workspace/agent-bricks/agent-bricks.go
@@ -24,9 +24,6 @@ func New() *cobra.Command {
 		Long: `The Custom LLMs service manages state and powers the UI for the Custom LLM
   product.`,
 		GroupID: "agentbricks",
-		Annotations: map[string]string{
-			"package": "agentbricks",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/alerts-legacy/alerts-legacy.go
+++ b/cmd/workspace/alerts-legacy/alerts-legacy.go
@@ -32,10 +32,7 @@ func New() *cobra.Command {
 
   [Learn more]: https://docs.databricks.com/en/sql/dbsql-api-latest.html`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/alerts-v2/alerts-v2.go
+++ b/cmd/workspace/alerts-v2/alerts-v2.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Short:   `New version of SQL Alerts.`,
 		Long:    `New version of SQL Alerts`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/alerts/alerts.go
+++ b/cmd/workspace/alerts/alerts.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   the condition was met. Alerts can be scheduled using the sql_task type of
   the Jobs API, e.g. :method:jobs/create.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/apps-settings/apps-settings.go
+++ b/cmd/workspace/apps-settings/apps-settings.go
@@ -24,9 +24,6 @@ func New() *cobra.Command {
 		Long: `Apps Settings manage the settings for the Apps service on a customer's
   Databricks instance.`,
 		GroupID: "apps",
-		Annotations: map[string]string{
-			"package": "apps",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/apps/apps.go
+++ b/cmd/workspace/apps/apps.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   data, use and extend Databricks services, and enable users to interact through
   single sign-on.`,
 		GroupID: "apps",
-		Annotations: map[string]string{
-			"package": "apps",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/artifact-allowlists/artifact-allowlists.go
+++ b/cmd/workspace/artifact-allowlists/artifact-allowlists.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   to the allowlist in UC so that users can leverage these artifacts on compute
   configured with shared access mode.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/catalogs/catalogs.go
+++ b/cmd/workspace/catalogs/catalogs.go
@@ -30,10 +30,7 @@ func New() *cobra.Command {
   different workspaces can share access to the same data, depending on
   privileges granted centrally in Unity Catalog.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/clean-room-asset-revisions/clean-room-asset-revisions.go
+++ b/cmd/workspace/clean-room-asset-revisions/clean-room-asset-revisions.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Long: `Clean Room Asset Revisions denote new versions of uploaded assets (e.g.
   notebooks) in the clean room.`,
 		GroupID: "cleanrooms",
-		Annotations: map[string]string{
-			"package": "cleanrooms",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/clean-room-assets/clean-room-assets.go
+++ b/cmd/workspace/clean-room-assets/clean-room-assets.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Clean room assets are data and code objects — Tables, volumes, and notebooks
   that are shared with the clean room.`,
 		GroupID: "cleanrooms",
-		Annotations: map[string]string{
-			"package": "cleanrooms",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/clean-room-auto-approval-rules/clean-room-auto-approval-rules.go
+++ b/cmd/workspace/clean-room-auto-approval-rules/clean-room-auto-approval-rules.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   when an asset (e.g. notebook) meeting specific criteria is shared in a clean
   room.`,
 		GroupID: "cleanrooms",
-		Annotations: map[string]string{
-			"package": "cleanrooms",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/clean-room-task-runs/clean-room-task-runs.go
+++ b/cmd/workspace/clean-room-task-runs/clean-room-task-runs.go
@@ -20,10 +20,7 @@ func New() *cobra.Command {
 		Short:   `Clean room task runs are the executions of notebooks in a clean room.`,
 		Long:    `Clean room task runs are the executions of notebooks in a clean room.`,
 		GroupID: "cleanrooms",
-		Annotations: map[string]string{
-			"package": "cleanrooms",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/clean-rooms/clean-rooms.go
+++ b/cmd/workspace/clean-rooms/clean-rooms.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   privacy-protecting environment where multiple parties can work together on
   sensitive enterprise data without direct access to each other's data.`,
 		GroupID: "cleanrooms",
-		Annotations: map[string]string{
-			"package": "cleanrooms",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/cluster-policies/cluster-policies.go
+++ b/cmd/workspace/cluster-policies/cluster-policies.go
@@ -45,10 +45,7 @@ func New() *cobra.Command {
   Only admin users can create, edit, and delete policies. Admin users also have
   access to all policies.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/clusters/clusters.go
+++ b/cmd/workspace/clusters/clusters.go
@@ -49,10 +49,7 @@ func New() *cobra.Command {
   it has been terminated for more than 30 days, an administrator can pin a
   cluster to the cluster list.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/connections/connections.go
+++ b/cmd/workspace/connections/connections.go
@@ -33,10 +33,7 @@ func New() *cobra.Command {
   set of configuration options to support credential management and other
   settings.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/consumer-fulfillments/consumer-fulfillments.go
+++ b/cmd/workspace/consumer-fulfillments/consumer-fulfillments.go
@@ -20,10 +20,7 @@ func New() *cobra.Command {
 		Short:   `Fulfillments are entities that allow consumers to preview installations.`,
 		Long:    `Fulfillments are entities that allow consumers to preview installations.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/consumer-installations/consumer-installations.go
+++ b/cmd/workspace/consumer-installations/consumer-installations.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Installations are entities that allow consumers to interact with Databricks
   Marketplace listings.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/consumer-listings/consumer-listings.go
+++ b/cmd/workspace/consumer-listings/consumer-listings.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Long: `Listings are the core entities in the Marketplace. They represent the products
   that are available for consumption.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/consumer-personalization-requests/consumer-personalization-requests.go
+++ b/cmd/workspace/consumer-personalization-requests/consumer-personalization-requests.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Personalization Requests allow customers to interact with the individualized
   Marketplace listing flow.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/consumer-providers/consumer-providers.go
+++ b/cmd/workspace/consumer-providers/consumer-providers.go
@@ -22,10 +22,7 @@ func New() *cobra.Command {
 		Short:   `Providers are the entities that publish listings to the Marketplace.`,
 		Long:    `Providers are the entities that publish listings to the Marketplace.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/credentials-manager/credentials-manager.go
+++ b/cmd/workspace/credentials-manager/credentials-manager.go
@@ -24,9 +24,6 @@ func New() *cobra.Command {
 		Long: `Credentials manager interacts with with Identity Providers to to perform token
   exchanges using stored credentials and refresh tokens.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/credentials/credentials.go
+++ b/cmd/workspace/credentials/credentials.go
@@ -30,10 +30,7 @@ func New() *cobra.Command {
   CREATE SERVICE CREDENTIAL privilege. The user who creates the credential can
   delegate ownership to another user or group to manage permissions on it.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/current-user/current-user.go
+++ b/cmd/workspace/current-user/current-user.go
@@ -20,10 +20,7 @@ func New() *cobra.Command {
 		Long: `This API allows retrieving information about currently authenticated user or
   service principal.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/dashboard-widgets/dashboard-widgets.go
+++ b/cmd/workspace/dashboard-widgets/dashboard-widgets.go
@@ -25,9 +25,6 @@ func New() *cobra.Command {
   from existing dashboards within the Databricks Workspace. Data structures may
   change over time.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/dashboards/dashboards.go
+++ b/cmd/workspace/dashboards/dashboards.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   to create a new one. Dashboards can be scheduled using the sql_task type of
   the Jobs API, e.g. :method:jobs/create.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/data-quality/data-quality.go
+++ b/cmd/workspace/data-quality/data-quality.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Manage the data quality of Unity Catalog objects (currently support schema
   and table)`,
 		GroupID: "dataquality",
-		Annotations: map[string]string{
-			"package": "dataquality",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/data-sources/data-sources.go
+++ b/cmd/workspace/data-sources/data-sources.go
@@ -33,10 +33,7 @@ func New() *cobra.Command {
 
   [Learn more]: https://docs.databricks.com/en/sql/dbsql-api-latest.html`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/database/database.go
+++ b/cmd/workspace/database/database.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Short:   `Database Instances provide access to a database via REST API or direct SQL.`,
 		Long:    `Database Instances provide access to a database via REST API or direct SQL.`,
 		GroupID: "database",
-		Annotations: map[string]string{
-			"package": "database",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/entity-tag-assignments/entity-tag-assignments.go
+++ b/cmd/workspace/entity-tag-assignments/entity-tag-assignments.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   With these APIs, users can create, update, delete, and list tag assignments
   across Unity Catalog entities`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/experiments/experiments.go
+++ b/cmd/workspace/experiments/experiments.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   using the same tools you use to manage other workspace objects such as
   folders, notebooks, and libraries.`,
 		GroupID: "ml",
-		Annotations: map[string]string{
-			"package": "ml",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/external-lineage/external-lineage.go
+++ b/cmd/workspace/external-lineage/external-lineage.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
   With these APIs, users can create, update, delete, and list lineage
   relationships with support for column-level mappings and custom properties.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/external-locations/external-locations.go
+++ b/cmd/workspace/external-locations/external-locations.go
@@ -35,10 +35,7 @@ func New() *cobra.Command {
   To create external locations, you must be a metastore admin or a user with the
   **CREATE_EXTERNAL_LOCATION** privilege.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/external-metadata/external-metadata.go
+++ b/cmd/workspace/external-metadata/external-metadata.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
   users with appropriate permissions can view and manage external metadata
   objects.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/feature-engineering/feature-engineering.go
+++ b/cmd/workspace/feature-engineering/feature-engineering.go
@@ -23,9 +23,6 @@ func New() *cobra.Command {
 		Short:   `[description].`,
 		Long:    `[description]`,
 		GroupID: "ml",
-		Annotations: map[string]string{
-			"package": "ml",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/feature-store/feature-store.go
+++ b/cmd/workspace/feature-store/feature-store.go
@@ -29,9 +29,6 @@ func New() *cobra.Command {
   An online store is a low-latency database used for feature lookup during
   real-time model inference or serve feature for real-time applications.`,
 		GroupID: "ml",
-		Annotations: map[string]string{
-			"package": "ml",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/forecasting/forecasting.go
+++ b/cmd/workspace/forecasting/forecasting.go
@@ -25,9 +25,6 @@ func New() *cobra.Command {
 		Long: `The Forecasting API allows you to create and get serverless forecasting
   experiments`,
 		GroupID: "ml",
-		Annotations: map[string]string{
-			"package": "ml",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/functions/functions.go
+++ b/cmd/workspace/functions/functions.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
   function resides at the same level as a table, so it can be referenced with
   the form __catalog_name__.__schema_name__.__function_name__.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/genie/genie.go
+++ b/cmd/workspace/genie/genie.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
   least CAN USE permission on a Pro or Serverless SQL warehouse. Also,
   Databricks Assistant must be enabled.`,
 		GroupID: "dashboards",
-		Annotations: map[string]string{
-			"package": "dashboards",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/git-credentials/git-credentials.go
+++ b/cmd/workspace/git-credentials/git-credentials.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
 
   [more info]: https://docs.databricks.com/repos/get-access-tokens-from-git-provider.html`,
 		GroupID: "workspace",
-		Annotations: map[string]string{
-			"package": "workspace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/global-init-scripts/global-init-scripts.go
+++ b/cmd/workspace/global-init-scripts/global-init-scripts.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   launch and init scripts with later position are skipped. If enough containers
   fail, the entire cluster fails with a GLOBAL_INIT_SCRIPT_FAILURE error code.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/grants/grants.go
+++ b/cmd/workspace/grants/grants.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   the catalog. Similarly, privileges granted on a schema are inherited by all
   current and future objects within that schema.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/groups-v2/groups-v2.go
+++ b/cmd/workspace/groups-v2/groups-v2.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   workspace identities can be assigned as members of groups, and members inherit
   permissions that are assigned to their group.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/instance-pools/instance-pools.go
+++ b/cmd/workspace/instance-pools/instance-pools.go
@@ -40,10 +40,7 @@ func New() *cobra.Command {
   Databricks does not charge DBUs while instances are idle in the pool. Instance
   provider billing does apply. See pricing.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/instance-profiles/instance-profiles.go
+++ b/cmd/workspace/instance-profiles/instance-profiles.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
 
   [Secure access to S3 buckets]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/instance-profiles.html`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/ip-access-lists/ip-access-lists.go
+++ b/cmd/workspace/ip-access-lists/ip-access-lists.go
@@ -43,10 +43,7 @@ func New() *cobra.Command {
   After changes to the IP access list feature, it can take a few minutes for
   changes to take effect.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/jobs/jobs.go
+++ b/cmd/workspace/jobs/jobs.go
@@ -41,10 +41,7 @@ func New() *cobra.Command {
   [Secrets CLI]: https://docs.databricks.com/dev-tools/cli/secrets-cli.html
   [Secrets utility]: https://docs.databricks.com/dev-tools/databricks-utils.html#dbutils-secrets`,
 		GroupID: "jobs",
-		Annotations: map[string]string{
-			"package": "jobs",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/lakeview-embedded/lakeview-embedded.go
+++ b/cmd/workspace/lakeview-embedded/lakeview-embedded.go
@@ -20,10 +20,7 @@ func New() *cobra.Command {
 		Short:   `Token-based Lakeview APIs for embedding dashboards in external applications.`,
 		Long:    `Token-based Lakeview APIs for embedding dashboards in external applications.`,
 		GroupID: "dashboards",
-		Annotations: map[string]string{
-			"package": "dashboards",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/lakeview/lakeview.go
+++ b/cmd/workspace/lakeview/lakeview.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   Generic resource management can be done with Workspace API (import, export,
   get-status, list, delete).`,
 		GroupID: "dashboards",
-		Annotations: map[string]string{
-			"package": "dashboards",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/libraries/libraries.go
+++ b/cmd/workspace/libraries/libraries.go
@@ -38,10 +38,7 @@ func New() *cobra.Command {
   you restart the cluster. Until you restart the cluster, the status of the
   uninstalled library appears as Uninstall pending restart.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/materialized-features/materialized-features.go
+++ b/cmd/workspace/materialized-features/materialized-features.go
@@ -24,9 +24,6 @@ func New() *cobra.Command {
 		Long: `Materialized Features are columns in tables and views that can be directly
   used as features to train and serve ML models.`,
 		GroupID: "ml",
-		Annotations: map[string]string{
-			"package": "ml",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/metastores/metastores.go
+++ b/cmd/workspace/metastores/metastores.go
@@ -35,10 +35,7 @@ func New() *cobra.Command {
   includes a legacy Hive metastore, the data in that metastore is available in a
   catalog named hive_metastore.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/model-registry/model-registry.go
+++ b/cmd/workspace/model-registry/model-registry.go
@@ -30,10 +30,7 @@ func New() *cobra.Command {
   The Workspace Model Registry is a centralized model repository and a UI and
   set of APIs that enable you to manage the full lifecycle of MLflow Models.`,
 		GroupID: "ml",
-		Annotations: map[string]string{
-			"package": "ml",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/model-versions/model-versions.go
+++ b/cmd/workspace/model-versions/model-versions.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
   Unity Catalog. For more details, see the [registered models API
   docs](/api/workspace/registeredmodels).`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/notification-destinations/notification-destinations.go
+++ b/cmd/workspace/notification-destinations/notification-destinations.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   Databricks. Only workspace admins can create, update, and delete notification
   destinations.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/online-tables/online-tables.go
+++ b/cmd/workspace/online-tables/online-tables.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
 		Long: `Online tables provide lower latency and higher QPS access to data from Delta
   tables.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/permission-migration/permission-migration.go
+++ b/cmd/workspace/permission-migration/permission-migration.go
@@ -24,9 +24,6 @@ func New() *cobra.Command {
 		Long: `APIs for migrating acl permissions, used only by the ucx tool:
   https://github.com/databrickslabs/ucx`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/permissions/permissions.go
+++ b/cmd/workspace/permissions/permissions.go
@@ -51,10 +51,7 @@ func New() *cobra.Command {
 
   [Access Control]: https://docs.databricks.com/security/auth-authz/access-control/index.html`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/pipelines/pipelines.go
+++ b/cmd/workspace/pipelines/pipelines.go
@@ -37,10 +37,7 @@ func New() *cobra.Command {
   expected data quality and specify how to handle records that fail those
   expectations.`,
 		GroupID: "pipelines",
-		Annotations: map[string]string{
-			"package": "pipelines",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/policies/policies.go
+++ b/cmd/workspace/policies/policies.go
@@ -30,10 +30,7 @@ func New() *cobra.Command {
   MANAGE privilege on a securable to view, create, update, or delete ABAC
   policies.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/policy-compliance-for-clusters/policy-compliance-for-clusters.go
+++ b/cmd/workspace/policy-compliance-for-clusters/policy-compliance-for-clusters.go
@@ -32,10 +32,7 @@ func New() *cobra.Command {
   status of a cluster. The enforce compliance API allows you to update a cluster
   to be compliant with the current version of its policy.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/policy-compliance-for-jobs/policy-compliance-for-jobs.go
+++ b/cmd/workspace/policy-compliance-for-jobs/policy-compliance-for-jobs.go
@@ -35,10 +35,7 @@ func New() *cobra.Command {
   status of a job. The enforce compliance API allows you to update a job so that
   it becomes compliant with all of its policies.`,
 		GroupID: "jobs",
-		Annotations: map[string]string{
-			"package": "jobs",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/policy-families/policy-families.go
+++ b/cmd/workspace/policy-families/policy-families.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
   create cluster policies using a policy family. Cluster policies created using
   a policy family inherit the policy family's policy definition.`,
 		GroupID: "compute",
-		Annotations: map[string]string{
-			"package": "compute",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-exchange-filters/provider-exchange-filters.go
+++ b/cmd/workspace/provider-exchange-filters/provider-exchange-filters.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Short:   `Marketplace exchanges filters curate which groups can access an exchange.`,
 		Long:    `Marketplace exchanges filters curate which groups can access an exchange.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-exchanges/provider-exchanges.go
+++ b/cmd/workspace/provider-exchanges/provider-exchanges.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Marketplace exchanges allow providers to share their listings with a curated
   set of customers.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-files/provider-files.go
+++ b/cmd/workspace/provider-files/provider-files.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Marketplace offers a set of file APIs for various purposes such as preview
   notebooks and provider icons.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-listings/provider-listings.go
+++ b/cmd/workspace/provider-listings/provider-listings.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Listings are the core entities in the Marketplace. They represent the products
   that are available for consumption.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-personalization-requests/provider-personalization-requests.go
+++ b/cmd/workspace/provider-personalization-requests/provider-personalization-requests.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `Personalization requests are an alternate to instantly available listings.
   Control the lifecycle of personalized solutions.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-provider-analytics-dashboards/provider-provider-analytics-dashboards.go
+++ b/cmd/workspace/provider-provider-analytics-dashboards/provider-provider-analytics-dashboards.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `Manage templated analytics solution for providers.`,
 		Long:    `Manage templated analytics solution for providers.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/provider-providers/provider-providers.go
+++ b/cmd/workspace/provider-providers/provider-providers.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Short:   `Providers are entities that manage assets in Marketplace.`,
 		Long:    `Providers are entities that manage assets in Marketplace.`,
 		GroupID: "marketplace",
-		Annotations: map[string]string{
-			"package": "marketplace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/providers/providers.go
+++ b/cmd/workspace/providers/providers.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   who shares the data. A provider contains shares which further contain the
   shared data.`,
 		GroupID: "sharing",
-		Annotations: map[string]string{
-			"package": "sharing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/quality-monitor-v2/quality-monitor-v2.go
+++ b/cmd/workspace/quality-monitor-v2/quality-monitor-v2.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Short:   `Manage data quality of UC objects (currently support schema).`,
 		Long:    `Manage data quality of UC objects (currently support schema)`,
 		GroupID: "qualitymonitor",
-		Annotations: map[string]string{
-			"package": "qualitymonitorv2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/quality-monitors/quality-monitors.go
+++ b/cmd/workspace/quality-monitors/quality-monitors.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
   to have **SELECT** privileges on the table (along with **USE_SCHEMA** and
   **USE_CATALOG**).`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/queries-legacy/queries-legacy.go
+++ b/cmd/workspace/queries-legacy/queries-legacy.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
 
   [Learn more]: https://docs.databricks.com/en/sql/dbsql-api-latest.html`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/queries/queries.go
+++ b/cmd/workspace/queries/queries.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   name, description, tags, and parameters. Queries can be scheduled using the
   sql_task type of the Jobs API, e.g. :method:jobs/create.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/query-history/query-history.go
+++ b/cmd/workspace/query-history/query-history.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Long: `A service responsible for storing and retrieving the list of queries run
   against SQL endpoints and serverless compute.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/query-visualizations-legacy/query-visualizations-legacy.go
+++ b/cmd/workspace/query-visualizations-legacy/query-visualizations-legacy.go
@@ -30,9 +30,6 @@ func New() *cobra.Command {
 
   [Learn more]: https://docs.databricks.com/en/sql/dbsql-api-latest.html`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/query-visualizations/query-visualizations.go
+++ b/cmd/workspace/query-visualizations/query-visualizations.go
@@ -25,9 +25,6 @@ func New() *cobra.Command {
   visualizations from existing queries in the Databricks Workspace. Data
   structures can change over time.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/recipient-activation/recipient-activation.go
+++ b/cmd/workspace/recipient-activation/recipient-activation.go
@@ -29,10 +29,7 @@ func New() *cobra.Command {
   treat the downloaded credential as a secret and must not share it outside of
   their organization.`,
 		GroupID: "sharing",
-		Annotations: map[string]string{
-			"package": "sharing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/recipient-federation-policies/recipient-federation-policies.go
+++ b/cmd/workspace/recipient-federation-policies/recipient-federation-policies.go
@@ -45,10 +45,7 @@ func New() *cobra.Command {
   https://www.databricks.com/blog/announcing-oidc-token-federation-enhanced-delta-sharing-security
   and https://docs.databricks.com/en/delta-sharing/create-recipient-oidc-fed`,
 		GroupID: "sharing",
-		Annotations: map[string]string{
-			"package": "sharing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/recipients/recipients.go
+++ b/cmd/workspace/recipients/recipients.go
@@ -39,10 +39,7 @@ func New() *cobra.Command {
   file to establish a secure connection to receive the shared data. This sharing
   mode is called **open sharing**.`,
 		GroupID: "sharing",
-		Annotations: map[string]string{
-			"package": "sharing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/redash-config/redash-config.go
+++ b/cmd/workspace/redash-config/redash-config.go
@@ -19,9 +19,6 @@ func New() *cobra.Command {
 		Short:   `Redash V2 service for workspace configurations (internal).`,
 		Long:    `Redash V2 service for workspace configurations (internal)`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
 
 		// This service is being previewed; hide from help output.
 		Hidden: true,

--- a/cmd/workspace/registered-models/registered-models.go
+++ b/cmd/workspace/registered-models/registered-models.go
@@ -51,10 +51,7 @@ func New() *cobra.Command {
   tagging, grants) that specify a securable type, use FUNCTION as the securable
   type.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/repos/repos.go
+++ b/cmd/workspace/repos/repos.go
@@ -32,10 +32,7 @@ func New() *cobra.Command {
   science and engineering code development best practices using Git for version
   control, collaboration, and CI/CD.`,
 		GroupID: "workspace",
-		Annotations: map[string]string{
-			"package": "workspace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/resource-quotas/resource-quotas.go
+++ b/cmd/workspace/resource-quotas/resource-quotas.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
 
   [Unity Catalog documentation]: https://docs.databricks.com/en/data-governance/unity-catalog/index.html#resource-quotas`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/rfa/rfa.go
+++ b/cmd/workspace/rfa/rfa.go
@@ -28,10 +28,7 @@ func New() *cobra.Command {
   request destinations. Fine-grained authorization ensures that only users with
   appropriate permissions can manage access request destinations.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/schemas/schemas.go
+++ b/cmd/workspace/schemas/schemas.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   data permission on the schema and its parent catalog, and they must have the
   SELECT permission on the table or view.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/secrets/secrets.go
+++ b/cmd/workspace/secrets/secrets.go
@@ -34,10 +34,7 @@ func New() *cobra.Command {
   that might be displayed in notebooks, it is not possible to prevent such users
   from reading secrets.`,
 		GroupID: "workspace",
-		Annotations: map[string]string{
-			"package": "workspace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/service-principal-secrets-proxy/service-principal-secrets-proxy.go
+++ b/cmd/workspace/service-principal-secrets-proxy/service-principal-secrets-proxy.go
@@ -35,10 +35,7 @@ func New() *cobra.Command {
   [Authentication using OAuth tokens for service principals]: https://docs.databricks.com/dev-tools/authentication-oauth.html
   [Databricks Terraform Provider]: https://github.com/databricks/terraform-provider-databricks/blob/master/docs/index.md#authenticating-with-service-principal`,
 		GroupID: "oauth2",
-		Annotations: map[string]string{
-			"package": "oauth2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/service-principals-v2/service-principals-v2.go
+++ b/cmd/workspace/service-principals-v2/service-principals-v2.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   write, delete, or modify privileges in production. This eliminates the risk of
   a user overwriting production data by accident.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/serving-endpoints/serving-endpoints.go
+++ b/cmd/workspace/serving-endpoints/serving-endpoints.go
@@ -36,10 +36,7 @@ func New() *cobra.Command {
   entities behind an endpoint. Additionally, you can configure the scale of
   resources that should be applied to each served entity.`,
 		GroupID: "serving",
-		Annotations: map[string]string{
-			"package": "serving",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/settings/settings.go
+++ b/cmd/workspace/settings/settings.go
@@ -34,10 +34,7 @@ func New() *cobra.Command {
 		Short:   `Workspace Settings API allows users to manage settings at the workspace level.`,
 		Long:    `Workspace Settings API allows users to manage settings at the workspace level.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add subservices

--- a/cmd/workspace/shares/shares.go
+++ b/cmd/workspace/shares/shares.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   under their original name, qualified by their original schema, or provide
   alternate exposed names.`,
 		GroupID: "sharing",
-		Annotations: map[string]string{
-			"package": "sharing",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/storage-credentials/storage-credentials.go
+++ b/cmd/workspace/storage-credentials/storage-credentials.go
@@ -35,10 +35,7 @@ func New() *cobra.Command {
   account admin who creates the storage credential can delegate ownership to
   another user or group to manage permissions on it.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/system-schemas/system-schemas.go
+++ b/cmd/workspace/system-schemas/system-schemas.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
   schema may contain information about customer usage of Unity Catalog such as
   audit-logs, billing-logs, lineage information, etc.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/table-constraints/table-constraints.go
+++ b/cmd/workspace/table-constraints/table-constraints.go
@@ -35,10 +35,7 @@ func New() *cobra.Command {
   specification during table creation. You can also add or drop constraints on
   existing tables.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/tables/tables.go
+++ b/cmd/workspace/tables/tables.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   A table can be managed or external. From an API perspective, a __VIEW__ is a
   particular kind of table (rather than a managed or external table).`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/tag-policies/tag-policies.go
+++ b/cmd/workspace/tag-policies/tag-policies.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
 
   [Account Access Control Proxy API]: https://docs.databricks.com/api/workspace/accountaccesscontrolproxy`,
 		GroupID: "tags",
-		Annotations: map[string]string{
-			"package": "tags",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/temporary-path-credentials/temporary-path-credentials.go
+++ b/cmd/workspace/temporary-path-credentials/temporary-path-credentials.go
@@ -48,10 +48,7 @@ func New() *cobra.Command {
   This API only supports temporary path credentials for external locations and
   external tables, and volumes will be supported in the future.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/temporary-table-credentials/temporary-table-credentials.go
+++ b/cmd/workspace/temporary-table-credentials/temporary-table-credentials.go
@@ -37,10 +37,7 @@ func New() *cobra.Command {
   can only be granted by catalog admin explicitly and is not included in schema
   ownership or ALL PRIVILEGES on the schema for security reasons.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/token-management/token-management.go
+++ b/cmd/workspace/token-management/token-management.go
@@ -25,10 +25,7 @@ func New() *cobra.Command {
   Admins can either get every token, get a specific token by ID, or get all
   tokens for a particular user.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/tokens/tokens.go
+++ b/cmd/workspace/tokens/tokens.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `The Token API allows you to create, list, and revoke tokens that can be used
   to authenticate and access Databricks REST APIs.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/users-v2/users-v2.go
+++ b/cmd/workspace/users-v2/users-v2.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   workspace. This ensures a consistent offboarding process and prevents
   unauthorized users from accessing sensitive data.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iam",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/vector-search-endpoints/vector-search-endpoints.go
+++ b/cmd/workspace/vector-search-endpoints/vector-search-endpoints.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Short:   `**Endpoint**: Represents the compute resources to host vector search indexes.`,
 		Long:    `**Endpoint**: Represents the compute resources to host vector search indexes.`,
 		GroupID: "vectorsearch",
-		Annotations: map[string]string{
-			"package": "vectorsearch",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/vector-search-indexes/vector-search-indexes.go
+++ b/cmd/workspace/vector-search-indexes/vector-search-indexes.go
@@ -31,10 +31,7 @@ func New() *cobra.Command {
   and write of vectors and metadata through our REST and SDK APIs. With this
   model, the user manages index updates.`,
 		GroupID: "vectorsearch",
-		Annotations: map[string]string{
-			"package": "vectorsearch",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/volumes/volumes.go
+++ b/cmd/workspace/volumes/volumes.go
@@ -30,10 +30,7 @@ func New() *cobra.Command {
   centrally and providing secure access across workspaces to it, or transforming
   and querying non-tabular data files in ETL.`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/warehouses/warehouses.go
+++ b/cmd/workspace/warehouses/warehouses.go
@@ -26,10 +26,7 @@ func New() *cobra.Command {
   objects within Databricks SQL. Compute resources are infrastructure resources
   that provide processing capabilities in the cloud.`,
 		GroupID: "sql",
-		Annotations: map[string]string{
-			"package": "sql",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/workspace-bindings/workspace-bindings.go
+++ b/cmd/workspace/workspace-bindings/workspace-bindings.go
@@ -39,10 +39,7 @@ func New() *cobra.Command {
   Securable types that support binding: - catalog - storage_credential -
   credential - external_location`,
 		GroupID: "catalog",
-		Annotations: map[string]string{
-			"package": "catalog",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/workspace-conf/workspace-conf.go
+++ b/cmd/workspace/workspace-conf/workspace-conf.go
@@ -23,10 +23,7 @@ func New() *cobra.Command {
 		Short:   `This API allows updating known workspace settings for advanced users.`,
 		Long:    `This API allows updating known workspace settings for advanced users.`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settings",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/workspace-iam-v2/workspace-iam-v2.go
+++ b/cmd/workspace/workspace-iam-v2/workspace-iam-v2.go
@@ -24,10 +24,7 @@ func New() *cobra.Command {
 		Long: `These APIs are used to manage identities and the workspace access of these
   identities in <Databricks>.`,
 		GroupID: "iam",
-		Annotations: map[string]string{
-			"package": "iamv2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/workspace-settings-v2/workspace-settings-v2.go
+++ b/cmd/workspace/workspace-settings-v2/workspace-settings-v2.go
@@ -21,10 +21,7 @@ func New() *cobra.Command {
 		Short:   `APIs to manage workspace level settings.`,
 		Long:    `APIs to manage workspace level settings`,
 		GroupID: "settings",
-		Annotations: map[string]string{
-			"package": "settingsv2",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods

--- a/cmd/workspace/workspace/workspace.go
+++ b/cmd/workspace/workspace/workspace.go
@@ -27,10 +27,7 @@ func New() *cobra.Command {
   A notebook is a web-based interface to a document that contains runnable code,
   visualizations, and explanatory text.`,
 		GroupID: "workspace",
-		Annotations: map[string]string{
-			"package": "workspace",
-		},
-		RunE: root.ReportUnknownSubcommand,
+		RunE:    root.ReportUnknownSubcommand,
 	}
 
 	// Add methods


### PR DESCRIPTION
## Why

This annotation isn't used anywhere. Grouping of commands is done with the `GroupID` field on the command struct.
