### PR TITLE
fix: multi field env vars

### DIFF
--- a/libs/apps/generator/generator.go
+++ b/libs/apps/generator/generator.go
@@ -243,17 +243,23 @@ func GenerateAppEnv(plugins []manifest.Plugin, cfg Config) string {
 }
 
 // appEnvLines returns app.yaml env entries for a resource.
-// Each field with an Env produces "- name: <ENV>\n  valueFrom: <resourceKey>".
+// Single-field resources use "valueFrom: <key>"; multi-field resources
+// use "valueFrom: <key>.<field>" so the runtime can resolve each field.
 func appEnvLines(r manifest.Resource) []string {
 	var lines []string
+	multiField := len(r.FieldNames()) > 1
 	for _, fieldName := range r.FieldNames() {
 		field := r.Fields[fieldName]
 		if field.Env == "" || !validEnvVar.MatchString(field.Env) {
 			continue
 		}
+		valueFrom := r.Key()
+		if multiField {
+			valueFrom = r.Key() + "." + fieldName
+		}
 		lines = append(lines,
 			"  - name: "+field.Env,
-			"    valueFrom: "+r.Key(),
+			"    valueFrom: "+valueFrom,
 		)
 	}
 	return lines


### PR DESCRIPTION
## Changes
<!-- Brief summary of your changes that is easy to understand -->

when generating the app.yaml file, we need to set the `valueFrom` correctly when the resource has more than one value, like secrets

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
