### PR TITLE
Sync registered model aliases via SetAlias/DeleteAlias in direct mode

### DIFF
--- a/.nextchanges/bundles/registered-model-aliases-direct.md
+++ b/.nextchanges/bundles/registered-model-aliases-direct.md
@@ -1,0 +1,1 @@
+direct: Sync registered model aliases via SetAlias/DeleteAlias ([#4637](https://github.com/databricks/cli/pull/4637))

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bundles
 * Modify grants to use SDK types ([#4666](https://github.com/databricks/cli/pull/4666))
 * Modify permissions to use SDK types where available. This makes DABs validate permission levels, producing a warning on the unknown ones ([#4686](https://github.com/databricks/cli/pull/4686))
+* direct: Sync registered model aliases via SetAlias/DeleteAlias ([#4637](https://github.com/databricks/cli/pull/4637))
 
 ### Dependency updates
 * Bump databricks-sdk-go from v0.112.0 to v0.119.0 ([#4631](https://github.com/databricks/cli/pull/4631), [#4695](https://github.com/databricks/cli/pull/4695))

--- a/acceptance/bundle/resources/registered_models/aliases/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/registered_models/aliases/databricks.yml.tmpl
@@ -1,0 +1,10 @@
+bundle:
+  name: deploy-registered-models-aliases-$UNIQUE_NAME
+
+resources:
+  registered_models:
+    my_registered_model:
+      name: $NAME
+      comment: $COMMENT
+      catalog_name: $CATALOG_NAME
+      schema_name: $SCHEMA_NAME

--- a/acceptance/bundle/resources/registered_models/aliases/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases/out.test.toml
@@ -1,0 +1,7 @@
+Local = true
+Cloud = true
+RequiresUnityCatalog = true
+RunsOnDbr = true
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/aliases/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases/out.test.toml
@@ -1,0 +1,4 @@
+Cloud = true
+RequiresUnityCatalog = true
+RunsOnDbr = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/registered_models/aliases/output.txt
+++ b/acceptance/bundle/resources/registered_models/aliases/output.txt
@@ -1,0 +1,92 @@
+
+>>> export NAME=my-registered-model-[UNIQUE_NAME]
+
+>>> export COMMENT=test model
+
+>>> export CATALOG_NAME=mycatalog-[UNIQUE_NAME]
+
+>>> export SCHEMA_NAME=myschema-[UNIQUE_NAME]
+
+>>> [CLI] catalogs create mycatalog-[UNIQUE_NAME]
+{
+  "full_name": "mycatalog-[UNIQUE_NAME]"
+}
+
+>>> [CLI] schemas create myschema-[UNIQUE_NAME] mycatalog-[UNIQUE_NAME]
+{
+  "full_name": "mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME]"
+}
+
+=== create with aliases
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] registered-models get mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME].my-registered-model-[UNIQUE_NAME] --include-aliases
+{
+  "aliases": [
+    {
+      "alias_name": "champion",
+      "version_num": 1
+    },
+    {
+      "alias_name": "staging",
+      "version_num": 2
+    }
+  ]
+}
+
+=== redeploy unchanged (idempotence check)
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== update: modify champion version, remove staging, add latest
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] registered-models get mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME].my-registered-model-[UNIQUE_NAME] --include-aliases
+{
+  "aliases": [
+    {
+      "alias_name": "champion",
+      "version_num": 5
+    },
+    {
+      "alias_name": "latest",
+      "version_num": 3
+    }
+  ]
+}
+
+=== remove all aliases
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> [CLI] registered-models get mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME].my-registered-model-[UNIQUE_NAME] --include-aliases
+{
+  "aliases": []
+}
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.registered_models.my_registered_model
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!
+
+>>> [CLI] schemas delete mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME] --force
+
+>>> [CLI] catalogs delete mycatalog-[UNIQUE_NAME] --force

--- a/acceptance/bundle/resources/registered_models/aliases/output.txt
+++ b/acceptance/bundle/resources/registered_models/aliases/output.txt
@@ -1,0 +1,90 @@
+
+>>> export NAME=my-registered-model-[UNIQUE_NAME]
+
+>>> export COMMENT=test model
+
+>>> export CATALOG_NAME=mycatalog-[UNIQUE_NAME]
+
+>>> export SCHEMA_NAME=myschema-[UNIQUE_NAME]
+
+>>> [CLI] catalogs create mycatalog-[UNIQUE_NAME]
+{
+  "full_name": "mycatalog-[UNIQUE_NAME]"
+}
+
+>>> [CLI] schemas create myschema-[UNIQUE_NAME] mycatalog-[UNIQUE_NAME]
+{
+  "full_name": "mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME]"
+}
+
+=== create with aliases
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Created registered_models.my_registered_model
+Files: 6 uploaded, 0 deleted
+Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] registered-models get mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME].my-registered-model-[UNIQUE_NAME] --include-aliases
+{
+  "aliases": [
+    {
+      "alias_name": "champion",
+      "version_num": 1
+    },
+    {
+      "alias_name": "staging",
+      "version_num": 2
+    }
+  ]
+}
+
+=== redeploy unchanged (idempotence check)
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Files: 1 uploaded, 0 deleted
+Resources: 0 created, 0 changed, 0 deleted, 1 unchanged
+
+=== update: modify champion version, remove staging, add latest
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Updated registered_models.my_registered_model
+Files: 2 uploaded, 0 deleted
+Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] registered-models get mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME].my-registered-model-[UNIQUE_NAME] --include-aliases
+{
+  "aliases": [
+    {
+      "alias_name": "champion",
+      "version_num": 5
+    },
+    {
+      "alias_name": "latest",
+      "version_num": 3
+    }
+  ]
+}
+
+=== remove all aliases
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default/files...
+Updated registered_models.my_registered_model
+Files: 2 uploaded, 0 deleted
+Resources: 0 created, 1 changed, 0 deleted, 0 unchanged
+
+>>> [CLI] registered-models get mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME].my-registered-model-[UNIQUE_NAME] --include-aliases
+{
+  "aliases": []
+}
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.registered_models.my_registered_model
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-registered-models-aliases-[UNIQUE_NAME]/default
+
+Destroy: 1 deleted
+
+>>> [CLI] schemas delete mycatalog-[UNIQUE_NAME].myschema-[UNIQUE_NAME] --force
+
+>>> [CLI] catalogs delete mycatalog-[UNIQUE_NAME] --force

--- a/acceptance/bundle/resources/registered_models/aliases/script
+++ b/acceptance/bundle/resources/registered_models/aliases/script
@@ -1,0 +1,47 @@
+trace export NAME="my-registered-model-$UNIQUE_NAME"
+trace export COMMENT="test model"
+trace export CATALOG_NAME="mycatalog-${UNIQUE_NAME}"
+trace export SCHEMA_NAME="myschema-${UNIQUE_NAME}"
+envsubst < databricks.yml.tmpl > databricks.yml
+
+trace $CLI catalogs create ${CATALOG_NAME} | jq '{full_name}'
+trace $CLI schemas create ${SCHEMA_NAME} ${CATALOG_NAME} | jq '{full_name}'
+
+# Append aliases to the config.
+cat >> databricks.yml <<'YAML'
+      aliases:
+        - alias_name: champion
+          version_num: 1
+        - alias_name: staging
+          version_num: 2
+YAML
+
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+    trace $CLI schemas delete ${CATALOG_NAME}.${SCHEMA_NAME} --force
+    trace $CLI catalogs delete ${CATALOG_NAME} --force
+}
+trap cleanup EXIT
+
+deploy_and_get_aliases() {
+    trace $CLI bundle deploy
+    registered_model_id=$($CLI bundle summary --output json | jq -r '.resources.registered_models.my_registered_model.id')
+    trace $CLI registered-models get "${registered_model_id}" --include-aliases | jq '{aliases: [.aliases[]? | {alias_name, version_num}] | sort_by(.alias_name)}'
+}
+
+title "create with aliases"
+deploy_and_get_aliases
+
+title "redeploy unchanged (idempotence check)"
+trace $CLI bundle deploy
+
+title "update: modify champion version, remove staging, add latest"
+update_file.py databricks.yml "version_num: 1" "version_num: 5"
+update_file.py databricks.yml "staging" "latest"
+update_file.py databricks.yml "version_num: 2" "version_num: 3"
+deploy_and_get_aliases
+
+title "remove all aliases"
+# Replace the aliases block with no aliases.
+envsubst < databricks.yml.tmpl > databricks.yml
+deploy_and_get_aliases

--- a/acceptance/bundle/resources/registered_models/aliases/test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases/test.toml
@@ -1,0 +1,5 @@
+Cloud = true
+Local = true
+RecordRequests = false
+RunsOnDbr = true
+RequiresUnityCatalog = true

--- a/acceptance/bundle/resources/registered_models/aliases/test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases/test.toml
@@ -1,0 +1,8 @@
+Cloud = true
+RecordRequests = false
+RunsOnDbr = true
+RequiresUnityCatalog = true
+
+# Alias syncing via SetAlias/DeleteAlias lives in the direct engine; the
+# terraform provider does not apply aliases, so scope this test there.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/registered_models/aliases_converge/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/databricks.yml.tmpl
@@ -8,9 +8,9 @@ resources:
       comment: $COMMENT
       catalog_name: main
       schema_name: default
-      # Aliases live on model versions and GET does not echo them back
-      # (DoRead uses IncludeAliases=false), so a config that sets them used to
-      # report a perpetual in-place update and never converge.
+      # Aliases are synced via SetAlias/DeleteAlias and read back with
+      # IncludeAliases=true; a config that sets them must converge instead of
+      # reporting a perpetual in-place update.
       aliases:
         - alias_name: champion
-          id: alias-champion
+          version_num: 1

--- a/acceptance/bundle/resources/registered_models/aliases_converge/output.txt
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/output.txt
@@ -8,28 +8,20 @@ Created registered_models.my_registered_model
 Files: 0 uploaded, 0 deleted
 Resources: 1 created, 0 changed, 0 deleted, 0 unchanged
 
-=== Plan is a no-op: GET never echoes aliases, so they must not drift
->>> [CLI] bundle plan
-Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
-
-=== The config-set aliases are skipped as input_only (confirms the matched rule)
->>> [CLI] bundle plan --output json
+=== Aliases are applied to the model
+>>> [CLI] registered-models get main.default.my-registered-model-aliases-[UNIQUE_NAME] --include-aliases
 {
-  "action": "skip",
-  "reason": "input_only",
-  "old": [
+  "aliases": [
     {
       "alias_name": "champion",
-      "id": "alias-champion"
-    }
-  ],
-  "new": [
-    {
-      "alias_name": "champion",
-      "id": "alias-champion"
+      "version_num": 1
     }
   ]
 }
+
+=== Plan is a no-op: GET echoes the synced aliases, so they must not drift
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
 
 === Edit the comment: an in-place update, not a recreate
 >>> [CLI] bundle plan

--- a/acceptance/bundle/resources/registered_models/aliases_converge/script
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/script
@@ -11,11 +11,11 @@ trap cleanup EXIT
 title "Initial deployment with aliases set"
 trace $CLI bundle deploy
 
-title "Plan is a no-op: GET never echoes aliases, so they must not drift"
-trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
+title "Aliases are applied to the model"
+trace $CLI registered-models get "main.default.my-registered-model-aliases-${UNIQUE_NAME}" --include-aliases | jq '{aliases: [.aliases[] | {alias_name, version_num}]}'
 
-title "The config-set aliases are skipped as input_only (confirms the matched rule)"
-trace $CLI bundle plan --output json | jq '.plan[].changes.aliases'
+title "Plan is a no-op: GET echoes the synced aliases, so they must not drift"
+trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
 
 title "Edit the comment: an in-place update, not a recreate"
 export COMMENT="updated comment"

--- a/acceptance/bundle/resources/registered_models/aliases_converge/test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/test.toml
@@ -1,5 +1,5 @@
 RecordRequests = false
 
-# The aliases input_only classification lives in the direct engine, so scope
+# Alias syncing via SetAlias/DeleteAlias lives in the direct engine, so scope
 # this regression there.
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/bundle/direct/dresources/registered_model.go
+++ b/bundle/direct/dresources/registered_model.go
@@ -4,10 +4,15 @@ import (
 	"context"
 
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/databricks/cli/libs/utils"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"golang.org/x/sync/errgroup"
 )
+
+// Precalculated paths for HasChange checks.
+var pathAliases = structpath.MustParsePath("aliases")
 
 type ResourceRegisteredModel struct {
 	client *databricks.WorkspaceClient
@@ -16,6 +21,16 @@ type ResourceRegisteredModel struct {
 func (*ResourceRegisteredModel) New(client *databricks.WorkspaceClient) *ResourceRegisteredModel {
 	return &ResourceRegisteredModel{
 		client: client,
+	}
+}
+
+func getAliasKey(a catalog.RegisteredModelAlias) (string, string) {
+	return "alias_name", a.AliasName
+}
+
+func (*ResourceRegisteredModel) KeyedSlices() map[string]any {
+	return map[string]any{
+		"aliases": getAliasKey,
 	}
 }
 
@@ -49,7 +64,7 @@ func (*ResourceRegisteredModel) RemapState(model *catalog.RegisteredModelInfo) *
 func (r *ResourceRegisteredModel) DoRead(ctx context.Context, id string) (*catalog.RegisteredModelInfo, error) {
 	return r.client.RegisteredModels.Get(ctx, catalog.GetRegisteredModelRequest{
 		FullName:        id,
-		IncludeAliases:  false,
+		IncludeAliases:  true,
 		IncludeBrowse:   false,
 		ForceSendFields: nil,
 	})
@@ -64,7 +79,17 @@ func (r *ResourceRegisteredModel) DoCreate(ctx context.Context, config *catalog.
 	return response.FullName, response, nil
 }
 
-func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, config *catalog.CreateRegisteredModelRequest, _ Changes) (*catalog.RegisteredModelInfo, error) {
+// WaitAfterCreate syncs aliases after the model is created and state is saved.
+// The Create API does not apply aliases, so we sync them separately.
+func (r *ResourceRegisteredModel) WaitAfterCreate(ctx context.Context, config *catalog.CreateRegisteredModelRequest) (*catalog.RegisteredModelInfo, error) {
+	fullName := config.CatalogName + "." + config.SchemaName + "." + config.Name
+	if err := r.syncAliases(ctx, fullName, config.Aliases, []catalog.RegisteredModelAlias{}); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, config *catalog.CreateRegisteredModelRequest, changes Changes) (*catalog.RegisteredModelInfo, error) {
 	updateRequest := catalog.UpdateRegisteredModelRequest{
 		FullName:        id,
 		Comment:         config.Comment,
@@ -77,7 +102,9 @@ func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, confi
 		// Note: TF also does not support changing name without a recreate so the current behavior matches TF.
 		NewName: "",
 
-		Aliases:         config.Aliases,
+		// Aliases are synced separately via SetAlias/DeleteAlias calls because
+		// the Update API ignores the Aliases field.
+		Aliases:         nil,
 		BrowseOnly:      config.BrowseOnly,
 		CreatedAt:       config.CreatedAt,
 		CreatedBy:       config.CreatedBy,
@@ -95,6 +122,12 @@ func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, confi
 		return nil, err
 	}
 
+	if changes.HasChange(pathAliases) {
+		if err := r.syncAliases(ctx, id, config.Aliases, nil); err != nil {
+			return nil, err
+		}
+	}
+
 	return response, nil
 }
 
@@ -102,4 +135,64 @@ func (r *ResourceRegisteredModel) DoDelete(ctx context.Context, id string) error
 	return r.client.RegisteredModels.Delete(ctx, catalog.DeleteRegisteredModelRequest{
 		FullName: id,
 	})
+}
+
+// syncAliases compares desired and current aliases and calls SetAlias/DeleteAlias
+// APIs to reconcile the difference. The Update API ignores the Aliases field,
+// so separate API calls are required.
+// If current is nil, the current aliases are fetched from the remote.
+func (r *ResourceRegisteredModel) syncAliases(ctx context.Context, fullName string, desired, current []catalog.RegisteredModelAlias) error {
+	if current == nil {
+		remote, err := r.client.RegisteredModels.Get(ctx, catalog.GetRegisteredModelRequest{
+			FullName:        fullName,
+			IncludeAliases:  true,
+			IncludeBrowse:   false,
+			ForceSendFields: nil,
+		})
+		if err != nil {
+			return err
+		}
+		current = remote.Aliases
+	}
+
+	desiredByName := make(map[string]int, len(desired))
+	for _, a := range desired {
+		desiredByName[a.AliasName] = a.VersionNum
+	}
+
+	currentByName := make(map[string]int, len(current))
+	for _, a := range current {
+		currentByName[a.AliasName] = a.VersionNum
+	}
+
+	var eg errgroup.Group
+
+	// Set new or updated aliases.
+	for name, version := range desiredByName {
+		if v, ok := currentByName[name]; ok && v == version {
+			continue
+		}
+		eg.Go(func() error {
+			_, err := r.client.RegisteredModels.SetAlias(ctx, catalog.SetRegisteredModelAliasRequest{
+				FullName:   fullName,
+				Alias:      name,
+				VersionNum: version,
+			})
+			return err
+		})
+	}
+
+	// Delete removed aliases.
+	for name := range currentByName {
+		if _, ok := desiredByName[name]; !ok {
+			eg.Go(func() error {
+				return r.client.RegisteredModels.DeleteAlias(ctx, catalog.DeleteAliasRequest{
+					FullName: fullName,
+					Alias:    name,
+				})
+			})
+		}
+	}
+
+	return eg.Wait()
 }

--- a/bundle/direct/dresources/registered_model.go
+++ b/bundle/direct/dresources/registered_model.go
@@ -2,12 +2,17 @@ package dresources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/databricks/cli/libs/utils"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
+
+// Precalculated paths for HasChange checks.
+var pathAliases = structpath.MustParsePath("aliases")
 
 type ResourceRegisteredModel struct {
 	client *databricks.WorkspaceClient
@@ -16,6 +21,16 @@ type ResourceRegisteredModel struct {
 func (*ResourceRegisteredModel) New(client *databricks.WorkspaceClient) *ResourceRegisteredModel {
 	return &ResourceRegisteredModel{
 		client: client,
+	}
+}
+
+func getAliasKey(a catalog.RegisteredModelAlias) (string, string) {
+	return "alias_name", a.AliasName
+}
+
+func (*ResourceRegisteredModel) KeyedSlices() map[string]any {
+	return map[string]any{
+		"aliases": getAliasKey,
 	}
 }
 
@@ -50,7 +65,7 @@ func (*ResourceRegisteredModel) RemapState(model *catalog.RegisteredModelInfo) *
 func (r *ResourceRegisteredModel) DoRead(ctx context.Context, id string) (*catalog.RegisteredModelInfo, error) {
 	return r.client.RegisteredModels.Get(ctx, catalog.GetRegisteredModelRequest{
 		FullName:        id,
-		IncludeAliases:  false,
+		IncludeAliases:  true,
 		IncludeBrowse:   false,
 		ForceSendFields: nil,
 	})
@@ -65,7 +80,14 @@ func (r *ResourceRegisteredModel) DoCreate(ctx context.Context, config *catalog.
 	return response.FullName, response, nil
 }
 
-func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, config *catalog.CreateRegisteredModelRequest, _ *PlanEntry) (*catalog.RegisteredModelInfo, error) {
+// WaitAfterCreate syncs aliases after the model is created and state is saved.
+// The Create API does not apply aliases, so we sync them separately.
+func (r *ResourceRegisteredModel) WaitAfterCreate(ctx context.Context, id string, config *catalog.CreateRegisteredModelRequest) (*catalog.RegisteredModelInfo, error) {
+	// The model was just created, so there are no current aliases.
+	return nil, r.syncAliases(ctx, id, config.Aliases, nil)
+}
+
+func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, config *catalog.CreateRegisteredModelRequest, entry *PlanEntry) (*catalog.RegisteredModelInfo, error) {
 	updateRequest := catalog.UpdateRegisteredModelRequest{
 		FullName:        id,
 		Comment:         config.Comment,
@@ -78,7 +100,9 @@ func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, confi
 		// Note: TF also does not support changing name without a recreate so the current behavior matches TF.
 		NewName: "",
 
-		Aliases:         config.Aliases,
+		// Aliases are synced separately via SetAlias/DeleteAlias calls because
+		// the Update API ignores the Aliases field.
+		Aliases:         nil,
 		BrowseOnly:      config.BrowseOnly,
 		CreatedAt:       config.CreatedAt,
 		CreatedBy:       config.CreatedBy,
@@ -96,6 +120,18 @@ func (r *ResourceRegisteredModel) DoUpdate(ctx context.Context, id string, confi
 		return nil, err
 	}
 
+	if entry.Changes.HasChange(pathAliases) {
+		// The planner read the remote state with IncludeAliases=true, so the
+		// current aliases come from the plan entry instead of a second GET.
+		remote, ok := entry.RemoteState.(*catalog.RegisteredModelInfo)
+		if !ok {
+			return nil, fmt.Errorf("internal error: unexpected remote state type %T", entry.RemoteState)
+		}
+		if err := r.syncAliases(ctx, id, config.Aliases, remote.Aliases); err != nil {
+			return nil, err
+		}
+	}
+
 	return response, nil
 }
 
@@ -103,4 +139,49 @@ func (r *ResourceRegisteredModel) DoDelete(ctx context.Context, id string, _ *ca
 	return r.client.RegisteredModels.Delete(ctx, catalog.DeleteRegisteredModelRequest{
 		FullName: id,
 	})
+}
+
+// syncAliases diffs desired against current aliases and calls SetAlias/DeleteAlias
+// to reconcile the difference. The Create and Update APIs ignore the Aliases field,
+// so separate API calls are required.
+func (r *ResourceRegisteredModel) syncAliases(ctx context.Context, fullName string, desired, current []catalog.RegisteredModelAlias) error {
+	desiredByName := make(map[string]int, len(desired))
+	for _, a := range desired {
+		desiredByName[a.AliasName] = a.VersionNum
+	}
+
+	currentByName := make(map[string]int, len(current))
+	for _, a := range current {
+		currentByName[a.AliasName] = a.VersionNum
+	}
+
+	// Set new or updated aliases.
+	for _, a := range desired {
+		if v, ok := currentByName[a.AliasName]; ok && v == a.VersionNum {
+			continue
+		}
+		_, err := r.client.RegisteredModels.SetAlias(ctx, catalog.SetRegisteredModelAliasRequest{
+			FullName:   fullName,
+			Alias:      a.AliasName,
+			VersionNum: a.VersionNum,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// Delete removed aliases.
+	for _, a := range current {
+		if _, ok := desiredByName[a.AliasName]; !ok {
+			err := r.client.RegisteredModels.DeleteAlias(ctx, catalog.DeleteAliasRequest{
+				FullName: fullName,
+				Alias:    a.AliasName,
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/bundle/direct/dresources/registered_model_test.go
+++ b/bundle/direct/dresources/registered_model_test.go
@@ -1,0 +1,110 @@
+package dresources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRegisteredModelTest(t *testing.T) *ResourceRegisteredModel {
+	server := testserver.New(t)
+	testserver.AddDefaultHandlers(server)
+
+	client, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:  server.URL,
+		Token: "testtoken",
+	})
+	require.NoError(t, err)
+
+	return (&ResourceRegisteredModel{}).New(client)
+}
+
+func TestSyncAliases_AddsNewAliases(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+	ctx := context.Background()
+
+	config := &catalog.CreateRegisteredModelRequest{
+		Name: "my_model", CatalogName: "main", SchemaName: "default",
+		Aliases: []catalog.RegisteredModelAlias{
+			{AliasName: "champion", VersionNum: 1},
+			{AliasName: "staging", VersionNum: 2},
+		},
+	}
+	id, _, err := r.DoCreate(ctx, config)
+	require.NoError(t, err)
+
+	_, err = r.WaitAfterCreate(ctx, config)
+	require.NoError(t, err)
+
+	remote, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+	assert.Len(t, remote.Aliases, 2)
+
+	m := aliasMap(remote.Aliases)
+	assert.Equal(t, 1, m["champion"])
+	assert.Equal(t, 2, m["staging"])
+}
+
+func TestSyncAliases_UpdatesAndDeletesAliases(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+	ctx := context.Background()
+
+	id, _, err := r.DoCreate(ctx, &catalog.CreateRegisteredModelRequest{
+		Name: "my_model", CatalogName: "main", SchemaName: "default",
+		Aliases: []catalog.RegisteredModelAlias{
+			{AliasName: "champion", VersionNum: 1},
+			{AliasName: "staging", VersionNum: 2},
+		},
+	})
+	require.NoError(t, err)
+
+	// Modify champion version, remove staging, add latest.
+	err = r.syncAliases(ctx, id, []catalog.RegisteredModelAlias{
+		{AliasName: "champion", VersionNum: 5},
+		{AliasName: "latest", VersionNum: 3},
+	}, nil)
+	require.NoError(t, err)
+
+	remote, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+	assert.Len(t, remote.Aliases, 2)
+
+	m := aliasMap(remote.Aliases)
+	assert.Equal(t, 5, m["champion"])
+	assert.Equal(t, 3, m["latest"])
+	_, hasStaging := m["staging"]
+	assert.False(t, hasStaging)
+}
+
+func TestSyncAliases_RemovesAllAliases(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+	ctx := context.Background()
+
+	id, _, err := r.DoCreate(ctx, &catalog.CreateRegisteredModelRequest{
+		Name: "my_model", CatalogName: "main", SchemaName: "default",
+		Aliases: []catalog.RegisteredModelAlias{
+			{AliasName: "champion", VersionNum: 1},
+		},
+	})
+	require.NoError(t, err)
+
+	err = r.syncAliases(ctx, id, nil, nil)
+	require.NoError(t, err)
+
+	remote, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+	assert.Empty(t, remote.Aliases)
+}
+
+func aliasMap(aliases []catalog.RegisteredModelAlias) map[string]int {
+	m := make(map[string]int, len(aliases))
+	for _, a := range aliases {
+		m[a.AliasName] = a.VersionNum
+	}
+	return m
+}

--- a/bundle/direct/dresources/registered_model_test.go
+++ b/bundle/direct/dresources/registered_model_test.go
@@ -1,0 +1,134 @@
+package dresources
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRegisteredModelTest(t *testing.T) *ResourceRegisteredModel {
+	server := testserver.New(t)
+	testserver.AddDefaultHandlers(server)
+
+	client, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:  server.URL,
+		Token: "testtoken",
+	})
+	require.NoError(t, err)
+
+	return (&ResourceRegisteredModel{}).New(client)
+}
+
+func createRegisteredModelWithAliases(t *testing.T, r *ResourceRegisteredModel, aliases []catalog.RegisteredModelAlias) (string, *catalog.CreateRegisteredModelRequest) {
+	ctx := t.Context()
+	config := &catalog.CreateRegisteredModelRequest{
+		Name: "my_model", CatalogName: "main", SchemaName: "default",
+		Aliases: aliases,
+	}
+	id, _, err := r.DoCreate(ctx, config)
+	require.NoError(t, err)
+
+	_, err = r.WaitAfterCreate(ctx, id, config)
+	require.NoError(t, err)
+
+	return id, config
+}
+
+func TestRegisteredModelWaitAfterCreateSyncsAliases(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+
+	id, _ := createRegisteredModelWithAliases(t, r, []catalog.RegisteredModelAlias{
+		{AliasName: "champion", VersionNum: 1},
+		{AliasName: "staging", VersionNum: 2},
+	})
+
+	remote, err := r.DoRead(t.Context(), id)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{"champion": 1, "staging": 2}, aliasMap(remote.Aliases))
+}
+
+func TestRegisteredModelDoUpdateSyncsChangedAliases(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+	ctx := t.Context()
+
+	id, config := createRegisteredModelWithAliases(t, r, []catalog.RegisteredModelAlias{
+		{AliasName: "champion", VersionNum: 1},
+		{AliasName: "staging", VersionNum: 2},
+	})
+
+	remoteBefore, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+
+	// Modify champion version, remove staging, add latest.
+	config.Aliases = []catalog.RegisteredModelAlias{
+		{AliasName: "champion", VersionNum: 5},
+		{AliasName: "latest", VersionNum: 3},
+	}
+	_, err = r.DoUpdate(ctx, id, config, &PlanEntry{
+		Changes:     Changes{"aliases": &ChangeDesc{Action: deployplan.Update}},
+		RemoteState: remoteBefore,
+	})
+	require.NoError(t, err)
+
+	remote, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{"champion": 5, "latest": 3}, aliasMap(remote.Aliases))
+}
+
+func TestRegisteredModelDoUpdateRemovesAllAliases(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+	ctx := t.Context()
+
+	id, config := createRegisteredModelWithAliases(t, r, []catalog.RegisteredModelAlias{
+		{AliasName: "champion", VersionNum: 1},
+	})
+
+	remoteBefore, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+
+	config.Aliases = nil
+	_, err = r.DoUpdate(ctx, id, config, &PlanEntry{
+		Changes:     Changes{"aliases": &ChangeDesc{Action: deployplan.Update}},
+		RemoteState: remoteBefore,
+	})
+	require.NoError(t, err)
+
+	remote, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+	assert.Empty(t, remote.Aliases)
+}
+
+func TestRegisteredModelDoUpdateSkipsAliasSyncWhenUnchanged(t *testing.T) {
+	r := setupRegisteredModelTest(t)
+	ctx := t.Context()
+
+	id, config := createRegisteredModelWithAliases(t, r, []catalog.RegisteredModelAlias{
+		{AliasName: "champion", VersionNum: 1},
+	})
+
+	// No "aliases" entry in Changes: DoUpdate must not touch aliases even
+	// though the config differs from remote.
+	config.Aliases = nil
+	config.Comment = "updated"
+	_, err := r.DoUpdate(ctx, id, config, &PlanEntry{
+		Changes: Changes{"comment": &ChangeDesc{Action: deployplan.Update}},
+	})
+	require.NoError(t, err)
+
+	remote, err := r.DoRead(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{"champion": 1}, aliasMap(remote.Aliases))
+}
+
+func aliasMap(aliases []catalog.RegisteredModelAlias) map[string]int {
+	m := make(map[string]int, len(aliases))
+	for _, a := range aliases {
+		m[a.AliasName] = a.VersionNum
+	}
+	return m
+}

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -394,11 +394,16 @@ resources:
         reason: output_only
       - field: updated_by
         reason: output_only
-      # Aliases are managed on model versions through a separate API, and DoRead
-      # passes IncludeAliases=false, so GET never echoes them back. Without this a
-      # config that sets aliases reports a perpetual update (remote stays empty).
-      - field: aliases
-        reason: input_only
+      # Output-only alias fields populated by the backend on read; the user
+      # only sets alias_name and version_num.
+      - field: aliases[*].id
+        reason: output_only
+      - field: aliases[*].catalog_name
+        reason: output_only
+      - field: aliases[*].model_name
+        reason: output_only
+      - field: aliases[*].schema_name
+        reason: output_only
     provided_id_fields:
       # The name can technically be updated without recreate. We recreate for now though
       # to match TF implementation.

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -485,6 +485,14 @@ func AddDefaultHandlers(server *Server) {
 		return MapDelete(req.Workspace, req.Workspace.RegisteredModels, req.Vars["full_name"])
 	})
 
+	server.Handle("PUT", "/api/2.1/unity-catalog/models/{full_name}/aliases/{alias}", func(req Request) any {
+		return req.Workspace.RegisteredModelsSetAlias(req, req.Vars["full_name"], req.Vars["alias"])
+	})
+
+	server.Handle("DELETE", "/api/2.1/unity-catalog/models/{full_name}/aliases/{alias}", func(req Request) any {
+		return req.Workspace.RegisteredModelsDeleteAlias(req.Vars["full_name"], req.Vars["alias"])
+	})
+
 	// Volumes:
 
 	server.Handle("GET", "/api/2.1/unity-catalog/volumes/{full_name}", func(req Request) any {

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -602,6 +602,14 @@ func AddDefaultHandlers(server *Server) {
 		return MapDelete(req.Workspace, req.Workspace.RegisteredModels, req.Vars["full_name"])
 	})
 
+	server.Handle("PUT", "/api/2.1/unity-catalog/models/{full_name}/aliases/{alias}", func(req Request) any {
+		return req.Workspace.RegisteredModelsSetAlias(req, req.Vars["full_name"], req.Vars["alias"])
+	})
+
+	server.Handle("DELETE", "/api/2.1/unity-catalog/models/{full_name}/aliases/{alias}", func(req Request) any {
+		return req.Workspace.RegisteredModelsDeleteAlias(req.Vars["full_name"], req.Vars["alias"])
+	})
+
 	// Volumes:
 
 	server.Handle("GET", "/api/2.1/unity-catalog/volumes/{full_name}", func(req Request) any {

--- a/libs/testserver/registered_models.go
+++ b/libs/testserver/registered_models.go
@@ -83,3 +83,68 @@ func (s *FakeWorkspace) RegisteredModelsUpdate(req Request, fullName string) Res
 		Body: existing,
 	}
 }
+
+func (s *FakeWorkspace) RegisteredModelsSetAlias(req Request, fullName, alias string) Response {
+	defer s.LockUnlock()()
+
+	existing, ok := s.RegisteredModels[fullName]
+	if !ok {
+		return Response{
+			StatusCode: http.StatusNotFound,
+			Body:       fmt.Sprintf("registered model %s not found", fullName),
+		}
+	}
+
+	var setRequest catalog.SetRegisteredModelAliasRequest
+	if err := json.Unmarshal(req.Body, &setRequest); err != nil {
+		return Response{
+			Body:       fmt.Sprintf("internal error: %s", err),
+			StatusCode: http.StatusInternalServerError,
+		}
+	}
+
+	newAlias := catalog.RegisteredModelAlias{
+		AliasName:  alias,
+		VersionNum: setRequest.VersionNum,
+	}
+
+	// Update existing alias or append new one.
+	found := false
+	for i, a := range existing.Aliases {
+		if a.AliasName == alias {
+			existing.Aliases[i] = newAlias
+			found = true
+			break
+		}
+	}
+	if !found {
+		existing.Aliases = append(existing.Aliases, newAlias)
+	}
+
+	s.RegisteredModels[fullName] = existing
+	return Response{
+		Body: newAlias,
+	}
+}
+
+func (s *FakeWorkspace) RegisteredModelsDeleteAlias(fullName, alias string) Response {
+	defer s.LockUnlock()()
+
+	existing, ok := s.RegisteredModels[fullName]
+	if !ok {
+		return Response{
+			StatusCode: http.StatusNotFound,
+			Body:       fmt.Sprintf("registered model %s not found", fullName),
+		}
+	}
+
+	for i, a := range existing.Aliases {
+		if a.AliasName == alias {
+			existing.Aliases = append(existing.Aliases[:i], existing.Aliases[i+1:]...)
+			break
+		}
+	}
+
+	s.RegisteredModels[fullName] = existing
+	return Response{}
+}

--- a/libs/testserver/registered_models.go
+++ b/libs/testserver/registered_models.go
@@ -91,3 +91,68 @@ func (s *FakeWorkspace) RegisteredModelsUpdate(req Request, fullName string) Res
 		Body: existing,
 	}
 }
+
+func (s *FakeWorkspace) RegisteredModelsSetAlias(req Request, fullName, alias string) Response {
+	defer s.LockUnlock()()
+
+	existing, ok := s.RegisteredModels[fullName]
+	if !ok {
+		return Response{
+			StatusCode: http.StatusNotFound,
+			Body:       fmt.Sprintf("registered model %s not found", fullName),
+		}
+	}
+
+	var setRequest catalog.SetRegisteredModelAliasRequest
+	if err := json.Unmarshal(req.Body, &setRequest); err != nil {
+		return Response{
+			Body:       fmt.Sprintf("internal error: %s", err),
+			StatusCode: http.StatusInternalServerError,
+		}
+	}
+
+	newAlias := catalog.RegisteredModelAlias{
+		AliasName:  alias,
+		VersionNum: setRequest.VersionNum,
+	}
+
+	// Update existing alias or append new one.
+	found := false
+	for i, a := range existing.Aliases {
+		if a.AliasName == alias {
+			existing.Aliases[i] = newAlias
+			found = true
+			break
+		}
+	}
+	if !found {
+		existing.Aliases = append(existing.Aliases, newAlias)
+	}
+
+	s.RegisteredModels[fullName] = existing
+	return Response{
+		Body: newAlias,
+	}
+}
+
+func (s *FakeWorkspace) RegisteredModelsDeleteAlias(fullName, alias string) Response {
+	defer s.LockUnlock()()
+
+	existing, ok := s.RegisteredModels[fullName]
+	if !ok {
+		return Response{
+			StatusCode: http.StatusNotFound,
+			Body:       fmt.Sprintf("registered model %s not found", fullName),
+		}
+	}
+
+	for i, a := range existing.Aliases {
+		if a.AliasName == alias {
+			existing.Aliases = append(existing.Aliases[:i], existing.Aliases[i+1:]...)
+			break
+		}
+	}
+
+	s.RegisteredModels[fullName] = existing
+	return Response{}
+}


### PR DESCRIPTION
Fixes https://github.com/databricks/cli/issues/4012

## Summary
- The Update API ignores the `aliases` field on registered models, so aliases defined in bundle config were silently not applied in direct deployment mode.
- Sync aliases after create/update using explicit `SetAlias`/`DeleteAlias` API calls.
- Enable `IncludeAliases` on read so drift detection picks up alias changes.

## Test plan
- [x] Unit tests for create with aliases, update add/modify/delete aliases, remove all aliases, and no-op when unchanged
- [x] Existing `TestAll/registered_models` CRUD test passes