### PR TITLE
Fix directory not empty check for DBFS filer

### DIFF
--- a/libs/filer/dbfs_client.go
+++ b/libs/filer/dbfs_client.go
@@ -227,7 +227,7 @@ func (w *DbfsClient) Delete(ctx context.Context, name string, mode ...DeleteMode
 	case http.StatusBadRequest:
 		// Anecdotally, this error is returned when attempting to delete a non-empty directory.
 		if aerr.ErrorCode == "IO_ERROR" {
-			return err
+			return DirectoryNotEmptyError{absPath}
 		}
 
 		// Since 17th december we are observing the backend return an error_code of BAD_REQUEST


### PR DESCRIPTION
The backend was modified to return "BAD_REQUEST" instead of "IO_ERROR" for when the directory is not empty. This PR adds both checks to fix the failing filer integration test because of the backend change in DBFS.