### PR TITLE
Fix --commit flag in gh_report.py to use check-runs API

### DIFF
--- a/tools/gh_report.py
+++ b/tools/gh_report.py
@@ -89,9 +89,9 @@ def get_pr_run_id_integration():
 
 
 def get_commit_run_id_integration(commit):
-    data = run_json(["gh", "api", f"repos/databricks/cli/commits/{commit}/status"])
-    items = data.get("statuses")
-    return get_run_id_from_items(items, "target_url", DECO_TESTS_PREFIX, data)
+    data = run_json(["gh", "api", f"repos/{CLI_REPO}/commits/{commit}/check-runs"])
+    items = data.get("check_runs")
+    return get_run_id_from_items(items, "details_url", DECO_TESTS_PREFIX, data)
 
 
 def get_pr_run_id_unit():


### PR DESCRIPTION
The commit status API returns empty statuses for commits on main. Switch to the check-runs API which has the "Integration Tests" check run with the deco-tests run ID in its details_url.
