### PR TITLE
Fix postgres_endpoints recreate test to use endpoint_id change

### DIFF
--- a/acceptance/bundle/resources/postgres_endpoints/recreate/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/databricks.yml.tmpl
@@ -25,7 +25,7 @@ resources:
   postgres_endpoints:
     my_endpoint:
       parent: ${resources.postgres_branches.main.id}
-      endpoint_id: test-endpoint-$UNIQUE_NAME
-      endpoint_type: ENDPOINT_TYPE_PLACEHOLDER
+      endpoint_id: ENDPOINT_ID_PLACEHOLDER
+      endpoint_type: ENDPOINT_TYPE_READ_ONLY
       autoscaling_limit_min_cu: 0.5
       autoscaling_limit_max_cu: 2

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/output.txt
@@ -28,7 +28,7 @@ resources:
     my_endpoint:
       parent: ${resources.postgres_branches.main.id}
       endpoint_id: test-endpoint-[UNIQUE_NAME]
-      endpoint_type: ENDPOINT_TYPE_READ_WRITE
+      endpoint_type: ENDPOINT_TYPE_READ_ONLY
       autoscaling_limit_min_cu: 0.5
       autoscaling_limit_max_cu: 2
 
@@ -70,7 +70,7 @@ Deployment complete!
     "branch_id": "main"
       "autoscaling_limit_max_cu": 2,
       "autoscaling_limit_min_cu": 0.5,
-      "endpoint_type": "ENDPOINT_TYPE_READ_WRITE"
+      "endpoint_type": "ENDPOINT_TYPE_READ_ONLY"
   "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints",
     "endpoint_id": "test-endpoint-[UNIQUE_NAME]"
 
@@ -102,7 +102,7 @@ resources:
   postgres_endpoints:
     my_endpoint:
       parent: ${resources.postgres_branches.main.id}
-      endpoint_id: test-endpoint-[UNIQUE_NAME]
+      endpoint_id: test-endpoint-[UNIQUE_NAME]-v2
       endpoint_type: ENDPOINT_TYPE_READ_ONLY
       autoscaling_limit_min_cu: 0.5
       autoscaling_limit_max_cu: 2
@@ -133,11 +133,11 @@ Deployment complete!
   "method": "POST",
   "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints",
   "q": {
-    "endpoint_id": "test-endpoint-[UNIQUE_NAME]"
+    "endpoint_id": "test-endpoint-[UNIQUE_NAME]-v2"
   }
 
-=== Fetch endpoint ID and verify it has the new type (READ_ONLY)
->>> [CLI] postgres get-endpoint [MY_ENDPOINT_ID]
+=== Fetch endpoint and verify it exists after recreation
+>>> [CLI] postgres get-endpoint [MY_ENDPOINT_ID]-v2
 "ENDPOINT_TYPE_READ_ONLY"
 
 === Destroy and verify cleanup
@@ -155,7 +155,7 @@ Destroy complete!
 >>> print_requests
 {
   "method": "DELETE",
-  "path": "/api/2.0/postgres/[MY_ENDPOINT_ID]"
+  "path": "/api/2.0/postgres/[MY_ENDPOINT_ID]-v2"
 }
   "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main"
   "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]"

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/script
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/script
@@ -3,13 +3,14 @@ cleanup() {
    # Try to delete with current config
    trace $CLI bundle destroy --auto-approve
 
-   # Also try to delete the old endpoint directly in case it wasn't cleaned up
+   # Also try to delete the endpoints directly in case they weren't cleaned up
    $CLI postgres delete-endpoint "projects/test-pg-proj-${UNIQUE_NAME}/branches/main/endpoints/test-endpoint-${UNIQUE_NAME}" 2>/dev/null || true
+   $CLI postgres delete-endpoint "projects/test-pg-proj-${UNIQUE_NAME}/branches/main/endpoints/test-endpoint-${UNIQUE_NAME}-v2" 2>/dev/null || true
 }
 trap cleanup EXIT
 
-# Deploy with first endpoint_type (READ_WRITE)
-envsubst < databricks.yml.tmpl | sed "s/ENDPOINT_TYPE_PLACEHOLDER/ENDPOINT_TYPE_READ_WRITE/" > databricks.yml
+# Deploy with first endpoint_id
+envsubst < databricks.yml.tmpl | sed "s/ENDPOINT_ID_PLACEHOLDER/test-endpoint-${UNIQUE_NAME}/" > databricks.yml
 
 trace cat databricks.yml
 
@@ -29,9 +30,8 @@ print_requests() {
 
 trace print_requests
 
-# Change endpoint_type (should trigger recreation)
-sed "s/ENDPOINT_TYPE_READ_WRITE/ENDPOINT_TYPE_READ_ONLY/" databricks.yml > databricks.yml.new
-mv databricks.yml.new databricks.yml
+# Change endpoint_id (should trigger recreation)
+envsubst < databricks.yml.tmpl | sed "s/ENDPOINT_ID_PLACEHOLDER/test-endpoint-${UNIQUE_NAME}-v2/" > databricks.yml
 
 trace cat databricks.yml
 
@@ -40,14 +40,11 @@ trace $CLI bundle deploy --auto-approve
 
 trace print_requests
 
-title "Fetch endpoint ID and verify it has the new type (READ_ONLY)"
+title "Fetch endpoint and verify it exists after recreation"
 
 endpoint_id_2=`read_id.py my_endpoint`
-# Verify the endpoint was recreated by checking the type changed
+# Verify the endpoint was recreated (DELETE/POST in requests proves recreation)
 trace $CLI postgres get-endpoint $endpoint_id_2 | jq 'del(.create_time, .update_time)' | jq '.status.endpoint_type'
-
-# Note: We cannot verify the old endpoint is gone because it has the same hierarchical name
-# (endpoint_id didn't change, only endpoint_type). The DELETE/POST in requests proves recreation.
 
 title "Destroy and verify cleanup"
 trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/databricks.yml.tmpl
@@ -25,6 +25,6 @@ resources:
   postgres_endpoints:
     primary:
       parent: ${resources.postgres_branches.main.id}
-      endpoint_type: ENDPOINT_TYPE_READ_WRITE
+      endpoint_type: ENDPOINT_TYPE_READ_ONLY
       autoscaling_limit_min_cu: 0.5
       autoscaling_limit_max_cu: 2


### PR DESCRIPTION
## Summary
- The `postgres_endpoints/recreate` test was triggering recreation by changing `endpoint_type` from `READ_WRITE` to `READ_ONLY`. This is no longer valid because read/write endpoints can no longer be deleted, which breaks the recreation flow (delete + create). Changed the test to trigger recreation by changing `endpoint_id` instead.
- Updated `postgres_endpoints/without_endpoint_id` to use `ENDPOINT_TYPE_READ_ONLY` for consistency with the other postgres_endpoints tests.

## Test plan
- [x] `postgres_endpoints/recreate` passed locally (mock server)
- [x] `postgres_endpoints/recreate` passed on aws-prod-ucws
- [x] `postgres_endpoints/without_endpoint_id` passed locally (both direct and terraform engines)
- [x] `postgres_endpoints/without_endpoint_id` passed on aws-prod-ucws (both engines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)