### PR TITLE
Switch Azure test node type to E4ds_v5

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1303,7 +1303,7 @@ func getNodeTypeID(cloudEnv string) string {
 	case "aws":
 		return "i3.xlarge"
 	case "azure":
-		return "Standard_DS4_v2"
+		return "Standard_E4ds_v5"
 	case "gcp":
 		return "n1-standard-4"
 	case "":

--- a/internal/testutil/cloud.go
+++ b/internal/testutil/cloud.go
@@ -33,7 +33,7 @@ func (c Cloud) NodeTypeID() string {
 	case AWS:
 		return "i3.xlarge"
 	case Azure:
-		return "Standard_DS4_v2"
+		return "Standard_E4ds_v5"
 	case GCP:
 		return "n1-standard-4"
 	default:


### PR DESCRIPTION
## Changes

Standardize on Standard_E4ds_v5 for Azure integration and acceptance tests. This is a newer, memory-optimized node type with better availability that better suits our Spark-based test workloads.

Node type comparison:
- DS4_v2: 8 vCPUs, 28GB RAM, Broadwell CPU (v2 gen)
- E4ds_v5: 4 vCPUs, 32GB RAM, Ice Lake CPU (v5 gen)

Notable differences:
- 4x cores vs 8, but tests primarily need memory not CPU
- More RAM per core: 8GB vs 3.5GB (better for Spark)
- Latest generation CPU (20% faster per-core)
- Memory-optimized family vs general-purpose
- Better quota availability for concurrent test execution

Affected tests:
- Python task execution tests
- Spark JAR execution tests
- Bundle generation tests (jobs and pipelines)
