### PR TITLE
Remove nil context fallback from libs/log

### DIFF
--- a/libs/log/logger.go
+++ b/libs/log/logger.go
@@ -24,9 +24,6 @@ func log(ctx context.Context, logger *slog.Logger, level slog.Level, msg string)
 	// skip [runtime.Callers, this function, this function's caller].
 	runtime.Callers(3, pcs[:])
 	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	_ = logger.Handler().Handle(ctx, r)
 }
 

--- a/libs/log/sdk.go
+++ b/libs/log/sdk.go
@@ -37,9 +37,6 @@ func (s slogAdapter) log(ctx context.Context, logger *slog.Logger, level slog.Le
 	runtime.Callers(4, pcs[:])
 	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
 	r.AddAttrs(slog.Bool("sdk", true))
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	_ = logger.Handler().Handle(ctx, r)
 }
 


### PR DESCRIPTION
## Summary
- Remove the `nil` context fallback from functions in `libs/log`
- Passing a nil context is an error; callers should always pass a valid context

From https://pkg.go.dev/context:
> Do not pass a nil [Context](https://pkg.go.dev/context#Context), even if a function permits it. Pass [context.TODO](https://pkg.go.dev/context#TODO) if you are unsure about which Context to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)