### PR TITLE
internal: structdiff: ignore fields with json:"-" annotation

### DIFF
--- a/libs/structs/structdiff/diff.go
+++ b/libs/structs/structdiff/diff.go
@@ -202,6 +202,10 @@ func diffStruct(ctx *diffContext, path *structpath.PathNode, s1, s2 reflect.Valu
 
 		// Resolve field name from JSON tag or fall back to Go field name
 		fieldName := jsonTag.Name()
+		if fieldName == "-" {
+			continue
+		}
+
 		if fieldName == "" {
 			fieldName = sf.Name
 		}

--- a/libs/structs/structdiff/diff_test.go
+++ b/libs/structs/structdiff/diff_test.go
@@ -10,12 +10,13 @@ import (
 type B struct{ S string }
 
 type A struct {
-	XX int            `json:"xx"`
-	X  int            `json:"x,omitempty"`
-	B  B              `json:"b,omitempty"`
-	P  *B             `json:"p,omitempty"`
-	M  map[string]int `json:"m,omitempty"`
-	L  []string       `json:"l,omitempty"`
+	XX      int            `json:"xx"`
+	X       int            `json:"x,omitempty"`
+	B       B              `json:"b,omitempty"`
+	P       *B             `json:"p,omitempty"`
+	M       map[string]int `json:"m,omitempty"`
+	L       []string       `json:"l,omitempty"`
+	Ignored string         `json:"-"`
 }
 
 type C struct {
@@ -154,6 +155,12 @@ func TestGetStructDiff(t *testing.T) {
 			a:    A{L: []string{"a"}},
 			b:    A{L: []string{"a", "b"}},
 			want: []ResolvedChange{{Field: "l", Old: []string{"a"}, New: []string{"a", "b"}}},
+		},
+		{
+			name: "ignored field change",
+			a:    A{X: 5, Ignored: "old"},
+			b:    A{X: 5, Ignored: "new"},
+			want: nil,
 		},
 
 		// ForceSendFields with non-empty fields (omitempty)

--- a/libs/structs/structdiff/equal.go
+++ b/libs/structs/structdiff/equal.go
@@ -110,6 +110,11 @@ func equalStruct(s1, s2 reflect.Value) bool {
 
 		jsonTag := structtag.JSONTag(sf.Tag.Get("json"))
 
+		// Skip fields with json:"-"
+		if jsonTag.Name() == "-" {
+			continue
+		}
+
 		v1Field := s1.Field(i)
 		v2Field := s2.Field(i)
 


### PR DESCRIPTION
## Why
Certain structs in SDK (e.g. catalog.CreateMonitor) have this annotation for fields that are part of the path. We need those fields in input schema and state, so we typically add our own replacement for it. The original field still shows up in diff though, until this PR.

## Tests
Unit tests.