### PR TITLE
Update NOTICE file and add test to enforce completeness

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,11 +17,11 @@ Copyright (c) 2011-2019 Canonical Ltd
 Copyright (c) 2006-2011 Kirill Simonov
 License - https://github.com/yaml/go-yaml/blob/v3/LICENSE
 
-—--
+---
 
-This software contains code from the following open source projects, licensed under the MPL 2.0 license:
+This Software contains code from the following open source projects, licensed under the MPL 2.0 license:
 
-hashicopr/go-version - https://github.com/hashicorp/go-version
+hashicorp/go-version - https://github.com/hashicorp/go-version
 Copyright 2014 HashiCorp, Inc.
 License - https://github.com/hashicorp/go-version/blob/main/LICENSE
 
@@ -29,9 +29,9 @@ hashicorp/hc-install - https://github.com/hashicorp/hc-install
 Copyright 2020 HashiCorp, Inc.
 License - https://github.com/hashicorp/hc-install/blob/main/LICENSE
 
-hashicopr/terraform-exec - https://github.com/hashicorp/terraform-exec
+hashicorp/terraform-exec - https://github.com/hashicorp/terraform-exec
 Copyright 2020 HashiCorp, Inc.
-LIcense - https://github.com/hashicorp/terraform-exec/blob/main/LICENSE
+License - https://github.com/hashicorp/terraform-exec/blob/main/LICENSE
 
 hashicorp/terraform-json - https://github.com/hashicorp/terraform-json
 Copyright 2019 HashiCorp, Inc.
@@ -43,24 +43,24 @@ License - https://github.com/hashicorp/terraform/blob/v1.5.5/LICENSE
 
 ---
 
-This software contains code from the following open source projects, licensed under the BSD (2-clause) license:
+This Software contains code from the following open source projects, licensed under the BSD (2-clause) license:
 
 pkg/browser - https://github.com/pkg/browser
 Copyright (c) 2014, Dave Cheney <dave@cheney.net>
 License - https://github.com/pkg/browser/blob/master/LICENSE
 
-gorilla/websocket - github.com/gorilla/websocket
+gorilla/websocket - https://github.com/gorilla/websocket
 Copyright (c) 2013 The Gorilla WebSocket Authors. All rights reserved.
 License - https://github.com/gorilla/websocket/blob/main/LICENSE
 
 ---
 
-This software contains code from the following open source projects, licensed under the BSD (3-clause) license:
+This Software contains code from the following open source projects, licensed under the BSD (3-clause) license:
 
 spf13/pflag - https://github.com/spf13/pflag
 Copyright (c) 2012 Alex Ogier. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
-License - https://raw.githubusercontent.com/spf13/pflag/master/LICENSE
+License - https://github.com/spf13/pflag/blob/master/LICENSE
 
 google/uuid - https://github.com/google/uuid
 Copyright (c) 2009,2014 Google Inc. All rights reserved.
@@ -70,7 +70,60 @@ manifoldco/promptui - https://github.com/manifoldco/promptui
 Copyright (c) 2017, Arigato Machine Inc. All rights reserved.
 License - https://github.com/manifoldco/promptui/blob/master/LICENSE.md
 
-—--
+hexops/gotextdiff - https://github.com/hexops/gotextdiff
+Copyright (c) 2009 The Go Authors. All rights reserved.
+License - https://github.com/hexops/gotextdiff/blob/main/LICENSE
+
+dario.cat/mergo - https://github.com/darccio/mergo
+Copyright (c) 2013 Dario Castañé. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+License - https://github.com/darccio/mergo/blob/master/LICENSE
+
+gorilla/mux - https://github.com/gorilla/mux
+Copyright (c) 2023 The Gorilla Authors. All rights reserved.
+License - https://github.com/gorilla/mux/blob/main/LICENSE
+
+palantir/pkg - https://github.com/palantir/pkg
+Copyright (c) 2016, Palantir Technologies, Inc.
+License - https://github.com/palantir/pkg/blob/master/LICENSE
+
+quasilyte/go-ruleguard - https://github.com/quasilyte/go-ruleguard
+Copyright (c) 2022, Iskander (Alex) Sharipov / quasilyte
+License - https://github.com/quasilyte/go-ruleguard/blob/master/LICENSE
+
+tailscale/hujson - https://github.com/tailscale/hujson
+Copyright (c) 2019 Tailscale Inc. All rights reserved.
+License - https://github.com/tailscale/hujson/blob/master/LICENSE
+
+golang.org/x/crypto - https://github.com/golang/crypto
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/crypto/blob/master/LICENSE
+
+golang.org/x/exp - https://github.com/golang/exp
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/exp/blob/master/LICENSE
+
+golang.org/x/mod - https://github.com/golang/mod
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/mod/blob/master/LICENSE
+
+golang.org/x/oauth2 - https://github.com/golang/oauth2
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/oauth2/blob/master/LICENSE
+
+golang.org/x/sync - https://github.com/golang/sync
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/sync/blob/master/LICENSE
+
+golang.org/x/sys - https://github.com/golang/sys
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/sys/blob/master/LICENSE
+
+golang.org/x/text - https://github.com/golang/text
+Copyright 2009 The Go Authors.
+License - https://github.com/golang/text/blob/master/LICENSE
+
+---
 
 This Software contains code from the following open source projects, licensed under the MIT license:
 
@@ -84,7 +137,7 @@ License - https://github.com/charmbracelet/bubbles/blob/master/LICENSE
 
 charmbracelet/bubbletea - https://github.com/charmbracelet/bubbletea
 Copyright (c) 2020-2025 Charmbracelet, Inc
-License - https://github.com/charmbracelet/bubbletea/blob/master/LICENSE
+License - https://github.com/charmbracelet/bubbletea/blob/main/LICENSE
 
 charmbracelet/huh - https://github.com/charmbracelet/huh
 Copyright (c) 2023 Charmbracelet, Inc.
@@ -104,7 +157,7 @@ License - https://github.com/Masterminds/semver/blob/master/LICENSE.txt
 
 mattn/go-isatty - https://github.com/mattn/go-isatty
 Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
-https://github.com/mattn/go-isatty/blob/master/LICENSE
+License - https://github.com/mattn/go-isatty/blob/master/LICENSE
 
 nwidger/jsoncolor - https://github.com/nwidger/jsoncolor
 Copyright (c) 2016 Niels Widger
@@ -114,35 +167,13 @@ sabhiram/go-gitignore - https://github.com/sabhiram/go-gitignore
 Copyright (c) 2015 Shaba Abhiram
 License - https://github.com/sabhiram/go-gitignore/blob/master/LICENSE
 
-
 stretchr/testify - https://github.com/stretchr/testify
 Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 License - https://github.com/stretchr/testify/blob/master/LICENSE
 
-whilp/git-urls - https://github.com/whilp/git-urls
-Copyright (c) 2020 Will Maier
-License - https://github.com/whilp/git-urls/blob/master/LICENSE
-
-github.com/wI2L/jsondiff v0.6.1
-Copyright (c) 2020-2024 William Poussier <william.poussier@gmail.com>
-License - https://github.com/wI2L/jsondiff/blob/master/LICENSE
-
-https://github.com/hexops/gotextdiff
-Copyright (c) 2009 The Go Authors. All rights reserved.
-License - https://github.com/hexops/gotextdiff/blob/main/LICENSE
-
-https://github.com/BurntSushi/toml
+BurntSushi/toml - https://github.com/BurntSushi/toml
 Copyright (c) 2013 TOML authors
-https://github.com/BurntSushi/toml/blob/master/COPYING
-
-dario.cat/mergo
-Copyright (c) 2013 Dario Castañé. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-https://github.com/darccio/mergo/blob/master/LICENSE
-
-https://github.com/gorilla/mux
-Copyright (c) 2023 The Gorilla Authors. All rights reserved.
-https://github.com/gorilla/mux/blob/main/LICENSE
+License - https://github.com/BurntSushi/toml/blob/master/COPYING
 
 go-yaml/yaml - https://github.com/yaml/go-yaml
 Copyright (c) 2011-2019 Canonical Ltd

--- a/internal/build/notice_test.go
+++ b/internal/build/notice_test.go
@@ -1,0 +1,177 @@
+package build
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
+)
+
+// moduleToGitHub maps non-GitHub go.mod paths to their GitHub org/repo slug.
+var moduleToGitHub = map[string]string{
+	"gopkg.in/ini.v1":    "go-ini/ini",
+	"go.yaml.in/yaml/v3": "yaml/go-yaml",
+	"dario.cat/mergo":    "darccio/mergo",
+}
+
+// Modules excluded from NOTICE requirements (Databricks-owned).
+var noticeExclude = map[string]bool{
+	"github.com/databricks/databricks-sdk-go": true,
+}
+
+// Additional entries required in the NOTICE file that are not direct go.mod
+// dependencies (e.g. bundled binaries).
+var noticeExtra = map[string][]string{
+	"hashicorp/terraform": {"MPL-2.0"},
+}
+
+// Expected order of license sections in the NOTICE file.
+var expectedSectionOrder = []string{
+	"Apache-2.0",
+	"MPL-2.0",
+	"BSD-2-Clause",
+	"BSD-3-Clause",
+	"MIT",
+}
+
+var headerToSPDX = map[string]string{
+	"apache 2.0":     "Apache-2.0",
+	"mpl 2.0":        "MPL-2.0",
+	"bsd (2-clause)": "BSD-2-Clause",
+	"bsd (3-clause)": "BSD-3-Clause",
+	"mit":            "MIT",
+}
+
+var (
+	githubSlugRe    = regexp.MustCompile(`github\.com/([^/\s]+/[^/\s]+)`)
+	sectionHeaderRe = regexp.MustCompile(`(?i)licensed under the (.+?) license`)
+)
+
+func githubSlugFromModule(modPath string) string {
+	if slug, ok := moduleToGitHub[modPath]; ok {
+		return slug
+	}
+	if strings.HasPrefix(modPath, "github.com/") {
+		parts := strings.SplitN(modPath, "/", 4)
+		if len(parts) >= 3 {
+			return parts[1] + "/" + parts[2]
+		}
+	}
+	if strings.HasPrefix(modPath, "golang.org/x/") {
+		return "golang/" + strings.TrimPrefix(modPath, "golang.org/x/")
+	}
+	return ""
+}
+
+// parseNoticeSections parses the NOTICE file into a map from SPDX license
+// identifier to the list of GitHub org/repo slugs in that section.
+// It also returns the order in which sections appear.
+func parseNoticeSections(content string) (map[string][]string, []string) {
+	sections := map[string][]string{}
+	var order []string
+	var currentSPDX string
+	var block []string
+
+	flush := func() {
+		if currentSPDX != "" && len(block) > 0 {
+			text := strings.Join(block, "\n")
+			if m := githubSlugRe.FindStringSubmatch(text); m != nil {
+				sections[currentSPDX] = append(sections[currentSPDX], m[1])
+			}
+		}
+		block = nil
+	}
+
+	for _, line := range strings.Split(content, "\n") {
+		if m := sectionHeaderRe.FindStringSubmatch(line); m != nil {
+			flush()
+			key := strings.ToLower(strings.TrimSpace(m[1]))
+			if spdx, ok := headerToSPDX[key]; ok {
+				currentSPDX = spdx
+				order = append(order, spdx)
+			}
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.Trim(trimmed, "-—") == "" {
+			flush()
+			continue
+		}
+
+		if currentSPDX != "" {
+			block = append(block, line)
+		}
+	}
+	flush()
+
+	return sections, order
+}
+
+func extractLicenseComment(r *modfile.Require) string {
+	for _, c := range r.Syntax.Suffix {
+		text := strings.TrimPrefix(c.Token, "//")
+		text = strings.TrimSpace(text)
+		if text != "indirect" {
+			return text
+		}
+	}
+	return ""
+}
+
+func TestNoticeFileCompleteness(t *testing.T) {
+	goModBytes, err := os.ReadFile("../../go.mod")
+	require.NoError(t, err)
+	modFile, err := modfile.Parse("../../go.mod", goModBytes, nil)
+	require.NoError(t, err)
+
+	// Build expected: license → sorted list of slugs.
+	expected := map[string][]string{}
+	for _, r := range modFile.Require {
+		if r.Indirect || noticeExclude[r.Mod.Path] {
+			continue
+		}
+		slug := githubSlugFromModule(r.Mod.Path)
+		if slug == "" {
+			assert.Failf(t, r.Mod.Path, "cannot map to GitHub slug for NOTICE verification")
+			continue
+		}
+		license := extractLicenseComment(r)
+		if license == "" {
+			continue // license_test.go catches missing comments
+		}
+		ids, _ := parseSPDXExpression(license)
+		for _, id := range ids {
+			expected[id] = append(expected[id], slug)
+		}
+	}
+	for slug, licenses := range noticeExtra {
+		for _, id := range licenses {
+			expected[id] = append(expected[id], slug)
+		}
+	}
+	for k := range expected {
+		slices.Sort(expected[k])
+	}
+
+	// Parse NOTICE file.
+	noticeBytes, err := os.ReadFile("../../NOTICE")
+	require.NoError(t, err)
+	actual, sectionOrder := parseNoticeSections(string(noticeBytes))
+	for k := range actual {
+		slices.Sort(actual[k])
+	}
+
+	// Check section order.
+	assert.Equal(t, expectedSectionOrder, sectionOrder, "NOTICE section order")
+
+	// Check entries per section.
+	for _, license := range expectedSectionOrder {
+		assert.Equal(t, expected[license], actual[license], "NOTICE %s section", license)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix NOTICE file: add 13 missing BSD-3-Clause entries, remove 2 stale entries, move 3 wrongly attributed entries from MIT to BSD-3-Clause
- Fix typos (`hashicopr` → `hashicorp`, `LIcense` → `License`, `—--` → `---`)
- Fix broken license URLs (`palantir/pkg` branch `develop` → `master`, `tailscale/hujson` branch `main` → `master`)
- Add `internal/build/notice_test.go` that cross-references go.mod against NOTICE, checking section order and exact entry sets per license

## Test plan
- [x] `go test ./internal/build/` — all 5 tests pass
- [x] All 38 license URLs verified with curl (HTTP 200, valid license text)

This pull request was AI-assisted by Isaac.