### PR TITLE
fix: improve apps deploy error when APP_NAME is missing

### DIFF
--- a/cmd/apps/bundle_helpers.go
+++ b/cmd/apps/bundle_helpers.go
@@ -48,7 +48,7 @@ Alternatively, run this command from a project directory containing
 databricks.yml to auto-detect the app name.`
 
 	if hint != "" {
-		msg += fmt.Sprintf("\n\nDid you mean?\n  databricks apps deploy %s", hint)
+		msg += "\n\nDid you mean?\n  databricks apps deploy " + hint
 	}
 
 	return errors.New(msg)

--- a/cmd/apps/bundle_helpers.go
+++ b/cmd/apps/bundle_helpers.go
@@ -55,13 +55,21 @@ databricks.yml to auto-detect the app name.`
 }
 
 // inferAppNameHint tries to suggest an app name from the local environment.
-// It checks the current directory name as a best-effort hint.
+// Only returns a hint if the current directory looks like a Databricks app
+// (contains app.yml or app.yaml), using the directory name as the suggestion.
 func inferAppNameHint() string {
 	wd, err := os.Getwd()
 	if err != nil {
 		return ""
 	}
-	return filepath.Base(wd)
+
+	for _, filename := range []string{"app.yml", "app.yaml"} {
+		if _, err := os.Stat(filepath.Join(wd, filename)); err == nil {
+			return filepath.Base(wd)
+		}
+	}
+
+	return ""
 }
 
 // getAppNameFromArgs returns the app name from args or detects it from the bundle.

--- a/cmd/apps/bundle_helpers.go
+++ b/cmd/apps/bundle_helpers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -27,10 +29,39 @@ func makeArgsOptionalWithBundle(cmd *cobra.Command, usage string) {
 			return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
 		}
 		if !hasBundleConfig() && len(args) != 1 {
-			return fmt.Errorf("accepts 1 arg(s), received %d", len(args))
+			return missingAppNameError()
 		}
 		return nil
 	}
+}
+
+// missingAppNameError returns an error message that explains what the positional
+// argument should be, and attempts to infer a suggestion from the local environment.
+func missingAppNameError() error {
+	hint := inferAppNameHint()
+	msg := `missing required argument: APP_NAME
+
+Usage: databricks apps <command> APP_NAME
+
+APP_NAME is the name of the Databricks app to operate on.
+Alternatively, run this command from a project directory containing
+databricks.yml to auto-detect the app name.`
+
+	if hint != "" {
+		msg += fmt.Sprintf("\n\nDid you mean?\n  databricks apps deploy %s", hint)
+	}
+
+	return errors.New(msg)
+}
+
+// inferAppNameHint tries to suggest an app name from the local environment.
+// It checks the current directory name as a best-effort hint.
+func inferAppNameHint() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return filepath.Base(wd)
 }
 
 // getAppNameFromArgs returns the app name from args or detects it from the bundle.

--- a/cmd/apps/bundle_helpers_test.go
+++ b/cmd/apps/bundle_helpers_test.go
@@ -110,31 +110,32 @@ func TestFormatAppStatusMessage(t *testing.T) {
 
 func TestInferAppNameHint(t *testing.T) {
 	t.Run("returns empty when no app config exists", func(t *testing.T) {
-		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(t.TempDir())
 
 		assert.Equal(t, "", inferAppNameHint())
 	})
 
 	t.Run("returns dir name when app.yml exists", func(t *testing.T) {
 		dir := t.TempDir()
-		testChdir(t, dir)
-		os.WriteFile(filepath.Join(dir, "app.yml"), []byte("command: [\"python\"]"), 0o644)
+		t.Chdir(dir)
+		err := os.WriteFile(filepath.Join(dir, "app.yml"), []byte("command: [\"python\"]"), 0o644)
+		assert.NoError(t, err)
 
 		assert.Equal(t, filepath.Base(dir), inferAppNameHint())
 	})
 
 	t.Run("returns dir name when app.yaml exists", func(t *testing.T) {
 		dir := t.TempDir()
-		testChdir(t, dir)
-		os.WriteFile(filepath.Join(dir, "app.yaml"), []byte("command: [\"python\"]"), 0o644)
+		t.Chdir(dir)
+		err := os.WriteFile(filepath.Join(dir, "app.yaml"), []byte("command: [\"python\"]"), 0o644)
+		assert.NoError(t, err)
 
 		assert.Equal(t, filepath.Base(dir), inferAppNameHint())
 	})
 
 	t.Run("returns empty when cwd has been deleted", func(t *testing.T) {
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 		os.Remove(dir)
 
 		assert.Equal(t, "", inferAppNameHint())
@@ -143,8 +144,7 @@ func TestInferAppNameHint(t *testing.T) {
 
 func TestMissingAppNameError(t *testing.T) {
 	t.Run("includes APP_NAME and usage info", func(t *testing.T) {
-		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(t.TempDir())
 
 		err := missingAppNameError()
 		assert.Contains(t, err.Error(), "APP_NAME")
@@ -154,8 +154,9 @@ func TestMissingAppNameError(t *testing.T) {
 
 	t.Run("includes hint when app.yml exists", func(t *testing.T) {
 		dir := t.TempDir()
-		testChdir(t, dir)
-		os.WriteFile(filepath.Join(dir, "app.yml"), []byte("command: [\"python\"]"), 0o644)
+		t.Chdir(dir)
+		writeErr := os.WriteFile(filepath.Join(dir, "app.yml"), []byte("command: [\"python\"]"), 0o644)
+		assert.NoError(t, writeErr)
 
 		err := missingAppNameError()
 		assert.Contains(t, err.Error(), "Did you mean")
@@ -164,22 +165,13 @@ func TestMissingAppNameError(t *testing.T) {
 
 	t.Run("gracefully handles deleted cwd", func(t *testing.T) {
 		dir := t.TempDir()
-		testChdir(t, dir)
+		t.Chdir(dir)
 		os.Remove(dir)
 
 		err := missingAppNameError()
 		assert.Contains(t, err.Error(), "APP_NAME")
 		assert.NotContains(t, err.Error(), "Did you mean")
 	})
-}
-
-// testChdir changes to the given directory for the duration of the test.
-func testChdir(t *testing.T, dir string) {
-	t.Helper()
-	orig, err := os.Getwd()
-	assert.NoError(t, err)
-	assert.NoError(t, os.Chdir(dir))
-	t.Cleanup(func() { os.Chdir(orig) })
 }
 
 func TestMakeArgsOptionalWithBundle(t *testing.T) {

--- a/cmd/apps/bundle_helpers_test.go
+++ b/cmd/apps/bundle_helpers_test.go
@@ -3,6 +3,8 @@ package apps
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/service/apps"
@@ -104,6 +106,80 @@ func TestFormatAppStatusMessage(t *testing.T) {
 		msg := formatAppStatusMessage(appInfo, "test-app", "started")
 		assert.Equal(t, "✔ App 'test-app' status: unknown", msg)
 	})
+}
+
+func TestInferAppNameHint(t *testing.T) {
+	t.Run("returns empty when no app config exists", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+
+		assert.Equal(t, "", inferAppNameHint())
+	})
+
+	t.Run("returns dir name when app.yml exists", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+		os.WriteFile(filepath.Join(dir, "app.yml"), []byte("command: [\"python\"]"), 0o644)
+
+		assert.Equal(t, filepath.Base(dir), inferAppNameHint())
+	})
+
+	t.Run("returns dir name when app.yaml exists", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+		os.WriteFile(filepath.Join(dir, "app.yaml"), []byte("command: [\"python\"]"), 0o644)
+
+		assert.Equal(t, filepath.Base(dir), inferAppNameHint())
+	})
+
+	t.Run("returns empty when cwd has been deleted", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+		os.Remove(dir)
+
+		assert.Equal(t, "", inferAppNameHint())
+	})
+}
+
+func TestMissingAppNameError(t *testing.T) {
+	t.Run("includes APP_NAME and usage info", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+
+		err := missingAppNameError()
+		assert.Contains(t, err.Error(), "APP_NAME")
+		assert.Contains(t, err.Error(), "databricks.yml")
+		assert.NotContains(t, err.Error(), "Did you mean")
+	})
+
+	t.Run("includes hint when app.yml exists", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+		os.WriteFile(filepath.Join(dir, "app.yml"), []byte("command: [\"python\"]"), 0o644)
+
+		err := missingAppNameError()
+		assert.Contains(t, err.Error(), "Did you mean")
+		assert.Contains(t, err.Error(), filepath.Base(dir))
+	})
+
+	t.Run("gracefully handles deleted cwd", func(t *testing.T) {
+		dir := t.TempDir()
+		testChdir(t, dir)
+		os.Remove(dir)
+
+		err := missingAppNameError()
+		assert.Contains(t, err.Error(), "APP_NAME")
+		assert.NotContains(t, err.Error(), "Did you mean")
+	})
+}
+
+// testChdir changes to the given directory for the duration of the test.
+func testChdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { os.Chdir(orig) })
 }
 
 func TestMakeArgsOptionalWithBundle(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the opaque `accepts 1 arg(s), received 0` error with a clear message explaining that `APP_NAME` is required
- Show usage, mention the `databricks.yml` auto-detect alternative, and suggest an app name inferred from the current directory name

## Test plan
- [x] `go test ./cmd/apps/ -run TestMakeArgsOptional` passes
- [x] `go build ./cmd/apps/` succeeds

This pull request was AI-assisted by Isaac.