### PR TITLE
testserver: Add Name field to TestUser for current-user me API

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,7 +32,8 @@
       "Bash(gh pr view:*)",
       "Bash(gh pr checks:*)",
       "Bash(gh pr list:*)",
-      "WebSearch"
+      "WebSearch",
+      "Bash(testme-win:*)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,8 +32,7 @@
       "Bash(gh pr view:*)",
       "Bash(gh pr checks:*)",
       "Bash(gh pr list:*)",
-      "WebSearch",
-      "Bash(testme-win:*)"
+      "WebSearch"
     ]
   }
 }

--- a/acceptance/auth/credentials/basic/output.txt
+++ b/acceptance/auth/credentials/basic/output.txt
@@ -1,4 +1,8 @@
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }

--- a/acceptance/auth/credentials/oauth/output.txt
+++ b/acceptance/auth/credentials/oauth/output.txt
@@ -1,4 +1,8 @@
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }

--- a/acceptance/auth/credentials/pat/output.txt
+++ b/acceptance/auth/credentials/pat/output.txt
@@ -1,4 +1,8 @@
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }

--- a/acceptance/auth/credentials/unified-host/output.txt
+++ b/acceptance/auth/credentials/unified-host/output.txt
@@ -2,6 +2,10 @@
 === With workspace_id
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }
 

--- a/acceptance/bundle/deployment/bind/pipelines/update/out.summary.json
+++ b/acceptance/bundle/deployment/bind/pipelines/update/out.summary.json
@@ -40,6 +40,10 @@
     "current_user": {
       "domain_friendly_name": "[USERNAME]",
       "id": "[USERID]",
+      "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+      },
       "short_name": "[USERNAME]",
       "userName": "[USERNAME]"
     },

--- a/acceptance/bundle/python/experimental-compatibility-both-equal/output.txt
+++ b/acceptance/bundle/python/experimental-compatibility-both-equal/output.txt
@@ -57,14 +57,14 @@
         [
           0,
           1,
-          880
+          942
         ]
       ],
       "resources.jobs": [
         [
           0,
           1,
-          889
+          951
         ]
       ],
       "resources.jobs.my_job": [

--- a/acceptance/bundle/python/experimental-compatibility/output.txt
+++ b/acceptance/bundle/python/experimental-compatibility/output.txt
@@ -50,14 +50,14 @@
         [
           0,
           1,
-          825
+          887
         ]
       ],
       "resources.jobs": [
         [
           0,
           1,
-          834
+          896
         ]
       ],
       "resources.jobs.my_job": [

--- a/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/output.txt
+++ b/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/output.txt
@@ -2,5 +2,9 @@
 >>> [CLI] bundle run --profile myprofile -- [CLI] current-user me
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }

--- a/acceptance/bundle/run/scripts/basic/output.txt
+++ b/acceptance/bundle/run/scripts/basic/output.txt
@@ -5,6 +5,10 @@ hello
 >>> [CLI] bundle run me
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }
 

--- a/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/output.txt
+++ b/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/output.txt
@@ -2,5 +2,9 @@
 >>> [CLI] bundle run me --profile myprofile
 {
   "id":"[USERID]",
+  "name": {
+    "familyName":"[USERNAME]",
+    "givenName":"[USERNAME]"
+  },
   "userName":"[USERNAME]"
 }

--- a/acceptance/bundle/validate/job-references/output.txt
+++ b/acceptance/bundle/validate/job-references/output.txt
@@ -57,6 +57,10 @@
     "current_user": {
       "domain_friendly_name": "[USERNAME]",
       "id": "[USERID]",
+      "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+      },
       "short_name": "[USERNAME]",
       "userName": "[USERNAME]"
     },

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.with_empty_prefix.json
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.with_empty_prefix.json
@@ -77,6 +77,10 @@
     "current_user": {
       "domain_friendly_name": "[USERNAME]",
       "id": "[USERID]",
+      "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+      },
       "short_name": "[USERNAME]",
       "userName": "[USERNAME]"
     },

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.with_nil_prefix.json
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.with_nil_prefix.json
@@ -77,6 +77,10 @@
     "current_user": {
       "domain_friendly_name": "[USERNAME]",
       "id": "[USERID]",
+      "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+      },
       "short_name": "[USERNAME]",
       "userName": "[USERNAME]"
     },

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.with_static_prefix.json
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.with_static_prefix.json
@@ -71,6 +71,10 @@
     "current_user": {
       "domain_friendly_name": "[USERNAME]",
       "id": "[USERID]",
+      "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+      },
       "short_name": "[USERNAME]",
       "userName": "[USERNAME]"
     },

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.without_presets.json
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.without_presets.json
@@ -77,6 +77,10 @@
     "current_user": {
       "domain_friendly_name": "[USERNAME]",
       "id": "[USERID]",
+      "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+      },
       "short_name": "[USERNAME]",
       "userName": "[USERNAME]"
     },

--- a/acceptance/selftest/diff/out_dir_a/output.txt
+++ b/acceptance/selftest/diff/out_dir_a/output.txt
@@ -1,6 +1,10 @@
 Hello! 🚀
 {
     "id": "[USERID]",
+    "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+    },
     "userName": "[USERNAME]"
 }
 

--- a/acceptance/selftest/diff/output.txt
+++ b/acceptance/selftest/diff/output.txt
@@ -4,10 +4,14 @@ Only in out_dir_a: only_in_a
 Only in out_dir_b: only_in_b
 --- out_dir_a/output.txt
 +++ out_dir_b/output.txt
-@@ -1,5 +1,5 @@
+@@ -1,9 +1,5 @@
  Hello! 🚀
  {
 -    "id": "[USERID]",
+-    "name": {
+-        "familyName": "[USERNAME]",
+-        "givenName": "[USERNAME]"
+-    },
 +    "id": "[UUID]",
      "userName": "[USERNAME]"
  }
@@ -17,10 +21,14 @@ Only in .: only_in_a
 Only in ../out_dir_b: only_in_b
 --- output.txt
 +++ ../out_dir_b/output.txt
-@@ -1,5 +1,5 @@
+@@ -1,9 +1,5 @@
  Hello! 🚀
  {
 -    "id": "[USERID]",
+-    "name": {
+-        "familyName": "[USERNAME]",
+-        "givenName": "[USERNAME]"
+-    },
 +    "id": "[UUID]",
      "userName": "[USERNAME]"
  }
@@ -28,10 +36,14 @@ Only in ../out_dir_b: only_in_b
 >>> diff.py out_dir_a/output.txt out_dir_b/output.txt
 --- out_dir_a/output.txt
 +++ out_dir_b/output.txt
-@@ -1,5 +1,5 @@
+@@ -1,9 +1,5 @@
  Hello! 🚀
  {
 -    "id": "[USERID]",
+-    "name": {
+-        "familyName": "[USERNAME]",
+-        "givenName": "[USERNAME]"
+-    },
 +    "id": "[UUID]",
      "userName": "[USERNAME]"
  }

--- a/acceptance/selftest/record_cloud/basic/out.test.toml
+++ b/acceptance/selftest/record_cloud/basic/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 
 [EnvMatrix]

--- a/acceptance/selftest/record_cloud/basic/test.toml
+++ b/acceptance/selftest/record_cloud/basic/test.toml
@@ -1,0 +1,1 @@
+Local = true

--- a/acceptance/selftest/server/output.txt
+++ b/acceptance/selftest/server/output.txt
@@ -2,6 +2,10 @@
 >>> curl -s [DATABRICKS_URL]/api/2.0/preview/scim/v2/Me
 {
     "id": "[USERID]",
+    "name": {
+        "familyName": "[USERNAME]",
+        "givenName": "[USERNAME]"
+    },
     "userName": "[USERNAME]"
 }
 >>> curl -sD - [DATABRICKS_URL]/custom/endpoint?query=param

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -41,6 +41,10 @@ const (
 var TestUser = iam.User{
 	Id:       UserID,
 	UserName: "tester@databricks.com",
+	Name: &iam.Name{
+		GivenName:  "Tester",
+		FamilyName: "McTesterson",
+	},
 }
 
 var TestUserSP = iam.User{


### PR DESCRIPTION
### Changes

- Added `Name` field to `TestUser` struct in `libs/testserver/fake_workspace.go`
- Set `GivenName: "Tester"` and `FamilyName: "McTesterson"`
- Created `test.toml` for `acceptance/selftest/record_cloud/basic` to enable it independently
- Updated expected outputs for the basic test

### Why

The `current-user me` endpoint (SCIM Me API) was returning a user object without the `Name` field populated. This caused tests that query `.name.givenName` to receive null values.

Changed FamilyName to "McTesterson" (instead of "User") to avoid conflicts with the word "User" in workspace paths like "/Workspace/Users/" which could cause replacement issues in test outputs.

The testserver now matches the real Databricks API by returning proper Name structure with GivenName and FamilyName fields.

### Tests

- ✅ Enables `acceptance/selftest/record_cloud/basic` test to run locally
- ✅ Tested on macOS (arm64) - PASS
- ✅ Tested on Windows (amd64) - PASS
- ✅ Both terraform and direct deployment modes work

🤖 Generated with [Claude Code](https://claude.com/claude-code)