### PR TITLE
Fix maintainer-approval not blocking PRs without approval

### DIFF
--- a/.github/workflows/maintainer-approval.js
+++ b/.github/workflows/maintainer-approval.js
@@ -516,7 +516,10 @@ module.exports = async ({ github, context, core }) => {
     core
   );
 
-  // Set commit status. Approved PRs return early (commit status is sufficient).
+  // Approved PRs get a success check run and return early.
+  // Pending PRs intentionally create NO check run or status. The required
+  // status check "maintainer-approval" stays as "Expected" (yellow dot) in
+  // the GitHub UI, which blocks the merge until approval is granted.
   if (result.allCovered && approverLogins.length > 0) {
     core.info("All ownership groups have per-path approval.");
     await github.rest.checks.create({
@@ -531,36 +534,20 @@ module.exports = async ({ github, context, core }) => {
 
   if (result.hasWildcardFiles) {
     const fileList = result.wildcardFiles.join(", ");
-    const msg =
+    core.info(
       `Files need maintainer review: ${fileList}. ` +
-      `Maintainers: ${maintainers.join(", ")}`;
-    core.info(msg);
-    await github.rest.checks.create({
-      ...checkParams,
-      status: "in_progress",
-      output: { title: STATUS_CONTEXT, summary: msg },
-    });
+      `Maintainers: ${maintainers.join(", ")}`
+    );
   } else if (result.uncovered && result.uncovered.length > 0) {
     const groupList = result.uncovered
       .map(({ pattern, owners }) => `${pattern} (needs: ${owners.join(", ")})`)
       .join("; ");
-    const msg = `Needs approval: ${groupList}`;
     core.info(
-      `${msg}. Alternatively, any maintainer can approve: ${maintainers.join(", ")}.`
+      `Needs approval: ${groupList}. ` +
+      `Alternatively, any maintainer can approve: ${maintainers.join(", ")}.`
     );
-    await github.rest.checks.create({
-      ...checkParams,
-      status: "in_progress",
-      output: { title: STATUS_CONTEXT, summary: msg },
-    });
   } else {
-    const msg = `Waiting for maintainer approval: ${maintainers.join(", ")}`;
-    core.info(msg);
-    await github.rest.checks.create({
-      ...checkParams,
-      status: "in_progress",
-      output: { title: STATUS_CONTEXT, summary: msg },
-    });
+    core.info(`Waiting for maintainer approval: ${maintainers.join(", ")}`);
   }
 
   // Score contributors via git history

--- a/.github/workflows/maintainer-approval.test.js
+++ b/.github/workflows/maintainer-approval.test.js
@@ -251,12 +251,11 @@ describe("maintainer-approval", () => {
 
     await runModule({ github, context, core });
 
-    assert.equal(github._checkRuns.length, 1);
-    assert.equal(github._checkRuns[0].status, "in_progress");
-    assert.ok(github._checkRuns[0].output.summary.includes("/bundle/"));
+    // No check run created; the required check stays as "Expected" (yellow dot).
+    assert.equal(github._checkRuns.length, 0);
   });
 
-  it("wildcard files present -> pending, mentions maintainer", async () => {
+  it("wildcard files present -> pending, no check run", async () => {
     const github = makeGithub({
       reviews: [
         { state: "APPROVED", user: { login: "randomreviewer" } },
@@ -268,12 +267,10 @@ describe("maintainer-approval", () => {
 
     await runModule({ github, context, core });
 
-    assert.equal(github._checkRuns.length, 1);
-    assert.equal(github._checkRuns[0].status, "in_progress");
-    assert.ok(github._checkRuns[0].output.summary.includes("maintainer"));
+    assert.equal(github._checkRuns.length, 0);
   });
 
-  it("no approvals at all -> pending", async () => {
+  it("no approvals at all -> pending, no check run", async () => {
     const github = makeGithub({
       reviews: [],
       files: [{ filename: "cmd/pipelines/foo.go" }],
@@ -283,8 +280,7 @@ describe("maintainer-approval", () => {
 
     await runModule({ github, context, core });
 
-    assert.equal(github._checkRuns.length, 1);
-    assert.equal(github._checkRuns[0].status, "in_progress");
+    assert.equal(github._checkRuns.length, 0);
   });
 
   it("team member approved -> success for team-owned path", async () => {
@@ -317,8 +313,7 @@ describe("maintainer-approval", () => {
 
     await runModule({ github, context, core });
 
-    assert.equal(github._checkRuns.length, 1);
-    assert.equal(github._checkRuns[0].status, "in_progress");
+    assert.equal(github._checkRuns.length, 0);
   });
 
   it("CHANGES_REQUESTED does not count as approval", async () => {
@@ -333,8 +328,7 @@ describe("maintainer-approval", () => {
 
     await runModule({ github, context, core });
 
-    assert.equal(github._checkRuns.length, 1);
-    assert.equal(github._checkRuns[0].status, "in_progress");
+    assert.equal(github._checkRuns.length, 0);
   });
 
   it("self-approval by PR author is excluded", async () => {
@@ -349,8 +343,7 @@ describe("maintainer-approval", () => {
 
     await runModule({ github, context, core });
 
-    assert.equal(github._checkRuns.length, 1);
-    assert.equal(github._checkRuns[0].status, "in_progress");
+    assert.equal(github._checkRuns.length, 0);
   });
 
   it("no * rule in OWNERS -> setFailed", async () => {


### PR DESCRIPTION
## Why

PR #4931 switched `maintainer-approval` from commit statuses (`createCommitStatus`) to check runs (`checks.create`) so the check is clickable in the GitHub UI. The pending state used `status: "in_progress"`, which GitHub treats as "still running" rather than "blocking". This meant all PRs could merge without maintainer approval.

## Changes

Removes the three `checks.create` calls for pending states (wildcard files, uncovered groups, no approval). When no check run or status exists for `maintainer-approval` on a SHA, GitHub shows the required check as "Expected" (yellow dot) and blocks the merge. Approved PRs still get a success check run (green, clickable).

The result:
- **No approval**: yellow dot, merge blocked, reviewer info in PR comment
- **Approved**: green checkmark, clickable, shows who approved
- **Merge queue**: green checkmark, auto-approved (unchanged)

## Test plan

- [x] All 20 tests in `maintainer-approval.test.js` pass
- [ ] Verify on a subsequent PR (after merge) that `maintainer-approval` shows yellow "Expected" without approval, then turns green after approval

Note: the workflow uses `pull_request_target`, so it runs from main. This PR cannot test itself.