### PR TITLE
Add fallback `default_catalog` property for `pydabs` template

### DIFF
--- a/libs/template/templates/pydabs/databricks_template_schema.json
+++ b/libs/template/templates/pydabs/databricks_template_schema.json
@@ -48,7 +48,7 @@
         },
         "default_catalog": {
             "type": "string",
-            "default": "{{default_catalog}}",
+            "default": "{{if eq (default_catalog) \"\"}}hive_metastore{{else}}{{default_catalog}}{{end}}",
             "pattern": "^\\w*$",
             "pattern_match_failure_message": "Invalid catalog name.",
             "description": "Default catalog for any tables created by this project{{if eq (default_catalog) \"\"}} (leave blank when not using Unity Catalog){{end}}",


### PR DESCRIPTION
## Changes

This adds the `hive_metastore` fallback for the `default_catalog` property of the `pydabs` template.

## Why

I asked Claude Code about any template inconsistencies and this is what it cae up with.

More contetxg: this fallback value serves as a sentinel that allows pipeline templates to detect non-UC workspace configurations. When `default_catalog` resolves to `hive_metastore`, the pipeline templates comment out the catalog field (which would otherwise be rejected by the DLT API, since it doesn't accept 'hive_metastore' as a catalog name).

See the same logic in default-python here:
https://github.com/databricks/cli/blob/main/libs/template/templates/default-python/databricks_template_schema.json#L51

## Testing

- Tested template initialization with both UC and non-UC configurations
- Ran `make test-update-templates` to regenerate acceptance tests
- Verified `make fmt` and `make lint` pass