### PR TITLE
Fix tests in libs/python/pythontest not to install seed packages

### DIFF
--- a/libs/python/pythontest/pythontest.go
+++ b/libs/python/pythontest/pythontest.go
@@ -44,7 +44,7 @@ func CreatePythonEnv(opts *VenvOpts) error {
 		opts.Name = testutil.RandomName("test-venv-")
 	}
 
-	cmd := exec.Command("uv", "venv", opts.Name, "--python", opts.PythonVersion, "--seed", "-q")
+	cmd := exec.Command("uv", "venv", opts.Name, "--python", opts.PythonVersion, "-q")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Dir = opts.Dir


### PR DESCRIPTION
With PyPI blocked it was failing with:

```
  × Failed to install seed packages
  ├─▶ No solution found when resolving: `pip`, `setuptools`, `wheel`
  ├─▶ Failed to fetch: `https://pypi.org/simple/wheel/`
  ├─▶ Request failed after 3 retries
  ├─▶ error sending request for url (https://pypi.org/simple/wheel/)
  ├─▶ client error (Connect)
  ╰─▶ invalid peer certificate: UnknownIssuer
```

## Tests
```
% go test ./libs/python/... -count=1
ok      github.com/databricks/cli/libs/python   0.455s
ok      github.com/databricks/cli/libs/python/pythontest        0.718s
```