### PR TITLE
Fix breakglass behavior for jobs in production mode when yaml sync flag is enabled

### DIFF
--- a/bundle/deploy/metadata/annotate_jobs.go
+++ b/bundle/deploy/metadata/annotate_jobs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/libs/dbr"
 	"github.com/databricks/cli/libs/diag"
@@ -30,7 +31,7 @@ func (m *annotateJobs) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 
 		isDatabricksWorkspace := dbr.RunsOnRuntime(ctx) && strings.HasPrefix(b.SyncRootPath, "/Workspace/")
 		_, experimentalYamlSyncEnabled := env.ExperimentalYamlSync(ctx)
-		if isDatabricksWorkspace && experimentalYamlSyncEnabled {
+		if isDatabricksWorkspace && experimentalYamlSyncEnabled && b.Config.Bundle.Mode == config.Development {
 			job.EditMode = jobs.JobEditModeEditable
 		} else {
 			job.EditMode = jobs.JobEditModeUiLocked


### PR DESCRIPTION
## Changes

Fix breakglass behavior for production jobs when `experimentalYamlSyncEnabled` is enabled. 

## Why
Jobs deployed with this flag enabled are unlocked by default, this behavior is expected only for development mode

## Tests
Add unit test, it's not yet possible to run acceptance tests on DBR

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
