### PR TITLE
Fixed apps incorrectly using local filesystem path from artifacts path

### DIFF
--- a/acceptance/bundle/apps/artifact_and_app_same_path/databricks.yml
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/databricks.yml
@@ -1,0 +1,13 @@
+bundle:
+  name: test-bundle
+
+artifacts:
+  my_artifact:
+    type: whl
+    path: ./src/app
+
+resources:
+  apps:
+    my_app:
+      name: my-app
+      source_code_path: ./src/app

--- a/acceptance/bundle/apps/artifact_and_app_same_path/out.test.toml
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/artifact_and_app_same_path/output.txt
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/output.txt
@@ -1,0 +1,6 @@
+
+>>> [CLI] bundle validate -o json
+/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/src/app
+
+>>> [CLI] bundle validate -o json
+[TEST_TMP_DIR]/src/app

--- a/acceptance/bundle/apps/artifact_and_app_same_path/script
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/script
@@ -1,0 +1,2 @@
+trace $CLI bundle validate -o json | jq -r '.resources.apps.my_app.source_code_path'
+trace $CLI bundle validate -o json | jq -r '.artifacts.my_artifact.path'

--- a/acceptance/bundle/apps/artifact_and_app_same_path/test.toml
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/test.toml
@@ -1,0 +1,5 @@
+RecordRequests = false
+
+Ignore = [
+    '.databricks',
+]

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -47,6 +47,14 @@ func (err ErrIsNotNotebook) Error() string {
 	return fmt.Sprintf("file at %s is not a notebook", err.path)
 }
 
+// seenKey is the cache key for the seen map in translateContext.
+// It includes both the local path and the translation mode to prevent
+// cross-mode cache collisions (e.g. artifact vs. workspace path translations).
+type seenKey struct {
+	path string
+	mode paths.TranslateMode
+}
+
 type translatePaths struct{}
 
 type translatePathsDashboards struct{}
@@ -76,9 +84,9 @@ func (m *translatePathsDashboards) Name() string {
 type translateContext struct {
 	b *bundle.Bundle
 
-	// seen is a map of local paths to their corresponding remote paths.
-	// If a local path has already been successfully resolved, we do not need to resolve it again.
-	seen map[string]string
+	// seen is a map of (local path, translation mode) pairs to their corresponding remote paths.
+	// If a local path has already been successfully resolved for a given mode, we do not need to resolve it again.
+	seen map[seenKey]string
 
 	// remoteRoot is the root path of the remote workspace.
 	// It is equal to ${workspace.file_path} for regular deployments.
@@ -135,7 +143,8 @@ func (t *translateContext) rewritePath(
 
 	// Local path is relative to the directory the resource was defined in.
 	localPath := filepath.Join(dir, input)
-	if interp, ok := t.seen[localPath]; ok {
+	key := seenKey{path: localPath, mode: opts.Mode}
+	if interp, ok := t.seen[key]; ok {
 		return interp, nil
 	}
 
@@ -181,7 +190,7 @@ func (t *translateContext) rewritePath(
 		return "", err
 	}
 
-	t.seen[localPath] = interp
+	t.seen[key] = interp
 	return interp, nil
 }
 
@@ -337,7 +346,7 @@ func applyTranslations(ctx context.Context, b *bundle.Bundle, t *translateContex
 func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	t := &translateContext{
 		b:                       b,
-		seen:                    make(map[string]string),
+		seen:                    make(map[seenKey]string),
 		skipLocalFileValidation: b.SkipLocalFileValidation,
 	}
 
@@ -354,7 +363,7 @@ func (m *translatePaths) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 func (m *translatePathsDashboards) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	t := &translateContext{
 		b:                       b,
-		seen:                    make(map[string]string),
+		seen:                    make(map[seenKey]string),
 		skipLocalFileValidation: b.SkipLocalFileValidation,
 	}
 

--- a/bundle/config/mutator/translate_paths_apps_test.go
+++ b/bundle/config/mutator/translate_paths_apps_test.go
@@ -1,7 +1,6 @@
 package mutator_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,57 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestTranslatePathsApps_SharedDirectoryWithArtifact reproduces the bug from
-// https://github.com/databricks/cli/issues/4924 where the shared `seen` cache
-// in translateContext caused an artifact's local absolute path to be returned
-// for an app's source_code_path when both point to the same directory.
-func TestTranslatePathsApps_SharedDirectoryWithArtifact(t *testing.T) {
-	dir := t.TempDir()
-	// Create the shared directory that both the artifact and the app reference.
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "app"), 0o755))
-
-	b := &bundle.Bundle{
-		SyncRootPath:   dir,
-		BundleRootPath: dir,
-		SyncRoot:       vfs.MustNew(dir),
-		Config: config.Root{
-			Workspace: config.Workspace{
-				FilePath: "/bundle/files",
-			},
-			Artifacts: map[string]*config.Artifact{
-				"my_artifact": {
-					Type: config.ArtifactPythonWheel,
-					// Points to the same local directory as the app below.
-					Path: "src/app",
-				},
-			},
-			Resources: config.Resources{
-				Apps: map[string]*resources.App{
-					"my_app": {
-						App: apps.App{
-							Name: "My App",
-						},
-						// Points to the same local directory as the artifact above.
-						SourceCodePath: "src/app",
-					},
-				},
-			},
-		},
-	}
-
-	bundletest.SetLocation(b, "artifacts", []dyn.Location{{File: filepath.Join(dir, "databricks.yml")}})
-	bundletest.SetLocation(b, "resources.apps", []dyn.Location{{File: filepath.Join(dir, "databricks.yml")}})
-
-	diags := bundle.ApplySeq(t.Context(), b, mutator.NormalizePaths(), mutator.TranslatePaths())
-	require.NoError(t, diags.Error())
-
-	// The artifact path must be a local absolute path.
-	assert.Equal(t, filepath.ToSlash(filepath.Join(dir, "src/app")), b.Config.Artifacts["my_artifact"].Path)
-
-	// The app source_code_path must be a remote workspace path, not the local absolute path.
-	assert.Equal(t, "/bundle/files/src/app", b.Config.Resources.Apps["my_app"].SourceCodePath)
-}
 
 func TestTranslatePathsApps_FilePathRelativeSubDirectory(t *testing.T) {
 	dir := t.TempDir()

--- a/bundle/config/mutator/translate_paths_apps_test.go
+++ b/bundle/config/mutator/translate_paths_apps_test.go
@@ -1,6 +1,7 @@
 package mutator_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,6 +16,57 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestTranslatePathsApps_SharedDirectoryWithArtifact reproduces the bug from
+// https://github.com/databricks/cli/issues/4924 where the shared `seen` cache
+// in translateContext caused an artifact's local absolute path to be returned
+// for an app's source_code_path when both point to the same directory.
+func TestTranslatePathsApps_SharedDirectoryWithArtifact(t *testing.T) {
+	dir := t.TempDir()
+	// Create the shared directory that both the artifact and the app reference.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src", "app"), 0o755))
+
+	b := &bundle.Bundle{
+		SyncRootPath:   dir,
+		BundleRootPath: dir,
+		SyncRoot:       vfs.MustNew(dir),
+		Config: config.Root{
+			Workspace: config.Workspace{
+				FilePath: "/bundle/files",
+			},
+			Artifacts: map[string]*config.Artifact{
+				"my_artifact": {
+					Type: config.ArtifactPythonWheel,
+					// Points to the same local directory as the app below.
+					Path: "src/app",
+				},
+			},
+			Resources: config.Resources{
+				Apps: map[string]*resources.App{
+					"my_app": {
+						App: apps.App{
+							Name: "My App",
+						},
+						// Points to the same local directory as the artifact above.
+						SourceCodePath: "src/app",
+					},
+				},
+			},
+		},
+	}
+
+	bundletest.SetLocation(b, "artifacts", []dyn.Location{{File: filepath.Join(dir, "databricks.yml")}})
+	bundletest.SetLocation(b, "resources.apps", []dyn.Location{{File: filepath.Join(dir, "databricks.yml")}})
+
+	diags := bundle.ApplySeq(t.Context(), b, mutator.NormalizePaths(), mutator.TranslatePaths())
+	require.NoError(t, diags.Error())
+
+	// The artifact path must be a local absolute path.
+	assert.Equal(t, filepath.ToSlash(filepath.Join(dir, "src/app")), b.Config.Artifacts["my_artifact"].Path)
+
+	// The app source_code_path must be a remote workspace path, not the local absolute path.
+	assert.Equal(t, "/bundle/files/src/app", b.Config.Resources.Apps["my_app"].SourceCodePath)
+}
 
 func TestTranslatePathsApps_FilePathRelativeSubDirectory(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Changes
Fixed apps incorrectly using local filesystem path from artifacts path

## Why
Fixes #4924

## Tests
Added an acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
