### PR TITLE
fix: manifest load from local template path

### DIFF
--- a/cmd/apps/init_test.go
+++ b/cmd/apps/init_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/databricks/cli/libs/apps/manifest"
 	"github.com/databricks/cli/libs/apps/prompt"
+	"github.com/databricks/cli/libs/env"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -642,8 +643,7 @@ func TestRunManifestOnlyFound(t *testing.T) {
 	var buf bytes.Buffer
 	_, _ = io.Copy(&buf, r)
 	out := buf.String()
-	assert.Contains(t, out, `"version": "1.0"`)
-	assert.Contains(t, out, `"analytics"`)
+	assert.Equal(t, content, out)
 }
 
 func TestRunManifestOnlyNotFound(t *testing.T) {
@@ -663,4 +663,27 @@ func TestRunManifestOnlyNotFound(t *testing.T) {
 	_, _ = io.Copy(&buf, r)
 	out := buf.String()
 	assert.Equal(t, "No appkit.plugins.json manifest found in this template.\n", out)
+}
+
+func TestRunManifestOnlyUsesTemplatePathEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, manifest.ManifestFileName)
+	content := `{"version":"1.0","scaffolding":{"command":"databricks apps init"}}`
+	require.NoError(t, os.WriteFile(manifestPath, []byte(content), 0o644))
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	ctx := env.Set(t.Context(), templatePathEnvVar, dir)
+	err = runManifestOnly(ctx, "", "", "")
+	w.Close()
+	os.Stdout = old
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	out := buf.String()
+	assert.Equal(t, content, out)
 }

--- a/cmd/apps/manifest.go
+++ b/cmd/apps/manifest.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -55,15 +54,15 @@ func runManifestOnly(ctx context.Context, templatePath, branch, version string) 
 	}
 
 	if manifest.HasManifest(templateDir) {
-		m, err := manifest.Load(templateDir)
+		path := filepath.Join(templateDir, manifest.ManifestFileName)
+		data, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("load manifest: %w", err)
+			return fmt.Errorf("read manifest: %w", err)
 		}
-		enc, err := json.MarshalIndent(m, "", "  ")
+		_, err = os.Stdout.Write(data)
 		if err != nil {
-			return fmt.Errorf("encode manifest: %w", err)
+			return fmt.Errorf("write manifest: %w", err)
 		}
-		fmt.Fprintln(os.Stdout, string(enc))
 		return nil
 	}
 
@@ -83,7 +82,7 @@ func newManifestCmd() *cobra.Command {
 		Short:  "Print template manifest with available plugins and required resources",
 		Hidden: true,
 		Long: `Resolves a template (default AppKit repo or --template URL), locates appkit.plugins.json,
-and prints its contents to stdout. No workspace authentication is required.
+and prints its raw contents to stdout. No workspace authentication is required.
 
 Use the same --template, --branch, and --version flags as "databricks apps init" to target
 a specific template. Without --template, uses the default AppKit template (main branch).


### PR DESCRIPTION
## Summary

This branch fixes `databricks apps manifest` so it behaves like a true manifest viewer for AppKit templates, especially when resolving a local template via `DATABRICKS_APPKIT_TEMPLATE_PATH` or `--template`.

**Preserve raw manifest output** (`cmd/apps/manifest.go`):
Previously, the command loaded `appkit.plugins.json` into the CLI's internal manifest struct and then re-serialized it, which dropped fields not represented in that struct such as `scaffolding`, `rules`, and richer field metadata. The change now reads `appkit.plugins.json` directly and writes the raw file contents to stdout, so local templates and newer manifest schema fields are preserved exactly as authored.

### Supporting infrastructure

- **`cmd/apps/init_test.go`** — Strengthens manifest-related tests by asserting exact raw output instead of checking for a couple of JSON substrings.
- **`cmd/apps/init_test.go`** — Adds coverage for the `DATABRICKS_APPKIT_TEMPLATE_PATH` fallback so `runManifestOnly()` is verified to resolve and print a local template manifest when no explicit `--template` is provided.

### Other changes

- Updates the `apps manifest` help text in `cmd/apps/manifest.go` to clarify that it prints the manifest's raw contents.
- Keeps template resolution behavior aligned with `apps init`; only the output format of `apps manifest` changed.