### PR TITLE
fix(appkit-template): replace getRequestContext with WorkspaceClient

### DIFF
--- a/experimental/aitools/templates/appkit/template/{{.project_name}}/docs/trpc.md
+++ b/experimental/aitools/templates/appkit/template/{{.project_name}}/docs/trpc.md
@@ -15,17 +15,17 @@ Use tRPC ONLY for:
 ```typescript
 // server/trpc.ts
 import { initTRPC } from '@trpc/server';
-import { getRequestContext } from '@databricks/appkit';
+import { WorkspaceClient } from '@databricks/sdk-experimental';
 import { z } from 'zod';
 
 const t = initTRPC.create({ transformer: superjson });
 const publicProcedure = t.procedure;
+const workspaceClient = new WorkspaceClient({});
 
 export const appRouter = t.router({
   // Example: Query a serving endpoint
   queryModel: publicProcedure.input(z.object({ prompt: z.string() })).query(async ({ input: { prompt } }) => {
-    const { serviceDatabricksClient: client } = getRequestContext();
-    const response = await client.servingEndpoints.query({
+    const response = await workspaceClient.servingEndpoints.query({
       name: 'your-endpoint-name',
       messages: [{ role: 'user', content: prompt }],
     });


### PR DESCRIPTION
## Summary
- replace `getRequestContext` usage in the appkit tRPC template with `WorkspaceClient` from `@databricks/sdk-experimental`
- lazily initialize and reuse the workspace client in `server/trpc.ts`
- update the tRPC template unit test to mock `WorkspaceClient` construction and serving endpoint calls
- update `docs/trpc.md` so the documented server-side pattern matches the template implementation

Fixes #4339

## Why
Current published versions of `@databricks/appkit` do not export `getRequestContext`, which causes generated appkit projects to fail typecheck/runtime import resolution.

## Verification
- `npx tsc -p ./tsconfig.server.json --noEmit`
- `npx vitest run server/trpc.test.ts`