### PR TITLE
Add composite action to Dependabot config

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
 
     - name: Setup Go
-      uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
         cache-dependency-path: |
@@ -30,12 +30,12 @@ runs:
         python-version: '3.13'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         version: "0.8.9"
 
     - name: Install ruff (Python linter and formatter)
-      uses: astral-sh/ruff-action@57714a7c8a2e59f32539362ba31877a1957dded1 # v3.5.1
+      uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
       with:
         version: "0.9.1"
         args: "--version"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
     directory: "/tools"
     schedule:
       interval: "weekly"
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/.github/workflows"
+      - "/.github/actions/setup-build-environment"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## Summary

- Dependabot's `github-actions` ecosystem with `directory: "/"` only scans `.github/workflows/`, not `.github/actions/` subdirectories. This caused the composite action's pinned action versions to drift behind the workflow files.
- Switch to `directories` (plural) to include both `.github/workflows/` and `.github/actions/setup-build-environment/` in a single Dependabot entry, so future bumps produce a single PR covering both locations.
- Align the stale action pins in the composite action (`setup-go`, `setup-uv`, `ruff-action`) with the current workflow versions.

## Test plan

- [ ] Verify Dependabot picks up the composite action on its next scheduled run.
- [ ] Confirm no CI regressions from the updated action pins.

This pull request was AI-assisted by Isaac.