### PR TITLE
Add RecordRequests to out.test.toml

### DIFF
--- a/acceptance/apps/deploy/bundle-with-appname/out.test.toml
+++ b/acceptance/apps/deploy/bundle-with-appname/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/no-bundle-with-appname/out.test.toml
+++ b/acceptance/apps/deploy/no-bundle-with-appname/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/basic/out.test.toml
+++ b/acceptance/auth/credentials/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/oauth/out.test.toml
+++ b/acceptance/auth/credentials/oauth/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/pat/out.test.toml
+++ b/acceptance/auth/credentials/pat/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/unified-host/out.test.toml
+++ b/acceptance/auth/credentials/unified-host/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/app_yaml/out.test.toml
+++ b/acceptance/bundle/apps/app_yaml/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_for_volumes/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_for_volumes/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_for_workspace/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_for_workspace/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_with_no_library_reference/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_with_no_library_reference/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifacts_dynamic_version/out.test.toml
+++ b/acceptance/bundle/artifacts/artifacts_dynamic_version/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/build_and_files/out.test.toml
+++ b/acceptance/bundle/artifacts/build_and_files/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/build_and_files_whl/out.test.toml
+++ b/acceptance/bundle/artifacts/build_and_files_whl/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/glob_exact_whl/out.test.toml
+++ b/acceptance/bundle/artifacts/glob_exact_whl/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_in_files/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_in_files/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_in_files_in_include/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_in_files_in_include/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_invalid/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_invalid/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/issue_3109/out.test.toml
+++ b/acceptance/bundle/artifacts/issue_3109/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/nil_artifacts/out.test.toml
+++ b/acceptance/bundle/artifacts/nil_artifacts/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/same_name_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/same_name_libraries/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/bash/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/bash/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/artifacts/shell/basic/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/cmd/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/cmd/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [GOOS]
   darwin = false

--- a/acceptance/bundle/artifacts/shell/default/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/default/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/artifacts/shell/err-bash/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/err-bash/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/err-sh/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/err-sh/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/invalid/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/invalid/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/sh/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/sh/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/artifacts/unique_name_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/unique_name_libraries/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/upload_multiple_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/upload_multiple_libraries/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_change_version/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_change_version/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_dbfs/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_dbfs/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_dynamic/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_dynamic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_explicit/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_explicit/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit_custom_path/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit_custom_path/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit_notebook/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit_notebook/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_multiple/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_multiple/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_no_cleanup/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_no_cleanup/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_multiple/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_multiple/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_via_environment_key/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_via_environment_key/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/id/out.test.toml
+++ b/acceptance/bundle/bundle_tag/id/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url_ref/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url_ref/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/output_json/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_json/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/target_override/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/target_override/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/deploy/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/deploy/fail-on-active-runs/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/readplan/basic/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/cli-version-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/cli-version-mismatch/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/serial-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/serial-mismatch/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
+++ b/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/environments/dependencies/out.test.toml
+++ b/acceptance/bundle/environments/dependencies/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/maven/out.test.toml
+++ b/acceptance/bundle/libraries/maven/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/outside_of_bundle_root/out.test.toml
+++ b/acceptance/bundle/libraries/outside_of_bundle_root/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/pypi/out.test.toml
+++ b/acceptance/bundle/libraries/pypi/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/basic/out.test.toml
+++ b/acceptance/bundle/migrate/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/dashboards/out.test.toml
+++ b/acceptance/bundle/migrate/dashboards/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/default-python/out.test.toml
+++ b/acceptance/bundle/migrate/default-python/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/grants/out.test.toml
+++ b/acceptance/bundle/migrate/grants/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/permissions/out.test.toml
+++ b/acceptance/bundle/migrate/permissions/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/profile_arg/out.test.toml
+++ b/acceptance/bundle/migrate/profile_arg/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/runas/out.test.toml
+++ b/acceptance/bundle/migrate/runas/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/var_arg/out.test.toml
+++ b/acceptance/bundle/migrate/var_arg/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/plan/no_upload/out.test.toml
+++ b/acceptance/bundle/plan/no_upload/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/create_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/create_error/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_chain/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_chain/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_star/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_star/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/job_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_self/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_self/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [CloudEnvs]
   azure = false

--- a/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/basic/out.test.toml
+++ b/acceptance/bundle/resources/alerts/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/default_description/out.test.toml
+++ b/acceptance/bundle/resources/apps/default_description/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/update/out.test.toml
+++ b/acceptance/bundle/resources/apps/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 CloudSlow = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-name/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-name/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/destroy/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/experiments/basic/out.test.toml
+++ b/acceptance/bundle/resources/experiments/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/catalogs/out.test.toml
+++ b/acceptance/bundle/resources/grants/catalogs/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/registered_models/out.test.toml
+++ b/acceptance/bundle/resources/grants/registered_models/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/volumes/out.test.toml
+++ b/acceptance/bundle/resources/grants/volumes/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/independent/out.test.toml
+++ b/acceptance/bundle/resources/independent/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/big_id/out.test.toml
+++ b/acceptance/bundle/resources/jobs/big_id/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/create-error/out.test.toml
+++ b/acceptance/bundle/resources/jobs/create-error/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/delete_job/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_job/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/delete_task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_task/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/num_workers/out.test.toml
+++ b/acceptance/bundle/resources/jobs/num_workers/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
+++ b/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/basic/out.test.toml
+++ b/acceptance/bundle/resources/models/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresWarehouse = true
+RecordRequests = true
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 CloudSlow = true
+RecordRequests = false
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/local/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/local/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [CloudEnvs]
   azure = false

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = false
 
 [CloudEnvs]
   azure = false

--- a/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/quality_monitors/create/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/create/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/basic/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/recreate/out.test.toml
+++ b/acceptance/bundle/resources/schemas/recreate/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/update/out.test.toml
+++ b/acceptance/bundle/resources/schemas/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RecordRequests = false
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/sql_warehouses/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = false
 CloudSlow = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [CloudEnvs]
   gcp = false

--- a/acceptance/bundle/resources/volumes/change-comment/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-comment/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-name/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
@@ -1,6 +1,7 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [CloudEnvs]
   azure = false

--- a/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/jobs/partial_run/out.test.toml
+++ b/acceptance/bundle/run/jobs/partial_run/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/refresh-flags/out.test.toml
+++ b/acceptance/bundle/run/refresh-flags/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/basic/out.test.toml
+++ b/acceptance/bundle/state/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/lineage_different/out.test.toml
+++ b/acceptance/bundle/state/lineage_different/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/state_present/out.test.toml
+++ b/acceptance/bundle/state/state_present/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-mode/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-mode/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/classic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/serverless/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/custom-template/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/custom-template/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/dbt-sql/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/default-python/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/default-python/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/default-sql/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/default-sql/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/out.test.toml
+++ b/acceptance/bundle/user_agent/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/simple/out.test.toml
+++ b/acceptance/bundle/user_agent/simple/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/sync_patterns/out.test.toml
+++ b/acceptance/bundle/validate/sync_patterns/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cache/simple/out.test.toml
+++ b/acceptance/cache/simple/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/apps/out.test.toml
+++ b/acceptance/cmd/workspace/apps/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/apps/run-local/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = false
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -17,6 +17,7 @@ type MaterializedConfig struct {
 	RequiresUnityCatalog *bool               `toml:"RequiresUnityCatalog,omitempty"`
 	RequiresCluster      *bool               `toml:"RequiresCluster,omitempty"`
 	RequiresWarehouse    *bool               `toml:"RequiresWarehouse,omitempty"`
+	RecordRequests       *bool               `toml:"RecordRequests,omitempty"`
 	EnvMatrix            map[string][]string `toml:"EnvMatrix,omitempty"`
 }
 
@@ -32,6 +33,7 @@ func GenerateMaterializedConfig(config TestConfig) (string, error) {
 		RequiresUnityCatalog: config.RequiresUnityCatalog,
 		RequiresCluster:      config.RequiresCluster,
 		RequiresWarehouse:    config.RequiresWarehouse,
+		RecordRequests:       config.RecordRequests,
 		EnvMatrix:            config.EnvMatrix,
 	}
 

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/restart/out.test.toml
+++ b/acceptance/pipelines/dry-run/restart/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/refresh-flags/out.test.toml
+++ b/acceptance/pipelines/run/refresh-flags/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/restart/out.test.toml
+++ b/acceptance/pipelines/run/restart/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/stop/out.test.toml
+++ b/acceptance/pipelines/stop/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/basic/out.test.toml
+++ b/acceptance/selftest/record_cloud/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/error/out.test.toml
+++ b/acceptance/selftest/record_cloud/error/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
+++ b/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/volume-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/volume-io/out.test.toml
@@ -1,6 +1,7 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
@@ -1,5 +1,6 @@
 Local = false
 Cloud = true
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/server/out.test.toml
+++ b/acceptance/selftest/server/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/failure/out.test.toml
+++ b/acceptance/telemetry/failure/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/partial-success/out.test.toml
+++ b/acceptance/telemetry/partial-success/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/skipped/out.test.toml
+++ b/acceptance/telemetry/skipped/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/success/out.test.toml
+++ b/acceptance/telemetry/success/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/timeout/out.test.toml
+++ b/acceptance/telemetry/timeout/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/jobs/create-error/out.test.toml
+++ b/acceptance/workspace/jobs/create-error/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/jobs/create/out.test.toml
+++ b/acceptance/workspace/jobs/create/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/lakeview/publish/out.test.toml
+++ b/acceptance/workspace/lakeview/publish/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/create_with_provider/out.test.toml
+++ b/acceptance/workspace/repos/create_with_provider/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/create_without_provider/out.test.toml
+++ b/acceptance/workspace/repos/create_without_provider/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/delete_by_path/out.test.toml
+++ b/acceptance/workspace/repos/delete_by_path/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/get_errors/out.test.toml
+++ b/acceptance/workspace/repos/get_errors/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/update/out.test.toml
+++ b/acceptance/workspace/repos/update/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RecordRequests = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]


### PR DESCRIPTION
This is good to know metadata that should be serialized.

I'll followup with a PR that makes this more granular so that tests that don't need it do not record requests. This is necessary because RecordRequests does not work on DBR, because DBR does not allow connecting to localhost servers.

acceptance/internal/materialized_config.go is the only code change. Everything else is generated.