### PR TITLE
Added secrets resource support to DABs

### DIFF
--- a/acceptance/bundle/resources/secret_scopes/test.toml
+++ b/acceptance/bundle/resources/secret_scopes/test.toml
@@ -2,7 +2,8 @@ Cloud = true
 Local = true
 RecordRequests = false
 
-EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]  # secret scopes not implemented
+# direct mode doesn't support secret scope permissions yet
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]
 
 Ignore = [
     "databricks.yml",

--- a/acceptance/bundle/resources/secrets/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/secrets/databricks.yml.tmpl
@@ -1,0 +1,7 @@
+bundle:
+  name: deploy-secrets-test-$UNIQUE_NAME
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: $SECRET_SCOPE_NAME

--- a/acceptance/bundle/resources/secrets/out.test.toml
+++ b/acceptance/bundle/resources/secrets/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = true
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secrets/output.txt
+++ b/acceptance/bundle/resources/secrets/output.txt
@@ -1,0 +1,49 @@
+
+=== Deploy the secret scope first
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-secrets-test-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Verify the secret scope was created
+>>> [CLI] secrets list-scopes -o json
+{
+  "backend_type": "DATABRICKS",
+  "name": "secrets-test-[UUID]"
+}
+
+=== Create a secret via CLI
+>>> [CLI] secrets put-secret secrets-test-[UUID] my-secret-key --string-value my-secret-value
+
+=== Verify secret was created
+>>> [CLI] secrets get-secret secrets-test-[UUID] my-secret-key
+{
+  "key":"my-secret-key",
+  "value":"bXktc2VjcmV0LXZhbHVl"
+}
+
+=== Now add a secret to the bundle
+=== Deploy bundle with secret (scope already exists)
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-secrets-test-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Verify bundle secret was created
+>>> [CLI] secrets get-secret secrets-test-[UUID] bundle_secret
+{
+  "key":"bundle_secret",
+  "value":"YnVuZGxlLXNlY3JldC12YWx1ZQ=="
+}
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.secret_scopes.test_scope
+  delete resources.secrets.secret1
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-secrets-test-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/resources/secrets/script
+++ b/acceptance/bundle/resources/secrets/script
@@ -1,0 +1,47 @@
+SECRET_SCOPE_NAME="secrets-test-$(uuid)"
+if [ -z "$CLOUD_ENV" ]; then
+    SECRET_SCOPE_NAME="secrets-test-6260d50f-e8ff-4905-8f28-812345678903"   # use hard-coded uuid when running locally
+fi
+export SECRET_SCOPE_NAME
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+title "Deploy the secret scope first"
+trace $CLI bundle deploy
+
+title "Verify the secret scope was created"
+trace $CLI secrets list-scopes -o json | jq --arg name "${SECRET_SCOPE_NAME}" '.[] | select(.name == $name)'
+
+title "Create a secret via CLI"
+trace $CLI secrets put-secret ${SECRET_SCOPE_NAME} my-secret-key --string-value "my-secret-value"
+
+title "Verify secret was created"
+trace $CLI secrets get-secret ${SECRET_SCOPE_NAME} my-secret-key
+
+title "Now add a secret to the bundle"
+cat > databricks.yml <<EOF
+bundle:
+  name: deploy-secrets-test-${UNIQUE_NAME}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: ${SECRET_SCOPE_NAME}
+
+  secrets:
+    secret1:
+      scope: ${SECRET_SCOPE_NAME}
+      key: bundle_secret
+      string_value: "bundle-secret-value"
+EOF
+
+title "Deploy bundle with secret (scope already exists)"
+trace $CLI bundle deploy
+
+title "Verify bundle secret was created"
+trace $CLI secrets get-secret ${SECRET_SCOPE_NAME} bundle_secret

--- a/acceptance/bundle/resources/secrets/test.toml
+++ b/acceptance/bundle/resources/secrets/test.toml
@@ -1,0 +1,10 @@
+Cloud = true
+Local = true
+RecordRequests = false
+
+# Use FakeWorkspace handlers for secrets which properly maintain state
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+
+Ignore = [
+    "databricks.yml",
+]

--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
@@ -25,6 +25,7 @@ var unsupportedResources = []string{
 	"registered_models",
 	"database_catalogs",
 	"synced_database_tables",
+	"secrets",
 }
 
 func TestApplyBundlePermissions(t *testing.T) {

--- a/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_target_mode_test.go
@@ -162,6 +162,12 @@ func mockBundle(mode config.Mode) *bundle.Bundle {
 						Name: "secretScope1",
 					},
 				},
+				Secrets: map[string]*resources.Secret{
+					"secret1": {
+						Scope: "secretScope1",
+						Key:   "secret1",
+					},
+				},
 				SqlWarehouses: map[string]*resources.SqlWarehouse{
 					"sql_warehouse1": {
 						CreateWarehouseRequest: sql.CreateWarehouseRequest{
@@ -365,7 +371,7 @@ func TestAllNonUcResourcesAreRenamed(t *testing.T) {
 				resourceType := resources.Type().Field(i).Name
 
 				// Skip resources that are not renamed
-				if resourceType == "Apps" || resourceType == "SecretScopes" || resourceType == "DatabaseInstances" || resourceType == "DatabaseCatalogs" || resourceType == "SyncedDatabaseTables" {
+				if resourceType == "Apps" || resourceType == "SecretScopes" || resourceType == "Secrets" || resourceType == "DatabaseInstances" || resourceType == "DatabaseCatalogs" || resourceType == "SyncedDatabaseTables" {
 					continue
 				}
 

--- a/bundle/config/mutator/resourcemutator/run_as_test.go
+++ b/bundle/config/mutator/resourcemutator/run_as_test.go
@@ -47,6 +47,7 @@ func allResourceTypes(t *testing.T) []string {
 		"registered_models",
 		"schemas",
 		"secret_scopes",
+		"secrets",
 		"sql_warehouses",
 		"synced_database_tables",
 		"volumes",
@@ -156,6 +157,7 @@ var allowList = []string{
 	"experiments",
 	"schemas",
 	"secret_scopes",
+	"secrets",
 	"sql_warehouses",
 	"volumes",
 }

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -25,6 +25,7 @@ type Resources struct {
 	Dashboards            map[string]*resources.Dashboard            `json:"dashboards,omitempty"`
 	Apps                  map[string]*resources.App                  `json:"apps,omitempty"`
 	SecretScopes          map[string]*resources.SecretScope          `json:"secret_scopes,omitempty"`
+	Secrets               map[string]*resources.Secret               `json:"secrets,omitempty"`
 	// Alerts                map[string]*resources.Alert                `json:"alerts,omitempty"`
 	SqlWarehouses        map[string]*resources.SqlWarehouse        `json:"sql_warehouses,omitempty"`
 	DatabaseInstances    map[string]*resources.DatabaseInstance    `json:"database_instances,omitempty"`
@@ -94,6 +95,7 @@ func (r *Resources) AllResources() []ResourceGroup {
 		collectResourceMap(descriptions["apps"], r.Apps),
 		// collectResourceMap(descriptions["alerts"], r.Alerts),
 		collectResourceMap(descriptions["secret_scopes"], r.SecretScopes),
+		collectResourceMap(descriptions["secrets"], r.Secrets),
 		collectResourceMap(descriptions["sql_warehouses"], r.SqlWarehouses),
 		collectResourceMap(descriptions["database_instances"], r.DatabaseInstances),
 		collectResourceMap(descriptions["database_catalogs"], r.DatabaseCatalogs),
@@ -175,6 +177,12 @@ func (r *Resources) FindResourceByConfigKey(key string) (ConfigResource, error) 
 		}
 	}
 
+	for k := range r.Secrets {
+		if k == key {
+			found = append(found, r.Secrets[k])
+		}
+	}
+
 	// for k := range r.Alerts {
 	// 	if k == key {
 	// 		found = append(found, r.Alerts[k])
@@ -236,6 +244,7 @@ func SupportedResources() map[string]resources.ResourceDescription {
 		"volumes":                 (&resources.Volume{}).ResourceDescription(),
 		"apps":                    (&resources.App{}).ResourceDescription(),
 		"secret_scopes":           (&resources.SecretScope{}).ResourceDescription(),
+		"secrets":                 (&resources.Secret{}).ResourceDescription(),
 		// "alerts":                  (&resources.Alert{}).ResourceDescription(),
 		"sql_warehouses":         (&resources.SqlWarehouse{}).ResourceDescription(),
 		"database_instances":     (&resources.DatabaseInstance{}).ResourceDescription(),

--- a/bundle/config/resources/secret.go
+++ b/bundle/config/resources/secret.go
@@ -1,0 +1,78 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/marshal"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+type Secret struct {
+	BaseResource
+
+	// The name of the secret scope containing the secret.
+	Scope string `json:"scope"`
+
+	// A unique name to identify the secret.
+	Key string `json:"key"`
+
+	// The string value of the secret. Only one of string_value or bytes_value can be specified.
+	StringValue string `json:"string_value,omitempty"`
+
+	// The base64-encoded bytes value of the secret. Only one of string_value or bytes_value can be specified.
+	BytesValue string `json:"bytes_value,omitempty"`
+}
+
+func (s *Secret) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, s)
+}
+
+func (s Secret) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(s)
+}
+
+func (s Secret) Exists(ctx context.Context, w *databricks.WorkspaceClient, id string) (bool, error) {
+	// Secrets don't have a direct "get" API - we can check if it exists by trying to get its metadata
+	// The GetSecret API returns the secret metadata (not the value)
+	_, err := w.Secrets.GetSecret(ctx, workspace.GetSecretRequest{
+		Scope: s.Scope,
+		Key:   s.Key,
+	})
+	if err != nil {
+		if apierr.IsMissing(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (s Secret) ResourceDescription() ResourceDescription {
+	return ResourceDescription{
+		SingularName:  "secret",
+		PluralName:    "secrets",
+		SingularTitle: "Secret",
+		PluralTitle:   "Secrets",
+	}
+}
+
+func (s Secret) GetName() string {
+	if s.ID != "" {
+		return s.ID
+	}
+	// Return a composite name of scope/key
+	return fmt.Sprintf("%s/%s", s.Scope, s.Key)
+}
+
+func (s Secret) GetURL() string {
+	// Secrets do not have a URL in the Databricks UI
+	return ""
+}
+
+func (s Secret) InitializeURL(_ url.URL) {
+	// Secrets do not have a URL
+}

--- a/bundle/config/resources/secret_scope.go
+++ b/bundle/config/resources/secret_scope.go
@@ -61,7 +61,7 @@ func (s SecretScope) Exists(ctx context.Context, w *databricks.WorkspaceClient, 
 	// The indirect methods are not semantically ideal for simple existence checks, so we use the list API here
 	scopes, err := w.Secrets.ListScopesAll(ctx)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	for _, scope := range scopes {

--- a/bundle/config/resources/secret_scope_test.go
+++ b/bundle/config/resources/secret_scope_test.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretScopeExists(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockSecretsAPI().On("ListScopesAll", mock.Anything).Return([]workspace.SecretScope{
+		{Name: "my_scope"},
+		{Name: "other_scope"},
+	}, nil)
+
+	s := &SecretScope{
+		Name: "my_scope",
+	}
+	exists, err := s.Exists(ctx, m.WorkspaceClient, "my_scope")
+
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestSecretScopeNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockSecretsAPI().On("ListScopesAll", mock.Anything).Return([]workspace.SecretScope{
+		{Name: "other_scope"},
+	}, nil)
+
+	s := &SecretScope{
+		Name: "my_scope",
+	}
+	exists, err := s.Exists(ctx, m.WorkspaceClient, "my_scope")
+
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestSecretScopeGetName(t *testing.T) {
+	s := &SecretScope{
+		Name: "my_scope",
+	}
+	assert.Equal(t, "my_scope", s.GetName())
+
+	s.ID = "custom_id"
+	assert.Equal(t, "custom_id", s.GetName())
+}
+
+func TestSecretScopeResourceDescription(t *testing.T) {
+	s := &SecretScope{}
+	desc := s.ResourceDescription()
+
+	assert.Equal(t, "secret_scope", desc.SingularName)
+	assert.Equal(t, "secret_scopes", desc.PluralName)
+	assert.Equal(t, "Secret Scope", desc.SingularTitle)
+	assert.Equal(t, "Secret Scopes", desc.PluralTitle)
+}

--- a/bundle/config/resources/secret_test.go
+++ b/bundle/config/resources/secret_test.go
@@ -1,0 +1,88 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretExists(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockSecretsAPI().On("GetSecret", mock.Anything, workspace.GetSecretRequest{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}).Return(&workspace.GetSecretResponse{
+		Key: "my_key",
+	}, nil)
+
+	s := &Secret{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}
+	exists, err := s.Exists(ctx, m.WorkspaceClient, "my_scope/my_key")
+
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestSecretNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockSecretsAPI().On("GetSecret", mock.Anything, workspace.GetSecretRequest{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}).Return((*workspace.GetSecretResponse)(nil), &apierr.APIError{
+		StatusCode: 404,
+		ErrorCode:  "RESOURCE_DOES_NOT_EXIST",
+	})
+
+	s := &Secret{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}
+	exists, err := s.Exists(ctx, m.WorkspaceClient, "my_scope/my_key")
+
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestSecretExistsError(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockSecretsAPI().On("GetSecret", mock.Anything, workspace.GetSecretRequest{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}).Return((*workspace.GetSecretResponse)(nil), &apierr.APIError{
+		StatusCode: 500,
+		ErrorCode:  "INTERNAL_ERROR",
+	})
+
+	s := &Secret{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}
+	_, err := s.Exists(ctx, m.WorkspaceClient, "my_scope/my_key")
+
+	require.Error(t, err)
+}
+
+func TestSecretGetName(t *testing.T) {
+	s := &Secret{
+		Scope: "my_scope",
+		Key:   "my_key",
+	}
+	assert.Equal(t, "my_scope/my_key", s.GetName())
+
+	s.ID = "custom_id"
+	assert.Equal(t, "custom_id", s.GetName())
+}

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -180,6 +180,12 @@ func TestResourcesBindSupport(t *testing.T) {
 				Name: "0",
 			},
 		},
+		Secrets: map[string]*resources.Secret{
+			"my_secret": {
+				Scope: "0",
+				Key:   "0",
+			},
+		},
 		SqlWarehouses: map[string]*resources.SqlWarehouse{
 			"my_sql_warehouse": {
 				CreateWarehouseRequest: sql.CreateWarehouseRequest{},
@@ -220,6 +226,7 @@ func TestResourcesBindSupport(t *testing.T) {
 	m.GetMockSecretsAPI().EXPECT().ListScopesAll(mock.Anything).Return([]workspace.SecretScope{
 		{Name: "0"},
 	}, nil)
+	m.GetMockSecretsAPI().EXPECT().GetSecret(mock.Anything, mock.Anything).Return(&workspace.GetSecretResponse{}, nil)
 	m.GetMockWarehousesAPI().EXPECT().GetById(mock.Anything, mock.Anything).Return(nil, nil)
 	m.GetMockDatabaseAPI().EXPECT().GetDatabaseInstance(mock.Anything, mock.Anything).Return(nil, nil)
 	m.GetMockDatabaseAPI().EXPECT().GetDatabaseCatalog(mock.Anything, mock.Anything).Return(nil, nil)

--- a/bundle/deploy/terraform/pkg.go
+++ b/bundle/deploy/terraform/pkg.go
@@ -116,6 +116,7 @@ var GroupToTerraformName = map[string]string{
 	"volumes":                 "databricks_volume",
 	"apps":                    "databricks_app",
 	"secret_scopes":           "databricks_secret_scope",
+	"secrets":                 "databricks_secret",
 	"alerts":                  "databricks_alert_v2",
 	"sql_warehouses":          "databricks_sql_endpoint",
 	"database_instances":      "databricks_database_instance",

--- a/bundle/deploy/terraform/tfdyn/convert_secret.go
+++ b/bundle/deploy/terraform/tfdyn/convert_secret.go
@@ -1,0 +1,34 @@
+package tfdyn
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle/internal/tf/schema"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/cli/libs/log"
+)
+
+type secretConverter struct{}
+
+func (secretConverter) Convert(ctx context.Context, key string, vin dyn.Value, out *schema.Resources) error {
+	// Normalize the output value to the target schema.
+	vout, diags := convert.Normalize(schema.ResourceSecret{}, vin)
+	for _, diag := range diags {
+		log.Debugf(ctx, "secret normalization diagnostic: %s", diag.Summary)
+	}
+
+	vout, err := convertLifecycle(ctx, vout, vin.Get("lifecycle"))
+	if err != nil {
+		return err
+	}
+
+	// Add the converted resource to the output.
+	out.Secret[key] = vout.AsAny()
+
+	return nil
+}
+
+func init() {
+	registerConverter("secrets", secretConverter{})
+}

--- a/bundle/deploy/terraform/tfdyn/convert_secret_scope_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_secret_scope_test.go
@@ -1,0 +1,109 @@
+package tfdyn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/tf/schema"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertSecretScope(t *testing.T) {
+	src := resources.SecretScope{
+		Name:        "my_scope",
+		BackendType: workspace.ScopeBackendTypeDatabricks,
+	}
+
+	vin, err := convert.FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	out := schema.NewResources()
+	err = secretScopeConverter{}.Convert(ctx, "my_scope", vin, out)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"name":         "my_scope",
+		"backend_type": "DATABRICKS",
+	}, out.SecretScope["my_scope"])
+}
+
+func TestConvertSecretScopeWithPermissions(t *testing.T) {
+	src := resources.SecretScope{
+		Name:        "my_scope",
+		BackendType: workspace.ScopeBackendTypeDatabricks,
+		Permissions: []resources.SecretScopePermission{
+			{
+				Level:    "READ",
+				UserName: "user@example.com",
+			},
+			{
+				Level:     "MANAGE",
+				GroupName: "admins",
+			},
+		},
+	}
+
+	vin, err := convert.FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	out := schema.NewResources()
+	err = secretScopeConverter{}.Convert(ctx, "my_scope", vin, out)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"name":         "my_scope",
+		"backend_type": "DATABRICKS",
+	}, out.SecretScope["my_scope"])
+
+	// Verify ACLs are created
+	assert.Len(t, out.SecretAcl, 2)
+
+	acl0 := out.SecretAcl["secret_acl_my_scope_0"]
+	require.NotNil(t, acl0)
+	acl0Typed := acl0.(*resourceSecretAcl)
+	assert.Equal(t, "READ", acl0Typed.Permission)
+	assert.Equal(t, "user@example.com", acl0Typed.Principal)
+	assert.Equal(t, "my_scope", acl0Typed.Scope)
+	assert.Contains(t, acl0Typed.DependsOn, "databricks_secret_scope.my_scope")
+
+	acl1 := out.SecretAcl["secret_acl_my_scope_1"]
+	require.NotNil(t, acl1)
+	acl1Typed := acl1.(*resourceSecretAcl)
+	assert.Equal(t, "MANAGE", acl1Typed.Permission)
+	assert.Equal(t, "admins", acl1Typed.Principal)
+	assert.Equal(t, "my_scope", acl1Typed.Scope)
+}
+
+func TestConvertSecretScopeWithAzureKeyvault(t *testing.T) {
+	src := resources.SecretScope{
+		Name:        "my_keyvault_scope",
+		BackendType: workspace.ScopeBackendTypeAzureKeyvault,
+		KeyvaultMetadata: &workspace.AzureKeyVaultSecretScopeMetadata{
+			DnsName:    "https://mykeyvault.vault.azure.net/",
+			ResourceId: "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/mykeyvault",
+		},
+	}
+
+	vin, err := convert.FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	out := schema.NewResources()
+	err = secretScopeConverter{}.Convert(ctx, "my_keyvault_scope", vin, out)
+	require.NoError(t, err)
+
+	scopeOut := out.SecretScope["my_keyvault_scope"].(map[string]any)
+	assert.Equal(t, "my_keyvault_scope", scopeOut["name"])
+	assert.Equal(t, "AZURE_KEYVAULT", scopeOut["backend_type"])
+
+	keyvaultMeta := scopeOut["keyvault_metadata"].(map[string]any)
+	assert.Equal(t, "https://mykeyvault.vault.azure.net/", keyvaultMeta["dns_name"])
+	assert.Equal(t, "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/mykeyvault", keyvaultMeta["resource_id"])
+}

--- a/bundle/deploy/terraform/tfdyn/convert_secret_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_secret_test.go
@@ -1,0 +1,65 @@
+package tfdyn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/tf/schema"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/convert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertSecret(t *testing.T) {
+	src := resources.Secret{
+		Scope:       "my_scope",
+		Key:         "my_key",
+		StringValue: "my_secret_value",
+	}
+
+	vin, err := convert.FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	out := schema.NewResources()
+	err = secretConverter{}.Convert(ctx, "my_secret", vin, out)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"scope":        "my_scope",
+		"key":          "my_key",
+		"string_value": "my_secret_value",
+	}, out.Secret["my_secret"])
+}
+
+func TestConvertSecretWithLifecycle(t *testing.T) {
+	src := resources.Secret{
+		Scope:       "my_scope",
+		Key:         "my_key",
+		StringValue: "my_secret_value",
+		BaseResource: resources.BaseResource{
+			Lifecycle: resources.Lifecycle{
+				PreventDestroy: true,
+			},
+		},
+	}
+
+	vin, err := convert.FromTyped(src, dyn.NilValue)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	out := schema.NewResources()
+	err = secretConverter{}.Convert(ctx, "my_secret", vin, out)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{
+		"scope":        "my_scope",
+		"key":          "my_key",
+		"string_value": "my_secret_value",
+		"lifecycle": map[string]any{
+			"prevent_destroy": true,
+		},
+	}, out.Secret["my_secret"])
+}

--- a/bundle/direct/dresources/all.go
+++ b/bundle/direct/dresources/all.go
@@ -23,6 +23,8 @@ var SupportedResources = map[string]any{
 	"registered_models":       (*ResourceRegisteredModel)(nil),
 	"dashboards":              (*ResourceDashboard)(nil),
 	"model_serving_endpoints": (*ResourceModelServingEndpoint)(nil),
+	"secret_scopes":           (*ResourceSecretScope)(nil),
+	"secrets":                 (*ResourceSecret)(nil),
 
 	// Permissions
 	"jobs.permissions":                    (*ResourcePermissions)(nil),

--- a/bundle/direct/dresources/secret.go
+++ b/bundle/direct/dresources/secret.go
@@ -1,0 +1,146 @@
+package dresources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+type ResourceSecret struct {
+	client *databricks.WorkspaceClient
+}
+
+func (*ResourceSecret) New(client *databricks.WorkspaceClient) *ResourceSecret {
+	return &ResourceSecret{client: client}
+}
+
+// SecretState represents the state we store for secrets
+type SecretState struct {
+	Scope       string `json:"scope"`
+	Key         string `json:"key"`
+	StringValue string `json:"string_value,omitempty"`
+	BytesValue  string `json:"bytes_value,omitempty"`
+}
+
+func (*ResourceSecret) PrepareState(input *resources.Secret) *SecretState {
+	return &SecretState{
+		Scope:       input.Scope,
+		Key:         input.Key,
+		StringValue: input.StringValue,
+		BytesValue:  input.BytesValue,
+	}
+}
+
+func (*ResourceSecret) RemapState(info *SecretMetadata) *SecretState {
+	// Note: The API doesn't return the actual secret value for security reasons
+	// We only track the scope and key in remote state
+	return &SecretState{
+		Scope:       info.Scope,
+		Key:         info.Key,
+		StringValue: "", // Not returned by the API for security
+		BytesValue:  "", // Not returned by the API for security
+	}
+}
+
+func (r *ResourceSecret) DoRead(ctx context.Context, id string) (*SecretMetadata, error) {
+	// ID format is "scope/key"
+	scope, key, err := parseSecretID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.client.Secrets.GetSecret(ctx, workspace.GetSecretRequest{
+		Scope: scope,
+		Key:   key,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to our metadata type that includes scope
+	return &SecretMetadata{
+		Scope: scope,
+		Key:   resp.Key,
+	}, nil
+}
+
+// SecretMetadata holds metadata about a secret (not the actual value)
+type SecretMetadata struct {
+	Scope string `json:"scope"`
+	Key   string `json:"key"`
+}
+
+func (r *ResourceSecret) DoCreate(ctx context.Context, config *SecretState) (string, *SecretMetadata, error) {
+	err := r.client.Secrets.PutSecret(ctx, workspace.PutSecret{
+		Scope:           config.Scope,
+		Key:             config.Key,
+		StringValue:     config.StringValue,
+		BytesValue:      config.BytesValue,
+		ForceSendFields: nil,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	id := fmt.Sprintf("%s/%s", config.Scope, config.Key)
+
+	// Read back the secret to get remote state
+	remoteState, err := r.DoRead(ctx, id)
+	if err != nil {
+		return id, nil, err
+	}
+
+	return id, remoteState, nil
+}
+
+// DoUpdate updates the secret value in place
+func (r *ResourceSecret) DoUpdate(ctx context.Context, id string, config *SecretState) (*SecretMetadata, error) {
+	// PutSecret with the same scope/key updates the value
+	err := r.client.Secrets.PutSecret(ctx, workspace.PutSecret{
+		Scope:           config.Scope,
+		Key:             config.Key,
+		StringValue:     config.StringValue,
+		BytesValue:      config.BytesValue,
+		ForceSendFields: nil,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Read back the secret to get remote state
+	return r.DoRead(ctx, id)
+}
+
+func (r *ResourceSecret) DoDelete(ctx context.Context, id string) error {
+	scope, key, err := parseSecretID(id)
+	if err != nil {
+		return err
+	}
+
+	return r.client.Secrets.DeleteSecret(ctx, workspace.DeleteSecret{
+		Scope: scope,
+		Key:   key,
+	})
+}
+
+func (*ResourceSecret) FieldTriggers(_ bool) map[string]deployplan.ActionType {
+	return map[string]deployplan.ActionType{
+		"scope": deployplan.ActionTypeRecreate,
+		"key":   deployplan.ActionTypeRecreate,
+	}
+}
+
+// parseSecretID parses a secret ID in the format "scope/key"
+func parseSecretID(id string) (string, string, error) {
+	// Simple parsing - find the first slash
+	for i := range len(id) {
+		if id[i] == '/' {
+			return id[:i], id[i+1:], nil
+		}
+	}
+	return "", "", fmt.Errorf("invalid secret ID format: %s (expected scope/key)", id)
+}

--- a/bundle/direct/dresources/secret_scope.go
+++ b/bundle/direct/dresources/secret_scope.go
@@ -1,0 +1,111 @@
+package dresources
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+type ResourceSecretScope struct {
+	client *databricks.WorkspaceClient
+}
+
+func (*ResourceSecretScope) New(client *databricks.WorkspaceClient) *ResourceSecretScope {
+	return &ResourceSecretScope{client: client}
+}
+
+// SecretScopeState represents the state we store for secret scopes
+type SecretScopeState struct {
+	Name             string                                      `json:"name"`
+	BackendType      workspace.ScopeBackendType                  `json:"backend_type,omitempty"`
+	KeyvaultMetadata *workspace.AzureKeyVaultSecretScopeMetadata `json:"keyvault_metadata,omitempty"`
+}
+
+func (*ResourceSecretScope) PrepareState(input *resources.SecretScope) *SecretScopeState {
+	return &SecretScopeState{
+		Name:             input.Name,
+		BackendType:      input.BackendType,
+		KeyvaultMetadata: input.KeyvaultMetadata,
+	}
+}
+
+func (*ResourceSecretScope) RemapState(info *workspace.SecretScope) *SecretScopeState {
+	return &SecretScopeState{
+		Name:             info.Name,
+		BackendType:      info.BackendType,
+		KeyvaultMetadata: info.KeyvaultMetadata,
+	}
+}
+
+func (r *ResourceSecretScope) DoRead(ctx context.Context, id string) (*workspace.SecretScope, error) {
+	// ID is the scope name
+	// The Secrets API doesn't have a direct "get by name" endpoint, so we list and find
+	scopes, err := r.client.Secrets.ListScopesAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, scope := range scopes {
+		if scope.Name == id {
+			return &scope, nil
+		}
+	}
+
+	// Return not found error (will be handled as resource gone)
+	return nil, &apierr.APIError{
+		StatusCode:      404,
+		Message:         "Secret scope not found: " + id,
+		ErrorCode:       "",
+		ResponseWrapper: nil,
+		Details:         nil,
+	}
+}
+
+func (r *ResourceSecretScope) DoCreate(ctx context.Context, config *SecretScopeState) (string, *workspace.SecretScope, error) {
+	createRequest := workspace.CreateScope{
+		Scope:                  config.Name,
+		ScopeBackendType:       config.BackendType,
+		BackendAzureKeyvault:   config.KeyvaultMetadata,
+		InitialManagePrincipal: "", // Not supported by DABs
+		ForceSendFields:        nil,
+	}
+
+	err := r.client.Secrets.CreateScope(ctx, createRequest)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Read back the scope to get remote state
+	remoteState, err := r.DoRead(ctx, config.Name)
+	if err != nil {
+		return config.Name, nil, err
+	}
+
+	return config.Name, remoteState, nil
+}
+
+// DoUpdate is not applicable for secret scopes - most fields cannot be updated
+// The scope would need to be recreated
+func (r *ResourceSecretScope) DoUpdate(ctx context.Context, id string, config *SecretScopeState) (*workspace.SecretScope, error) {
+	// Secret scopes cannot be updated in place
+	// Any changes should trigger a recreate
+	// But we still need this method for the interface
+	// Just return the current state
+	return r.DoRead(ctx, id)
+}
+
+func (r *ResourceSecretScope) DoDelete(ctx context.Context, id string) error {
+	return r.client.Secrets.DeleteScopeByScope(ctx, id)
+}
+
+func (*ResourceSecretScope) FieldTriggers(_ bool) map[string]deployplan.ActionType {
+	return map[string]deployplan.ActionType{
+		"name":              deployplan.ActionTypeRecreate,
+		"backend_type":      deployplan.ActionTypeRecreate,
+		"keyvault_metadata": deployplan.ActionTypeRecreate,
+	}
+}

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -220,6 +220,11 @@ github.com/databricks/cli/bundle/config.Resources:
       The secret scope definitions for the bundle, where each key is the name of the secret scope.
     "markdown_description": |-
       The secret scope definitions for the bundle, where each key is the name of the secret scope. See [\_](/dev-tools/bundles/resources.md#secret_scopes).
+  "secrets":
+    "description": |-
+      The secret definitions for the bundle, where each key is the name of the secret.
+    "markdown_description": |-
+      The secret definitions for the bundle, where each key is the name of the secret. See [\_](/dev-tools/bundles/resources.md#secrets).
   "sql_warehouses":
     "description": |-
       The SQL warehouse definitions for the bundle, where each key is the name of the warehouse.
@@ -628,6 +633,22 @@ github.com/databricks/cli/bundle/config/resources.SecretScopePermission:
   "user_name":
     "description": |-
       The name of the user that has the permission set in level. This field translates to a `principal` field in secret scope ACL.
+github.com/databricks/cli/bundle/config/resources.Secret:
+  "bytes_value":
+    "description": |-
+      The base64-encoded bytes value of the secret. Only one of `string_value` or `bytes_value` can be specified.
+  "key":
+    "description": |-
+      A unique name to identify the secret.
+  "lifecycle":
+    "description": |-
+      Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+  "scope":
+    "description": |-
+      The name of the secret scope containing the secret.
+  "string_value":
+    "description": |-
+      The string value of the secret. Only one of `string_value` or `bytes_value` can be specified.
 github.com/databricks/cli/bundle/config/resources.SqlWarehousePermission:
   "group_name":
     "description": |-

--- a/bundle/statemgmt/state_load_test.go
+++ b/bundle/statemgmt/state_load_test.go
@@ -39,6 +39,7 @@ func TestStateToBundleEmptyLocalResources(t *testing.T) {
 		"resources.dashboards.test_dashboard":                         {ID: "1"},
 		"resources.apps.test_app":                                     {ID: "app1"},
 		"resources.secret_scopes.test_secret_scope":                   {ID: "secret_scope1"},
+		"resources.secrets.test_secret":                               {ID: "test_secret_scope/test_secret"},
 		"resources.sql_warehouses.test_sql_warehouse":                 {ID: "1"},
 		"resources.database_instances.test_database_instance":         {ID: "1"},
 		"resources.database_catalogs.test_database_catalog":           {ID: "1"},
@@ -192,6 +193,12 @@ func TestStateToBundleEmptyRemoteResources(t *testing.T) {
 			SecretScopes: map[string]*resources.SecretScope{
 				"test_secret_scope": {
 					Name: "test_secret_scope",
+				},
+			},
+			Secrets: map[string]*resources.Secret{
+				"test_secret": {
+					Scope: "test_secret_scope",
+					Key:   "test_secret",
 				},
 			},
 			SqlWarehouses: map[string]*resources.SqlWarehouse{
@@ -451,6 +458,16 @@ func TestStateToBundleModifiedResources(t *testing.T) {
 					Name: "test_secret_scope_new",
 				},
 			},
+			Secrets: map[string]*resources.Secret{
+				"test_secret": {
+					Scope: "test_secret_scope",
+					Key:   "test_secret",
+				},
+				"test_secret_new": {
+					Scope: "test_secret_scope",
+					Key:   "test_secret_new",
+				},
+			},
 			SqlWarehouses: map[string]*resources.SqlWarehouse{
 				"test_sql_warehouse": {
 					CreateWarehouseRequest: sql.CreateWarehouseRequest{
@@ -540,6 +557,8 @@ func TestStateToBundleModifiedResources(t *testing.T) {
 		"resources.apps.test_app_old":                              {ID: "test_app_old"},
 		"resources.secret_scopes.test_secret_scope":                {ID: "test_secret_scope"},
 		"resources.secret_scopes.test_secret_scope_old":            {ID: "test_secret_scope_old"},
+		"resources.secrets.test_secret":                            {ID: "test_secret_scope/test_secret"},
+		"resources.secrets.test_secret_old":                        {ID: "test_secret_scope/test_secret_old"},
 		"resources.sql_warehouses.test_sql_warehouse":              {ID: "1"},
 		"resources.sql_warehouses.test_sql_warehouse_old":          {ID: "2"},
 		"resources.database_instances.test_database_instance":      {ID: "1"},

--- a/integration/bundle/secrets_modes_test.go
+++ b/integration/bundle/secrets_modes_test.go
@@ -1,0 +1,227 @@
+package bundle_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/integration/internal/acc"
+	"github.com/databricks/cli/internal/testcli"
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBundleSecretsWithTerraformMode tests secrets deployment using Terraform mode (default)
+func TestBundleSecretsWithTerraformMode(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-tf-test-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    test_secret:
+      scope: %s
+      key: test_key
+      string_value: "terraform_mode_value"
+`, uniqueId, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Explicitly set Terraform mode (this is the default)
+	ctx = env.Set(ctx, "DATABRICKS_BUNDLE_ENGINE", "terraform")
+
+	// Deploy the bundle
+	t.Log("Deploying bundle with Terraform mode...")
+	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
+	c := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve")
+	_, _, err = c.Run()
+	require.NoError(t, err)
+
+	// Verify the secret exists and has correct value
+	t.Log("Verifying secret...")
+	assertSecretValue(t, wt, scopeName, "test_key", "terraform_mode_value")
+
+	// Clean up
+	t.Log("Destroying bundle...")
+	destroyBundle(t, ctx, bundleRoot)
+}
+
+// TestBundleSecretsWithDirectMode tests secrets deployment using direct mode
+func TestBundleSecretsWithDirectMode(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-direct-test-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    test_secret:
+      scope: %s
+      key: test_key
+      string_value: "direct_mode_value"
+`, uniqueId, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Set direct mode
+	ctx = env.Set(ctx, "DATABRICKS_BUNDLE_ENGINE", "direct")
+
+	// Deploy the bundle
+	t.Log("Deploying bundle with direct mode...")
+	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
+	c := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve")
+	_, _, err = c.Run()
+	require.NoError(t, err)
+
+	// Verify the secret exists and has correct value
+	t.Log("Verifying secret...")
+	assertSecretValue(t, wt, scopeName, "test_key", "direct_mode_value")
+
+	// Clean up
+	t.Log("Destroying bundle...")
+	c2 := testcli.NewRunner(t, ctx, "bundle", "destroy", "--auto-approve")
+	_, _, err = c2.Run()
+	require.NoError(t, err)
+}
+
+// TestBundleSecretsSwitchModes tests switching between modes
+func TestBundleSecretsSwitchModes(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-switch-test-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    test_secret:
+      scope: %s
+      key: test_key
+      string_value: "initial_value"
+`, uniqueId, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy with Terraform mode first
+	t.Log("Deploying with Terraform mode...")
+	ctx = env.Set(ctx, "DATABRICKS_BUNDLE_ENGINE", "terraform")
+	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
+	c := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve")
+	_, _, err = c.Run()
+	require.NoError(t, err)
+
+	// Verify the secret
+	assertSecretValue(t, wt, scopeName, "test_key", "initial_value")
+
+	// Update the config
+	updatedConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    test_secret:
+      scope: %s
+      key: test_key
+      string_value: "updated_value"
+`, uniqueId, scopeName, scopeName)
+
+	err = os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(updatedConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy with direct mode
+	t.Log("Deploying with direct mode...")
+	ctx = env.Set(ctx, "DATABRICKS_BUNDLE_ENGINE", "direct")
+	c2 := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve")
+	_, _, err = c2.Run()
+
+	// Note: Switching modes may or may not be supported depending on state management
+	// If it's not supported, we should get an error
+	if err != nil {
+		t.Log("Mode switching not supported (expected):", err)
+		assert.Contains(t, err.Error(), "state") // Should mention state issues
+	} else {
+		t.Log("Mode switching succeeded")
+		// If it works, verify the value was updated
+		assertSecretValue(t, wt, scopeName, "test_key", "updated_value")
+	}
+
+	// Clean up
+	t.Log("Cleaning up...")
+	// Use the same mode for cleanup
+	c3 := testcli.NewRunner(t, ctx, "bundle", "destroy", "--auto-approve")
+	_, _, _ = c3.Run() // Best effort cleanup
+}

--- a/integration/bundle/secrets_test.go
+++ b/integration/bundle/secrets_test.go
@@ -1,0 +1,371 @@
+package bundle_test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/integration/internal/acc"
+	"github.com/databricks/cli/internal/testcli"
+	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleSecretsDeployAndUpdate(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-test-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    secret1:
+      scope: %s
+      key: secret_key_1
+      string_value: "initial_value_1"
+
+    secret2:
+      scope: %s
+      key: secret_key_2
+      string_value: "initial_value_2"
+
+    secret3:
+      scope: %s
+      key: secret_key_3
+      string_value: "value_with_special_chars_!@#$%%"
+`, uniqueId, scopeName, scopeName, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy the bundle
+	t.Log("Deploying bundle with secrets...")
+	deployBundle(t, ctx, bundleRoot)
+
+	// Verify the secret scope was created
+	t.Log("Verifying secret scope exists...")
+	scopes, err := wt.W.Secrets.ListScopesAll(ctx)
+	require.NoError(t, err)
+
+	var foundScope bool
+	for _, scope := range scopes {
+		if scope.Name == scopeName {
+			foundScope = true
+			break
+		}
+	}
+	assert.True(t, foundScope, "Secret scope should be created")
+
+	// Verify secrets exist and have correct values
+	t.Log("Verifying secrets exist and have correct values...")
+	assertSecretValue(t, wt, scopeName, "secret_key_1", "initial_value_1")
+	assertSecretValue(t, wt, scopeName, "secret_key_2", "initial_value_2")
+	assertSecretValue(t, wt, scopeName, "secret_key_3", "value_with_special_chars_!@#$%")
+
+	// Update one of the secrets
+	t.Log("Updating secret value...")
+	updatedConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    secret1:
+      scope: %s
+      key: secret_key_1
+      string_value: "updated_value_1"
+
+    secret2:
+      scope: %s
+      key: secret_key_2
+      string_value: "initial_value_2"
+
+    secret3:
+      scope: %s
+      key: secret_key_3
+      string_value: "value_with_special_chars_!@#$%%"
+`, uniqueId, scopeName, scopeName, scopeName, scopeName)
+
+	err = os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(updatedConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy the updated bundle
+	t.Log("Deploying updated bundle...")
+	deployBundle(t, ctx, bundleRoot)
+
+	// Verify the secret was updated
+	t.Log("Verifying secret was updated...")
+	assertSecretValue(t, wt, scopeName, "secret_key_1", "updated_value_1")
+	assertSecretValue(t, wt, scopeName, "secret_key_2", "initial_value_2")
+
+	// Clean up
+	t.Log("Destroying bundle...")
+	destroyBundle(t, ctx, bundleRoot)
+
+	// Verify the scope was deleted
+	t.Log("Verifying secret scope was deleted...")
+	scopes, err = wt.W.Secrets.ListScopesAll(ctx)
+	require.NoError(t, err)
+
+	foundScope = false
+	for _, scope := range scopes {
+		if scope.Name == scopeName {
+			foundScope = true
+			break
+		}
+	}
+	assert.False(t, foundScope, "Secret scope should be deleted after bundle destroy")
+}
+
+func TestBundleSecretsWithVariables(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-var-test-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration with variables
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+variables:
+  secret_value_1:
+    description: "Secret value from variable"
+    default: "variable_value_1"
+  secret_value_2:
+    description: "Secret value from variable"
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    secret_from_var1:
+      scope: %s
+      key: var_secret_1
+      string_value: ${var.secret_value_1}
+
+    secret_from_var2:
+      scope: %s
+      key: var_secret_2
+      string_value: ${var.secret_value_2}
+`, uniqueId, scopeName, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy the bundle with a variable override for secret_value_2
+	t.Log("Deploying bundle with variable-based secrets...")
+	ctx = env.Set(ctx, "BUNDLE_ROOT", bundleRoot)
+	c := testcli.NewRunner(t, ctx, "bundle", "deploy", "--force-lock", "--auto-approve", "--var", "secret_value_2=variable_value_2_from_flag")
+	_, _, err = c.Run()
+	require.NoError(t, err)
+
+	// Verify secrets have the correct values from variables
+	t.Log("Verifying secrets from variables...")
+	assertSecretValue(t, wt, scopeName, "var_secret_1", "variable_value_1")
+	assertSecretValue(t, wt, scopeName, "var_secret_2", "variable_value_2_from_flag")
+
+	// Clean up
+	t.Log("Destroying bundle...")
+	destroyBundle(t, ctx, bundleRoot)
+}
+
+func TestBundleSecretsWithEmptyValue(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-empty-test-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration with an empty secret value
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    empty_secret:
+      scope: %s
+      key: empty_key
+      string_value: ""
+`, uniqueId, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy the bundle
+	t.Log("Deploying bundle with empty secret...")
+	deployBundle(t, ctx, bundleRoot)
+
+	// Verify the secret exists and has an empty value
+	t.Log("Verifying empty secret...")
+	assertSecretValue(t, wt, scopeName, "empty_key", "")
+
+	// Clean up
+	t.Log("Destroying bundle...")
+	destroyBundle(t, ctx, bundleRoot)
+}
+
+func TestBundleSecretsLifecycle(t *testing.T) {
+	if os.Getenv("CLOUD_ENV") == "ucws" {
+		t.Skip("Skipping on ucws environment")
+	}
+
+	ctx, wt := acc.WorkspaceTest(t)
+
+	// Generate unique names for the test
+	uniqueId := testutil.RandomName("secrets-lifecycle-")
+	scopeName := fmt.Sprintf("%s-scope", uniqueId)
+
+	// Create a temporary directory for the bundle
+	bundleRoot := t.TempDir()
+
+	// Write the bundle configuration with a secret that prevents deletion
+	bundleConfig := fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    lifecycle_secret:
+      scope: %s
+      key: lifecycle_key
+      string_value: "test_value"
+      lifecycle:
+        prevent_destroy: true
+`, uniqueId, scopeName, scopeName)
+
+	err := os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy the bundle
+	t.Log("Deploying bundle with lifecycle-protected secret...")
+	deployBundle(t, ctx, bundleRoot)
+
+	// Verify the secret exists
+	assertSecretValue(t, wt, scopeName, "lifecycle_key", "test_value")
+
+	// Update the bundle to remove the lifecycle protection
+	bundleConfig = fmt.Sprintf(`
+bundle:
+  name: %s
+
+workspace:
+  root_path: ~/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  secret_scopes:
+    test_scope:
+      name: %s
+
+  secrets:
+    lifecycle_secret:
+      scope: %s
+      key: lifecycle_key
+      string_value: "test_value"
+`, uniqueId, scopeName, scopeName)
+
+	err = os.WriteFile(filepath.Join(bundleRoot, "databricks.yml"), []byte(bundleConfig), 0o644)
+	require.NoError(t, err)
+
+	// Deploy the updated bundle
+	t.Log("Deploying updated bundle without lifecycle protection...")
+	deployBundle(t, ctx, bundleRoot)
+
+	// Clean up
+	t.Log("Destroying bundle...")
+	destroyBundle(t, ctx, bundleRoot)
+}
+
+// assertSecretValue verifies that a secret exists and has the expected value
+func assertSecretValue(t *testing.T, wt *acc.WorkspaceT, scope, key, expected string) {
+	ctx := context.Background()
+
+	// Get the secret metadata to verify it exists
+	_, err := wt.W.Secrets.GetSecret(ctx, workspace.GetSecretRequest{
+		Scope: scope,
+		Key:   key,
+	})
+	require.NoError(t, err, "Secret %s/%s should exist", scope, key)
+
+	// Use dbutils to get the actual secret value
+	// We need to run Python code on a cluster to access dbutils.secrets
+	out, err := wt.RunPython(fmt.Sprintf(`
+		import base64
+		value = dbutils.secrets.get(scope="%s", key="%s")
+		encoded_value = base64.b64encode(value.encode('utf-8'))
+		print(encoded_value.decode('utf-8'))
+	`, scope, key))
+	require.NoError(t, err, "Failed to retrieve secret value via dbutils")
+
+	decoded, err := base64.StdEncoding.DecodeString(out)
+	require.NoError(t, err, "Failed to decode secret value")
+	assert.Equal(t, expected, string(decoded), "Secret %s/%s should have the expected value", scope, key)
+}

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -138,6 +138,10 @@ type FakeWorkspace struct {
 
 	Acls map[string][]workspace.AclItem
 
+	// Secret scopes and secrets
+	SecretScopes map[string]workspace.SecretScope
+	Secrets      map[string]workspace.SecretMetadata // key is "scope/key"
+
 	// Generic permissions storage: key is "{object_type}:{object_id}"
 	Permissions map[string]iam.ObjectPermissions
 
@@ -235,6 +239,8 @@ func NewFakeWorkspace(url, token string) *FakeWorkspace {
 		ServingEndpoints:     map[string]serving.ServingEndpointDetailed{},
 		Repos:                map[string]workspace.RepoInfo{},
 		Acls:                 map[string][]workspace.AclItem{},
+		SecretScopes:         map[string]workspace.SecretScope{},
+		Secrets:              map[string]workspace.SecretMetadata{},
 		Permissions:          map[string]iam.ObjectPermissions{},
 		DatabaseInstances:    map[string]database.DatabaseInstance{},
 		DatabaseCatalogs:     map[string]database.DatabaseCatalog{},

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -477,6 +477,33 @@ func AddDefaultHandlers(server *Server) {
 	server.Handle("POST", "/api/2.0/secrets/acls/delete", func(req Request) any {
 		return req.Workspace.SecretsAclsDelete(req)
 	})
+
+	// Secret Scopes:
+	server.Handle("POST", "/api/2.0/secrets/scopes/create", func(req Request) any {
+		return req.Workspace.SecretScopeCreate(req)
+	})
+
+	server.Handle("GET", "/api/2.0/secrets/scopes/list", func(req Request) any {
+		return req.Workspace.SecretScopeList(req)
+	})
+
+	server.Handle("POST", "/api/2.0/secrets/scopes/delete", func(req Request) any {
+		return req.Workspace.SecretScopeDelete(req)
+	})
+
+	// Secrets:
+	server.Handle("POST", "/api/2.0/secrets/put", func(req Request) any {
+		return req.Workspace.SecretPut(req)
+	})
+
+	server.Handle("GET", "/api/2.0/secrets/get", func(req Request) any {
+		return req.Workspace.SecretGet(req)
+	})
+
+	server.Handle("POST", "/api/2.0/secrets/delete", func(req Request) any {
+		return req.Workspace.SecretDelete(req)
+	})
+
 	// Database Instances:
 
 	server.Handle("POST", "/api/2.0/database/instances", func(req Request) any {

--- a/libs/testserver/secrets.go
+++ b/libs/testserver/secrets.go
@@ -1,0 +1,187 @@
+package testserver
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+// SecretScopeCreate handles POST /api/2.0/secrets/scopes/create
+func (s *FakeWorkspace) SecretScopeCreate(req Request) Response {
+	defer s.LockUnlock()()
+
+	var createReq workspace.CreateScope
+	if err := json.Unmarshal(req.Body, &createReq); err != nil {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": err.Error()},
+		}
+	}
+
+	if createReq.Scope == "" {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": "Scope name is required"},
+		}
+	}
+
+	if _, exists := s.SecretScopes[createReq.Scope]; exists {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"error_code": "RESOURCE_ALREADY_EXISTS", "message": "Scope already exists"},
+		}
+	}
+
+	scope := workspace.SecretScope{
+		Name:             createReq.Scope,
+		BackendType:      createReq.ScopeBackendType,
+		KeyvaultMetadata: createReq.BackendAzureKeyvault,
+	}
+
+	s.SecretScopes[createReq.Scope] = scope
+
+	return Response{}
+}
+
+// SecretScopeList handles GET /api/2.0/secrets/scopes/list
+func (s *FakeWorkspace) SecretScopeList(req Request) Response {
+	defer s.LockUnlock()()
+
+	scopes := make([]workspace.SecretScope, 0, len(s.SecretScopes))
+	for _, scope := range s.SecretScopes {
+		scopes = append(scopes, scope)
+	}
+
+	return Response{
+		Body: map[string]any{
+			"scopes": scopes,
+		},
+	}
+}
+
+// SecretScopeDelete handles POST /api/2.0/secrets/scopes/delete
+func (s *FakeWorkspace) SecretScopeDelete(req Request) Response {
+	defer s.LockUnlock()()
+
+	var deleteReq struct {
+		Scope string `json:"scope"`
+	}
+	if err := json.Unmarshal(req.Body, &deleteReq); err != nil {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": err.Error()},
+		}
+	}
+
+	if _, exists := s.SecretScopes[deleteReq.Scope]; !exists {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Scope not found"},
+		}
+	}
+
+	delete(s.SecretScopes, deleteReq.Scope)
+
+	// Also delete all secrets in this scope
+	for key := range s.Secrets {
+		// Key format is "scope/key"
+		if len(key) > len(deleteReq.Scope) && key[:len(deleteReq.Scope)] == deleteReq.Scope && key[len(deleteReq.Scope)] == '/' {
+			delete(s.Secrets, key)
+		}
+	}
+
+	return Response{}
+}
+
+// SecretPut handles POST /api/2.0/secrets/put
+func (s *FakeWorkspace) SecretPut(req Request) Response {
+	defer s.LockUnlock()()
+
+	var putReq workspace.PutSecret
+	if err := json.Unmarshal(req.Body, &putReq); err != nil {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": err.Error()},
+		}
+	}
+
+	if putReq.Scope == "" || putReq.Key == "" {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": "Scope and key are required"},
+		}
+	}
+
+	// Check if scope exists
+	if _, exists := s.SecretScopes[putReq.Scope]; !exists {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Scope not found"},
+		}
+	}
+
+	secretKey := fmt.Sprintf("%s/%s", putReq.Scope, putReq.Key)
+	s.Secrets[secretKey] = workspace.SecretMetadata{
+		Key:                  putReq.Key,
+		LastUpdatedTimestamp: nowMilli(),
+	}
+
+	return Response{}
+}
+
+// SecretGet handles GET /api/2.0/secrets/get
+func (s *FakeWorkspace) SecretGet(req Request) Response {
+	defer s.LockUnlock()()
+
+	scope := req.URL.Query().Get("scope")
+	key := req.URL.Query().Get("key")
+
+	if scope == "" || key == "" {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": "Scope and key are required"},
+		}
+	}
+
+	secretKey := fmt.Sprintf("%s/%s", scope, key)
+	secret, exists := s.Secrets[secretKey]
+	if !exists {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Secret not found"},
+		}
+	}
+
+	return Response{
+		Body: workspace.GetSecretResponse{
+			Key:   secret.Key,
+			Value: "", // Value is never returned for security reasons
+		},
+	}
+}
+
+// SecretDelete handles POST /api/2.0/secrets/delete
+func (s *FakeWorkspace) SecretDelete(req Request) Response {
+	defer s.LockUnlock()()
+
+	var deleteReq workspace.DeleteSecret
+	if err := json.Unmarshal(req.Body, &deleteReq); err != nil {
+		return Response{
+			StatusCode: 400,
+			Body:       map[string]string{"message": err.Error()},
+		}
+	}
+
+	secretKey := fmt.Sprintf("%s/%s", deleteReq.Scope, deleteReq.Key)
+	if _, exists := s.Secrets[secretKey]; !exists {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Secret not found"},
+		}
+	}
+
+	delete(s.Secrets, secretKey)
+
+	return Response{}
+}


### PR DESCRIPTION
## Changes

Add `secrets` and `secret_scopes` as bundle resources

```yaml
resources:
  secret_scopes:
    my_scope:
      name: my-secret-scope
      permissions:
        - user_name: user@example.com
          level: READ

  secrets:
    api_key:
      scope: my-secret-scope
      key: api-key
      string_value: ${var.api_key_value}
```

## Why

Closes #3689

Users need to manage secrets alongside their jobs/pipelines in bundles rather than creating them manually.

## Tests

- Unit tests for resource definitions and Terraform converters
- Acceptance tests for both Terraform and direct deployment modes
- Integration tests for deploy/update/destroy workflows
- Manual verification against the actual Databricks workspace