### PR TITLE
Inline hujson dependency in main require block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/cobra v1.10.2 // Apache 2.0
 	github.com/spf13/pflag v1.0.10 // BSD-3-Clause
 	github.com/stretchr/testify v1.11.1 // MIT
+	github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a // BSD-3-Clause
 	go.yaml.in/yaml/v3 v3.0.4 // MIT, Apache 2.0
 	golang.org/x/crypto v0.49.0 // BSD-3-Clause
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
@@ -45,9 +46,6 @@ require (
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect
-
-// Dependencies for experimental SSH commands
-require github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a // BSD-3-Clause
 
 require (
 	cloud.google.com/go/auth v0.18.1 // indirect


### PR DESCRIPTION
## Summary
- Move the `hujson` dependency (added in #4559) into the main `require` block instead of keeping it in a separate block with a comment.

This library is needed to read and write VS Code's `settings.json`, which uses JSONC (JSON with Comments and trailing commas). It allows the CLI to parse, patch, and write back settings without destroying user comments.

This pull request was AI-assisted by Isaac.