### PR TITLE
Inline indirect gopkg.in/yaml.v3 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,6 @@ require (
 	gopkg.in/ini.v1 v1.67.1 // Apache 2.0
 )
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
-
 // Dependencies for experimental SSH commands
 require github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a // BSD-3-Clause
 
@@ -107,4 +105,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary
- Move `gopkg.in/yaml.v3` from a standalone indirect `require` line into the grouped indirect block via `go mod tidy`
- #4353 migrated direct imports to `go.yaml.in/yaml/v3` and moved `gopkg.in/yaml.v3` into the grouped indirect block
- #4289 added a direct dependency on `gopkg.in/yaml.v3` (via `palantir/pkg/yamlpatch`), pulling it back out as a standalone `require` line
- #4400 marked it as `// indirect` but left it as a standalone line

## Test plan
- [x] `go mod tidy` produces no diff

This pull request was AI-assisted by Isaac.