### PR TITLE
Support JSON output formatting for `apps logs` command

### DIFF
--- a/cmd/workspace/apps/logs.go
+++ b/cmd/workspace/apps/logs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdgroup"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/service/apps"
@@ -142,7 +143,9 @@ via --source APP|SYSTEM. Use --output-file to mirror the stream to a local file 
 				defer file.Close()
 				writer = io.MultiWriter(writer, file)
 			}
-			colorizeLogs := outputPath == "" && cmdio.IsTTY(cmd.OutOrStdout())
+
+			outputFormat := root.OutputType(cmd)
+			colorizeLogs := outputPath == "" && outputFormat == flags.OutputText && cmdio.IsTTY(cmd.OutOrStdout())
 
 			sourceMap, err := buildSourceFilter(sourceFilters)
 			if err != nil {
@@ -165,6 +168,7 @@ via --source APP|SYSTEM. Use --output-file to mirror the stream to a local file 
 				Writer:           writer,
 				UserAgent:        "databricks-cli apps logs",
 				Colorize:         colorizeLogs,
+				OutputFormat:     outputFormat,
 			})
 		},
 	}

--- a/libs/apps/logstream/formatter_test.go
+++ b/libs/apps/logstream/formatter_test.go
@@ -1,0 +1,37 @@
+package logstream
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/databricks/cli/libs/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatter_FormatEntry(t *testing.T) {
+	entry := &wsEntry{Source: "app", Timestamp: 1705315800.0, Message: "hello world\n"}
+
+	t.Run("json output", func(t *testing.T) {
+		jsonFormatter := newLogFormatter(false, flags.OutputJSON)
+		output := jsonFormatter.FormatEntry(entry)
+
+		var parsed wsEntry
+		require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+
+		assert.Equal(t, "APP", parsed.Source)
+		assert.Greater(t, parsed.Timestamp, 0.0)
+		assert.Equal(t, "hello world", parsed.Message)
+		assert.NotContains(t, output, "\x1b[")
+	})
+
+	t.Run("text output", func(t *testing.T) {
+		textFormatter := newLogFormatter(false, flags.OutputText)
+		output := textFormatter.FormatEntry(entry)
+
+		assert.Contains(t, output, "[APP]")
+		assert.Contains(t, output, "hello world")
+		assert.Contains(t, output, "2024-01-15")
+		assert.NotContains(t, output, "\x1b[")
+	})
+}

--- a/libs/apps/logstream/streamer.go
+++ b/libs/apps/logstream/streamer.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/databricks/cli/libs/flags"
 	"github.com/gorilla/websocket"
 )
 
@@ -50,6 +51,7 @@ type Config struct {
 	Writer           io.Writer
 	UserAgent        string
 	Colorize         bool
+	OutputFormat     flags.Output
 }
 
 // Run connects to the log stream described by cfg and copies frames to the writer.
@@ -72,7 +74,7 @@ func Run(ctx context.Context, cfg Config) error {
 		prefetch:         cfg.Prefetch,
 		writer:           cfg.Writer,
 		userAgent:        cfg.UserAgent,
-		formatter:        newLogFormatter(cfg.Colorize),
+		formatter:        newLogFormatter(cfg.Colorize, cfg.OutputFormat),
 	}
 	if streamer.userAgent == "" {
 		streamer.userAgent = defaultUserAgent
@@ -267,7 +269,7 @@ func (s *logStreamer) formatMessage(message []byte) string {
 	source := strings.ToUpper(entry.Source)
 	if len(s.sources) > 0 {
 		if _, ok := s.sources[source]; !ok {
-			return "" // Filtered out
+			return ""
 		}
 	}
 	return s.formatter.FormatEntry(entry)


### PR DESCRIPTION
## Changes
- Support JSON output formatting for `apps logs` command

## Why
To be consistent with the global flags we have.

## Tests
Unit tests are in place

## Screenshot

<img width="1164" height="252" alt="image" src="https://github.com/user-attachments/assets/57df83dc-0e9d-4841-a20f-98a13d1422b3" />

## Caveat
While we disable coloring on CLI side for JSON output, you might still see sth like:
<img width="590" height="499" alt="image" src="https://github.com/user-attachments/assets/6dc9848c-14c0-49ad-9a25-fe3a186d15e9" />

Those ANSI codes come from server and I decided not to alter them and print as they are. In theory we could add a regex pattern and strip them out but I believe it's better to print exactly what comes from the server.