### PR TITLE
Use slices.Backward and slices.Reverse for reverse iteration

### DIFF
--- a/bundle/run/pipeline.go
+++ b/bundle/run/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/databricks/cli/bundle"
@@ -63,10 +64,9 @@ func (r *pipelineRunner) logErrorEvent(ctx context.Context, pipelineId, updateId
 		return err
 	}
 	updateEvents := filterEventsByUpdateId(events, updateId)
-	// The events API returns most recent events first. We iterate in a reverse order
-	// to print the events chronologically
-	for i := len(updateEvents) - 1; i >= 0; i-- {
-		r.logEvent(ctx, updateEvents[i])
+	// The events API returns most recent events first.
+	for _, event := range slices.Backward(updateEvents) {
+		r.logEvent(ctx, event)
 	}
 	return nil
 }

--- a/bundle/run/progress/pipeline.go
+++ b/bundle/run/progress/pipeline.go
@@ -3,6 +3,7 @@ package progress
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go"
@@ -83,9 +84,8 @@ func (l *UpdateTracker) Events(ctx context.Context) ([]ProgressEvent, error) {
 	}
 
 	var result []ProgressEvent
-	// we iterate in reverse to return events in chronological order
-	for i := len(events) - 1; i >= 0; i-- {
-		event := events[i]
+	// Return events in chronological order.
+	for _, event := range slices.Backward(events) {
 		// filter to only include update_progress and flow_progress events
 		if event.EventType == "flow_progress" || event.EventType == "update_progress" {
 			result = append(result, ProgressEvent(event))

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -1404,8 +1404,8 @@ func removeEmptyDirs(root string) error {
 	if err != nil {
 		return err
 	}
-	for i := len(dirs) - 1; i >= 0; i-- {
-		_ = os.Remove(dirs[i])
+	for _, dir := range slices.Backward(dirs) {
+		_ = os.Remove(dir)
 	}
 	return nil
 }

--- a/cmd/root/user_agent_command.go
+++ b/cmd/root/user_agent_command.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/useragent"
@@ -24,12 +25,8 @@ func commandString(cmd *cobra.Command) string {
 		reversed = append(reversed, p.Name())
 	})
 
-	ordered := make([]string, 0, len(reversed))
-	for i := len(reversed) - 1; i >= 0; i-- {
-		ordered = append(ordered, reversed[i])
-	}
-
-	return strings.Join(ordered, commandSeparator)
+	slices.Reverse(reversed)
+	return strings.Join(reversed, commandSeparator)
 }
 
 func withCommandInUserAgent(ctx context.Context, cmd *cobra.Command) context.Context {

--- a/libs/dagrun/dagrun.go
+++ b/libs/dagrun/dagrun.go
@@ -2,6 +2,7 @@ package dagrun
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -129,12 +130,8 @@ func (g *Graph) DetectCycle() error {
 							break
 						}
 					}
-					for i, j := 0, len(nodes)-1; i < j; i, j = i+1, j-1 {
-						nodes[i], nodes[j] = nodes[j], nodes[i]
-					}
-					for i, j := 0, len(edges)-1; i < j; i, j = i+1, j-1 {
-						edges[i], edges[j] = edges[j], edges[i]
-					}
+					slices.Reverse(nodes)
+					slices.Reverse(edges)
 					edges = append(edges, closeLbl)
 					return &CycleError{Nodes: nodes, Edges: edges}
 				}

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -326,8 +326,8 @@ func (w *FilesClient) recursiveDelete(ctx context.Context, name string) error {
 	// Delete the directories in reverse order to ensure that the parent
 	// directories are deleted after the children. This is possible because
 	// fs.WalkDir walks the directories in lexicographical order.
-	for i := len(dirsToDelete) - 1; i >= 0; i-- {
-		err := w.deleteDirectory(ctx, dirsToDelete[i])
+	for _, dir := range slices.Backward(dirsToDelete) {
+		err := w.deleteDirectory(ctx, dir)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- Replace manual `for i := len(s) - 1; i >= 0; i--` loops with `slices.Backward` (4 sites)
- Replace manual swap-based reversals with `slices.Reverse` (2 sites)
- Simplify `commandString` by reversing in place instead of copying to a new slice

## Test plan
- [x] `go build ./...`
- [x] `go test` passes for all 6 affected packages

This pull request was AI-assisted by Isaac.