### PR TITLE
Migrate release-snapshot workflow to JFrog proxy and large runner pool

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -22,8 +22,8 @@ on:
 jobs:
   goreleaser:
     runs-on:
-      group: databricks-large-runner-group
-      labels: ubuntu-latest-large
+      group: databricks-protected-runner-group-large
+      labels: linux-ubuntu-latest-large
 
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Use the new `setup-jfrog` composite action to proxy Go module downloads through JFrog Artifactory
- Switch from `databricks-deco-testing-runner-group` to `databricks-large-runner-group`
- Trigger workflow on changes to the `setup-jfrog` action

## Test plan
- [x] Verify the release-snapshot workflow succeeds on this PR

This pull request was AI-assisted by Isaac.