### PR TITLE
Fix the TestImportFileFormatSource integration test

### DIFF
--- a/integration/cmd/workspace/workspace_test.go
+++ b/integration/cmd/workspace/workspace_test.go
@@ -377,6 +377,7 @@ func TestImportFileFormatSource(t *testing.T) {
 	assertFilerFileContents(t, ctx, workspaceFiler, "scalaNotebook", "// Databricks notebook source\nprintln(\"scala\")")
 	assertWorkspaceFileType(t, ctx, workspaceFiler, "scalaNotebook", workspace.ObjectTypeNotebook)
 
+	// Upload a non-zip archive without a specifying a format: expect API to throw an error that the uploaded item is not a zip archive
 	_, _, err := testcli.RequireErrorRun(t, ctx, "workspace", "import", path.Join(targetDir, "scalaNotebook-error"), "--file", "./testdata/import_dir/scalaNotebook.scala")
 	assert.ErrorContains(t, err, "The zip archive contains no items.")
 }


### PR DESCRIPTION
## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

The backend API has apparently changed:
- it does not allow to import with an existing object's name
- it prints a shorter error message if the format is not specified and the file is not proper zip archive

## Tests
<!-- How have you tested the changes? -->

Tested agains a cloud environment and saw it passes

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
