### PR TITLE
Move permission level mapping to resource definitions

### DIFF
--- a/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_bundle_permissions_test.go
@@ -185,17 +185,46 @@ func TestWarningOnOverlapPermission(t *testing.T) {
 }
 
 func TestAllResourcesExplicitlyDefinedForPermissionsSupport(t *testing.T) {
-	r := config.Resources{}
+	full := resourcesWithOneOfEach()
+	levelsMap := buildLevelsMap(full)
 
-	for _, resource := range unsupportedResources {
-		_, ok := levelsMap[resource]
-		assert.False(t, ok, "Resource %s is defined in both levelsMap and unsupportedResources", resource)
-	}
+	for _, group := range full.AllResources() {
+		name := group.Description.PluralName
+		_, inLevels := levelsMap[name]
+		isUnsupported := slices.Contains(unsupportedResources, name)
 
-	for _, resource := range r.AllResources() {
-		_, ok := levelsMap[resource.Description.PluralName]
-		if !slices.Contains(unsupportedResources, resource.Description.PluralName) && !ok {
-			assert.Fail(t, fmt.Sprintf("Resource %s is not explicitly defined in levelsMap or unsupportedResources", resource.Description.PluralName))
+		if !inLevels && !isUnsupported {
+			assert.Fail(t, fmt.Sprintf("Resource %s does not implement PermissionedResource and is not in unsupportedResources", name))
 		}
+		if inLevels && isUnsupported {
+			assert.Fail(t, fmt.Sprintf("Resource %s implements PermissionedResource but is also in unsupportedResources", name))
+		}
+	}
+}
+
+func resourcesWithOneOfEach() *config.Resources {
+	return &config.Resources{
+		Jobs:                  map[string]*resources.Job{"j": {}},
+		Pipelines:             map[string]*resources.Pipeline{"p": {}},
+		Models:                map[string]*resources.MlflowModel{"m": {}},
+		Experiments:           map[string]*resources.MlflowExperiment{"e": {}},
+		ModelServingEndpoints: map[string]*resources.ModelServingEndpoint{"mse": {}},
+		RegisteredModels:      map[string]*resources.RegisteredModel{"rm": {}},
+		QualityMonitors:       map[string]*resources.QualityMonitor{"qm": {}},
+		Catalogs:              map[string]*resources.Catalog{"c": {}},
+		Schemas:               map[string]*resources.Schema{"s": {}},
+		Clusters:              map[string]*resources.Cluster{"cl": {}},
+		Dashboards:            map[string]*resources.Dashboard{"d": {}},
+		Volumes:               map[string]*resources.Volume{"v": {}},
+		Apps:                  map[string]*resources.App{"a": {}},
+		SecretScopes:          map[string]*resources.SecretScope{"ss": {}},
+		Alerts:                map[string]*resources.Alert{"al": {}},
+		SqlWarehouses:         map[string]*resources.SqlWarehouse{"sw": {}},
+		DatabaseInstances:     map[string]*resources.DatabaseInstance{"di": {}},
+		DatabaseCatalogs:      map[string]*resources.DatabaseCatalog{"dc": {}},
+		SyncedDatabaseTables:  map[string]*resources.SyncedDatabaseTable{"sdt": {}},
+		PostgresProjects:      map[string]*resources.PostgresProject{"pp": {}},
+		PostgresBranches:      map[string]*resources.PostgresBranch{"pb": {}},
+		PostgresEndpoints:     map[string]*resources.PostgresEndpoint{"pe": {}},
 	}
 }

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -54,6 +54,16 @@ type ConfigResource interface {
 	InitializeURL(baseURL url.URL)
 }
 
+// PermissionedResource is implemented by resources that support bundle-level
+// permission mapping. The returned map translates bundle permission levels
+// (e.g. CAN_MANAGE, CAN_VIEW, CAN_RUN) to resource-specific API levels.
+//
+// Note: implementations use string literals instead of permissions.CAN_MANAGE
+// etc. to avoid an import cycle (resources -> permissions -> resources).
+type PermissionedResource interface {
+	PermissionLevelMapping() map[string]string
+}
+
 // ResourceGroup represents a group of resources of the same type.
 // It includes a description of the resource type and a map of resources.
 type ResourceGroup struct {

--- a/bundle/config/resources/alerts.go
+++ b/bundle/config/resources/alerts.go
@@ -63,3 +63,11 @@ func (a *Alert) GetName() string {
 func (a *Alert) GetURL() string {
 	return a.URL
 }
+
+func (*Alert) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_READ",
+		"CAN_RUN":    "CAN_RUN",
+	}
+}

--- a/bundle/config/resources/apps.go
+++ b/bundle/config/resources/apps.go
@@ -93,3 +93,10 @@ func (a *App) GetName() string {
 func (a *App) GetURL() string {
 	return a.URL
 }
+
+func (*App) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_USE",
+	}
+}

--- a/bundle/config/resources/clusters.go
+++ b/bundle/config/resources/clusters.go
@@ -58,3 +58,12 @@ func (s *Cluster) GetName() string {
 func (s *Cluster) GetURL() string {
 	return s.URL
 }
+
+func (*Cluster) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		// https://docs.databricks.com/aws/en/security/auth/access-control/#compute-acls
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_ATTACH_TO",
+		"CAN_RUN":    "CAN_RESTART",
+	}
+}

--- a/bundle/config/resources/dashboard.go
+++ b/bundle/config/resources/dashboard.go
@@ -125,3 +125,10 @@ func (r *Dashboard) GetName() string {
 func (r *Dashboard) GetURL() string {
 	return r.URL
 }
+
+func (*Dashboard) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_READ",
+	}
+}

--- a/bundle/config/resources/database_instance.go
+++ b/bundle/config/resources/database_instance.go
@@ -53,3 +53,10 @@ func (d *DatabaseInstance) InitializeURL(baseURL url.URL) {
 	baseURL.Path = "compute/database-instances/" + d.Name
 	d.URL = baseURL.String()
 }
+
+func (*DatabaseInstance) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_USE",
+	}
+}

--- a/bundle/config/resources/job.go
+++ b/bundle/config/resources/job.go
@@ -65,3 +65,11 @@ func (j *Job) GetName() string {
 func (j *Job) GetURL() string {
 	return j.URL
 }
+
+func (*Job) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_VIEW",
+		"CAN_RUN":    "CAN_MANAGE_RUN",
+	}
+}

--- a/bundle/config/resources/mlflow_experiment.go
+++ b/bundle/config/resources/mlflow_experiment.go
@@ -60,3 +60,10 @@ func (s *MlflowExperiment) GetName() string {
 func (s *MlflowExperiment) GetURL() string {
 	return s.URL
 }
+
+func (*MlflowExperiment) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_READ",
+	}
+}

--- a/bundle/config/resources/mlflow_model.go
+++ b/bundle/config/resources/mlflow_model.go
@@ -60,3 +60,10 @@ func (s *MlflowModel) GetName() string {
 func (s *MlflowModel) GetURL() string {
 	return s.URL
 }
+
+func (*MlflowModel) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_READ",
+	}
+}

--- a/bundle/config/resources/model_serving_endpoint.go
+++ b/bundle/config/resources/model_serving_endpoint.go
@@ -65,3 +65,11 @@ func (s *ModelServingEndpoint) GetName() string {
 func (s *ModelServingEndpoint) GetURL() string {
 	return s.URL
 }
+
+func (*ModelServingEndpoint) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_VIEW",
+		"CAN_RUN":    "CAN_QUERY",
+	}
+}

--- a/bundle/config/resources/pipeline.go
+++ b/bundle/config/resources/pipeline.go
@@ -60,3 +60,11 @@ func (p *Pipeline) GetName() string {
 func (p *Pipeline) GetURL() string {
 	return p.URL
 }
+
+func (*Pipeline) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_VIEW",
+		"CAN_RUN":    "CAN_RUN",
+	}
+}

--- a/bundle/config/resources/secret_scope.go
+++ b/bundle/config/resources/secret_scope.go
@@ -103,3 +103,10 @@ func (s SecretScope) GetURL() string {
 func (s SecretScope) InitializeURL(_ url.URL) {
 	// Secret scopes do not have a URL
 }
+
+func (SecretScope) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "MANAGE",
+		"CAN_VIEW":   "READ",
+	}
+}

--- a/bundle/config/resources/sql_warehouses.go
+++ b/bundle/config/resources/sql_warehouses.go
@@ -58,3 +58,11 @@ func (sw *SqlWarehouse) GetName() string {
 func (sw *SqlWarehouse) GetURL() string {
 	return sw.URL
 }
+
+func (*SqlWarehouse) PermissionLevelMapping() map[string]string {
+	return map[string]string{
+		"CAN_MANAGE": "CAN_MANAGE",
+		"CAN_VIEW":   "CAN_VIEW",
+		"CAN_RUN":    "CAN_MONITOR",
+	}
+}


### PR DESCRIPTION
## Summary
- Add `PermissionedResource` interface with `PermissionLevelMapping()` method
- Each permissioned resource (12 types) declares its own permission level mapping
- `apply_bundle_permissions.go` builds levelsMap dynamically from resource definitions
- Adding a new permissioned resource only requires implementing the method on the struct

## Test plan
- [x] `go test ./bundle/config/mutator/resourcemutator/...` passes
- [x] `go test ./bundle/config/resources/...` passes
- [x] Permission mappings are identical to the original levelsMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)