### PR TITLE
Propagate `INPUT_ONLY` from container types to generate field behaviors

### DIFF
--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
@@ -25,13 +25,13 @@
   "changes": {
     "is_protected": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": false,
       "new": false
     },
     "no_expiry": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": true,
       "new": true
     }

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
@@ -38,7 +38,7 @@
     },
     "no_expiry": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": true,
       "new": true
     }

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
@@ -38,7 +38,7 @@
     },
     "no_expiry": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": true,
       "new": true
     }

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
@@ -28,19 +28,19 @@
   "changes": {
     "autoscaling_limit_max_cu": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 8,
       "new": 8
     },
     "autoscaling_limit_min_cu": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 0.5,
       "new": 0.5
     },
     "endpoint_type": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": "ENDPOINT_TYPE_READ_WRITE",
       "new": "ENDPOINT_TYPE_READ_WRITE",
       "remote": ""

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
@@ -43,13 +43,13 @@
     },
     "autoscaling_limit_min_cu": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 0.5,
       "new": 0.5
     },
     "endpoint_type": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": "ENDPOINT_TYPE_READ_WRITE",
       "new": "ENDPOINT_TYPE_READ_WRITE",
       "remote": ""

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
@@ -43,13 +43,13 @@
     },
     "autoscaling_limit_min_cu": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 0.5,
       "new": 0.5
     },
     "endpoint_type": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": "ENDPOINT_TYPE_READ_WRITE",
       "new": "ENDPOINT_TYPE_READ_WRITE",
       "remote": ""

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -22,7 +22,7 @@
   "changes": {
     "default_endpoint_settings": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,
@@ -36,7 +36,7 @@
     },
     "display_name": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": "Original Name",
       "new": "Original Name"
     },
@@ -48,7 +48,7 @@
     },
     "pg_version": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 16,
       "new": 16
     }

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -35,7 +35,7 @@
   "changes": {
     "default_endpoint_settings": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,
@@ -60,7 +60,7 @@
     },
     "pg_version": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 16,
       "new": 16
     }

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -35,7 +35,7 @@
   "changes": {
     "default_endpoint_settings": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,
@@ -60,7 +60,7 @@
     },
     "pg_version": {
       "action": "skip",
-      "reason": "builtin_rule",
+      "reason": "api_schema",
       "old": 16,
       "new": 16
     }

--- a/bundle/direct/dresources/resources.generated.yml
+++ b/bundle/direct/dresources/resources.generated.yml
@@ -127,16 +127,43 @@ resources:
       - source_branch_lsn
       - source_branch_time
 
+    ignore_remote_changes:
+      # INPUT_ONLY:
+      - expire_time
+      - is_protected
+      - no_expiry
+      - source_branch
+      - source_branch_lsn
+      - source_branch_time
+      - ttl
+
   postgres_endpoints:
 
     recreate_on_changes:
       # IMMUTABLE:
       - endpoint_type
 
+    ignore_remote_changes:
+      # INPUT_ONLY:
+      - autoscaling_limit_max_cu
+      - autoscaling_limit_min_cu
+      - disabled
+      - endpoint_type
+      - no_suspension
+      - settings
+      - suspend_timeout_duration
+
   postgres_projects:
 
     recreate_on_changes:
       # IMMUTABLE:
+      - pg_version
+
+    ignore_remote_changes:
+      # INPUT_ONLY:
+      - default_endpoint_settings
+      - display_name
+      - history_retention_duration
       - pg_version
 
   # quality_monitors: no api field behaviors

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -127,44 +127,17 @@ resources:
 
   postgres_projects:
     recreate_on_changes:
-      # project_id is immutable (part of hierarchical name)
+      # project_id is immutable (part of hierarchical name, not in API spec)
       - project_id
-    ignore_remote_changes:
-      # The read API does not return spec fields, only status.
-      # We cannot detect remote drift for these fields.
-      - display_name
-      - pg_version
-      - history_retention_duration
-      - default_endpoint_settings
 
   postgres_branches:
     recreate_on_changes:
-      # parent and branch_id are immutable (part of hierarchical name)
+      # parent and branch_id are immutable (part of hierarchical name, not in API spec)
       - parent
       - branch_id
-    ignore_remote_changes:
-      # The read API does not return spec fields, only status.
-      # We cannot detect remote drift for these fields.
-      - source_branch
-      - source_branch_lsn
-      - source_branch_time
-      - ttl
-      - expire_time
-      - is_protected
-      - no_expiry
 
   postgres_endpoints:
     recreate_on_changes:
-      # parent and endpoint_id are immutable (part of hierarchical name)
+      # parent and endpoint_id are immutable (part of hierarchical name, not in API spec)
       - parent
       - endpoint_id
-    ignore_remote_changes:
-      # The read API does not return spec fields, only status.
-      # We cannot detect remote drift for these fields.
-      - endpoint_type
-      - autoscaling_limit_min_cu
-      - autoscaling_limit_max_cu
-      - suspend_timeout_duration
-      - disabled
-      - no_suspension
-      - settings

--- a/bundle/direct/tools/generate_resources.py
+++ b/bundle/direct/tools/generate_resources.py
@@ -49,31 +49,50 @@ def parse_out_fields(path):
 
 
 def get_field_behaviors(schemas, type_name):
-    """Extract all field behaviors from a schema."""
+    """Extract field behaviors from a schema, propagating INPUT_ONLY/OUTPUT_ONLY from containers."""
     if type_name not in schemas:
         return {}
 
-    def extract(schema, prefix, visited, depth):
+    def extract(schema, prefix, visited, depth, inherited):
         if depth > 4:
             return {}
         results = {}
         for name, prop in schema.get("properties", {}).items():
             path = f"{prefix}.{name}" if prefix else name
-            behaviors = prop.get("x-databricks-field-behaviors", [])
+            behaviors = list(prop.get("x-databricks-field-behaviors", []))
             if prop.get("x-databricks-immutable") and "IMMUTABLE" not in behaviors:
                 behaviors.append("IMMUTABLE")
-
+            for b in inherited:
+                if b not in behaviors:
+                    behaviors.append(b)
             if behaviors:
                 results[path] = behaviors
-
             if "$ref" in prop:
                 ref = prop["$ref"].split("/")[-1]
                 if ref in schemas and ref not in visited:
                     visited.add(ref)
-                    results.update(extract(schemas[ref], path, visited, depth + 1))
+                    propagate = [b for b in behaviors if b in ("INPUT_ONLY", "OUTPUT_ONLY")]
+                    results.update(extract(schemas[ref], path, visited, depth + 1, propagate))
         return results
 
-    return extract(schemas[type_name], "", set(), 0)
+    # Find INPUT_ONLY/OUTPUT_ONLY from container types that reference this type
+    inherited = find_inherited_behaviors(schemas, type_name)
+    return extract(schemas[type_name], "", set(), 0, inherited)
+
+
+def find_inherited_behaviors(schemas, type_name):
+    """Find INPUT_ONLY/OUTPUT_ONLY behaviors from containers that reference type_name."""
+    inherited = []
+    for container_schema in schemas.values():
+        for field_prop in container_schema.get("properties", {}).values():
+            if field_prop.get("$ref", "").split("/")[-1] != type_name:
+                continue
+            behaviors = field_prop.get("x-databricks-field-behaviors", [])
+            if "INPUT_ONLY" in behaviors and "INPUT_ONLY" not in inherited:
+                inherited.append("INPUT_ONLY")
+            if "OUTPUT_ONLY" in behaviors and "OUTPUT_ONLY" not in inherited:
+                inherited.append("OUTPUT_ONLY")
+    return inherited
 
 
 def filter_prefixes(fields):


### PR DESCRIPTION
## Changes

The postgres resources use a spec/status pattern where the container type (e.g., `postgres.Branch`) has `spec` marked as `INPUT_ONLY`, but the spec type (e.g., `postgres.BranchSpec`) fields are only marked `OPTIONAL`.

This change modifies generate_resources.py to:
1. Find container types that reference the target schema with `INPUT_ONLY`
2. Propagate that behavior to all fields in the target schema
3. Continue propagating through nested $ref chains

This moves the postgres ignore_remote_changes from the manual resources.yml to the auto-generated resources.generated.yml, changing the skip reason from "builtin_rule" to "api_schema".

## Tests

The generated output is correct.