### PR TITLE
Bump agent skills to v0.1.2

### DIFF
--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -21,7 +21,7 @@ const (
 	skillsRepoOwner      = "databricks"
 	skillsRepoName       = "databricks-agent-skills"
 	skillsRepoPath       = "skills"
-	defaultSkillsRepoRef = "v0.1.1"
+	defaultSkillsRepoRef = "v0.1.2"
 )
 
 func getSkillsRef() string {


### PR DESCRIPTION
## Summary
- Bump `defaultSkillsRepoRef` from `v0.1.1` to `v0.1.2` in the agent skills installer.

## Test plan
- [ ] Verify skills installation pulls from the correct tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)