### PR TITLE
Allow single and double quotes in environment dependencies

### DIFF
--- a/acceptance/bundle/environments/dependencies/databricks.yml
+++ b/acceptance/bundle/environments/dependencies/databricks.yml
@@ -21,6 +21,8 @@ resources:
             client: "1"
             dependencies:
               - "-r ./requirements.txt"
+              - -r "${workspace.file_path}/Path With Spaces/requirements.txt"
+              - "-r '${workspace.file_path}/Path With Spaces/requirements.txt'"
               - "-e ./file.py"
               - "-i http://myindexurl.com"
               - "--index-url http://myindexurl.com"

--- a/acceptance/bundle/environments/dependencies/output.txt
+++ b/acceptance/bundle/environments/dependencies/output.txt
@@ -23,6 +23,8 @@ Deployment complete!
       "client": "1",
       "dependencies": [
         "-r /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/requirements.txt",
+        "-r \"/Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/Path With Spaces/requirements.txt\"",
+        "-r '/Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/Path With Spaces/requirements.txt'",
         "-e /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/file.py",
         "-i http://myindexurl.com",
         "--index-url http://myindexurl.com",
@@ -88,6 +90,8 @@ Deployment complete!
       "client": "1",
       "dependencies": [
         "-r /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/requirements.txt",
+        "-r \"/Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/Path With Spaces/requirements.txt\"",
+        "-r '/Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/Path With Spaces/requirements.txt'",
         "-e /Workspace/Users/[USERNAME]/.bundle/dependencies/default/files/file.py",
         "-i http://myindexurl.com",
         "--index-url http://myindexurl.com",

--- a/bundle/libraries/local_path.go
+++ b/bundle/libraries/local_path.go
@@ -24,6 +24,9 @@ import (
 // - s3:/mybucket/myfile.txt
 // - /Users/jane@doe.com/myfile.txt
 func IsLocalPath(p string) bool {
+	// Trim single or double quotes from the path
+	p = strings.Trim(p, `"'`)
+
 	// If the path has the file:// scheme, it's a runtime path (remote).
 	// Users should use relative paths without scheme for local files to upload.
 	if strings.HasPrefix(p, "file://") {

--- a/bundle/libraries/local_path_test.go
+++ b/bundle/libraries/local_path_test.go
@@ -15,6 +15,8 @@ func TestIsLocalPath(t *testing.T) {
 	assert.True(t, IsLocalPath("myfile.txt"))
 	assert.True(t, IsLocalPath("./myfile.txt"))
 	assert.True(t, IsLocalPath("../myfile.txt"))
+	assert.True(t, IsLocalPath("'some/local/path'"))
+	assert.True(t, IsLocalPath("\"some/local/path\""))
 
 	// Absolute paths without scheme (remote).
 	assert.False(t, IsLocalPath("/some/full/path"))


### PR DESCRIPTION
## Changes
Allow single and double quotes in environment dependencies

## Why
Fixes #4456 

## Tests
Added an acceptance and unit test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
