### PR TITLE
acc: testserver: fix api/2.0/alerts/{id} error message to match cloud

### DIFF
--- a/acceptance/bundle/resources/alerts/basic/output.txt
+++ b/acceptance/bundle/resources/alerts/basic/output.txt
@@ -62,7 +62,7 @@ Deleting files...
 Destroy complete!
 
 >>> [CLI] alerts-v2 get-alert [ALERT_ID]
-Error: Node with resource name None does not exist.
+Error: Alert with ID '[ALERT_ID]' does not exist.
 
 Exit code: 1
 

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -543,12 +543,13 @@ func AddDefaultHandlers(server *Server) {
 	server.Handle("GET", "/api/2.0/alerts/{id}", func(req Request) any {
 		defer req.Workspace.LockUnlock()()
 
-		value, ok := req.Workspace.Alerts[req.Vars["id"]]
+		id := req.Vars["id"]
+
+		value, ok := req.Workspace.Alerts[id]
 		if !ok || value.LifecycleState == sql.AlertLifecycleStateDeleted {
 			return Response{
 				StatusCode: 404,
-				// Backend returns a terrible error message today.
-				Body: map[string]string{"message": "Node with resource name None does not exist."},
+				Body:       map[string]string{"message": "Alert with ID '" + id + "' does not exist."},
 			}
 		}
 


### PR DESCRIPTION
Fixes TestAccept/bundle/resources/alerts/basic/ on cloud
