### PR TITLE
Use libs/agent in MCP install command

### DIFF
--- a/experimental/aitools/cmd/install.go
+++ b/experimental/aitools/cmd/install.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/databricks/cli/experimental/aitools/lib/agents"
+	"github.com/databricks/cli/libs/agent"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -29,24 +30,25 @@ func runInstall(ctx context.Context) error {
 	// Check for non-interactive mode with agent detection
 	// If running in an AI agent, install automatically without prompts
 	if !cmdio.IsPromptSupported(ctx) {
-		if os.Getenv("CLAUDECODE") != "" {
+		switch agent.Product(ctx) {
+		case agent.ClaudeCode:
 			if err := agents.InstallClaude(); err != nil {
 				return err
 			}
 			cmdio.LogString(ctx, color.GreenString("✓ Installed Databricks MCP server for Claude Code"))
 			cmdio.LogString(ctx, color.YellowString("⚠️  Please restart Claude Code for changes to take effect"))
 			return nil
-		}
-		if os.Getenv("CURSOR_AGENT") != "" {
+		case agent.Cursor:
 			if err := agents.InstallCursor(); err != nil {
 				return err
 			}
 			cmdio.LogString(ctx, color.GreenString("✓ Installed Databricks MCP server for Cursor"))
 			cmdio.LogString(ctx, color.YellowString("⚠️  Please restart Cursor for changes to take effect"))
 			return nil
+		default:
+			// Unknown agent in non-interactive mode - show manual instructions
+			return agents.ShowCustomInstructions(ctx)
 		}
-		// Unknown agent in non-interactive mode - show manual instructions
-		return agents.ShowCustomInstructions(ctx)
 	}
 
 	cmdio.LogString(ctx, "")


### PR DESCRIPTION
## Why

This packages was added in #4287 and centralizes agent detection.

## Tests

Manually confirmed install with `CLAUDECODE=1` and `CURSOR_AGENT=1`.