### PR TITLE
Update error messages to suggest 'databricks auth login'

### DIFF
--- a/acceptance/workspace/jobs/create-error/output.txt
+++ b/acceptance/workspace/jobs/create-error/output.txt
@@ -8,6 +8,6 @@ Auth type: Personal Access Token (pat)
 Next steps:
   - Verify you have the required permissions for this operation
   - Check your identity: databricks auth describe
-  - Consider configuring a profile: databricks configure --profile <name>
+  - Consider setting up a profile: databricks auth login --profile <name>
 
 Exit code: 1

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -22,7 +22,7 @@ type ErrNoWorkspaceProfiles struct {
 }
 
 func (e ErrNoWorkspaceProfiles) Error() string {
-	return e.path + " does not contain workspace profiles; please create one by running 'databricks configure'"
+	return e.path + " does not contain workspace profiles; please create one by running 'databricks auth login'"
 }
 
 type ErrNoAccountProfiles struct {

--- a/libs/auth/error.go
+++ b/libs/auth/error.go
@@ -107,7 +107,7 @@ func EnrichAuthError(ctx context.Context, cfg *config.Config, err error) error {
 
 	// Nudge toward profiles when using env-var-based auth.
 	if cfg.Profile == "" {
-		fmt.Fprint(&b, "\n  - Consider configuring a profile: databricks configure --profile <name>")
+		fmt.Fprint(&b, "\n  - Consider setting up a profile: databricks auth login --profile <name>")
 	}
 
 	return fmt.Errorf("%w\n%s", err, b.String())
@@ -143,14 +143,14 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 
 	case AuthTypePat:
 		if cfg.Profile != "" {
-			fmt.Fprintf(b, "\n  - Regenerate your access token or run: databricks configure --profile %s", cfg.Profile)
+			fmt.Fprintf(b, "\n  - Regenerate your access token or run: databricks auth login --profile %s", cfg.Profile)
 		} else {
 			fmt.Fprint(b, "\n  - Regenerate your access token")
 		}
 
 	case AuthTypeBasic:
 		if cfg.Profile != "" {
-			fmt.Fprintf(b, "\n  - Check your username/password or run: databricks configure --profile %s", cfg.Profile)
+			fmt.Fprintf(b, "\n  - Check your username/password or run: databricks auth login --profile %s", cfg.Profile)
 		} else {
 			fmt.Fprint(b, "\n  - Check your username and password")
 		}

--- a/libs/auth/error_test.go
+++ b/libs/auth/error_test.go
@@ -99,7 +99,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\nHost:      https://my-workspace.cloud.databricks.com" +
 				"\nAuth type: Personal Access Token (pat)" +
 				"\n\nNext steps:" +
-				"\n  - Regenerate your access token or run: databricks configure --profile dev" +
+				"\n  - Regenerate your access token or run: databricks auth login --profile dev" +
 				"\n  - Check your identity: databricks auth describe --profile dev",
 		},
 		{
@@ -147,7 +147,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\nHost:      https://my-workspace.cloud.databricks.com" +
 				"\nAuth type: Basic" +
 				"\n\nNext steps:" +
-				"\n  - Check your username/password or run: databricks configure --profile basic-profile" +
+				"\n  - Check your username/password or run: databricks auth login --profile basic-profile" +
 				"\n  - Check your identity: databricks auth describe --profile basic-profile",
 		},
 		{
@@ -195,7 +195,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\n\nNext steps:" +
 				"\n  - Regenerate your access token" +
 				"\n  - Check your identity: databricks auth describe" +
-				"\n  - Consider configuring a profile: databricks configure --profile <name>",
+				"\n  - Consider setting up a profile: databricks auth login --profile <name>",
 		},
 		{
 			name: "403 without profile (env var auth)",
@@ -210,7 +210,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\n\nNext steps:" +
 				"\n  - Verify you have the required permissions for this operation" +
 				"\n  - Check your identity: databricks auth describe" +
-				"\n  - Consider configuring a profile: databricks configure --profile <name>",
+				"\n  - Consider setting up a profile: databricks auth login --profile <name>",
 		},
 		{
 			name: "401 with account host and no profile",
@@ -226,7 +226,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\n\nNext steps:" +
 				"\n  - Re-authenticate: databricks auth login --host https://accounts.cloud.databricks.com --account-id abc123" +
 				"\n  - Check your identity: databricks auth describe" +
-				"\n  - Consider configuring a profile: databricks configure --profile <name>",
+				"\n  - Consider setting up a profile: databricks auth login --profile <name>",
 		},
 		{
 			name: "401 with unified host includes workspace-id in login",
@@ -244,7 +244,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\n\nNext steps:" +
 				"\n  - Re-authenticate: databricks auth login --host https://unified.cloud.databricks.com --account-id acc-123 --experimental-is-unified-host --workspace-id ws-456" +
 				"\n  - Check your identity: databricks auth describe" +
-				"\n  - Consider configuring a profile: databricks configure --profile <name>",
+				"\n  - Consider setting up a profile: databricks auth login --profile <name>",
 		},
 	}
 

--- a/libs/databrickscfg/profile/file.go
+++ b/libs/databrickscfg/profile/file.go
@@ -57,7 +57,7 @@ func (f FileProfilerImpl) Get(ctx context.Context) (*config.File, error) {
 	configFile, err := config.LoadFile(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		// downstreams depend on ErrNoConfiguration. TODO: expose this error through SDK
-		return nil, fmt.Errorf("%w at %s; please create one by running 'databricks configure'", ErrNoConfiguration, path)
+		return nil, fmt.Errorf("%w at %s; please create one by running 'databricks auth login'", ErrNoConfiguration, path)
 	} else if err != nil {
 		return nil, err
 	}

--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -99,7 +99,7 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		// Get smallest node type (follows Terraform's GetSmallestNodeType)
 		"smallest_node_type": func() (string, error) {
 			if w.Config.Host == "" {
-				return "", errors.New("cannot determine target workspace, please first setup a configuration profile using 'databricks configure'")
+				return "", errors.New("cannot determine target workspace, please first setup a configuration profile using 'databricks auth login'")
 			}
 			if w.Config.IsAzure() {
 				return "Standard_D3_v2", nil
@@ -113,7 +113,7 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		},
 		"workspace_host": func() (string, error) {
 			if w.Config.Host == "" {
-				return "", errors.New("cannot determine target workspace, please first setup a configuration profile using 'databricks configure'")
+				return "", errors.New("cannot determine target workspace, please first setup a configuration profile using 'databricks auth login'")
 			}
 			return w.Config.Host, nil
 		},


### PR DESCRIPTION
## Why

Several error messages in the CLI suggest running `databricks configure` to create profiles. This is outdated — the golden path is `databricks auth login` (OAuth-based). Telling users to run `databricks configure` leads them into a PAT-based manual config flow instead of the preferred OAuth flow.

## Changes

Update all error messages that suggest `databricks configure` to suggest `databricks auth login` instead. No functional changes — only user-facing strings.

- `libs/auth/error.go` — PAT, basic auth, and env-var auth remediation suggestions
- `cmd/root/auth.go` — "no workspace profiles" error
- `libs/databrickscfg/profile/file.go` — "no configuration file" error
- `libs/template/helpers.go` — `smallest_node_type` and `workspace_host` template helpers
- `acceptance/workspace/jobs/create-error/output.txt` — acceptance test golden file

Template README files (`libs/template/templates/`) also reference `databricks configure` but those are onboarding instructions, not error messages, and are out of scope for this change.

## Test
Tested manually to verify the new error messages
  1. Missing config file: ...please create one by running 'databricks auth login'
  2. 401 with env-var PAT: Consider setting up a profile: databricks auth login --profile <name>

- `go test ./libs/auth/ ./cmd/root/ ./libs/databrickscfg/profile/ ./libs/template/` — all pass
- `go build ./...` — compiles cleanly
- `make checks` — passes
- `rg "databricks configure" --glob "*.go"` — zero matches in Go source
- `rg "databricks configure" --glob "**/output.txt"` — zero matches in acceptance golden files