### PR TITLE
Update NEXT_CHANGELOG.md with missing entries and fixes

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,15 +3,17 @@
 ## Release v0.282.0
 
 ### Notable Changes
-* engine/direct: Plan format changed to 2, see ([#4201](https://github.com/databricks/cli/pull/4201))
+* engine/direct: New plan format (v2) ([#4201](https://github.com/databricks/cli/pull/4201))
 
 ### CLI
-* Skip non-exportable objects (e.g., `MLFLOW_EXPERIMENT`) during `workspace export-dir` instead of failing ([#4081](https://github.com/databricks/cli/issues/4081))
-* Allow domain_friendly_name to be used in name_prefix in development mode ([#4173](https://github.com/databricks/cli/pull/4173))
+* Skip non-exportable objects (e.g., `MLFLOW_EXPERIMENT`) during `workspace export-dir` instead of failing ([#4101](https://github.com/databricks/cli/pull/4101))
 
 ### Bundles
-* Pass SYSTEM_ACCESSTOKEN from env to the Terraform provider ([#4135](https://github.com/databricks/cli/pull/4135))
-* Added missing schema grants privileges ([#4139](https://github.com/databricks/cli/pull/4139))
+* Allow `domain_friendly_name` to be used in `name_prefix` in development mode ([#4173](https://github.com/databricks/cli/pull/4173))
+* Add missing schema grants privileges ([#4139](https://github.com/databricks/cli/pull/4139))
+* Add support for `bundle generate alert` command ([#4108](https://github.com/databricks/cli/pull/4108))
+* Add support for `.dbalert.json` files ([#3602](https://github.com/databricks/cli/pull/3602))
+* Pass `SYSTEM_TEAMFOUNDATIONCOLLECTIONURI` from env to the Terraform provider for Azure DevOps OIDC auth ([#4169](https://github.com/databricks/cli/pull/4169))
 * Add `ipykernel` to the `default` template to enable Databricks Connect notebooks in Cursor/VS Code ([#4164](https://github.com/databricks/cli/pull/4164))
 * Add interactive SQL warehouse picker to `default-sql` and `dbt-sql` bundle templates ([#4170](https://github.com/databricks/cli/pull/4170))
 * Add `name`, `target` and `mode` fields to the deployment metadata file ([#4180](https://github.com/databricks/cli/pull/4180))


### PR DESCRIPTION
## Changes

- Remove #4135 (already released in v0.281.0)
- Update #4081 reference to #4101 (use PR instead of issue)
- Add #4108 (bundle generate alert command)
- Add #3602 (.dbalert.json files support)
- Add #4169 (SYSTEM_TEAMFOUNDATIONCOLLECTIONURI for Azure DevOps OIDC)
- Move domain_friendly_name entry from CLI to Bundles section
- Normalize formatting (backticks, verb tense, wording consistency)