### PR TITLE
Wire profile name through CLI ToOAuthArgument for profile-based cache keys

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -152,6 +152,8 @@ depends on the existing profiles you have set in your configuration file
 			return err
 		}
 
+		authArguments.Profile = profileName
+
 		var scopesList []string
 		if scopes != "" {
 			for _, s := range strings.Split(scopes, ",") {

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -113,6 +113,8 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 		return nil, err
 	}
 
+	args.authArguments.Profile = args.profileName
+
 	ctx, cancel := context.WithTimeout(ctx, args.tokenTimeout)
 	defer cancel()
 	oauthArgument, err := args.authArguments.ToOAuthArgument()

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -100,6 +100,13 @@ func TestToken_loadToken(t *testing.T) {
 				RefreshToken: "active",
 				Expiry:       time.Now().Add(1 * time.Hour), // Hopefully unit tests don't take an hour to run
 			},
+			"expired": {
+				RefreshToken: "expired",
+			},
+			"active": {
+				RefreshToken: "active",
+				Expiry:       time.Now().Add(1 * time.Hour),
+			},
 		},
 	}
 	validateToken := func(resp *oauth2.Token) {

--- a/libs/auth/arguments.go
+++ b/libs/auth/arguments.go
@@ -14,6 +14,10 @@ type AuthArguments struct {
 	AccountID     string
 	WorkspaceID   string
 	IsUnifiedHost bool
+
+	// Profile is the optional profile name. When set, the OAuth token cache
+	// key is the profile name instead of the host-based key.
+	Profile string
 }
 
 // ToOAuthArgument converts the AuthArguments to an OAuthArgument from the Go SDK.
@@ -28,13 +32,13 @@ func (a AuthArguments) ToOAuthArgument() (u2m.OAuthArgument, error) {
 
 	switch cfg.HostType() {
 	case config.AccountHost:
-		return u2m.NewBasicAccountOAuthArgument(host, cfg.AccountID)
+		return u2m.NewProfileAccountOAuthArgument(host, cfg.AccountID, a.Profile)
 	case config.WorkspaceHost:
-		return u2m.NewBasicWorkspaceOAuthArgument(host)
+		return u2m.NewProfileWorkspaceOAuthArgument(host, a.Profile)
 	case config.UnifiedHost:
 		// For unified hosts, always use the unified OAuth argument with account ID.
 		// The workspace ID is stored in the config for API routing, not OAuth.
-		return u2m.NewBasicUnifiedOAuthArgument(host, cfg.AccountID)
+		return u2m.NewProfileUnifiedOAuthArgument(host, cfg.AccountID, a.Profile)
 	default:
 		return nil, fmt.Errorf("unknown host type: %v", cfg.HostType())
 	}


### PR DESCRIPTION
## Changes
- Add `Profile` field to `AuthArguments` struct in `libs/auth/arguments.go`.
- Switch `ToOAuthArgument()` from `NewBasic*` to `NewProfile*` constructors, passing the profile name so the SDK uses profile-based cache keys when a profile is specified.
- Wire profile name from `cmd/auth/token.go` and `cmd/auth/login.go` into `AuthArguments` before calling `ToOAuthArgument()`.

## Why
The SDK already supports profile-based OAuth token cache keys, but the CLI never passes the profile name through to the SDK constructors. This means `auth token --profile X` and `auth login --profile X` still use host-based cache keys, making profile-based caching a no-op. This is a prerequisite for profile-based cache keys to work end-to-end.

## Tests
- [x] Unit tests pass (`libs/auth`, `cmd/auth`)
- [x] Added test cases for profile-based cache keys (workspace, account, unified host types)
- [x] Updated `token_test.go` in-memory cache with profile-based entries
- [x] Acceptance tests pass (`cmd/auth/*`)
- [x] `make checks` passes

Tested manually by creating two profiles that were with the same host. 
Results:
- e2-dogfood:        expiry=2026-02-20T14:37:20.935183+01:00
- duplicatedogfood:  expiry=2026-02-20T14:41:50.532528+01:00

Two profiles, same host, different tokens with different expiry times. That's the whole point of this change — before, they'd share one cache entry keyed by https://e2-dogfood.staging.cloud.databricks.com and one login would clobber the other. Now they each get their own entry keyed by profile name.