### PR TITLE
Check env filters early to avoid FUSE mount errors on DBR

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -713,7 +713,7 @@ func runTest(t *testing.T,
 }
 
 // checkEnvFilters skips the test if any env filter doesn't match testEnv.
-func checkEnvFilters(t *testing.T, testEnv []string, envFilters []string) {
+func checkEnvFilters(t *testing.T, testEnv, envFilters []string) {
 	envMap := make(map[string]string, len(testEnv))
 	for _, kv := range testEnv {
 		key, value, _ := strings.Cut(kv, "=")


### PR DESCRIPTION
## Changes
  Move env filter check to the beginning of runTest() before creating workspace directories. This prevents "unlinkat: directory not empty"  errors on the workspace FUSE mount which seem to happen when there are too many directory creation / deletion.