### PR TITLE
internal: structaccess: support key-value syntax; add NotFoundError

### DIFF
--- a/libs/structs/structaccess/set.go
+++ b/libs/structs/structaccess/set.go
@@ -85,6 +85,10 @@ func setValueAtNode(parentVal reflect.Value, node *structpath.PathNode, value an
 		return errors.New("wildcards not supported")
 	}
 
+	if key, matchValue, isKeyValue := node.KeyValue(); isKeyValue {
+		return fmt.Errorf("cannot set value at key-value selector [%s='%s'] - key-value syntax can only be used for path traversal, not as a final target", key, matchValue)
+	}
+
 	if key, hasKey := node.StringKey(); hasKey {
 		return setFieldOrMapValue(parentVal, key, valueVal)
 	}

--- a/libs/structs/structaccess/typecheck.go
+++ b/libs/structs/structaccess/typecheck.go
@@ -57,6 +57,16 @@ func Validate(t reflect.Type, path *structpath.PathNode) error {
 			return fmt.Errorf("wildcards not supported: %s", path.String())
 		}
 
+		// Handle key-value selector: validates that we can index the slice/array
+		if _, _, isKeyValue := node.KeyValue(); isKeyValue {
+			kind := cur.Kind()
+			if kind != reflect.Slice && kind != reflect.Array {
+				return fmt.Errorf("%s: cannot use key-value syntax on %s", node.String(), kind)
+			}
+			cur = cur.Elem()
+			continue
+		}
+
 		key, ok := node.StringKey()
 
 		if !ok {


### PR DESCRIPTION
## Changes
- Support key-value syntax (`tasks[task_key='foo']`) in structaccess.Get() and Set()
- Use separate type class for errors when structure is correct but item is not found.

## Why
Completeness. Using this features in https://github.com/databricks/cli/pull/4201

## Tests
Unit tests.