### PR TITLE
acc: add dashboards/unpublish-out-of-band test

### DIFF
--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/dashboard.lvdash.json
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/dashboard.lvdash.json
@@ -1,0 +1,1 @@
+{"pages":[{"name":"test-page","displayName":"Test Dashboard"}]}

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/databricks.yml.tmpl
@@ -1,0 +1,9 @@
+bundle:
+  name: unpublish-out-of-band-${UNIQUE_NAME}
+
+resources:
+  dashboards:
+    dashboard1:
+      display_name: ${DASHBOARD_DISPLAY_NAME}
+      warehouse_id: ${TEST_DEFAULT_WAREHOUSE_ID}
+      file_path: ./dashboard.lvdash.json

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.direct.json
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.direct.json
@@ -1,0 +1,27 @@
+{
+  "plan_version": 2,
+  "cli_version": "[DEV_VERSION]",
+  "lineage": "[UUID]",
+  "serial": 1,
+  "plan": {
+    "resources.dashboards.dashboard1": {
+      "action": "create",
+      "new_state": {
+        "value": {
+          "display_name": "test bundle-deploy-dashboard [UNIQUE_NAME])",
+          "embed_credentials": false,
+          "parent_path": "/Workspace/Users/[USERNAME]/.bundle/unpublish-out-of-band-[UNIQUE_NAME]/default/resources",
+          "serialized_dashboard": "{\"pages\":[{\"name\":\"test-page\",\"displayName\":\"Test Dashboard\"}]}\n",
+          "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
+        }
+      },
+      "changes": {
+        "etag": {
+          "action": "update",
+          "reason": "remote_already_set",
+          "old": [ETAG]
+        }
+      }
+    }
+  }
+}

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.direct.txt
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.direct.txt
@@ -1,0 +1,3 @@
+create dashboards.dashboard1
+
+Plan: 1 to add, 0 to change, 0 to delete, 0 unchanged

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.terraform.json
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.terraform.json
@@ -1,0 +1,9 @@
+{
+  "plan_version": 2,
+  "cli_version": "[DEV_VERSION]",
+  "plan": {
+    "resources.dashboards.dashboard1": {
+      "action": "skip"
+    }
+  }
+}

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.terraform.txt
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.plan.terraform.txt
@@ -1,0 +1,1 @@
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -1,0 +1,6 @@
+Local = true
+Cloud = true
+RequiresWarehouse = true
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/output.txt
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/output.txt
@@ -1,0 +1,15 @@
+
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/unpublish-out-of-band-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] lakeview get-published [DASHBOARD_ID]
+{
+  "embed_credentials": false
+}
+
+>>> [CLI] lakeview unpublish [DASHBOARD_ID]
+
+=== Run bundle plan after unpublishing

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/script
@@ -1,0 +1,33 @@
+export DASHBOARD_DISPLAY_NAME="test bundle-deploy-dashboard $UNIQUE_NAME)"
+
+if [ -z "$CLOUD_ENV" ]; then
+    export TEST_DEFAULT_WAREHOUSE_ID="warehouse-1234"
+    echo "warehouse-1234:TEST_DEFAULT_WAREHOUSE_ID" >> ACC_REPLS
+fi
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+    $CLI bundle destroy --auto-approve > /dev/null 2>&1
+}
+trap cleanup EXIT
+
+# Deploy the dashboard
+trace $CLI bundle deploy
+DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
+
+# Capture the dashboard ID as a replacement.
+echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
+
+# Verify dashboard was deployed and is published
+trace $CLI lakeview get-published $DASHBOARD_ID | jq '{embed_credentials}'
+
+# Unpublish the dashboard out of band (simulating external action)
+trace $CLI lakeview unpublish $DASHBOARD_ID
+
+title "Run bundle plan after unpublishing"
+# Terraform: shows "skip" because it only reads draft state, not published state
+# Direct: shows "create" because GetPublished returns 404, causing DoRead to fail
+$CLI bundle plan > out.plan.$DATABRICKS_BUNDLE_ENGINE.txt
+
+$CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/test.toml
@@ -1,0 +1,8 @@
+Local = true
+Cloud = true
+RequiresWarehouse = true
+RecordRequests = false
+
+Ignore = [
+    "databricks.yml",
+]

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -277,3 +277,22 @@ func (s *FakeWorkspace) DashboardTrash(req Request) Response {
 		Body: dashboard,
 	}
 }
+
+func (s *FakeWorkspace) DashboardUnpublish(req Request) Response {
+	defer s.LockUnlock()()
+
+	dashboardId := req.Vars["dashboard_id"]
+	_, ok := s.Dashboards[dashboardId]
+	if !ok {
+		return Response{
+			StatusCode: 404,
+		}
+	}
+
+	// Delete the published dashboard entry.
+	delete(s.PublishedDashboards, dashboardId)
+
+	return Response{
+		Body: "",
+	}
+}

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -243,6 +243,9 @@ func AddDefaultHandlers(server *Server) {
 	server.Handle("GET", "/api/2.0/lakeview/dashboards/{dashboard_id}/published", func(req Request) any {
 		return MapGet(req.Workspace, req.Workspace.PublishedDashboards, req.Vars["dashboard_id"])
 	})
+	server.Handle("DELETE", "/api/2.0/lakeview/dashboards/{dashboard_id}/published", func(req Request) any {
+		return req.Workspace.DashboardUnpublish(req)
+	})
 
 	// Pipelines:
 


### PR DESCRIPTION
New test that shows difference between TF and direct when dashboard is unpublished out of band.
