### PR TITLE
feat: skills installer codex

### DIFF
--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -25,7 +25,7 @@ const (
 	skillsRepoOwner      = "databricks"
 	skillsRepoName       = "databricks-agent-skills"
 	skillsRepoPath       = "skills"
-	defaultSkillsRepoRef = "v0.1.3"
+	defaultSkillsRepoRef = "v0.1.4"
 )
 
 // fetchFileFn is the function used to download individual skill files.
@@ -73,9 +73,20 @@ func FetchManifest(ctx context.Context) (*Manifest, error) {
 	return src.FetchManifest(ctx, ref)
 }
 
+// sharedFilePrefix marks files in the manifest that live at the repo root
+// rather than under skills/<name>/. The CLI strips this prefix when writing
+// to disk and adjusts the download URL accordingly.
+const sharedFilePrefix = "@root:"
+
 func fetchSkillFile(ctx context.Context, ref, skillName, filePath string) ([]byte, error) {
-	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s/%s/%s",
-		skillsRepoOwner, skillsRepoName, ref, skillsRepoPath, skillName, filePath)
+	var url string
+	if rootPath, ok := strings.CutPrefix(filePath, sharedFilePrefix); ok {
+		url = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
+			skillsRepoOwner, skillsRepoName, ref, rootPath)
+	} else {
+		url = fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s/%s/%s",
+			skillsRepoOwner, skillsRepoName, ref, skillsRepoPath, skillName, filePath)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -506,6 +517,11 @@ func installSkillToDir(ctx context.Context, ref, skillName, destDir string, file
 			return err
 		}
 
+		// Strip the @root: prefix so shared assets land at a local path
+		// (e.g. "@root:assets/databricks.svg" → "assets/databricks.svg").
+		if rootPath, ok := strings.CutPrefix(file, sharedFilePrefix); ok {
+			file = rootPath
+		}
 		destPath := filepath.Join(destDir, file)
 
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {

--- a/experimental/aitools/lib/installer/installer_test.go
+++ b/experimental/aitools/lib/installer/installer_test.go
@@ -208,7 +208,7 @@ func TestInstallSkillsForAgentsWritesState(t *testing.T) {
 	assert.Equal(t, "0.1.0", state.Skills["databricks-sql"])
 	assert.Equal(t, "0.1.0", state.Skills["databricks-jobs"])
 
-	assert.Contains(t, stderr.String(), "Installed 2 skills (v0.1.3).")
+	assert.Contains(t, stderr.String(), "Installed 2 skills (v0.1.4).")
 }
 
 func TestInstallSkillForSingleWritesState(t *testing.T) {
@@ -231,7 +231,7 @@ func TestInstallSkillForSingleWritesState(t *testing.T) {
 	assert.Len(t, state.Skills, 1)
 	assert.Equal(t, "0.1.0", state.Skills["databricks-sql"])
 
-	assert.Contains(t, stderr.String(), "Installed 1 skill (v0.1.3).")
+	assert.Contains(t, stderr.String(), "Installed 1 skill (v0.1.4).")
 }
 
 func TestInstallSkillsSpecificNotFound(t *testing.T) {
@@ -274,7 +274,7 @@ func TestExperimentalSkillsSkippedByDefault(t *testing.T) {
 	assert.Len(t, state.Skills, 2)
 	assert.NotContains(t, state.Skills, "databricks-experimental")
 
-	assert.Contains(t, stderr.String(), "Installed 2 skills (v0.1.3).")
+	assert.Contains(t, stderr.String(), "Installed 2 skills (v0.1.4).")
 }
 
 func TestExperimentalSkillsIncludedWithFlag(t *testing.T) {
@@ -304,7 +304,7 @@ func TestExperimentalSkillsIncludedWithFlag(t *testing.T) {
 	assert.Contains(t, state.Skills, "databricks-experimental")
 	assert.True(t, state.IncludeExperimental)
 
-	assert.Contains(t, stderr.String(), "Installed 3 skills (v0.1.3).")
+	assert.Contains(t, stderr.String(), "Installed 3 skills (v0.1.4).")
 }
 
 func TestMinCLIVersionSkipWithWarningForInstallAll(t *testing.T) {
@@ -338,7 +338,7 @@ func TestMinCLIVersionSkipWithWarningForInstallAll(t *testing.T) {
 	assert.Len(t, state.Skills, 2)
 	assert.NotContains(t, state.Skills, "databricks-future")
 
-	assert.Contains(t, stderr.String(), "Installed 2 skills (v0.1.3).")
+	assert.Contains(t, stderr.String(), "Installed 2 skills (v0.1.4).")
 	assert.Contains(t, logBuf.String(), "requires CLI version 0.300.0")
 }
 
@@ -723,4 +723,82 @@ func TestSupportsProjectScopeSetCorrectly(t *testing.T) {
 		require.True(t, ok, "missing expected entry for %s", agent.Name)
 		assert.Equal(t, want, agent.SupportsProjectScope, "SupportsProjectScope for %s", agent.Name)
 	}
+}
+
+// --- @root: prefix tests ---
+
+func TestFetchSharedFilePrefix(t *testing.T) {
+	tmp := setupTestHome(t)
+	ctx := cmdio.MockDiscard(t.Context())
+
+	var capturedURLs []string
+	orig := fetchFileFn
+	t.Cleanup(func() { fetchFileFn = orig })
+	fetchFileFn = func(_ context.Context, _, skillName, filePath string) ([]byte, error) {
+		capturedURLs = append(capturedURLs, skillName+":"+filePath)
+		return []byte("content-" + filePath), nil
+	}
+
+	src := &mockManifestSource{manifest: &Manifest{
+		Version:   "1",
+		UpdatedAt: "2024-01-01",
+		Skills: map[string]SkillMeta{
+			"databricks": {
+				Version: "0.1.0",
+				Files: []string{
+					"SKILL.md",
+					"agents/openai.yaml",
+					"@root:assets/databricks.svg",
+				},
+			},
+		},
+	}}
+
+	agent := testAgent(tmp)
+	err := InstallSkillsForAgents(ctx, src, []*agents.Agent{agent}, InstallOptions{})
+	require.NoError(t, err)
+
+	// Verify files were fetched with the correct paths (including @root: prefix).
+	assert.Contains(t, capturedURLs, "databricks:SKILL.md")
+	assert.Contains(t, capturedURLs, "databricks:agents/openai.yaml")
+	assert.Contains(t, capturedURLs, "databricks:@root:assets/databricks.svg")
+}
+
+func TestSharedFilePrefixStrippedOnDisk(t *testing.T) {
+	tmp := setupTestHome(t)
+	ctx := cmdio.MockDiscard(t.Context())
+
+	orig := fetchFileFn
+	t.Cleanup(func() { fetchFileFn = orig })
+	fetchFileFn = func(_ context.Context, _, _, filePath string) ([]byte, error) {
+		return []byte("content-" + filePath), nil
+	}
+
+	src := &mockManifestSource{manifest: &Manifest{
+		Version:   "1",
+		UpdatedAt: "2024-01-01",
+		Skills: map[string]SkillMeta{
+			"databricks": {
+				Version: "0.1.0",
+				Files: []string{
+					"SKILL.md",
+					"@root:assets/databricks.svg",
+					"@root:assets/databricks.png",
+				},
+			},
+		},
+	}}
+
+	agent := testAgent(tmp)
+	err := InstallSkillsForAgents(ctx, src, []*agents.Agent{agent}, InstallOptions{})
+	require.NoError(t, err)
+
+	// Canonical dir should have stripped prefix paths.
+	globalDir := filepath.Join(tmp, ".databricks", "aitools", "skills", "databricks")
+	_, err = os.Stat(filepath.Join(globalDir, "SKILL.md"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(globalDir, "assets", "databricks.svg"))
+	assert.NoError(t, err, "shared asset should be written under assets/ with @root: stripped")
+	_, err = os.Stat(filepath.Join(globalDir, "assets", "databricks.png"))
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Add Codex marketplace UI support to the skills installer so that `agents/openai.yaml` and brand assets (`assets/`) are installed for Codex while other agents receive only the skill content.

### Main changes

**Shared asset fetching via `@root:` prefix** (`experimental/aitools/lib/installer/installer.go`):
Files in the upstream manifest prefixed with `@root:` are fetched from the repo root instead of `skills/<name>/`. The prefix is stripped when writing to disk so `@root:assets/databricks.svg` lands at `<skill>/assets/databricks.svg`. This allows shared brand assets to live once at the repo root while appearing in every skill's installed directory.

**Per-agent metadata filtering** (`experimental/aitools/lib/installer/installer.go`, `experimental/aitools/lib/agents/agents.go`):
Two new `Agent` flags — `PreferSkillCopy` (always copy instead of symlink) and `InstallAgentMetadata` (include `agents/` and `assets/` dirs). Both are set only for Codex. When copying to a non-metadata agent, `copyDirFiltered` skips `agents/` and `assets/` subdirectories via `filepath.SkipDir`. Symlinked agents get the full canonical tree (metadata files are inert for them).

Needs this PR https://github.com/databricks/databricks-agent-skills/pull/38

and we will use this skill https://github.com/openai/skills/pull/307 to use the cli to install all the skills from our skills repo 
