### PR TITLE
Add substring matching to `databricks bundle open`

### DIFF
--- a/bundle/resources/lookup.go
+++ b/bundle/resources/lookup.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/databricks/cli/bundle/config/resources"
 
@@ -97,4 +98,16 @@ func Lookup(b *bundle.Bundle, key string, filters ...Filter) (Reference, error) 
 	default:
 		panic("unreachable")
 	}
+}
+
+// LookupByPrefix returns all resources whose key starts with the given prefix.
+func LookupByPrefix(b *bundle.Bundle, prefix string, filters ...Filter) []Reference {
+	keyOnly, _ := References(b, filters...)
+	var matches []Reference
+	for k, refs := range keyOnly {
+		if strings.HasPrefix(k, prefix) {
+			matches = append(matches, refs...)
+		}
+	}
+	return matches
 }

--- a/bundle/resources/lookup.go
+++ b/bundle/resources/lookup.go
@@ -100,12 +100,12 @@ func Lookup(b *bundle.Bundle, key string, filters ...Filter) (Reference, error) 
 	}
 }
 
-// LookupByPrefix returns all resources whose key starts with the given prefix.
-func LookupByPrefix(b *bundle.Bundle, prefix string, filters ...Filter) []Reference {
+// LookupBySubstring returns all resources whose key contains the given substring.
+func LookupBySubstring(b *bundle.Bundle, substr string, filters ...Filter) []Reference {
 	keyOnly, _ := References(b, filters...)
 	var matches []Reference
 	for k, refs := range keyOnly {
-		if strings.HasPrefix(k, prefix) {
+		if strings.Contains(k, substr) {
 			matches = append(matches, refs...)
 		}
 	}

--- a/bundle/resources/lookup_test.go
+++ b/bundle/resources/lookup_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/databricks/cli/bundle"
@@ -127,4 +128,110 @@ func TestLookup_NominalWithFilters(t *testing.T) {
 	_, err = Lookup(b, "bar", includeJobs)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, `resource with key "bar" not found`)
+}
+
+func TestLookupByPrefix_NoMatches(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"foo": {},
+					"bar": {},
+				},
+			},
+		},
+	}
+
+	matches := LookupByPrefix(b, "qux")
+	assert.Empty(t, matches)
+}
+
+func TestLookupByPrefix_SingleMatch(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"foo_job": {
+						JobSettings: jobs.JobSettings{Name: "Foo job"},
+					},
+					"bar_job": {},
+				},
+			},
+		},
+	}
+
+	matches := LookupByPrefix(b, "foo")
+	require.Len(t, matches, 1)
+	assert.Equal(t, "foo_job", matches[0].Key)
+	assert.Equal(t, "Foo job", matches[0].Resource.GetName())
+}
+
+func TestLookupByPrefix_MultipleMatches(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job_1": {},
+					"my_job_2": {},
+					"other":    {},
+				},
+			},
+		},
+	}
+
+	matches := LookupByPrefix(b, "my_")
+	require.Len(t, matches, 2)
+
+	keys := []string{matches[0].Key, matches[1].Key}
+	sort.Strings(keys)
+	assert.Equal(t, []string{"my_job_1", "my_job_2"}, keys)
+}
+
+func TestLookupByPrefix_WithFilters(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job": {},
+				},
+				Pipelines: map[string]*resources.Pipeline{
+					"my_pipeline": {},
+				},
+			},
+		},
+	}
+
+	includeJobs := func(ref Reference) bool {
+		_, ok := ref.Resource.(*resources.Job)
+		return ok
+	}
+
+	matches := LookupByPrefix(b, "my_", includeJobs)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "my_job", matches[0].Key)
+}
+
+func TestLookupByPrefix_ExactPrefixMatchesAll(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"foo":     {},
+					"foobar":  {},
+					"foobaz":  {},
+					"another": {},
+				},
+			},
+		},
+	}
+
+	matches := LookupByPrefix(b, "foo")
+	require.Len(t, matches, 3)
+
+	keys := make([]string, len(matches))
+	for i, m := range matches {
+		keys[i] = m.Key
+	}
+	sort.Strings(keys)
+	assert.Equal(t, []string{"foo", "foobar", "foobaz"}, keys)
 }

--- a/bundle/resources/lookup_test.go
+++ b/bundle/resources/lookup_test.go
@@ -130,7 +130,7 @@ func TestLookup_NominalWithFilters(t *testing.T) {
 	assert.ErrorContains(t, err, `resource with key "bar" not found`)
 }
 
-func TestLookupByPrefix_NoMatches(t *testing.T) {
+func TestLookupBySubstring_NoMatches(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
@@ -142,11 +142,11 @@ func TestLookupByPrefix_NoMatches(t *testing.T) {
 		},
 	}
 
-	matches := LookupByPrefix(b, "qux")
+	matches := LookupBySubstring(b, "qux")
 	assert.Empty(t, matches)
 }
 
-func TestLookupByPrefix_SingleMatch(t *testing.T) {
+func TestLookupBySubstring_SingleMatch(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
@@ -160,13 +160,13 @@ func TestLookupByPrefix_SingleMatch(t *testing.T) {
 		},
 	}
 
-	matches := LookupByPrefix(b, "foo")
+	matches := LookupBySubstring(b, "foo")
 	require.Len(t, matches, 1)
 	assert.Equal(t, "foo_job", matches[0].Key)
 	assert.Equal(t, "Foo job", matches[0].Resource.GetName())
 }
 
-func TestLookupByPrefix_MultipleMatches(t *testing.T) {
+func TestLookupBySubstring_MultipleMatches(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
@@ -179,7 +179,7 @@ func TestLookupByPrefix_MultipleMatches(t *testing.T) {
 		},
 	}
 
-	matches := LookupByPrefix(b, "my_")
+	matches := LookupBySubstring(b, "my_")
 	require.Len(t, matches, 2)
 
 	keys := []string{matches[0].Key, matches[1].Key}
@@ -187,7 +187,7 @@ func TestLookupByPrefix_MultipleMatches(t *testing.T) {
 	assert.Equal(t, []string{"my_job_1", "my_job_2"}, keys)
 }
 
-func TestLookupByPrefix_WithFilters(t *testing.T) {
+func TestLookupBySubstring_WithFilters(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
@@ -206,12 +206,52 @@ func TestLookupByPrefix_WithFilters(t *testing.T) {
 		return ok
 	}
 
-	matches := LookupByPrefix(b, "my_", includeJobs)
+	matches := LookupBySubstring(b, "my_", includeJobs)
 	require.Len(t, matches, 1)
 	assert.Equal(t, "my_job", matches[0].Key)
 }
 
-func TestLookupByPrefix_ExactPrefixMatchesAll(t *testing.T) {
+func TestLookupBySubstring_MiddleMatch(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_foo_job": {
+						JobSettings: jobs.JobSettings{Name: "My Foo Job"},
+					},
+					"bar_job": {},
+				},
+			},
+		},
+	}
+
+	matches := LookupBySubstring(b, "foo")
+	require.Len(t, matches, 1)
+	assert.Equal(t, "my_foo_job", matches[0].Key)
+}
+
+func TestLookupBySubstring_SuffixMatch(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_foo_job": {},
+					"my_bar_job": {},
+					"pipeline":   {},
+				},
+			},
+		},
+	}
+
+	matches := LookupBySubstring(b, "_job")
+	require.Len(t, matches, 2)
+
+	keys := []string{matches[0].Key, matches[1].Key}
+	sort.Strings(keys)
+	assert.Equal(t, []string{"my_bar_job", "my_foo_job"}, keys)
+}
+
+func TestLookupBySubstring_ExactMatchAndContains(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{
 			Resources: config.Resources{
@@ -225,7 +265,7 @@ func TestLookupByPrefix_ExactPrefixMatchesAll(t *testing.T) {
 		},
 	}
 
-	matches := LookupByPrefix(b, "foo")
+	matches := LookupBySubstring(b, "foo")
 	require.Len(t, matches, 3)
 
 	keys := make([]string, len(matches))

--- a/cmd/bundle/open.go
+++ b/cmd/bundle/open.go
@@ -53,8 +53,8 @@ func resolveOpenArgument(ctx context.Context, b *bundle.Bundle, args []string) (
 		return arg, nil
 	}
 
-	// Check for prefix matches.
-	matches := resources.LookupByPrefix(b, arg)
+	// Check for substring matches.
+	matches := resources.LookupBySubstring(b, arg)
 	switch {
 	case len(matches) == 1:
 		return matches[0].Key, nil
@@ -74,7 +74,7 @@ func resolveOpenArgument(ctx context.Context, b *bundle.Bundle, args []string) (
 		for _, ref := range matches {
 			keys = append(keys, ref.Key)
 		}
-		return "", fmt.Errorf("multiple resources match prefix %q: %v", arg, keys)
+		return "", fmt.Errorf("multiple resources match %q: %v", arg, keys)
 	}
 
 	// No matches; return the arg as-is and let Lookup handle the "not found" error.

--- a/cmd/bundle/open_test.go
+++ b/cmd/bundle/open_test.go
@@ -1,0 +1,98 @@
+package bundle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOpenArgument_NoArgs_NonInteractive(t *testing.T) {
+	ctx := cmdio.MockDiscard(context.Background())
+	b := &bundle.Bundle{}
+
+	_, err := resolveOpenArgument(ctx, b, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "expected a KEY of the resource to open")
+}
+
+func TestResolveOpenArgument_ExactMatch(t *testing.T) {
+	ctx := cmdio.MockDiscard(context.Background())
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job":   {JobSettings: jobs.JobSettings{Name: "My Job"}},
+					"my_job_2": {JobSettings: jobs.JobSettings{Name: "My Job 2"}},
+				},
+			},
+		},
+	}
+
+	key, err := resolveOpenArgument(ctx, b, []string{"my_job"})
+	require.NoError(t, err)
+	assert.Equal(t, "my_job", key)
+}
+
+func TestResolveOpenArgument_PrefixSingleMatch(t *testing.T) {
+	ctx := cmdio.MockDiscard(context.Background())
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"foo_job": {JobSettings: jobs.JobSettings{Name: "Foo Job"}},
+					"bar_job": {JobSettings: jobs.JobSettings{Name: "Bar Job"}},
+				},
+			},
+		},
+	}
+
+	key, err := resolveOpenArgument(ctx, b, []string{"foo"})
+	require.NoError(t, err)
+	assert.Equal(t, "foo_job", key)
+}
+
+func TestResolveOpenArgument_PrefixMultipleMatches_NonInteractive(t *testing.T) {
+	ctx := cmdio.MockDiscard(context.Background())
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job_1": {JobSettings: jobs.JobSettings{Name: "My Job 1"}},
+					"my_job_2": {JobSettings: jobs.JobSettings{Name: "My Job 2"}},
+					"other":    {JobSettings: jobs.JobSettings{Name: "Other"}},
+				},
+			},
+		},
+	}
+
+	_, err := resolveOpenArgument(ctx, b, []string{"my_"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "multiple resources match prefix")
+	assert.ErrorContains(t, err, "my_job_1")
+	assert.ErrorContains(t, err, "my_job_2")
+}
+
+func TestResolveOpenArgument_PrefixNoMatch(t *testing.T) {
+	ctx := cmdio.MockDiscard(context.Background())
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"foo": {JobSettings: jobs.JobSettings{Name: "Foo"}},
+				},
+			},
+		},
+	}
+
+	// No prefix match; returns the arg as-is.
+	key, err := resolveOpenArgument(ctx, b, []string{"zzz"})
+	require.NoError(t, err)
+	assert.Equal(t, "zzz", key)
+}

--- a/cmd/bundle/open_test.go
+++ b/cmd/bundle/open_test.go
@@ -40,7 +40,7 @@ func TestResolveOpenArgument_ExactMatch(t *testing.T) {
 	assert.Equal(t, "my_job", key)
 }
 
-func TestResolveOpenArgument_PrefixSingleMatch(t *testing.T) {
+func TestResolveOpenArgument_SubstringSingleMatch(t *testing.T) {
 	ctx := cmdio.MockDiscard(context.Background())
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -58,7 +58,7 @@ func TestResolveOpenArgument_PrefixSingleMatch(t *testing.T) {
 	assert.Equal(t, "foo_job", key)
 }
 
-func TestResolveOpenArgument_PrefixMultipleMatches_NonInteractive(t *testing.T) {
+func TestResolveOpenArgument_SubstringMultipleMatches_NonInteractive(t *testing.T) {
 	ctx := cmdio.MockDiscard(context.Background())
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -74,12 +74,30 @@ func TestResolveOpenArgument_PrefixMultipleMatches_NonInteractive(t *testing.T) 
 
 	_, err := resolveOpenArgument(ctx, b, []string{"my_"})
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "multiple resources match prefix")
+	assert.ErrorContains(t, err, "multiple resources match")
 	assert.ErrorContains(t, err, "my_job_1")
 	assert.ErrorContains(t, err, "my_job_2")
 }
 
-func TestResolveOpenArgument_PrefixNoMatch(t *testing.T) {
+func TestResolveOpenArgument_SubstringMiddleMatch(t *testing.T) {
+	ctx := cmdio.MockDiscard(context.Background())
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_foo_job": {JobSettings: jobs.JobSettings{Name: "My Foo Job"}},
+					"bar_job":    {JobSettings: jobs.JobSettings{Name: "Bar Job"}},
+				},
+			},
+		},
+	}
+
+	key, err := resolveOpenArgument(ctx, b, []string{"foo"})
+	require.NoError(t, err)
+	assert.Equal(t, "my_foo_job", key)
+}
+
+func TestResolveOpenArgument_SubstringNoMatch(t *testing.T) {
 	ctx := cmdio.MockDiscard(context.Background())
 	b := &bundle.Bundle{
 		Config: config.Root{
@@ -91,7 +109,7 @@ func TestResolveOpenArgument_PrefixNoMatch(t *testing.T) {
 		},
 	}
 
-	// No prefix match; returns the arg as-is.
+	// No substring match; returns the arg as-is.
 	key, err := resolveOpenArgument(ctx, b, []string{"zzz"})
 	require.NoError(t, err)
 	assert.Equal(t, "zzz", key)


### PR DESCRIPTION
## Changes
Add substring (contains) matching to `databricks bundle open` for flexible resource resolution.

- `databricks bundle open foo` matches any resource whose key **contains** `foo` (e.g. `my_foo_job`)
- Single match resolves automatically; multiple matches prompt for selection (interactive) or list candidates (non-interactive)
- Exact match still takes priority over substring matching

## Tests
Unit tests covering middle and suffix substring matching in both `bundle/resources/lookup_test.go` and `cmd/bundle/open_test.go`.

Supersedes #4461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)