### PR TITLE
Use `slices` and `cmp` packages instead of `sort`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,16 @@ linters:
           msg: Use env.UserHomeDir(ctx) from libs/env instead.
         - pattern: 'os\.Getenv'
           msg: Use env.Get(ctx) from the libs/env package instead of os.Getenv.
+        - pattern: 'sort\.Slice'
+          msg: Use slices.SortFunc from the standard library instead.
+        - pattern: 'sort\.SliceStable'
+          msg: Use slices.SortStableFunc from the standard library instead.
+        - pattern: 'sort\.Strings'
+          msg: Use slices.Sort from the standard library instead.
+        - pattern: 'sort\.Ints'
+          msg: Use slices.Sort from the standard library instead.
+        - pattern: 'sort\.Float64s'
+          msg: Use slices.Sort from the standard library instead.
       analyze-types: true
     copyloopvar:
       check-alias: true

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -17,7 +17,6 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -486,7 +485,7 @@ func getTests(t *testing.T) []string {
 	})
 	require.NoError(t, err)
 
-	sort.Strings(testDirs)
+	slices.Sort(testDirs)
 	return testDirs
 }
 

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -350,7 +349,7 @@ func ExpandEnvMatrix(matrix, exclude map[string][]string, extraVars []string) []
 	for key := range filteredMatrix {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	// Build an expansion of all combinations.
 	// At each step we look at a given key and append each possible value to each

--- a/bundle/config/loader/process_include.go
+++ b/bundle/config/loader/process_include.go
@@ -1,10 +1,10 @@
 package loader
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
@@ -98,7 +98,7 @@ func validateSingleResourceDefined(configRoot dyn.Value, ext, typ string) diag.D
 		lines = append(lines, fmt.Sprintf("  - %s (%s)\n", r.key, r.typ))
 	}
 	// Sort the lines to print to make the output deterministic.
-	sort.Strings(lines)
+	slices.Sort(lines)
 	// Compact the lines before writing them to the message to remove any duplicate lines.
 	// This is needed because we do not dedup earlier when gathering the resources
 	// and it's valid to define the same resource in both the resources and targets block.
@@ -114,11 +114,11 @@ func validateSingleResourceDefined(configRoot dyn.Value, ext, typ string) diag.D
 		paths = append(paths, rr.path)
 	}
 	// Sort the locations and paths to make the output deterministic.
-	sort.Slice(locations, func(i, j int) bool {
-		return locations[i].String() < locations[j].String()
+	slices.SortFunc(locations, func(a, b dyn.Location) int {
+		return cmp.Compare(a.String(), b.String())
 	})
-	sort.Slice(paths, func(i, j int) bool {
-		return paths[i].String() < paths[j].String()
+	slices.SortFunc(paths, func(a, b dyn.Path) int {
+		return cmp.Compare(a.String(), b.String())
 	})
 
 	return diag.Diagnostics{

--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -1,10 +1,10 @@
 package resourcemutator
 
 import (
+	"cmp"
 	"context"
 	"path"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
@@ -315,8 +315,8 @@ func toTagArray(tags map[string]string) []Tag {
 	for key, value := range tags {
 		tagArray = append(tagArray, Tag{Key: key, Value: value})
 	}
-	sort.Slice(tagArray, func(i, j int) bool {
-		return tagArray[i].Key < tagArray[j].Key
+	slices.SortFunc(tagArray, func(a, b Tag) int {
+		return cmp.Compare(a.Key, b.Key)
 	})
 	return tagArray
 }

--- a/bundle/config/validate/enum.go
+++ b/bundle/config/validate/enum.go
@@ -1,10 +1,10 @@
 package validate
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/internal/validation/generated"
@@ -86,16 +86,14 @@ func (f *enum) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	}
 
 	// Sort diagnostics to make them deterministic
-	sort.Slice(diags, func(i, j int) bool {
+	slices.SortFunc(diags, func(a, b diag.Diagnostic) int {
 		// First sort by summary
-		if diags[i].Summary != diags[j].Summary {
-			return diags[i].Summary < diags[j].Summary
+		if n := cmp.Compare(a.Summary, b.Summary); n != 0 {
+			return n
 		}
 
 		// Then sort by locations as a tie breaker if summaries are the same.
-		iLocs := fmt.Sprintf("%v", diags[i].Locations)
-		jLocs := fmt.Sprintf("%v", diags[j].Locations)
-		return iLocs < jLocs
+		return cmp.Compare(fmt.Sprintf("%v", a.Locations), fmt.Sprintf("%v", b.Locations))
 	})
 
 	return diags

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -1,10 +1,10 @@
 package validate
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/internal/validation/generated"
@@ -69,16 +69,14 @@ func warnForMissingFields(ctx context.Context, b *bundle.Bundle) diag.Diagnostic
 	}
 
 	// Sort diagnostics to make them deterministic
-	sort.Slice(diags, func(i, j int) bool {
+	slices.SortFunc(diags, func(a, b diag.Diagnostic) int {
 		// First sort by summary
-		if diags[i].Summary != diags[j].Summary {
-			return diags[i].Summary < diags[j].Summary
+		if n := cmp.Compare(a.Summary, b.Summary); n != 0 {
+			return n
 		}
 
 		// Finally sort by locations as a tie breaker if summaries are the same.
-		iLocs := fmt.Sprintf("%v", diags[i].Locations)
-		jLocs := fmt.Sprintf("%v", diags[j].Locations)
-		return iLocs < jLocs
+		return cmp.Compare(fmt.Sprintf("%v", a.Locations), fmt.Sprintf("%v", b.Locations))
 	})
 
 	return diags

--- a/bundle/config/validate/unique_resource_keys.go
+++ b/bundle/config/validate/unique_resource_keys.go
@@ -1,8 +1,9 @@
 package validate
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
@@ -99,20 +100,17 @@ func (m *uniqueResourceKeys) Apply(ctx context.Context, b *bundle.Bundle) diag.D
 
 		// Sort the locations and paths for consistent error messages. This helps
 		// with unit testing.
-		sort.Slice(v.locations, func(i, j int) bool {
-			l1 := v.locations[i]
-			l2 := v.locations[j]
-
-			if l1.File != l2.File {
-				return l1.File < l2.File
+		slices.SortFunc(v.locations, func(a, b dyn.Location) int {
+			if n := cmp.Compare(a.File, b.File); n != 0 {
+				return n
 			}
-			if l1.Line != l2.Line {
-				return l1.Line < l2.Line
+			if n := cmp.Compare(a.Line, b.Line); n != 0 {
+				return n
 			}
-			return l1.Column < l2.Column
+			return cmp.Compare(a.Column, b.Column)
 		})
-		sort.Slice(v.paths, func(i, j int) bool {
-			return v.paths[i].String() < v.paths[j].String()
+		slices.SortFunc(v.paths, func(a, b dyn.Path) int {
+			return cmp.Compare(a.String(), b.String())
 		})
 
 		// If there are multiple resources with the same key, report an error.

--- a/bundle/configsync/format.go
+++ b/bundle/configsync/format.go
@@ -2,7 +2,7 @@ package configsync
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -21,7 +21,7 @@ func FormatTextOutput(changes Changes) string {
 	for key := range changes {
 		resourceKeys = append(resourceKeys, key)
 	}
-	sort.Strings(resourceKeys)
+	slices.Sort(resourceKeys)
 
 	for _, resourceKey := range resourceKeys {
 		resourceChanges := changes[resourceKey]
@@ -31,7 +31,7 @@ func FormatTextOutput(changes Changes) string {
 		for path := range resourceChanges {
 			paths = append(paths, path)
 		}
-		sort.Strings(paths)
+		slices.Sort(paths)
 
 		for _, path := range paths {
 			configChange := resourceChanges[path]

--- a/bundle/configsync/patch.go
+++ b/bundle/configsync/patch.go
@@ -2,12 +2,13 @@ package configsync
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -62,8 +63,8 @@ func ApplyChangesToYAML(ctx context.Context, b *bundle.Bundle, fieldChanges []Fi
 		})
 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Path < result[j].Path
+	slices.SortFunc(result, func(a, b FileChange) int {
+		return cmp.Compare(a.Path, b.Path)
 	})
 
 	return result, nil

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -1,11 +1,12 @@
 package configsync
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
@@ -174,7 +175,7 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 	for resourceKey := range configChanges {
 		resourceKeys = append(resourceKeys, resourceKey)
 	}
-	sort.Strings(resourceKeys)
+	slices.Sort(resourceKeys)
 
 	for _, resourceKey := range resourceKeys {
 		resourceChanges := configChanges[resourceKey]
@@ -187,25 +188,25 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 		}
 
 		// Sort field paths by depth (deeper first), then operation type (removals before adds), then alphabetically
-		sort.SliceStable(fieldPaths, func(i, j int) bool {
-			depthI := fieldPathsDepths[fieldPaths[i]]
-			depthJ := fieldPathsDepths[fieldPaths[j]]
+		slices.SortStableFunc(fieldPaths, func(a, b string) int {
+			depthA := fieldPathsDepths[a]
+			depthB := fieldPathsDepths[b]
 
-			if depthI != depthJ {
-				return depthI > depthJ
+			if depthA != depthB {
+				return cmp.Compare(depthB, depthA)
 			}
 
-			opI := resourceChanges[fieldPaths[i]].Operation
-			opJ := resourceChanges[fieldPaths[j]].Operation
+			opA := resourceChanges[a].Operation
+			opB := resourceChanges[b].Operation
 
-			if opI == OperationRemove && opJ != OperationRemove {
-				return true
+			if opA == OperationRemove && opB != OperationRemove {
+				return -1
 			}
-			if opI != OperationRemove && opJ == OperationRemove {
-				return false
+			if opA != OperationRemove && opB == OperationRemove {
+				return 1
 			}
 
-			return fieldPaths[i] < fieldPaths[j]
+			return cmp.Compare(a, b)
 		})
 
 		// Create indices map for this resource, path -> indices, that we could use to replace with added elements

--- a/bundle/deploy/terraform/tfdyn/convert_job.go
+++ b/bundle/deploy/terraform/tfdyn/convert_job.go
@@ -1,10 +1,10 @@
 package tfdyn
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/databricks/cli/bundle/internal/tf/schema"
@@ -101,7 +101,7 @@ func patchApplyPolicyDefaultValues(_ dyn.Path, v dyn.Value) (dyn.Value, error) {
 		}
 	}
 
-	sort.Strings(paths)
+	slices.Sort(paths)
 	valList := make([]dyn.Value, len(paths))
 	for i, s := range paths {
 		valList[i] = dyn.V(s)
@@ -132,19 +132,22 @@ func convertJobResource(ctx context.Context, vin dyn.Value) (dyn.Value, error) {
 	var err error
 	tasks, ok := vin.Get("tasks").AsSequence()
 	if ok {
-		sort.Slice(tasks, func(i, j int) bool {
+		slices.SortFunc(tasks, func(a, b dyn.Value) int {
 			// We sort the tasks by their task key. Tasks without task keys are ordered
 			// before tasks with task keys. We do not error for those tasks
 			// since presence of a task_key is validated for in the Jobs backend.
-			tk1, ok := tasks[i].Get("task_key").AsString()
-			if !ok {
-				return true
+			tk1, ok1 := a.Get("task_key").AsString()
+			tk2, ok2 := b.Get("task_key").AsString()
+			if !ok1 && ok2 {
+				return -1
 			}
-			tk2, ok := tasks[j].Get("task_key").AsString()
-			if !ok {
-				return false
+			if ok1 && !ok2 {
+				return 1
 			}
-			return tk1 < tk2
+			if !ok1 && !ok2 {
+				return 0
+			}
+			return cmp.Compare(tk1, tk2)
 		})
 		vout, err = dyn.Set(vin, "tasks", dyn.V(tasks))
 		if err != nil {

--- a/bundle/docsgen/nodes.go
+++ b/bundle/docsgen/nodes.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/libs/jsonschema"
@@ -130,8 +131,8 @@ func buildNodes(s jsonschema.Schema, refs map[string]*jsonschema.Schema, ownFiel
 		}
 	}
 
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].Title < nodes[j].Title
+	slices.SortFunc(nodes, func(a, b rootNode) int {
+		return cmp.Compare(a.Title, b.Title)
 	})
 	return nodes
 }
@@ -193,8 +194,8 @@ func getAttributes(props, refs map[string]*jsonschema.Schema, ownFields map[stri
 			Link:        reference,
 		})
 	}
-	sort.Slice(attributes, func(i, j int) bool {
-		return attributes[i].Title < attributes[j].Title
+	slices.SortFunc(attributes, func(a, b attributeNode) int {
+		return cmp.Compare(a.Title, b.Title)
 	})
 	return attributes
 }

--- a/bundle/internal/validation/enum.go
+++ b/bundle/internal/validation/enum.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"go/format"
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
+	"slices"
 	"text/template"
 
 	"github.com/databricks/cli/bundle/config"
@@ -185,7 +186,7 @@ func sortGroupedPatternsEnum(groupedPatterns map[string][]EnumPatternInfo) [][]E
 	for key := range groupedPatterns {
 		groupKeys = append(groupKeys, key)
 	}
-	sort.Strings(groupKeys)
+	slices.Sort(groupKeys)
 
 	// Build sorted result
 	result := make([][]EnumPatternInfo, 0, len(groupKeys))
@@ -193,8 +194,8 @@ func sortGroupedPatternsEnum(groupedPatterns map[string][]EnumPatternInfo) [][]E
 		patterns := groupedPatterns[key]
 
 		// Sort patterns within each group by pattern
-		sort.Slice(patterns, func(i, j int) bool {
-			return patterns[i].Pattern < patterns[j].Pattern
+		slices.SortFunc(patterns, func(a, b EnumPatternInfo) int {
+			return cmp.Compare(a.Pattern, b.Pattern)
 		})
 
 		result = append(result, patterns)

--- a/bundle/internal/validation/required.go
+++ b/bundle/internal/validation/required.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"go/format"
 	"os"
 	"path/filepath"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -141,7 +142,7 @@ func sortGroupedPatterns(groupedPatterns map[string][]RequiredPatternInfo) [][]R
 	for key := range groupedPatterns {
 		groupKeys = append(groupKeys, key)
 	}
-	sort.Strings(groupKeys)
+	slices.Sort(groupKeys)
 
 	// Build sorted result
 	result := make([][]RequiredPatternInfo, 0, len(groupKeys))
@@ -149,8 +150,8 @@ func sortGroupedPatterns(groupedPatterns map[string][]RequiredPatternInfo) [][]R
 		patterns := groupedPatterns[key]
 
 		// Sort patterns within each group by parent path
-		sort.Slice(patterns, func(i, j int) bool {
-			return patterns[i].Parent < patterns[j].Parent
+		slices.SortFunc(patterns, func(a, b RequiredPatternInfo) int {
+			return cmp.Compare(a.Parent, b.Parent)
 		})
 
 		result = append(result, patterns)

--- a/bundle/permissions/permission_diagnostics.go
+++ b/bundle/permissions/permission_diagnostics.go
@@ -3,7 +3,7 @@ package permissions
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/bundle"
@@ -112,7 +112,7 @@ func analyzeBundlePermissions(b *bundle.Bundle) (bool, string) {
 	assistance := "For assistance, contact the owners of this project."
 	if otherManagers.Size() > 0 {
 		list := otherManagers.Values()
-		sort.Strings(list)
+		slices.Sort(list)
 		assistance = fmt.Sprintf(
 			"For assistance, users or groups with appropriate permissions may include: %s.",
 			strings.Join(list, ", "),

--- a/bundle/phases/telemetry.go
+++ b/bundle/phases/telemetry.go
@@ -1,9 +1,9 @@
 package phases
 
 import (
+	"cmp"
 	"context"
 	"slices"
-	"sort"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
@@ -18,8 +18,8 @@ func getExecutionTimes(b *bundle.Bundle) []protos.IntMapEntry {
 	executionTimes := b.Metrics.ExecutionTimes
 
 	// Sort the execution times in descending order.
-	sort.Slice(executionTimes, func(i, j int) bool {
-		return executionTimes[i].Value > executionTimes[j].Value
+	slices.SortFunc(executionTimes, func(a, b protos.IntMapEntry) int {
+		return cmp.Compare(b.Value, a.Value)
 	})
 
 	// Keep only the top 250 execution times. This keeps the telemetry event

--- a/bundle/render/render_text_output.go
+++ b/bundle/render/render_text_output.go
@@ -1,10 +1,11 @@
 package render
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
-	"sort"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -188,12 +189,12 @@ func RenderSummary(ctx context.Context, out io.Writer, b *bundle.Bundle) error {
 // Helper function to sort and render resource groups using the template
 func renderResourcesTemplate(out io.Writer, resourceGroups []ResourceGroup) error {
 	// Sort everything to ensure consistent output
-	sort.Slice(resourceGroups, func(i, j int) bool {
-		return resourceGroups[i].GroupName < resourceGroups[j].GroupName
+	slices.SortFunc(resourceGroups, func(a, b ResourceGroup) int {
+		return cmp.Compare(a.GroupName, b.GroupName)
 	})
 	for _, group := range resourceGroups {
-		sort.Slice(group.Resources, func(i, j int) bool {
-			return group.Resources[i].Key < group.Resources[j].Key
+		slices.SortFunc(group.Resources, func(a, b ResourceInfo) int {
+			return cmp.Compare(a.Key, b.Key)
 		})
 	}
 

--- a/bundle/run/output/job.go
+++ b/bundle/run/output/job.go
@@ -1,9 +1,10 @@
 package output
 
 import (
+	"cmp"
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -34,8 +35,8 @@ func (out *JobOutput) String() (string, error) {
 	}
 	result := strings.Builder{}
 	result.WriteString("Output:\n")
-	sort.Slice(out.TaskOutputs, func(i, j int) bool {
-		return out.TaskOutputs[i].EndTime < out.TaskOutputs[j].EndTime
+	slices.SortFunc(out.TaskOutputs, func(a, b TaskOutput) int {
+		return cmp.Compare(a.EndTime, b.EndTime)
 	})
 	for _, v := range out.TaskOutputs {
 		if v.Output == nil {

--- a/cmd/apps/import.go
+++ b/cmd/apps/import.go
@@ -2,12 +2,13 @@ package apps
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"go.yaml.in/yaml/v3"
@@ -117,13 +118,16 @@ Examples:
 				}
 
 				// Sort apps: owned by current user first
-				sort.Slice(appList, func(i, j int) bool {
-					iOwned := strings.ToLower(appList[i].Creator) == currentUserEmail
-					jOwned := strings.ToLower(appList[j].Creator) == currentUserEmail
-					if iOwned != jOwned {
-						return iOwned
+				slices.SortFunc(appList, func(a, b apps.App) int {
+					aOwned := strings.ToLower(a.Creator) == currentUserEmail
+					bOwned := strings.ToLower(b.Creator) == currentUserEmail
+					if aOwned != bOwned {
+						if aOwned {
+							return -1
+						}
+						return 1
 					}
-					return appList[i].Name < appList[j].Name
+					return cmp.Compare(a.Name, b.Name)
 				})
 
 				// Build selection map

--- a/cmd/bundle/debug/refschema.go
+++ b/cmd/bundle/debug/refschema.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/bundle/direct/dresources"
@@ -112,7 +112,7 @@ func dumpRemoteSchemas(out io.Writer) error {
 			}
 		}
 
-		sort.Strings(lines)
+		slices.Sort(lines)
 		for _, l := range lines {
 			fmt.Fprint(out, l)
 		}

--- a/cmd/fs/ls.go
+++ b/cmd/fs/ls.go
@@ -1,9 +1,10 @@
 package fs
 
 import (
+	"cmp"
 	"io/fs"
 	"path"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/databricks/cli/cmd/root"
@@ -72,8 +73,8 @@ func newLsCommand() *cobra.Command {
 			}
 			jsonDirEntries[i] = *jsonDirEntry
 		}
-		sort.Slice(jsonDirEntries, func(i, j int) bool {
-			return jsonDirEntries[i].Name < jsonDirEntries[j].Name
+		slices.SortFunc(jsonDirEntries, func(a, b jsonDirEntry) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 
 		// Use template for long mode if the flag is set

--- a/cmd/labs/project/interpreters.go
+++ b/cmd/labs/project/interpreters.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -8,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/libs/env"
@@ -100,14 +101,12 @@ func DetectInterpreters(ctx context.Context) (allInterpreters, error) {
 	if len(found) == 0 {
 		return nil, ErrNoPythonInterpreters
 	}
-	sort.Slice(found, func(i, j int) bool {
-		a := found[i].Version
-		b := found[j].Version
-		cmp := semver.Compare(a, b)
-		if cmp != 0 {
-			return cmp < 0
+	slices.SortFunc(found, func(a, b Interpreter) int {
+		c := semver.Compare(a.Version, b.Version)
+		if c != 0 {
+			return c
 		}
-		return a < b
+		return cmp.Compare(a.Version, b.Version)
 	})
 	return found, nil
 }

--- a/experimental/aitools/cmd/list.go
+++ b/experimental/aitools/cmd/list.go
@@ -3,7 +3,7 @@ package aitools
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"text/tabwriter"
 
@@ -84,7 +84,7 @@ func defaultListSkills(cmd *cobra.Command, scope string) error {
 	for name := range manifest.Skills {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 
 	version := strings.TrimPrefix(ref, "v")
 	cmdio.LogString(ctx, "Available skills (v"+version+"):")

--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -164,7 +164,7 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 	for name := range targetSkills {
 		skillNames = append(skillNames, name)
 	}
-	sort.Strings(skillNames)
+	slices.Sort(skillNames)
 
 	for _, name := range skillNames {
 		meta := targetSkills[name]

--- a/experimental/aitools/lib/installer/update.go
+++ b/experimental/aitools/lib/installer/update.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -236,7 +236,7 @@ func sortedKeys[V any](m map[string]V) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }
 

--- a/libs/apps/manifest/manifest.go
+++ b/libs/apps/manifest/manifest.go
@@ -1,11 +1,12 @@
 package manifest
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -58,7 +59,7 @@ func (r Resource) FieldNames() []string {
 	for k := range r.Fields {
 		names = append(names, k)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 
@@ -122,8 +123,8 @@ func (m *Manifest) GetPlugins() []Plugin {
 		}
 		plugins = append(plugins, p)
 	}
-	sort.Slice(plugins, func(i, j int) bool {
-		return plugins[i].Name < plugins[j].Name
+	slices.SortFunc(plugins, func(a, b Plugin) int {
+		return cmp.Compare(a.Name, b.Name)
 	})
 	return plugins
 }
@@ -174,7 +175,7 @@ func (m *Manifest) GetPluginNames() []string {
 	for name := range m.Plugins {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 

--- a/libs/dagrun/dagrun_test.go
+++ b/libs/dagrun/dagrun_test.go
@@ -3,7 +3,6 @@ package dagrun
 import (
 	"fmt"
 	"slices"
-	"sort"
 	"sync"
 	"testing"
 
@@ -194,7 +193,7 @@ func runTestCase(t *testing.T, tc testCase, g *Graph, p int) {
 	if tc.seen != nil {
 		assert.Equal(t, tc.seen, seen)
 	} else if tc.seenSorted != nil {
-		sort.Strings(seen)
+		slices.Sort(seen)
 		assert.Equal(t, tc.seenSorted, seen)
 	} else {
 		assert.Empty(t, seen)

--- a/libs/databrickscfg/cfgpickers/warehouses.go
+++ b/libs/databrickscfg/cfgpickers/warehouses.go
@@ -1,10 +1,11 @@
 package cfgpickers
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/libs/cmdio"
@@ -86,12 +87,11 @@ func sortWarehousesByState(all []sql.EndpointInfo) []sql.EndpointInfo {
 		sql.StateStopped:  3,
 		sql.StateStopping: 4,
 	}
-	sort.Slice(warehouses, func(i, j int) bool {
-		pi, pj := priorities[warehouses[i].State], priorities[warehouses[j].State]
-		if pi != pj {
-			return pi < pj
+	slices.SortFunc(warehouses, func(a, b sql.EndpointInfo) int {
+		if n := cmp.Compare(priorities[a.State], priorities[b.State]); n != 0 {
+			return n
 		}
-		return strings.ToLower(warehouses[i].Name) < strings.ToLower(warehouses[j].Name)
+		return cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 	})
 
 	return warehouses
@@ -187,13 +187,16 @@ func SelectWarehouse(ctx context.Context, w *databricks.WorkspaceClient, descrip
 	defaultId := warehouses[0].Id
 
 	// Sort by running state first, then alphabetically for display
-	sort.Slice(warehouses, func(i, j int) bool {
-		iRunning := warehouses[i].State == sql.StateRunning
-		jRunning := warehouses[j].State == sql.StateRunning
-		if iRunning != jRunning {
-			return iRunning
+	slices.SortFunc(warehouses, func(a, b sql.EndpointInfo) int {
+		aRunning := a.State == sql.StateRunning
+		bRunning := b.State == sql.StateRunning
+		if aRunning != bRunning {
+			if aRunning {
+				return -1
+			}
+			return 1
 		}
-		return strings.ToLower(warehouses[i].Name) < strings.ToLower(warehouses[j].Name)
+		return cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
 	})
 
 	// Build options for the picker (● = running, ○ = not running)

--- a/libs/dyn/dynloc/locations.go
+++ b/libs/dyn/dynloc/locations.go
@@ -5,7 +5,6 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
-	"sort"
 
 	"github.com/databricks/cli/libs/dyn"
 )
@@ -94,7 +93,7 @@ func (l *Locations) registerFileNames(locs []dyn.Location) error {
 	}
 
 	l.Files = slices.Collect(maps.Values(cache))
-	sort.Strings(l.Files)
+	slices.Sort(l.Files)
 
 	// Build the file-to-index map.
 	for i, file := range l.Files {

--- a/libs/dyn/merge/elements_by_key.go
+++ b/libs/dyn/merge/elements_by_key.go
@@ -1,7 +1,7 @@
 package merge
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/databricks/cli/libs/dyn"
 )
@@ -48,7 +48,7 @@ func (e elementsByKey) doMap(_ dyn.Path, v dyn.Value, mergeFunc func(a, b dyn.Va
 	}
 
 	if e.sortKeys {
-		sort.Strings(keys)
+		slices.Sort(keys)
 	}
 
 	// Gather resulting elements in natural order.

--- a/libs/dyn/yamlsaver/saver.go
+++ b/libs/dyn/yamlsaver/saver.go
@@ -1,11 +1,12 @@
 package yamlsaver
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 
 	"github.com/databricks/cli/libs/dyn"
@@ -79,8 +80,8 @@ func (s *saver) toYamlNodeWithStyle(v dyn.Value, style yaml.Style) (*yaml.Node, 
 		// The location is set when we convert API response struct to config.Value representation
 		// See convert.convertMap for details
 		pairs := m.Pairs()
-		sort.SliceStable(pairs, func(i, j int) bool {
-			return pairs[i].Value.Location().Line < pairs[j].Value.Location().Line
+		slices.SortStableFunc(pairs, func(a, b dyn.Pair) int {
+			return cmp.Compare(a.Value.Location().Line, b.Value.Location().Line)
 		})
 
 		var content []*yaml.Node

--- a/libs/filer/dbfs_client.go
+++ b/libs/filer/dbfs_client.go
@@ -1,6 +1,7 @@
 package filer
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"io"
@@ -8,7 +9,6 @@ import (
 	"net/http"
 	"path"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -273,7 +273,7 @@ func (w *DbfsClient) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, e
 	}
 
 	// Sort by name for parity with os.ReadDir.
-	sort.Slice(info, func(i, j int) bool { return info[i].Name() < info[j].Name() })
+	slices.SortFunc(info, func(a, b fs.DirEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 	return info, nil
 }
 

--- a/libs/filer/fake_filer.go
+++ b/libs/filer/fake_filer.go
@@ -1,12 +1,13 @@
 package filer
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"io"
 	"io/fs"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/libs/fakefs"
@@ -54,7 +55,7 @@ func (f *FakeFiler) ReadDir(ctx context.Context, p string) ([]fs.DirEntry, error
 		out = append(out, fakefs.DirEntry{FileInfo: v})
 	}
 
-	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	slices.SortFunc(out, func(a, b fs.DirEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 	return out, nil
 }
 

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -1,6 +1,7 @@
 package filer
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 	"net/url"
 	"path"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -381,7 +381,7 @@ func (w *FilesClient) ReadDir(ctx context.Context, name string) ([]fs.DirEntry, 
 		}
 
 		// Sort by name for parity with os.ReadDir.
-		sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+		slices.SortFunc(entries, func(a, b fs.DirEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 		return entries, nil
 	}
 

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -2,6 +2,7 @@ package filer
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"path"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -43,7 +43,7 @@ func wsfsDirEntriesFromObjectInfos(objects []workspace.ObjectInfo) []fs.DirEntry
 	}
 
 	// Sort by name for parity with os.ReadDir.
-	sort.Slice(info, func(i, j int) bool { return info[i].Name() < info[j].Name() })
+	slices.SortFunc(info, func(a, b fs.DirEntry) int { return cmp.Compare(a.Name(), b.Name()) })
 	return info
 }
 

--- a/libs/process/opts_test.go
+++ b/libs/process/opts_test.go
@@ -3,7 +3,7 @@ package process
 import (
 	"os/exec"
 	"runtime"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/databricks/cli/internal/testutil"
@@ -38,7 +38,7 @@ func TestWorksWithLibsEnv(t *testing.T) {
 	assert.NoError(t, err)
 
 	vars := cmd.Environ()
-	sort.Strings(vars)
+	slices.Sort(vars)
 
 	assert.GreaterOrEqual(t, len(vars), 2)
 	assert.Equal(t, "CCC=DDD", vars[0])

--- a/libs/structs/structdiff/diff.go
+++ b/libs/structs/structdiff/diff.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/databricks/cli/libs/structs/structaccess"
@@ -272,7 +271,7 @@ func diffMapStringKey(ctx *diffContext, path *structpath.PathNode, m1, m2 reflec
 	for s := range keySet {
 		keys = append(keys, s)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	for _, ks := range keys {
 		k := keySet[ks]

--- a/libs/structs/structwalk/walk.go
+++ b/libs/structs/structwalk/walk.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"reflect"
 	"slices"
-	"sort"
 
 	"github.com/databricks/cli/libs/structs/structaccess"
 	"github.com/databricks/cli/libs/structs/structpath"
@@ -90,7 +89,7 @@ func walkValue(path *structpath.PathNode, val reflect.Value, field *reflect.Stru
 		for _, k := range val.MapKeys() {
 			keys = append(keys, k.String())
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, ks := range keys {
 			v := val.MapIndex(reflect.ValueOf(ks))
 			node := structpath.NewBracketString(path, ks)

--- a/libs/sync/dirset.go
+++ b/libs/sync/dirset.go
@@ -2,7 +2,7 @@ package sync
 
 import (
 	"path"
-	"sort"
+	"slices"
 )
 
 // DirSet is a set of directories.
@@ -37,7 +37,7 @@ func (dirset DirSet) Slice() []string {
 	for dir := range dirset {
 		out = append(out, dir)
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }
 

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"path"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -288,8 +288,8 @@ func (r *renderer) walk() error {
 			return err
 		}
 		// Sort by name to ensure deterministic ordering
-		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].Name() < entries[j].Name()
+		slices.SortFunc(entries, func(a, b fs.DirEntry) int {
+			return cmp.Compare(a.Name(), b.Name())
 		})
 		for _, entry := range entries {
 			if entry.IsDir() {

--- a/libs/template/writer.go
+++ b/libs/template/writer.go
@@ -1,9 +1,10 @@
 package template
 
 import (
+	"cmp"
 	"context"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -198,8 +199,8 @@ func (tmpl *writerWithFullTelemetry) LogTelemetry(ctx context.Context) {
 	}
 
 	// Sort the arguments by key for deterministic telemetry logging
-	sort.Slice(args, func(i, j int) bool {
-		return args[i].Key < args[j].Key
+	slices.SortFunc(args, func(a, b protos.BundleInitTemplateEnumArg) int {
+		return cmp.Compare(a.Key, b.Key)
 	})
 
 	telemetry.Log(ctx, protos.DatabricksCliLog{

--- a/libs/testdiff/replacement.go
+++ b/libs/testdiff/replacement.go
@@ -1,12 +1,12 @@
 package testdiff
 
 import (
+	"cmp"
 	"encoding/json"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -51,8 +51,8 @@ func (r *ReplacementsContext) Replace(s string) string {
 	// Sort replacements stably by Order to guarantee deterministic application sequence.
 	// A cloned slice is used to avoid mutating the original order held in the context.
 	repls := slices.Clone(r.Repls)
-	sort.SliceStable(repls, func(i, j int) bool {
-		return repls[i].Order < repls[j].Order
+	slices.SortStableFunc(repls, func(a, b Replacement) int {
+		return cmp.Compare(a.Order, b.Order)
 	})
 	for _, repl := range repls {
 		if !repl.Distinct {

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -1,6 +1,7 @@
 package testserver
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,7 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -223,7 +224,7 @@ func (s *FakeWorkspace) JobsList() Response {
 		list = append(list, baseJob)
 	}
 
-	sort.Slice(list, func(i, j int) bool { return list[i].JobId < list[j].JobId })
+	slices.SortFunc(list, func(a, b jobs.BaseJob) int { return cmp.Compare(a.JobId, b.JobId) })
 	return Response{Body: jobs.ListJobsResponse{Jobs: list}}
 }
 

--- a/libs/testserver/serving_endpoints.go
+++ b/libs/testserver/serving_endpoints.go
@@ -3,7 +3,7 @@ package testserver
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/databricks/databricks-sdk-go/service/serving"
 )
@@ -298,7 +298,7 @@ func (s *FakeWorkspace) ServingEndpointPatchTags(req Request, name string) Respo
 	for key := range tagMap {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	for _, key := range keys {
 		tags = append(tags, serving.EndpointTag{Key: key, Value: tagMap[key]})
 	}

--- a/libs/utils/utils.go
+++ b/libs/utils/utils.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"reflect"
-	"sort"
+	"slices"
 )
 
 func SortedKeys[T any](m map[string]T) []string {
@@ -10,7 +10,7 @@ func SortedKeys[T any](m map[string]T) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }
 


### PR DESCRIPTION
## Summary

Migrate from the `sort` package to the `slices` and `cmp` packages across the codebase.

The `slices` package (stable since Go 1.21, extended in Go 1.23) provides type-safe, generic alternatives to `sort`. Go 1.23 added `slices.Sorted` and `slices.SortedFunc`, making the full migration more compelling since the `sort` import can often be dropped entirely.

Key replacements:
- `sort.Strings` → `slices.Sort`
- `sort.Slice` → `slices.SortFunc`
- `sort.SliceStable` → `slices.SortStableFunc`

The original prompt identified ~25 `sort.Strings` call sites and ~3 `sort.SliceStable` call sites across ~46 files importing `sort`. This is a low-risk, mechanical migration.

The `.golangci.yaml` configuration is updated to flag any new usage of the `sort` package.

## Test plan

- [x] Existing unit tests pass (`make test`)
- [x] Linter passes (`make lint`)

This pull request was AI-assisted by Isaac.