### PR TITLE
fix: default to DEFAULT profile in `init` command

### DIFF
--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -28,6 +28,7 @@ const (
 	appkitRepoURL       = "https://github.com/databricks/appkit"
 	appkitTemplateDir   = "template"
 	appkitDefaultBranch = "main"
+	defaultProfile      = "DEFAULT"
 )
 
 // normalizeVersion ensures the version string has a "v" prefix if it looks like a semver.
@@ -809,7 +810,8 @@ func runCreate(ctx context.Context, opts createOptions) error {
 			return fmt.Errorf("failed to change to project directory: %w", err)
 		}
 		if profile == "" {
-			profile = "DEFAULT"
+			// If the profile is not set, it means the DEFAULT profile was used to infer the workspace host, we set it so that it's used for the deploy and dev-remote commands
+			profile = defaultProfile
 		}
 	}
 
@@ -840,6 +842,7 @@ func runPostCreateDeploy(ctx context.Context, profile string) error {
 	}
 	args := []string{"apps", "deploy"}
 	if profile != "" {
+		// We ensure the same profile is used for the deploy command as the one used for the init command
 		args = append(args, "--profile", profile)
 	}
 	cmd := exec.CommandContext(ctx, executable, args...)
@@ -867,6 +870,7 @@ func runPostCreateDev(ctx context.Context, mode prompt.RunMode, projectInit init
 		}
 		args := []string{"apps", "dev-remote"}
 		if profile != "" {
+			// We ensure the same profile is used for the dev-remote command as the one used for the init command
 			args = append(args, "--profile", profile)
 		}
 		cmd := exec.CommandContext(ctx, executable, args...)


### PR DESCRIPTION
## Changes
- We default to the DEFAULT profile in the init command
- This is the behavior of the Databricks WorkspaeClient Go SDK when selecting the host. Basically, priorities are: Flag > Env var > DEFAULT profile > Prompt. [code pointer](https://github.com/databricks/databricks-sdk-go/blob/main/config/config_file.go#L90)
- However, the profile used by the Go SDK is not persisted in the CLI `Config.Profile` attribute in this scenario (ie, when the DEFAULT one is used).  

## Why
- The `init` command needs to a profile to resolve the host and instantiate the template. It does so successfully but then fails in the `deploy` step because the profile is ambiguous, despite a specific profile having been used earlier. This behavior is incoherent.

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
