### PR TITLE
make generate: skip fetch if commit already exists locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ GENKIT_BINARY := $(UNIVERSE_DIR)/bazel-bin/openapi/genkit/genkit_/genkit
 
 generate:
 	@echo "Checking out universe at SHA: $$(cat .codegen/_openapi_sha)"
-	cd $(UNIVERSE_DIR) && git fetch origin master && git checkout $$(cat $(PWD)/.codegen/_openapi_sha)
+	cd $(UNIVERSE_DIR) && git cat-file -e $$(cat $(PWD)/.codegen/_openapi_sha) 2>/dev/null || git fetch --filter=blob:none origin master && git checkout $$(cat $(PWD)/.codegen/_openapi_sha)
 	@echo "Building genkit..."
 	cd $(UNIVERSE_DIR) && bazel build //openapi/genkit
 	@echo "Generating CLI code..."


### PR DESCRIPTION
## Why
Reduce time "make generate" takes to fetch the commit from 70s to 0.5s.

## Tests
Manually running "make generate".