### PR TITLE
Improve IDE settings prompt formatting and default to yes

### DIFF
--- a/experimental/ssh/internal/vscode/settings.go
+++ b/experimental/ssh/internal/vscode/settings.go
@@ -215,29 +215,33 @@ func validateSettings(v hujson.Value, connectionName string) *missingSettings {
 func settingsMessage(connectionName string, missing *missingSettings) string {
 	var lines []string
 	if missing.portRange {
-		lines = append(lines, fmt.Sprintf("  \"%s\": {\"%s\": \"%s\"}", serverPickPortsKey, connectionName, portRange))
+		lines = append(lines, fmt.Sprintf("    \"%s\": {\"%s\": \"%s\"}", serverPickPortsKey, connectionName, portRange))
 	}
 	if missing.platform {
-		lines = append(lines, fmt.Sprintf("  \"%s\": {\"%s\": \"%s\"}", remotePlatformKey, connectionName, remotePlatform))
+		lines = append(lines, fmt.Sprintf("    \"%s\": {\"%s\": \"%s\"}", remotePlatformKey, connectionName, remotePlatform))
 	}
 	if missing.listenOnSocket {
-		lines = append(lines, fmt.Sprintf("  \"%s\": true // Global setting that affects all remote ssh connections", listenOnSocketKey))
+		lines = append(lines, fmt.Sprintf("    \"%s\": true // Global setting", listenOnSocketKey))
 	}
 	if len(missing.extensions) > 0 {
 		quoted := make([]string, len(missing.extensions))
 		for i, ext := range missing.extensions {
 			quoted[i] = fmt.Sprintf("\"%s\"", ext)
 		}
-		lines = append(lines, fmt.Sprintf("  \"%s\": [%s] // Global setting that affects all remote ssh connections", defaultExtensionsKey, strings.Join(quoted, ", ")))
+		lines = append(lines, fmt.Sprintf("    \"%s\": [%s] // Global setting", defaultExtensionsKey, strings.Join(quoted, ", ")))
 	}
-	return strings.Join(lines, "\n")
+	return "  {\n" + strings.Join(lines, ",\n") + "\n  }"
 }
 
 func promptUserForUpdate(ctx context.Context, ide, connectionName string, missing *missingSettings) (bool, error) {
 	question := fmt.Sprintf(
-		"The following settings will be applied to %s for '%s':\n%s\nApply these settings?",
+		"The following settings will be applied to %s for '%s':\n\n%s\n\nApply these settings?",
 		getIDE(ide).Name, connectionName, settingsMessage(connectionName, missing))
-	return cmdio.AskYesOrNo(ctx, question)
+	ans, err := cmdio.Ask(ctx, question+" [Y/n]", "y")
+	if err != nil {
+		return false, err
+	}
+	return strings.ToLower(ans) == "y", nil
 }
 
 func handleMissingFile(ctx context.Context, ide, connectionName, settingsPath string) error {


### PR DESCRIPTION
## Summary
- Wrap the settings JSON preview in `{ }` with proper indentation so it stands out visually
- Add blank lines around the settings block for padding
- Default the "Apply these settings?" prompt to yes (`[Y/n]`) — pressing Enter accepts
- Shorten inline comments (`// Global setting` instead of `// Global setting that affects all remote ssh connections`)

Stacked on #4701.

## Test plan
- [x] Existing vscode settings tests pass
- [ ] Manual test: verify the prompt renders with proper formatting and padding
- [ ] Manual test: pressing Enter without typing accepts the settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)