### PR TITLE
Update the Learn more link for DATABRICKS_BUNDLE_ENGINE

### DIFF
--- a/acceptance/bundle/validate/catalog_requires_direct_mode/output.txt
+++ b/acceptance/bundle/validate/catalog_requires_direct_mode/output.txt
@@ -2,7 +2,7 @@ Error: Catalog resources are only supported with direct deployment mode
   in databricks.yml:6:5
 
 Catalog resources require direct deployment mode. Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use catalog resources.
-Learn more at https://docs.databricks.com/dev-tools/bundles/deployment-modes.html
+Learn more at https://docs.databricks.com/dev-tools/bundles/direct
 
 
 Exit code: 1

--- a/bundle/config/mutator/validate_direct_only_resources.go
+++ b/bundle/config/mutator/validate_direct_only_resources.go
@@ -73,7 +73,7 @@ func (m *validateDirectOnlyResources) Apply(ctx context.Context, b *bundle.Bundl
 				Summary:  resource.pluralName + " resources are only supported with direct deployment mode",
 				Detail: fmt.Sprintf("%s resources require direct deployment mode. "+
 					"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use %s resources.\n"+
-					"Learn more at https://docs.databricks.com/dev-tools/bundles/deployment-modes.html",
+					"Learn more at https://docs.databricks.com/dev-tools/bundles/direct",
 					resource.pluralName, resource.singularName),
 				Locations: b.Config.GetLocations("resources." + resource.resourceType),
 			})


### PR DESCRIPTION
## Changes

Update the link for learning more about `DATABRICKS_BUNDLE_ENGINE` (terraform vs direct) from https://docs.databricks.com/dev-tools/bundles/deployment-modes.html to https://docs.databricks.com/dev-tools/bundles/direct

## Why

Wrong link, caused confusion

## Tests

Updated acceptance test too

```
% cd acceptance/bundle/resources/catalogs/basic
% DATABRICKS_BUNDLE_ENGINE=terraform databricks bundle plan
Error: Catalog resources are only supported with direct deployment mode
  in databricks.yml:9:5

Catalog resources require direct deployment mode. Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use catalog resources.
Learn more at https://docs.databricks.com/dev-tools/bundles/direct
```