### PR TITLE
Fix Serving Endpoint resource field mapping for `apps init` flow

### DIFF
--- a/libs/apps/generator/generator.go
+++ b/libs/apps/generator/generator.go
@@ -290,7 +290,7 @@ var appResourceSpecs = map[string]appResourceSpec{
 	},
 	"serving_endpoint": {
 		yamlKey:    "serving_endpoint",
-		varFields:  [][2]string{{"id", "name"}},
+		varFields:  [][2]string{{"name", "name"}},
 		permission: "CAN_QUERY",
 	},
 	"experiment": {

--- a/libs/apps/generator/generator_test.go
+++ b/libs/apps/generator/generator_test.go
@@ -392,7 +392,7 @@ func TestGenerateResourceYAMLAllTypes(t *testing.T) {
 			expectContains: []string{
 				"- name: endpoint",
 				"serving_endpoint:",
-				"name: ${var.endpoint_id}",
+				"name: ${var.endpoint_name}",
 				"permission: CAN_QUERY",
 			},
 		},

--- a/libs/apps/prompt/listers.go
+++ b/libs/apps/prompt/listers.go
@@ -382,7 +382,7 @@ func ListServingEndpoints(ctx context.Context) (*PagedFetcher, error) {
 		if name == "" {
 			name = e.Id
 		}
-		return ListItem{ID: e.Id, Label: name}
+		return ListItem{ID: e.Name, Label: name}
 	}
 	items, hasMore, err := collectN(ctx, iter, pageSize, mapFn)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Use Serving Endpoint name instead of id, as name is required for DABs

Proof: https://docs.databricks.com/gcp/en/dev-tools/bundles/resources#app-resources-serving_endpoint

## Demo

(Tested against https://github.com/databricks/appkit/compare/main...pkosiec/model-serving-impl)

https://github.com/user-attachments/assets/d24d5dbf-d4fa-442e-8c40-b9468a259612


## Test plan

- [x] `go test ./libs/apps/generator/...` passes
- [x] Manual: `databricks apps init` with serving plugin produces correct single-variable `databricks.yml`