### PR TITLE
Pin skill installer to v0.1.0 release tag

### DIFF
--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	skillsRepoOwner         = "databricks"
-	skillsRepoName          = "databricks-agent-skills"
-	skillsRepoPath          = "skills"
+	skillsRepoOwner      = "databricks"
+	skillsRepoName       = "databricks-agent-skills"
+	skillsRepoPath       = "skills"
 	defaultSkillsRepoRef = "v0.1.0"
 )
 


### PR DESCRIPTION
## Summary
- Pin skills installer to the `v0.1.0` released tag instead of `main` branch
- Rename `DATABRICKS_SKILLS_BRANCH` env var to `DATABRICKS_SKILLS_REF` (accepts any git ref)

## Test plan
- [x] Verify `databricks experimental aitools skills list` fetches manifest from the tagged release
- [x] Verify `DATABRICKS_SKILLS_REF` env var override still works