### PR TITLE
Migrate from math/rand to math/rand/v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,6 +34,10 @@ linters:
           deny:
             - pkg: "github.com/databricks/cli/experimental"
               desc: "must not import experimental/ packages; use an interface or move the dependency"
+        no-legacy-rand:
+          deny:
+            - pkg: "math/rand$"
+              desc: "use math/rand/v2 instead of math/rand"
     forbidigo:
       forbid:
         - pattern: 'term\.IsTerminal'

--- a/integration/libs/locker/locker_test.go
+++ b/integration/libs/locker/locker_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +40,7 @@ func TestLock(t *testing.T) {
 	var wg sync.WaitGroup
 	for currentIndex := range numConcurrentLocks {
 		wg.Go(func() {
-			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+			time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
 			lockerErrs[currentIndex] = lockers[currentIndex].Lock(ctx, false)
 		})
 	}

--- a/libs/template/helpers.go
+++ b/libs/template/helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"os"
 	"regexp"
@@ -66,9 +66,9 @@ func loadHelpers(ctx context.Context) template.FuncMap {
 		"regexp": func(expr string) (*regexp.Regexp, error) {
 			return regexp.Compile(expr)
 		},
-		// Alias for https://pkg.go.dev/math/rand#Intn. Returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n).
+		// Alias for https://pkg.go.dev/math/rand/v2#IntN. Returns, as an int, a non-negative pseudo-random number in the half-open interval [0,n).
 		"random_int": func(n int) int {
-			return rand.Intn(n)
+			return rand.IntN(n)
 		},
 		// Alias for https://pkg.go.dev/github.com/google/uuid#New. Returns, as a string, a UUID which is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC 4122.
 		"uuid": func() string {


### PR DESCRIPTION
## Summary
- Replace `math/rand` with `math/rand/v2` and `Intn` with `IntN` in the two files that used it
- Add depguard lint rule to prevent reintroduction of `math/rand` v1

Per the [Go 1.22 release notes](https://go.dev/doc/go1.22#math/rand/v2), `math/rand/v2` is the recommended replacement for `math/rand`.

This pull request was AI-assisted by Isaac.