### PR TITLE
Fix import-dir logging for notebooks in subdirectories on Windows

### DIFF
--- a/cmd/workspace/workspace/import_dir.go
+++ b/cmd/workspace/workspace/import_dir.go
@@ -71,8 +71,8 @@ func (opts importDirOptions) callback(ctx context.Context, workspaceFiler filer.
 			return err
 		}
 		if isNotebook {
-			ext := path.Ext(localName)
-			remoteName = strings.TrimSuffix(localName, ext)
+			ext := path.Ext(remoteName)
+			remoteName = strings.TrimSuffix(remoteName, ext)
 		}
 
 		// Open the local file


### PR DESCRIPTION
## Changes

When importing notebooks from subdirectories on Windows, the log output showed incorrect paths with backslashes instead of forward slashes.

Example buggy output:
```
  subdir\nested\notebook.py -> /Users/.../subdir\nested\notebook
```

Expected output:
```
  subdir\nested\notebook.py -> /Users/.../subdir/nested/notebook
```

The bug was in lines 74-75 of import_dir.go where path.Ext() and strings.TrimSuffix() operated on localName (with backslashes) instead of remoteName (already converted to forward slashes via filepath.ToSlash).

## Why

Found this while investigating the `TestImportDir` failures.

## Tests

Tested on Windows 10 (10.0.26100.7462) with nested notebook files. Root-level notebooks were unaffected. The actual import operation worked correctly in both versions - only log output was impacted.