### PR TITLE
Add elapsed time display to spinners

### DIFF
--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -279,8 +279,7 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 
 	if opts.ServerMetadata == "" {
 		cmdio.LogString(ctx, "Uploading binaries...")
-		sp := cmdio.NewSpinner(ctx)
-		sp.TrackElapsedTime()
+		sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
 		sp.Update("Uploading binaries...")
 		err := UploadTunnelReleases(ctx, client, version, opts.ReleasesDir)
 		sp.Close()
@@ -582,8 +581,7 @@ func runSSHProxy(ctx context.Context, client *databricks.WorkspaceClient, server
 }
 
 func checkClusterState(ctx context.Context, client *databricks.WorkspaceClient, clusterID string, autoStart bool) error {
-	sp := cmdio.NewSpinner(ctx)
-	sp.TrackElapsedTime()
+	sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
 	defer sp.Close()
 	if autoStart {
 		sp.Update("Ensuring the cluster is running...")
@@ -607,8 +605,7 @@ func checkClusterState(ctx context.Context, client *databricks.WorkspaceClient, 
 // waitForJobToStart polls the task status until the SSH server task is in RUNNING state or terminates.
 // Returns an error if the task fails to start or if polling times out.
 func waitForJobToStart(ctx context.Context, client *databricks.WorkspaceClient, runID int64, taskStartupTimeout time.Duration) error {
-	sp := cmdio.NewSpinner(ctx)
-	sp.TrackElapsedTime()
+	sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
 	defer sp.Close()
 	sp.Update("Starting SSH server...")
 	var prevState jobs.RunLifecycleStateV2State
@@ -677,9 +674,8 @@ func ensureSSHServerIsRunning(ctx context.Context, client *databricks.WorkspaceC
 			return "", 0, "", fmt.Errorf("failed to submit and start ssh server job: %w", err)
 		}
 
-		sp := cmdio.NewSpinner(ctx)
+		sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
 		defer sp.Close()
-		sp.TrackElapsedTime()
 		sp.Update("Waiting for the SSH server to start...")
 		maxRetries := 30
 		for retries := range maxRetries {

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -195,9 +195,9 @@ func RunSelect(ctx context.Context, prompt *promptui.Select) (int, string, error
 //
 // The spinner automatically degrades in non-interactive terminals (no output).
 // Context cancellation will automatically close the spinner.
-func NewSpinner(ctx context.Context) *spinner {
+func NewSpinner(ctx context.Context, opts ...SpinnerOption) *spinner {
 	c := fromContext(ctx)
-	return c.NewSpinner(ctx)
+	return c.NewSpinner(ctx, opts...)
 }
 
 type cmdIOType int

--- a/libs/cmdio/spinner.go
+++ b/libs/cmdio/spinner.go
@@ -21,13 +21,22 @@ type spinnerModel struct {
 
 // Message types for spinner updates.
 type (
-	suffixMsg      string
-	quitMsg        struct{}
-	elapsedTimeMsg struct{ startTime time.Time }
+	suffixMsg string
+	quitMsg   struct{}
 )
 
+// SpinnerOption configures spinner behavior.
+type SpinnerOption func(*spinnerModel)
+
+// WithElapsedTime enables an elapsed time prefix (MM:SS) on the spinner.
+func WithElapsedTime() SpinnerOption {
+	return func(m *spinnerModel) {
+		m.startTime = time.Now()
+	}
+}
+
 // newSpinnerModel creates a new spinner model.
-func newSpinnerModel() spinnerModel {
+func newSpinnerModel(opts ...SpinnerOption) spinnerModel {
 	s := bubblespinner.New()
 	// Braille spinner frames with 200ms timing
 	s.Spinner = bubblespinner.Spinner{
@@ -36,11 +45,13 @@ func newSpinnerModel() spinnerModel {
 	}
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // Green
 
-	return spinnerModel{
-		spinner:  s,
-		suffix:   "",
-		quitting: false,
+	m := spinnerModel{
+		spinner: s,
 	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return m
 }
 
 func (m spinnerModel) Init() tea.Cmd {
@@ -51,10 +62,6 @@ func (m spinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case suffixMsg:
 		m.suffix = string(msg)
-		return m, nil
-
-	case elapsedTimeMsg:
-		m.startTime = msg.startTime
 		return m, nil
 
 	case quitMsg:
@@ -76,13 +83,14 @@ func (m spinnerModel) View() string {
 		return ""
 	}
 
-	result := m.spinner.View()
-	if m.suffix != "" {
-		result += " " + m.suffix
-	}
+	var result string
 	if !m.startTime.IsZero() {
 		elapsed := time.Since(m.startTime)
-		result += fmt.Sprintf(" %02d:%02d", int(elapsed.Minutes()), int(elapsed.Seconds())%60)
+		result += fmt.Sprintf("%02d:%02d ", int(elapsed.Minutes()), int(elapsed.Seconds())%60)
+	}
+	result += m.spinner.View()
+	if m.suffix != "" {
+		result += " " + m.suffix
 	}
 	return result
 }
@@ -99,13 +107,6 @@ type spinner struct {
 	ctx  context.Context
 	once sync.Once
 	done chan struct{} // Closed when tea.Program finishes
-}
-
-// TrackElapsedTime enables an elapsed time display (MM:SS) next to the spinner message.
-func (sp *spinner) TrackElapsedTime() {
-	if sp.p != nil {
-		sp.p.Send(elapsedTimeMsg{startTime: time.Now()})
-	}
 }
 
 // Update sends a status message to the spinner.
@@ -139,14 +140,18 @@ func (sp *spinner) Close() {
 //	sp := cmdio.NewSpinner(ctx)
 //	defer sp.Close()
 //	sp.Update("processing files")
-func (c *cmdIO) NewSpinner(ctx context.Context) *spinner {
+//
+// Use WithElapsedTime() to show a running MM:SS prefix:
+//
+//	sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
+func (c *cmdIO) NewSpinner(ctx context.Context, opts ...SpinnerOption) *spinner {
 	// Don't show spinner if not interactive
 	if !c.capabilities.SupportsInteractive() {
 		return &spinner{p: nil, c: c, ctx: ctx}
 	}
 
 	// Create model and program
-	m := newSpinnerModel()
+	m := newSpinnerModel(opts...)
 	p := tea.NewProgram(
 		m,
 		tea.WithInput(nil),


### PR DESCRIPTION
## Summary
- Add `WithElapsedTime()` construction option to the spinner that shows a running `MM:SS` stopwatch as a prefix
- The elapsed time is displayed as a prefix (e.g., `00:15 ⣾ Starting SSH server...`) so it stays pinned to the left as the message changes
- Time starts at spinner construction — no separate method call needed
- The elapsed time updates on every spinner tick (200ms) with no extra goroutines
- Enable it for all SSH connect spinners (binary upload, cluster check, job startup, metadata polling)

Stacked on #4694

## Test plan
- [x] Run `databricks ssh connect` and verify elapsed time appears as a prefix and ticks next to each spinner
- [x] Verify other spinners in the codebase (without `WithElapsedTime()`) are unaffected
- [x] Verify the time stays stable on the left as the spinner message changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)