### PR TITLE
Add dashboard deploy metadata

### DIFF
--- a/bundle/deploy/metadata/compute_test.go
+++ b/bundle/deploy/metadata/compute_test.go
@@ -66,6 +66,18 @@ func TestComputeMetadataMutator(t *testing.T) {
 						},
 					},
 				},
+				Dashboards: map[string]*resources.Dashboard{
+					"my-dashboard-1": {
+						BaseResource:    resources.BaseResource{ID: "5555"},
+						DashboardConfig: resources.DashboardConfig{},
+						FilePath:        "i/h/g",
+					},
+					"my-dashboard-2": {
+						BaseResource:    resources.BaseResource{ID: "6666"},
+						DashboardConfig: resources.DashboardConfig{},
+						FilePath:        "l/k/j",
+					},
+				},
 			},
 		},
 	}
@@ -74,6 +86,8 @@ func TestComputeMetadataMutator(t *testing.T) {
 	bundletest.SetLocation(b, "resources.jobs.my-job-2", []dyn.Location{{File: "d/e/f"}})
 	bundletest.SetLocation(b, "resources.pipelines.my-pipeline-1", []dyn.Location{{File: "x/y/z"}})
 	bundletest.SetLocation(b, "resources.pipelines.my-pipeline-2", []dyn.Location{{File: "u/v/w"}})
+	bundletest.SetLocation(b, "resources.dashboards.my-dashboard-1", []dyn.Location{{File: "g/h/i"}})
+	bundletest.SetLocation(b, "resources.dashboards.my-dashboard-2", []dyn.Location{{File: "j/k/l"}})
 
 	expectedMetadata := metadata.Metadata{
 		Version: metadata.Version,
@@ -111,6 +125,18 @@ func TestComputeMetadataMutator(t *testing.T) {
 					"my-pipeline-2": {
 						RelativePath: "u/v/w",
 						ID:           "4444",
+					},
+				},
+				Dashboards: map[string]*metadata.DashboardResource{
+					"my-dashboard-1": {
+						RelativePath: "g/h/i",
+						ID:           "5555",
+						FilePath:     "i/h/g",
+					},
+					"my-dashboard-2": {
+						RelativePath: "j/k/l",
+						ID:           "6666",
+						FilePath:     "l/k/j",
 					},
 				},
 			},

--- a/bundle/metadata/metadata.go
+++ b/bundle/metadata/metadata.go
@@ -25,9 +25,20 @@ type Resource struct {
 	RelativePath string `json:"relative_path"`
 }
 
+type DashboardResource struct {
+	ID string `json:"id,omitempty"`
+	// Relative path from the bundle root to the configuration file that holds
+	// the dashboard definition
+	RelativePath string `json:"relative_path"`
+	// Relative path from the bundle root to the `.lvdash.json` file containing
+	// the dashboard source
+	FilePath string `json:"file_path"`
+}
+
 type Resources struct {
-	Jobs      map[string]*Resource `json:"jobs,omitempty"`
-	Pipelines map[string]*Resource `json:"pipelines,omitempty"`
+	Jobs       map[string]*Resource          `json:"jobs,omitempty"`
+	Pipelines  map[string]*Resource          `json:"pipelines,omitempty"`
+	Dashboards map[string]*DashboardResource `json:"dashboards,omitempty"`
 }
 
 type Presets struct {


### PR DESCRIPTION
## Changes
Output information in `metadata.json` about deployed dashboards 

## Why
To support dashboard integration in the workspace

## Tests
updated unit tests
