### PR TITLE
Fix update_github_links.py not to produce double parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,22 @@
 ## Release v0.289.0 (2026-02-19)
 
 ### CLI
-* Make auth profiles respect DATABRICKS_CLI_PATH env var (([#4467](https://github.com/databricks/cli/pull/4467)))
-* Fix arrow key navigation in prompts on Windows (([#4501](https://github.com/databricks/cli/pull/4501)))
+* Make auth profiles respect DATABRICKS_CLI_PATH env var ([#4467](https://github.com/databricks/cli/pull/4467))
+* Fix arrow key navigation in prompts on Windows ([#4501](https://github.com/databricks/cli/pull/4501))
 
 ### Bundles
 * Log artifact build output in debug mode ([#4208](https://github.com/databricks/cli/pull/4208))
 * Fix bundle init not working in Azure Government ([#4286](https://github.com/databricks/cli/pull/4286))
-* Allow single and double quotes in environment dependencies (([#4511](https://github.com/databricks/cli/pull/4511)))
-* Use purge option when deleting alerts (([#4505](https://github.com/databricks/cli/pull/4505)))
+* Allow single and double quotes in environment dependencies ([#4511](https://github.com/databricks/cli/pull/4511))
+* Use purge option when deleting alerts ([#4505](https://github.com/databricks/cli/pull/4505))
 * engine/direct: Replace server_side_default with more precise backend_default rule in bundle plan ([#4490](https://github.com/databricks/cli/pull/4490))
-* engine/direct: Extend pipelines recreate_on_changes configuration (([#4499](https://github.com/databricks/cli/pull/4499)))
+* engine/direct: Extend pipelines recreate_on_changes configuration ([#4499](https://github.com/databricks/cli/pull/4499))
 * engine/direct: Added support for UC external locations (direct only) ([#4484](https://github.com/databricks/cli/pull/4484))
 
 ### Dependency updates
-* Upgrade Go SDK to v0.106.0 (([#4486](https://github.com/databricks/cli/pull/4486)))
-* Upgrade Terraform provider to v1.106.0 (([#4542](https://github.com/databricks/cli/pull/4542)))
-* Upgrade Go to 1.25.7 (([#4547](https://github.com/databricks/cli/pull/4547)))
+* Upgrade Go SDK to v0.106.0 ([#4486](https://github.com/databricks/cli/pull/4486))
+* Upgrade Terraform provider to v1.106.0 ([#4542](https://github.com/databricks/cli/pull/4542))
+* Upgrade Go to 1.25.7 ([#4547](https://github.com/databricks/cli/pull/4547))
 
 
 ## Release v0.288.0 (2026-02-12)
@@ -49,7 +49,7 @@
 * Add support for Lakebase resources (postgres_projects, postgres_branches, postgres_endpoints) ([#4423](https://github.com/databricks/cli/pull/4423))
 * Add missing values to SchemaGrantPrivilege enum ([#4380](https://github.com/databricks/cli/pull/4380))
 * Added support for UC catalogs (only in direct mode) ([#4342](https://github.com/databricks/cli/pull/4342))
-* engine/direct: Fix updates to fields being ignored for database_catalogs, synced_database_tables (([#4388](https://github.com/databricks/cli/pull/4388)))
+* engine/direct: Fix updates to fields being ignored for database_catalogs, synced_database_tables ([#4388](https://github.com/databricks/cli/pull/4388))
 * engine/direct: Fix migration for database_instances, database_catalog, synced_database_tables ([#4424](https://github.com/databricks/cli/pull/4424))
 * Show warning message if valueFrom is used instead of value_from in app config section ([$4429](https://github.com/databricks/cli/pull/4429))
 
@@ -77,9 +77,9 @@
 * Pass additional Azure DevOps `SYSTEM_*` environment variables to Terraform for OIDC authentication: `SYSTEM_COLLECTIONURI`, `SYSTEM_DEFINITIONID`, `SYSTEM_HOSTTYPE`, `SYSTEM_JOBID`, `SYSTEM_TEAMPROJECT` ([#4318](https://github.com/databricks/cli/pull/4318))
 * Add support for valueFrom property (similar to app.yaml) inside Apps config field in bundle configuration ([#4297](https://github.com/databricks/cli/pull/4297))
 * engine/direct: Support bind & unbind. ([#4279](https://github.com/databricks/cli/pull/4279))
-* engine/direct: Ignore changes between nulls and empty slices/maps (([#4313](https://github.com/databricks/cli/pull/4313)))
-* engine/direct: Ignore changes between nulls and empty structs (([#4338](https://github.com/databricks/cli/pull/4338)))
-* On terraform `bundle plan -o json` will no longer include plan_version key, it's intended for direct engine only (([#4314](https://github.com/databricks/cli/pull/4314)))
+* engine/direct: Ignore changes between nulls and empty slices/maps ([#4313](https://github.com/databricks/cli/pull/4313))
+* engine/direct: Ignore changes between nulls and empty structs ([#4338](https://github.com/databricks/cli/pull/4338))
+* On terraform `bundle plan -o json` will no longer include plan_version key, it's intended for direct engine only ([#4314](https://github.com/databricks/cli/pull/4314))
 
 
 ## Release v0.283.0 (2026-01-14)
@@ -191,7 +191,7 @@ To disable this, set the environment variable DATABRICKS_CACHE_ENABLED to false.
 ### Bundles
 * Add `default-minimal` template for users who want a clean slate without sample code ([#3885](https://github.com/databricks/cli/pull/3885))
 * Add validation that served_models and served_entities are not used at the same time. Add client side translation logic. ([#3880](https://github.com/databricks/cli/pull/3880))
-* Filter out provided permissions, to select a single permissions level per principal (([#3904](https://github.com/databricks/cli/pull/3904))).
+* Filter out provided permissions, to select a single permissions level per principal ([#3904](https://github.com/databricks/cli/pull/3904)).
 
 
 ## Release v0.276.0 (2025-11-05)


### PR DESCRIPTION
This happened if you copy-paste title from github-generated commit into changelog.