### PR TITLE
Pin default AppKit version to 0.20.3

### DIFF
--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -37,7 +37,7 @@ const (
 	appkitTemplateDir    = "template"
 	appkitDefaultBranch  = "main"
 	appkitTemplateTagPfx = "template-v"
-	appkitDefaultVersion = "template-v0.20.2"
+	appkitDefaultVersion = "template-v0.20.3"
 	defaultProfile       = "DEFAULT"
 )
 


### PR DESCRIPTION
Bump appkitDefaultVersion from template-v0.14.1 to template-v0.20.2 so that `databricks apps init` scaffolds with AppKit 0.20.2 by default.

## Changes
[<!-- Brief summary of your changes that is easy to understand -->]
https://dev-evals-monitor-6177827686947384.gcp.databricksapps.com/

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
