### PR TITLE
Add .cursor/cli.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ go.work.sum
 .codegen/openapi.json
 
 .claude/settings.local.json
+.cursor/cli.json
 tools/gofumpt
 .claude/worktrees/
 .worktrees/


### PR DESCRIPTION
## Changes
- Add `.cursor/cli.json` to `.gitignore` so local Cursor CLI configuration is not tracked.

## Why
Similar to `.claude/settings.local.json` which is already ignored, `.cursor/cli.json` is a local editor config file that should not be committed.