### PR TITLE
Translate alert file_path to workspace path

### DIFF
--- a/acceptance/bundle/paths/alerts_file_path/databricks.yml
+++ b/acceptance/bundle/paths/alerts_file_path/databricks.yml
@@ -1,0 +1,13 @@
+bundle:
+  name: alerts_file_path
+
+resources:
+  alerts:
+    my_alert:
+      display_name: "My Alert"
+      file_path: ./src/my_alert.dbalert.json
+      warehouse_id: cafef00d
+
+targets:
+  development:
+    default: true

--- a/acceptance/bundle/paths/alerts_file_path/out.test.toml
+++ b/acceptance/bundle/paths/alerts_file_path/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/alerts_file_path/output.alert.txt
+++ b/acceptance/bundle/paths/alerts_file_path/output.alert.txt
@@ -1,0 +1,1 @@
+"/Workspace/Users/[USERNAME]/.bundle/alerts_file_path/development/files/src/my_alert.dbalert.json"

--- a/acceptance/bundle/paths/alerts_file_path/output.txt
+++ b/acceptance/bundle/paths/alerts_file_path/output.txt
@@ -1,0 +1,9 @@
+
+>>> [CLI] bundle validate -t development -o json
+Warning: required field "schedule" is not set
+  at resources.alerts.my_alert
+  in databricks.yml:7:7
+
+Warning: required field "source" is not set
+  at resources.alerts.my_alert.evaluation
+

--- a/acceptance/bundle/paths/alerts_file_path/script
+++ b/acceptance/bundle/paths/alerts_file_path/script
@@ -1,0 +1,6 @@
+errcode trace $CLI bundle validate -t development -o json > tmp.json
+
+# Capture the file_path for the alert after translation
+jq '.resources.alerts.my_alert.file_path' tmp.json > output.alert.txt
+
+rm -f tmp.json

--- a/acceptance/bundle/paths/alerts_file_path/src/my_alert.dbalert.json
+++ b/acceptance/bundle/paths/alerts_file_path/src/my_alert.dbalert.json
@@ -1,0 +1,12 @@
+{
+  "query_text": "SELECT 1",
+  "evaluation": {
+    "empty_result_state": "UNKNOWN",
+    "comparison_operator": "GREATER_THAN",
+    "threshold": {
+      "value": {
+        "double_value": 0
+      }
+    }
+  }
+}

--- a/bundle/config/mutator/paths/alert_paths_visitor.go
+++ b/bundle/config/mutator/paths/alert_paths_visitor.go
@@ -13,6 +13,6 @@ func VisitAlertPaths(value dyn.Value, fn VisitFunc) (dyn.Value, error) {
 	)
 
 	return dyn.MapByPattern(value, pattern, func(path dyn.Path, value dyn.Value) (dyn.Value, error) {
-		return fn(path, TranslateModeLocalRelative, value)
+		return fn(path, TranslateModeFile, value)
 	})
 }

--- a/bundle/config/mutator/paths/alert_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/alert_paths_visitor_test.go
@@ -1,0 +1,29 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVisitAlertPaths(t *testing.T) {
+	root := config.Root{
+		Resources: config.Resources{
+			Alerts: map[string]*resources.Alert{
+				"alert0": {
+					FilePath: "foo.dbalert.json",
+				},
+			},
+		},
+	}
+
+	actual := collectVisitedPaths(t, root, VisitAlertPaths)
+	expected := []dyn.Path{
+		dyn.MustPathFromString("resources.alerts.alert0.file_path"),
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -348,6 +348,7 @@ func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 		t.applyPipelineTranslations(paths.VisitPipelineLibrariesPaths, true),
 		t.applyArtifactTranslations,
 		t.applyAppsTranslations,
+		t.applyAlertTranslations,
 	})
 }
 

--- a/bundle/config/mutator/translate_paths_alerts.go
+++ b/bundle/config/mutator/translate_paths_alerts.go
@@ -1,0 +1,22 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle/config/mutator/paths"
+
+	"github.com/databricks/cli/libs/dyn"
+)
+
+func (t *translateContext) applyAlertTranslations(ctx context.Context, v dyn.Value) (dyn.Value, error) {
+	// Convert the `file_path` field to a remote absolute path.
+	// We use this path to point to the alert definition file in the workspace.
+
+	return paths.VisitAlertPaths(v, func(p dyn.Path, mode paths.TranslateMode, v dyn.Value) (dyn.Value, error) {
+		opts := translateOptions{
+			Mode: mode,
+		}
+
+		return t.rewriteValue(ctx, p, v, t.b.BundleRootPath, opts)
+	})
+}

--- a/bundle/config/mutator/translate_paths_alerts_test.go
+++ b/bundle/config/mutator/translate_paths_alerts_test.go
@@ -1,0 +1,52 @@
+package mutator_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/internal/bundletest"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/vfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslatePathsAlerts_FilePathRelativeSubDirectory(t *testing.T) {
+	dir := t.TempDir()
+	touchEmptyFile(t, filepath.Join(dir, "src", "my_alert.dbalert.json"))
+
+	b := &bundle.Bundle{
+		SyncRootPath:   dir,
+		BundleRootPath: dir,
+		SyncRoot:       vfs.MustNew(dir),
+		Config: config.Root{
+			Workspace: config.Workspace{
+				FilePath: "/bundle",
+			},
+			Resources: config.Resources{
+				Alerts: map[string]*resources.Alert{
+					"alert": {
+						FilePath: "../src/my_alert.dbalert.json",
+					},
+				},
+			},
+		},
+	}
+
+	bundletest.SetLocation(b, "resources.alerts", []dyn.Location{{
+		File: filepath.Join(dir, "resources/alert.yml"),
+	}})
+
+	diags := bundle.ApplySeq(t.Context(), b, mutator.NormalizePaths(), mutator.TranslatePaths())
+	require.NoError(t, diags.Error())
+
+	assert.Equal(
+		t,
+		"/bundle/src/my_alert.dbalert.json",
+		b.Config.Resources.Alerts["alert"].FilePath,
+	)
+}


### PR DESCRIPTION
## Summary
- Adds path translation for alert resource `file_path` field in the `TranslatePaths` mutator
- Changes the alert path translation mode from `TranslateModeLocalRelative` to `TranslateModeFile`, so the `.dbalert.json` file path is translated to a full workspace file path (e.g., `/Workspace/Users/.../.bundle/name/target/files/src/alert.dbalert.json`)
- This is consistent with how other path-based fields (notebook paths, SQL file paths) are handled in job tasks

## Test plan
- [x] Added unit test for `VisitAlertPaths` visitor
- [x] Added unit test for `TranslatePathsAlerts` translation
- [x] Added acceptance test `bundle/paths/alerts_file_path` that verifies the `file_path` is translated to a workspace path
- [x] All existing tests pass (`make test`, `make lintfull`, `make checks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)