### PR TITLE
Add lint rule for context.Background() in non-test code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,10 @@ Use table-driven tests when testing multiple similar cases (e.g., different inpu
 
 **Template tests**: Tests in `acceptance/bundle/templates` include materialized templates in output directories. These directories follow the same `out` convention — everything starting with `out` is generated output. Sources are in `libs/template/templates/`. Use `make test-update-templates` to regenerate. If linters or formatters find issues in materialized templates, do not fix the output files — fix the source in `libs/template/templates/`, then regenerate.
 
+# Context
+
+Always pass `context.Context` as a function argument; never store it in a struct. Storing context in a struct obscures the lifecycle and prevents callers from setting per-call deadlines, cancellation, and metadata (see https://go.dev/blog/context-and-structs). Do not use `context.Background()` outside of `main.go` files. In tests, use `t.Context()` (or `b.Context()` for benchmarks).
+
 # Logging
 
 Use the following for logging:
@@ -202,7 +206,7 @@ log.Errorf(ctx, "...")
 ```
 
 Note that the 'ctx' variable here is something that should be passed in as
-an argument by the caller. In tests, use `t.Context()` (or `b.Context()` for benchmarks) instead of `context.Background()`. This is enforced by a lint rule.
+an argument by the caller.
 
 Use cmdio.LogString to print to stdout:
 

--- a/cmd/labs/project/entrypoint.go
+++ b/cmd/labs/project/entrypoint.go
@@ -185,7 +185,7 @@ func (e *Entrypoint) getLoginConfig(cmd *cobra.Command) (*loginConfig, *config.C
 	if err != nil {
 		return nil, nil, err
 	}
-	if isNoLoginConfig && !e.IsBundleAware && e.isAuthConfigured(defaultConfig) {
+	if isNoLoginConfig && !e.IsBundleAware && e.isAuthConfigured(ctx, defaultConfig) {
 		log.Debugf(ctx, "Login is configured via environment variables")
 		return &loginConfig{}, defaultConfig, nil
 	}
@@ -291,8 +291,8 @@ func (e *Entrypoint) environmentFromConfig(cfg *config.Config) map[string]string
 	return env
 }
 
-func (e *Entrypoint) isAuthConfigured(cfg *config.Config) bool {
+func (e *Entrypoint) isAuthConfigured(ctx context.Context, cfg *config.Config) bool {
 	r := &http.Request{Header: http.Header{}}
-	err := cfg.Authenticate(r.WithContext(context.Background()))
+	err := cfg.Authenticate(r.WithContext(ctx))
 	return err == nil
 }

--- a/cmd/labs/project/login.go
+++ b/cmd/labs/project/login.go
@@ -53,7 +53,7 @@ func (lc *loginConfig) askWorkspaceProfile(ctx context.Context, cfg *config.Conf
 	// Check if authentication is already configured (e.g., via environment variables).
 	// This is consistent with askCluster() and askWarehouse() which check if their
 	// values are already set before prompting.
-	if lc.isAuthConfigured(cfg) {
+	if lc.isAuthConfigured(ctx, cfg) {
 		return err
 	}
 	if !cmdio.IsPromptSupported(ctx) {

--- a/experimental/aitools/cmd/query.go
+++ b/experimental/aitools/cmd/query.go
@@ -204,7 +204,8 @@ func executeAndPoll(ctx context.Context, api sql.StatementExecutionInterface, wa
 	// cancelStatement performs best-effort server-side cancellation.
 	// Called on any poll exit due to context cancellation (signal or parent).
 	cancelStatement := func() {
-		cancelCtx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
+		// Use the parent context (ctx), not the cancelled pollCtx.
+		cancelCtx, cancel := context.WithTimeout(ctx, cancelTimeout)
 		defer cancel()
 		if err := api.CancelExecution(cancelCtx, sql.CancelExecutionRequest{
 			StatementId: statementID,

--- a/experimental/aitools/lib/server/doc.go
+++ b/experimental/aitools/lib/server/doc.go
@@ -6,7 +6,7 @@ It uses the official MCP Go SDK and supports stdio transport.
 
 Usage:
 
-	ctx := context.Background()
+	ctx := context.TODO()
 	cfg := &config.Config{
 		WarehouseID: "abc123",
 	}

--- a/internal/testarchive/utils.go
+++ b/internal/testarchive/utils.go
@@ -29,7 +29,7 @@ func logf(format string, args ...any) {
 // getCacheDir returns the cache directory for downloads.
 // It uses ~/.cache/testarchive by default.
 func getCacheDir() (string, error) {
-	homeDir, err := env.UserHomeDir(context.Background())
+	homeDir, err := env.UserHomeDir(context.Background()) //nolint:gocritic // Test utility without caller context.
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}

--- a/libs/databrickscfg/loader.go
+++ b/libs/databrickscfg/loader.go
@@ -75,7 +75,7 @@ func (l profileFromHostLoader) Configure(cfg *config.Config) error {
 		return nil
 	}
 
-	ctx := context.Background()
+	ctx := context.Background() //nolint:gocritic // SDK interface does not accept context.
 	configFile, err := config.LoadFile(cfg.ConfigFile)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {

--- a/libs/gorules/rule_context_background.go
+++ b/libs/gorules/rule_context_background.go
@@ -2,9 +2,9 @@ package gorules
 
 import "github.com/quasilyte/go-ruleguard/dsl"
 
-// UseTestContext detects context.Background() in test files and suggests using t.Context().
-func UseTestContext(m dsl.Matcher) {
+// NoContextBackground detects context.Background() outside of main.go files.
+func NoContextBackground(m dsl.Matcher) {
 	m.Match(`context.Background()`).
-		Where(m.File().Name.Matches(`_test\.go$`)).
-		Report(`Use t.Context() or b.Context() in tests instead of context.Background()`)
+		Where(!m.File().Name.Matches(`^main\.go$`)).
+		Report(`Do not use context.Background(); use t.Context() in tests or pass context from caller`)
 }


### PR DESCRIPTION
## Summary
- Add a gorules lint rule that flags `context.Background()` usage in all files except `main.go`, suggesting `t.Context()` in tests or passing context from the caller
- Add context guidelines to AGENTS.md

Builds on #4655, #4656, and #4657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)