### PR TITLE
Fix Lakebase acceptance tests for backend changes

### DIFF
--- a/acceptance/bundle/resources/postgres_endpoints/basic/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/databricks.yml.tmpl
@@ -23,9 +23,9 @@ resources:
       no_expiry: true
 
   postgres_endpoints:
-    primary:
+    custom:
       parent: ${resources.postgres_branches.main.id}
-      endpoint_id: primary
+      endpoint_id: custom
       endpoint_type: ENDPOINT_TYPE_READ_ONLY
       autoscaling_limit_min_cu: 0.5
       autoscaling_limit_max_cu: 2

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.requests.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.requests.direct.json
@@ -33,7 +33,7 @@
   "method": "POST",
   "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints",
   "q": {
-    "endpoint_id": "primary"
+    "endpoint_id": "custom"
   },
   "body": {
     "spec": {
@@ -45,9 +45,9 @@
 }
 {
   "method": "GET",
-  "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/primary"
+  "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom"
 }
 {
   "method": "GET",
-  "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/primary"
+  "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom"
 }

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.requests.terraform.json
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.requests.terraform.json
@@ -34,7 +34,7 @@
   "method": "POST",
   "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints",
   "q": {
-    "endpoint_id": "primary"
+    "endpoint_id": "custom"
   },
   "body": {
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
@@ -47,5 +47,5 @@
 }
 {
   "method": "GET",
-  "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/primary"
+  "path": "/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom"
 }

--- a/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
@@ -20,7 +20,7 @@ Resources:
       Name: 
       URL:  (not deployed)
   Postgres endpoints:
-    primary:
+    custom:
       Name: 
       URL:  (not deployed)
   Postgres projects:
@@ -34,9 +34,9 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] postgres get-endpoint projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/primary
+>>> [CLI] postgres get-endpoint projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom
 {
-  "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/primary",
+  "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {
     "autoscaling_limit_max_cu": 2,
@@ -71,7 +71,7 @@ Resources:
       Name: 
       URL:  (not deployed)
   Postgres endpoints:
-    primary:
+    custom:
       Name: 
       URL:  (not deployed)
   Postgres projects:
@@ -84,7 +84,7 @@ Resources:
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
   delete resources.postgres_branches.main
-  delete resources.postgres_endpoints.primary
+  delete resources.postgres_endpoints.custom
   delete resources.postgres_projects.my_project
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-endpoint-[UNIQUE_NAME]/default

--- a/acceptance/bundle/resources/postgres_endpoints/basic/script
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/script
@@ -15,7 +15,7 @@ trace $CLI bundle deploy
 # Get endpoint details
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
-endpoint_name="${branch_name}/endpoints/primary"
+endpoint_name="${branch_name}/endpoints/custom"
 trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time)'
 
 trace $CLI bundle summary

--- a/acceptance/bundle/resources/postgres_projects/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/basic/output.txt
@@ -37,6 +37,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Test Postgres Project",
+    "enable_pg_native_login": true,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
@@ -9,6 +9,7 @@
       "suspend_timeout_duration":"300s"
     },
     "display_name":"Test Recreate",
+    "enable_pg_native_login":true,
     "history_retention_duration":"604800s",
     "owner":"[USERNAME]",
     "pg_version":16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -11,6 +11,7 @@
         "suspend_timeout_duration": "300s"
       },
       "display_name": "Original Name",
+      "enable_pg_native_login": true,
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -24,6 +24,7 @@
         "suspend_timeout_duration": "300s"
       },
       "display_name": "Updated Name",
+      "enable_pg_native_login": true,
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -24,6 +24,7 @@
         "suspend_timeout_duration": "300s"
       },
       "display_name": "Original Name",
+      "enable_pg_native_login": true,
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
@@ -35,6 +35,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Original Name",
+    "enable_pg_native_login": true,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
@@ -105,6 +106,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Updated Name",
+    "enable_pg_native_login": true,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
@@ -142,6 +144,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Original Name",
+    "enable_pg_native_login": true,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -77,6 +77,7 @@ func (s *FakeWorkspace) PostgresProjectCreate(req Request, projectID string) Res
 			DisplayName:                 project.Spec.DisplayName,
 			PgVersion:                   project.Spec.PgVersion,
 			HistoryRetentionDuration:    project.Spec.HistoryRetentionDuration,
+			EnablePgNativeLogin:         true,
 			Owner:                       TestUser.UserName,
 			BranchLogicalSizeLimitBytes: 8796093022208, // 8 TB (real API default)
 			SyntheticStorageSizeBytes:   0,


### PR DESCRIPTION
## Summary
- Rename endpoint from `primary` to `custom` in `postgres_endpoints/basic` test to avoid conflict with the auto-created primary endpoint
- Add `enable_pg_native_login` to the mock server's project response to match current backend behavior
- Update golden files

## Test plan
- [x] All 4 tests pass locally (both direct and terraform)
- [x] All 4 tests pass on AWS cloud (direct); terraform has pre-existing provider issues unrelated to this PR

This pull request was AI-assisted by Isaac.