### PR TITLE
Run check workflow on push to main to populate cache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,14 @@ on:
     types: [opened, synchronize]
   merge_group:
     types: [checks_requested]
+  push:
+    # Always run on push to main. The build cache can only be reused
+    # if it was saved by a run from the repository's default branch.
+    # The run result will be identical to that from the merge queue
+    # because the commit is identical, yet we need to perform it to
+    # seed the build cache.
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
## Why

Only if a cache is stored from a run from the main branch will it be picked up in PRs and the merge queue. After splitting out the lint job into a dedicated workflow (#4013), it no longer ran on the main branch, and we no longer had cache hits for the lint jobs on PRs and the merge queue.