### PR TITLE
Rename Apps DevEx team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 /acceptance/pipelines/    @jefferycheng1 @kanterov @lennartkats-db
 /cmd/pipelines/           @jefferycheng1 @kanterov @lennartkats-db
 /cmd/labs/                @alexott @nfx
-/cmd/apps/                @databricks/eng-app-devex
-/cmd/workspace/apps/      @databricks/eng-app-devex
-/libs/apps/               @databricks/eng-app-devex
-/acceptance/apps/         @databricks/eng-app-devex
-/experimental/aitools/    @databricks/eng-app-devex @lennartkats-db
+/cmd/apps/                @databricks/eng-apps-devex
+/cmd/workspace/apps/      @databricks/eng-apps-devex
+/libs/apps/               @databricks/eng-apps-devex
+/acceptance/apps/         @databricks/eng-apps-devex
+/experimental/aitools/    @databricks/eng-apps-devex @lennartkats-db


### PR DESCRIPTION
## Changes
Rename Apps DevEx team in CODEOWNERS.
This PR requires the team https://github.com/orgs/databricks/teams/eng-app-devex to be renamed to `eng-apps-devex`.

## Why
Unify team naming across different Databricks organizations
