### PR TITLE
Fix deployment failing when app is in DELETING state

### DIFF
--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -79,7 +79,6 @@ func (r *ResourceApp) WaitAfterCreate(ctx context.Context, config *apps.App) (*a
 	return r.waitForApp(ctx, r.client, config.Name)
 }
 
-// waitForDeletion waits for an app to be fully deleted.
 func (r *ResourceApp) waitForDeletion(ctx context.Context, name string) error {
 	retrier := retries.New[struct{}](retries.WithTimeout(10*time.Minute), retries.WithRetryFunc(shouldRetry))
 	_, err := retrier.Run(ctx, func(ctx context.Context) (*struct{}, error) {
@@ -97,7 +96,6 @@ func (r *ResourceApp) waitForDeletion(ctx context.Context, name string) error {
 
 		switch app.ComputeStatus.State {
 		case apps.ComputeStateDeleting:
-			log.Infof(ctx, "App %s is in DELETING state, waiting for it to be deleted...", name)
 			return nil, retries.Continues("app is deleting")
 		case apps.ComputeStateActive, apps.ComputeStateStopped, apps.ComputeStateError:
 			err := fmt.Errorf("app %s was not deleted, current state: %s", name, app.ComputeStatus.State)


### PR DESCRIPTION
Fixes: #4006

## Changes
Added a wait for apps in `DELETING` state to be fully deleted before deployment proceeds. 

## Why
Deployment fails when an app is in `DELETING` state because the app still exists but is being removed. This adds a pre-deployment check that polls and waits (up to 5 minutes) for apps to finish deleting.