### PR TITLE
Do not run unit tests on macos on merge group

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,7 +45,7 @@ jobs:
           # On merge_group events, only run the tests on Linux, to reduce time to merge.
           - ${{ github.event_name != 'merge_group' && fromJSON('{"group":"databricks-protected-runner-group-large","labels":"windows-server-latest-large"}') || null }}
           - ${{ github.event_name != 'merge_group' && 'macos-latest' || null }}
-          
+
         deployment:
           - "terraform"
           - "direct"


### PR DESCRIPTION
Running tests on mac-os does not give much additional coverage over running them on Linux. No need to run them on merge groups events.