### PR TITLE
Use `resource.yml` in field classification in config-remote-sync

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Bundles
 
+ * `bundle config-remote-sync` now derives its field filtering from the resource lifecycle metadata (`resources.yml`) instead of a hand-maintained table, so lifecycle rules added for the deploy plan automatically protect config sync ([#4677](https://github.com/databricks/cli/pull/4677)).
+ * direct: policy-injected `custom_tags` and `cluster_log_conf` on job and standalone clusters no longer cause perpetual `bundle plan` updates when the field is absent from config; same for backend-computed `driver_node_type_flexibility`/`worker_node_type_flexibility` and `performance_target` ([#4677](https://github.com/databricks/cli/pull/4677)).
+
 ### Dependency updates
 
 ### API Changes

--- a/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/databricks.yml.tmpl
@@ -1,0 +1,29 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+targets:
+  default:
+    mode: development
+
+resources:
+  jobs:
+    job1:
+      max_concurrent_runs: 1
+      job_clusters:
+        - job_cluster_key: shared
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+      tasks:
+        - task_key: shared_cluster_task
+          job_cluster_key: shared
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/notebook
+        - task_key: own_cluster_task
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/notebook
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1

--- a/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/out.test.toml
+++ b/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/output.txt
+++ b/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/output.txt
@@ -1,0 +1,26 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Simulate a cluster policy injecting custom_tags and cluster_log_conf
+These fields exist only remotely (the user never set them in config).
+
+=== Plan after injection: policy-injected fields alone must not produce an update
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
+
+=== A real remote edit must still be detected
+>>> [CLI] bundle plan
+update jobs.job1
+
+Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.job1
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/script
+++ b/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/script
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+job_id="$(read_id.py job1)"
+
+title "Simulate a cluster policy injecting custom_tags and cluster_log_conf"
+echo
+echo "These fields exist only remotely (the user never set them in config)."
+edit_resource.py jobs $job_id <<'PYEOF'
+# A DBFS destination is used instead of S3: the real backend rejects an S3
+# cluster log destination without a per-cluster instance-profile ARN.
+policy_tags = {"CostCenter": "dev-1234", "Team": "finops"}
+policy_log_conf = {"dbfs": {"destination": "dbfs:/cluster-logs/dev"}}
+
+for task in r.get("tasks", []):
+    if "new_cluster" in task:
+        task["new_cluster"]["custom_tags"] = dict(policy_tags)
+        task["new_cluster"]["cluster_log_conf"] = dict(policy_log_conf)
+
+for jc in r.get("job_clusters", []):
+    jc["new_cluster"]["custom_tags"] = dict(policy_tags)
+    jc["new_cluster"]["cluster_log_conf"] = dict(policy_log_conf)
+PYEOF
+
+title "Plan after injection: policy-injected fields alone must not produce an update"
+trace $CLI bundle plan
+
+title "A real remote edit must still be detected"
+edit_resource.py jobs $job_id <<'PYEOF'
+r["max_concurrent_runs"] = 5
+PYEOF
+
+trace $CLI bundle plan

--- a/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/test.toml
+++ b/acceptance/bundle/resources/jobs/policy_injected_cluster_fields/test.toml
@@ -1,0 +1,9 @@
+Cloud = true
+
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml"]
+
+# The suppression under test is the direct engine's backend_defaults
+# classification of policy-injected fields; the terraform engine delegates
+# these diffs to the terraform provider.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/bundle/configsync/defaults.go
+++ b/bundle/configsync/defaults.go
@@ -1,229 +1,122 @@
 package configsync
 
 import (
-	"reflect"
+	"slices"
 	"strings"
+
+	"github.com/databricks/cli/bundle/direct/dresources"
+	"github.com/databricks/cli/libs/structs/structpath"
 )
 
-type (
-	skipAlways           struct{}
-	skipIfZeroOrNil      struct{}
-	skipIfEmptyOrDefault struct {
-		defaults map[string]any
-	}
-	// skipBackendDefault skips a field, regardless of its remote value, when it is
-	// absent from config. Used for fields the backend or a cluster policy may fill
-	// in: their remote-only value must not be synced into config. Fields the user
-	// does manage (present in config) still sync normally.
-	skipBackendDefault struct{}
-)
+// shouldSkipForSync reports whether a remote change at path should be excluded
+// from config sync, based on the resource lifecycle metadata (resources.yml and
+// resources.generated.yml in bundle/direct/dresources).
+//
+// The metadata is matched directly instead of relying on the plan's per-field
+// actions: the plan answers "what will deploy do", which is not the same as
+// "does this field belong in configuration". For example, the plan re-promotes
+// dashboard etag drift to Update via ResourceDashboard.OverrideChangeDesc (for
+// modified-remotely detection), yet etag must never be written to YAML.
+//
+// Fields under ignore_remote_changes never belong in configuration (output-only,
+// etag-based, input-only), so they are skipped regardless of value. Fields under
+// backend_defaults are skipped only when absent from the config (hasConfigValue
+// is false) and the remote value matches the rule.
+func shouldSkipForSync(resourceType string, path *structpath.PathNode, value any, hasConfigValue bool) bool {
+	cfg := dresources.GetResourceConfig(resourceType)
+	generatedCfg := dresources.GetGeneratedResourceConfig(resourceType)
 
-var (
-	alwaysSkip              = skipAlways{}
-	zeroOrNil               = skipIfZeroOrNil{}
-	emptyEmailNotifications = skipIfEmptyOrDefault{defaults: map[string]any{"no_alert_for_skipped_runs": false}}
-	backendDefault          = skipBackendDefault{}
-)
-
-// serverSideDefaults contains all hardcoded server-side defaults.
-// This is a temporary solution until the bundle plan issue is resolved.
-// Fields mapped to alwaysSkip are always considered defaults regardless of value.
-// Other fields are compared using reflect.DeepEqual.
-var serverSideDefaults = map[string]any{
-	// Job-level fields
-	"resources.jobs.*.timeout_seconds":       zeroOrNil,
-	"resources.jobs.*.email_notifications":   emptyEmailNotifications,
-	"resources.jobs.*.webhook_notifications": map[string]any{},
-	"resources.jobs.*.edit_mode":             alwaysSkip, // set by CLI
-	"resources.jobs.*.performance_target":    "PERFORMANCE_OPTIMIZED",
-
-	// Task-level fields
-	"resources.jobs.*.tasks[*].run_if":                     "ALL_SUCCESS",
-	"resources.jobs.*.tasks[*].disabled":                   false,
-	"resources.jobs.*.tasks[*].timeout_seconds":            zeroOrNil,
-	"resources.jobs.*.tasks[*].notebook_task.source":       "WORKSPACE",
-	"resources.jobs.*.tasks[*].email_notifications":        emptyEmailNotifications,
-	"resources.jobs.*.tasks[*].webhook_notifications":      map[string]any{},
-	"resources.jobs.*.tasks[*].pipeline_task.full_refresh": false,
-
-	"resources.jobs.*.tasks[*].for_each_task.task.run_if":                "ALL_SUCCESS",
-	"resources.jobs.*.tasks[*].for_each_task.task.disabled":              false,
-	"resources.jobs.*.tasks[*].for_each_task.task.timeout_seconds":       zeroOrNil,
-	"resources.jobs.*.tasks[*].for_each_task.task.notebook_task.source":  "WORKSPACE",
-	"resources.jobs.*.tasks[*].for_each_task.task.email_notifications":   emptyEmailNotifications,
-	"resources.jobs.*.tasks[*].for_each_task.task.webhook_notifications": map[string]any{},
-
-	// Cluster fields (tasks)
-	"resources.jobs.*.tasks[*].new_cluster.aws_attributes":      alwaysSkip,
-	"resources.jobs.*.tasks[*].new_cluster.azure_attributes":    alwaysSkip,
-	"resources.jobs.*.tasks[*].new_cluster.gcp_attributes":      alwaysSkip,
-	"resources.jobs.*.tasks[*].new_cluster.data_security_mode":  "SINGLE_USER", // TODO this field is computed on some workspaces in integration tests, check why and if we can skip it
-	"resources.jobs.*.tasks[*].new_cluster.enable_elastic_disk": alwaysSkip,    // deprecated field
-	"resources.jobs.*.tasks[*].new_cluster.single_user_name":    alwaysSkip,
-	// custom_tags and cluster_log_conf are commonly injected by cluster policies
-	// when the user omits them, so they exist only remotely. Syncing them back leaks
-	// one environment's policy values into (often shared) config and breaks deploys in
-	// other environments. TODO: move to backend_defaults in resources.yml once
-	// configsync filtering is migrated to the direct engine lifecycle metadata.
-	"resources.jobs.*.tasks[*].new_cluster.custom_tags":      backendDefault,
-	"resources.jobs.*.tasks[*].new_cluster.cluster_log_conf": backendDefault,
-
-	// Cluster fields (job_clusters)
-	"resources.jobs.*.job_clusters[*].new_cluster.aws_attributes":      alwaysSkip,
-	"resources.jobs.*.job_clusters[*].new_cluster.azure_attributes":    alwaysSkip,
-	"resources.jobs.*.job_clusters[*].new_cluster.gcp_attributes":      alwaysSkip,
-	"resources.jobs.*.job_clusters[*].new_cluster.data_security_mode":  "SINGLE_USER", // TODO this field is computed on some workspaces in integration tests, check why and if we can skip it
-	"resources.jobs.*.job_clusters[*].new_cluster.enable_elastic_disk": alwaysSkip,    // deprecated field
-	"resources.jobs.*.job_clusters[*].new_cluster.single_user_name":    alwaysSkip,
-	"resources.jobs.*.job_clusters[*].new_cluster.custom_tags":         backendDefault, // see tasks[*].new_cluster.custom_tags
-	"resources.jobs.*.job_clusters[*].new_cluster.cluster_log_conf":    backendDefault, // see tasks[*].new_cluster.cluster_log_conf
-
-	// Standalone cluster fields
-	"resources.clusters.*.aws_attributes":      alwaysSkip,
-	"resources.clusters.*.azure_attributes":    alwaysSkip,
-	"resources.clusters.*.gcp_attributes":      alwaysSkip,
-	"resources.clusters.*.data_security_mode":  "SINGLE_USER",
-	"resources.clusters.*.driver_node_type_id": alwaysSkip,
-	"resources.clusters.*.enable_elastic_disk": alwaysSkip,
-	"resources.clusters.*.single_user_name":    alwaysSkip,
-	"resources.clusters.*.custom_tags":         backendDefault, // see jobs.*.tasks[*].new_cluster.custom_tags
-	"resources.clusters.*.cluster_log_conf":    backendDefault, // see jobs.*.tasks[*].new_cluster.cluster_log_conf
-
-	// Experiment fields
-	"resources.experiments.*.artifact_location": alwaysSkip,
-
-	// Registered model fields
-	"resources.registered_models.*.full_name":        alwaysSkip,
-	"resources.registered_models.*.metastore_id":     alwaysSkip,
-	"resources.registered_models.*.owner":            alwaysSkip,
-	"resources.registered_models.*.storage_location": alwaysSkip,
-
-	// Volume fields
-	"resources.volumes.*.storage_location": alwaysSkip,
-
-	// SQL warehouse fields
-	"resources.sql_warehouses.*.creator_name":     alwaysSkip,
-	"resources.sql_warehouses.*.min_num_clusters": int64(1),
-	"resources.sql_warehouses.*.warehouse_type":   "CLASSIC",
-
-	// Terraform defaults
-	"resources.jobs.*.run_as": alwaysSkip,
-
-	// Pipeline fields
-	"resources.pipelines.*.storage":    alwaysSkip,
-	"resources.pipelines.*.continuous": false,
-
-	// Dashboard fields
-	// etag is output-only and never present in config. The plan re-promotes etag
-	// drift to Update via ResourceDashboard.OverrideChangeDesc (needed for deploy's
-	// modified-remotely detection), so configsync cannot rely on the plan's Skip
-	// action and must exclude the field explicitly.
-	"resources.dashboards.*.etag": alwaysSkip,
-}
-
-// shouldSkipField checks if a field should be skipped in change detection.
-// When hasConfigValue is true (field is set in config or saved state), only
-// "always skip" fields are skipped. Backend defaults are only skipped when the
-// field is not in config/state, matching the behavior of shouldSkipBackendDefault
-// in the direct deployment engine.
-func shouldSkipField(path string, value any, hasConfigValue bool) bool {
-	for pattern, expected := range serverSideDefaults {
-		if matchPattern(pattern, path) {
-			if _, ok := expected.(skipAlways); ok {
-				return true
-			}
-			if hasConfigValue {
-				return false
-			}
-			if _, ok := expected.(skipBackendDefault); ok {
-				return true
-			}
-			if _, ok := expected.(skipIfZeroOrNil); ok {
-				return value == nil || value == int64(0)
-			}
-			if marker, ok := expected.(skipIfEmptyOrDefault); ok {
-				m, ok := value.(map[string]any)
-				if !ok {
-					return false
-				}
-				if len(m) == 0 {
-					return true
-				}
-				return reflect.DeepEqual(m, marker.defaults)
-			}
-			return reflect.DeepEqual(value, expected)
-		}
-	}
-	return false
-}
-
-func matchPattern(pattern, path string) bool {
-	patternParts := strings.Split(pattern, ".")
-	pathParts := strings.Split(path, ".")
-	return matchParts(patternParts, pathParts)
-}
-
-func matchParts(patternParts, pathParts []string) bool {
-	if len(patternParts) == 0 && len(pathParts) == 0 {
+	if _, ok := dresources.FindMatchingRule(path, cfg.IgnoreRemoteChanges); ok {
 		return true
 	}
-	if len(patternParts) == 0 || len(pathParts) == 0 {
+	if _, ok := dresources.FindMatchingRule(path, generatedCfg.IgnoreRemoteChanges); ok {
+		return true
+	}
+
+	if hasConfigValue {
 		return false
 	}
 
-	patternPart := patternParts[0]
-	pathPart := pathParts[0]
+	return cfg.MatchesBackendDefault(path, value) || generatedCfg.MatchesBackendDefault(path, value)
+}
 
-	if patternPart == "*" {
-		return matchParts(patternParts[1:], pathParts[1:])
-	}
+// fieldsIgnoredForSync defines fields set by the CLI that cannot be specified
+// in databricks.yml and should be excluded from config-remote-sync results.
+// These are sync-specific rules: the deploy plan has different drift semantics
+// for them, so they do not belong in resources.yml.
+var fieldsIgnoredForSync = map[string][]*structpath.PatternNode{
+	"jobs": {
+		structpath.MustParsePattern("edit_mode"),
+	},
+}
 
-	if strings.Contains(patternPart, "[*]") {
-		prefix, _, _ := strings.Cut(patternPart, "[*]")
+// fieldsKeptForSync lists fields that nested entity filtering (filterEntityDefaults)
+// must keep even though they match a backend_defaults rule. The rules are asymmetric
+// between plan and sync: for the plan, node_type_id is computed — policy-backed
+// clusters materialize the policy-resolved value remotely while config legitimately
+// omits it, so leaf-level drift must be skipped. For sync, a remotely added cluster's
+// explicit node_type_id is required configuration: stripping it would make the synced
+// YAML undeployable (cluster creation fails with 400 "Unknown node type id" unless a
+// pool or policy provides the node type).
+//
+// Keeping it unconditionally cannot produce a node_type_id/instance_pool_id conflict:
+// the Jobs API rejects requests carrying both ("The field 'node_type_id' cannot be
+// supplied when an instance pool ID is provided") and jobs/get does not materialize
+// node_type_id for pool-backed clusters, so a remote cluster never has both fields.
+var fieldsKeptForSync = map[string][]*structpath.PatternNode{
+	"jobs": {
+		structpath.MustParsePattern("tasks[*].new_cluster.node_type_id"),
+		structpath.MustParsePattern("job_clusters[*].new_cluster.node_type_id"),
+	},
+}
 
-		if strings.HasPrefix(pathPart, prefix) && strings.Contains(pathPart, "[") {
-			return matchParts(patternParts[1:], pathParts[1:])
-		}
-		return false
-	}
+// isKeptForSync reports whether a field of a remotely added entity must survive
+// filterEntityDefaults even though it matches the lifecycle metadata.
+func isKeptForSync(resourceType string, path *structpath.PathNode) bool {
+	return slices.ContainsFunc(fieldsKeptForSync[resourceType], path.HasPatternPrefix)
+}
 
-	if patternPart == pathPart {
-		return matchParts(patternParts[1:], pathParts[1:])
-	}
+func isIgnoredForSync(resourceType string, path *structpath.PathNode) bool {
+	return slices.ContainsFunc(fieldsIgnoredForSync[resourceType], path.HasPatternPrefix)
+}
 
-	return false
+type resetRule struct {
+	field *structpath.PatternNode
+	value any
 }
 
 // resetValues contains all values that should be used to reset CLI-defaulted fields.
 // If CLI-defaulted field is changed on remote and should be disabled (e.g. queueing disabled -> remote field is nil)
 // we can't define it in the config as "null" because CLI default will be applied again.
-var resetValues = map[string]any{
-	"resources.jobs.*.queue": map[string]any{
-		"enabled": false,
+var resetValues = map[string][]resetRule{
+	"jobs": {
+		{field: structpath.MustParsePattern("queue"), value: map[string]any{"enabled": false}},
 	},
 }
 
-func resetValueIfNeeded(path string, value any) any {
-	for pattern, expected := range resetValues {
-		if matchPattern(pattern, path) {
-			return expected
+func resetValueIfNeeded(resourceType string, path *structpath.PathNode, value any) any {
+	for _, rule := range resetValues[resourceType] {
+		// Exact match, not prefix: a change at a subfield (e.g. queue.enabled)
+		// must keep its own value; only a change of the whole field is reset.
+		if path.Len() == rule.field.Len() && path.HasPatternPrefix(rule.field) {
+			return rule.value
 		}
 	}
 	return value
 }
 
-// prefixedNameFields lists resource name field patterns where the name prefix
+// prefixedNameFields lists resource name fields where the name prefix
 // (e.g. "[dev user] ") is applied during deployment and should be stripped
 // when syncing remote changes back to config.
-var prefixedNameFields = []string{
-	"resources.jobs.*.name",
-	"resources.pipelines.*.name",
-	"resources.dashboards.*.display_name",
+var prefixedNameFields = map[string][]*structpath.PatternNode{
+	"jobs":       {structpath.MustParsePattern("name")},
+	"pipelines":  {structpath.MustParsePattern("name")},
+	"dashboards": {structpath.MustParsePattern("display_name")},
 }
 
 // stripNamePrefix strips the configured name prefix from name field values
 // so that the raw (unprefixed) name is written back to the config YAML.
-func stripNamePrefix(path string, value any, prefix string) any {
+func stripNamePrefix(resourceType string, path *structpath.PathNode, value any, prefix string) any {
 	if prefix == "" {
 		return value
 	}
@@ -233,10 +126,8 @@ func stripNamePrefix(path string, value any, prefix string) any {
 		return value
 	}
 
-	for _, pattern := range prefixedNameFields {
-		if matchPattern(pattern, path) {
-			return strings.TrimPrefix(s, prefix)
-		}
+	if slices.ContainsFunc(prefixedNameFields[resourceType], path.HasPatternPrefix) {
+		return strings.TrimPrefix(s, prefix)
 	}
 
 	return value

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/deploy"
 	"github.com/databricks/cli/bundle/deployplan"
@@ -19,6 +20,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/convert"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/structs/structdiff"
+	"github.com/databricks/cli/libs/structs/structpath"
 )
 
 type OperationType string
@@ -55,44 +57,68 @@ func normalizeValue(v any) (any, error) {
 	return dynValue.AsAny(), nil
 }
 
-func filterEntityDefaults(basePath string, value any) any {
-	if value == nil {
-		return nil
-	}
-
-	if arr, ok := value.([]any); ok {
-		result := make([]any, 0, len(arr))
-		for i, elem := range arr {
-			elementPath := fmt.Sprintf("%s[%d]", basePath, i)
-			result = append(result, filterEntityDefaults(elementPath, elem))
+// filterEntityDefaults removes server-side default fields from an entity that
+// is added remotely as a whole (e.g. a new task object). Each nested field is
+// matched against the same lifecycle metadata as top-level changes. Maps that
+// become empty after filtering are pruned to nil at the top level and in map
+// fields, but kept as {} inside arrays: pruning an element would change the
+// array arity. Element identity keys like task_key normally prevent full
+// pruning there anyway.
+func filterEntityDefaults(resourceType string, basePath *structpath.PathNode, value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		filtered := filterEntityMap(resourceType, basePath, v)
+		if len(filtered) == 0 {
+			return nil
+		}
+		return filtered
+	case []any:
+		result := make([]any, 0, len(v))
+		for i, elem := range v {
+			elementPath := structpath.NewIndex(basePath, i)
+			if m, ok := elem.(map[string]any); ok {
+				result = append(result, filterEntityMap(resourceType, elementPath, m))
+			} else {
+				result = append(result, filterEntityDefaults(resourceType, elementPath, elem))
+			}
 		}
 		return result
-	}
-
-	m, ok := value.(map[string]any)
-	if !ok {
+	default:
 		return value
 	}
+}
 
+// filterEntityMap drops map fields matched by the lifecycle metadata and prunes
+// nested map fields that become empty after filtering. The result may itself be
+// empty; pruning it is the caller's decision (see filterEntityDefaults).
+func filterEntityMap(resourceType string, basePath *structpath.PathNode, m map[string]any) map[string]any {
 	result := make(map[string]any)
 	for key, val := range m {
-		fieldPath := basePath + "." + key
+		fieldPath := structpath.NewStringKey(basePath, key)
 
-		if shouldSkipField(fieldPath, val, false) {
+		if shouldSkipForSync(resourceType, fieldPath, val, false) && !isKeptForSync(resourceType, fieldPath) {
 			continue
 		}
 
 		if nestedMap, ok := val.(map[string]any); ok {
-			result[key] = filterEntityDefaults(fieldPath, nestedMap)
-		} else {
-			result[key] = val
+			filtered := filterEntityMap(resourceType, fieldPath, nestedMap)
+			if len(filtered) > 0 {
+				result[key] = filtered
+			}
+			continue
 		}
+		result[key] = val
 	}
-
 	return result
 }
 
-func convertChangeDesc(path string, cd *deployplan.ChangeDesc) (*ConfigChangeDesc, error) {
+func convertChangeDesc(resourceType string, path *structpath.PathNode, cd *deployplan.ChangeDesc) (*ConfigChangeDesc, error) {
+	if isIgnoredForSync(resourceType, path) {
+		return &ConfigChangeDesc{
+			Operation: OperationSkip,
+		}, nil
+	}
+
 	// Use cd.New (current config) to decide whether the field exists "on the config side".
 	// cd.Old (saved state) must not be considered: when the user has already synced a rename
 	// locally (cd.New == nil for the old key) but state still holds the prior key, including
@@ -104,14 +130,14 @@ func convertChangeDesc(path string, cd *deployplan.ChangeDesc) (*ConfigChangeDes
 		return nil, fmt.Errorf("failed to normalize remote value: %w", err)
 	}
 
-	if shouldSkipField(path, normalizedValue, hasConfigValue) {
+	if shouldSkipForSync(resourceType, path, normalizedValue, hasConfigValue) {
 		return &ConfigChangeDesc{
 			Operation: OperationSkip,
 		}, nil
 	}
 
-	normalizedValue = filterEntityDefaults(path, normalizedValue)
-	normalizedValue = resetValueIfNeeded(path, normalizedValue)
+	normalizedValue = filterEntityDefaults(resourceType, path, normalizedValue)
+	normalizedValue = resetValueIfNeeded(resourceType, path, normalizedValue)
 
 	var op OperationType
 	if normalizedValue == nil && hasConfigValue {
@@ -160,6 +186,7 @@ func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan
 
 	for resourceKey, entry := range plan.Plan {
 		resourceChanges := make(ResourceChanges)
+		resourceType := config.GetResourceTypeFromKey(resourceKey)
 
 		if entry.Changes != nil {
 			for path, changeDesc := range entry.Changes {
@@ -167,8 +194,12 @@ func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan
 					continue
 				}
 
-				fullPath := resourceKey + "." + path
-				change, err := convertChangeDesc(fullPath, changeDesc)
+				fieldPath, err := structpath.ParsePath(path)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse path %s: %w", path, err)
+				}
+
+				change, err := convertChangeDesc(resourceType, fieldPath, changeDesc)
 				if err != nil {
 					return nil, fmt.Errorf("failed to compute config change for path %s: %w", path, err)
 				}
@@ -183,7 +214,7 @@ func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan
 				if engine.IsDirect() && !structdiff.IsEqual(changeDesc.Old, changeDesc.New) {
 					change.LocalEdit = true
 				}
-				change.Value = stripNamePrefix(fullPath, change.Value, b.Config.Presets.NamePrefix)
+				change.Value = stripNamePrefix(resourceType, fieldPath, change.Value, b.Config.Presets.NamePrefix)
 				resourceChanges[path] = change
 			}
 		}

--- a/bundle/configsync/diff_test.go
+++ b/bundle/configsync/diff_test.go
@@ -4,45 +4,51 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConvertChangeDesc(t *testing.T) {
 	tests := []struct {
-		name    string
-		path    string
-		cd      *deployplan.ChangeDesc
-		wantOp  OperationType
-		wantVal any
+		name         string
+		resourceType string
+		path         string
+		cd           *deployplan.ChangeDesc
+		wantOp       OperationType
+		wantVal      any
 	}{
 		{
-			name:    "add: new in remote only",
-			path:    "resources.jobs.my_job.description",
-			cd:      &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "remote-desc"},
-			wantOp:  OperationAdd,
-			wantVal: "remote-desc",
+			name:         "add: new in remote only",
+			resourceType: "jobs",
+			path:         "description",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "remote-desc"},
+			wantOp:       OperationAdd,
+			wantVal:      "remote-desc",
 		},
 		{
-			name:    "remove: in config, missing from remote",
-			path:    "resources.jobs.my_job.description",
-			cd:      &deployplan.ChangeDesc{Old: "state-desc", New: "config-desc", Remote: nil},
-			wantOp:  OperationRemove,
-			wantVal: nil,
+			name:         "remove: in config, missing from remote",
+			resourceType: "jobs",
+			path:         "description",
+			cd:           &deployplan.ChangeDesc{Old: "state-desc", New: "config-desc", Remote: nil},
+			wantOp:       OperationRemove,
+			wantVal:      nil,
 		},
 		{
-			name:    "replace: differs between config and remote",
-			path:    "resources.jobs.my_job.description",
-			cd:      &deployplan.ChangeDesc{Old: "state-desc", New: "config-desc", Remote: "remote-desc"},
-			wantOp:  OperationReplace,
-			wantVal: "remote-desc",
+			name:         "replace: differs between config and remote",
+			resourceType: "jobs",
+			path:         "description",
+			cd:           &deployplan.ChangeDesc{Old: "state-desc", New: "config-desc", Remote: "remote-desc"},
+			wantOp:       OperationReplace,
+			wantVal:      "remote-desc",
 		},
 		{
-			name:    "skip: absent everywhere",
-			path:    "resources.jobs.my_job.description",
-			cd:      &deployplan.ChangeDesc{Old: nil, New: nil, Remote: nil},
-			wantOp:  OperationSkip,
-			wantVal: nil,
+			name:         "skip: absent everywhere",
+			resourceType: "jobs",
+			path:         "description",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: nil},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
 		},
 		// Regression: rename-back-and-forth. State holds the old key (user did not
 		// redeploy after the first sync), config holds the intermediate key, and
@@ -50,8 +56,9 @@ func TestConvertChangeDesc(t *testing.T) {
 		// config, so the change must be Add — Replace would error in resolveSelectors
 		// because the keyed element no longer exists in the YAML.
 		{
-			name: "add: rename-back path, state has it but config does not",
-			path: "resources.jobs.my_job.tasks[task_key='new_task']",
+			name:         "add: rename-back path, state has it but config does not",
+			resourceType: "jobs",
+			path:         "tasks[task_key='new_task']",
 			cd: &deployplan.ChangeDesc{
 				Old:    map[string]any{"task_key": "new_task"},
 				New:    nil,
@@ -61,8 +68,9 @@ func TestConvertChangeDesc(t *testing.T) {
 			wantVal: map[string]any{"task_key": "new_task"},
 		},
 		{
-			name: "skip: state has it, config and remote do not",
-			path: "resources.jobs.my_job.tasks[task_key='gone']",
+			name:         "skip: state has it, config and remote do not",
+			resourceType: "jobs",
+			path:         "tasks[task_key='gone']",
 			cd: &deployplan.ChangeDesc{
 				Old:    map[string]any{"task_key": "gone"},
 				New:    nil,
@@ -71,11 +79,147 @@ func TestConvertChangeDesc(t *testing.T) {
 			wantOp:  OperationSkip,
 			wantVal: nil,
 		},
+		// The plan re-promotes etag drift to Update via
+		// ResourceDashboard.OverrideChangeDesc, so sync must skip it based on
+		// the ignore_remote_changes metadata, not the plan action.
+		{
+			name:         "skip: dashboard etag is output-only",
+			resourceType: "dashboards",
+			path:         "etag",
+			cd:           &deployplan.ChangeDesc{Old: "etag-1", New: nil, Remote: "etag-2"},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
+		},
+		// create_time comes from resources.generated.yml (spec:output_only).
+		{
+			name:         "skip: dashboard create_time is output-only (generated rule)",
+			resourceType: "dashboards",
+			path:         "create_time",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "2025-01-01T00:00:00Z"},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
+		},
+		{
+			name:         "skip: backend default not in config",
+			resourceType: "jobs",
+			path:         "performance_target",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "PERFORMANCE_OPTIMIZED"},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
+		},
+		{
+			name:         "replace: backend default value but field is set in config",
+			resourceType: "jobs",
+			path:         "performance_target",
+			cd:           &deployplan.ChangeDesc{Old: "STANDARD", New: "STANDARD", Remote: "PERFORMANCE_OPTIMIZED"},
+			wantOp:       OperationReplace,
+			wantVal:      "PERFORMANCE_OPTIMIZED",
+		},
+		{
+			name:         "add: non-default value of backend default field",
+			resourceType: "jobs",
+			path:         "performance_target",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "STANDARD"},
+			wantOp:       OperationAdd,
+			wantVal:      "STANDARD",
+		},
+		{
+			name:         "skip: edit_mode is CLI-managed",
+			resourceType: "jobs",
+			path:         "edit_mode",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "UI_LOCKED"},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
+		},
+		// node_type_id drift on a cluster that omits it in config comes from a
+		// cluster policy (jobs/get returns the policy-resolved value in stored
+		// settings) or, for standalone clusters, from clusters/get reporting the
+		// pool's node type; it must not be written to YAML.
+		{
+			name:         "skip: node_type_id materialized remotely for cluster omitting it",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].new_cluster.node_type_id",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "i3.xlarge"},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
+		},
+		{
+			name:         "skip: standalone cluster node_type_id materialized for pool-backed cluster",
+			resourceType: "clusters",
+			path:         "node_type_id",
+			cd:           &deployplan.ChangeDesc{Old: nil, New: nil, Remote: "c5d.xlarge"},
+			wantOp:       OperationSkip,
+			wantVal:      nil,
+		},
+		{
+			name:         "replace: queue removed remotely resets to disabled",
+			resourceType: "jobs",
+			path:         "queue",
+			cd:           &deployplan.ChangeDesc{Old: map[string]any{"enabled": true}, New: map[string]any{"enabled": true}, Remote: nil},
+			wantOp:       OperationReplace,
+			wantVal:      map[string]any{"enabled": false},
+		},
+		// A task added remotely as a whole: backend defaults (run_if,
+		// timeout_seconds, data_security_mode, the deprecated
+		// no_alert_for_skipped_runs the backend populates in
+		// email_notifications) and ignored fields (aws_attributes) are
+		// stripped; maps that become empty are pruned (email_notifications,
+		// webhook_notifications); node_type_id must be kept or the synced
+		// config would be undeployable.
+		{
+			name:         "add: remotely added task is filtered by metadata",
+			resourceType: "jobs",
+			path:         "tasks[task_key='new_task']",
+			cd: &deployplan.ChangeDesc{
+				Old: nil,
+				New: nil,
+				Remote: map[string]any{
+					"task_key":              "new_task",
+					"run_if":                "ALL_SUCCESS",
+					"timeout_seconds":       0,
+					"email_notifications":   map[string]any{"no_alert_for_skipped_runs": false},
+					"webhook_notifications": map[string]any{},
+					"new_cluster": map[string]any{
+						"spark_version":      "13.3.x-scala2.12",
+						"node_type_id":       "i3.xlarge",
+						"num_workers":        1,
+						"data_security_mode": "SINGLE_USER",
+						"aws_attributes":     map[string]any{"availability": "SPOT_WITH_FALLBACK"},
+					},
+				},
+			},
+			wantOp: OperationAdd,
+			wantVal: map[string]any{
+				"task_key": "new_task",
+				"new_cluster": map[string]any{
+					"spark_version": "13.3.x-scala2.12",
+					"node_type_id":  "i3.xlarge",
+					"num_workers":   int64(1),
+				},
+			},
+		},
+		// When a field set in config filters entirely to backend defaults on
+		// the remote side, the operation is Remove (drop the field from YAML),
+		// not Replace-with-{}.
+		{
+			name:         "remove: config field whose remote value filters to empty",
+			resourceType: "jobs",
+			path:         "email_notifications",
+			cd: &deployplan.ChangeDesc{
+				Old:    map[string]any{"on_failure": []any{"someone@example.com"}},
+				New:    map[string]any{"on_failure": []any{"someone@example.com"}},
+				Remote: map[string]any{"no_alert_for_skipped_runs": false},
+			},
+			wantOp:  OperationRemove,
+			wantVal: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := convertChangeDesc(tt.path, tt.cd)
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			got, err := convertChangeDesc(tt.resourceType, path, tt.cd)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantOp, got.Operation)
 			assert.Equal(t, tt.wantVal, got.Value)
@@ -83,167 +227,325 @@ func TestConvertChangeDesc(t *testing.T) {
 	}
 }
 
-func TestShouldSkipFieldDashboardEtag(t *testing.T) {
-	// etag is output-only: alwaysSkip must apply regardless of hasConfigValue,
-	// otherwise out-of-band etag drift is written back into the user's YAML.
-	path := "resources.dashboards.my_dashboard.etag"
-	assert.True(t, shouldSkipField(path, "some-etag", false))
-	assert.True(t, shouldSkipField(path, "some-etag", true))
-}
-
-func TestStripNamePrefix(t *testing.T) {
+func TestFilterEntityDefaults(t *testing.T) {
 	tests := []struct {
-		name   string
-		path   string
-		value  any
-		prefix string
-		want   any
+		name     string
+		basePath string
+		value    any
+		want     any
 	}{
 		{
-			name:   "job name with normal prefix",
-			path:   "resources.jobs.my_job.name",
-			value:  "[dev user] my_job",
-			prefix: "[dev user] ",
-			want:   "my_job",
+			name:     "array element filtering to empty is kept to preserve arity",
+			basePath: "tasks",
+			value: []any{
+				map[string]any{"task_key": "t1", "run_if": "ALL_SUCCESS"},
+				map[string]any{"run_if": "ALL_SUCCESS"},
+			},
+			want: []any{
+				map[string]any{"task_key": "t1"},
+				map[string]any{},
+			},
 		},
 		{
-			name:   "pipeline name with normal prefix",
-			path:   "resources.pipelines.my_pipeline.name",
-			value:  "[dev user] my_pipeline",
-			prefix: "[dev user] ",
-			want:   "my_pipeline",
+			name:     "map field filtering to empty is pruned",
+			basePath: "tasks[task_key='t1']",
+			value: map[string]any{
+				"task_key":            "t1",
+				"email_notifications": map[string]any{"no_alert_for_skipped_runs": false},
+			},
+			want: map[string]any{"task_key": "t1"},
 		},
 		{
-			name:   "dashboard display_name with prefix",
-			path:   "resources.dashboards.my_dash.display_name",
-			value:  "[dev user] my_dash",
-			prefix: "[dev user] ",
-			want:   "my_dash",
+			name:     "whole value filtering to empty becomes nil",
+			basePath: "email_notifications",
+			value:    map[string]any{"no_alert_for_skipped_runs": false},
+			want:     nil,
 		},
 		{
-			name:   "name does not start with prefix",
-			path:   "resources.jobs.my_job.name",
-			value:  "my_job",
-			prefix: "[dev user] ",
-			want:   "my_job",
+			name:     "scalar is returned unchanged",
+			basePath: "description",
+			value:    "desc",
+			want:     "desc",
 		},
+		// node_type_id matches backend_defaults (policy-backed clusters
+		// materialize it remotely) but is in fieldsKeptForSync: a remotely
+		// added cluster carrying it explicitly, even alongside policy_id,
+		// must keep it or the synced config would be undeployable.
 		{
-			name:   "empty prefix is noop",
-			path:   "resources.jobs.my_job.name",
-			value:  "[dev user] my_job",
-			prefix: "",
-			want:   "[dev user] my_job",
-		},
-		{
-			name:   "non-name field is not stripped",
-			path:   "resources.jobs.my_job.description",
-			value:  "[dev user] some description",
-			prefix: "[dev user] ",
-			want:   "[dev user] some description",
-		},
-		{
-			name:   "non-string value is unchanged",
-			path:   "resources.jobs.my_job.name",
-			value:  42,
-			prefix: "[dev user] ",
-			want:   42,
-		},
-		{
-			name:   "nil value is unchanged",
-			path:   "resources.jobs.my_job.name",
-			value:  nil,
-			prefix: "[dev user] ",
-			want:   nil,
+			name:     "remotely added policy-backed cluster keeps node_type_id",
+			basePath: "job_clusters[0].new_cluster",
+			value: map[string]any{
+				"policy_id":          "ABC123",
+				"node_type_id":       "i3.xlarge",
+				"spark_version":      "13.3.x-scala2.12",
+				"num_workers":        1,
+				"data_security_mode": "SINGLE_USER",
+			},
+			want: map[string]any{
+				"policy_id":     "ABC123",
+				"node_type_id":  "i3.xlarge",
+				"spark_version": "13.3.x-scala2.12",
+				"num_workers":   1,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := stripNamePrefix(tt.path, tt.value, tt.prefix)
+			basePath, err := structpath.ParsePath(tt.basePath)
+			require.NoError(t, err)
+			got := filterEntityDefaults("jobs", basePath, tt.value)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestMatchPattern(t *testing.T) {
+func TestShouldSkipForSync(t *testing.T) {
 	tests := []struct {
-		name    string
-		pattern string
-		path    string
-		want    bool
+		name           string
+		resourceType   string
+		path           string
+		value          any
+		hasConfigValue bool
+		want           bool
 	}{
 		{
-			name:    "exact match",
-			pattern: "timeout_seconds",
-			path:    "timeout_seconds",
-			want:    true,
+			name:         "ignore_remote_changes skips regardless of value",
+			resourceType: "dashboards",
+			path:         "etag",
+			value:        "etag-2",
+			want:         true,
 		},
 		{
-			name:    "exact match no match",
-			pattern: "timeout_seconds",
-			path:    "other_field",
-			want:    false,
+			name:           "ignore_remote_changes skips even when field is in config",
+			resourceType:   "dashboards",
+			path:           "serialized_dashboard",
+			value:          "{}",
+			hasConfigValue: true,
+			want:           true,
 		},
 		{
-			name:    "array wildcard match",
-			pattern: "tasks[*].run_if",
-			path:    "tasks[task_key='my_task'].run_if",
-			want:    true,
+			name:         "generated ignore_remote_changes rule",
+			resourceType: "dashboards",
+			path:         "lifecycle_state",
+			value:        "ACTIVE",
+			want:         true,
 		},
 		{
-			name:    "array wildcard no match",
-			pattern: "tasks[*].run_if",
-			path:    "tasks[task_key='my_task'].disabled",
-			want:    false,
+			name:         "ignore_remote_changes matches nested path by prefix",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].new_cluster.aws_attributes.availability",
+			value:        "SPOT",
+			want:         true,
 		},
 		{
-			name:    "nested array wildcard match",
-			pattern: "tasks[*].new_cluster.azure_attributes.availability",
-			path:    "tasks[task_key='task1'].new_cluster.azure_attributes.availability",
-			want:    true,
+			name:         "backend default with matching value",
+			resourceType: "jobs",
+			path:         "performance_target",
+			value:        "PERFORMANCE_OPTIMIZED",
+			want:         true,
 		},
 		{
-			name:    "job_clusters array wildcard match",
-			pattern: "job_clusters[*].new_cluster.aws_attributes.availability",
-			path:    "job_clusters[job_cluster_key='cluster1'].new_cluster.aws_attributes.availability",
-			want:    true,
+			name:         "backend default with non-matching value",
+			resourceType: "jobs",
+			path:         "performance_target",
+			value:        "STANDARD",
+			want:         false,
 		},
 		{
-			name:    "wildcard segment match",
-			pattern: "*.timeout_seconds",
-			path:    "timeout_seconds",
-			want:    false,
+			name:           "backend default not applied when field is in config",
+			resourceType:   "jobs",
+			path:           "performance_target",
+			value:          "PERFORMANCE_OPTIMIZED",
+			hasConfigValue: true,
+			want:           false,
 		},
 		{
-			name:    "different array prefix no match",
-			pattern: "tasks[*].run_if",
-			path:    "jobs[task_key='my_task'].run_if",
-			want:    false,
+			name:         "backend default without values matches any value",
+			resourceType: "jobs",
+			path:         "run_as",
+			value:        map[string]any{"user_name": "someone@example.com"},
+			want:         true,
 		},
 		{
-			name:    "nested path match",
-			pattern: "tasks[*].notebook_task.source",
-			path:    "tasks[task_key='notebook'].notebook_task.source",
-			want:    true,
+			name:         "backend default with wildcard pattern",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].run_if",
+			value:        "ALL_SUCCESS",
+			want:         true,
+		},
+		// node_type_id matches backend_defaults; nested filtering overrides
+		// this via fieldsKeptForSync (see TestFilterEntityDefaults).
+		{
+			name:         "backend default node_type_id",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].new_cluster.node_type_id",
+			value:        "i3.xlarge",
+			want:         true,
 		},
 		{
-			name:    "path shorter than pattern",
-			pattern: "tasks[*].new_cluster.azure_attributes",
-			path:    "tasks[task_key='task1'].new_cluster",
-			want:    false,
+			name:         "regular field is not skipped",
+			resourceType: "jobs",
+			path:         "description",
+			value:        "some description",
+			want:         false,
 		},
 		{
-			name:    "path longer than pattern",
-			pattern: "tasks[*].new_cluster",
-			path:    "tasks[task_key='task1'].new_cluster.azure_attributes",
-			want:    false,
+			name:         "unknown resource type is not skipped",
+			resourceType: "unknown",
+			path:         "anything",
+			value:        "value",
+			want:         false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchPattern(tt.pattern, tt.path)
-			assert.Equal(t, tt.want, got, "matchPattern(%q, %q)", tt.pattern, tt.path)
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			got := shouldSkipForSync(tt.resourceType, path, tt.value, tt.hasConfigValue)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResetValueIfNeeded(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		path         string
+		value        any
+		want         any
+	}{
+		{
+			name:         "whole queue field is reset",
+			resourceType: "jobs",
+			path:         "queue",
+			value:        nil,
+			want:         map[string]any{"enabled": false},
+		},
+		{
+			name:         "queue subfield keeps its own value",
+			resourceType: "jobs",
+			path:         "queue.enabled",
+			value:        false,
+			want:         false,
+		},
+		{
+			name:         "unrelated field is unchanged",
+			resourceType: "jobs",
+			path:         "description",
+			value:        "desc",
+			want:         "desc",
+		},
+		{
+			name:         "other resource type is unchanged",
+			resourceType: "pipelines",
+			path:         "queue",
+			value:        nil,
+			want:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			got := resetValueIfNeeded(tt.resourceType, path, tt.value)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripNamePrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		path         string
+		value        any
+		prefix       string
+		want         any
+	}{
+		{
+			name:         "job name with normal prefix",
+			resourceType: "jobs",
+			path:         "name",
+			value:        "[dev user] my_job",
+			prefix:       "[dev user] ",
+			want:         "my_job",
+		},
+		{
+			name:         "pipeline name with normal prefix",
+			resourceType: "pipelines",
+			path:         "name",
+			value:        "[dev user] my_pipeline",
+			prefix:       "[dev user] ",
+			want:         "my_pipeline",
+		},
+		{
+			name:         "dashboard display_name with prefix",
+			resourceType: "dashboards",
+			path:         "display_name",
+			value:        "[dev user] my_dash",
+			prefix:       "[dev user] ",
+			want:         "my_dash",
+		},
+		{
+			name:         "name does not start with prefix",
+			resourceType: "jobs",
+			path:         "name",
+			value:        "my_job",
+			prefix:       "[dev user] ",
+			want:         "my_job",
+		},
+		{
+			name:         "empty prefix is noop",
+			resourceType: "jobs",
+			path:         "name",
+			value:        "[dev user] my_job",
+			prefix:       "",
+			want:         "[dev user] my_job",
+		},
+		{
+			name:         "non-name field is not stripped",
+			resourceType: "jobs",
+			path:         "description",
+			value:        "[dev user] some description",
+			prefix:       "[dev user] ",
+			want:         "[dev user] some description",
+		},
+		{
+			name:         "name of resource type without prefix support",
+			resourceType: "experiments",
+			path:         "name",
+			value:        "[dev user] my_experiment",
+			prefix:       "[dev user] ",
+			want:         "[dev user] my_experiment",
+		},
+		{
+			name:         "non-string value is unchanged",
+			resourceType: "jobs",
+			path:         "name",
+			value:        42,
+			prefix:       "[dev user] ",
+			want:         42,
+		},
+		{
+			name:         "nil value is unchanged",
+			resourceType: "jobs",
+			path:         "name",
+			value:        nil,
+			prefix:       "[dev user] ",
+			want:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			got := stripNamePrefix(tt.resourceType, path, tt.value, tt.prefix)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/bundle/configsync/diff_test.go
+++ b/bundle/configsync/diff_test.go
@@ -384,6 +384,66 @@ func TestShouldSkipForSync(t *testing.T) {
 			want:         true,
 		},
 		{
+			name:         "backend default pipeline_task full_refresh false",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].pipeline_task.full_refresh",
+			value:        false,
+			want:         true,
+		},
+		{
+			name:         "pipeline_task full_refresh true is not a backend default",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].pipeline_task.full_refresh",
+			value:        true,
+			want:         false,
+		},
+		// Policy-injected fields on job and standalone clusters: skipped only
+		// when absent from config. The classification ladder is shared with the
+		// deploy plan, so these pin the resources.yml rules for all cluster sites.
+		{
+			name:         "backend default custom_tags on for_each task cluster",
+			resourceType: "jobs",
+			path:         "tasks[task_key='t1'].for_each_task.task.new_cluster.custom_tags",
+			value:        map[string]any{"CostCenter": "dev-1234"},
+			want:         true,
+		},
+		{
+			name:         "backend default custom_tags on standalone cluster",
+			resourceType: "clusters",
+			path:         "custom_tags",
+			value:        map[string]any{"CostCenter": "dev-1234"},
+			want:         true,
+		},
+		{
+			name:           "custom_tags on standalone cluster kept when in config",
+			resourceType:   "clusters",
+			path:           "custom_tags",
+			value:          map[string]any{"CostCenter": "dev-1234"},
+			hasConfigValue: true,
+			want:           false,
+		},
+		{
+			name:         "backend default cluster_log_conf on standalone cluster",
+			resourceType: "clusters",
+			path:         "cluster_log_conf",
+			value:        map[string]any{"dbfs": map[string]any{"destination": "dbfs:/cluster-logs/dev"}},
+			want:         true,
+		},
+		{
+			name:         "backend default driver_node_type_flexibility on standalone cluster",
+			resourceType: "clusters",
+			path:         "driver_node_type_flexibility",
+			value:        map[string]any{"alternate_node_type_ids": []any{"i4i.xlarge"}},
+			want:         true,
+		},
+		{
+			name:         "backend default worker_node_type_flexibility on standalone cluster",
+			resourceType: "clusters",
+			path:         "worker_node_type_flexibility",
+			value:        map[string]any{"alternate_node_type_ids": []any{"i4i.xlarge"}},
+			want:         true,
+		},
+		{
 			name:         "regular field is not skipped",
 			resourceType: "jobs",
 			path:         "description",

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -2,7 +2,6 @@ package direct
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -393,10 +392,10 @@ func addPerFieldActions(ctx context.Context, adapter *dresources.Adapter, change
 		} else if isFieldMissingInRemote(adapter, path) && structdiff.IsEqual(ch.Old, ch.New) {
 			ch.Action = deployplan.Skip
 			ch.Reason = deployplan.ReasonMissingInRemote
-		} else if reason, ok := findMatchingRule(path, cfg.RecreateOnChanges); ok {
+		} else if reason, ok := dresources.FindMatchingRule(path, cfg.RecreateOnChanges); ok {
 			ch.Action = deployplan.Recreate
 			ch.Reason = reason
-		} else if reason, ok := findMatchingRule(path, generatedCfg.RecreateOnChanges); ok {
+		} else if reason, ok := dresources.FindMatchingRule(path, generatedCfg.RecreateOnChanges); ok {
 			ch.Action = deployplan.Recreate
 			ch.Reason = reason
 		} else {
@@ -439,23 +438,14 @@ func isFieldMissingInRemote(adapter *dresources.Adapter, path *structpath.PathNo
 	return structaccess.ValidatePath(adapter.RemoteType(), path) != nil
 }
 
-func findMatchingRule(path *structpath.PathNode, rules []dresources.FieldRule) (string, bool) {
-	for _, r := range rules {
-		if path.HasPatternPrefix(r.Field) {
-			return r.Reason, true
-		}
-	}
-	return "", false
-}
-
 func shouldSkip(cfg *dresources.ResourceLifecycleConfig, path *structpath.PathNode, ch *deployplan.ChangeDesc) (string, bool) {
 	if cfg == nil {
 		return "", false
 	}
-	if reason, ok := findMatchingRule(path, cfg.IgnoreLocalChanges); ok && !structdiff.IsEqual(ch.Old, ch.New) {
+	if reason, ok := dresources.FindMatchingRule(path, cfg.IgnoreLocalChanges); ok && !structdiff.IsEqual(ch.Old, ch.New) {
 		return reason, true
 	}
-	if reason, ok := findMatchingRule(path, cfg.IgnoreRemoteChanges); ok && structdiff.IsEqual(ch.Old, ch.New) {
+	if reason, ok := dresources.FindMatchingRule(path, cfg.IgnoreRemoteChanges); ok && structdiff.IsEqual(ch.Old, ch.New) {
 		return reason, true
 	}
 	return "", false
@@ -476,13 +466,13 @@ func classifyIDField(cfg *dresources.ResourceLifecycleConfig, path *structpath.P
 		return deployplan.Undefined, "", false
 	}
 	localChange := !structdiff.IsEqual(ch.Old, ch.New)
-	if reason, ok := findMatchingRule(path, cfg.ProvidedIDFields); ok {
+	if reason, ok := dresources.FindMatchingRule(path, cfg.ProvidedIDFields); ok {
 		if localChange {
 			return deployplan.Recreate, reason, true
 		}
 		return deployplan.Skip, reason, true
 	}
-	if reason, ok := findMatchingRule(path, cfg.UpdatableIDFields); ok {
+	if reason, ok := dresources.FindMatchingRule(path, cfg.UpdatableIDFields); ok {
 		if localChange {
 			return deployplan.UpdateWithID, reason, true
 		}
@@ -505,7 +495,7 @@ func shouldSkipNormalized(cfg *dresources.ResourceLifecycleConfig, path *structp
 	if !newOk || !remoteOk {
 		return "", false
 	}
-	if reason, ok := findMatchingRule(path, cfg.NormalizeSlash); ok && strings.TrimRight(newStr, "/") == strings.TrimRight(remoteStr, "/") {
+	if reason, ok := dresources.FindMatchingRule(path, cfg.NormalizeSlash); ok && strings.TrimRight(newStr, "/") == strings.TrimRight(remoteStr, "/") {
 		return reason, true
 	}
 	return "", false
@@ -515,64 +505,13 @@ func shouldSkipNormalized(cfg *dresources.ResourceLifecycleConfig, path *structp
 // is a known backend default. Applies when old and new are nil but remote is set.
 // If the rule has allowed values, the remote value must match one of them.
 func shouldSkipBackendDefault(cfg *dresources.ResourceLifecycleConfig, path *structpath.PathNode, ch *deployplan.ChangeDesc) (string, bool) {
-	if cfg == nil || ch.Old != nil || ch.New != nil || ch.Remote == nil {
+	if ch.Old != nil || ch.New != nil {
 		return "", false
 	}
-	if matchesAnyBackendDefault(cfg, path, ch.Remote) {
+	if cfg.MatchesBackendDefault(path, ch.Remote) {
 		return deployplan.ReasonBackendDefault, true
 	}
-
-	// Nil-vs-map case from structdiff: a remote-only map change is emitted at the
-	// parent path rather than per key. Only skip the parent map if every remote
-	// entry matches a configured backend-default child rule; any unmanaged key
-	// must still surface as drift. rv is always valid here (ch.Remote != nil
-	// above) and a nil map is excluded by Len() == 0.
-	rv := reflect.ValueOf(ch.Remote)
-	if rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String || rv.Len() == 0 {
-		return "", false
-	}
-	iter := rv.MapRange()
-	for iter.Next() {
-		childPath := structpath.NewBracketString(path, iter.Key().String())
-		if !matchesAnyBackendDefault(cfg, childPath, iter.Value().Interface()) {
-			return "", false
-		}
-	}
-	return deployplan.ReasonBackendDefault, true
-}
-
-// matchesAnyBackendDefault reports whether the remote value at path matches any of
-// the resource's configured backend-default rules (and the rule's allowed values,
-// if specified).
-func matchesAnyBackendDefault(cfg *dresources.ResourceLifecycleConfig, path *structpath.PathNode, remote any) bool {
-	for _, rule := range cfg.BackendDefaults {
-		if !path.HasPatternPrefix(rule.Field) {
-			continue
-		}
-		if len(rule.Values) == 0 {
-			return true
-		}
-		if matchesAllowedValue(remote, rule.Values) {
-			return true
-		}
-	}
-	return false
-}
-
-// matchesAllowedValue checks if the remote value matches one of the allowed JSON values.
-// Each json.RawMessage is unmarshaled into the same type as remote for comparison.
-func matchesAllowedValue(remote any, values []json.RawMessage) bool {
-	remoteType := reflect.TypeOf(remote)
-	for _, raw := range values {
-		candidate := reflect.New(remoteType).Interface()
-		if err := json.Unmarshal(raw, candidate); err != nil {
-			continue
-		}
-		if structdiff.IsEqual(remote, reflect.ValueOf(candidate).Elem().Interface()) {
-			return true
-		}
-	}
-	return false
+	return "", false
 }
 
 func allEmpty(values ...any) bool {

--- a/bundle/direct/dresources/README.md
+++ b/bundle/direct/dresources/README.md
@@ -17,7 +17,7 @@
 
 Each field with special plan/deploy behavior must be declared in `resources.yml`. Choose the right category:
 
- - **`backend_defaults`**: The backend may fill in a value when the user doesn't specify one. Suppresses the diff when the user's config is nil/empty but remote has a value. Optionally restrict to specific allowed remote values via `values:`. Use for fields the API fills in as defaults (e.g., `format`, `run_if`, `node_type_id`). Link to TF provider suppression comment in the same format as existing entries.
+ - **`backend_defaults`**: The backend may fill in a value when the user doesn't specify one. Suppresses the diff when the user's config is nil/empty but remote has a value. Optionally restrict to specific allowed remote values via `values:`. Use for fields the API fills in as defaults (e.g., `format`, `run_if`, `driver_node_type_id`). Link to TF provider suppression comment in the same format as existing entries.
  - **`ignore_remote_changes`**: Ignore changes the remote makes to this field. Use for fields the backend manages (e.g., cloud-provider attributes like `aws_attributes`, `gcp_attributes`) or fields not returned by the update endpoint. Do not zero out such fields in `RemapState` to hide them from diff computation: carry the real remote value through and declare the field here instead, since zeroing discards information and duplicates the suppression logic. For `output_only` fields this rule is often already produced by `resources.generated.yml` from the OpenAPI annotation. Reason codes:
    - `output_only` — the field is computed by the backend; the user never sets it
    - `input_only` — accepted on create/update but not returned by GET (e.g., write-only tokens, flags)

--- a/bundle/direct/dresources/match.go
+++ b/bundle/direct/dresources/match.go
@@ -1,0 +1,84 @@
+package dresources
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/databricks/cli/libs/structs/structdiff"
+	"github.com/databricks/cli/libs/structs/structpath"
+)
+
+// FindMatchingRule returns the reason of the first rule whose field pattern
+// is a prefix of the given path.
+func FindMatchingRule(path *structpath.PathNode, rules []FieldRule) (string, bool) {
+	for _, r := range rules {
+		if path.HasPatternPrefix(r.Field) {
+			return r.Reason, true
+		}
+	}
+	return "", false
+}
+
+// MatchesBackendDefault reports whether the remote value at path matches one of
+// the backend_defaults rules. If a rule has allowed values, the remote value
+// must match one of them.
+func (cfg *ResourceLifecycleConfig) MatchesBackendDefault(path *structpath.PathNode, remote any) bool {
+	if cfg == nil || remote == nil {
+		return false
+	}
+	if cfg.matchesBackendDefaultRule(path, remote) {
+		return true
+	}
+
+	// Nil-vs-map case from structdiff: a remote-only map change is emitted at the
+	// parent path rather than per key. Only skip the parent map if every remote
+	// entry matches a configured backend-default child rule; any unmanaged key
+	// must still surface as drift. rv is always valid here (remote != nil
+	// above) and a nil map is excluded by Len() == 0.
+	rv := reflect.ValueOf(remote)
+	if rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String || rv.Len() == 0 {
+		return false
+	}
+	iter := rv.MapRange()
+	for iter.Next() {
+		childPath := structpath.NewBracketString(path, iter.Key().String())
+		if !cfg.matchesBackendDefaultRule(childPath, iter.Value().Interface()) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchesBackendDefaultRule reports whether the remote value at path matches any of
+// the resource's configured backend-default rules (and the rule's allowed values,
+// if specified).
+func (cfg *ResourceLifecycleConfig) matchesBackendDefaultRule(path *structpath.PathNode, remote any) bool {
+	for _, rule := range cfg.BackendDefaults {
+		if !path.HasPatternPrefix(rule.Field) {
+			continue
+		}
+		if len(rule.Values) == 0 {
+			return true
+		}
+		if MatchesAllowedValue(remote, rule.Values) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesAllowedValue checks if the remote value matches one of the allowed JSON values.
+// Each json.RawMessage is unmarshaled into the same type as remote for comparison.
+func MatchesAllowedValue(remote any, values []json.RawMessage) bool {
+	remoteType := reflect.TypeOf(remote)
+	for _, raw := range values {
+		candidate := reflect.New(remoteType).Interface()
+		if err := json.Unmarshal(raw, candidate); err != nil {
+			continue
+		}
+		if structdiff.IsEqual(remote, reflect.ValueOf(candidate).Elem().Interface()) {
+			return true
+		}
+	}
+	return false
+}

--- a/bundle/direct/dresources/match_test.go
+++ b/bundle/direct/dresources/match_test.go
@@ -1,0 +1,177 @@
+package dresources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/databricks/cli/libs/structs/structpath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindMatchingRule(t *testing.T) {
+	rules := []FieldRule{
+		{Field: structpath.MustParsePattern("tasks[*].run_if"), Reason: "first"},
+		{Field: structpath.MustParsePattern("aws_attributes"), Reason: "second"},
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantReason string
+		wantOk     bool
+	}{
+		{
+			name:       "wildcard match",
+			path:       "tasks[task_key='t1'].run_if",
+			wantReason: "first",
+			wantOk:     true,
+		},
+		{
+			name:       "prefix match on nested path",
+			path:       "aws_attributes.availability",
+			wantReason: "second",
+			wantOk:     true,
+		},
+		{
+			name:   "no match",
+			path:   "description",
+			wantOk: false,
+		},
+		{
+			name:   "path shorter than pattern",
+			path:   "tasks[task_key='t1']",
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			reason, ok := FindMatchingRule(path, rules)
+			assert.Equal(t, tt.wantOk, ok)
+			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}
+
+func TestMatchesAllowedValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote any
+		values []json.RawMessage
+		want   bool
+	}{
+		{
+			name:   "string match",
+			remote: "ALL_SUCCESS",
+			values: []json.RawMessage{json.RawMessage(`"ALL_SUCCESS"`)},
+			want:   true,
+		},
+		{
+			name:   "string no match",
+			remote: "ALL_DONE",
+			values: []json.RawMessage{json.RawMessage(`"ALL_SUCCESS"`)},
+			want:   false,
+		},
+		{
+			name:   "one of several values",
+			remote: "SINGLE_TASK",
+			values: []json.RawMessage{json.RawMessage(`"MULTI_TASK"`), json.RawMessage(`"SINGLE_TASK"`)},
+			want:   true,
+		},
+		{
+			name:   "int match",
+			remote: int64(0),
+			values: []json.RawMessage{json.RawMessage(`0`)},
+			want:   true,
+		},
+		{
+			name:   "bool match",
+			remote: false,
+			values: []json.RawMessage{json.RawMessage(`false`)},
+			want:   true,
+		},
+		{
+			name:   "type mismatch",
+			remote: int64(1),
+			values: []json.RawMessage{json.RawMessage(`"1"`)},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MatchesAllowedValue(tt.remote, tt.values))
+		})
+	}
+}
+
+func TestMatchesBackendDefault(t *testing.T) {
+	cfg := &ResourceLifecycleConfig{
+		BackendDefaults: []BackendDefaultRule{
+			{Field: structpath.MustParsePattern("run_as")},
+			{Field: structpath.MustParsePattern("tasks[*].run_if"), Values: []json.RawMessage{json.RawMessage(`"ALL_SUCCESS"`)}},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		cfg    *ResourceLifecycleConfig
+		path   string
+		remote any
+		want   bool
+	}{
+		{
+			name:   "rule without values matches any remote value",
+			cfg:    cfg,
+			path:   "run_as",
+			remote: map[string]any{"user_name": "someone@example.com"},
+			want:   true,
+		},
+		{
+			name:   "rule with values matches allowed value",
+			cfg:    cfg,
+			path:   "tasks[task_key='t1'].run_if",
+			remote: "ALL_SUCCESS",
+			want:   true,
+		},
+		{
+			name:   "rule with values rejects other value",
+			cfg:    cfg,
+			path:   "tasks[task_key='t1'].run_if",
+			remote: "ALL_DONE",
+			want:   false,
+		},
+		{
+			name:   "no rule for path",
+			cfg:    cfg,
+			path:   "description",
+			remote: "x",
+			want:   false,
+		},
+		{
+			name:   "nil remote never matches",
+			cfg:    cfg,
+			path:   "run_as",
+			remote: nil,
+			want:   false,
+		},
+		{
+			name:   "nil config never matches",
+			cfg:    nil,
+			path:   "run_as",
+			remote: "x",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, tt.cfg.MatchesBackendDefault(path, tt.remote))
+		})
+	}
+}

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -145,6 +145,12 @@ resources:
       - field: tasks[*].for_each_task.task.disabled
         values: [false]
 
+      # The backend returns full_refresh: false for pipeline tasks when not
+      # set. Same as timeout_seconds above: inert for the plan, needed by
+      # config-remote-sync for remotely added pipeline tasks.
+      - field: tasks[*].pipeline_task.full_refresh
+        values: [false]
+
       # When notifications are not configured, the backend returns
       # email_notifications populated with the deprecated
       # no_alert_for_skipped_runs: false field. Inert for the plan: the

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -84,6 +84,11 @@ resources:
 
       # Same as clusters.node_type_id — see clusters/resource_cluster.go#L333
       # s.SchemaPath("node_type_id").SetComputed()
+      # Config legitimately omits node_type_id when a cluster policy fixes it: jobs/get
+      # then returns the policy-resolved value in the stored settings (with or without
+      # apply_policy_default_values), so the drift must be skipped.
+      # config-remote-sync keeps these fields for remotely added clusters via
+      # fieldsKeptForSync in bundle/configsync/defaults.go.
       - field: tasks[*].new_cluster.node_type_id
       - field: tasks[*].for_each_task.task.new_cluster.node_type_id
       - field: job_clusters[*].new_cluster.node_type_id
@@ -119,6 +124,41 @@ resources:
       # s.SchemaPath("run_as").SetComputed()
       - field: run_as
 
+      # The backend returns PERFORMANCE_OPTIMIZED for all jobs when the field
+      # is not set, not only for serverless jobs.
+      - field: performance_target
+        values: ["PERFORMANCE_OPTIMIZED"]
+
+      # The backend returns timeout_seconds: 0 for tasks when not set. The plan
+      # already skips this via the all-empty check; the rule is needed so that
+      # config-remote-sync does not write timeout_seconds: 0 into YAML for
+      # tasks added remotely.
+      - field: tasks[*].timeout_seconds
+        values: [0]
+      - field: tasks[*].for_each_task.task.timeout_seconds
+        values: [0]
+
+      # The backend returns disabled: false for tasks when not set. Same as
+      # timeout_seconds above: inert for the plan, needed by config-remote-sync.
+      - field: tasks[*].disabled
+        values: [false]
+      - field: tasks[*].for_each_task.task.disabled
+        values: [false]
+
+      # When notifications are not configured, the backend returns
+      # email_notifications populated with the deprecated
+      # no_alert_for_skipped_runs: false field. Inert for the plan: the
+      # all-empty check in addPerFieldActions runs before backend defaults
+      # and already skips zero values. Needed so config-remote-sync drops the
+      # leaf (and then prunes the empty email_notifications map) instead of
+      # writing it into YAML.
+      - field: email_notifications.no_alert_for_skipped_runs
+        values: [false]
+      - field: tasks[*].email_notifications.no_alert_for_skipped_runs
+        values: [false]
+      - field: tasks[*].for_each_task.task.email_notifications.no_alert_for_skipped_runs
+        values: [false]
+
       # https://github.com/databricks/terraform-provider-databricks/blob/4eba541abe1a9f50993ea7b9dd83874207e224a1/jobs/resource_job.go#L521-L524
       # s.SchemaPath("task", "notebook_task", "source").SetSuppressDiff()
       # s.SchemaPath("task", "spark_python_task", "source").SetSuppressDiff()
@@ -137,6 +177,24 @@ resources:
       - field: tasks[*].new_cluster.data_security_mode
       - field: tasks[*].for_each_task.task.new_cluster.data_security_mode
       - field: job_clusters[*].new_cluster.data_security_mode
+
+      # Same as clusters.single_user_name: backend sets it when the effective
+      # data security mode is single-user.
+      # See https://github.com/databricks/cli/issues/4418
+      - field: tasks[*].new_cluster.single_user_name
+      - field: job_clusters[*].new_cluster.single_user_name
+
+      # custom_tags and cluster_log_conf are commonly injected by cluster policies
+      # when the user omits them, so they exist only remotely. Treating them as
+      # backend defaults keeps the plan free of perpetual policy-injected drift and
+      # keeps config-remote-sync from leaking one environment's policy values into
+      # (often shared) config, which breaks deploys in other environments.
+      - field: tasks[*].new_cluster.custom_tags
+      - field: tasks[*].new_cluster.cluster_log_conf
+      - field: tasks[*].for_each_task.task.new_cluster.custom_tags
+      - field: tasks[*].for_each_task.task.new_cluster.cluster_log_conf
+      - field: job_clusters[*].new_cluster.custom_tags
+      - field: job_clusters[*].new_cluster.cluster_log_conf
 
   pipelines:
     recreate_on_changes:
@@ -184,10 +242,6 @@ resources:
       # s.SchemaPath("storage").SetCustomSuppressDiff(suppressStorageDiff)
       # Backend generates storage path like dbfs:/pipelines/<id> when not set by user.
       - field: storage
-
-      # https://github.com/databricks/terraform-provider-databricks/blob/4eba541abe1a9f50993ea7b9dd83874207e224a1/pipelines/resource_pipeline.go#L218
-      # s.SchemaPath("cluster", "node_type_id").SetComputed()
-      - field: clusters[*].node_type_id
 
       # https://github.com/databricks/terraform-provider-databricks/blob/4eba541abe1a9f50993ea7b9dd83874207e224a1/pipelines/resource_pipeline.go#L219
       # s.SchemaPath("cluster", "driver_node_type_id").SetComputed()
@@ -411,6 +465,14 @@ resources:
       - field: serialized_dashboard
         reason: etag_based
 
+      # "etag" is output-only and never present in the config. This rule does not
+      # change deploy behavior: ResourceDashboard.OverrideChangeDesc runs after the
+      # metadata chain and re-promotes etag drift to Update so that out-of-band
+      # modifications are detected during deploy. config-remote-sync matches this
+      # rule directly (not the plan action) to keep etag out of YAML.
+      - field: etag
+        reason: output_only
+
       # "dataset_catalog" and "dataset_schema" are write-only fields that are not returned by the server.
       # They will always differ between local config (which has values) and remote state (which has empty strings).
       - field: dataset_catalog
@@ -558,6 +620,9 @@ resources:
 
       # https://github.com/databricks/terraform-provider-databricks/blob/4eba541abe1a9f50993ea7b9dd83874207e224a1/clusters/resource_cluster.go#L333
       # s.SchemaPath("node_type_id").SetComputed()
+      # Config legitimately omits node_type_id when instance_pool_id is set (the API
+      # rejects specifying both) or a cluster policy fixes it; clusters/get reports the
+      # actual node type at the top level, so the drift must be skipped.
       - field: node_type_id
 
       # https://github.com/databricks/terraform-provider-databricks/blob/4eba541abe1a9f50993ea7b9dd83874207e224a1/clusters/resource_cluster.go#L334
@@ -571,6 +636,17 @@ resources:
       # Terraform currently does not do this, but it is a field with backend default.
       # See https://github.com/databricks/cli/issues/4418
       - field: single_user_name
+
+      # Some backends compute alternate node types for standalone clusters when
+      # flexibility is not specified in the config (observed on AWS staging
+      # workspaces).
+      - field: driver_node_type_flexibility
+      - field: worker_node_type_flexibility
+
+      # See jobs.tasks[*].new_cluster.custom_tags: cluster policies inject these
+      # when the user omits them.
+      - field: custom_tags
+      - field: cluster_log_conf
 
     # We have custom handler for this in cluster.go
     # https://github.com/databricks/terraform-provider-databricks/blob/4eba541abe1a9f50993ea7b9dd83874207e224a1/clusters/resource_cluster.go#L109-L118

--- a/libs/structs/structpath/path.go
+++ b/libs/structs/structpath/path.go
@@ -637,6 +637,15 @@ func MustParsePath(s string) *PathNode {
 	return path
 }
 
+// MustParsePattern parses a pattern string and panics on error. Wildcards are allowed.
+func MustParsePattern(s string) *PatternNode {
+	pattern, err := ParsePattern(s)
+	if err != nil {
+		panic(err)
+	}
+	return pattern
+}
+
 // isReservedFieldChar checks if character is reserved and cannot be used in field names
 func isReservedFieldChar(ch byte) bool {
 	switch ch {

--- a/libs/structs/structpath/path_test.go
+++ b/libs/structs/structpath/path_test.go
@@ -567,6 +567,15 @@ func TestParseErrors(t *testing.T) {
 	}
 }
 
+func TestMustParsePattern(t *testing.T) {
+	pattern := MustParsePattern("tasks[*].run_if")
+	assert.Equal(t, "tasks[*].run_if", pattern.String())
+
+	assert.Panics(t, func() {
+		MustParsePattern("tasks[")
+	})
+}
+
 func TestNewIndexPanic(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
## Changes

`bundle config-remote-sync` derives its field filtering from the resource lifecycle metadata (`resources.yml` + `resources.generated.yml`) instead of the hand-maintained `serverSideDefaults` table:

- `ignore_remote_changes` fields are excluded from sync unconditionally; `backend_defaults` fields only when absent from config, honoring `values`.
- The metadata is matched directly, never via plan actions or `OverrideChangeDesc` hooks — those answer "what will deploy do", not "what belongs in config" (e.g. dashboard `etag` is re-promoted to Update for modified-remotely detection, yet must never be synced).
- Sync-specific rules stay in the configsync package: jobs `edit_mode`, `queue` reset values, name-prefix stripping, and a `node_type_id` keep-list so remotely added job clusters stay deployable.
- The matching helpers move unchanged to `dresources/match.go` so plan and sync share one implementation.

`resources.yml` changes:

- `custom_tags` / `cluster_log_conf` become `backend_defaults` on job and standalone clusters (moved from the configsync-only rule in #5610, per its TODO). This also stops perpetual direct-engine plan updates for policy-injected values.
- New backend defaults: `performance_target ["PERFORMANCE_OPTIMIZED"]`, task `timeout_seconds [0]` / `disabled [false]` / `pipeline_task.full_refresh [false]`, `email_notifications.no_alert_for_skipped_runs [false]`, task/job-cluster `single_user_name`, cluster `driver/worker_node_type_flexibility`; dashboards `etag` → `ignore_remote_changes` (inert for deploy). The zero-value rules are inert for the plan (the all-empty check runs before backend defaults, and any other remote value fails the `values` constraint); they exist for config-remote-sync's nested entity filtering.
- jobs/clusters `node_type_id` entries are kept — policy- and pool-backed clusters materialize it remotely while config legitimately omits it. Only the never-matching pipelines `clusters[*].node_type_id` entry is removed (`pipelines/get` returns the stored spec verbatim).

Two intentional sync semantic changes, pinned by unit tests: (a) a remote value that filters entirely to defaults emits `remove` instead of `replace {}`; (b) `backend_defaults` without `values` strip any remote value when the field is absent from config (the old table matched one specific value). One narrow divergence: a remote-only `data_security_mode` on a standalone cluster now syncs verbatim instead of being stripped when equal to `SINGLE_USER` — its resources.yml rule is deliberately absent because clusters use the alias handler in cluster.go.

## Why

The table constantly lagged behind `resources.yml`: every new field had to be added in two places, and gaps leaked server-side values into users' YAML. Lifecycle metadata added for the deploy plan now automatically protects config-remote-sync.

## Tests

- Unit tests for the metadata-driven skip logic and nested entity filtering; all related acceptance suites pass on both engines with no output changes.
- New acceptance test pins the plan behavior change: policy-injected `custom_tags`/`cluster_log_conf` alone produce no update; a real remote edit still does.
- Live state/local/remote presence matrix on a real AWS workspace: for every touched field, plan classification differs from v1.5.0 only in the (absent from state, absent from config, present remotely) cell; in particular, removing a previously-deployed field from config still plans an update on both versions.
- Live A/B on a real AWS workspace (v1.5.0 vs this branch, direct engine, policy fixing `node_type_id`/`custom_tags`/`cluster_log_conf`/`spark_conf`): spurious plan updates drop to `spark_conf` only (known gap, unchanged), no new drift fields, legit remote edits detected and synced identically, deploy end state identical; changing the policy's fixed node type after deploy stays suppressed on both.
