### PR TITLE
[Internal] Refactor WorkspaceId to WorkspaceID in CLI-owned types

### DIFF
--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -43,7 +43,7 @@ type Workspace struct {
 
 	// Unified host specific attributes.
 	ExperimentalIsUnifiedHost bool   `json:"experimental_is_unified_host,omitempty"`
-	WorkspaceId               string `json:"workspace_id,omitempty"`
+	WorkspaceID               string `json:"workspace_id,omitempty"`
 
 	// CurrentUser holds the current user.
 	// This is set after configuration initialization.
@@ -124,7 +124,7 @@ func (w *Workspace) Config() *config.Config {
 
 		// Unified host
 		Experimental_IsUnifiedHost: w.ExperimentalIsUnifiedHost,
-		WorkspaceId:                w.WorkspaceId,
+		WorkspaceId:                w.WorkspaceID,
 	}
 
 	for k := range config.ConfigAttributes {

--- a/cmd/apps/run_local.go
+++ b/cmd/apps/run_local.go
@@ -28,7 +28,7 @@ const SHUTDOWN_TIMEOUT = 15 * time.Second
 func setupWorkspaceAndConfig(cmd *cobra.Command, entryPoint string, appPort int) (*runlocal.Config, *runlocal.AppSpec, error) {
 	ctx := cmd.Context()
 	w := cmdctx.WorkspaceClient(ctx)
-	workspaceId, err := w.CurrentWorkspaceID(ctx)
+	workspaceID, err := w.CurrentWorkspaceID(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -38,7 +38,7 @@ func setupWorkspaceAndConfig(cmd *cobra.Command, entryPoint string, appPort int)
 		return nil, nil, err
 	}
 
-	config := runlocal.NewConfig(w.Config.Host, workspaceId, cwd, runlocal.DEFAULT_HOST, appPort)
+	config := runlocal.NewConfig(w.Config.Host, workspaceID, cwd, runlocal.DEFAULT_HOST, appPort)
 	if entryPoint != "" {
 		config.AppSpecFiles = []string{entryPoint}
 	}

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -26,7 +26,7 @@ GCP: https://docs.gcp.databricks.com/dev-tools/auth/index.html`,
 	cmd.PersistentFlags().StringVar(&authArguments.Host, "host", "", "Databricks Host")
 	cmd.PersistentFlags().StringVar(&authArguments.AccountID, "account-id", "", "Databricks Account ID")
 	cmd.PersistentFlags().BoolVar(&authArguments.IsUnifiedHost, "experimental-is-unified-host", false, "Flag to indicate if the host is a unified host")
-	cmd.PersistentFlags().StringVar(&authArguments.WorkspaceId, "workspace-id", "", "Databricks Workspace ID")
+	cmd.PersistentFlags().StringVar(&authArguments.WorkspaceID, "workspace-id", "", "Databricks Workspace ID")
 
 	cmd.AddCommand(newEnvCommand())
 	cmd.AddCommand(newLoginCommand(&authArguments))

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -144,7 +144,7 @@ depends on the existing profiles you have set in your configuration file
 			authArguments.IsUnifiedHost = existingProfile.IsUnifiedHost
 		}
 		if !cmd.Flag("workspace-id").Changed && existingProfile != nil {
-			authArguments.WorkspaceId = existingProfile.WorkspaceId
+			authArguments.WorkspaceID = existingProfile.WorkspaceID
 		}
 
 		err = setHostAndAccountId(ctx, existingProfile, authArguments, args)
@@ -196,7 +196,7 @@ depends on the existing profiles you have set in your configuration file
 			w, err := databricks.NewWorkspaceClient(&databricks.Config{
 				Host:                       authArguments.Host,
 				AccountID:                  authArguments.AccountID,
-				WorkspaceId:                authArguments.WorkspaceId,
+				WorkspaceId:                authArguments.WorkspaceID,
 				Experimental_IsUnifiedHost: authArguments.IsUnifiedHost,
 				Credentials:                config.NewTokenSourceStrategy("login-token", authconv.AuthTokenSource(persistentAuth)),
 			})
@@ -230,7 +230,7 @@ depends on the existing profiles you have set in your configuration file
 				Host:                       authArguments.Host,
 				AuthType:                   authTypeDatabricksCLI,
 				AccountID:                  authArguments.AccountID,
-				WorkspaceId:                authArguments.WorkspaceId,
+				WorkspaceId:                authArguments.WorkspaceID,
 				Experimental_IsUnifiedHost: authArguments.IsUnifiedHost,
 				ClusterID:                  clusterID,
 				ConfigFile:                 os.Getenv("DATABRICKS_CONFIG_FILE"),
@@ -291,7 +291,7 @@ func setHostAndAccountId(ctx context.Context, existingProfile *profile.Profile, 
 	cfg := &config.Config{
 		Host:                       authArguments.Host,
 		AccountID:                  authArguments.AccountID,
-		WorkspaceId:                authArguments.WorkspaceId,
+		WorkspaceId:                authArguments.WorkspaceID,
 		Experimental_IsUnifiedHost: authArguments.IsUnifiedHost,
 	}
 
@@ -327,17 +327,17 @@ func setHostAndAccountId(ctx context.Context, existingProfile *profile.Profile, 
 		// - With workspace ID: workspace-level APIs
 		// - Without workspace ID: account-level APIs
 		// If neither is provided via flags, prompt for workspace ID (most common case)
-		hasWorkspaceID := authArguments.WorkspaceId != ""
+		hasWorkspaceID := authArguments.WorkspaceID != ""
 		if !hasWorkspaceID {
-			if existingProfile != nil && existingProfile.WorkspaceId != "" {
-				authArguments.WorkspaceId = existingProfile.WorkspaceId
+			if existingProfile != nil && existingProfile.WorkspaceID != "" {
+				authArguments.WorkspaceID = existingProfile.WorkspaceID
 			} else {
 				// Prompt for workspace ID for workspace-level access
 				workspaceId, err := promptForWorkspaceID(ctx)
 				if err != nil {
 					return err
 				}
-				authArguments.WorkspaceId = workspaceId
+				authArguments.WorkspaceID = workspaceId
 			}
 		}
 	case config.WorkspaceHost:

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -101,7 +101,7 @@ func TestSetAccountId(t *testing.T) {
 	assert.EqualError(t, err, "the command is being run in a non-interactive environment, please specify an account ID using --account-id")
 }
 
-func TestSetWorkspaceIdForUnifiedHost(t *testing.T) {
+func TestSetWorkspaceIDForUnifiedHost(t *testing.T) {
 	var authArguments auth.AuthArguments
 	t.Setenv("DATABRICKS_CONFIG_FILE", "./testdata/.databrickscfg")
 	ctx, _ := cmdio.SetupTest(context.Background(), cmdio.TestOptions{})
@@ -113,14 +113,14 @@ func TestSetWorkspaceIdForUnifiedHost(t *testing.T) {
 	authArguments = auth.AuthArguments{
 		Host:          "https://unified.databricks.com",
 		AccountID:     "test-unified-account",
-		WorkspaceId:   "val from --workspace-id",
+		WorkspaceID:   "val from --workspace-id",
 		IsUnifiedHost: true,
 	}
 	err := setHostAndAccountId(ctx, unifiedWorkspaceProfile, &authArguments, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "https://unified.databricks.com", authArguments.Host)
 	assert.Equal(t, "test-unified-account", authArguments.AccountID)
-	assert.Equal(t, "val from --workspace-id", authArguments.WorkspaceId)
+	assert.Equal(t, "val from --workspace-id", authArguments.WorkspaceID)
 
 	// Test setting workspace_id from profile for unified host
 	authArguments = auth.AuthArguments{
@@ -132,7 +132,7 @@ func TestSetWorkspaceIdForUnifiedHost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://unified.databricks.com", authArguments.Host)
 	assert.Equal(t, "test-unified-account", authArguments.AccountID)
-	assert.Equal(t, "123456789", authArguments.WorkspaceId)
+	assert.Equal(t, "123456789", authArguments.WorkspaceID)
 
 	// Test workspace_id is optional - should default to empty in non-interactive mode
 	authArguments = auth.AuthArguments{
@@ -144,7 +144,7 @@ func TestSetWorkspaceIdForUnifiedHost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://unified.databricks.com", authArguments.Host)
 	assert.Equal(t, "test-unified-account", authArguments.AccountID)
-	assert.Equal(t, "", authArguments.WorkspaceId) // Empty is valid for account-level access
+	assert.Equal(t, "", authArguments.WorkspaceID) // Empty is valid for account-level access
 
 	// Test workspace_id is optional - should default to empty when no profile exists
 	authArguments = auth.AuthArguments{
@@ -156,10 +156,10 @@ func TestSetWorkspaceIdForUnifiedHost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://unified.databricks.com", authArguments.Host)
 	assert.Equal(t, "test-unified-account", authArguments.AccountID)
-	assert.Equal(t, "", authArguments.WorkspaceId) // Empty is valid for account-level access
+	assert.Equal(t, "", authArguments.WorkspaceID) // Empty is valid for account-level access
 }
 
-func TestPromptForWorkspaceIdInNonInteractiveMode(t *testing.T) {
+func TestPromptForWorkspaceIDInNonInteractiveMode(t *testing.T) {
 	// Setup non-interactive context
 	ctx, _ := cmdio.SetupTest(context.Background(), cmdio.TestOptions{})
 

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -103,8 +103,8 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 		if !args.authArguments.IsUnifiedHost && existingProfile.IsUnifiedHost {
 			args.authArguments.IsUnifiedHost = existingProfile.IsUnifiedHost
 		}
-		if args.authArguments.WorkspaceId == "" && existingProfile.WorkspaceId != "" {
-			args.authArguments.WorkspaceId = existingProfile.WorkspaceId
+		if args.authArguments.WorkspaceID == "" && existingProfile.WorkspaceID != "" {
+			args.authArguments.WorkspaceID = existingProfile.WorkspaceID
 		}
 	}
 

--- a/libs/apps/runlocal/cfg.go
+++ b/libs/apps/runlocal/cfg.go
@@ -5,7 +5,7 @@ import "fmt"
 type Config struct {
 	AppName       string
 	AppURL        string
-	WorkspaceId   int64
+	WorkspaceID   int64
 	ServerName    string
 	Host          string
 	WorkspaceHost string
@@ -21,11 +21,11 @@ const (
 	DEFAULT_PORT     = 8000
 )
 
-func NewConfig(workspaceHost string, workpaceId int64, appDir, host string, port int) *Config {
+func NewConfig(workspaceHost string, workspaceID int64, appDir, host string, port int) *Config {
 	c := &Config{
 		AppName:       DEFAULT_APP_NAME,
 		AppURL:        fmt.Sprintf("http://%s:%d", host, port),
-		WorkspaceId:   workpaceId,
+		WorkspaceID:   workspaceID,
 		ServerName:    host,
 		Port:          port,
 		Host:          host,

--- a/libs/apps/runlocal/env.go
+++ b/libs/apps/runlocal/env.go
@@ -18,7 +18,7 @@ func GetBaseEnvVars(config *Config) []EnvVar {
 		{Name: "PYTHONUNBUFFERED", Value: "1"},
 		{Name: "DATABRICKS_APP_NAME", Value: config.AppName},
 		{Name: "DATABRICKS_APP_URL", Value: config.AppURL},
-		{Name: "DATABRICKS_WORKSPACE_ID", Value: strconv.FormatInt(config.WorkspaceId, 10)},
+		{Name: "DATABRICKS_WORKSPACE_ID", Value: strconv.FormatInt(config.WorkspaceID, 10)},
 		{Name: "DATABRICKS_HOST", Value: config.WorkspaceHost},
 		{Name: "DATABRICKS_APP_PORT", Value: strconv.Itoa(config.Port)},
 		{Name: "GRADIO_SERVER_NAME", Value: config.ServerName},

--- a/libs/auth/arguments.go
+++ b/libs/auth/arguments.go
@@ -12,7 +12,7 @@ import (
 type AuthArguments struct {
 	Host          string
 	AccountID     string
-	WorkspaceId   string
+	WorkspaceID   string
 	IsUnifiedHost bool
 }
 
@@ -21,7 +21,7 @@ func (a AuthArguments) ToOAuthArgument() (u2m.OAuthArgument, error) {
 	cfg := &config.Config{
 		Host:                       a.Host,
 		AccountID:                  a.AccountID,
-		WorkspaceId:                a.WorkspaceId,
+		WorkspaceId:                a.WorkspaceID,
 		Experimental_IsUnifiedHost: a.IsUnifiedHost,
 	}
 	host := cfg.CanonicalHostName()

--- a/libs/auth/arguments_test.go
+++ b/libs/auth/arguments_test.go
@@ -72,7 +72,7 @@ func TestToOAuthArgument(t *testing.T) {
 			args: AuthArguments{
 				Host:          "https://unified.cloud.databricks.com",
 				AccountID:     "123456789",
-				WorkspaceId:   "123456789",
+				WorkspaceID:   "123456789",
 				IsUnifiedHost: true,
 			},
 			wantHost: "https://unified.cloud.databricks.com",

--- a/libs/databrickscfg/profile/file.go
+++ b/libs/databrickscfg/profile/file.go
@@ -82,7 +82,7 @@ func (f FileProfilerImpl) LoadProfiles(ctx context.Context, fn ProfileMatchFunct
 			Name:                v.Name(),
 			Host:                host,
 			AccountID:           all["account_id"],
-			WorkspaceId:         all["workspace_id"],
+			WorkspaceID:         all["workspace_id"],
 			IsUnifiedHost:       all["experimental_is_unified_host"] == "true",
 			ClusterID:           all["cluster_id"],
 			ServerlessComputeID: all["serverless_compute_id"],

--- a/libs/databrickscfg/profile/profile.go
+++ b/libs/databrickscfg/profile/profile.go
@@ -13,7 +13,7 @@ type Profile struct {
 	Name                string
 	Host                string
 	AccountID           string
-	WorkspaceId         string
+	WorkspaceID         string
 	IsUnifiedHost       bool
 	ClusterID           string
 	ServerlessComputeID string

--- a/libs/databrickscfg/profile/profiler.go
+++ b/libs/databrickscfg/profile/profiler.go
@@ -10,14 +10,14 @@ func MatchWorkspaceProfiles(p Profile) bool {
 	// Match workspace profiles: regular workspace profiles (no account ID)
 	// or unified hosts with workspace ID
 	return (p.AccountID == "" && !p.IsUnifiedHost) ||
-		(p.IsUnifiedHost && p.WorkspaceId != "")
+		(p.IsUnifiedHost && p.WorkspaceID != "")
 }
 
 func MatchAccountProfiles(p Profile) bool {
 	// Match account profiles: regular account profiles (with account ID)
 	// or unified hosts with account ID but no workspace ID
 	return (p.Host != "" && p.AccountID != "" && !p.IsUnifiedHost) ||
-		(p.IsUnifiedHost && p.AccountID != "" && p.WorkspaceId == "")
+		(p.IsUnifiedHost && p.AccountID != "" && p.WorkspaceID == "")
 }
 
 func MatchAllProfiles(p Profile) bool {


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->
  - Rename WorkspaceId to WorkspaceID across CLI-owned struct fields, parameters, and local variables to follow idiomatic Go naming conventions (acronyms should be all caps)
  - Fix a pre-existing typo in runlocal.NewConfig parameter name (workpaceId → workspaceID, which was missing an r in "workspace")
  - This is will be followed-up by #4486 which renames the upstream SDK field; this PR covers the CLI's own types: AuthArguments, Profile, Workspace, and runlocal.Config

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->
Best practice to use Workspace`ID`
## Tests
<!-- How have you tested the changes? -->
Existing tests
<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
