### PR TITLE
Make conftest more robust

### DIFF
--- a/libs/template/templates/default/template/{{.project_name}}/tests/conftest.py
+++ b/libs/template/templates/default/template/{{.project_name}}/tests/conftest.py
@@ -59,7 +59,8 @@ def load_fixture(spark: SparkSession):
 def _enable_fallback_compute():
     """Enable serverless compute if no compute is specified."""
     conf = WorkspaceClient().config
-    if conf.serverless_compute_id or conf.cluster_id or os.environ.get("SPARK_REMOTE"):
+    has_serverles_compute_id = hasattr(conf, "serverless_compute_id") and conf.serverless_compute_id
+    if has_serverles_compute_id or conf.cluster_id or os.environ.get("SPARK_REMOTE"):
         return
 
     url = "https://docs.databricks.com/dev-tools/databricks-connect/cluster-config"
@@ -83,6 +84,8 @@ def _allow_stderr_output(config: pytest.Config):
 def pytest_configure(config: pytest.Config):
     """Configure pytest session."""
     with _allow_stderr_output(config):
+        src_path = pathlib.Path(__file__).parent.parent / "src"
+        sys.path.insert(0, str(src_path))
         _enable_fallback_compute()
 
         # Initialize Spark session eagerly, so it is available even when


### PR DESCRIPTION
## Changes

1. Make checking for serverless_comput_id more robust since that field does not exist on serverless client v1 and fill throw an error right now otherwise.
2. Add the test path to sys.path

<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

This will make the example test compatible with the upcoming workspace unit testing feature.

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
