### PR TITLE
Temporarily disable integration test trigger

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -379,70 +379,25 @@ jobs:
             exit 1
           fi
 
-  # Trigger integration tests in a separate repository.
-  # Requires secrets from "test-trigger-is" environment (not available for fork PRs or dependabot).
-  # Auto-approves for merge groups to avoid running twice and queue timeouts.
+  # Skip integration tests (temporarily disabled).
+  # Creates a passing check for PRs and auto-approves for merge groups.
   integration-trigger:
-    needs:
-      - testmask
-
     if: >-
       (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]') ||
-      (github.event_name == 'merge_group') ||
-      (github.event_name == 'push')
+      (github.event_name == 'merge_group')
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group-large
+      labels: linux-ubuntu-latest-large
 
     permissions:
       checks: write
-      contents: read
-
-    environment: "test-trigger-is"
 
     steps:
-      - name: Generate GitHub App Token
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
-        id: generate-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
-          private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
-          owner: ${{ secrets.ORG_NAME }}
-          repositories: ${{ secrets.REPO_NAME }}
-
-      - name: Generate GitHub App Token (check runs)
-        if: >-
-          (github.event_name == 'merge_group') ||
-          (github.event_name == 'pull_request' && !contains(fromJSON(needs.testmask.outputs.targets), 'test'))
-        id: generate-check-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ secrets.DECO_TEST_APPROVAL_APP_ID }}
-          private-key: ${{ secrets.DECO_TEST_APPROVAL_PRIVATE_KEY }}
-          # DECO_TEST_APPROVAL is installed on the databricks org (not databricks-eng).
-          owner: databricks
-          repositories: cli
-
-      # Trigger integration tests if the primary "test" target is triggered by this change.
-      - name: Trigger integration tests (pull request)
-        if: ${{ github.event_name == 'pull_request' && (contains(fromJSON(needs.testmask.outputs.targets), 'test') || contains(fromJSON(needs.testmask.outputs.targets), 'test-exp-ssh')) }}
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |-
-          gh workflow run cli-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{ secrets.REPO_NAME }} \
-            --ref main \
-            -f pull_request_number=${{ github.event.pull_request.number }} \
-            -f commit_sha=${{ github.event.pull_request.head.sha }}
-
-      # Skip integration tests if the primary "test" target is not triggered by this change.
-      # Use Checks API (not Statuses API) to match the required "Integration Tests" check.
       - name: Skip integration tests (pull request)
-        if: ${{ github.event_name == 'pull_request' && !contains(fromJSON(needs.testmask.outputs.targets), 'test') && !contains(fromJSON(needs.testmask.outputs.targets), 'test-exp-ssh') }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.generate-check-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,
@@ -453,17 +408,14 @@ jobs:
               conclusion: 'success',
               output: {
                 title: 'Integration Tests',
-                summary: '⏭️ Skipped (changes do not require integration tests)'
+                summary: '⏭️ Skipped (integration test trigger is temporarily disabled)'
               }
             });
 
-      # Auto-approve for merge group since tests already passed on the PR.
-      # Use Checks API (not Statuses API) to match the required "Integration Tests" check.
       - name: Auto-approve for merge group
         if: ${{ github.event_name == 'merge_group' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ steps.generate-check-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,
@@ -474,18 +426,9 @@ jobs:
               conclusion: 'success',
               output: {
                 title: 'Integration Tests',
-                summary: '⏭️ Auto-approved for merge queue (tests already passed on PR)'
+                summary: '⏭️ Skipped (integration test trigger is temporarily disabled)'
               }
             });
-
-      - name: Trigger integration tests (push to main)
-        if: ${{ github.event_name == 'push' }}
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |-
-          gh workflow run cli-isolated-nightly.yml -R ${{ secrets.ORG_NAME }}/${{ secrets.REPO_NAME }} \
-            --ref main \
-            -f commit_sha=${{ github.event.after }}
 
   # Skip integration tests for dependabot PRs.
   # Dependabot has no access to the "test-trigger-is" environment secrets,


### PR DESCRIPTION
## Summary
- Skip integration test triggering on PRs and pushes to main while the integration test infrastructure is not working
- The required "Integration Tests" check still passes (marked as skipped) so PRs and merge queue are not blocked
- Removed dependency on `test-trigger-is` environment and app tokens since no external workflows are triggered
- Revert this PR when integration tests are working again

## Test plan
- [x] Verify the "Integration Tests" check shows as passed with skip message on a PR
- [x] Verify merge queue auto-approves correctly

This pull request was AI-assisted by Isaac.