### PR TITLE
Add depguard rule to prevent imports of experimental/ packages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,7 +19,21 @@ linters:
     - exhaustive
     - copyloopvar
     - forbidigo
+    - depguard
   settings:
+    depguard:
+      rules:
+        no-experimental-imports:
+          # depguard matches against absolute file paths, so patterns must
+          # start with **/ to match regardless of the repository location.
+          files:
+            - "**"
+            - "!**/cmd/cmd.go"
+            - "!**/cmd/experimental/**"
+            - "!**/experimental/**"
+          deny:
+            - pkg: "github.com/databricks/cli/experimental"
+              desc: "must not import experimental/ packages; use an interface or move the dependency"
     forbidigo:
       forbid:
         - pattern: 'term\.IsTerminal'
@@ -107,6 +121,10 @@ linters:
       - path: bundle/direct/dresources/.*_test.go
         linters:
           - exhaustruct
+      # TODO: remove these exceptions by moving the dependency out of experimental/.
+      - path: cmd/apps/init.go
+        linters:
+          - depguard
 issues:
   max-issues-per-linter: 1000
   max-same-issues: 1000


### PR DESCRIPTION
## Summary
- Adds a `depguard` lint rule that prevents non-experimental code from importing `experimental/` packages
- Only `cmd/cmd.go` and `cmd/experimental/` are allowed as entry points into experimental code
- The existing violation in `cmd/apps/init.go` is excluded with a TODO to address later

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] Verified that new imports of `experimental/` from outside the allowed files are flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)