### PR TITLE
Only run suggest-reviewers on PR open, not on every push

### DIFF
--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -2,7 +2,7 @@ name: suggest-reviewers
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The `suggest-reviewers` action was re-triggering on every push to an open PR because the `synchronize` event type was included. This caused unnecessary re-runs after the PR was already reviewed/approved.

## Changes

Remove the `synchronize` trigger type from the workflow. The action now only runs on `opened` and `ready_for_review` events, so it fires once when a PR is created (or when a draft is marked ready) and never re-runs on subsequent pushes.

## Test plan

- Verified the workflow YAML is valid.
- The existing `if: !github.event.pull_request.draft` guard still correctly skips draft PRs.