### PR TITLE
Use SPDX license identifiers in go.mod and add test to enforce them

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,36 +5,36 @@ go 1.25.0
 toolchain go1.25.7
 
 require (
-	dario.cat/mergo v1.0.2 // BSD 3-Clause
+	dario.cat/mergo v1.0.2 // BSD-3-Clause
 	github.com/BurntSushi/toml v1.6.0 // MIT
 	github.com/Masterminds/semver/v3 v3.4.0 // MIT
 	github.com/charmbracelet/bubbles v1.0.0 // MIT
 	github.com/charmbracelet/bubbletea v1.3.10 // MIT
 	github.com/charmbracelet/huh v1.0.0 // MIT
 	github.com/charmbracelet/lipgloss v1.1.0 // MIT
-	github.com/databricks/databricks-sdk-go v0.126.0 // Apache 2.0
+	github.com/databricks/databricks-sdk-go v0.126.0 // Apache-2.0
 	github.com/fatih/color v1.19.0 // MIT
 	github.com/google/jsonschema-go v0.4.2 // MIT
 	github.com/google/uuid v1.6.0 // BSD-3-Clause
-	github.com/gorilla/mux v1.8.1 // BSD 3-Clause
-	github.com/gorilla/websocket v1.5.3 // BSD 2-Clause
-	github.com/hashicorp/go-version v1.8.0 // MPL 2.0
-	github.com/hashicorp/hc-install v0.9.3 // MPL 2.0
-	github.com/hashicorp/terraform-exec v0.25.0 // MPL 2.0
-	github.com/hashicorp/terraform-json v0.27.2 // MPL 2.0
-	github.com/hexops/gotextdiff v1.0.3 // BSD 3-Clause "New" or "Revised" License
+	github.com/gorilla/mux v1.8.1 // BSD-3-Clause
+	github.com/gorilla/websocket v1.5.3 // BSD-2-Clause
+	github.com/hashicorp/go-version v1.8.0 // MPL-2.0
+	github.com/hashicorp/hc-install v0.9.3 // MPL-2.0
+	github.com/hashicorp/terraform-exec v0.25.0 // MPL-2.0
+	github.com/hashicorp/terraform-json v0.27.2 // MPL-2.0
+	github.com/hexops/gotextdiff v1.0.3 // BSD-3-Clause
 	github.com/manifoldco/promptui v0.9.0 // BSD-3-Clause
 	github.com/mattn/go-isatty v0.0.20 // MIT
 	github.com/nwidger/jsoncolor v0.3.2 // MIT
 	github.com/palantir/pkg/yamlpatch v1.5.0 // BSD-3-Clause
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // BSD-2-Clause
-	github.com/quasilyte/go-ruleguard/dsl v0.3.22 // BSD 3-Clause
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22 // BSD-3-Clause
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // MIT
-	github.com/spf13/cobra v1.10.2 // Apache 2.0
+	github.com/spf13/cobra v1.10.2 // Apache-2.0
 	github.com/spf13/pflag v1.0.10 // BSD-3-Clause
 	github.com/stretchr/testify v1.11.1 // MIT
 	github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a // BSD-3-Clause
-	go.yaml.in/yaml/v3 v3.0.4 // MIT, Apache 2.0
+	go.yaml.in/yaml/v3 v3.0.4 // MIT AND Apache-2.0
 	golang.org/x/crypto v0.49.0 // BSD-3-Clause
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // BSD-3-Clause
 	golang.org/x/mod v0.34.0 // BSD-3-Clause
@@ -42,7 +42,7 @@ require (
 	golang.org/x/sync v0.20.0 // BSD-3-Clause
 	golang.org/x/sys v0.43.0 // BSD-3-Clause
 	golang.org/x/text v0.35.0 // BSD-3-Clause
-	gopkg.in/ini.v1 v1.67.1 // Apache 2.0
+	gopkg.in/ini.v1 v1.67.1 // Apache-2.0
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/build/license_test.go
+++ b/internal/build/license_test.go
@@ -1,0 +1,97 @@
+package build
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
+)
+
+// Allowlist of SPDX license identifiers we accept for direct dependencies.
+// See https://spdx.org/licenses/ for the full list.
+var spdxLicenses = map[string]bool{
+	"Apache-2.0":   true,
+	"BSD-2-Clause": true,
+	"BSD-3-Clause": true,
+	"MIT":          true,
+	"MPL-2.0":      true,
+}
+
+// parseSPDXExpression validates that expr is a valid SPDX license expression
+// composed of allowed identifiers joined by AND/OR operators.
+// Returns the list of license identifiers found, or an error string.
+func parseSPDXExpression(expr string) ([]string, string) {
+	tokens := strings.Fields(expr)
+	if len(tokens) == 0 {
+		return nil, "empty expression"
+	}
+
+	var ids []string
+	expectID := true
+	for _, tok := range tokens {
+		if expectID {
+			if !spdxLicenses[tok] {
+				return nil, tok + " is not an allowed SPDX license identifier; allowed: " + allowedList()
+			}
+			ids = append(ids, tok)
+			expectID = false
+		} else {
+			if tok != "AND" && tok != "OR" {
+				return nil, tok + " unexpected; expected AND or OR operator"
+			}
+			expectID = true
+		}
+	}
+
+	if expectID {
+		return nil, "expression ends with an operator"
+	}
+
+	return ids, ""
+}
+
+func allowedList() string {
+	var out []string
+	for k := range spdxLicenses {
+		out = append(out, k)
+	}
+	return strings.Join(out, ", ")
+}
+
+func TestRequireSPDXLicenseComment(t *testing.T) {
+	b, err := os.ReadFile("../../go.mod")
+	require.NoError(t, err)
+
+	modFile, err := modfile.Parse("../../go.mod", b, nil)
+	require.NoError(t, err)
+
+	for _, r := range modFile.Require {
+		if r.Indirect {
+			continue
+		}
+
+		// Find the license comment in suffix comments (excluding "indirect").
+		var license string
+		for _, c := range r.Syntax.Suffix {
+			text := strings.TrimPrefix(c.Token, "//")
+			text = strings.TrimSpace(text)
+			if text == "indirect" {
+				continue
+			}
+			license = text
+		}
+
+		if license == "" {
+			assert.Failf(t, r.Mod.Path, "missing SPDX license comment; add one like: // MIT")
+			continue
+		}
+
+		_, errMsg := parseSPDXExpression(license)
+		if errMsg != "" {
+			assert.Failf(t, r.Mod.Path, "license comment %q: %s", license, errMsg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize all license comments in `go.mod` to use standard SPDX identifiers (e.g. `Apache 2.0` → `Apache-2.0`, `BSD 3-Clause` → `BSD-3-Clause`)
- Use `MIT AND Apache-2.0` for `go.yaml.in/yaml/v3` (different files under different licenses)
- Add `internal/build/license_test.go` that parses `go.mod` with `x/mod/modfile` and validates every direct dependency has a valid SPDX license comment

## Test plan
- [x] `go test ./internal/build/ -run TestRequireSPDXLicenseComment` passes
- [x] Cross-checked all 38 license comments against upstream LICENSE files

This pull request was AI-assisted by Isaac.