### PR TITLE
Migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,6 +12,11 @@ go-ini/ini - https://github.com/go-ini/ini
 Copyright ini authors
 License - https://github.com/go-ini/ini/blob/main/LICENSE
 
+go-yaml/yaml - https://github.com/yaml/go-yaml
+Copyright (c) 2011-2019 Canonical Ltd
+Copyright (c) 2006-2011 Kirill Simonov
+License - https://github.com/yaml/go-yaml/blob/v3/LICENSE
+
 —--
 
 This software contains code from the following open source projects, licensed under the MPL 2.0 license:
@@ -130,3 +135,8 @@ https://github.com/darccio/mergo/blob/master/LICENSE
 https://github.com/gorilla/mux
 Copyright (c) 2023 The Gorilla Authors. All rights reserved.
 https://github.com/gorilla/mux/blob/main/LICENSE
+
+go-yaml/yaml - https://github.com/yaml/go-yaml
+Copyright (c) 2011-2019 Canonical Ltd
+Copyright (c) 2006-2011 Kirill Simonov
+License - https://github.com/yaml/go-yaml/blob/v3/LICENSE

--- a/acceptance/internal/bundle_config.go
+++ b/acceptance/internal/bundle_config.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"dario.cat/mergo"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func MergeBundleConfig(source string, bundleConfig map[string]any) (string, error) {

--- a/acceptance/internal/bundle_config_test.go
+++ b/acceptance/internal/bundle_config_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestMergeBundleConfig(t *testing.T) {

--- a/bundle/direct/dresources/config.go
+++ b/bundle/direct/dresources/config.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/databricks/cli/libs/structs/structpath"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // ResourceLifecycleConfig defines lifecycle behavior for a resource type.

--- a/bundle/internal/schema/annotations.go
+++ b/bundle/internal/schema/annotations.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"strings"
 
-	yaml3 "gopkg.in/yaml.v3"
+	yaml3 "go.yaml.in/yaml/v3"
 
 	"github.com/databricks/cli/bundle/internal/annotation"
 	"github.com/databricks/cli/libs/dyn"

--- a/bundle/internal/schema/main_test.go
+++ b/bundle/internal/schema/main_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/yamlloader"
 	"github.com/databricks/cli/libs/jsonschema"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func copyFile(src, dst string) error {

--- a/cmd/bundle/generate/alert.go
+++ b/cmd/bundle/generate/alert.go
@@ -19,7 +19,7 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func NewGenerateAlertCommand() *cobra.Command {

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -32,8 +32,8 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/dashboards"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/exp/maps"
-	"gopkg.in/yaml.v3"
 )
 
 type dashboard struct {

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -18,7 +18,7 @@ import (
 	"github.com/databricks/cli/libs/textutil"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func NewGenerateJobCommand() *cobra.Command {

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -17,7 +17,7 @@ import (
 	"github.com/databricks/cli/libs/textutil"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func NewGeneratePipelineCommand() *cobra.Command {

--- a/cmd/labs/project/project.go
+++ b/cmd/labs/project/project.go
@@ -16,7 +16,7 @@ import (
 	"github.com/databricks/cli/libs/python"
 	"github.com/databricks/databricks-sdk-go/logger"
 	"github.com/fatih/color"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.10.1 // Apache 2.0
 	github.com/spf13/pflag v1.0.10 // BSD-3-Clause
 	github.com/stretchr/testify v1.11.1 // MIT
+	go.yaml.in/yaml/v3 v3.0.4 // MIT, Apache 2.0
 	golang.org/x/crypto v0.47.0 // BSD-3-Clause
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621
 	golang.org/x/mod v0.32.0
@@ -38,7 +39,6 @@ require (
 	golang.org/x/sys v0.40.0
 	golang.org/x/text v0.33.0
 	gopkg.in/ini.v1 v1.67.1 // Apache 2.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 // Dependencies for experimental MCP commands
@@ -92,4 +92,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250922171735-9219d122eba9 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ go.opentelemetry.io/otel/sdk/metric v1.38.0 h1:aSH66iL0aZqo//xXzQLYozmWrXxyFkBJ6
 go.opentelemetry.io/otel/sdk/metric v1.38.0/go.mod h1:dg9PBnW9XdQ1Hd6ZnRz689CbtrUp0wMMs9iPcgT9EZA=
 go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20250911091902-df9299821621 h1:2id6c1/gto0kaHYyrixvknJ8tUK/Qs5IsmBtrc+FtgU=

--- a/libs/apps/runlocal/spec.go
+++ b/libs/apps/runlocal/spec.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/libs/env"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type AppEnvVar struct {

--- a/libs/dyn/yamlloader/loader.go
+++ b/libs/dyn/yamlloader/loader.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/libs/dyn"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type loader struct {

--- a/libs/dyn/yamlloader/yaml.go
+++ b/libs/dyn/yamlloader/yaml.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/databricks/cli/libs/dyn"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func LoadYAML(path string, r io.Reader) (dyn.Value, error) {

--- a/libs/dyn/yamlloader/yaml_error_test.go
+++ b/libs/dyn/yamlloader/yaml_error_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/yamlloader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestYAMLErrorMapMerge(t *testing.T) {

--- a/libs/dyn/yamlloader/yaml_spec_test.go
+++ b/libs/dyn/yamlloader/yaml_spec_test.go
@@ -265,7 +265,7 @@ func TestYAMLSpecExample_2_11(t *testing.T) {
 	input, err := os.ReadFile(file)
 	require.NoError(t, err)
 
-	// Note: non-string mapping keys are not supported by "gopkg.in/yaml.v3".
+	// Note: non-string mapping keys are not supported by "go.yaml.in/yaml/v3".
 	_, err = yamlloader.LoadYAML(file, bytes.NewBuffer(input))
 	assert.ErrorContains(t, err, `: key is not a scalar`)
 }
@@ -530,7 +530,7 @@ func TestYAMLSpecExample_2_22(t *testing.T) {
 			),
 			"spaced": dyn.NewValue(
 				// This is parsed as a string, not a timestamp,
-				// both by "gopkg.in/yaml.v3" and by our implementation.
+				// both by "go.yaml.in/yaml/v3" and by our implementation.
 				"2001-12-14 21:59:43.10 -5",
 				[]dyn.Location{{File: file, Line: 5, Column: 9}},
 			),

--- a/libs/dyn/yamlloader/yaml_test.go
+++ b/libs/dyn/yamlloader/yaml_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/yamlloader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func loadYAML(t *testing.T, path string) dyn.Value {

--- a/libs/dyn/yamlsaver/saver.go
+++ b/libs/dyn/yamlsaver/saver.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/databricks/cli/libs/dyn"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type saver struct {

--- a/libs/dyn/yamlsaver/saver_test.go
+++ b/libs/dyn/yamlsaver/saver_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestMarshalNilValue(t *testing.T) {

--- a/libs/structs/structpath/path_test.go
+++ b/libs/structs/structpath/path_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestPathNode(t *testing.T) {


### PR DESCRIPTION
## Changes

Update all direct yaml imports to use the actively maintained fork under the official YAML organization. The new package is a drop-in replacement with an identical API.

The old gopkg.in/yaml.v3 remains as an indirect dependency from external libraries (testify, databricks-sdk-go, cobra, etc.) until they migrate.

Prompted by https://github.com/spf13/cobra/pull/2336.

## Why

The original gopkg.in/yaml.v3 repository was archived and marked unmaintained in April 2025. The YAML organization has taken over maintenance and published go.yaml.in/yaml/v3 as the successor. This migration ensures we receive future bug fixes and security updates.