### PR TITLE
Fix AppKit template documentation for LLMs

### DIFF
--- a/experimental/aitools/templates/appkit/template/{{.project_name}}/CLAUDE.md
+++ b/experimental/aitools/templates/appkit/template/{{.project_name}}/CLAUDE.md
@@ -53,7 +53,7 @@ import { BarChart } from '@databricks/appkit-ui/react';
 
 **That's it!** The component handles data fetching, loading states, and rendering automatically.
 
-**⚠️ CRITICAL: Always run `npm run typegen` after modifying `config/queries/schema.ts`**
+**⚠️ CRITICAL: Always run `npm run typegen` after modifying files in `config/queries/`**
 - DO NOT manually edit `client/src/appKitTypes.d.ts` - it is auto-generated
 - If you see errors like `'"my_query"' is not assignable to parameter of type`, run `npm run typegen`
 


### PR DESCRIPTION
## Summary

Fixes critical documentation issues causing build failures in LLM-generated AppKit apps.

**Changes:**
1. **Typegen step**: Made `npm run typegen` a required explicit step after schema changes
2. **Chart components**: Clarified that AppKit charts do NOT accept children (Recharts pattern doesn't work)
3. **Import fixes**: Fixed typo `app-kit-ui` -> `appkit-ui`, added missing `sql` import
4. **Type usage**: Removed incorrect generic type on `useAnalyticsQuery`

**Root causes addressed:**
- Agents skipping `npm run typegen` -> "not assignable to type" errors
- Agents using `<BarChart><Bar .../></BarChart>` -> TypeScript errors (charts don't accept children)
- Agents using wrong import path -> module not found errors

## Test plan
- Documentation changes only
- Manual testing with app generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)