### PR TITLE
acc: Fix recorded error message in dashboards/unpublish-out-of-band

### DIFF
--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.get_published.terraform.txt
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.get_published.terraform.txt
@@ -1,5 +1,5 @@
 
 >>> errcode [CLI] lakeview get-published [DASHBOARD1_ID]
-Error: Unable to find published dashboard [dashboardId=[DASHBOARD1_ID]]
+Error: Unable to find published dashboard [[DASHBOARD1_ID]]
 
 Exit code: 1

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -313,7 +313,7 @@ func (s *FakeWorkspace) DashboardGetPublished(req Request) Response {
 		return Response{
 			StatusCode: 404,
 			Body: map[string]string{
-				"message": fmt.Sprintf("Unable to find published dashboard [dashboardId=%s]", dashboardId),
+				"message": fmt.Sprintf("Unable to find published dashboard [%s]", dashboardId),
 			},
 		}
 	}


### PR DESCRIPTION
## Why

It started to fail on cloud in all test envs. If it keeps on failing we might redact the message out but for now updating it.