### PR TITLE
Switch `auth logout` from `--force` to `--auto-approve`

### DIFF
--- a/acceptance/cmd/auth/logout/default-profile/output.txt
+++ b/acceptance/cmd/auth/logout/default-profile/output.txt
@@ -11,7 +11,7 @@ host = [DATABRICKS_URL]
 auth_type = databricks-cli
 
 === Delete the DEFAULT profile
->>> [CLI] auth logout --profile DEFAULT --force --delete
+>>> [CLI] auth logout --profile DEFAULT --auto-approve --delete
 Logged out of and deleted profile "DEFAULT".
 
 === Backup file should exist

--- a/acceptance/cmd/auth/logout/default-profile/script
+++ b/acceptance/cmd/auth/logout/default-profile/script
@@ -16,7 +16,7 @@ title "Initial config\n"
 cat "./home/.databrickscfg"
 
 title "Delete the DEFAULT profile"
-trace $CLI auth logout --profile DEFAULT --force --delete
+trace $CLI auth logout --profile DEFAULT --auto-approve --delete
 
 title "Backup file should exist\n"
 assert_backup_exists

--- a/acceptance/cmd/auth/logout/delete-clears-default/output.txt
+++ b/acceptance/cmd/auth/logout/delete-clears-default/output.txt
@@ -4,14 +4,14 @@
 default_profile = workspace-a
 
 === Delete the default profile
->>> [CLI] auth logout --profile workspace-a --force --delete
+>>> [CLI] auth logout --profile workspace-a --auto-approve --delete
 Deleted profile "workspace-a" with no tokens to clear.
 
 === Settings after deleting default — default_profile should be cleared
 [__settings__]
 
 === Delete a non-default profile
->>> [CLI] auth logout --profile workspace-b --force --delete
+>>> [CLI] auth logout --profile workspace-b --auto-approve --delete
 Deleted profile "workspace-b" with no tokens to clear.
 
 === Settings after deleting non-default — section should still be present but empty

--- a/acceptance/cmd/auth/logout/delete-clears-default/script
+++ b/acceptance/cmd/auth/logout/delete-clears-default/script
@@ -22,13 +22,13 @@ title "Initial settings section\n"
 cat "./home/.databrickscfg" | grep -A1 __settings__
 
 title "Delete the default profile"
-trace $CLI auth logout --profile workspace-a --force --delete
+trace $CLI auth logout --profile workspace-a --auto-approve --delete
 
 title "Settings after deleting default — default_profile should be cleared\n"
 cat "./home/.databrickscfg" | grep -A1 __settings__
 
 title "Delete a non-default profile"
-trace $CLI auth logout --profile workspace-b --force --delete
+trace $CLI auth logout --profile workspace-b --auto-approve --delete
 
 title "Settings after deleting non-default — section should still be present but empty\n"
 cat "./home/.databrickscfg" | grep -A1 __settings__

--- a/acceptance/cmd/auth/logout/delete-pat-token-profile/output.txt
+++ b/acceptance/cmd/auth/logout/delete-pat-token-profile/output.txt
@@ -8,7 +8,7 @@ host = https://dev.cloud.databricks.com
 token = dev-pat-token
 
 === Logout without --delete — should report no changes for non-U2M profile
->>> [CLI] auth logout --profile dev --force
+>>> [CLI] auth logout --profile dev --auto-approve
 No tokens to clear for profile "dev". Use --delete to remove it from the config file.
 
 === Config after logout — profile should be unchanged
@@ -20,7 +20,7 @@ host = https://dev.cloud.databricks.com
 token = dev-pat-token
 
 === Logout with --delete — should delete the profile
->>> [CLI] auth logout --profile dev --force --delete
+>>> [CLI] auth logout --profile dev --auto-approve --delete
 Deleted profile "dev" with no tokens to clear.
 
 === Backup file should exist

--- a/acceptance/cmd/auth/logout/delete-pat-token-profile/script
+++ b/acceptance/cmd/auth/logout/delete-pat-token-profile/script
@@ -13,13 +13,13 @@ title "Initial config\n"
 cat "./home/.databrickscfg"
 
 title "Logout without --delete — should report no changes for non-U2M profile"
-trace $CLI auth logout --profile dev --force
+trace $CLI auth logout --profile dev --auto-approve
 
 title "Config after logout — profile should be unchanged\n"
 cat "./home/.databrickscfg"
 
 title "Logout with --delete — should delete the profile"
-trace $CLI auth logout --profile dev --force --delete
+trace $CLI auth logout --profile dev --auto-approve --delete
 
 title "Backup file should exist\n"
 assert_backup_exists

--- a/acceptance/cmd/auth/logout/error-cases/script
+++ b/acceptance/cmd/auth/logout/error-cases/script
@@ -10,7 +10,7 @@ auth_type = databricks-cli
 EOF
 
 title "Logout of non-existent profile\n"
-errcode $CLI auth logout --profile nonexistent --force
+errcode $CLI auth logout --profile nonexistent --auto-approve
 
 title "Logout without --profile in non-interactive mode\n"
-errcode $CLI auth logout --force
+errcode $CLI auth logout --auto-approve

--- a/acceptance/cmd/auth/logout/last-non-default/output.txt
+++ b/acceptance/cmd/auth/logout/last-non-default/output.txt
@@ -9,7 +9,7 @@ host = [DATABRICKS_URL]
 auth_type = databricks-cli
 
 === Delete the only non-default profile
->>> [CLI] auth logout --profile only-profile --force --delete
+>>> [CLI] auth logout --profile only-profile --auto-approve --delete
 Logged out of and deleted profile "only-profile".
 
 === Backup file should exist

--- a/acceptance/cmd/auth/logout/last-non-default/script
+++ b/acceptance/cmd/auth/logout/last-non-default/script
@@ -14,7 +14,7 @@ title "Initial config\n"
 cat "./home/.databrickscfg"
 
 title "Delete the only non-default profile"
-trace $CLI auth logout --profile only-profile --force --delete
+trace $CLI auth logout --profile only-profile --auto-approve --delete
 
 title "Backup file should exist\n"
 assert_backup_exists

--- a/acceptance/cmd/auth/logout/ordering-preserved/output.txt
+++ b/acceptance/cmd/auth/logout/ordering-preserved/output.txt
@@ -22,7 +22,7 @@ account_id = account-id
 auth_type  = databricks-cli
 
 === Delete first non-default profile (alpha)
->>> [CLI] auth logout --profile alpha --force --delete
+>>> [CLI] auth logout --profile alpha --auto-approve --delete
 Logged out of and deleted profile "alpha".
 
 === Backup file should exist
@@ -46,7 +46,7 @@ account_id = account-id
 auth_type  = databricks-cli
 
 === Delete last profile (gamma)
->>> [CLI] auth logout --profile gamma --force --delete
+>>> [CLI] auth logout --profile gamma --auto-approve --delete
 Logged out of and deleted profile "gamma".
 
 === Config after deleting gamma

--- a/acceptance/cmd/auth/logout/ordering-preserved/script
+++ b/acceptance/cmd/auth/logout/ordering-preserved/script
@@ -27,7 +27,7 @@ title "Initial config\n"
 cat "./home/.databrickscfg"
 
 title "Delete first non-default profile (alpha)"
-trace $CLI auth logout --profile alpha --force --delete
+trace $CLI auth logout --profile alpha --auto-approve --delete
 
 title "Backup file should exist\n"
 assert_backup_exists
@@ -36,7 +36,7 @@ title "Config after deleting alpha\n"
 cat "./home/.databrickscfg"
 
 title "Delete last profile (gamma)"
-trace $CLI auth logout --profile gamma --force --delete
+trace $CLI auth logout --profile gamma --auto-approve --delete
 
 title "Config after deleting gamma\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/stale-account-id-workspace-host/output.txt
+++ b/acceptance/cmd/auth/logout/stale-account-id-workspace-host/output.txt
@@ -11,7 +11,7 @@ logfood (Default)  [DATABRICKS_URL]  YES
 ]
 
 === Logout without --delete
->>> [CLI] auth logout --profile logfood --force
+>>> [CLI] auth logout --profile logfood --auto-approve
 Logged out of profile "logfood". Use --delete to also remove it from the config file.
 
 === Config after logout — profile should still exist

--- a/acceptance/cmd/auth/logout/stale-account-id-workspace-host/script
+++ b/acceptance/cmd/auth/logout/stale-account-id-workspace-host/script
@@ -37,7 +37,7 @@ title "Token cache keys before logout\n"
 jq -S '.tokens | keys' "./home/.databricks/token-cache.json"
 
 title "Logout without --delete"
-trace $CLI auth logout --profile logfood --force
+trace $CLI auth logout --profile logfood --auto-approve
 
 title "Config after logout — profile should still exist\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/token-only-shared-host/output.txt
+++ b/acceptance/cmd/auth/logout/token-only-shared-host/output.txt
@@ -7,7 +7,7 @@
 ]
 
 === Logout dev without --delete
->>> [CLI] auth logout --profile dev --force
+>>> [CLI] auth logout --profile dev --auto-approve
 Logged out of profile "dev". Use --delete to also remove it from the config file.
 
 === Config after logout — both profiles should still exist

--- a/acceptance/cmd/auth/logout/token-only-shared-host/script
+++ b/acceptance/cmd/auth/logout/token-only-shared-host/script
@@ -38,7 +38,7 @@ title "Token cache keys before logout\n"
 jq -S '.tokens | keys' "./home/.databricks/token-cache.json"
 
 title "Logout dev without --delete"
-trace $CLI auth logout --profile dev --force
+trace $CLI auth logout --profile dev --auto-approve
 
 title "Config after logout — both profiles should still exist\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/token-only/output.txt
+++ b/acceptance/cmd/auth/logout/token-only/output.txt
@@ -6,7 +6,7 @@
 ]
 
 === Logout without --delete
->>> [CLI] auth logout --profile dev --force
+>>> [CLI] auth logout --profile dev --auto-approve
 Logged out of profile "dev". Use --delete to also remove it from the config file.
 
 === Config after logout — profile should still exist

--- a/acceptance/cmd/auth/logout/token-only/script
+++ b/acceptance/cmd/auth/logout/token-only/script
@@ -31,7 +31,7 @@ title "Token cache keys before logout\n"
 jq -S '.tokens | keys' "./home/.databricks/token-cache.json"
 
 title "Logout without --delete"
-trace $CLI auth logout --profile dev --force
+trace $CLI auth logout --profile dev --auto-approve
 
 title "Config after logout — profile should still exist\n"
 cat "./home/.databrickscfg"

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -49,26 +49,26 @@ the profile is an error.
 
 1. If you specify a profile (via argument or --profile), the command logs
    out of that profile. In an interactive terminal you'll be asked to
-   confirm unless --force is set.
+   confirm unless --auto-approve is set.
 
 2. If you omit the profile in an interactive terminal, you'll be shown
    an interactive picker listing all profiles from your configuration file.
    You can search by profile name, host, or account ID. After selecting a
-   profile, you'll be asked to confirm unless --force is specified.
+   profile, you'll be asked to confirm unless --auto-approve is specified.
 
 3. If you omit the profile in a non-interactive environment (e.g. CI/CD
    pipeline), the command will fail with an error asking you to specify
    a profile.
 
-4. Use --force to skip the confirmation prompt. This is required when
+4. Use --auto-approve to skip the confirmation prompt. This is required when
    running in non-interactive environments.
 
 5. Use --delete to also remove the selected profile from ~/.databrickscfg.`,
 	}
 
-	var force bool
+	var autoApprove bool
 	var deleteProfile bool
-	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&deleteProfile, "delete", false, "Delete the profile from the config file")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
@@ -127,7 +127,7 @@ the profile is an error.
 
 		return runLogout(ctx, logoutArgs{
 			profileName:    profileName,
-			force:          force,
+			autoApprove:    autoApprove,
 			deleteProfile:  deleteProfile,
 			profiler:       profiler,
 			tokenCache:     tokenCache,
@@ -140,7 +140,7 @@ the profile is an error.
 
 type logoutArgs struct {
 	profileName    string
-	force          bool
+	autoApprove    bool
 	deleteProfile  bool
 	profiler       profile.Profiler
 	tokenCache     cache.TokenCache
@@ -153,9 +153,9 @@ func runLogout(ctx context.Context, args logoutArgs) error {
 		return err
 	}
 
-	if !args.force {
+	if !args.autoApprove {
 		if !cmdio.IsPromptSupported(ctx) {
-			return errors.New("please specify --force to skip confirmation in non-interactive mode")
+			return errors.New("please specify --auto-approve to skip confirmation in non-interactive mode")
 		}
 
 		configPath, err := args.profiler.GetPath(ctx)

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -89,7 +89,7 @@ func TestLogout(t *testing.T) {
 		hostBasedKey  string
 		isSharedKey   bool
 		isNonU2M      bool // true for profiles that are not created by login (PAT, M2M, etc.)
-		force         bool
+		autoApprove   bool
 		deleteProfile bool
 		wantErr       string
 	}{
@@ -98,46 +98,46 @@ func TestLogout(t *testing.T) {
 			profileName:  "my-workspace",
 			hostBasedKey: "https://my-workspace.cloud.databricks.com",
 			isSharedKey:  true,
-			force:        true,
+			autoApprove:  true,
 		},
 		{
 			name:         "existing workspace profile with unique host",
 			profileName:  "my-unique-workspace",
 			hostBasedKey: "https://my-unique-workspace.cloud.databricks.com",
 			isSharedKey:  false,
-			force:        true,
+			autoApprove:  true,
 		},
 		{
 			name:         "existing workspace profile with stale account id",
 			profileName:  "my-workspace-stale-account",
 			hostBasedKey: "https://stale-account.cloud.databricks.com",
 			isSharedKey:  false,
-			force:        true,
+			autoApprove:  true,
 		},
 		{
 			name:         "existing account profile",
 			profileName:  "my-account",
 			hostBasedKey: "https://accounts.cloud.databricks.com/oidc/accounts/abc123",
 			isSharedKey:  false,
-			force:        true,
+			autoApprove:  true,
 		},
 		{
 			name:         "existing unified profile",
 			profileName:  "my-unified",
 			hostBasedKey: "https://unified.cloud.databricks.com/oidc/accounts/def456",
 			isSharedKey:  false,
-			force:        true,
+			autoApprove:  true,
 		},
 		{
-			name:        "existing workspace profile without force in non-interactive mode",
+			name:        "existing workspace profile without auto-approve in non-interactive mode",
 			profileName: "my-workspace",
-			force:       false,
-			wantErr:     "please specify --force to skip confirmation in non-interactive mode",
+			autoApprove: false,
+			wantErr:     "please specify --auto-approve to skip confirmation in non-interactive mode",
 		},
 		{
 			name:        "non-existing workspace profile",
 			profileName: "nonexistent",
-			force:       false,
+			autoApprove: false,
 			wantErr:     `profile "nonexistent" not found`,
 		},
 		{
@@ -145,7 +145,7 @@ func TestLogout(t *testing.T) {
 			profileName:   "my-workspace",
 			hostBasedKey:  "https://my-workspace.cloud.databricks.com",
 			isSharedKey:   true,
-			force:         true,
+			autoApprove:   true,
 			deleteProfile: true,
 		},
 		{
@@ -153,7 +153,7 @@ func TestLogout(t *testing.T) {
 			profileName:   "my-unique-workspace",
 			hostBasedKey:  "https://my-unique-workspace.cloud.databricks.com",
 			isSharedKey:   false,
-			force:         true,
+			autoApprove:   true,
 			deleteProfile: true,
 		},
 		{
@@ -161,7 +161,7 @@ func TestLogout(t *testing.T) {
 			profileName:   "my-account",
 			hostBasedKey:  "https://accounts.cloud.databricks.com/oidc/accounts/abc123",
 			isSharedKey:   false,
-			force:         true,
+			autoApprove:   true,
 			deleteProfile: true,
 		},
 		{
@@ -169,7 +169,7 @@ func TestLogout(t *testing.T) {
 			profileName:   "my-unified",
 			hostBasedKey:  "https://unified.cloud.databricks.com/oidc/accounts/def456",
 			isSharedKey:   false,
-			force:         true,
+			autoApprove:   true,
 			deleteProfile: true,
 		},
 		{
@@ -177,7 +177,7 @@ func TestLogout(t *testing.T) {
 			profileName:   "my-m2m",
 			hostBasedKey:  "https://my-m2m.cloud.databricks.com",
 			isNonU2M:      true,
-			force:         true,
+			autoApprove:   true,
 			deleteProfile: false,
 		},
 	}
@@ -194,7 +194,7 @@ func TestLogout(t *testing.T) {
 
 			err := runLogout(ctx, logoutArgs{
 				profileName:    tc.profileName,
-				force:          tc.force,
+				autoApprove:    tc.autoApprove,
 				deleteProfile:  tc.deleteProfile,
 				profiler:       profile.DefaultProfiler,
 				tokenCache:     tokenCache,
@@ -243,7 +243,7 @@ func TestLogoutNoTokens(t *testing.T) {
 
 	err := runLogout(ctx, logoutArgs{
 		profileName:    "my-workspace",
-		force:          true,
+		autoApprove:    true,
 		profiler:       profile.DefaultProfiler,
 		tokenCache:     tokenCache,
 		configFilePath: configPath,
@@ -267,7 +267,7 @@ func TestLogoutNoTokensWithDelete(t *testing.T) {
 
 	err := runLogout(ctx, logoutArgs{
 		profileName:    "my-workspace",
-		force:          true,
+		autoApprove:    true,
 		deleteProfile:  true,
 		profiler:       profile.DefaultProfiler,
 		tokenCache:     tokenCache,
@@ -332,7 +332,7 @@ default_profile = my-workspace
 
 			err := runLogout(ctx, logoutArgs{
 				profileName:    tc.profileName,
-				force:          true,
+				autoApprove:    true,
 				deleteProfile:  true,
 				profiler:       profile.DefaultProfiler,
 				tokenCache:     tokenCache,
@@ -393,7 +393,7 @@ auth_type = databricks-cli
 
 	err := runLogout(ctx, logoutArgs{
 		profileName:    "spog-profile",
-		force:          true,
+		autoApprove:    true,
 		profiler:       profile.DefaultProfiler,
 		tokenCache:     tokenCache,
 		configFilePath: configPath,


### PR DESCRIPTION
## Changes

* Replace the logout-specific `--force` flag with `--auto-approve`, matching the pattern used by `bundle deploy`, `bundle destroy`, and other commands.
* Register `--auto-approve` directly on the `auth logout` command instead of relying on an unregistered global `--yes` flag.
* Stop registering a local `--profile` flag on `auth logout` — read the value from the shared flag already available on the command tree.
* Update the logout help text, non-interactive error message, and unit/acceptance tests to reflect the `--auto-approve` behavior.

## Why

The `--force` flag was specific to `auth logout`. Switching to `--auto-approve` aligns with the rest of the CLI's confirmation-skip pattern (`bundle deploy --auto-approve`, `bundle destroy --auto-approve`, etc.).

`auth logout` was defining its own `--profile` flag, overriding the global one. Removing it and defaulting to the root behavior keeps UX aligned with other commands and removes a duplicate flag definition that can drift over time.

## Tests

* `go test ./cmd/auth -run TestLogout -count=1`
* `go test ./acceptance -run TestAccept/cmd/auth/logout -test.v`