### PR TITLE
Remove wheel installation from github action

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -43,9 +43,3 @@ runs:
       with:
         version: "0.9.1"
         args: "--version"
-
-    - name: Pull external libraries
-      run: |
-        go mod download
-        pip3 install wheel==0.45.1
-      shell: bash


### PR DESCRIPTION
## Why
`uv build --wheel` does not need wheel package.