### PR TITLE
Move user-facing messages to stderr

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -343,7 +343,7 @@ func getBrowserFunc(cmd *cobra.Command) func(url string) error {
 		return openURLSuppressingStderr
 	case "none":
 		return func(url string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "Please complete authentication by opening this link in your browser:\n%s\n", url)
+			cmdio.LogString(cmd.Context(), "Please complete authentication by opening this link in your browser:\n"+url)
 			return nil
 		}
 	default:

--- a/cmd/bundle/deployment/migrate.go
+++ b/cmd/bundle/deployment/migrate.go
@@ -187,7 +187,7 @@ To start using direct engine, deploy with DATABRICKS_BUNDLE_ENGINE=direct env va
 
 		// Run plan check unless --noplancheck is set
 		if !noPlanCheck {
-			fmt.Fprintf(cmd.OutOrStdout(), "Note: Migration should be done after a full deploy. Running plan now to verify that deployment was done:\n")
+			cmdio.LogString(ctx, "Note: Migration should be done after a full deploy. Running plan now to verify that deployment was done:")
 			if err = runPlanCheck(cmd, extraArgs, extraArgsStr); err != nil {
 				return err
 			}

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -165,7 +165,7 @@ func remarshalJSON(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (d *dashboard) saveSerializedDashboard(_ context.Context, b *bundle.Bundle, dashboard *dashboards.Dashboard, filename string) error {
+func (d *dashboard) saveSerializedDashboard(ctx context.Context, b *bundle.Bundle, dashboard *dashboards.Dashboard, filename string) error {
 	// Unmarshal and remarshal the serialized dashboard to ensure it is formatted correctly.
 	// The result will have alphabetically sorted keys and be indented.
 	data, err := remarshalJSON([]byte(dashboard.SerializedDashboard))
@@ -198,7 +198,7 @@ func (d *dashboard) saveSerializedDashboard(_ context.Context, b *bundle.Bundle,
 		}
 	}
 
-	fmt.Fprintf(d.out, "Writing dashboard to %q\n", rel)
+	cmdio.LogString(ctx, fmt.Sprintf("Writing dashboard to %q", rel))
 	return os.WriteFile(filename, data, 0o644)
 }
 
@@ -242,7 +242,7 @@ func (d *dashboard) saveConfiguration(ctx context.Context, b *bundle.Bundle, das
 		rel = resourcePath
 	}
 
-	fmt.Fprintf(d.out, "Writing configuration to %q\n", rel)
+	cmdio.LogString(ctx, fmt.Sprintf("Writing configuration to %q", rel))
 	err = saver.SaveAsYAML(result, resourcePath, d.force)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Changes

Change progress messages and auth prompts to use cmdio.LogString, writing to stderr instead of stdout.

## Why

Keeps stdout clean for data output.