### PR TITLE
Resolve --host to matching profile for token cache lookup

### DIFF
--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -168,6 +168,8 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 				return nil, err
 			}
 			args.profileName = selected
+		} else if len(matchingProfiles) == 1 {
+			args.profileName = matchingProfiles[0].Name
 		}
 	}
 


### PR DESCRIPTION
## Why

When you run `databricks auth token --host <url>`, the CLI looks up the token using the host URL as the cache key. But if you logged in with `--profile`, the token was stored under the profile name, not the host URL. So `--host` can't find it — even though the token exists and the profile points to exactly that host.

This is the flip side of the bug fixed in databricks/databricks-sdk-go#1497: that PR made `--profile` fall back to the host key. This PR makes `--host` resolve to the profile key.

Together, both directions work: `--profile` finds host-keyed tokens, and `--host` finds profile-keyed tokens.

## Changes

Two-line change in `loadToken` (`cmd/auth/token.go`).

The CLI already loads all profiles matching a given host and errors when there are multiple matches (the ambiguity check). This PR adds an `else if` branch: when exactly one profile matches, use that profile's name as the cache key instead of the raw host URL.

```go
if len(matchingProfiles) > 1 {
    // existing: ambiguity error
} else if len(matchingProfiles) == 1 {
    args.profileName = matchingProfiles[0].Name
}
```

The matching is already host-type-aware from the existing code:
- Workspace hosts match by host URL
- Account/unified hosts match by host URL + account ID

No new matching logic was added.

**Side effect**: error messages now suggest `--profile <name>` instead of `--host <url>` when the host resolves to a profile. This is better UX — if we know the profile, we should suggest it.

## Test plan

Three new test cases added to `TestToken_loadToken`:

1. **Host with one matching profile resolves to profile key** — token exists only under the profile key (not the host URL). `--host` finds it by resolving to the profile first.
2. **Host with no matching profile uses host key** — no profile in `.databrickscfg` matches the host. Falls back to looking up by host URL directly. Unchanged behavior.
3. **Host with one matching profile, host-key-only token (migration)** — profile exists in `.databrickscfg` but the token was stored under the host URL only (legacy). CLI resolves `--host` to the profile name, then the SDK's read-fallback (from [#1497](https://github.com/databricks/databricks-sdk-go/pull/1497?timeline_per_page=5)) finds the token under the host key.

All existing tests continue to pass. One existing test's expected error message changed from `--host ... --account-id ...` to `--profile expired` because the host now resolves to the `expired` profile.

### Manual testing

I tested this manually with my local `.databrickscfg`:

```
$ databricks auth token --host https://adb-2548836972759138.18.azuredatabricks.net/
```

This host matches my `logfood` profile. Before this change, it would look up by host URL. After this change, it resolves to `logfood` and looks up by profile key. The token is returned in both cases (because `dualWrite` currently populates both keys), but the cache key used is now the profile name.