### PR TITLE
Fix actions/github-script pin to match tagged v8.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
       - name: Update setup-cli
-        uses: actions/github-script@450193c5abd4cdb17ba9f3ffcfe8f635c4bb6c2a # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
           script: |
@@ -227,7 +227,7 @@ jobs:
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
       - name: Update homebrew-tap
-        uses: actions/github-script@450193c5abd4cdb17ba9f3ffcfe8f635c4bb6c2a # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
           script: |
@@ -268,7 +268,7 @@ jobs:
           echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
 
       - name: Update CLI version in the VSCode extension
-        uses: actions/github-script@450193c5abd4cdb17ba9f3ffcfe8f635c4bb6c2a # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.DECO_GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

Dependabot PR #4413 bumped `actions/github-script` from v7 to v8, but picked up the `main` branch HEAD (`450193c5abd4`) instead of the tagged `v8.0.0` SHA (`ed597411d8f9`) — likely because the `v8` major version tag hadn't been updated when Dependabot ran. The `# v8.0.0` comment was preserved, making the mismatch invisible without SHA verification.

This fixes the 3 occurrences in `release.yml`. The references in `push.yml` already use the correct SHA.

```
$ git ls-remote https://github.com/actions/github-script refs/tags/v8 refs/tags/v8.0.0
ed597411d8f924073f98dfc5c65a23a2325f34cd	refs/tags/v8
ed597411d8f924073f98dfc5c65a23a2325f34cd	refs/tags/v8.0.0
```

This pull request was AI-assisted by Isaac.