### PR TITLE
testserver: match cloud API behavior for database_catalogs

### DIFF
--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -607,7 +607,7 @@ func AddDefaultHandlers(server *Server) {
 	})
 
 	server.Handle("GET", "/api/2.0/database/catalogs/{name}", func(req Request) any {
-		return MapGet(req.Workspace, req.Workspace.DatabaseCatalogs, req.Vars["name"])
+		return req.Workspace.DatabaseCatalogGet(req.Vars["name"])
 	})
 
 	server.Handle("PATCH", "/api/2.0/database/catalogs/{name}", func(req Request) any {


### PR DESCRIPTION
## Changes
- Assign uid in CREATE response
- Do not return create_database_if_not_exists in GET (write-only field)

## Why

This causes the migrate test to exercise the code path where
database_catalogs has an Update action (due to the field difference),
which triggered a nil pointer panic before commit https://github.com/databricks/cli/commit/a0418ac81bb29e0cd5c4f019fb34a6b0411d97cb.

## Tests
Revert https://github.com/databricks/cli/pull/4438 - can now see panic with local testserver.
