### PR TITLE
gitattributes: use union merge strategy for NEXT_CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+NEXT_CHANGELOG.md merge=union
 cmd/account/access-control/access-control.go linguist-generated=true
 cmd/account/billable-usage/billable-usage.go linguist-generated=true
 cmd/account/budget-policy/budget-policy.go linguist-generated=true


### PR DESCRIPTION
## Why

This prevents merge conflicts when multiple branches each add an entry to NEXT_CHANGELOG.md at the same location.

## Tests

Manually by creating two conflicting branches and doing git merge & rebase.