### PR TITLE
Pin flit_core build dependency to exact version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["flit_core >=3.11,<4"]
+requires = ["flit_core==3.12.0"]
 build-backend = "flit_core.buildapi"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Pin `flit_core` from `>=3.11,<4` to `==3.12.0` in `python/pyproject.toml`
- `uv lock` doesn't lock build-system dependencies, so an unpinned range allows non-reproducible builds

This pull request was AI-assisted by Isaac.