### PR TITLE
SSH: refactor Jupyter init script to use better Spark session initialization flow

### DIFF
--- a/experimental/ssh/internal/server/jupyter-init.py
+++ b/experimental/ssh/internal/server/jupyter-init.py
@@ -191,6 +191,7 @@ def _register_formatters():
 
 def _create_spark_session(builder_fn):
     from databricks.connect import DatabricksSession
+
     user_ns = get_ipython().user_ns
     existing_session = user_ns.get("spark")
     # Clear the existing local spark session, otherwise DatabricksSession will re-use it.
@@ -210,11 +211,13 @@ def _initialize_spark(is_serverless: bool, existing_spark: any):
         return _create_spark_session(lambda b: b.serverless(True))
     # On dedicated or standard initialize a new remote session if the existing spark session is local.
     if existing_spark is None or isinstance(existing_spark, SparkSession):
-        return _create_spark_session(lambda b: b.remote(
-            host=os.environ["DATABRICKS_HOST"],
-            token=os.environ["DATABRICKS_TOKEN"],
-            cluster_id=os.environ["DATABRICKS_CLUSTER_ID"],
-        ))
+        return _create_spark_session(
+            lambda b: b.remote(
+                host=os.environ["DATABRICKS_HOST"],
+                token=os.environ["DATABRICKS_TOKEN"],
+                cluster_id=os.environ["DATABRICKS_CLUSTER_ID"],
+            )
+        )
     # Otherwise re-use the existing remote session.
     return existing_spark
 


### PR DESCRIPTION
## Changes
* Always use UserNamespaceInitializer do initialize global jupyter variables (sql, table, display, etc), even in serverless context.
* Always use Databricks Connect to initialize spark, even on dedicated clusters (where we point it to the cluster itself). 

## Why
We've had different path for serverless spark before, where we didn't use UserNamespaceInitializer, which was not ideal, since the global jupyter scope for serverless and dedicated was different because of that.

The reason to use Databricks Connect on dedicated cluster is to expose the same spark connect API in all environments, avoiding compatibility issues. Local spark has access to some internal jvm APIs, which are not available in spark connect mode, but the rest is the same.



## Tests
Manually and existing e2e tests
