### PR TITLE
Use `dependency-groups.dev` in `python/pyproject.toml`

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
 requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
   "pyright==1.1.380",
   "pytest-cov==5.0.0",
   "pytest==8.3.3",


### PR DESCRIPTION
## Changes

Fix warning:

```
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```