### PR TITLE
Update NEXT_CHANGELOG.md with proper sections

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## Release v0.289.1
 
-Internal:
+### Internal:
 * Pin docker version to fix release process.


### PR DESCRIPTION
Otherwise tagging.py does not work:

```
Run python internal/genkit/tagging.py
/home/runner/work/cli/cli/internal/genkit/tagging.py:512: DeprecationWarning: Argument login_or_token is deprecated, please use auth=github.Auth.Token(...) instead
  g = Github(token)
Processing package
All sections are empty. No changes will be made to the changelog.
```

Follow up to https://github.com/databricks/cli/pull/4555