### PR TITLE
Run cloud integration tests if experimental/ssh files are changed

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -388,7 +388,7 @@ jobs:
 
       # Trigger integration tests if the primary "test" target is triggered by this change.
       - name: Trigger integration tests (pull request)
-        if: ${{ github.event_name == 'pull_request' && contains(fromJSON(needs.testmask.outputs.targets), 'test') }}
+        if: ${{ github.event_name == 'pull_request' && (contains(fromJSON(needs.testmask.outputs.targets), 'test') || contains(fromJSON(needs.testmask.outputs.targets), 'test-exp-ssh')) }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |-
@@ -400,7 +400,7 @@ jobs:
       # Skip integration tests if the primary "test" target is not triggered by this change.
       # Use Checks API (not Statuses API) to match the required "Integration Tests" check.
       - name: Skip integration tests (pull request)
-        if: ${{ github.event_name == 'pull_request' && !contains(fromJSON(needs.testmask.outputs.targets), 'test') }}
+        if: ${{ github.event_name == 'pull_request' && !contains(fromJSON(needs.testmask.outputs.targets), 'test') && !contains(fromJSON(needs.testmask.outputs.targets), 'test-exp-ssh') }}
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->

Push workflow now triggers integration tests if there is a `test-exp-ssh` target detected for the changed files

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

Without this change the integration tests are not triggered for pull requests that only change experimental/ssh files (or acceptance tests for them). This is not correct since experimental ssh project does have acceptance tests that run in the cloud.

## Tests
<!-- How have you tested the changes? -->

Created a PR to this PR and verified that the integration tests are triggered for it: https://github.com/databricks/cli/pull/4579

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
