### PR TITLE
Use context-based stderr in logdiag

### DIFF
--- a/bundle/render/render_text_output_test.go
+++ b/bundle/render/render_text_output_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/logdiag"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -277,8 +278,11 @@ func TestRenderDiagnostics(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			writer := &bytes.Buffer{}
+			ctx := context.Background()
+			cmdIO := cmdio.NewIO(ctx, flags.OutputText, nil, io.Discard, writer, "", "")
+			ctx = cmdio.InContext(ctx, cmdIO)
 
-			err := cmdio.RenderDiagnostics(writer, tc.diags)
+			err := cmdio.RenderDiagnostics(ctx, tc.diags)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expected, writer.String())

--- a/libs/cmdio/render.go
+++ b/libs/cmdio/render.go
@@ -449,12 +449,18 @@ const recommendationTemplate = `{{ "Recommendation" | blue }}: {{ .Summary }}
 
 `
 
-func RenderDiagnosticsToErrorOut(ctx context.Context, diags diag.Diagnostics) error {
+func RenderDiagnostics(ctx context.Context, diags diag.Diagnostics) error {
 	c := fromContext(ctx)
-	return RenderDiagnostics(c.err, diags)
+	return renderDiagnostics(c.err, diags)
 }
 
-func RenderDiagnostics(out io.Writer, diags diag.Diagnostics) error {
+// RenderDiagnosticsToErrorOut is a compatibility alias for RenderDiagnostics.
+// Deprecated: Use RenderDiagnostics instead.
+func RenderDiagnosticsToErrorOut(ctx context.Context, diags diag.Diagnostics) error {
+	return RenderDiagnostics(ctx, diags)
+}
+
+func renderDiagnostics(out io.Writer, diags diag.Diagnostics) error {
 	errorT := template.Must(template.New("error").Funcs(renderFuncMap).Parse(errorTemplate))
 	warningT := template.Must(template.New("warning").Funcs(renderFuncMap).Parse(warningTemplate))
 	recommendationT := template.Must(template.New("recommendation").Funcs(renderFuncMap).Parse(recommendationTemplate))

--- a/libs/logdiag/logdiag.go
+++ b/libs/logdiag/logdiag.go
@@ -2,8 +2,6 @@ package logdiag
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -147,9 +145,9 @@ func LogDiag(ctx context.Context, d diag.Diagnostic) {
 	if val.Collect {
 		val.Collected = append(val.Collected, d)
 	} else {
-		err := cmdio.RenderDiagnostics(os.Stderr, []diag.Diagnostic{d})
+		err := cmdio.RenderDiagnostics(ctx, []diag.Diagnostic{d})
 		if err != nil {
-			fmt.Fprint(os.Stderr, "\nRendering error: "+err.Error()+"\n")
+			cmdio.LogString(ctx, "\nRendering error: "+err.Error())
 		}
 	}
 }


### PR DESCRIPTION
## Changes

Replace direct `os.Stderr` usage in logdiag with `cmdio.RenderDiagnostics`. Since cmdio is always initialized before logdiag in production, we can safely use the context-based writer.

Also rename `cmdio.RenderDiagnosticsToErrorOut` to `cmdio.RenderDiagnostics` because writing to stderr is implicit (keeping the old name as a deprecated alias for compatibility with autogenerated commands).