### PR TITLE
[apps-mcp] Fix token-based authentication for default profile

### DIFF
--- a/experimental/apps-mcp/lib/providers/clitools/invoke_databricks_cli.go
+++ b/experimental/apps-mcp/lib/providers/clitools/invoke_databricks_cli.go
@@ -23,7 +23,6 @@ func InvokeDatabricksCLI(ctx context.Context, args []string, workingDirectory st
 		return "", fmt.Errorf("get databricks client: %w", err)
 	}
 	host := workspaceClient.Config.Host
-	profile := middlewares.GetDatabricksProfile(ctx)
 	cliPath := common.GetCLIPath()
 
 	cmd := exec.CommandContext(ctx, cliPath, args...)
@@ -31,9 +30,7 @@ func InvokeDatabricksCLI(ctx context.Context, args []string, workingDirectory st
 
 	env := os.Environ()
 	env = append(env, "DATABRICKS_HOST="+host)
-	if profile != "" {
-		env = append(env, "DATABRICKS_CONFIG_PROFILE="+profile)
-	}
+	env = append(env, "DATABRICKS_TOKEN="+workspaceClient.Config.Token)
 	env = append(env, "DATABRICKS_CLI_UPSTREAM=cli-mcp")
 	env = append(env, "DATABRICKS_CLI_UPSTREAM_VERSION="+build.GetInfo().Version)
 


### PR DESCRIPTION
# [apps-mcp] Fix token-based authentication for default profile

## Changes

Fix authentication in `apps-mcp` for the `DEFAULT` profile.

## Why

When `InvokeDatabricksCLI` runs a subprocess, it sets `DATABRICKS_HOST` explicitly. This prevents the SDK from falling back to the DEFAULT profile in `~/.databrickscfg`, causing auth failures.

The old code tried to pass `DATABRICKS_CONFIG_PROFILE`, but `GetDatabricksProfile()` always returned empty because the profile was never stored in the session during auto-authentication.

Passing the token directly works for all auth methods (OAuth, PAT, profile-based).

## Tests

Manual testing via MCP server:
```bash
# Without fix: auth error
agent -p 'invoke databricks cli with "current-user me"'  # ✗

# With fix: succeeds  
agent -p 'invoke databricks cli with "current-user me"'  # ✓
```

Root cause confirmed by reproducing SDK behavior directly:
```bash
# SDK falls back to DEFAULT profile when no host is set
./cli current-user me  # ✓

# SDK fails when DATABRICKS_HOST is set without credentials
DATABRICKS_HOST=https://... ./cli current-user me  # ✗
```

OAuth-based auth also works since `Config.Token` is populated with the OAuth access token after authentication.