### PR TITLE
Fix alerts generate acceptante test

### DIFF
--- a/acceptance/bundle/generate/alert/test.toml
+++ b/acceptance/bundle/generate/alert/test.toml
@@ -6,6 +6,11 @@ Local = false
 # See: https://github.com/databricks/cli/issues/4221
 TimeoutCloud = "5m"
 
+# Normalize paths for windows.
+[[Repls]]
+Old = '\\\\'
+New = '/'
+
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI


### PR DESCRIPTION
This should fix CI failure:
```
Diff:
--- Expected
+++ Actual
@@ -4,4 +4,4 @@
 >>> [CLI] bundle generate alert --existing-id [NUMID] --source-dir out/alert --config-dir out/resource
-Alert configuration successfully saved to [TEST_TMP_DIR]/out/resource/test_alert.alert.yml
-Serialized alert definition to [TEST_TMP_DIR]/out/alert/test_alert.dbalert.json
+Alert configuration successfully saved to [TEST_TMP_DIR]\out\resource\test_alert.alert.yml
+Serialized alert definition to [TEST_TMP_DIR]\out\alert\test_alert.dbalert.json
```