### PR TITLE
Bump Go toolchain to 1.25.5

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,4 +10,6 @@
 
 ### Dependency updates
 
+* Bump Go toolchain to 1.25.5.
+
 ### API Changes

--- a/bundle/internal/tf/codegen/go.mod
+++ b/bundle/internal/tf/codegen/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/bundle/internal/tf/codegen
 
 go 1.25.0
 
-toolchain go1.25.1
+toolchain go1.25.5
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli
 
 go 1.25.0
 
-toolchain go1.25.1
+toolchain go1.25.5
 
 require (
 	dario.cat/mergo v1.0.2 // BSD 3-Clause

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/tools
 
 go 1.25.0
 
-toolchain go1.25.1
+toolchain go1.25.5
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect


### PR DESCRIPTION
## Why

This release includes security fixes for crypto/x509:

- CVE-2025-61729: HostnameError.Error() could consume excessive resources due to unbounded string concatenation when processing certificates with many hostnames.

- CVE-2025-61727: Excluded subdomain constraints did not restrict wildcard SANs in leaf certificates (e.g., excluding test.example.com did not prevent *.example.com).