### PR TITLE
Add 5-minute timeout to alert tests to prevent CI hangs

### DIFF
--- a/acceptance/bundle/deployment/bind/alert/test.toml
+++ b/acceptance/bundle/deployment/bind/alert/test.toml
@@ -1,6 +1,11 @@
 Cloud = true
 Local = false
 
+# Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
+# Use aggressive 5-minute timeout until the issue is resolved.
+# See: https://github.com/databricks/cli/issues/4221
+TimeoutCloud = "5m"
+
 # On aws the host URL includes the workspace ID as well. Thus skipping it to keep the test simple.
 CloudEnvs.aws = false
 

--- a/acceptance/bundle/generate/alert/test.toml
+++ b/acceptance/bundle/generate/alert/test.toml
@@ -1,6 +1,11 @@
 Cloud = true
 Local = false
 
+# Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
+# Use aggressive 5-minute timeout until the issue is resolved.
+# See: https://github.com/databricks/cli/issues/4221
+TimeoutCloud = "5m"
+
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI

--- a/acceptance/bundle/resources/alerts/basic/test.toml
+++ b/acceptance/bundle/resources/alerts/basic/test.toml
@@ -2,3 +2,8 @@ Local = true
 Cloud = true
 RecordRequests = false
 Ignore = [".databricks"]
+
+# Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
+# Use aggressive 5-minute timeout until the issue is resolved.
+# See: https://github.com/databricks/cli/issues/4221
+TimeoutCloud = "5m"

--- a/acceptance/bundle/resources/alerts/with_file/test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/test.toml
@@ -3,6 +3,11 @@ Cloud = true
 RecordRequests = false
 Ignore = [".databricks"]
 
+# Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
+# Use aggressive 5-minute timeout until the issue is resolved.
+# See: https://github.com/databricks/cli/issues/4221
+TimeoutCloud = "5m"
+
 # redact ?o=[NUMID]. Different clouds can have different URL serialization, like [DATABRICKS_URL]/sql/alerts-v2/[ALERT_ID] vs [DATABRICKS_URL]/sql/alerts-v2/[ALERT_ID]?o=[NUMID].
 [[Repls]]
 Old = '\?o=\d+'


### PR DESCRIPTION
## Changes

Add an aggressive 5-minute timeout (TimeoutCloud = "5m") to prevent wasting CI time while still allowing the tests to run and potentially catch if the quota issue gets resolved.

Affected tests:
- bundle/resources/alerts/basic
- bundle/resources/alerts/with_file
- bundle/deployment/bind/alert
- bundle/generate/alert

## Why

Alert integration tests are timing out because alert creation is hitting QUOTA_EXCEEDED errors (429) and retrying indefinitely. Tests hang for 50+ minutes (terraform) or 15+ minutes (direct engine) before being killed by the test timeout.

This was discovered during investigation of AWS integration test runtime increases from ~1.5 hours to 5-6 hours starting Jan 5, 2026.