### PR TITLE
Add GitHub Action to suggest PR reviewers based on git history

### DIFF
--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -21,10 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          version: "0.6.5"
+
       - name: Suggest reviewers
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: python3 tools/suggest_reviewers.py
+        run: uv run tools/suggest_reviewers.py

--- a/tools/suggest_reviewers.py
+++ b/tools/suggest_reviewers.py
@@ -20,8 +20,6 @@ def classify_file(path: str) -> float:
     p = Path(path)
     if p.name.startswith("out.") or p.name == "output.txt":
         return 0.0
-    if path.startswith(("cmd/workspace/", "cmd/account/")):
-        return 0.0
     if path.startswith(("acceptance/", "integration/")):
         return 0.2
     if path.endswith("_test.go"):


### PR DESCRIPTION
## Why

The CLI's CODEOWNERS catch-all assigns 6 people to every PR outside a few narrow paths. This creates review noise and diffuses responsibility. We want targeted reviewer suggestions based on who actually worked on the changed code recently.

## Changes

Before: Every PR touching core code auto-assigns all 6 CODEOWNERS. No signal about who is best suited to review.

Now: A new GitHub Action analyzes git history of the changed files and posts a PR comment with two sections:
- **Suggested reviewers** (1-3 people best suited based on recency-weighted git history)
- **Eligible reviewers** (everyone from CODEOWNERS who could review, minus the suggested ones)

This is additive only. CODEOWNERS and auto-assign stay unchanged.

How it works:
- Triggers on PR open, synchronize, and ready-for-review (skips drafts and fork PRs)
- Classifies changed files by type (source=1.0, tests=0.3, acceptance=0.2, generated=0.0)
- Scores contributors using recency-weighted commit history (half-life 150 days)
- Resolves git author names to GitHub logins via the GitHub API (no hardcoded alias table to maintain)
- Parses `.github/CODEOWNERS` to find eligible reviewers for the changed paths
- Updates the comment in-place on re-runs (no notification churn)

Implementation: a single Python script (`tools/suggest_reviewers.py`, 281 lines) and a minimal workflow YAML.

## Test plan

- [x] Action ran on this PR itself and posted a comment successfully
- [x] Verified script parses cleanly, passed `make checks`, passed `ruff format`
- [x] Dry-run tested against 4 recent merged PRs with different characteristics:

**PR #4784** (66 files, by pietern, big DABs rename):
```
## Suggested reviewers
- @denik -- recent work in `./`, `bundle/`, `cmd/bundle/generate/`
Confidence: high

## Eligible reviewers
@andrewnester, @anton-107, @lennartkats-db, @shreyas-goenka, @simonfaltum
```
Correctly identifies Denis as the clear top reviewer (2x second place score). All 6 CODEOWNERS shown as eligible.

**PR #4782** (13 files, by denik, bundle engine priority):
```
## Suggested reviewers
- @andrewnester -- recent work in `bundle/schema/`, `bundle/internal/schema/`, `cmd/bundle/generate/`
- @pietern -- recent work in `bundle/schema/`, `cmd/bundle/generate/`, `bundle/internal/schema/`
- @shreyas-goenka -- recent work in `bundle/schema/`, `bundle/internal/schema/`, `cmd/bundle/`
Confidence: medium

## Eligible reviewers
@anton-107, @simonfaltum
```
Suggests 3 reviewers when scores are close. Remaining CODEOWNERS shown as eligible.

**PR #4785** (2 files, by MarioCadenas, apps bug fix):
```
## Suggested reviewers
- @arsenyinfo -- recent work in `cmd/apps/`
- @pietern -- recent work in `cmd/apps/`
- @pkosiec -- recent work in `cmd/apps/`
Confidence: low

## Eligible reviewers
@databricks/eng-apps-devex
```
Correctly suggests apps-area contributors (not the catch-all CODEOWNERS). Shows the apps team as eligible. Low confidence since only 2 files.

**PR #4774** (28 files, by denik, direct engine grants):
```
## Suggested reviewers
- @andrewnester -- recent work in `bundle/direct/dresources/`, `acceptance/bundle/invariant/`
- @shreyas-goenka -- recent work in `bundle/direct/dresources/`
Confidence: high

## Eligible reviewers
@anton-107, @pietern, @simonfaltum
```
Correctly identifies the two main bundle/direct contributors. High confidence with clear score separation.