### PR TITLE
Include old & new values for changes in the plan

### DIFF
--- a/acceptance/bundle/artifacts/whl_dynamic/out.plan_update.direct.json
+++ b/acceptance/bundle/artifacts/whl_dynamic/out.plan_update.direct.json
@@ -148,13 +148,19 @@
       "changes": {
         "local": {
           "environments[0].spec.dependencies[0]": {
-            "action": "update"
+            "action": "update",
+            "old": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal/my_test_code-0.0.1+[UNIX_TIME_NANOS][2]-py3-none-any.whl",
+            "new": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal/my_test_code-0.0.1+[UNIX_TIME_NANOS][0]-py3-none-any.whl"
           },
           "tasks[task_key='TestTask'].for_each_task.task.libraries[0].whl": {
-            "action": "update"
+            "action": "update",
+            "old": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal/my_test_code-0.0.1+[UNIX_TIME_NANOS][2]-py3-none-any.whl",
+            "new": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal/my_test_code-0.0.1+[UNIX_TIME_NANOS][0]-py3-none-any.whl"
           },
           "tasks[task_key='TestTask'].libraries[0].whl": {
-            "action": "update"
+            "action": "update",
+            "old": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal/my_test_code-0.0.1+[UNIX_TIME_NANOS][2]-py3-none-any.whl",
+            "new": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal/my_test_code-0.0.1+[UNIX_TIME_NANOS][0]-py3-none-any.whl"
           }
         },
         "remote": {

--- a/acceptance/bundle/migrate/basic/out.plan_update.json
+++ b/acceptance/bundle/migrate/basic/out.plan_update.json
@@ -59,7 +59,9 @@
       "changes": {
         "local": {
           "name": {
-            "action": "update"
+            "action": "update",
+            "old": "Test Migration Job",
+            "new": "Test Migrated Job"
           }
         },
         "remote": {
@@ -173,10 +175,14 @@
       "changes": {
         "local": {
           "name": {
-            "action": "update"
+            "action": "update",
+            "old": "Test Migration Pipeline",
+            "new": "Test Migrated Pipeline"
           },
           "tags['myjob_name']": {
-            "action": "update"
+            "action": "update",
+            "old": "Test Migration Job",
+            "new": "Test Migrated Job"
           }
         },
         "remote": {

--- a/acceptance/bundle/migrate/dashboards/out.plan_after_migrate.json
+++ b/acceptance/bundle/migrate/dashboards/out.plan_after_migrate.json
@@ -18,12 +18,15 @@
       "changes": {
         "local": {
           "etag": {
-            "action": "skip"
+            "action": "skip",
+            "old": "[NUMID]"
           }
         },
         "remote": {
           "serialized_dashboard": {
-            "action": "skip"
+            "action": "skip",
+            "old": "{\"pages\":[{\"name\":\"02724bf2\",\"displayName\":\"Dashboard test bundle-deploy-dashboard\"}]}\n",
+            "new": "{\"pages\":[{\"displayName\":\"Dashboard test bundle-deploy-dashboard\",\"name\":\"02724bf2\",\"pageType\":\"PAGE_TYPE_CANVAS\"}]}\n"
           }
         }
       }

--- a/acceptance/bundle/migrate/runas/out.plan.json
+++ b/acceptance/bundle/migrate/runas/out.plan.json
@@ -33,7 +33,10 @@
       "changes": {
         "remote": {
           "run_as": {
-            "action": "skip"
+            "action": "skip",
+            "old": {
+              "service_principal_name": "[UUID]"
+            }
           }
         }
       }

--- a/acceptance/bundle/resource_deps/id_chain/out.plan_update.direct.json
+++ b/acceptance/bundle/resource_deps/id_chain/out.plan_update.direct.json
@@ -44,7 +44,9 @@
       "changes": {
         "local": {
           "description": {
-            "action": "update"
+            "action": "update",
+            "old": "aa_desc",
+            "new": "aa_new_desc"
           }
         },
         "remote": {
@@ -113,7 +115,9 @@
       "changes": {
         "local": {
           "description": {
-            "action": "update"
+            "action": "update",
+            "old": "prefix [NUMID]",
+            "new": "new_prefix [NUMID]"
           }
         },
         "remote": {
@@ -182,7 +186,9 @@
       "changes": {
         "local": {
           "description": {
-            "action": "update"
+            "action": "update",
+            "old": "prefix [NUMID]",
+            "new": "new_prefix [NUMID]"
           }
         },
         "remote": {
@@ -251,7 +257,9 @@
       "changes": {
         "local": {
           "description": {
-            "action": "update"
+            "action": "update",
+            "old": "prefix [NUMID]",
+            "new": "new_prefix [NUMID]"
           }
         },
         "remote": {
@@ -320,7 +328,9 @@
       "changes": {
         "local": {
           "description": {
-            "action": "update"
+            "action": "update",
+            "old": "prefix [NUMID]",
+            "new": "new_prefix [NUMID]"
           }
         },
         "remote": {

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.plan_update.direct.json
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.plan_update.direct.json
@@ -130,7 +130,9 @@
             "reason": "server_side_default"
           },
           "trigger.periodic.unit": {
-            "action": "update"
+            "action": "update",
+            "old": "DAYS",
+            "new": "HOURS"
           },
           "webhook_notifications": {
             "action": "skip",

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.plan_update.direct.json
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.plan_update.direct.json
@@ -53,7 +53,9 @@
       "changes": {
         "local": {
           "description": {
-            "action": "update"
+            "action": "update",
+            "old": "depends on foo id [FOO_ID]",
+            "new": "depends on foo id ${resources.pipelines.foo.id}"
           }
         },
         "remote": {
@@ -89,7 +91,9 @@
       "changes": {
         "local": {
           "catalog": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "mycatalog",
+            "new": "mynewcatalog"
           }
         }
       }

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.plan_.direct.json
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.plan_.direct.json
@@ -41,10 +41,15 @@
       "changes": {
         "local": {
           "autoscale": {
-            "action": "update"
+            "action": "update",
+            "new": {
+              "max_workers": 4,
+              "min_workers": 2
+            }
           },
           "num_workers": {
-            "action": "update"
+            "action": "update",
+            "old": 2
           }
         }
       }
@@ -81,10 +86,14 @@
       "changes": {
         "local": {
           "autoscale.max_workers": {
-            "action": "update"
+            "action": "update",
+            "old": 4,
+            "new": 5
           },
           "autoscale.min_workers": {
-            "action": "update"
+            "action": "update",
+            "old": 2,
+            "new": 3
           }
         }
       }
@@ -122,10 +131,14 @@
       "changes": {
         "local": {
           "autoscale.max_workers": {
-            "action": "resize"
+            "action": "resize",
+            "old": 5,
+            "new": 6
           },
           "autoscale.min_workers": {
-            "action": "resize"
+            "action": "resize",
+            "old": 3,
+            "new": 4
           }
         }
       }
@@ -160,10 +173,15 @@
       "changes": {
         "local": {
           "autoscale": {
-            "action": "resize"
+            "action": "resize",
+            "old": {
+              "max_workers": 6,
+              "min_workers": 4
+            }
           },
           "num_workers": {
-            "action": "resize"
+            "action": "resize",
+            "new": 3
           }
         }
       }

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.plan_.direct.json
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.plan_.direct.json
@@ -47,7 +47,9 @@
       "changes": {
         "local": {
           "num_workers": {
-            "action": "update"
+            "action": "update",
+            "old": 2,
+            "new": 3
           }
         }
       }
@@ -85,7 +87,9 @@
       "changes": {
         "local": {
           "num_workers": {
-            "action": "resize"
+            "action": "resize",
+            "old": 3,
+            "new": 4
           }
         }
       }
@@ -123,10 +127,14 @@
       "changes": {
         "local": {
           "num_workers": {
-            "action": "resize"
+            "action": "resize",
+            "old": 4,
+            "new": 5
           },
           "spark_conf['spark.executor.memory']": {
-            "action": "update"
+            "action": "update",
+            "old": "2g",
+            "new": "4g"
           }
         }
       }

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.plan.direct.json
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.plan.direct.json
@@ -14,7 +14,8 @@
       "changes": {
         "local": {
           "etag": {
-            "action": "skip"
+            "action": "skip",
+            "old": [ETAG]
           }
         }
       }

--- a/acceptance/bundle/resources/dashboards/simple/out.plan.direct.json
+++ b/acceptance/bundle/resources/dashboards/simple/out.plan.direct.json
@@ -18,12 +18,15 @@
       "changes": {
         "local": {
           "etag": {
-            "action": "skip"
+            "action": "skip",
+            "old": [ETAG]
           }
         },
         "remote": {
           "serialized_dashboard": {
-            "action": "skip"
+            "action": "skip",
+            "old": "{ }\n",
+            "new": "{}\n"
           }
         }
       }

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.plan2.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.plan2.direct.json
@@ -52,10 +52,14 @@
       "changes": {
         "local": {
           "grants[0].privileges[0]": {
-            "action": "update"
+            "action": "update",
+            "old": "CREATE_TABLE",
+            "new": "APPLY_TAG"
           },
           "grants[0].privileges[1]": {
-            "action": "update"
+            "action": "update",
+            "old": "USE_SCHEMA",
+            "new": "CREATE_TABLE"
           }
         }
       }

--- a/acceptance/bundle/resources/grants/volumes/out.plan2.direct.json
+++ b/acceptance/bundle/resources/grants/volumes/out.plan2.direct.json
@@ -80,10 +80,14 @@
       "changes": {
         "local": {
           "grants[0].privileges[0]": {
-            "action": "update"
+            "action": "update",
+            "old": "READ_VOLUME",
+            "new": "MANAGE"
           },
           "grants[0].privileges[1]": {
-            "action": "update"
+            "action": "update",
+            "old": "WRITE_VOLUME",
+            "new": "READ_VOLUME"
           }
         }
       }

--- a/acceptance/bundle/resources/jobs/delete_task/out.plan_update.direct.json
+++ b/acceptance/bundle/resources/jobs/delete_task/out.plan_update.direct.json
@@ -97,7 +97,20 @@
       "changes": {
         "local": {
           "tasks[task_key='TestTask1']": {
-            "action": "update"
+            "action": "update",
+            "old": {
+              "existing_cluster_id": "0717-132531-5opeqon1",
+              "libraries": [
+                {
+                  "whl": "/Workspace/Users/foo@bar.com/mywheel.whl"
+                }
+              ],
+              "python_wheel_task": {
+                "entry_point": "run",
+                "package_name": "whl"
+              },
+              "task_key": "TestTask1"
+            }
           }
         },
         "remote": {

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.plan_post_update.direct.json
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.plan_post_update.direct.json
@@ -83,7 +83,8 @@
             "reason": "server_side_default"
           },
           "tags['new_tag']": {
-            "action": "update"
+            "action": "update",
+            "new": "new_value"
           },
           "timeout_seconds": {
             "action": "skip",

--- a/acceptance/bundle/resources/jobs/update/out.plan_update.direct.json
+++ b/acceptance/bundle/resources/jobs/update/out.plan_update.direct.json
@@ -74,7 +74,9 @@
       "changes": {
         "local": {
           "trigger.periodic.unit": {
-            "action": "update"
+            "action": "update",
+            "old": "DAYS",
+            "new": "HOURS"
           }
         },
         "remote": {

--- a/acceptance/bundle/resources/jobs/update_single_node/out.plan_update.direct.json
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.plan_update.direct.json
@@ -88,7 +88,9 @@
       "changes": {
         "local": {
           "trigger.periodic.unit": {
-            "action": "update"
+            "action": "update",
+            "old": "DAYS",
+            "new": "HOURS"
           }
         },
         "remote": {

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.second-plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.second-plan.direct.json
@@ -10,7 +10,9 @@
       "changes": {
         "local": {
           "name": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "[ENDPOINT_NAME_1]",
+            "new": "[ENDPOINT_NAME_2]"
           }
         }
       }
@@ -57,7 +59,9 @@
       "changes": {
         "local": {
           "object_id": {
-            "action": "update"
+            "action": "update",
+            "old": "/serving-endpoints/[ENDPOINT_ID_1]",
+            "new": ""
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.second-plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.second-plan.direct.json
@@ -30,7 +30,9 @@
       "changes": {
         "local": {
           "config.auto_capture_config.catalog_name": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "main",
+            "new": "other_catalog"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.second-plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.second-plan.direct.json
@@ -25,7 +25,9 @@
       "changes": {
         "local": {
           "name": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "[ORIGINAL_ENDPOINT_ID]",
+            "new": "[NEW_ENDPOINT_ID]"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.second-plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.second-plan.direct.json
@@ -22,7 +22,9 @@
       "changes": {
         "local": {
           "route_optimized": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": false,
+            "new": true
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.second-plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.second-plan.direct.json
@@ -30,7 +30,9 @@
       "changes": {
         "local": {
           "config.auto_capture_config.schema_name": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "default",
+            "new": "other_schema"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.second-plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.second-plan.direct.json
@@ -30,7 +30,9 @@
       "changes": {
         "local": {
           "config.auto_capture_config.table_name_prefix": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "my_table",
+            "new": "other_table"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.plan.direct.json
@@ -61,7 +61,9 @@
       "changes": {
         "local": {
           "ai_gateway.inference_table_config.catalog_name": {
-            "action": "update"
+            "action": "update",
+            "old": "first-inference-catalog",
+            "new": "second-inference-catalog"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.plan.direct.json
@@ -73,10 +73,14 @@
       "changes": {
         "local": {
           "ai_gateway.inference_table_config.catalog_name": {
-            "action": "update"
+            "action": "update",
+            "old": "first-inference-catalog",
+            "new": "second-inference-catalog"
           },
           "tags[0].value": {
-            "action": "update"
+            "action": "update",
+            "old": "my-team-one",
+            "new": "my-team-two"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.plan.direct.json
@@ -51,7 +51,9 @@
       "changes": {
         "local": {
           "config.served_entities[0].external_model.name": {
-            "action": "update"
+            "action": "update",
+            "old": "gpt-4o-mini",
+            "new": "gpt-5o-mini"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.plan.direct.json
@@ -61,7 +61,9 @@
       "changes": {
         "local": {
           "email_notifications.on_update_success[0]": {
-            "action": "update"
+            "action": "update",
+            "old": "user1@example.com",
+            "new": "user2@example.com"
           }
         }
       }

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.plan.direct.json
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.plan.direct.json
@@ -63,7 +63,9 @@
       "changes": {
         "local": {
           "tags[0].value": {
-            "action": "update"
+            "action": "update",
+            "old": "my-team-one",
+            "new": "my-team-two"
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.plan.direct.json
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.plan.direct.json
@@ -93,7 +93,11 @@
       "changes": {
         "remote": {
           "permissions[group_name='admin-team']": {
-            "action": "update"
+            "action": "update",
+            "new": {
+              "group_name": "admin-team",
+              "permission_level": "CAN_MANAGE"
+            }
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/local/out.plan_update.direct.json
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/local/out.plan_update.direct.json
@@ -101,7 +101,11 @@
       "changes": {
         "local": {
           "permissions[user_name='test-dabs-1@databricks.com']": {
-            "action": "update"
+            "action": "update",
+            "old": {
+              "permission_level": "CAN_MANAGE_RUN",
+              "user_name": "test-dabs-1@databricks.com"
+            }
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.plan_restore.direct.json
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.plan_restore.direct.json
@@ -89,10 +89,18 @@
       "changes": {
         "remote": {
           "permissions[group_name='data-team']": {
-            "action": "update"
+            "action": "update",
+            "old": {
+              "group_name": "data-team",
+              "permission_level": "CAN_MANAGE"
+            }
           },
           "permissions[user_name='viewer@example.com']": {
-            "action": "update"
+            "action": "update",
+            "old": {
+              "permission_level": "CAN_VIEW",
+              "user_name": "viewer@example.com"
+            }
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/jobs/update/out.plan_delete_one.direct.json
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.plan_delete_one.direct.json
@@ -93,7 +93,11 @@
       "changes": {
         "local": {
           "permissions[group_name='data-team']": {
-            "action": "update"
+            "action": "update",
+            "old": {
+              "group_name": "data-team",
+              "permission_level": "CAN_MANAGE"
+            }
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/jobs/update/out.plan_update.direct.json
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.plan_update.direct.json
@@ -97,7 +97,9 @@
       "changes": {
         "local": {
           "permissions[user_name='viewer@example.com'].permission_level": {
-            "action": "update"
+            "action": "update",
+            "old": "CAN_VIEW",
+            "new": "CAN_MANAGE"
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.plan_delete_one.direct.json
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.plan_delete_one.direct.json
@@ -73,7 +73,11 @@
       "changes": {
         "local": {
           "permissions[group_name='data-team']": {
-            "action": "update"
+            "action": "update",
+            "old": {
+              "group_name": "data-team",
+              "permission_level": "CAN_MANAGE"
+            }
           }
         }
       }

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.plan_update.direct.json
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.plan_update.direct.json
@@ -77,7 +77,9 @@
       "changes": {
         "local": {
           "permissions[user_name='viewer@example.com'].permission_level": {
-            "action": "update"
+            "action": "update",
+            "old": "CAN_VIEW",
+            "new": "CAN_MANAGE"
           }
         }
       }

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-catalog/out.plan_recreate.direct.json
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-catalog/out.plan_recreate.direct.json
@@ -24,7 +24,9 @@
       "changes": {
         "local": {
           "catalog": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "mycatalog1",
+            "new": "mycatalog2"
           }
         }
       }

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.plan_recreate.direct.json
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.plan_recreate.direct.json
@@ -29,7 +29,9 @@
       "changes": {
         "local": {
           "ingestion_definition.connection_name": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "my_connection",
+            "new": "my_new_connection"
           }
         }
       }

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.plan_recreate.direct.json
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.plan_recreate.direct.json
@@ -24,7 +24,9 @@
       "changes": {
         "local": {
           "storage": {
-            "action": "recreate"
+            "action": "recreate",
+            "old": "dbfs:/pipelines/custom",
+            "new": "dbfs:/pipelines/newcustom"
           }
         }
       }

--- a/acceptance/bundle/resources/volumes/change-name/out.plan.direct.json
+++ b/acceptance/bundle/resources/volumes/change-name/out.plan.direct.json
@@ -27,7 +27,9 @@
       "changes": {
         "local": {
           "name": {
-            "action": "update_id"
+            "action": "update_id",
+            "old": "myvolume",
+            "new": "mynewvolume"
           }
         },
         "remote": {

--- a/bundle/deployplan/plan.go
+++ b/bundle/deployplan/plan.go
@@ -45,13 +45,15 @@ type DependsOnEntry struct {
 }
 
 type Changes struct {
-	Local  map[string]Trigger `json:"local,omitempty"`
-	Remote map[string]Trigger `json:"remote,omitempty"`
+	Local  map[string]ChangeDesc `json:"local,omitempty"`
+	Remote map[string]ChangeDesc `json:"remote,omitempty"`
 }
 
-type Trigger struct {
+type ChangeDesc struct {
 	Action string `json:"action"`
 	Reason string `json:"reason,omitempty"`
+	Old    any    `json:"old,omitempty"`
+	New    any    `json:"new,omitempty"`
 }
 
 // HasChange checks if there are any changes for fields with the given prefix.


### PR DESCRIPTION
## Why
Useful for debugging. Could also be useful for resource implementation given that we pass PlanEntry to DoUpdate() now.

Note, "new" value is redundant because it comes from remote_state or new_state that is already included in the plan. But it could be still difficult for 3rd party tools to parse this out as it requires to support semantics of structpath (which includes things like `tasks[task_key='mytask']`).

On the other hand, "old" value is not redundant as we don't include prior state in the plan at the moment.