### PR TITLE
Remove `resources/*/*.yml` include pattern from bundle templates

### DIFF
--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/databricks.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/databricks.yml
@@ -7,7 +7,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Deployment targets.
 # The default schema, catalog, etc. for dbt are defined in dbt_profiles/profiles.yml

--- a/acceptance/bundle/templates/default-minimal/output/my_default_minimal/databricks.yml
+++ b/acceptance/bundle/templates/default-minimal/output/my_default_minimal/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
+++ b/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
@@ -1,6 +1,6 @@
 --- [TESTROOT]/bundle/templates/default-python/classic/../serverless/output/my_default_python/databricks.yml
 +++ output/my_default_python/databricks.yml
-@@ -34,4 +34,6 @@
+@@ -33,4 +33,6 @@
        catalog: hive_metastore
        schema: ${workspace.current_user.short_name}
 +    presets:

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/databricks.yml
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 artifacts:
   python_artifact:

--- a/acceptance/bundle/templates/default-python/serverless-customcatalog/output.txt
+++ b/acceptance/bundle/templates/default-python/serverless-customcatalog/output.txt
@@ -15,14 +15,14 @@ To get started, refer to the project README.md file and the documentation at htt
 >>> diff.py [TESTROOT]/bundle/templates/default-python/serverless-customcatalog/../serverless/output output/
 --- [TESTROOT]/bundle/templates/default-python/serverless-customcatalog/../serverless/output/my_default_python/databricks.yml
 +++ output/my_default_python/databricks.yml
-@@ -32,5 +32,5 @@
+@@ -31,5 +31,5 @@
        host: [DATABRICKS_URL]
      variables:
 -      catalog: hive_metastore
 +      catalog: customcatalog
        schema: ${workspace.current_user.short_name}
    prod:
-@@ -41,5 +41,5 @@
+@@ -40,5 +40,5 @@
        root_path: /Workspace/Users/[USERNAME]/.bundle/${bundle.name}/${bundle.target}
      variables:
 -      catalog: hive_metastore

--- a/acceptance/bundle/templates/default-python/serverless/output/my_default_python/databricks.yml
+++ b/acceptance/bundle/templates/default-python/serverless/output/my_default_python/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 artifacts:
   python_artifact:

--- a/acceptance/bundle/templates/default-sql/output/my_default_sql/databricks.yml
+++ b/acceptance/bundle/templates/default-sql/output/my_default_sql/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/databricks.yml
+++ b/acceptance/bundle/templates/experimental-jobs-as-code/output/my_jobs_as_code/databricks.yml
@@ -23,7 +23,6 @@ artifacts:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 targets:
   dev:

--- a/acceptance/bundle/templates/lakeflow-pipelines/python/output/my_lakeflow_pipelines/databricks.yml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/python/output/my_lakeflow_pipelines/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/bundle/templates/lakeflow-pipelines/sql/output/my_lakeflow_pipelines/databricks.yml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/sql/output/my_lakeflow_pipelines/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/databricks.yml
+++ b/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/databricks.yml
@@ -12,7 +12,6 @@ python:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 artifacts:
   python_artifact:

--- a/acceptance/bundle/templates/telemetry/dbt-sql/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/out.databricks.yml
@@ -7,7 +7,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Deployment targets.
 # The default schema, catalog, etc. for dbt are defined in dbt_profiles/profiles.yml

--- a/acceptance/bundle/templates/telemetry/default-python/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/default-python/out.databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 artifacts:
   python_artifact:

--- a/acceptance/bundle/templates/telemetry/default-sql/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/default-sql/out.databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/pipelines/e2e/output/lakeflow_project/databricks.yml
+++ b/acceptance/pipelines/e2e/output/lakeflow_project/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/pipelines/init/python/output/my_python_project/databricks.yml
+++ b/acceptance/pipelines/init/python/output/my_python_project/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/acceptance/pipelines/init/sql/output/my_sql_project/databricks.yml
+++ b/acceptance/pipelines/init/sql/output/my_sql_project/databricks.yml
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -7,7 +7,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Deployment targets.
 # The default schema, catalog, etc. for dbt are defined in dbt_profiles/profiles.yml

--- a/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -6,7 +6,6 @@ bundle:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 # Variable declarations. These variables are assigned in the dev/prod targets below.
 variables:

--- a/libs/template/templates/default/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default/template/{{.project_name}}/databricks.yml.tmpl
@@ -17,7 +17,6 @@ python:
 
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 {{- if $with_python}}
 

--- a/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/experimental-jobs-as-code/template/{{.project_name}}/databricks.yml.tmpl
@@ -25,7 +25,6 @@ artifacts:
 {{ end -}}
 include:
   - resources/*.yml
-  - resources/*/*.yml
 
 targets:
   dev:


### PR DESCRIPTION
## Changes

Remove the unused `resources/*/*.yml` include pattern from bundle templates. Only `resources/*.yml` is needed. We abandoned the other pattern some time back.