### PR TITLE
direct: Use ignore_remote_changes in CRUD test assertions

### DIFF
--- a/bundle/direct/dresources/registered_model.go
+++ b/bundle/direct/dresources/registered_model.go
@@ -34,13 +34,15 @@ func (*ResourceRegisteredModel) RemapState(model *catalog.RegisteredModelInfo) *
 
 		Aliases:     model.Aliases,
 		BrowseOnly:  model.BrowseOnly,
-		CreatedAt:   model.CreatedAt,
-		CreatedBy:   model.CreatedBy,
 		FullName:    model.FullName,
 		MetastoreId: model.MetastoreId,
 		Owner:       model.Owner,
-		UpdatedAt:   model.UpdatedAt,
-		UpdatedBy:   model.UpdatedBy,
+
+		// Clear output only fields. They should not show up on remote diff computation.
+		CreatedAt: 0,
+		CreatedBy: "",
+		UpdatedAt: 0,
+		UpdatedBy: "",
 	}
 }
 


### PR DESCRIPTION
## Changes

Introduce `testIgnoreFilter` helper to encapsulate field filtering logic based on `ignore_remote_changes` configuration from resource configuration files.

Replace hardcoded filter for `updated_at` with a proper fix in the relevant resource.

## Tests

This change adds an entry for a dashboard resource test to exercise this filter.
