### PR TITLE
Fix alert threshold double_value with terraform engine

### DIFF
--- a/acceptance/bundle/resources/alerts/basic/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/alerts/basic/databricks.yml.tmpl
@@ -21,7 +21,7 @@ resources:
           name: "1"
         threshold:
           value:
-            double_value: 2
+            double_value: 1.3
       query_text: "select 2"
       schedule:
         pause_status: "UNPAUSED"

--- a/acceptance/bundle/resources/alerts/basic/output.txt
+++ b/acceptance/bundle/resources/alerts/basic/output.txt
@@ -23,7 +23,7 @@ Deployment complete!
     },
     "threshold": {
       "value": {
-        "double_value": 2
+        "double_value": 1.3
       }
     }
   },

--- a/bundle/internal/tf/codegen/generator/walker.go
+++ b/bundle/internal/tf/codegen/generator/walker.go
@@ -33,6 +33,9 @@ type walker struct {
 // that should be mapped to float64 instead of int for cty.Number types.
 // Generated from Terraform provider schema based on databricks-sdk-go types.
 var floatAttributePaths = map[string]bool{
+	// Alert thresholds - double_value fields hold fractional values (e.g., 1.3)
+	"databricks_alert_v2.evaluation.threshold.value.double_value": true,
+
 	// Postgres Service - autoscaling compute units support fractional values (e.g., 0.5 CU)
 	"databricks_postgres_endpoint.spec.autoscaling_limit_max_cu":                                      true,
 	"databricks_postgres_endpoint.spec.autoscaling_limit_min_cu":                                      true,

--- a/bundle/internal/tf/schema/resource_alert_v2.go
+++ b/bundle/internal/tf/schema/resource_alert_v2.go
@@ -33,9 +33,9 @@ type ResourceAlertV2EvaluationThresholdColumn struct {
 }
 
 type ResourceAlertV2EvaluationThresholdValue struct {
-	BoolValue   bool   `json:"bool_value,omitempty"`
-	DoubleValue int    `json:"double_value,omitempty"`
-	StringValue string `json:"string_value,omitempty"`
+	BoolValue   bool    `json:"bool_value,omitempty"`
+	DoubleValue float64 `json:"double_value,omitempty"`
+	StringValue string  `json:"string_value,omitempty"`
 }
 
 type ResourceAlertV2EvaluationThreshold struct {


### PR DESCRIPTION
## Summary
- The TF schema codegen maps `cty.Number` to Go `int` by default. The alert `double_value` field was not in the `float64` allowlist, so fractional values like `1.3` were dropped during normalization, causing terraform to fail with `"evaluation.threshold is provided but doesn't contain any value"`.
- Add alert `double_value` paths to the float64 allowlist and update the generated schema types from `int` to `float64`.

## Test plan
- [x] Unit test `TestConvertAlertWithThresholdDoubleValue` verifies fractional `double_value` survives normalization
- [x] Updated existing `acceptance/bundle/resources/alerts/basic` acceptance test to use fractional `double_value: 1.3` instead of integer `2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)