### PR TITLE
Regenerate CLI commands with new spinner API

### DIFF
--- a/cmd/account/ip-access-lists/ip-access-lists.go
+++ b/cmd/account/ip-access-lists/ip-access-lists.go
@@ -198,10 +198,10 @@ func newDelete() *cobra.Command {
 		a := cmdctx.AccountClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No IP_ACCESS_LIST_ID argument specified. Loading names for Account Ip Access Lists drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No IP_ACCESS_LIST_ID argument specified. Loading names for Account Ip Access Lists drop-down.")
 			names, err := a.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -266,10 +266,10 @@ func newGet() *cobra.Command {
 		a := cmdctx.AccountClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No IP_ACCESS_LIST_ID argument specified. Loading names for Account Ip Access Lists drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No IP_ACCESS_LIST_ID argument specified. Loading names for Account Ip Access Lists drop-down.")
 			names, err := a.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -516,10 +516,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No IP_ACCESS_LIST_ID argument specified. Loading names for Account Ip Access Lists drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No IP_ACCESS_LIST_ID argument specified. Loading names for Account Ip Access Lists drop-down.")
 			names, err := a.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Account Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/account/log-delivery/log-delivery.go
+++ b/cmd/account/log-delivery/log-delivery.go
@@ -225,10 +225,10 @@ func newGet() *cobra.Command {
 		a := cmdctx.AccountClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No LOG_DELIVERY_CONFIGURATION_ID argument specified. Loading names for Log Delivery drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No LOG_DELIVERY_CONFIGURATION_ID argument specified. Loading names for Log Delivery drop-down.")
 			names, err := a.LogDelivery.LogDeliveryConfigurationConfigNameToConfigIdMap(ctx, billing.ListLogDeliveryRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Log Delivery drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/account/workspaces/workspaces.go
+++ b/cmd/account/workspaces/workspaces.go
@@ -171,12 +171,12 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *provisioning.Workspace) {
 			statusMessage := i.WorkspaceStatusMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -454,12 +454,12 @@ func newUpdate() *cobra.Command {
 		if updateSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *provisioning.Workspace) {
 			statusMessage := i.WorkspaceStatusMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(updateTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/alerts-v2/alerts-v2.go
+++ b/cmd/workspace/alerts-v2/alerts-v2.go
@@ -181,10 +181,10 @@ func newGetAlert() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Alerts V2 drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Alerts V2 drop-down.")
 			names, err := w.AlertsV2.AlertV2DisplayNameToIdMap(ctx, sql.ListAlertsV2Request{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Alerts V2 drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -301,10 +301,10 @@ func newTrashAlert() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Alerts V2 drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Alerts V2 drop-down.")
 			names, err := w.AlertsV2.AlertV2DisplayNameToIdMap(ctx, sql.ListAlertsV2Request{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Alerts V2 drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/alerts/alerts.go
+++ b/cmd/workspace/alerts/alerts.go
@@ -145,10 +145,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Alerts drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Alerts drop-down.")
 			names, err := w.Alerts.ListAlertsResponseAlertDisplayNameToIdMap(ctx, sql.ListAlertsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Alerts drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -210,10 +210,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Alerts drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Alerts drop-down.")
 			names, err := w.Alerts.ListAlertsResponseAlertDisplayNameToIdMap(ctx, sql.ListAlertsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Alerts drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/apps/apps.go
+++ b/cmd/workspace/apps/apps.go
@@ -156,7 +156,7 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *apps.App) {
 			if i.ComputeStatus == nil {
 				return
@@ -166,9 +166,9 @@ func newCreate() *cobra.Command {
 			if i.ComputeStatus != nil {
 				statusMessage = i.ComputeStatus.Message
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -296,8 +296,8 @@ func newCreateSpace() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for create-space to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for create-space to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(createSpaceTimeout)
@@ -305,7 +305,7 @@ func newCreateSpace() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -412,7 +412,7 @@ func newCreateUpdate() *cobra.Command {
 		if createUpdateSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *apps.AppUpdate) {
 			if i.Status == nil {
 				return
@@ -422,9 +422,9 @@ func newCreateUpdate() *cobra.Command {
 			if i.Status != nil {
 				statusMessage = i.Status.Message
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createUpdateTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -574,8 +574,8 @@ func newDeleteSpace() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for delete-space to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for delete-space to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(deleteSpaceTimeout)
@@ -584,7 +584,7 @@ func newDeleteSpace() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return nil
 		}
 	}
@@ -676,7 +676,7 @@ func newDeploy() *cobra.Command {
 		if deploySkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *apps.AppDeployment) {
 			if i.Status == nil {
 				return
@@ -686,9 +686,9 @@ func newDeploy() *cobra.Command {
 			if i.Status != nil {
 				statusMessage = i.Status.Message
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(deployTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1396,7 +1396,7 @@ func newStart() *cobra.Command {
 		if startSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *apps.App) {
 			if i.ComputeStatus == nil {
 				return
@@ -1406,9 +1406,9 @@ func newStart() *cobra.Command {
 			if i.ComputeStatus != nil {
 				statusMessage = i.ComputeStatus.Message
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(startTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1477,7 +1477,7 @@ func newStop() *cobra.Command {
 		if stopSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *apps.App) {
 			if i.ComputeStatus == nil {
 				return
@@ -1487,9 +1487,9 @@ func newStop() *cobra.Command {
 			if i.ComputeStatus != nil {
 				statusMessage = i.ComputeStatus.Message
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(stopTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1786,8 +1786,8 @@ func newUpdateSpace() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for update-space to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for update-space to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(updateSpaceTimeout)
@@ -1795,7 +1795,7 @@ func newUpdateSpace() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}

--- a/cmd/workspace/clean-rooms/clean-rooms.go
+++ b/cmd/workspace/clean-rooms/clean-rooms.go
@@ -121,13 +121,13 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *cleanrooms.CleanRoom) {
 			status := i.Status
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/cluster-policies/cluster-policies.go
+++ b/cmd/workspace/cluster-policies/cluster-policies.go
@@ -200,10 +200,10 @@ func newDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 				names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -304,10 +304,10 @@ func newEdit() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 				names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -374,10 +374,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 			names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -442,10 +442,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 			names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -511,10 +511,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 			names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -649,10 +649,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 			names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -735,10 +735,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_POLICY_ID argument specified. Loading names for Cluster Policies drop-down.")
 			names, err := w.ClusterPolicies.PolicyNameToPolicyIdMap(ctx, compute.ListClusterPoliciesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Cluster Policies drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/clusters/clusters.go
+++ b/cmd/workspace/clusters/clusters.go
@@ -307,12 +307,12 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -397,10 +397,10 @@ func newDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -423,12 +423,12 @@ func newDelete() *cobra.Command {
 		if deleteSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(deleteTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -583,12 +583,12 @@ func newEdit() *cobra.Command {
 		if editSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(editTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -675,10 +675,10 @@ func newEvents() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -743,10 +743,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 			names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -811,10 +811,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 			names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -880,10 +880,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 			names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1120,10 +1120,10 @@ func newPermanentDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1214,10 +1214,10 @@ func newPin() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1319,10 +1319,10 @@ func newResize() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1346,12 +1346,12 @@ func newResize() *cobra.Command {
 		if resizeSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(resizeTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1436,10 +1436,10 @@ func newRestart() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1463,12 +1463,12 @@ func newRestart() *cobra.Command {
 		if restartSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(restartTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1537,10 +1537,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 			names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1686,10 +1686,10 @@ func newStart() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1712,12 +1712,12 @@ func newStart() *cobra.Command {
 		if startSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(startTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1792,10 +1792,10 @@ func newUnpin() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 				names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1932,12 +1932,12 @@ func newUpdate() *cobra.Command {
 		if updateSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *compute.ClusterDetails) {
 			statusMessage := i.StateMessage
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(updateTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -2005,10 +2005,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CLUSTER_ID argument specified. Loading names for Clusters drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CLUSTER_ID argument specified. Loading names for Clusters drop-down.")
 			names, err := w.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/connections/connections.go
+++ b/cmd/workspace/connections/connections.go
@@ -154,10 +154,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Connections drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Connections drop-down.")
 			names, err := w.Connections.ConnectionInfoNameToFullNameMap(ctx, catalog.ListConnectionsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Connections drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -222,10 +222,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Connections drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Connections drop-down.")
 			names, err := w.Connections.ConnectionInfoNameToFullNameMap(ctx, catalog.ListConnectionsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Connections drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/consumer-listings/consumer-listings.go
+++ b/cmd/workspace/consumer-listings/consumer-listings.go
@@ -123,10 +123,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Consumer Listings drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Consumer Listings drop-down.")
 			names, err := w.ConsumerListings.ListingSummaryNameToIdMap(ctx, marketplace.ListListingsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Consumer Listings drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -260,10 +260,10 @@ func newSearch() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No QUERY argument specified. Loading names for Consumer Listings drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No QUERY argument specified. Loading names for Consumer Listings drop-down.")
 			names, err := w.ConsumerListings.ListingSummaryNameToIdMap(ctx, marketplace.ListListingsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Consumer Listings drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/consumer-providers/consumer-providers.go
+++ b/cmd/workspace/consumer-providers/consumer-providers.go
@@ -121,10 +121,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Consumer Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Consumer Providers drop-down.")
 			names, err := w.ConsumerProviders.ProviderInfoNameToIdMap(ctx, marketplace.ListConsumerProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Consumer Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/database/database.go
+++ b/cmd/workspace/database/database.go
@@ -235,13 +235,13 @@ func newCreateDatabaseInstance() *cobra.Command {
 		if createDatabaseInstanceSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *database.DatabaseInstance) {
 			status := i.State
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createDatabaseInstanceTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/forecasting/forecasting.go
+++ b/cmd/workspace/forecasting/forecasting.go
@@ -160,13 +160,13 @@ func newCreateExperiment() *cobra.Command {
 		if createExperimentSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *ml.ForecastingExperiment) {
 			status := i.State
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createExperimentTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/functions/functions.go
+++ b/cmd/workspace/functions/functions.go
@@ -155,10 +155,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Functions drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Functions drop-down.")
 			names, err := w.Functions.FunctionInfoNameToFullNameMap(ctx, catalog.ListFunctionsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Functions drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -232,10 +232,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Functions drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Functions drop-down.")
 			names, err := w.Functions.FunctionInfoNameToFullNameMap(ctx, catalog.ListFunctionsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Functions drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -398,10 +398,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Functions drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Functions drop-down.")
 			names, err := w.Functions.FunctionInfoNameToFullNameMap(ctx, catalog.ListFunctionsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Functions drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/genie/genie.go
+++ b/cmd/workspace/genie/genie.go
@@ -146,13 +146,13 @@ func newCreateMessage() *cobra.Command {
 		if createMessageSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *dashboards.GenieMessage) {
 			status := i.Status
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createMessageTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1670,13 +1670,13 @@ func newStartConversation() *cobra.Command {
 		if startConversationSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *dashboards.GenieMessage) {
 			status := i.Status
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(startConversationTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/git-credentials/git-credentials.go
+++ b/cmd/workspace/git-credentials/git-credentials.go
@@ -170,10 +170,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CREDENTIAL_ID argument specified. Loading names for Git Credentials drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CREDENTIAL_ID argument specified. Loading names for Git Credentials drop-down.")
 			names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx, workspace.ListCredentialsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -243,10 +243,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No CREDENTIAL_ID argument specified. Loading names for Git Credentials drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No CREDENTIAL_ID argument specified. Loading names for Git Credentials drop-down.")
 			names, err := w.GitCredentials.CredentialInfoGitProviderToCredentialIdMap(ctx, workspace.ListCredentialsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Git Credentials drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/global-init-scripts/global-init-scripts.go
+++ b/cmd/workspace/global-init-scripts/global-init-scripts.go
@@ -167,10 +167,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No SCRIPT_ID argument specified. Loading names for Global Init Scripts drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No SCRIPT_ID argument specified. Loading names for Global Init Scripts drop-down.")
 			names, err := w.GlobalInitScripts.GlobalInitScriptDetailsNameToScriptIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Global Init Scripts drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -235,10 +235,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No SCRIPT_ID argument specified. Loading names for Global Init Scripts drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No SCRIPT_ID argument specified. Loading names for Global Init Scripts drop-down.")
 			names, err := w.GlobalInitScripts.GlobalInitScriptDetailsNameToScriptIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Global Init Scripts drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/instance-pools/instance-pools.go
+++ b/cmd/workspace/instance-pools/instance-pools.go
@@ -224,10 +224,10 @@ func newDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down.")
 				names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -393,10 +393,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down.")
 			names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -461,10 +461,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down.")
 			names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -530,10 +530,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down.")
 			names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -656,10 +656,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down.")
 			names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -742,10 +742,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No INSTANCE_POOL_ID argument specified. Loading names for Instance Pools drop-down.")
 			names, err := w.InstancePools.InstancePoolAndStatsInstancePoolNameToInstancePoolIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Instance Pools drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/ip-access-lists/ip-access-lists.go
+++ b/cmd/workspace/ip-access-lists/ip-access-lists.go
@@ -199,10 +199,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No IP_ACCESS_LIST_ID argument specified. Loading names for Ip Access Lists drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No IP_ACCESS_LIST_ID argument specified. Loading names for Ip Access Lists drop-down.")
 			names, err := w.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -267,10 +267,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No IP_ACCESS_LIST_ID argument specified. Loading names for Ip Access Lists drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No IP_ACCESS_LIST_ID argument specified. Loading names for Ip Access Lists drop-down.")
 			names, err := w.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -521,10 +521,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No IP_ACCESS_LIST_ID argument specified. Loading names for Ip Access Lists drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No IP_ACCESS_LIST_ID argument specified. Loading names for Ip Access Lists drop-down.")
 			names, err := w.IpAccessLists.IpAccessListInfoLabelToListIdMap(ctx)
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Ip Access Lists drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/jobs/jobs.go
+++ b/cmd/workspace/jobs/jobs.go
@@ -209,10 +209,10 @@ func newCancelRun() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No RUN_ID argument specified. Loading names for Jobs drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No RUN_ID argument specified. Loading names for Jobs drop-down.")
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -239,7 +239,7 @@ func newCancelRun() *cobra.Command {
 		if cancelRunSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *jobs.Run) {
 			if i.State == nil {
 				return
@@ -249,9 +249,9 @@ func newCancelRun() *cobra.Command {
 			if i.State != nil {
 				statusMessage = i.State.StateMessage
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(cancelRunTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -389,10 +389,10 @@ func newDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -488,10 +488,10 @@ func newDeleteRun() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No RUN_ID argument specified. Loading names for Jobs drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No RUN_ID argument specified. Loading names for Jobs drop-down.")
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -563,10 +563,10 @@ func newExportRun() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No RUN_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No RUN_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -646,10 +646,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -717,10 +717,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -786,10 +786,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -868,10 +868,10 @@ func newGetRun() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No RUN_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No RUN_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -948,10 +948,10 @@ func newGetRunOutput() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No RUN_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No RUN_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1181,10 +1181,10 @@ func newRepairRun() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No RUN_ID argument specified. Loading names for Jobs drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No RUN_ID argument specified. Loading names for Jobs drop-down.")
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1211,7 +1211,7 @@ func newRepairRun() *cobra.Command {
 		if repairRunSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *jobs.Run) {
 			if i.State == nil {
 				return
@@ -1221,9 +1221,9 @@ func newRepairRun() *cobra.Command {
 			if i.State != nil {
 				statusMessage = i.State.StateMessage
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(repairRunTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1384,10 +1384,10 @@ func newRunNow() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1414,7 +1414,7 @@ func newRunNow() *cobra.Command {
 		if runNowSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *jobs.Run) {
 			if i.State == nil {
 				return
@@ -1424,9 +1424,9 @@ func newRunNow() *cobra.Command {
 			if i.State != nil {
 				statusMessage = i.State.StateMessage
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(runNowTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1495,10 +1495,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1619,7 +1619,7 @@ func newSubmit() *cobra.Command {
 		if submitSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *jobs.Run) {
 			if i.State == nil {
 				return
@@ -1629,9 +1629,9 @@ func newSubmit() *cobra.Command {
 			if i.State != nil {
 				statusMessage = i.State.StateMessage
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(submitTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1711,10 +1711,10 @@ func newUpdate() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 				names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1802,10 +1802,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No JOB_ID argument specified. Loading names for Jobs drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No JOB_ID argument specified. Loading names for Jobs drop-down.")
 			names, err := w.Jobs.BaseJobSettingsNameToJobIdMap(ctx, jobs.ListJobsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Jobs drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/online-tables/online-tables.go
+++ b/cmd/workspace/online-tables/online-tables.go
@@ -107,13 +107,13 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *catalog.OnlineTable) {
 			status := i.UnityCatalogProvisioningState
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/pipelines/pipelines.go
+++ b/cmd/workspace/pipelines/pipelines.go
@@ -238,10 +238,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -301,10 +301,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -369,10 +369,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -438,10 +438,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -569,10 +569,10 @@ func newListPipelineEvents() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -691,10 +691,10 @@ func newListUpdates() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -778,10 +778,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -877,10 +877,10 @@ func newStartUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -949,10 +949,10 @@ func newStop() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -974,12 +974,12 @@ func newStop() *cobra.Command {
 		if stopSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *pipelines.GetPipelineResponse) {
 			statusMessage := i.Cause
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(stopTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1076,10 +1076,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1162,10 +1162,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PIPELINE_ID argument specified. Loading names for Pipelines drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PIPELINE_ID argument specified. Loading names for Pipelines drop-down.")
 			names, err := w.Pipelines.PipelineStateInfoNameToPipelineIdMap(ctx, pipelines.ListPipelinesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Pipelines drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/postgres/postgres.go
+++ b/cmd/workspace/postgres/postgres.go
@@ -176,8 +176,8 @@ func newCreateBranch() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for create-branch to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for create-branch to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(createBranchTimeout)
@@ -185,7 +185,7 @@ func newCreateBranch() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -302,8 +302,8 @@ func newCreateDatabase() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for create-database to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for create-database to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(createDatabaseTimeout)
@@ -311,7 +311,7 @@ func newCreateDatabase() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -427,8 +427,8 @@ func newCreateEndpoint() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for create-endpoint to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for create-endpoint to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(createEndpointTimeout)
@@ -436,7 +436,7 @@ func newCreateEndpoint() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -550,8 +550,8 @@ func newCreateProject() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for create-project to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for create-project to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(createProjectTimeout)
@@ -559,7 +559,7 @@ func newCreateProject() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -673,8 +673,8 @@ func newCreateRole() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for create-role to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for create-role to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(createRoleTimeout)
@@ -682,7 +682,7 @@ func newCreateRole() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -772,8 +772,8 @@ func newDeleteBranch() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for delete-branch to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for delete-branch to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(deleteBranchTimeout)
@@ -782,7 +782,7 @@ func newDeleteBranch() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return nil
 		}
 	}
@@ -873,8 +873,8 @@ func newDeleteDatabase() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for delete-database to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for delete-database to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(deleteDatabaseTimeout)
@@ -883,7 +883,7 @@ func newDeleteDatabase() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return nil
 		}
 	}
@@ -973,8 +973,8 @@ func newDeleteEndpoint() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for delete-endpoint to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for delete-endpoint to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(deleteEndpointTimeout)
@@ -983,7 +983,7 @@ func newDeleteEndpoint() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return nil
 		}
 	}
@@ -1073,8 +1073,8 @@ func newDeleteProject() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for delete-project to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for delete-project to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(deleteProjectTimeout)
@@ -1083,7 +1083,7 @@ func newDeleteProject() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return nil
 		}
 	}
@@ -1178,8 +1178,8 @@ func newDeleteRole() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for delete-role to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for delete-role to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(deleteRoleTimeout)
@@ -1188,7 +1188,7 @@ func newDeleteRole() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return nil
 		}
 	}
@@ -2020,8 +2020,8 @@ func newUpdateBranch() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for update-branch to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for update-branch to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(updateBranchTimeout)
@@ -2029,7 +2029,7 @@ func newUpdateBranch() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -2146,8 +2146,8 @@ func newUpdateDatabase() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for update-database to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for update-database to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(updateDatabaseTimeout)
@@ -2155,7 +2155,7 @@ func newUpdateDatabase() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -2272,8 +2272,8 @@ func newUpdateEndpoint() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for update-endpoint to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for update-endpoint to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(updateEndpointTimeout)
@@ -2281,7 +2281,7 @@ func newUpdateEndpoint() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}
@@ -2398,8 +2398,8 @@ func newUpdateProject() *cobra.Command {
 			}
 
 			// Show spinner while waiting for completion.
-			spinner := cmdio.Spinner(ctx)
-			spinner <- "Waiting for update-project to complete..."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("Waiting for update-project to complete...")
 
 			// Wait for completion.
 			opts := api.WithTimeout(updateProjectTimeout)
@@ -2407,7 +2407,7 @@ func newUpdateProject() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			close(spinner)
+			sp.Close()
 			return cmdio.Render(ctx, response)
 		}
 	}

--- a/cmd/workspace/provider-exchange-filters/provider-exchange-filters.go
+++ b/cmd/workspace/provider-exchange-filters/provider-exchange-filters.go
@@ -132,10 +132,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Provider Exchange Filters drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Provider Exchange Filters drop-down.")
 			names, err := w.ProviderExchangeFilters.ExchangeFilterNameToIdMap(ctx, marketplace.ListExchangeFiltersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Exchange Filters drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/provider-files/provider-files.go
+++ b/cmd/workspace/provider-files/provider-files.go
@@ -136,10 +136,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No FILE_ID argument specified. Loading names for Provider Files drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No FILE_ID argument specified. Loading names for Provider Files drop-down.")
 			names, err := w.ProviderFiles.FileInfoDisplayNameToIdMap(ctx, marketplace.ListFilesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Files drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -201,10 +201,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No FILE_ID argument specified. Loading names for Provider Files drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No FILE_ID argument specified. Loading names for Provider Files drop-down.")
 			names, err := w.ProviderFiles.FileInfoDisplayNameToIdMap(ctx, marketplace.ListFilesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Files drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/provider-listings/provider-listings.go
+++ b/cmd/workspace/provider-listings/provider-listings.go
@@ -134,10 +134,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Provider Listings drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Provider Listings drop-down.")
 			names, err := w.ProviderListings.ListingSummaryNameToIdMap(ctx, marketplace.GetListingsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Listings drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -199,10 +199,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Provider Listings drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Provider Listings drop-down.")
 			names, err := w.ProviderListings.ListingSummaryNameToIdMap(ctx, marketplace.GetListingsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Listings drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/provider-providers/provider-providers.go
+++ b/cmd/workspace/provider-providers/provider-providers.go
@@ -133,10 +133,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Provider Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Provider Providers drop-down.")
 			names, err := w.ProviderProviders.ProviderInfoNameToIdMap(ctx, marketplace.ListProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -198,10 +198,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Provider Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Provider Providers drop-down.")
 			names, err := w.ProviderProviders.ProviderInfoNameToIdMap(ctx, marketplace.ListProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Provider Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/providers/providers.go
+++ b/cmd/workspace/providers/providers.go
@@ -170,10 +170,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Providers drop-down.")
 			names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -240,10 +240,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Providers drop-down.")
 			names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -434,10 +434,10 @@ func newListShares() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Providers drop-down.")
 			names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -522,10 +522,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Providers drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Providers drop-down.")
 			names, err := w.Providers.ProviderInfoNameToMetastoreIdMap(ctx, sharing.ListProvidersRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Providers drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/queries/queries.go
+++ b/cmd/workspace/queries/queries.go
@@ -146,10 +146,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Queries drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Queries drop-down.")
 			names, err := w.Queries.ListQueryObjectsResponseQueryDisplayNameToIdMap(ctx, sql.ListQueriesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -211,10 +211,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Queries drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Queries drop-down.")
 			names, err := w.Queries.ListQueryObjectsResponseQueryDisplayNameToIdMap(ctx, sql.ListQueriesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -335,10 +335,10 @@ func newListVisualizations() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Queries drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Queries drop-down.")
 			names, err := w.Queries.ListQueryObjectsResponseQueryDisplayNameToIdMap(ctx, sql.ListQueriesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Queries drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/registered-models/registered-models.go
+++ b/cmd/workspace/registered-models/registered-models.go
@@ -201,10 +201,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No FULL_NAME argument specified. Loading names for Registered Models drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No FULL_NAME argument specified. Loading names for Registered Models drop-down.")
 			names, err := w.RegisteredModels.RegisteredModelInfoNameToFullNameMap(ctx, catalog.ListRegisteredModelsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Registered Models drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -340,10 +340,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No FULL_NAME argument specified. Loading names for Registered Models drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No FULL_NAME argument specified. Loading names for Registered Models drop-down.")
 			names, err := w.RegisteredModels.RegisteredModelInfoNameToFullNameMap(ctx, catalog.ListRegisteredModelsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Registered Models drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -609,10 +609,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No FULL_NAME argument specified. Loading names for Registered Models drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No FULL_NAME argument specified. Loading names for Registered Models drop-down.")
 			names, err := w.RegisteredModels.RegisteredModelInfoNameToFullNameMap(ctx, catalog.ListRegisteredModelsRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Registered Models drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/repos/repos.go
+++ b/cmd/workspace/repos/repos.go
@@ -177,10 +177,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -248,10 +248,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -319,10 +319,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -388,10 +388,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -527,10 +527,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -615,10 +615,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -704,10 +704,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No REPO_ID argument specified. Loading names for Repos drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No REPO_ID argument specified. Loading names for Repos drop-down.")
 			names, err := w.Repos.RepoInfoPathToIdMap(ctx, workspace.ListReposRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Repos drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/serving-endpoints/serving-endpoints.go
+++ b/cmd/workspace/serving-endpoints/serving-endpoints.go
@@ -213,13 +213,13 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *serving.ServingEndpointDetailed) {
 			status := i.State.ConfigUpdate
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -299,13 +299,13 @@ func newCreateProvisionedThroughputEndpoint() *cobra.Command {
 		if createProvisionedThroughputEndpointSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *serving.ServingEndpointDetailed) {
 			status := i.State.ConfigUpdate
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createProvisionedThroughputEndpointTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1298,13 +1298,13 @@ func newUpdateConfig() *cobra.Command {
 		if updateConfigSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *serving.ServingEndpointDetailed) {
 			status := i.State.ConfigUpdate
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(updateConfigTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1540,13 +1540,13 @@ func newUpdateProvisionedThroughputEndpointConfig() *cobra.Command {
 		if updateProvisionedThroughputEndpointConfigSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *serving.ServingEndpointDetailed) {
 			status := i.State.ConfigUpdate
 			statusMessage := fmt.Sprintf("current status: %s", status)
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(updateProvisionedThroughputEndpointConfigTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/token-management/token-management.go
+++ b/cmd/workspace/token-management/token-management.go
@@ -106,10 +106,10 @@ func newCreateOboToken() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No APPLICATION_ID argument specified. Loading names for Token Management drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No APPLICATION_ID argument specified. Loading names for Token Management drop-down.")
 				names, err := w.TokenManagement.TokenInfoCommentToTokenIdMap(ctx, settings.ListTokenManagementRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -176,10 +176,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No TOKEN_ID argument specified. Loading names for Token Management drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No TOKEN_ID argument specified. Loading names for Token Management drop-down.")
 			names, err := w.TokenManagement.TokenInfoCommentToTokenIdMap(ctx, settings.ListTokenManagementRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -244,10 +244,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No TOKEN_ID argument specified. Loading names for Token Management drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No TOKEN_ID argument specified. Loading names for Token Management drop-down.")
 			names, err := w.TokenManagement.TokenInfoCommentToTokenIdMap(ctx, settings.ListTokenManagementRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Token Management drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/tokens/tokens.go
+++ b/cmd/workspace/tokens/tokens.go
@@ -173,10 +173,10 @@ func newDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No TOKEN_ID argument specified. Loading names for Tokens drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No TOKEN_ID argument specified. Loading names for Tokens drop-down.")
 				names, err := w.Tokens.PublicTokenInfoCommentToTokenIdMap(ctx)
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Tokens drop-down. Please manually specify required arguments. Original error: %w", err)
 				}

--- a/cmd/workspace/vector-search-endpoints/vector-search-endpoints.go
+++ b/cmd/workspace/vector-search-endpoints/vector-search-endpoints.go
@@ -131,7 +131,7 @@ func newCreateEndpoint() *cobra.Command {
 		if createEndpointSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *vectorsearch.EndpointInfo) {
 			if i.EndpointStatus == nil {
 				return
@@ -141,9 +141,9 @@ func newCreateEndpoint() *cobra.Command {
 			if i.EndpointStatus != nil {
 				statusMessage = i.EndpointStatus.Message
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createEndpointTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/volumes/volumes.go
+++ b/cmd/workspace/volumes/volumes.go
@@ -205,10 +205,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Volumes drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Volumes drop-down.")
 			names, err := w.Volumes.VolumeInfoNameToVolumeIdMap(ctx, catalog.ListVolumesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -354,10 +354,10 @@ func newRead() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Volumes drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Volumes drop-down.")
 			names, err := w.Volumes.VolumeInfoNameToVolumeIdMap(ctx, catalog.ListVolumesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -448,10 +448,10 @@ func newUpdate() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Volumes drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Volumes drop-down.")
 			names, err := w.Volumes.VolumeInfoNameToVolumeIdMap(ctx, catalog.ListVolumesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Volumes drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/warehouses/warehouses.go
+++ b/cmd/workspace/warehouses/warehouses.go
@@ -134,7 +134,7 @@ func newCreate() *cobra.Command {
 		if createSkipWait {
 			return cmdio.Render(ctx, wait.Response)
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *sql.GetWarehouseResponse) {
 			if i.Health == nil {
 				return
@@ -144,9 +144,9 @@ func newCreate() *cobra.Command {
 			if i.Health != nil {
 				statusMessage = i.Health.Summary
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(createTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -290,10 +290,10 @@ func newDelete() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -363,10 +363,10 @@ func newDeleteDefaultWarehouseOverride() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -466,10 +466,10 @@ func newEdit() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -491,7 +491,7 @@ func newEdit() *cobra.Command {
 		if editSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *sql.GetWarehouseResponse) {
 			if i.Health == nil {
 				return
@@ -501,9 +501,9 @@ func newEdit() *cobra.Command {
 			if i.Health != nil {
 				statusMessage = i.Health.Summary
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(editTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -553,10 +553,10 @@ func newGet() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -626,10 +626,10 @@ func newGetDefaultWarehouseOverride() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No NAME argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No NAME argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -694,10 +694,10 @@ func newGetPermissionLevels() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -763,10 +763,10 @@ func newGetPermissions() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -997,10 +997,10 @@ func newSetPermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1150,10 +1150,10 @@ func newStart() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1175,7 +1175,7 @@ func newStart() *cobra.Command {
 		if startSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *sql.GetWarehouseResponse) {
 			if i.Health == nil {
 				return
@@ -1185,9 +1185,9 @@ func newStart() *cobra.Command {
 			if i.Health != nil {
 				statusMessage = i.Health.Summary
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(startTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1243,10 +1243,10 @@ func newStop() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -1268,7 +1268,7 @@ func newStop() *cobra.Command {
 		if stopSkipWait {
 			return nil
 		}
-		spinner := cmdio.Spinner(ctx)
+		sp := cmdio.NewSpinner(ctx)
 		info, err := wait.OnProgress(func(i *sql.GetWarehouseResponse) {
 			if i.Health == nil {
 				return
@@ -1278,9 +1278,9 @@ func newStop() *cobra.Command {
 			if i.Health != nil {
 				statusMessage = i.Health.Summary
 			}
-			spinner <- statusMessage
+			sp.Update(statusMessage)
 		}).GetWithTimeout(stopTimeout)
-		close(spinner)
+		sp.Close()
 		if err != nil {
 			return err
 		}
@@ -1368,10 +1368,10 @@ func newUpdateDefaultWarehouseOverride() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No TYPE argument specified. Loading names for Warehouses drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No TYPE argument specified. Loading names for Warehouses drop-down.")
 				names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -1464,10 +1464,10 @@ func newUpdatePermissions() *cobra.Command {
 			}
 		}
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No WAREHOUSE_ID argument specified. Loading names for Warehouses drop-down.")
 			names, err := w.Warehouses.EndpointInfoNameToIdMap(ctx, sql.ListWarehousesRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Warehouses drop-down. Please manually specify required arguments. Original error: %w", err)
 			}

--- a/cmd/workspace/workspace/workspace.go
+++ b/cmd/workspace/workspace/workspace.go
@@ -116,10 +116,10 @@ func newDelete() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No PATH argument specified. Loading names for Workspace drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No PATH argument specified. Loading names for Workspace drop-down.")
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}
@@ -204,10 +204,10 @@ func newExport() *cobra.Command {
 		w := cmdctx.WorkspaceClient(ctx)
 
 		if len(args) == 0 {
-			promptSpinner := cmdio.Spinner(ctx)
-			promptSpinner <- "No PATH argument specified. Loading names for Workspace drop-down."
+			sp := cmdio.NewSpinner(ctx)
+			sp.Update("No PATH argument specified. Loading names for Workspace drop-down.")
 			names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
-			close(promptSpinner)
+			sp.Close()
 			if err != nil {
 				return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 			}
@@ -639,10 +639,10 @@ func newMkdirs() *cobra.Command {
 			}
 		} else {
 			if len(args) == 0 {
-				promptSpinner := cmdio.Spinner(ctx)
-				promptSpinner <- "No PATH argument specified. Loading names for Workspace drop-down."
+				sp := cmdio.NewSpinner(ctx)
+				sp.Update("No PATH argument specified. Loading names for Workspace drop-down.")
 				names, err := w.Workspace.ObjectInfoPathToObjectIdMap(ctx, workspace.ListWorkspaceRequest{})
-				close(promptSpinner)
+				sp.Close()
 				if err != nil {
 					return fmt.Errorf("failed to load names for Workspace drop-down. Please manually specify required arguments. Original error: %w", err)
 				}


### PR DESCRIPTION
## Summary
- Regenerate auto-generated CLI commands to use `NewSpinner`/`.Update()`/`.Close()` instead of the channel-based `Spinner()` API.
- Follow-up to #4351 and #4377.

Manually confirmed this works.

The upstream templates have already been updated.