### PR TITLE
Experimental SSH: normalize URL paths to fix double-slash redirects from driver proxy

### DIFF
--- a/experimental/ssh/internal/server/server.go
+++ b/experimental/ssh/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -93,7 +94,11 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ServerOpt
 
 	go handleTimeout(ctx, connections.TimedOut, opts.ShutdownDelay)
 
-	return http.ListenAndServe(listenAddr, nil)
+	return http.ListenAndServe(listenAddr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Normalize double slashes from the driver proxy (e.g. //metadata -> /metadata)
+		r.URL.Path = path.Clean(r.URL.Path)
+		http.DefaultServeMux.ServeHTTP(w, r)
+	}))
 }
 
 func serveMetadata(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- The driver proxy rewrites URLs with double slashes (e.g. `//metadata`), which causes Go's default mux to issue a 301 redirect to `/metadata/`, resulting in an infinite redirect loop.
- Adds a `path.Clean` normalization step in the HTTP handler to clean up paths before routing.

## Test plan
- [x] Deploy to a cluster behind driver proxy and verify `/metadata` responds with 200
- [x] Verify SSH connections still work through the proxy

This pull request was AI-assisted by Isaac.