### PR TITLE
Add get-default-warehouse command to aitools

### DIFF
--- a/experimental/aitools/cmd/get_default_warehouse.go
+++ b/experimental/aitools/cmd/get_default_warehouse.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/experimental/aitools/lib/middlewares"
+	"github.com/databricks/cli/experimental/aitools/lib/session"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+	"github.com/spf13/cobra"
+)
+
+type warehouseInfo struct {
+	Id    string    `json:"id"`
+	Name  string    `json:"name"`
+	State sql.State `json:"state"`
+}
+
+func newGetDefaultWarehouseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-default-warehouse",
+		Short: "Get the default warehouse ID",
+		Long: `Get the default warehouse ID for the current workspace.
+
+The command auto-detects an available warehouse unless DATABRICKS_WAREHOUSE_ID is set.
+
+Returns warehouse ID of the default warehouse. Use --output json to get the full warehouse info including name and state.`,
+		Example: `  # Get warehouse ID in text format (default)
+  databricks experimental aitools tools get-default-warehouse
+  # Output: abc123def456...
+
+  # Get full warehouse info including name and state in JSON format
+  databricks experimental aitools tools get-default-warehouse --output json
+  # Output: {"id":"abc123def456...","name":"My Warehouse","state":"RUNNING"}`,
+		Args:    cobra.NoArgs,
+		PreRunE: root.MustWorkspaceClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := cmdctx.WorkspaceClient(ctx)
+
+			// set up session with client for middleware compatibility
+			sess := session.NewSession()
+			sess.Set(middlewares.DatabricksClientKey, w)
+			ctx = session.WithSession(ctx, sess)
+
+			warehouse, err := middlewares.GetWarehouseEndpoint(ctx)
+			if err != nil {
+				return err
+			}
+
+			info := warehouseInfo{
+				Id:    warehouse.Id,
+				Name:  warehouse.Name,
+				State: warehouse.State,
+			}
+
+			return cmdio.RenderWithTemplate(ctx, info, "", "{{.Id}}\n")
+		},
+	}
+
+	return cmd
+}

--- a/experimental/aitools/cmd/tools.go
+++ b/experimental/aitools/cmd/tools.go
@@ -17,6 +17,7 @@ func newToolsCmd() *cobra.Command {
 	cmd.AddCommand(init_template.NewInitTemplateCommand())
 	cmd.AddCommand(newValidateCmd())
 	cmd.AddCommand(newDeployCmd())
+	cmd.AddCommand(newGetDefaultWarehouseCmd())
 
 	return cmd
 }


### PR DESCRIPTION
## Why

This is something we need for experimenting with skills. There is currently no command that finds the default waregouse.

## Summary
- Add `databricks experimental aitools tools get-default-warehouse` command
- Returns warehouse ID in text mode (default) for easy scripting
- Returns full warehouse info (id, name, state) in JSON mode with `--output json`
- Uses existing `GetWarehouseID` function from middlewares package

## Examples
```bash
# Text output (default)
databricks experimental aitools tools get-default-warehouse
# Output: abc123def456...

# JSON output
databricks experimental aitools tools get-default-warehouse --output json
# Output: {"id":"abc123def456...","name":"My Warehouse","state":"RUNNING"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)