### PR TITLE
Trigger all builds when go.mod/go.sum changes

### DIFF
--- a/tools/testmask/targets.go
+++ b/tools/testmask/targets.go
@@ -11,31 +11,43 @@ type targetMapping struct {
 	target   string
 }
 
+// goTriggerPatterns lists patterns that trigger all Go-dependent targets.
+var goTriggerPatterns = []string{
+	"go.mod",
+	"go.sum",
+}
+
 var fileTargetMappings = []targetMapping{
 	{
-		prefixes: []string{
+		prefixes: slices.Concat(goTriggerPatterns, []string{
+			// Specify files that match targets below and should still trigger the "test" target.
+		}),
+		target: "test",
+	},
+	{
+		prefixes: slices.Concat(goTriggerPatterns, []string{
 			"experimental/aitools/",
-		},
+		}),
 		target: "test-exp-aitools",
 	},
 	{
-		prefixes: []string{
+		prefixes: slices.Concat(goTriggerPatterns, []string{
 			"experimental/apps-mcp/",
-		},
+		}),
 		target: "test-exp-apps-mcp",
 	},
 	{
-		prefixes: []string{
+		prefixes: slices.Concat(goTriggerPatterns, []string{
 			"experimental/ssh/",
 			"acceptance/ssh/",
-		},
+		}),
 		target: "test-exp-ssh",
 	},
 	{
-		prefixes: []string{
+		prefixes: slices.Concat(goTriggerPatterns, []string{
 			"cmd/pipelines/",
 			"acceptance/pipelines/",
-		},
+		}),
 		target: "test-pipelines",
 	},
 }
@@ -46,6 +58,7 @@ func GetTargets(files []string) []string {
 	unmatchedFiles := []string{}
 
 	for _, file := range files {
+		// Check all mappings for this file (a file can match multiple targets).
 		matched := false
 		for _, mapping := range fileTargetMappings {
 			for _, prefix := range mapping.prefixes {
@@ -54,9 +67,6 @@ func GetTargets(files []string) []string {
 					matched = true
 					break
 				}
-			}
-			if matched {
-				break
 			}
 		}
 		if !matched {

--- a/tools/testmask/targets_test.go
+++ b/tools/testmask/targets_test.go
@@ -47,12 +47,26 @@ func TestGetTargets(t *testing.T) {
 			targets: []string{"test"},
 		},
 		{
-			name: "mixed_matching_and_unmatched",
+			name: "go_mod_triggers_all",
+			files: []string{
+				"go.mod",
+			},
+			targets: []string{"test", "test-exp-aitools", "test-exp-apps-mcp", "test-exp-ssh", "test-pipelines"},
+		},
+		{
+			name: "go_sum_triggers_all",
+			files: []string{
+				"go.sum",
+			},
+			targets: []string{"test", "test-exp-aitools", "test-exp-apps-mcp", "test-exp-ssh", "test-pipelines"},
+		},
+		{
+			name: "go_mod_with_other_files_triggers_all",
 			files: []string{
 				"experimental/ssh/main.go",
 				"go.mod",
 			},
-			targets: []string{"test", "test-exp-ssh"},
+			targets: []string{"test", "test-exp-aitools", "test-exp-apps-mcp", "test-exp-ssh", "test-pipelines"},
 		},
 		{
 			name:    "empty_files",


### PR DESCRIPTION
## Why

When dependencies changes (go.mod/go.sum), all Go test targets must run.