### PR TITLE
Return clear error when `auth token` is used with M2M profile

### DIFF
--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -211,7 +211,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 
 	// Check if the resolved profile uses M2M authentication (client credentials).
 	// The auth token command only supports U2M OAuth tokens.
-	if existingProfile != nil && existingProfile.ClientID != "" {
+	if existingProfile != nil && existingProfile.HasClientCredentials {
 		return nil, fmt.Errorf(
 			"profile %q uses M2M authentication (client_id/client_secret). "+
 				"`databricks auth token` only supports U2M (user-to-machine) authentication tokens. "+

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -126,9 +126,9 @@ func TestToken_loadToken(t *testing.T) {
 				Host: "https://legacy-ws.cloud.databricks.com",
 			},
 			{
-				Name:     "m2m-profile",
-				Host:     "https://m2m.cloud.databricks.com",
-				ClientID: "my-client-id",
+				Name:                 "m2m-profile",
+				Host:                 "https://m2m.cloud.databricks.com",
+				HasClientCredentials: true,
 			},
 		},
 	}

--- a/libs/databrickscfg/profile/file.go
+++ b/libs/databrickscfg/profile/file.go
@@ -79,14 +79,14 @@ func (f FileProfilerImpl) LoadProfiles(ctx context.Context, fn ProfileMatchFunct
 			continue
 		}
 		profile := Profile{
-			Name:                v.Name(),
-			Host:                host,
-			AccountID:           all["account_id"],
-			WorkspaceID:         all["workspace_id"],
-			IsUnifiedHost:       all["experimental_is_unified_host"] == "true",
-			ClusterID:           all["cluster_id"],
-			ServerlessComputeID: all["serverless_compute_id"],
-			ClientID:            all["client_id"],
+			Name:                 v.Name(),
+			Host:                 host,
+			AccountID:            all["account_id"],
+			WorkspaceID:          all["workspace_id"],
+			IsUnifiedHost:        all["experimental_is_unified_host"] == "true",
+			ClusterID:            all["cluster_id"],
+			ServerlessComputeID:  all["serverless_compute_id"],
+			HasClientCredentials: all["client_id"] != "" && all["client_secret"] != "",
 		}
 		if fn(profile) {
 			profiles = append(profiles, profile)

--- a/libs/databrickscfg/profile/profile.go
+++ b/libs/databrickscfg/profile/profile.go
@@ -10,14 +10,14 @@ import (
 // It should only be used for prompting and filtering.
 // Use its name to construct a config.Config.
 type Profile struct {
-	Name                string
-	Host                string
-	AccountID           string
-	WorkspaceID         string
-	IsUnifiedHost       bool
-	ClusterID           string
-	ServerlessComputeID string
-	ClientID            string
+	Name                 string
+	Host                 string
+	AccountID            string
+	WorkspaceID          string
+	IsUnifiedHost        bool
+	ClusterID            string
+	ServerlessComputeID  string
+	HasClientCredentials bool
 }
 
 func (p Profile) Cloud() string {


### PR DESCRIPTION
## Summary

Fixes #1939

When `databricks auth token --profile <m2m-profile>` is used with a profile that has `client_id`/`client_secret` configured (M2M / service principal auth), the command currently either:

1. **Silently returns the wrong token** — a cached U2M token for the same host, identifying the user instead of the service principal
2. **Triggers an interactive browser login** — pushing the user into U2M auth with no explanation

This PR adds early detection of M2M profiles and returns a clear error:

```
Error: profile "my-sp" uses M2M authentication (client_id/client_secret).
`databricks auth token` only supports U2M (user-to-machine) authentication tokens.
To authenticate as a service principal, use the Databricks SDK directly
```

### Changes

- Added `ClientID` field to `profile.Profile` struct (populated from `.databrickscfg`)
- Added check in `loadToken` that detects M2M profiles before attempting U2M token lookup
- After host-based profile resolution, `existingProfile` is reloaded so the M2M guard also covers `--host` invocations that resolve to a single M2M profile
- Works for all three profile resolution paths: `--profile` flag, positional argument, and host-based matching

## Test plan

- [x] `M2M profile returns clear error` — explicit `--profile` targeting M2M profile
- [x] `M2M profile detected via positional arg` — positional arg resolves to M2M profile
- [x] `M2M profile detected via host resolution` — `--host` uniquely matches an M2M profile
- [x] All existing `TestToken_loadToken` cases pass (no regressions)
- [x] `make checks` passes
- [x] `make lintfull` passes