### PR TITLE
Fix line ending related integration failures

### DIFF
--- a/integration/.gitattributes
+++ b/integration/.gitattributes
@@ -1,0 +1,9 @@
+# We should always treat new lines in integration test files on Windows as \n.
+# This is important because the characters themselves are semantically important in tests.
+# For example, an additional \r character in Windows changes the upload payload when
+# uploading file content to a workspace.
+*.py text eol=lf
+*.sql text eol=lf
+*.r text eol=lf
+*.scala text eol=lf
+*.ipynb text eol=lf

--- a/integration/cmd/workspace/workspace_test.go
+++ b/integration/cmd/workspace/workspace_test.go
@@ -279,7 +279,7 @@ func TestExport(t *testing.T) {
 	assert.Equal(t, "abc", string(b))
 
 	// Export python notebook
-	err = f.Write(ctx, "pyNotebook.py", strings.NewReader("# Databricks notebook source"))
+	err = f.Write(ctx, "pyNotebook.py", strings.NewReader("# Databricks notebook source\n"))
 	require.NoError(t, err)
 	stdout, _ = testcli.RequireSuccessfulRun(t, ctx, "workspace", "export", path.Join(sourceDir, "pyNotebook"))
 	b, err = io.ReadAll(&stdout)
@@ -311,7 +311,7 @@ func TestExportWithFileFlag(t *testing.T) {
 	assertLocalFileContents(t, filepath.Join(localTmpDir, "file.txt"), "abc")
 
 	// Export python notebook
-	err = f.Write(ctx, "pyNotebook.py", strings.NewReader("# Databricks notebook source"))
+	err = f.Write(ctx, "pyNotebook.py", strings.NewReader("# Databricks notebook source\n"))
 	require.NoError(t, err)
 	stdout, _ = testcli.RequireSuccessfulRun(t, ctx, "workspace", "export", path.Join(sourceDir, "pyNotebook"), "--file", filepath.Join(localTmpDir, "pyNb.py"))
 	b, err = io.ReadAll(&stdout)


### PR DESCRIPTION
## Why

The root cause of TestExport and TestImportDir test failures was that we relied on the backend to normalize line endings. Previously, the backend would normalize line endings during import/export. Starting 2025-12-16, the backend changed to preserve line endings exactly as provided, without any normalization.

This change fixes the tests by:
1. Including trailing newlines in input notebook content that we upload (fixes TestExport and TestExportWithFileFlag)
2. Adding integration/.gitattributes to enforce LF line endings on all platforms (Linux, Mac, Windows) for test files (fixes TestImportDir, TestImportDirDoesNotOverwrite, TestImportDirWithOverwriteFlag, TestImportFileFormatAuto, TestImportFileFormatSource)

By sending payloads with the expected line endings and ensuring consistent checkout behavior via .gitattributes, the tests now validate correct round-trip behavior across all platforms.

Without .gitattributes, Windows would check out test files with CRLF, causing the uploaded content to differ from what Linux/Mac upload, leading to platform-specific test failures.

## Tests

The mentioned tests should show up as "recovered" in this run.