### PR TITLE
[minor] Improve variable assignment error message

### DIFF
--- a/acceptance/bundle/variables/empty/output.txt
+++ b/acceptance/bundle/variables/empty/output.txt
@@ -5,7 +5,7 @@ cleaned up during bundle destroy.
   at bundle.name
   in databricks.yml:7:9
 
-Error: no value assigned to required variable a. Assignment can be done using "--var", by setting the BUNDLE_VAR_a environment variable, or in .databricks/bundle/<target>/variable-overrides.json file
+Error: no value assigned to required variable a. Variables are usually assigned in databricks.yml, and they can be overridden using "--var", the BUNDLE_VAR_a environment variable, or .databricks/bundle/<target>/variable-overrides.json
 
 Name: empty${var.a}
 Target: default

--- a/acceptance/bundle/variables/env_overrides/output.txt
+++ b/acceptance/bundle/variables/env_overrides/output.txt
@@ -9,7 +9,7 @@
 "prod-a env-var-b"
 
 >>> errcode [CLI] bundle validate -t env-missing-a-required-variable-assignment
-Error: no value assigned to required variable b. Assignment can be done using "--var", by setting the BUNDLE_VAR_b environment variable, or in .databricks/bundle/<target>/variable-overrides.json file
+Error: no value assigned to required variable b. Variables are usually assigned in databricks.yml, and they can be overridden using "--var", the BUNDLE_VAR_b environment variable, or .databricks/bundle/<target>/variable-overrides.json
 
 Name: test bundle
 Target: env-missing-a-required-variable-assignment

--- a/acceptance/bundle/variables/file-defaults/output.txt
+++ b/acceptance/bundle/variables/file-defaults/output.txt
@@ -100,7 +100,7 @@ Exit code: 1
 
 === variable is required but it's not provided in the file
 >>> errcode [CLI] bundle validate -o json --target without_defaults
-Error: no value assigned to required variable cluster. Assignment can be done using "--var", by setting the BUNDLE_VAR_cluster environment variable, or in .databricks/bundle/<target>/variable-overrides.json file
+Error: no value assigned to required variable cluster. Variables are usually assigned in databricks.yml, and they can be overridden using "--var", the BUNDLE_VAR_cluster environment variable, or .databricks/bundle/<target>/variable-overrides.json
 
 
 Exit code: 1

--- a/acceptance/bundle/variables/vanilla/output.txt
+++ b/acceptance/bundle/variables/vanilla/output.txt
@@ -3,7 +3,7 @@
 "abc def"
 
 >>> errcode [CLI] bundle validate
-Error: no value assigned to required variable b. Assignment can be done using "--var", by setting the BUNDLE_VAR_b environment variable, or in .databricks/bundle/<target>/variable-overrides.json file
+Error: no value assigned to required variable b. Variables are usually assigned in databricks.yml, and they can be overridden using "--var", the BUNDLE_VAR_b environment variable, or .databricks/bundle/<target>/variable-overrides.json
 
 Name: foobar
 Target: default

--- a/bundle/config/mutator/set_variables.go
+++ b/bundle/config/mutator/set_variables.go
@@ -91,7 +91,7 @@ func setVariable(ctx context.Context, v dyn.Value, variable *variable.Variable, 
 	}
 
 	// We should have had a value to set for the variable at this point.
-	return dyn.InvalidValue, fmt.Errorf(`no value assigned to required variable %s. Assignment can be done using "--var", by setting the %s environment variable, or in %s file`, name, bundleVarPrefix+name, getDefaultVariableFilePath("<target>"))
+	return dyn.InvalidValue, fmt.Errorf(`no value assigned to required variable %s. Variables are usually assigned in databricks.yml, and they can be overridden using "--var", the %s environment variable, or %s`, name, bundleVarPrefix+name, getDefaultVariableFilePath("<target>"))
 }
 
 func readVariablesFromFile(b *bundle.Bundle) (dyn.Value, diag.Diagnostics) {

--- a/bundle/config/mutator/set_variables_test.go
+++ b/bundle/config/mutator/set_variables_test.go
@@ -108,7 +108,7 @@ func TestSetVariablesErrorsIfAValueCouldNotBeResolved(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = setVariable(context.Background(), v, &variable, "foo", dyn.NilValue)
-	assert.ErrorContains(t, err, "no value assigned to required variable foo. Assignment can be done using \"--var\", by setting the BUNDLE_VAR_foo environment variable, or in .databricks/bundle/<target>/variable-overrides.json file")
+	assert.ErrorContains(t, err, "no value assigned to required variable foo. Variables are usually assigned in databricks.yml, and they can be overridden using \"--var\", the BUNDLE_VAR_foo environment variable, or .databricks/bundle/<target>/variable-overrides.json")
 }
 
 func TestSetVariablesMutator(t *testing.T) {


### PR DESCRIPTION
This clarifies the error message for unassigned variables, making it more AI-friendly.

## Why
The original error could send an AI into a wild goose chase related to advanced overriding techniques whenever the AI would generate a databricks.yml without all variables being assigned.