### PR TITLE
Pin Docker to 28.0.4 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Set up QEMU dependency
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
+      # Pin Docker to 28.0.4 because Docker 29.x changed how buildx pushes
+      # images (they become manifest lists), which breaks goreleaser's
+      # docker manifest create step with "is a manifest list" error.
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
+        with:
+          version: v28.0.4
+
       - name: Run GoReleaser for Unix
         id: releaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
Docker 29.x changed how buildx pushes single-platform images: they are now pushed as OCI manifest lists instead of plain image manifests. This breaks goreleaser's docker_manifests step with "is a manifest list" error.

Pin to 28.0.4 (the last known-good version) using docker/setup-docker-action.

