### PR TITLE
Fix incorrect test selection when -update if present

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -333,16 +333,6 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 
 			expanded := internal.ExpandEnvMatrix(config.EnvMatrix)
 
-			if testdiff.OverwriteMode && len(expanded) > 1 {
-				// All variants of the test are producing the same output,
-				// there is no need to run the concurrently when updating.
-				// Exception: if EnvVaryOutput is configured, we must
-				// run all variants to record variant-specific outputs.
-				if config.EnvVaryOutput == nil || len(config.EnvMatrix[*config.EnvVaryOutput]) <= 1 {
-					expanded = expanded[0:1]
-				}
-			}
-
 			if len(expanded) == 1 {
 				// env vars aren't part of the test case name, so log them for debugging
 				if len(expanded[0]) > 0 {


### PR DESCRIPTION
## Why

If -update flag is present, the test runner does not select the right subtest but picks the first one always. This made sense when all subtests were expected to generate the same output but that's not the case anymore. There is attempt to fix it by checking EnvVaryOutput but that just makes it more confusing.

When debugging a test, it is sometimes useful to record output of specific subtest as a comparison base.
