### PR TITLE
Prevent SDK from invoking `az` during cmd/root tests

### DIFF
--- a/cmd/root/auth_test.go
+++ b/cmd/root/auth_test.go
@@ -88,7 +88,8 @@ func TestAccountClientOrPrompt(t *testing.T) {
 		0o755)
 	require.NoError(t, err)
 	t.Setenv("DATABRICKS_CONFIG_FILE", configFile)
-	t.Setenv("PATH", "/nothing")
+	// Clear PATH to prevent the SDK from invoking external tools (e.g. az) during auth resolution.
+	t.Setenv("PATH", "")
 
 	t.Run("Prompt if nothing is specified", func(t *testing.T) {
 		expectPrompts(t, accountPromptFn, &config.Config{})
@@ -157,7 +158,8 @@ func TestWorkspaceClientOrPrompt(t *testing.T) {
 		0o755)
 	require.NoError(t, err)
 	t.Setenv("DATABRICKS_CONFIG_FILE", configFile)
-	t.Setenv("PATH", "/nothing")
+	// Clear PATH to prevent the SDK from invoking external tools (e.g. az) during auth resolution.
+	t.Setenv("PATH", "")
 
 	t.Run("Prompt if nothing is specified", func(t *testing.T) {
 		expectPrompts(t, workspacePromptFn, &config.Config{})
@@ -248,6 +250,8 @@ func TestMustAccountClientErrorsWithNoDatabricksCfg(t *testing.T) {
 
 func TestMustAnyClientCanCreateWorkspaceClient(t *testing.T) {
 	testutil.CleanupEnvironment(t)
+	// Clear PATH to prevent the SDK from invoking external tools (e.g. az) during auth resolution.
+	t.Setenv("PATH", "")
 
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, ".databrickscfg")
@@ -276,6 +280,8 @@ func TestMustAnyClientCanCreateWorkspaceClient(t *testing.T) {
 
 func TestMustAnyClientCanCreateAccountClient(t *testing.T) {
 	testutil.CleanupEnvironment(t)
+	// Clear PATH to prevent the SDK from invoking external tools (e.g. az) during auth resolution.
+	t.Setenv("PATH", "")
 
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, ".databrickscfg")
@@ -305,6 +311,8 @@ func TestMustAnyClientCanCreateAccountClient(t *testing.T) {
 
 func TestMustAnyClientWithEmptyDatabricksCfg(t *testing.T) {
 	testutil.CleanupEnvironment(t)
+	// Clear PATH to prevent the SDK from invoking external tools (e.g. az) during auth resolution.
+	t.Setenv("PATH", "")
 
 	dir := t.TempDir()
 	configFile := filepath.Join(dir, ".databrickscfg")

--- a/cmd/root/bundle_test.go
+++ b/cmd/root/bundle_test.go
@@ -85,6 +85,14 @@ workspace:
 
 func TestBundleConfigureDefault(t *testing.T) {
 	testutil.CleanupEnvironment(t)
+	// Restrict PATH to system directories to prevent the SDK from invoking
+	// external tools (e.g. az) during auth resolution.
+	// Bundle loading requires a shell so PATH cannot be fully cleared.
+	if runtime.GOOS == "windows" {
+		t.Setenv("PATH", `C:\Windows\System32`)
+	} else {
+		t.Setenv("PATH", "/usr/bin:/bin")
+	}
 
 	cmd := emptyCommand(t)
 	diags := setupWithHost(t, cmd, "https://x.com")


### PR DESCRIPTION
## Summary

- Clear `PATH` in `cmd/root` auth tests to prevent the Go SDK (v0.117.0+) from shelling out to `az account show` during credential resolution
- For `TestBundleConfigureDefault`, restrict `PATH` to system directories instead of clearing it fully — the bundle loader's script hook mutator currently requires a shell to be present even when no scripts are configured (fixing that separately)
- Normalize existing `PATH="/nothing"` in prompt tests to `PATH=""`

The SDK upgrade to v0.117.0 (databricks/databricks-sdk-go#1505, bumped in #4631) removed per-strategy cloud guards from Azure CLI credentials, causing `az` to be probed on all platforms regardless of the configured host. This added ~0.5–2.5s per affected test and wrote `.azure/` cache files into the source tree.

Verified on macOS and Windows.

## Test plan

- [x] `go test -count=1 ./cmd/root` passes on macOS (1.2s, down from 5.2s)
- [x] `go test -count=1 ./cmd/root` passes on Windows (0.19s)
- [x] No `.azure/` or `Library/` directories created in `cmd/root/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)