### PR TITLE
Use bigger windows runner machines

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,7 +42,8 @@ jobs:
           - macos-latest
           - group: databricks-protected-runner-group-large
             labels: linux-ubuntu-latest-large
-          - ${{ github.event_name != 'merge_group' && 'windows-latest' || null }}
+            # Do not run tests on windows on merge.
+          - ${{ github.event_name != 'merge_group' && fromJSON('{"group":"databricks-protected-runner-group-large","labels":"windows-server-latest-large"}') || null }}
         deployment:
           - "terraform"
           - "direct"


### PR DESCRIPTION
We were recently provisioned a larger machine for running unit tests on Windows. This PR modifies our unit test workflow to use it. 

Prior PR:  https://github.com/databricks/cli/pull/3925 

## Timing info:

direct: 4m 54s (previous runs: 5m 47s, 7m 42s,  7m 9s)
terraform: 12m 23s (previous runs: 19m 18s, 8m 24s, 18m 38s)