### PR TITLE
[Python] Fix README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -22,7 +22,7 @@ To use `databricks-bundles`, you must first:
 3. To create a new project, initialize a bundle using the `experimental-jobs-as-code` template:
 
   ```bash
-  databricks bundle init experimental-jobs-as-code
+  databricks bundle init pydabs
   ```
 
 ## Privacy Notice


### PR DESCRIPTION
## Changes
Reference correct package in databricks-bundles Python package README

## Why
README was pointing to outdated template
