### PR TITLE
Add worktree and gofumpt directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ go.work.sum
 .codegen/openapi.json
 
 .claude/settings.local.json
+tools/gofumpt
+.claude/worktrees/
+.worktrees/


### PR DESCRIPTION
## Why

Local development with Claude Code creates worktree directories (`.claude/worktrees/`, `.worktrees/`) and the gofumpt tool binary (`tools/gofumpt`). These should not be tracked in version control.

## Changes

Added three entries to `.gitignore`:
- `.claude/worktrees/` - Claude Code git worktrees
- `.worktrees/` - general worktrees directory
- `tools/gofumpt` - locally built gofumpt binary

## Test plan

- [x] Verified the ignore patterns match the intended directories

This pull request was AI-assisted by Isaac.