### PR TITLE
Clear agent environment variables in acceptance tests

### DIFF
--- a/acceptance/bundle/user_agent/test.toml
+++ b/acceptance/bundle/user_agent/test.toml
@@ -4,7 +4,3 @@ IncludeRequestHeaders = ["User-Agent"]
 
 [Env]
 DATABRICKS_CACHE_ENABLED = 'false'
-# Clear agent env vars to prevent them from affecting test output
-CLAUDECODE = ''
-GEMINI_CLI = ''
-CURSOR_AGENT = ''

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -17,6 +17,11 @@ Env.PYTHONDONTWRITEBYTECODE = "1"
 Env.PYTHONUNBUFFERED = "1"
 Env.PYTHONUTF8 = "1"
 
+# Clear agent env vars to prevent them from affecting test output
+Env.CLAUDECODE = ""
+Env.GEMINI_CLI = ""
+Env.CURSOR_AGENT = ""
+
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrixExclude.noplantf = ["DATABRICKS_BUNDLE_ENGINE=terraform", "READPLAN=1"]
 EnvRepl.DATABRICKS_BUNDLE_ENGINE = false


### PR DESCRIPTION
## Changes

Agent detection environment variables (`CLAUDECODE`, `GEMINI_CLI`, `CURSOR_AGENT`) were causing the `User-Agent` header to include agent information in acceptance test output. This made tests fail when run from within Claude Code or other agent environments.

Moved the agent environment variable clearing from the bundle-specific test.toml to the root test.toml so it applies to all tests globally.