### PR TITLE
MCP: Nudge the the agent to use an explore agent for finding tables

### DIFF
--- a/experimental/apps-mcp/lib/prompts/flow.tmpl
+++ b/experimental/apps-mcp/lib/prompts/flow.tmpl
@@ -54,3 +54,5 @@ Unity Catalog:
 
 Use separate arguments for catalog/schema: 'tables list samples tpcds_sf1' (not dot notation).
 Dot notation is only supported in `experimental apps-mcp tools discover-schema` and `experimental apps-mcp tools query`.
+
+It is STRONGLY RECOMMENDED to delegate the task of exploring catalogs, schemas, or tables in Unity Catalog to an Explore agent or a sub agent.


### PR DESCRIPTION
## Changes

Finding the right data set can consume a lot of tokens and we are usually only interested in the final outcome. I've added a nudge to use an `Explore Agent` when discovering tables. 

<img width="1159" height="473" alt="Screenshot 2025-12-16 at 10 57 43" src="https://github.com/user-attachments/assets/b810e9ca-68c6-42a6-8fee-ad61cbcfb007" />


## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
