### PR TITLE
Replace "DO NOT EDIT" header in legacy SCIM command files

### DIFF
--- a/cmd/account/groups/groups.go
+++ b/cmd/account/groups/groups.go
@@ -2,6 +2,7 @@
 // but are now manually maintained because the v2 API versions have taken
 // over as the generated commands. See https://github.com/databricks/cli/pull/4722.
 
+//nolint:staticcheck,perfsprint
 package groups
 
 import (

--- a/cmd/account/service-principals/service-principals.go
+++ b/cmd/account/service-principals/service-principals.go
@@ -2,6 +2,7 @@
 // but are now manually maintained because the v2 API versions have taken
 // over as the generated commands. See https://github.com/databricks/cli/pull/4722.
 
+//nolint:staticcheck,perfsprint
 package service_principals
 
 import (

--- a/cmd/account/users/users.go
+++ b/cmd/account/users/users.go
@@ -2,6 +2,7 @@
 // but are now manually maintained because the v2 API versions have taken
 // over as the generated commands. See https://github.com/databricks/cli/pull/4722.
 
+//nolint:staticcheck,perfsprint
 package users
 
 import (

--- a/cmd/workspace/groups/groups.go
+++ b/cmd/workspace/groups/groups.go
@@ -2,6 +2,7 @@
 // but are now manually maintained because the v2 API versions have taken
 // over as the generated commands. See https://github.com/databricks/cli/pull/4722.
 
+//nolint:staticcheck,perfsprint
 package groups
 
 import (

--- a/cmd/workspace/service-principals/service-principals.go
+++ b/cmd/workspace/service-principals/service-principals.go
@@ -2,6 +2,7 @@
 // but are now manually maintained because the v2 API versions have taken
 // over as the generated commands. See https://github.com/databricks/cli/pull/4722.
 
+//nolint:staticcheck,perfsprint
 package service_principals
 
 import (

--- a/cmd/workspace/users/users.go
+++ b/cmd/workspace/users/users.go
@@ -2,6 +2,7 @@
 // but are now manually maintained because the v2 API versions have taken
 // over as the generated commands. See https://github.com/databricks/cli/pull/4722.
 
+//nolint:staticcheck,perfsprint
 package users
 
 import (


### PR DESCRIPTION
## Summary
- The legacy SCIM command files (groups, users, service-principals) for both account and workspace were last regenerated in f09257e43.
- Since c0a0f04ba introduced the v2 SCIM commands, the legacy files are no longer auto-generated; the v2 replacements are the generated files now.
- Replace the stale `// Code generated ... DO NOT EDIT.` header with a comment explaining these files are manually maintained.