### PR TITLE
acc: Require Unity Catalog for config-remote-sync/multiple_resources test

### DIFF
--- a/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 
 [GOOS]
   windows = false

--- a/acceptance/bundle/config-remote-sync/multiple_resources/test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/test.toml
@@ -1,4 +1,5 @@
 Cloud = true
+RequiresUnityCatalog = true
 
 RecordRequests = false
 Ignore = [".databricks", "dummy.whl", "databricks.yml", "databricks.yml.backup"]


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

The test deploys registered_models and volumes which require a UC metastore, so it should not run on non-UCWS environments.


## Tests
<!-- How have you tested the changes? -->

Existing tests should pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
