### PR TITLE
Add go.work files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ dist/
 # Local development notes, tmp
 /pr-*
 /tmp/
+
+# Go workspace file
+go.work
+go.work.sum


### PR DESCRIPTION
## Changes
Adding `go.work` files to the `.gitignore`, as we don't use monorepos and don't need it in to be tracked.

See example in .gitignore template collection: https://github.com/github/gitignore/blob/main/Go.gitignore#L23

## Why
It is convenient when you need to run `go run` from any directory, e.g. if I have my bundle collection I can do
```
go work init /Users/ilya/www/cli
go run /Users/ilya/www/cli --version
```

Without `go.work` I need to either build the CLI, or configure launch targets in IDE, or put a bundle inside the CLI repo. Using `go run` is slightly more convenient, especially when using with agents 

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
