### PR TITLE
fix: improve confirm prompt button visibility in appkit theme

### DIFF
--- a/libs/apps/prompt/prompt.go
+++ b/libs/apps/prompt/prompt.go
@@ -31,6 +31,7 @@ var (
 	colorGray   = lipgloss.Color("#A1A1AA") // Light gray, legible on dark backgrounds
 	colorYellow = lipgloss.Color("#FFAB00") // Databricks yellow / amber
 	colorOrange = lipgloss.Color("#FF5F40") // Databricks orange (code blocks)
+	colorDimmed = lipgloss.AdaptiveColor{Light: "#A1A1AA", Dark: "#52525B"}
 )
 
 // AppkitTheme returns a custom theme for appkit prompts.
@@ -41,6 +42,19 @@ func AppkitTheme() *huh.Theme {
 	t.Focused.Description = t.Focused.Description.Foreground(colorGray)
 	t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(colorYellow)
 	t.Focused.TextInput.Placeholder = t.Focused.TextInput.Placeholder.Foreground(colorGray)
+	bracketBorder := lipgloss.Border{Left: "[", Right: "]"}
+	t.Focused.FocusedButton = t.Focused.FocusedButton.
+		Foreground(colorYellow).
+		Background(lipgloss.Color("")).
+		Bold(true).
+		BorderStyle(bracketBorder).
+		BorderLeft(true).BorderRight(true).
+		BorderTop(false).BorderBottom(false).
+		BorderForeground(colorYellow)
+	t.Focused.BlurredButton = t.Focused.BlurredButton.
+		Foreground(colorDimmed).
+		Background(lipgloss.Color("")).
+		Bold(false)
 
 	return t
 }


### PR DESCRIPTION
## Summary

- The Yes/No confirm buttons in `databricks apps init` inherited `ThemeBase` defaults (ANSI colors 0/7), making it very hard to tell which option was currently selected.
- Style the focused button with bold yellow underlined text and the blurred button with dim adaptive gray, removing background rectangles for a cleaner text-only look.
- Uses `lipgloss.AdaptiveColor` for the blurred button so it's legible on both light and dark terminals.

### After

<img width="515" height="135" alt="image" src="https://github.com/user-attachments/assets/0de502e9-0786-468d-84ef-1ad032212622" />


## Test plan

- [ ] Run `databricks apps init` and verify the Yes/No confirm prompt clearly highlights the selected option with yellow bold underlined text
- [ ] Test on both light and dark terminal backgrounds to confirm legibility