### PR TITLE
Use per-target .PHONY declarations instead of combined list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: default
 default: checks fmt lint
 
 # Default packages to test (all)
@@ -12,24 +13,30 @@ GOTESTSUM_CMD ?= ${GO_TOOL} gotestsum --format ${GOTESTSUM_FORMAT} --no-summary=
 LOCAL_TIMEOUT ?= 30m
 
 
+.PHONY: lintfull
 lintfull: ./tools/golangci-lint
 	./tools/golangci-lint run --fix
 
+.PHONY: lint
 lint: ./tools/golangci-lint
 	./tools/lintdiff.py ./tools/golangci-lint run --fix
 
+.PHONY: tidy
 tidy:
 	@# not part of golangci-lint, apparently
 	go mod tidy
 
+.PHONY: lintcheck
 lintcheck: ./tools/golangci-lint
 	./tools/golangci-lint run ./...
 
+.PHONY: fmtfull
 fmtfull: ./tools/golangci-lint ./tools/yamlfmt
 	ruff format -n
 	./tools/golangci-lint fmt
 	./tools/yamlfmt .
 
+.PHONY: fmt
 fmt: ./tools/golangci-lint ./tools/yamlfmt
 	ruff format -n
 	./tools/lintdiff.py ./tools/golangci-lint fmt
@@ -46,60 +53,77 @@ tools/yamlfmt.exe: tools/go.mod tools/go.sum
 tools/golangci-lint: tools/go.mod tools/go.sum
 	go build -modfile=tools/go.mod -o tools/golangci-lint github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
+.PHONY: ws
 ws:
 	./tools/validate_whitespace.py
 
+.PHONY: wsfix
 wsfix:
 	./tools/validate_whitespace.py --fix
 
+.PHONY: links
 links:
 	./tools/update_github_links.py
 
 # Checks other than 'fmt' and 'lint'; these are fast, so can be run first
+.PHONY: checks
 checks: tidy ws links
 
 
 # Run short unit and acceptance tests (testing.Short() is true).
+.PHONY: test
 test: test-unit test-acc
 
 # Run all unit and acceptance tests.
+.PHONY: test-slow
 test-slow: test-slow-unit test-slow-acc
 
+.PHONY: test-unit
 test-unit:
 	${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -timeout=${LOCAL_TIMEOUT} -short
 
+.PHONY: test-slow-unit
 test-slow-unit:
 	${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -timeout=${LOCAL_TIMEOUT}
 
+.PHONY: test-acc
 test-acc:
 	${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -short -run ${ACCEPTANCE_TEST_FILTER}
 
+.PHONY: test-slow-acc
 test-slow-acc:
 	${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -run ${ACCEPTANCE_TEST_FILTER}
 
 # Updates acceptance test output (local tests)
+.PHONY: test-update
 test-update:
 	-go test ./acceptance -run '^TestAccept$$' -update -timeout=${LOCAL_TIMEOUT}
 	@# at the moment second pass is required because some tests show diff against output of another test for easier review
 	-go test ./acceptance -run '^TestAccept$$' -update -timeout=${LOCAL_TIMEOUT}
 
 # Updates acceptance test output for template tests only
+.PHONY: test-update-templates
 test-update-templates:
 	-go test ./acceptance -run '^TestAccept/bundle/templates' -update -timeout=${LOCAL_TIMEOUT}
 
 # Regenerate out.test.toml files without running tests
+.PHONY: generate-out-test-toml
 generate-out-test-toml:
 	go test ./acceptance -run '^TestAccept$$' -only-out-test-toml -timeout=${LOCAL_TIMEOUT}
 
 # Updates acceptance test output (integration tests, requires access)
+.PHONY: test-update-aws
 test-update-aws:
 	deco env run -i -n aws-prod-ucws -- env DATABRICKS_TEST_SKIPLOCAL=1 go test ./acceptance -run ^TestAccept$$ -update -timeout=1h -v
 
+.PHONY: test-update-all
 test-update-all: test-update test-update-aws
 
+.PHONY: slowest
 slowest:
 	${GO_TOOL} gotestsum tool slowest --jsonfile test-output.json --threshold 1s --num 50
 
+.PHONY: cover
 cover:
 	rm -fr ./acceptance/build/cover/
 	VERBOSE_TEST=1 ${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -coverprofile=coverage.txt -timeout=${LOCAL_TIMEOUT}
@@ -109,53 +133,67 @@ cover:
 	go tool covdata merge -i $$(printf '%s,' acceptance/build/cover/* | sed 's/,$$//') -o acceptance/build/cover-merged/
 	go tool covdata textfmt -i acceptance/build/cover-merged -o coverage-acceptance.txt
 
+.PHONY: showcover
 showcover:
 	go tool cover -html=coverage.txt
 
+.PHONY: acc-showcover
 acc-showcover:
 	go tool cover -html=coverage-acceptance.txt
 
+.PHONY: build
 build: tidy
 	go build
 
 # builds the binary in a VM environment (such as Parallels Desktop) where your files are mirrored from the host os
+.PHONY: build-vm
 build-vm: tidy
 	go build -buildvcs=false
 
+.PHONY: snapshot
 snapshot:
 	go build -o .databricks/databricks
 
 # Produce release binaries and archives in the dist folder without uploading them anywhere.
 # Useful for "databricks ssh" development, as it needs to upload linux releases to the /Workspace.
+.PHONY: snapshot-release
 snapshot-release:
 	goreleaser release --clean --skip docker --snapshot
 
+.PHONY: schema
 schema:
 	go run ./bundle/internal/schema ./bundle/internal/schema ./bundle/schema/jsonschema.json
 
+.PHONY: schema-for-docs
 schema-for-docs:
 	go run ./bundle/internal/schema ./bundle/internal/schema ./bundle/schema/jsonschema_for_docs.json --docs
 
+.PHONY: docs
 docs:
 	go run ./bundle/docsgen ./bundle/internal/schema ./bundle/docsgen
 
 INTEGRATION = go run -modfile=tools/go.mod ./tools/testrunner/main.go ${GO_TOOL} gotestsum --format github-actions --rerun-fails --jsonfile output.json --packages "./acceptance ./integration/..." -- -parallel 4 -timeout=2h
 
+.PHONY: integration
 integration:
 	$(INTEGRATION)
 
+.PHONY: integration-short
 integration-short:
 	DATABRICKS_TEST_SKIPLOCAL=1 VERBOSE_TEST=1 $(INTEGRATION) -short
 
+.PHONY: dbr-integration
 dbr-integration:
 	DBR_ENABLED=true go test -v -timeout 4h -run TestDbrAcceptance$$ ./acceptance
 
 # DBR acceptance tests - run on Databricks Runtime using serverless compute
 # These require deco env run for authentication
 # Set DBR_TEST_VERBOSE=1 for detailed output (e.g., DBR_TEST_VERBOSE=1 make dbr-test)
+.PHONY: dbr-test
 dbr-test:
 	deco env run -i -n aws-prod-ucws -- make dbr-integration
 
+.PHONY: generate-validation
 generate-validation:
 	go run ./bundle/internal/validation/.
 	gofmt -w -s ./bundle/internal/validation/generated
@@ -174,6 +212,7 @@ generate-validation:
 UNIVERSE_DIR ?= $(HOME)/universe
 GENKIT_BINARY := $(UNIVERSE_DIR)/bazel-bin/openapi/genkit/genkit_/genkit
 
+.PHONY: generate
 generate:
 	@echo "Checking out universe at SHA: $$(cat .codegen/_openapi_sha)"
 	cd $(UNIVERSE_DIR) && git cat-file -e $$(cat $(PWD)/.codegen/_openapi_sha) 2>/dev/null || git fetch --filter=blob:none origin master && git checkout $$(cat $(PWD)/.codegen/_openapi_sha)
@@ -190,12 +229,18 @@ generate:
 .codegen/openapi.json: .codegen/_openapi_sha
 	wget -O $@.tmp "https://openapi.dev.databricks.com/$$(cat $<)/specs/all-internal.json" && mv $@.tmp $@ && touch $@
 
+.PHONY: generate-direct
 generate-direct: generate-direct-apitypes generate-direct-resources
+
+.PHONY: generate-direct-apitypes
 generate-direct-apitypes: bundle/direct/dresources/apitypes.generated.yml
+
+.PHONY: generate-direct-resources
 generate-direct-resources: bundle/direct/dresources/resources.generated.yml
+
+.PHONY: generate-direct-clean
 generate-direct-clean:
 	rm -f bundle/direct/dresources/apitypes.generated.yml bundle/direct/dresources/resources.generated.yml
-.PHONY: generate-direct generate-direct-apitypes generate-direct-resources generate-direct-clean
 
 bundle/direct/dresources/apitypes.generated.yml: ./bundle/direct/tools/generate_apitypes.py .codegen/openapi.json acceptance/bundle/refschema/out.fields.txt
 	python3 $^ > $@
@@ -203,27 +248,31 @@ bundle/direct/dresources/apitypes.generated.yml: ./bundle/direct/tools/generate_
 bundle/direct/dresources/resources.generated.yml: ./bundle/direct/tools/generate_resources.py .codegen/openapi.json bundle/direct/dresources/apitypes.generated.yml bundle/direct/dresources/apitypes.yml acceptance/bundle/refschema/out.fields.txt
 	python3 $^ > $@
 
-.PHONY: lint lintfull tidy lintcheck fmt fmtfull test test-unit test-acc test-slow test-slow-unit test-slow-acc cover showcover build snapshot snapshot-release schema schema-for-docs integration integration-short acc-cover acc-showcover docs ws wsfix links checks test-update test-update-templates generate-out-test-toml test-update-aws test-update-all generate-validation
-
+.PHONY: test-exp-aitools
 test-exp-aitools:
 	make test TEST_PACKAGES="./experimental/aitools/..." ACCEPTANCE_TEST_FILTER="TestAccept/apps"
 
+.PHONY: test-exp-ssh
 test-exp-ssh:
 	make test TEST_PACKAGES="./experimental/ssh/..." ACCEPTANCE_TEST_FILTER="TestAccept/ssh"
 
+.PHONY: test-pipelines
 test-pipelines:
 	make test TEST_PACKAGES="./cmd/pipelines/..." ACCEPTANCE_TEST_FILTER="TestAccept/pipelines"
 
 
 # Benchmarks:
 
+.PHONY: bench1k
 bench1k:
 	BENCHMARK_PARAMS="--jobs 1000" go test ./acceptance -v -tail -run TestAccept/bundle/benchmarks -timeout=120m
 
+.PHONY: bench100
 bench100:
 	BENCHMARK_PARAMS="--jobs 100" go test ./acceptance -v -tail -run TestAccept/bundle/benchmarks -timeout=120m
 
 # small benchmark to quickly test benchmark-related code
+.PHONY: bench10
 bench10:
 	BENCHMARK_PARAMS="--jobs 10" go test ./acceptance -v -tail -run TestAccept/bundle/benchmarks -timeout=120m
 
@@ -236,11 +285,14 @@ bench100.log:
 bench10.log:
 	make bench10 | tee $@
 
+.PHONY: bench1k_summary
 bench1k_summary: bench1k.log
 	./tools/bench_parse.py $<
 
+.PHONY: bench100_summary
 bench100_summary: bench100.log
 	./tools/bench_parse.py $<
 
+.PHONY: bench10_summary
 bench10_summary: bench10.log
 	./tools/bench_parse.py $<


### PR DESCRIPTION
## Summary

- Replaces the two combined `.PHONY` lines with individual `.PHONY: <target>` declarations placed immediately before each target definition, making it easier to see at a glance which targets are phony.
- Fixes bugs in the previous `.PHONY` declarations:
  - **Missing** (targets that existed but were not declared `.PHONY`): `slowest`, `build-vm`, `dbr-integration`, `dbr-test`, `generate`, `test-exp-aitools`, `test-exp-ssh`, `test-pipelines`, `bench1k`, `bench100`, `bench10`, `bench1k_summary`, `bench100_summary`, `bench10_summary`
  - **Extra** (declared `.PHONY` but target does not exist): `acc-cover`

## Test plan

- [ ] No functional changes; verify `make build` and `make test` still work as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)