### PR TITLE
Bump agent skills version to v0.1.3

### DIFF
--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -21,7 +21,7 @@ const (
 	skillsRepoOwner      = "databricks"
 	skillsRepoName       = "databricks-agent-skills"
 	skillsRepoPath       = "skills"
-	defaultSkillsRepoRef = "v0.1.2"
+	defaultSkillsRepoRef = "v0.1.3"
 )
 
 func getSkillsRef(ctx context.Context) string {


### PR DESCRIPTION
## Summary
- Bump pinned `databricks-agent-skills` version from v0.1.2 to v0.1.3
