### PR TITLE
Fix persistent drift for model permissions object_id after v0.293

### DIFF
--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -1,5 +1,4 @@
 Cloud = false
-Slow = true
 
 # $resources references to permissions and grants are not supported on v0.293.0
 EnvMatrixExclude.no_permission_ref = ["INPUT_CONFIG=job_permission_ref.yml.tmpl"]

--- a/bundle/direct/dresources/all.go
+++ b/bundle/direct/dresources/all.go
@@ -40,7 +40,7 @@ var SupportedResources = map[string]any{
 	"database_instances.permissions":      (*ResourcePermissions)(nil),
 	"postgres_projects.permissions":       (*ResourcePermissions)(nil),
 	"experiments.permissions":             (*ResourcePermissions)(nil),
-	"models.permissions":                  (*ResourcePermissions)(nil),
+	"models.permissions":                  (*ResourceModelPermissions)(nil),
 	"sql_warehouses.permissions":          (*ResourcePermissions)(nil),
 	"secret_scopes.permissions":           (*ResourceSecretScopeAcls)(nil),
 	"model_serving_endpoints.permissions": (*ResourcePermissions)(nil),

--- a/bundle/direct/dresources/permissions.go
+++ b/bundle/direct/dresources/permissions.go
@@ -228,6 +228,26 @@ func (r *ResourcePermissions) DoCreate(ctx context.Context, newState *Permission
 	return newState.ObjectID, nil, nil
 }
 
+// ResourceModelPermissions extends ResourcePermissions with DoUpdateWithID.
+// Model permissions object_id changed from /registered-models/MODEL_NAME to
+// /registered-models/NUMERIC_ID. DoUpdateWithID ensures the state entry ID
+// is updated when the object_id changes (e.g. migrating from v0.293 state).
+type ResourceModelPermissions struct {
+	ResourcePermissions
+}
+
+func (*ResourceModelPermissions) New(client *databricks.WorkspaceClient) *ResourceModelPermissions {
+	return &ResourceModelPermissions{ResourcePermissions: ResourcePermissions{client: client}}
+}
+
+func (r *ResourceModelPermissions) DoUpdateWithID(ctx context.Context, _ string, newState *PermissionsState) (string, *PermissionsState, error) {
+	_, err := r.DoUpdate(ctx, "", newState, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	return newState.ObjectID, nil, nil
+}
+
 // DoUpdate calls https://docs.databricks.com/api/workspace/jobs/setjobpermissions.
 func (r *ResourcePermissions) DoUpdate(ctx context.Context, _ string, newState *PermissionsState, _ *PlanEntry) (*PermissionsState, error) {
 	extractedType, extractedID, err := parsePermissionsID(newState.ObjectID)

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -399,6 +399,13 @@ resources:
       - field: initial_manage_principal
         reason: immutable
 
+  # Model permissions object_id changed from /registered-models/MODEL_NAME to
+  # /registered-models/NUMERIC_ID. UpdateWithID ensures the state entry ID is updated.
+  models.permissions:
+    update_id_on_changes:
+      - field: object_id
+        reason: id_changes
+
   # Permissions for secret scopes use ResourceSecretScopeAcls.
   secret_scopes.permissions:
     update_id_on_changes:


### PR DESCRIPTION
## Changes
- Model permissions object_id changed from /registered-models/MODEL_NAME to /registered-models/NUMERIC_ID, but the state entry `__id__` was not updated during deploy, causing perpetual drift on subsequent plans.
- Add ResourceModelPermissions type with DoUpdateWithID so the state ID is updated when object_id changes.

## Tests
It was detected by invariant/continue_293 test with the config added in https://github.com/databricks/cli/pull/4941

The test was marked as Slow, so it did not run on PR.