### PR TITLE
Update "make generate" to update acceptance/bundle/refschema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ generate:
 	@echo "Generating CLI code..."
 	$(GENKIT_BINARY) update-sdk
 	cat .gitattributes.manual .gitattributes > .gitattributes.tmp && mv .gitattributes.tmp .gitattributes
+	-go test ./acceptance -run TestAccept/bundle/refschema -update &> /dev/null
 	@echo "Updating direct engine config..."
 	make generate-direct
 	go test ./bundle/internal/schema


### PR DESCRIPTION
## Why
It's frequently changed so it should be included with all other schemas. That way you might not need more expensive "make test-update" after SDK update.