### PR TITLE
Fix secret scope ACL deletion loop exiting early on NotFound

### DIFF
--- a/bundle/direct/dresources/secret_scope_acls.go
+++ b/bundle/direct/dresources/secret_scope_acls.go
@@ -188,7 +188,7 @@ func (r *ResourceSecretScopeAcls) setACLs(ctx context.Context, scopeName string,
 		err := r.client.Secrets.DeleteAcl(ctx, acl)
 		// Ignore not found errors for ACLs.
 		if errors.Is(err, apierr.ErrNotFound) {
-			return nil
+			continue
 		}
 		if err != nil {
 			return fmt.Errorf("failed to delete ACL %v for principal %q: %w", acl, acl.Principal, err)


### PR DESCRIPTION
## Changes

When deleting multiple secret scope ACLs, if one ACL returns NotFound (due to race conditions or eventual consistency), the code would `return nil` and exit the loop early. This prevented remaining ACLs from being deleted. Changed to `continue` to skip NotFound errors and proceed with remaining deletions.

## Tests

Only static analysis, no tests.