### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Ignore Databricks Go SDK because its upgrade requires code generation
+      - dependency-name: github.com/databricks/databricks-sdk-go
   - package-ecosystem: "gomod"
     directory: "/tools"
     schedule:
@@ -15,7 +18,9 @@ updates:
       - "/.github/actions/setup-build-environment"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     # tagging.yml is generated and maintained externally. Ignore
     # actions/create-github-app-token since it is only used in tagging.yml.
-    ignore:
-      - dependency-name: "actions/create-github-app-token"
+    exclude-paths:
+      - .github/workflows/tagging.yml


### PR DESCRIPTION
Ignore the Databricks Go SDK because its upgrade requires code
generation and cannot be handled by Dependabot alone.

Update the github-actions package ecosystem configuration. Use a monthly
update interval to keep churn low while ensuring deprecation notices and
security fixes flow in through PRs. The 7-day cooldown avoids bumping
actions that were just released, letting them bake first.

Exclude tagging.yml because it is generated and maintained externally.

Co-authored-by: Isaac