### PR TITLE
Fix arrow key navigation in prompts on Windows

### DIFF
--- a/libs/cmdio/compat.go
+++ b/libs/cmdio/compat.go
@@ -123,7 +123,7 @@ func AskSelect(ctx context.Context, question string, choices []string) (string, 
 			Label:    "{{.}}: ",
 			Selected: last + ": {{.}}",
 		},
-		Stdin:  io.NopCloser(c.in),
+		Stdin:  c.promptStdin(),
 		Stdout: nopWriteCloser{c.err},
 	}
 

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -89,7 +90,7 @@ func (c *cmdIO) Select(items []Tuple, label string) (id string, err error) {
 			Active:   `{{.Name | bold}} ({{.Id|faint}})`,
 			Inactive: `{{.Name}}`,
 		},
-		Stdin:  io.NopCloser(c.in),
+		Stdin:  c.promptStdin(),
 		Stdout: nopWriteCloser{c.err},
 	}).Run()
 	if err != nil {
@@ -125,7 +126,7 @@ func (c *cmdIO) Secret(label string) (value string, err error) {
 		Label:       label,
 		Mask:        '*',
 		HideEntered: true,
-		Stdin:       io.NopCloser(c.in),
+		Stdin:       c.promptStdin(),
 		Stdout:      nopWriteCloser{c.err},
 	})
 
@@ -135,6 +136,19 @@ func (c *cmdIO) Secret(label string) (value string, err error) {
 func Secret(ctx context.Context, label string) (value string, err error) {
 	c := fromContext(ctx)
 	return c.Secret(label)
+}
+
+// promptStdin returns the stdin reader for use with promptui.
+// If the reader is os.Stdin, it returns nil to let the underlying readline
+// library use its platform-specific default. On Windows, this is critical
+// because readline's default uses ReadConsoleInputW to read arrow keys
+// as virtual key events. Passing a wrapped os.Stdin would bypass this
+// and break arrow key navigation in selection prompts.
+func (c *cmdIO) promptStdin() io.ReadCloser {
+	if c.in == os.Stdin {
+		return nil
+	}
+	return io.NopCloser(c.in)
 }
 
 type nopWriteCloser struct {
@@ -148,14 +162,14 @@ func (nopWriteCloser) Close() error {
 func Prompt(ctx context.Context) *promptui.Prompt {
 	c := fromContext(ctx)
 	return &promptui.Prompt{
-		Stdin:  io.NopCloser(c.in),
+		Stdin:  c.promptStdin(),
 		Stdout: nopWriteCloser{c.err},
 	}
 }
 
 func RunSelect(ctx context.Context, prompt *promptui.Select) (int, string, error) {
 	c := fromContext(ctx)
-	prompt.Stdin = io.NopCloser(c.in)
+	prompt.Stdin = c.promptStdin()
 	prompt.Stdout = nopWriteCloser{c.err}
 	return prompt.Run()
 }


### PR DESCRIPTION
## Summary
- Fixes #4481 — arrow keys stopped working for yes/no and enum selection during `databricks bundle init` on Windows
- Root cause: PR #4301 started passing `io.NopCloser(os.Stdin)` as explicit `Stdin` to `promptui`, which bypasses `chzyer/readline`'s Windows-specific `RawReader`. That reader uses `ReadConsoleInputW` to translate arrow key virtual key codes (`VK_UP`/`VK_DOWN`) into readline navigation — without it, arrow keys are silently ignored on Windows.
- Fix: introduce `promptStdin()` helper that returns `nil` when `c.in` is `os.Stdin` (letting readline use its platform default) and wraps custom readers for test scenarios.

## Test plan
- [x] `go test ./libs/cmdio/...` passes
- [x] `go test ./libs/template/...` passes
- [x] Verify on Windows that arrow keys work in `databricks bundle init` selection prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)