### PR TITLE
acc: Use production as default postgres branch name

### DIFF
--- a/acceptance/bundle/resources/postgres_branches/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/basic/output.txt
@@ -38,7 +38,7 @@ Deployment complete!
     "current_state": "READY",
     "default": false,
     "is_protected": false,
-    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
     "source_branch_lsn": "[LSN]",
     "source_branch_time": "[TIMESTAMP]",
     "state_change_time": "[TIMESTAMP]"

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.get_branch.txt
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.get_branch.txt
@@ -5,7 +5,7 @@
     "current_state": "READY",
     "default": false,
     "is_protected": false,
-    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
     "source_branch_lsn": "[LSN]",
     "source_branch_time": "[TIMESTAMP]",
     "state_change_time": "[TIMESTAMP]"

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
@@ -14,7 +14,7 @@
       "current_state": "READY",
       "default": false,
       "is_protected": false,
-      "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+      "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
       "source_branch_lsn": "[LSN]",
       "source_branch_time": "[TIMESTAMP]",
       "state_change_time": "[TIMESTAMP]"

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
@@ -22,7 +22,7 @@
       "current_state": "READY",
       "default": false,
       "is_protected": true,
-      "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+      "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
       "source_branch_lsn": "[LSN]",
       "source_branch_time": "[TIMESTAMP]",
       "state_change_time": "[TIMESTAMP]"

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
@@ -22,7 +22,7 @@
       "current_state": "READY",
       "default": false,
       "is_protected": false,
-      "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+      "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
       "source_branch_lsn": "[LSN]",
       "source_branch_time": "[TIMESTAMP]",
       "state_change_time": "[TIMESTAMP]"

--- a/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
@@ -33,7 +33,7 @@ Deployment complete!
     "current_state": "READY",
     "default": false,
     "is_protected": false,
-    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
     "source_branch_lsn": "[LSN]",
     "source_branch_time": "[TIMESTAMP]",
     "state_change_time": "[TIMESTAMP]"
@@ -107,7 +107,7 @@ Deployment complete!
     "current_state": "READY",
     "default": false,
     "is_protected": true,
-    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
     "source_branch_lsn": "[LSN]",
     "source_branch_time": "[TIMESTAMP]",
     "state_change_time": "[TIMESTAMP]"
@@ -141,7 +141,7 @@ Deployment complete!
     "current_state": "READY",
     "default": false,
     "is_protected": false,
-    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/[BRANCH_UID]",
+    "source_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
     "source_branch_lsn": "[LSN]",
     "source_branch_time": "[TIMESTAMP]",
     "state_change_time": "[TIMESTAMP]"

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -618,10 +618,11 @@ func (s *FakeWorkspace) createOperationLocked(resourceName string, response any)
 }
 
 // createDefaultBranchLocked creates a default branch for a project (caller must hold lock).
+// The default branch is named "production" to match cloud API behavior.
 func (s *FakeWorkspace) createDefaultBranchLocked(projectName string) {
 	now := nowTime()
 	branchUID := "br-" + nextUUID()[:20]
-	branchName := projectName + "/branches/" + branchUID
+	branchName := projectName + "/branches/production"
 
 	defaultBranch := postgres.Branch{
 		Name:       branchName,


### PR DESCRIPTION
## Changes

The testserver was creating default branches with UID-based names (`br-XXXX`), but cloud uses a fixed name "production". This caused `source_branch` in branch responses to differ between local and cloud runs, breaking `postgres_branches` acceptance tests on cloud.