### PR TITLE
Use nowMilli() in testserver to prevent flaky timestamp collisions

### DIFF
--- a/libs/gorules/rule_time_now_in_testserver.go
+++ b/libs/gorules/rule_time_now_in_testserver.go
@@ -1,0 +1,14 @@
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// NoTimeNowUnixMilliInTestServer forbids direct time.Now().UnixMilli() calls in libs/testserver.
+// Use nowMilli() instead to guarantee unique, strictly increasing timestamps.
+// Integer millisecond timestamps get indexed replacements in test output (e.g. [UNIX_TIME_MILLIS][0])
+// and collisions between resources cause flaky tests.
+func NoTimeNowUnixMilliInTestServer(m dsl.Matcher) {
+	m.Match(`time.Now().UnixMilli()`).
+		Where(m.File().PkgPath.Matches(`.*/libs/testserver`) &&
+			!m.File().Name.Matches(`fake_workspace\.go$`)).
+		Report(`Use nowMilli() instead of time.Now().UnixMilli() in testserver to ensure unique timestamps`)
+}

--- a/libs/testserver/catalogs.go
+++ b/libs/testserver/catalogs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
@@ -29,14 +28,14 @@ func (s *FakeWorkspace) CatalogsCreate(req Request) Response {
 		Options:      createRequest.Options,
 		Properties:   createRequest.Properties,
 		FullName:     createRequest.Name,
-		CreatedAt:    time.Now().UnixMilli(),
+		CreatedAt:    nowMilli(),
 		CreatedBy:    s.CurrentUser().UserName,
-		UpdatedAt:    time.Now().UnixMilli(),
 		UpdatedBy:    s.CurrentUser().UserName,
 		MetastoreId:  nextUUID(),
 		Owner:        s.CurrentUser().UserName,
 		CatalogType:  catalog.CatalogTypeManagedCatalog,
 	}
+	catalogInfo.UpdatedAt = catalogInfo.CreatedAt
 
 	s.Catalogs[createRequest.Name] = catalogInfo
 	return Response{
@@ -79,7 +78,7 @@ func (s *FakeWorkspace) CatalogsUpdate(req Request, name string) Response {
 		name = updateRequest.NewName
 	}
 
-	existing.UpdatedAt = time.Now().UnixMilli()
+	existing.UpdatedAt = nowMilli()
 	existing.UpdatedBy = s.CurrentUser().UserName
 
 	s.Catalogs[name] = existing

--- a/libs/testserver/external_locations.go
+++ b/libs/testserver/external_locations.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
@@ -37,13 +36,13 @@ func (s *FakeWorkspace) ExternalLocationsCreate(req Request) Response {
 		Fallback:          createRequest.Fallback,
 		EncryptionDetails: createRequest.EncryptionDetails,
 		FileEventQueue:    createRequest.FileEventQueue,
-		CreatedAt:         time.Now().UnixMilli(),
+		CreatedAt:         nowMilli(),
 		CreatedBy:         s.CurrentUser().UserName,
-		UpdatedAt:         time.Now().UnixMilli(),
 		UpdatedBy:         s.CurrentUser().UserName,
 		MetastoreId:       nextUUID(),
 		Owner:             s.CurrentUser().UserName,
 	}
+	locationInfo.UpdatedAt = locationInfo.CreatedAt
 
 	s.ExternalLocations[createRequest.Name] = locationInfo
 	return Response{
@@ -95,7 +94,7 @@ func (s *FakeWorkspace) ExternalLocationsUpdate(req Request, name string) Respon
 		name = updateRequest.NewName
 	}
 
-	existing.UpdatedAt = time.Now().UnixMilli()
+	existing.UpdatedAt = nowMilli()
 	existing.UpdatedBy = s.CurrentUser().UserName
 
 	s.ExternalLocations[name] = existing

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -3,7 +3,6 @@ package testserver
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
 )
@@ -41,7 +40,7 @@ func (s *FakeWorkspace) PipelineCreate(req Request) Response {
 	pipelineId := nextUUID()
 	r.PipelineId = pipelineId
 	r.CreatorUserName = "tester@databricks.com"
-	r.LastModified = time.Now().UnixMilli()
+	r.LastModified = nowMilli()
 	r.Name = r.Spec.Name
 	r.RunAsUserName = "tester@databricks.com"
 	r.State = "IDLE"

--- a/libs/testserver/registered_models.go
+++ b/libs/testserver/registered_models.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/databricks/databricks-sdk-go/service/catalog"
 )
@@ -30,13 +29,13 @@ func (s *FakeWorkspace) RegisteredModelsCreate(req Request) Response {
 		SchemaName:      createRequest.SchemaName,
 		StorageLocation: createRequest.StorageLocation,
 		FullName:        fullName,
-		CreatedAt:       time.Now().UnixMilli(),
+		CreatedAt:       nowMilli(),
 		CreatedBy:       s.CurrentUser().UserName,
-		UpdatedAt:       time.Now().UnixMilli(),
 		UpdatedBy:       s.CurrentUser().UserName,
 		MetastoreId:     nextUUID(),
 		Owner:           s.CurrentUser().UserName,
 	}
+	registeredModel.UpdatedAt = registeredModel.CreatedAt
 
 	s.RegisteredModels[fullName] = registeredModel
 	return Response{
@@ -78,7 +77,7 @@ func (s *FakeWorkspace) RegisteredModelsUpdate(req Request, fullName string) Res
 		fullName = existing.CatalogName + "." + existing.SchemaName + "." + updateRequest.NewName
 	}
 
-	existing.UpdatedAt = time.Now().UnixMilli()
+	existing.UpdatedAt = nowMilli()
 	s.RegisteredModels[fullName] = existing
 	return Response{
 		Body: existing,


### PR DESCRIPTION
## Summary
- Replace `time.Now().UnixMilli()` with `nowMilli()` in testserver fake implementations (pipelines, catalogs, external locations, registered models) to guarantee strictly increasing millisecond timestamps
- Add a `ruleguard` lint rule to prevent `time.Now().UnixMilli()` in `libs/testserver/` (except `fake_workspace.go` where the helper is defined)
- Fix `CreatedAt`/`UpdatedAt` in create handlers to use the same timestamp value, matching real API behavior

Fixes flaky test `TestAccept/bundle/resource_deps/pipelines_recreate/DATABRICKS_BUNDLE_ENGINE=direct` where a pipeline's `last_modified` and a job's `created_time` could collide to the same millisecond, causing `[UNIX_TIME_MILLIS][0]` vs `[UNIX_TIME_MILLIS][1]` index mismatch in test output.

Example failure: https://github.com/databricks/cli/actions/runs/22710298364/job/65846540329

## Test plan
- [x] `TestAccept/bundle/resource_deps/pipelines_recreate` passes consistently (verified with `-count=3`)
- [x] `make lintfull` passes with 0 issues
- [x] `make test` passes (template test failures are pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)