### PR TITLE
Fix "make cover"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ slowest:
 
 cover:
 	rm -fr ./acceptance/build/cover/
-	VERBOSE_TEST=1 CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} --packages ${TEST_PACKAGES} -- -coverprofile=coverage.txt -timeout=${LOCAL_TIMEOUT}
+	VERBOSE_TEST=1 ${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -coverprofile=coverage.txt -timeout=${LOCAL_TIMEOUT}
+	VERBOSE_TEST=1 CLI_GOCOVERDIR=build/cover ${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -run ${ACCEPTANCE_TEST_FILTER}
 	rm -fr ./acceptance/build/cover-merged/
 	mkdir -p acceptance/build/cover-merged/
 	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/


### PR DESCRIPTION
## Changes

The `TEST_PACKAGES` variable no longer includes acceptance tests (#4017).

This made the step that merges acceptance test coverage fail.

## Tests

Locally:
```
make cover TEST_PACKAGES=./libs/env ACCEPTANCE_TEST_FILTER=TestAccept/selftest
```