### PR TITLE
Skip Windows test runs while runners are offline

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -95,10 +95,11 @@ jobs:
               group: databricks-protected-runner-group-large
               labels: linux-ubuntu-latest-large
 
-          - name: windows
-            runner:
-              group: databricks-protected-runner-group-large
-              labels: windows-server-latest-large
+          # Windows runners are offline; commented out temporarily.
+          # - name: windows
+          #   runner:
+          #     group: databricks-protected-runner-group-large
+          #     labels: windows-server-latest-large
 
           - name: macos
             runner:
@@ -226,10 +227,11 @@ jobs:
               group: databricks-protected-runner-group-large
               labels: linux-ubuntu-latest-large
 
-          - name: windows
-            runner:
-              group: databricks-protected-runner-group-large
-              labels: windows-server-latest-large
+          # Windows runners are offline; commented out temporarily.
+          # - name: windows
+          #   runner:
+          #     group: databricks-protected-runner-group-large
+          #     labels: windows-server-latest-large
 
           - name: macos
             runner:
@@ -271,10 +273,11 @@ jobs:
               group: databricks-protected-runner-group-large
               labels: linux-ubuntu-latest-large
 
-          - name: windows
-            runner:
-              group: databricks-protected-runner-group-large
-              labels: windows-server-latest-large
+          # Windows runners are offline; commented out temporarily.
+          # - name: windows
+          #   runner:
+          #     group: databricks-protected-runner-group-large
+          #     labels: windows-server-latest-large
 
           - name: macos
             runner:


### PR DESCRIPTION
Comment out Windows runner matrix entries in `test`, `test-exp-ssh`, and `test-pipelines` jobs in `push.yml`.

To be reverted when runners come back online.

This pull request was AI-assisted by Isaac.