### PR TITLE
Fix WorkspaceDelete to delete directories in testserver

### DIFF
--- a/acceptance/bundle/resources/sql_warehouses/output.txt
+++ b/acceptance/bundle/resources/sql_warehouses/output.txt
@@ -137,7 +137,4 @@ Resources:
       URL:  (not deployed)
 
 >>> [CLI] bundle destroy --auto-approve
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test_sql_warehouse/default
-
-Deleting files...
-Destroy complete!
+No active deployment found to destroy!

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -341,10 +341,16 @@ func (s *FakeWorkspace) WorkspaceDelete(path string, recursive bool) {
 	defer s.LockUnlock()()
 	if !recursive {
 		delete(s.files, path)
+		delete(s.directories, path)
 	} else {
 		for key := range s.files {
 			if strings.HasPrefix(key, path) {
 				delete(s.files, key)
+			}
+		}
+		for key := range s.directories {
+			if strings.HasPrefix(key, path) {
+				delete(s.directories, key)
 			}
 		}
 	}


### PR DESCRIPTION
## Changes

The testserver's WorkspaceDelete method now properly deletes directories in addition to files, both for non-recursive and recursive deletion modes. This ensures proper cleanup of workspace paths during tests.

Updated sql_warehouses acceptance test output to reflect the corrected behavior where destroy properly cleans up and shows "No active deployment found to destroy!" on subsequent destroy calls.

## Tests

Acceptance tests pass locally.