### PR TITLE
Do not run 'bundle migrate' tests twice

### DIFF
--- a/acceptance/bundle/migrate/basic/out.test.toml
+++ b/acceptance/bundle/migrate/basic/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/basic/script
+++ b/acceptance/bundle/migrate/basic/script
@@ -1,3 +1,4 @@
+export DATABRICKS_BUNDLE_ENGINE=
 # Migrating without state, should print a message about missing state.
 trace musterr $CLI bundle deployment migrate
 

--- a/acceptance/bundle/migrate/dashboards/out.test.toml
+++ b/acceptance/bundle/migrate/dashboards/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/default-python/out.test.toml
+++ b/acceptance/bundle/migrate/default-python/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/default-python/script
+++ b/acceptance/bundle/migrate/default-python/script
@@ -1,3 +1,4 @@
+export DATABRICKS_BUNDLE_ENGINE=
 trace $CLI bundle init default-python --config-file ./input.json
 cd my_default_python
 

--- a/acceptance/bundle/migrate/grants/out.test.toml
+++ b/acceptance/bundle/migrate/grants/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/grants/script
+++ b/acceptance/bundle/migrate/grants/script
@@ -1,3 +1,4 @@
+export DATABRICKS_BUNDLE_ENGINE=
 trace DATABRICKS_BUNDLE_ENGINE=terraform $CLI bundle deploy
 print_state.py > out.original_state.json
 

--- a/acceptance/bundle/migrate/permissions/out.test.toml
+++ b/acceptance/bundle/migrate/permissions/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/profile_arg/out.test.toml
+++ b/acceptance/bundle/migrate/profile_arg/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/runas/out.test.toml
+++ b/acceptance/bundle/migrate/runas/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/test.toml
+++ b/acceptance/bundle/migrate/test.toml
@@ -2,3 +2,6 @@ Cloud = false
 RecordRequests = true
 IncludeRequestHeaders = ["User-Agent"]
 Ignore = [".databricks"]
+
+# All tests explicitly set DATABRICKS_BUNDLE_ENGINE, so there is no need for matrix testing
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/var_arg/out.test.toml
+++ b/acceptance/bundle/migrate/var_arg/out.test.toml
@@ -2,4 +2,4 @@ Local = true
 Cloud = false
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]


### PR DESCRIPTION
## Why
Those tests set DATABRICKS_BUNDLE_ENGINE in the script, so execution is identical between engines, no need to run it twice. Since terraform tests take a lot longer than direct, this should reduce critical path to get PR tested.