### PR TITLE
Fix acceptance tests to use explicit job ID replacements

### DIFF
--- a/acceptance/bundle/integration_whl/base/output.txt
+++ b/acceptance/bundle/integration_whl/base/output.txt
@@ -39,7 +39,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS
@@ -57,7 +57,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/base/script
+++ b/acceptance/bundle/integration_whl/base/script
@@ -3,6 +3,11 @@ envsubst < databricks.yml.tmpl > databricks.yml
 trace cat databricks.yml
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job
 
 title "Make a change to code without version change and run the job again"

--- a/acceptance/bundle/integration_whl/custom_params/output.txt
+++ b/acceptance/bundle/integration_whl/custom_params/output.txt
@@ -39,7 +39,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job --python-params param1,param2
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/custom_params/script
+++ b/acceptance/bundle/integration_whl/custom_params/script
@@ -4,4 +4,9 @@ cp -r $TESTDIR/../base/{$EXTRA_CONFIG,setup.py,my_test_code} .
 trace cat databricks.yml
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job --python-params param1,param2

--- a/acceptance/bundle/integration_whl/interactive_cluster/output.txt
+++ b/acceptance/bundle/integration_whl/interactive_cluster/output.txt
@@ -39,7 +39,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS
@@ -57,7 +57,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/interactive_cluster/script
+++ b/acceptance/bundle/integration_whl/interactive_cluster/script
@@ -3,6 +3,11 @@ envsubst < databricks.yml.tmpl > databricks.yml
 trace cat databricks.yml
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job
 
 title "Make a change to code without version change and run the job again"

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/output.txt
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/output.txt
@@ -8,7 +8,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS
@@ -26,7 +26,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/script
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/script
@@ -2,6 +2,11 @@ envsubst < databricks.yml.tmpl > databricks.yml
 cp -r $TESTDIR/../interactive_cluster/{setup.py,my_test_code} .
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job
 
 title "Make a change to code without version change and run the job again"

--- a/acceptance/bundle/integration_whl/interactive_single_user/output.txt
+++ b/acceptance/bundle/integration_whl/interactive_single_user/output.txt
@@ -39,7 +39,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS
@@ -54,7 +54,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/interactive_single_user/script
+++ b/acceptance/bundle/integration_whl/interactive_single_user/script
@@ -4,6 +4,11 @@ trace cat databricks.yml
 cp -r $TESTDIR/../interactive_cluster/{setup.py,my_test_code} .
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job > out.$DATABRICKS_BUNDLE_ENGINE.txt
 
 title "Make a change to code without version change and run the job again"

--- a/acceptance/bundle/integration_whl/serverless/output.txt
+++ b/acceptance/bundle/integration_whl/serverless/output.txt
@@ -10,7 +10,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "My Wheel Job" RUNNING
 [TIMESTAMP] "My Wheel Job" TERMINATED SUCCESS
@@ -28,7 +28,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "My Wheel Job" RUNNING
 [TIMESTAMP] "My Wheel Job" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/serverless/script
+++ b/acceptance/bundle/integration_whl/serverless/script
@@ -2,6 +2,11 @@ envsubst < databricks.yml.tmpl > databricks.yml
 trace cp -r $TESTDIR/../base/{setup.py,my_test_code} .
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job
 
 title "Make a change to code without version change and run the job again"

--- a/acceptance/bundle/integration_whl/serverless_custom_params/output.txt
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/output.txt
@@ -8,7 +8,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job With Environments [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job With Environments [UNIQUE_NAME]" TERMINATED SUCCESS
@@ -17,7 +17,7 @@ Got arguments:
 ['my_test_code', 'one', 'two']
 
 >>> [CLI] bundle run some_other_job --python-params=param1,param2
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job With Environments [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job With Environments [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/serverless_custom_params/script
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/script
@@ -7,5 +7,9 @@ trap cleanup EXIT
 
 trace $CLI bundle deploy
 
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job
 trace $CLI bundle run some_other_job --python-params=param1,param2

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/output.txt
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/output.txt
@@ -10,7 +10,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "My Wheel Job" RUNNING
 [TIMESTAMP] "My Wheel Job" TERMINATED SUCCESS
@@ -28,7 +28,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "My Wheel Job" RUNNING
 [TIMESTAMP] "My Wheel Job" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/script
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/script
@@ -2,6 +2,11 @@ envsubst < databricks.yml.tmpl > databricks.yml
 trace cp -r $TESTDIR/../base/{setup.py,my_test_code} .
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job
 
 title "Make a change to code without version change and run the job again"

--- a/acceptance/bundle/integration_whl/wrapper/output.txt
+++ b/acceptance/bundle/integration_whl/wrapper/output.txt
@@ -39,7 +39,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run some_other_job
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "[default] Test Wheel Job [UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/integration_whl/wrapper/script
+++ b/acceptance/bundle/integration_whl/wrapper/script
@@ -9,4 +9,9 @@ cp -r $TESTDIR/../base/{$EXTRA_CONFIG,setup.py,my_test_code} .
 trace cat databricks.yml
 trap "errcode trace '$CLI' bundle destroy --auto-approve" EXIT
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs some_other_job)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run some_other_job

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/output.txt
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/output.txt
@@ -10,7 +10,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] bundle run foo
-Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
+Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[JOB_ID]/run/[NUMID]
 
 [TIMESTAMP] "test-job-with-cluster-[UNIQUE_NAME]" RUNNING
 [TIMESTAMP] "test-job-with-cluster-[UNIQUE_NAME]" TERMINATED SUCCESS

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/script
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/script
@@ -8,4 +8,9 @@ cleanup() {
 trap cleanup EXIT
 
 trace $CLI bundle deploy
+
+# Capture job ID and add to runtime replacements to avoid pattern matching ambiguity
+job_id=$(read_id.py jobs foo)
+echo "$job_id:JOB_ID" >> ACC_REPLS
+
 trace $CLI bundle run foo


### PR DESCRIPTION
## Changes

Captures job ID after deployment and adds to `ACC_REPLS` for runtime replacement. This prevents non-deterministic test failures when job IDs happen to match timestamp patterns (13-digit numbers starting with `1[78]`).

## Why

Discovered in integration test run where job ID 1719463871887 matched the timestamp regex and was incorrectly replaced with `[UNIX_TIME_MILLIS]` instead of `[NUMID]`:

```
           >>> [CLI] bundle run some_other_job --python-params param1,param2
          -Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[NUMID]/run/[NUMID]
          +Run URL: [DATABRICKS_URL]/?o=[NUMID]#job/[UNIX_TIME_MILLIS]/run/[NUMID]
```

## Tests

Updates 10 acceptance tests:
- 9 in bundle/integration_whl/
- 1 in bundle/resources/clusters/run/spark_python_task

Each test now:
1. Captures job ID with `read_id.py` after deployment
2. Adds `job_id:JOB_ID` mapping to `ACC_REPLS`
3. Expects `[JOB_ID]` instead of `[NUMID]` in Run URLs

This follows the pattern established in bundle/resources/jobs/update.