### PR TITLE
Remove setuptools from patchwheel test

### DIFF
--- a/libs/patchwheel/patch_test.go
+++ b/libs/patchwheel/patch_test.go
@@ -65,10 +65,6 @@ func minimalPythonProject() map[string]string {
 name = "myproj"
 version = "0.1.0"
 
-[build-system]
-requires = ["setuptools>=61.0.0"]
-build-backend = "setuptools.build_meta"
-
 [tool.setuptools.packages.find]
 where = ["src"]
 `,


### PR DESCRIPTION
Switch patchwheel test to use uv build backend instead.

Follow up to https://github.com/databricks/cli/pull/4830