### PR TITLE
Remove exhaustruct linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,6 @@ linters:
     - testifylint
     - unconvert
     - unused
-    - exhaustruct
     - exhaustive
     - copyloopvar
     - forbidigo
@@ -98,13 +97,7 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - path-except: bundle/direct/dresources|bundle/config/mutator/load_dbalert_files.go
-        linters:
-          - exhaustruct
-      - path: bundle/direct/dresources/.*_test.go
-        linters:
-          - exhaustruct
+    rules: []
 issues:
   max-issues-per-linter: 1000
   max-same-issues: 1000


### PR DESCRIPTION
## Summary

Removes the `exhaustruct` linter from the CI lint workflow.

## Why

The `exhaustruct` linter requires every field in a struct literal to be explicitly initialized, even when the zero value is intentional. This goes against idiomatic Go, where leveraging zero values is a core language feature and a deliberate design choice.

The linter was scoped to `bundle/direct/dresources` to catch missing fields when constructing API resource structs. In practice, the Go compiler and tests already catch meaningful omissions, and the linter creates friction without proportional benefit — it forces boilerplate like `Field: ""` or `Field: nil` that adds noise without adding safety.

## What changed

### Interface changes

None.

### Behavioral changes

None. The linter only ran in CI; removing it has no effect on the CLI's behavior.

### Internal changes

- Removed `exhaustruct` from the `enable` list in `.golangci.yaml`.
- Removed the associated path-scoping rules in the `exclusions` section.

## How is this tested?

`make lintfull` passes with 0 issues.