### PR TITLE
Add CI guard to prevent direct CHANGELOG.md modifications

### DIFF
--- a/.github/workflows/changelog-guard.yml
+++ b/.github/workflows/changelog-guard.yml
@@ -1,0 +1,18 @@
+name: Changelog Guard
+
+on:
+  pull_request:
+    paths:
+      - CHANGELOG.md
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block direct CHANGELOG.md edits
+        if: "!contains(github.event.pull_request.labels.*.name, 'override-changelog-guard')"
+        run: |-
+          echo "::error::CHANGELOG.md should not be modified directly by PRs."
+          echo "The release workflow manages CHANGELOG.md automatically from NEXT_CHANGELOG.md."
+          echo "If this is intentional, add the 'override-changelog-guard' label to this PR."
+          exit 1


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that fails PRs which modify `CHANGELOG.md` directly
- Provides a break-glass override via the `override-changelog-guard` label

## Problem

PR #4675 directly modified `CHANGELOG.md`, which caused the release tagging workflow (`tagging.py`) to incorrectly detect a pending release. This resulted in a broken v0.293.0 release where recovery mode tagged the wrong commit.

The root cause is that `tagging.py` uses `CHANGELOG.md` entries to detect pending releases. When a PR adds a release entry directly to `CHANGELOG.md` (rather than going through the standard release flow via `NEXT_CHANGELOG.md`), the tagging logic gets confused.

## Solution

A lightweight CI guard that:
1. Triggers only on PRs that touch `CHANGELOG.md`
2. Fails with a clear error message explaining that `CHANGELOG.md` is managed by the release workflow
3. Can be overridden by adding the `override-changelog-guard` label to the PR

## Test plan

- [ ] Verify the workflow triggers on a PR that modifies `CHANGELOG.md`
- [ ] Verify the workflow does not trigger on PRs that don't touch `CHANGELOG.md`
- [ ] Verify adding the `override-changelog-guard` label allows the PR to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)