### PR TITLE
Add NEXT_CHANGELOG entry for #4627

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,7 +5,7 @@
 ### CLI
 
 ### Bundles
-* Suppress `/Workspace` prefix diff for experiment names in direct deployment ([#4627](https://github.com/databricks/cli/pull/4627))
+* engine/direct: Fix permanent drift on experiment name field ([#4627](https://github.com/databricks/cli/pull/4627))
 
 ### Dependency updates
 


### PR DESCRIPTION
## Summary
Add changelog entry for #4627 (suppress `/Workspace` prefix diff for experiment names in direct deployment).

This pull request was AI-assisted by Isaac.