### PR TITLE
Use App for Integration Test Check Runs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -403,7 +403,9 @@ jobs:
         with:
           app-id: ${{ secrets.DECO_TEST_APPROVAL_APP_ID }}
           private-key: ${{ secrets.DECO_TEST_APPROVAL_PRIVATE_KEY }}
+          # DECO_TEST_APPROVAL is installed on the databricks org (not databricks-eng).
           owner: databricks
+          repositories: cli
 
       # Trigger integration tests if the primary "test" target is triggered by this change.
       - name: Trigger integration tests (pull request)


### PR DESCRIPTION
The "mark as pending" job in the integration test workflow has been broken since late January. The nightly run fails with:

```
gh: Invalid app_id `15368` - check run can only be modified by the GitHub App that created it. (HTTP 403)
```

The "Auto-approve for merge group" and "Skip integration tests" steps in `push.yml` create "Integration Tests" checks using `actions/github-script`, which runs under the built-in `GITHUB_TOKEN` — the `github-actions` app (ID 15368). When that same commit lands on main and triggers the nightly, the `update-check` action in eng-dev-ecosystem tries to update that check using the `DECO_TEST_APPROVAL` app token. GitHub's Checks API rejects this because only the app that created a check can modify it.

This PR generates a `DECO_TEST_APPROVAL` token for both steps and passes it via `github-token` to `actions/github-script`, so checks are created by the same app that later updates them.