### PR TITLE
Add interactive mode telemetry to track terminal capabilities

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -191,6 +191,7 @@ Stack Trace:
 		Command:         commandStr,
 		OperatingSystem: runtime.GOOS,
 		DbrVersion:      dbr.RuntimeVersion(ctx),
+		InteractiveMode: cmdio.GetInteractiveMode(ctx),
 		ExecutionTimeMs: time.Since(startTime).Milliseconds(),
 		ExitCode:        int64(exitCode),
 	})

--- a/libs/cmdio/capabilities.go
+++ b/libs/cmdio/capabilities.go
@@ -66,3 +66,23 @@ func detectGitBash(ctx context.Context) bool {
 
 	return false
 }
+
+// Interactive mode constants for telemetry.
+const (
+	InteractiveModeFull       = "full"        // Both interactive output and prompts supported
+	InteractiveModeOutputOnly = "output_only" // Interactive output only, no prompts (stdin not TTY or Git Bash)
+	InteractiveModeNone       = "none"        // Non-interactive (CI, cron, stderr redirected)
+)
+
+// InteractiveMode returns the interactive mode based on terminal capabilities.
+// Returns one of: "full", "output_only", or "none".
+func (c Capabilities) InteractiveMode() string {
+	// SupportsPrompt() implies SupportsInteractive() (it's a stricter check).
+	if c.SupportsPrompt() {
+		return InteractiveModeFull
+	}
+	if c.SupportsInteractive() {
+		return InteractiveModeOutputOnly
+	}
+	return InteractiveModeNone
+}

--- a/libs/cmdio/capabilities_test.go
+++ b/libs/cmdio/capabilities_test.go
@@ -146,6 +146,81 @@ func TestDetectGitBash(t *testing.T) {
 	assert.True(t, detectGitBash(ctx))
 }
 
+func TestCapabilities_InteractiveMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		caps     Capabilities
+		expected string
+	}{
+		{
+			name: "full interactive - all TTYs, color, no Git Bash",
+			caps: Capabilities{
+				stdinIsTTY:  true,
+				stderrIsTTY: true,
+				color:       true,
+				isGitBash:   false,
+			},
+			expected: InteractiveModeFull,
+		},
+		{
+			name: "output only - stdin not TTY",
+			caps: Capabilities{
+				stdinIsTTY:  false,
+				stderrIsTTY: true,
+				color:       true,
+				isGitBash:   false,
+			},
+			expected: InteractiveModeOutputOnly,
+		},
+		{
+			name: "output only - Git Bash",
+			caps: Capabilities{
+				stdinIsTTY:  true,
+				stderrIsTTY: true,
+				color:       true,
+				isGitBash:   true,
+			},
+			expected: InteractiveModeOutputOnly,
+		},
+		{
+			name: "none - stderr not TTY",
+			caps: Capabilities{
+				stdinIsTTY:  true,
+				stderrIsTTY: false,
+				color:       true,
+				isGitBash:   false,
+			},
+			expected: InteractiveModeNone,
+		},
+		{
+			name: "none - NO_COLOR set",
+			caps: Capabilities{
+				stdinIsTTY:  true,
+				stderrIsTTY: true,
+				color:       false,
+				isGitBash:   false,
+			},
+			expected: InteractiveModeNone,
+		},
+		{
+			name: "none - no TTY support at all",
+			caps: Capabilities{
+				stdinIsTTY:  false,
+				stderrIsTTY: false,
+				color:       false,
+				isGitBash:   false,
+			},
+			expected: InteractiveModeNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.caps.InteractiveMode())
+		})
+	}
+}
+
 func TestCapabilities_SupportsColor(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -69,6 +69,17 @@ func SupportsColor(ctx context.Context, w io.Writer) bool {
 	return c.capabilities.SupportsColor(w)
 }
 
+// GetInteractiveMode returns the interactive mode based on terminal capabilities.
+// Returns one of: "full", "output_only", or "none".
+// Returns empty string if cmdio is not initialized in the context.
+func GetInteractiveMode(ctx context.Context) string {
+	c, ok := ctx.Value(cmdIOKey).(*cmdIO)
+	if !ok {
+		return ""
+	}
+	return c.capabilities.InteractiveMode()
+}
+
 type Tuple struct{ Name, Id string }
 
 func (c *cmdIO) Select(items []Tuple, label string) (id string, err error) {

--- a/libs/telemetry/protos/databricks_cli_log.go
+++ b/libs/telemetry/protos/databricks_cli_log.go
@@ -23,6 +23,12 @@ type ExecutionContext struct {
 	// If true, the CLI is being run from a Databricks notebook / cluster web terminal.
 	FromWebTerminal bool `json:"from_web_terminal,omitempty"`
 
+	// Interactive mode of the terminal. Possible values:
+	// - "full": Both interactive output (spinners, colors) and prompts are supported
+	// - "output_only": Interactive output is supported, but prompts are not (stdin not TTY or Git Bash)
+	// - "none": Non-interactive environment (CI, cron, stderr redirected)
+	InteractiveMode string `json:"interactive_mode,omitempty"`
+
 	// Time taken for the CLI command to execute.
 	// We want to serialize the zero value as well so the omitempty tag is not set.
 	ExecutionTimeMs int64 `json:"execution_time_ms"`


### PR DESCRIPTION
This change adds a new `interactive_mode` field to telemetry to measure what proportion of CLI invocations can support interactive features like selection prompts.

The field captures one of three values:
- "full": Both interactive output (spinners, colors) and user prompts are supported. This requires stderr to be a TTY, color enabled, stdin to be a TTY, and not running in Git Bash.
- "output_only": Interactive output is supported but prompts are not. This occurs when stdin is not a TTY (e.g., input piped) or when running in Git Bash (which has broken readline/ANSI support).
- "none": Non-interactive environment where neither spinners nor prompts work. This includes CI/CD pipelines, cron jobs, and cases where stderr is redirected.

## Changes

- Add `InteractiveMode` field to `ExecutionContext` in telemetry protos
- Add `InteractiveMode()` method to `Capabilities` struct in cmdio
- Add `GetInteractiveMode(ctx)` public function for context-safe access
- Populate the field during telemetry upload in `root.Execute()`

## Why

This telemetry helps inform decisions about when the CLI can prompt users for missing information versus requiring explicit flags. By measuring the proportion of invocations in each mode, we can understand how often interactive prompts would actually be shown to users.
This will also help give us some numbers when we want to track impact of a given change

## Tests

Added unit tests in `capabilities_test.go` covering all three interactive modes:
- Full interactive (all TTYs, color enabled, no Git Bash)
- Output only (stdin not TTY, or Git Bash)
- None (stderr not TTY, or color disabled)