### PR TITLE
Use env.UserHomeDir(ctx) in experimental/ssh package

### DIFF
--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -220,7 +220,7 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		return fmt.Errorf("failed to get or generate SSH key pair from secrets: %w", err)
 	}
 
-	keyPath, err := keys.GetLocalSSHKeyPath(sessionID, opts.SSHKeysDir)
+	keyPath, err := keys.GetLocalSSHKeyPath(ctx, sessionID, opts.SSHKeysDir)
 	if err != nil {
 		return fmt.Errorf("failed to get local keys folder: %w", err)
 	}
@@ -323,7 +323,7 @@ func runIDE(ctx context.Context, client *databricks.WorkspaceClient, userName, k
 	databricksUserName := currentUser.UserName
 
 	// Ensure SSH config entry exists
-	configPath, err := sshconfig.GetMainConfigPath()
+	configPath, err := sshconfig.GetMainConfigPath(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get SSH config path: %w", err)
 	}
@@ -354,7 +354,7 @@ func runIDE(ctx context.Context, client *databricks.WorkspaceClient, userName, k
 
 func ensureSSHConfigEntry(ctx context.Context, configPath, hostName, userName, keyPath string, serverPort int, clusterID string, opts ClientOptions) error {
 	// Ensure the Include directive exists in the main SSH config
-	err := sshconfig.EnsureIncludeDirective(configPath)
+	err := sshconfig.EnsureIncludeDirective(ctx, configPath)
 	if err != nil {
 		return err
 	}

--- a/experimental/ssh/internal/keys/keys.go
+++ b/experimental/ssh/internal/keys/keys.go
@@ -10,15 +10,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go"
 	"golang.org/x/crypto/ssh"
 )
 
 // We use different client keys for each session as a good practice for better isolation and control.
 // sessionID is the unique identifier for the session (cluster ID for dedicated clusters, connection name for serverless).
-func GetLocalSSHKeyPath(sessionID, keysDir string) (string, error) {
+func GetLocalSSHKeyPath(ctx context.Context, sessionID, keysDir string) (string, error) {
 	if keysDir == "" {
-		homeDir, err := os.UserHomeDir() //nolint:forbidigo // TODO: thread ctx through public API
+		homeDir, err := env.UserHomeDir(ctx)
 		if err != nil {
 			return "", fmt.Errorf("failed to get home directory: %w", err)
 		}

--- a/experimental/ssh/internal/setup/setup.go
+++ b/experimental/ssh/internal/setup/setup.go
@@ -43,8 +43,8 @@ func validateClusterAccess(ctx context.Context, client *databricks.WorkspaceClie
 	return nil
 }
 
-func generateHostConfig(opts SetupOptions) (string, error) {
-	identityFilePath, err := keys.GetLocalSSHKeyPath(opts.ClusterID, opts.SSHKeysDir)
+func generateHostConfig(ctx context.Context, opts SetupOptions) (string, error) {
+	identityFilePath, err := keys.GetLocalSSHKeyPath(ctx, opts.ClusterID, opts.SSHKeysDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to get local keys folder: %w", err)
 	}
@@ -90,22 +90,22 @@ func Setup(ctx context.Context, client *databricks.WorkspaceClient, opts SetupOp
 		return err
 	}
 
-	configPath, err := sshconfig.GetMainConfigPathOrDefault(opts.SSHConfigPath)
+	configPath, err := sshconfig.GetMainConfigPathOrDefault(ctx, opts.SSHConfigPath)
 	if err != nil {
 		return err
 	}
 
-	err = sshconfig.EnsureIncludeDirective(configPath)
+	err = sshconfig.EnsureIncludeDirective(ctx, configPath)
 	if err != nil {
 		return err
 	}
 
-	hostConfig, err := generateHostConfig(opts)
+	hostConfig, err := generateHostConfig(ctx, opts)
 	if err != nil {
 		return err
 	}
 
-	exists, err := sshconfig.HostConfigExists(opts.HostName)
+	exists, err := sshconfig.HostConfigExists(ctx, opts.HostName)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func Setup(ctx context.Context, client *databricks.WorkspaceClient, opts SetupOp
 		return err
 	}
 
-	hostConfigPath, err := sshconfig.GetHostConfigPath(opts.HostName)
+	hostConfigPath, err := sshconfig.GetHostConfigPath(ctx, opts.HostName)
 	if err != nil {
 		return err
 	}

--- a/experimental/ssh/internal/setup/setup_test.go
+++ b/experimental/ssh/internal/setup/setup_test.go
@@ -138,7 +138,7 @@ func TestGenerateHostConfig_Valid(t *testing.T) {
 		ProxyCommand:  proxyCommand,
 	}
 
-	result, err := generateHostConfig(opts)
+	result, err := generateHostConfig(t.Context(), opts)
 	assert.NoError(t, err)
 
 	assert.Contains(t, result, "Host test-host")
@@ -173,7 +173,7 @@ func TestGenerateHostConfig_WithoutProfile(t *testing.T) {
 		ProxyCommand:  proxyCommand,
 	}
 
-	result, err := generateHostConfig(opts)
+	result, err := generateHostConfig(t.Context(), opts)
 	assert.NoError(t, err)
 
 	assert.NotContains(t, result, "--profile=")
@@ -194,7 +194,7 @@ func TestGenerateHostConfig_PathEscaping(t *testing.T) {
 		ShutdownDelay: 30 * time.Second,
 	}
 
-	result, err := generateHostConfig(opts)
+	result, err := generateHostConfig(t.Context(), opts)
 	assert.NoError(t, err)
 
 	// Check that quotes are properly escaped

--- a/experimental/ssh/internal/sshconfig/sshconfig.go
+++ b/experimental/ssh/internal/sshconfig/sshconfig.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/env"
 )
 
 const (
@@ -15,27 +16,27 @@ const (
 	configDirName = ".databricks/ssh-tunnel-configs"
 )
 
-func GetConfigDir() (string, error) {
-	homeDir, err := os.UserHomeDir() //nolint:forbidigo // TODO: thread ctx through public API
+func GetConfigDir(ctx context.Context) (string, error) {
+	homeDir, err := env.UserHomeDir(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
 	return filepath.Join(homeDir, configDirName), nil
 }
 
-func GetMainConfigPath() (string, error) {
-	homeDir, err := os.UserHomeDir() //nolint:forbidigo // TODO: thread ctx through public API
+func GetMainConfigPath(ctx context.Context) (string, error) {
+	homeDir, err := env.UserHomeDir(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
 	return filepath.Join(homeDir, ".ssh", "config"), nil
 }
 
-func GetMainConfigPathOrDefault(configPath string) (string, error) {
+func GetMainConfigPathOrDefault(ctx context.Context, configPath string) (string, error) {
 	if configPath != "" {
 		return configPath, nil
 	}
-	return GetMainConfigPath()
+	return GetMainConfigPath(ctx)
 }
 
 func EnsureMainConfigExists(configPath string) error {
@@ -55,8 +56,8 @@ func EnsureMainConfigExists(configPath string) error {
 	return err
 }
 
-func EnsureIncludeDirective(configPath string) error {
-	configDir, err := GetConfigDir()
+func EnsureIncludeDirective(ctx context.Context, configPath string) error {
+	configDir, err := GetConfigDir(ctx)
 	if err != nil {
 		return err
 	}
@@ -98,16 +99,16 @@ func EnsureIncludeDirective(configPath string) error {
 	return nil
 }
 
-func GetHostConfigPath(hostName string) (string, error) {
-	configDir, err := GetConfigDir()
+func GetHostConfigPath(ctx context.Context, hostName string) (string, error) {
+	configDir, err := GetConfigDir(ctx)
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(configDir, hostName), nil
 }
 
-func HostConfigExists(hostName string) (bool, error) {
-	configPath, err := GetHostConfigPath(hostName)
+func HostConfigExists(ctx context.Context, hostName string) (bool, error) {
+	configPath, err := GetHostConfigPath(ctx, hostName)
 	if err != nil {
 		return false, err
 	}
@@ -123,12 +124,12 @@ func HostConfigExists(hostName string) (bool, error) {
 
 // Returns true if the config was created/updated, false if it was skipped.
 func CreateOrUpdateHostConfig(ctx context.Context, hostName, hostConfig string, recreate bool) (bool, error) {
-	configPath, err := GetHostConfigPath(hostName)
+	configPath, err := GetHostConfigPath(ctx, hostName)
 	if err != nil {
 		return false, err
 	}
 
-	exists, err := HostConfigExists(hostName)
+	exists, err := HostConfigExists(ctx, hostName)
 	if err != nil {
 		return false, err
 	}

--- a/experimental/ssh/internal/sshconfig/sshconfig_test.go
+++ b/experimental/ssh/internal/sshconfig/sshconfig_test.go
@@ -12,23 +12,23 @@ import (
 )
 
 func TestGetConfigDir(t *testing.T) {
-	dir, err := GetConfigDir()
+	dir, err := GetConfigDir(t.Context())
 	assert.NoError(t, err)
 	assert.Contains(t, dir, filepath.Join(".databricks", "ssh-tunnel-configs"))
 }
 
 func TestGetMainConfigPath(t *testing.T) {
-	path, err := GetMainConfigPath()
+	path, err := GetMainConfigPath(t.Context())
 	assert.NoError(t, err)
 	assert.Contains(t, path, filepath.Join(".ssh", "config"))
 }
 
 func TestGetMainConfigPathOrDefault(t *testing.T) {
-	path, err := GetMainConfigPathOrDefault("/custom/path")
+	path, err := GetMainConfigPathOrDefault(t.Context(), "/custom/path")
 	assert.NoError(t, err)
 	assert.Equal(t, "/custom/path", path)
 
-	path, err = GetMainConfigPathOrDefault("")
+	path, err = GetMainConfigPathOrDefault(t.Context(), "")
 	assert.NoError(t, err)
 	assert.Contains(t, path, filepath.Join(".ssh", "config"))
 }
@@ -59,7 +59,7 @@ func TestEnsureIncludeDirective_NewConfig(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir)
 
-	err := EnsureIncludeDirective(configPath)
+	err := EnsureIncludeDirective(t.Context(), configPath)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(configPath)
@@ -78,7 +78,7 @@ func TestEnsureIncludeDirective_AlreadyExists(t *testing.T) {
 
 	configPath := filepath.Join(tmpDir, ".ssh", "config")
 
-	configDir, err := GetConfigDir()
+	configDir, err := GetConfigDir(t.Context())
 	require.NoError(t, err)
 
 	// Use forward slashes as that's what SSH config uses
@@ -89,7 +89,7 @@ func TestEnsureIncludeDirective_AlreadyExists(t *testing.T) {
 	err = os.WriteFile(configPath, []byte(existingContent), 0o600)
 	require.NoError(t, err)
 
-	err = EnsureIncludeDirective(configPath)
+	err = EnsureIncludeDirective(t.Context(), configPath)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(configPath)
@@ -111,7 +111,7 @@ func TestEnsureIncludeDirective_PrependsToExisting(t *testing.T) {
 	err = os.WriteFile(configPath, []byte(existingContent), 0o600)
 	require.NoError(t, err)
 
-	err = EnsureIncludeDirective(configPath)
+	err = EnsureIncludeDirective(t.Context(), configPath)
 	assert.NoError(t, err)
 
 	content, err := os.ReadFile(configPath)
@@ -129,7 +129,7 @@ func TestEnsureIncludeDirective_PrependsToExisting(t *testing.T) {
 }
 
 func TestGetHostConfigPath(t *testing.T) {
-	path, err := GetHostConfigPath("test-host")
+	path, err := GetHostConfigPath(t.Context(), "test-host")
 	assert.NoError(t, err)
 	assert.Contains(t, path, filepath.Join(".databricks", "ssh-tunnel-configs", "test-host"))
 }
@@ -139,7 +139,7 @@ func TestHostConfigExists(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir)
 
-	exists, err := HostConfigExists("nonexistent")
+	exists, err := HostConfigExists(t.Context(), "nonexistent")
 	assert.NoError(t, err)
 	assert.False(t, exists)
 
@@ -149,7 +149,7 @@ func TestHostConfigExists(t *testing.T) {
 	err = os.WriteFile(filepath.Join(configDir, "existing-host"), []byte("config"), 0o600)
 	require.NoError(t, err)
 
-	exists, err = HostConfigExists("existing-host")
+	exists, err = HostConfigExists(t.Context(), "existing-host")
 	assert.NoError(t, err)
 	assert.True(t, exists)
 }
@@ -165,7 +165,7 @@ func TestCreateOrUpdateHostConfig_NewConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, created)
 
-	configPath, err := GetHostConfigPath("test-host")
+	configPath, err := GetHostConfigPath(ctx, "test-host")
 	require.NoError(t, err)
 	content, err := os.ReadFile(configPath)
 	assert.NoError(t, err)
@@ -190,7 +190,7 @@ func TestCreateOrUpdateHostConfig_ExistingConfigNoRecreate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, created)
 
-	configPath, err := GetHostConfigPath("test-host")
+	configPath, err := GetHostConfigPath(ctx, "test-host")
 	require.NoError(t, err)
 	content, err := os.ReadFile(configPath)
 	assert.NoError(t, err)
@@ -215,7 +215,7 @@ func TestCreateOrUpdateHostConfig_ExistingConfigWithRecreate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, created)
 
-	configPath, err := GetHostConfigPath("test-host")
+	configPath, err := GetHostConfigPath(ctx, "test-host")
 	require.NoError(t, err)
 	content, err := os.ReadFile(configPath)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- Accept `context.Context` in SSH config and key path functions to use `env.UserHomeDir(ctx)` instead of `os.UserHomeDir()`
- Follow-up to #4654 which made this change for the rest of the codebase

## Test plan
- [x] `go test ./experimental/ssh/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)