### PR TITLE
Add AGENTS.md symlink and enable symlink embedding

### DIFF
--- a/.goreleaser-unix.yaml
+++ b/.goreleaser-unix.yaml
@@ -7,6 +7,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+      - GODEBUG=embedfollowsymlinks=1
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -8,6 +8,7 @@ builds:
   - id: cli
     env:
       - CGO_ENABLED=0
+      - GODEBUG=embedfollowsymlinks=1
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+      - GODEBUG=embedfollowsymlinks=1
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath

--- a/Makefile
+++ b/Makefile
@@ -95,14 +95,14 @@ acc-showcover:
 	go tool cover -html=coverage-acceptance.txt
 
 build: tidy
-	go build
+	GODEBUG=embedfollowsymlinks=1 go build
 
 # builds the binary in a VM environment (such as Parallels Desktop) where your files are mirrored from the host os
 build-vm: tidy
-	go build -buildvcs=false
+	GODEBUG=embedfollowsymlinks=1 go build -buildvcs=false
 
 snapshot:
-	go build -o .databricks/databricks
+	GODEBUG=embedfollowsymlinks=1 go build -o .databricks/databricks
 
 # Produce release binaries and archives in the dist folder without uploading them anywhere.
 # Useful for "databricks ssh" development, as it needs to upload linux releases to the /Workspace.

--- a/experimental/apps-mcp/lib/templates/appkit/AGENTS.md
+++ b/experimental/apps-mcp/lib/templates/appkit/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Add AGENTS.md as symlink to CLAUDE.md in appkit template
- Enable symlink embedding using GODEBUG=embedfollowsymlinks=1 in Makefile and goreleaser configs

## Changes
- Create symlink for alternative naming convention support
- Update build targets to follow symlinks during embedding (Go 1.25+)
- No duplication needed - changes to CLAUDE.md automatically appear in AGENTS.md