### PR TITLE
Add run_as support for alerts

### DIFF
--- a/bundle/config/mutator/resourcemutator/run_as_test.go
+++ b/bundle/config/mutator/resourcemutator/run_as_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/convert"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -99,6 +100,13 @@ func TestRunAsWorksForAllowedResources(t *testing.T) {
 			Pipelines: map[string]*resources.Pipeline{
 				"pipeline_one": {},
 			},
+			Alerts: map[string]*resources.Alert{
+				"alert_one": {
+					AlertV2: sql.AlertV2{
+						DisplayName: "alert",
+					},
+				},
+			},
 		},
 	}
 
@@ -111,6 +119,10 @@ func TestRunAsWorksForAllowedResources(t *testing.T) {
 
 	for _, job := range b.Config.Resources.Jobs {
 		assert.Equal(t, "bob", job.RunAs.UserName)
+	}
+
+	for _, alert := range b.Config.Resources.Alerts {
+		assert.Equal(t, "bob", alert.RunAs.UserName)
 	}
 }
 
@@ -145,6 +157,7 @@ func TestRunAsWorksForAllowedResources(t *testing.T) {
 // some point in the future. These resources are (implicitly) on the deny list, since
 // they are not on the allow list below.
 var allowList = []string{
+	"alerts",
 	"clusters",
 	"database_catalogs",
 	"database_instances",


### PR DESCRIPTION
## Changes
This PR adds support for top level run_as, which was missing before due to pending API side changes.

## Tests
Unit test coverage.