### PR TITLE
Replace gorilla/mux with Go 1.22 stdlib ServeMux in test server

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -79,10 +79,6 @@ Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
 License - https://github.com/darccio/mergo/blob/master/LICENSE
 
-gorilla/mux - https://github.com/gorilla/mux
-Copyright (c) 2023 The Gorilla Authors. All rights reserved.
-License - https://github.com/gorilla/mux/blob/main/LICENSE
-
 palantir/pkg - https://github.com/palantir/pkg
 Copyright (c) 2016, Palantir Technologies, Inc.
 License - https://github.com/palantir/pkg/blob/master/LICENSE

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -73,5 +73,5 @@ Pattern = "POST /api/2.0/sql/statements/"
 Response.Body = '{"status": {"state": "SUCCEEDED"}, "manifest": {"schema": {"columns": []}}}'
 
 [[Server]]
-Pattern = "DELETE /api/2.1/unity-catalog/tables/{name}"
+Pattern = "DELETE /api/2.1/unity-catalog/tables/{full_name}"
 Response.Body = '{"status": "OK"}'

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -81,5 +81,5 @@ Pattern = "POST /api/2.0/sql/statements/"
 Response.Body = '{"status": {"state": "SUCCEEDED"}, "manifest": {"schema": {"columns": []}}}'
 
 [[Server]]
-Pattern = "DELETE /api/2.1/unity-catalog/tables/{name}"
+Pattern = "DELETE /api/2.1/unity-catalog/tables/{full_name}"
 Response.Body = '{"status": "OK"}'

--- a/acceptance/bundle/resources/synced_database_tables/basic/test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/test.toml
@@ -20,5 +20,5 @@ Pattern = "POST /api/2.0/sql/statements/"
 Response.Body = '{"status": {"state": "SUCCEEDED"}, "manifest": {"schema": {"columns": []}}}'
 
 [[Server]]
-Pattern = "DELETE /api/2.1/unity-catalog/tables/{name}"
+Pattern = "DELETE /api/2.1/unity-catalog/tables/{full_name}"
 Response.Body = '{"status": "OK"}'

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -188,8 +188,8 @@ func startLocalServer(t *testing.T,
 	killCountersMu := &sync.Mutex{}
 
 	for ind := range stubs {
-		// We want later stubs takes precedence, because then leaf configs take precedence over parent directory configs
-		// In gorilla/mux earlier handlers take precedence, so we need to reverse the order
+		// Later stubs take precedence over earlier ones (leaf configs override parent configs).
+		// The first handler registered for a given pattern wins, so we reverse the order.
 		stub := stubs[len(stubs)-1-ind]
 		require.NotEmpty(t, stub.Pattern)
 		items := strings.Split(stub.Pattern, " ")
@@ -226,7 +226,8 @@ func startLocalServer(t *testing.T,
 		})
 	}
 
-	// The earliest handlers take precedence, add default handlers last
+	// The first handler registered for a given pattern wins, so default
+	// handlers registered last serve as fallbacks.
 	testserver.AddDefaultHandlers(s)
 	return s.URL
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/fatih/color v1.19.0 // MIT
 	github.com/google/jsonschema-go v0.4.2 // MIT
 	github.com/google/uuid v1.6.0 // BSD-3-Clause
-	github.com/gorilla/mux v1.8.1 // BSD-3-Clause
 	github.com/gorilla/websocket v1.5.3 // BSD-2-Clause
 	github.com/hashicorp/go-version v1.8.0 // MPL-2.0
 	github.com/hashicorp/hc-install v0.9.3 // MPL-2.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/databricks/databricks-sdk-go v0.128.0 // Apache-2.0
 	github.com/google/jsonschema-go v0.4.3 // MIT
 	github.com/google/uuid v1.6.0 // BSD-3-Clause
-	github.com/gorilla/mux v1.8.1 // BSD-3-Clause
 	github.com/gorilla/websocket v1.5.3 // BSD-2-Clause
 	github.com/hashicorp/go-version v1.9.0 // MPL-2.0
 	github.com/hashicorp/hc-install v0.9.3 // MPL-2.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.11 h1:vAe81Msw+8tKUxi2Dq
 github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
 github.com/googleapis/gax-go/v2 v2.17.0 h1:RksgfBpxqff0EZkDWYuz9q/uWsTVz+kf43LsZ1J6SMc=
 github.com/googleapis/gax-go/v2 v2.17.0/go.mod h1:mzaqghpQp4JDh3HvADwrat+6M3MOIDp5YKHhb9PAgDY=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.11 h1:vAe81Msw+8tKUxi2Dq
 github.com/googleapis/enterprise-certificate-proxy v0.3.11/go.mod h1:RFV7MUdlb7AgEq2v7FmMCfeSMCllAzWxFgRdusoGks8=
 github.com/googleapis/gax-go/v2 v2.17.0 h1:RksgfBpxqff0EZkDWYuz9q/uWsTVz+kf43LsZ1J6SMc=
 github.com/googleapis/gax-go/v2 v2.17.0/go.mod h1:mzaqghpQp4JDh3HvADwrat+6M3MOIDp5YKHhb9PAgDY=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -109,7 +109,7 @@ func AddDefaultHandlers(server *Server) {
 		return ""
 	})
 
-	server.Handle("POST", "/api/2.0/workspace-files/import-file/{path:.*}", func(req Request) any {
+	server.Handle("POST", "/api/2.0/workspace-files/import-file/{path...}", func(req Request) any {
 		path := req.Vars["path"]
 		overwrite := req.URL.Query().Get("overwrite") == "true"
 		return req.Workspace.WorkspaceFilesImportFile(path, req.Body, overwrite)
@@ -145,12 +145,12 @@ func AddDefaultHandlers(server *Server) {
 		return req.Workspace.WorkspaceFilesImportFile(request.Path, decoded, request.Overwrite)
 	})
 
-	server.Handle("GET", "/api/2.0/workspace-files/{path:.*}", func(req Request) any {
+	server.Handle("GET", "/api/2.0/workspace-files/{path...}", func(req Request) any {
 		path := req.Vars["path"]
 		return req.Workspace.WorkspaceFilesExportFile(path)
 	})
 
-	server.Handle("HEAD", "/api/2.0/fs/directories/{path:.*}", func(req Request) any {
+	server.Handle("HEAD", "/api/2.0/fs/directories/{path...}", func(req Request) any {
 		dirPath := req.Vars["path"]
 		if !strings.HasPrefix(dirPath, "/") {
 			dirPath = "/" + dirPath
@@ -165,7 +165,7 @@ func AddDefaultHandlers(server *Server) {
 		return Response{StatusCode: 404}
 	})
 
-	server.Handle("HEAD", "/api/2.0/fs/files/{path:.*}", func(req Request) any {
+	server.Handle("HEAD", "/api/2.0/fs/files/{path...}", func(req Request) any {
 		path := req.Vars["path"]
 		if req.Workspace.FileExists(path) {
 			return Response{StatusCode: 200}
@@ -173,7 +173,7 @@ func AddDefaultHandlers(server *Server) {
 		return Response{StatusCode: 404}
 	})
 
-	server.Handle("PUT", "/api/2.0/fs/directories/{path:.*}", func(req Request) any {
+	server.Handle("PUT", "/api/2.0/fs/directories/{path...}", func(req Request) any {
 		dirPath := req.Vars["path"]
 		if !strings.HasPrefix(dirPath, "/") {
 			dirPath = "/" + dirPath
@@ -194,13 +194,13 @@ func AddDefaultHandlers(server *Server) {
 		return Response{}
 	})
 
-	server.Handle("PUT", "/api/2.0/fs/files/{path:.*}", func(req Request) any {
+	server.Handle("PUT", "/api/2.0/fs/files/{path...}", func(req Request) any {
 		path := req.Vars["path"]
 		overwrite := req.URL.Query().Get("overwrite") == "true"
 		return req.Workspace.WorkspaceFilesImportFile(path, req.Body, overwrite)
 	})
 
-	server.Handle("GET", "/api/2.0/fs/files/{path:.*}", func(req Request) any {
+	server.Handle("GET", "/api/2.0/fs/files/{path...}", func(req Request) any {
 		path := req.Vars["path"]
 		data := req.Workspace.WorkspaceFilesExportFile(path)
 		if data == nil {

--- a/libs/testserver/router.go
+++ b/libs/testserver/router.go
@@ -1,0 +1,124 @@
+package testserver
+
+import (
+	"net/http"
+	"strings"
+)
+
+// HandlerFunc is the test-server handler signature.
+type HandlerFunc func(req Request) any
+
+// Router maps method+path to a HandlerFunc. Wildcards use Go 1.22 ServeMux
+// placeholder syntax ({name} or {name...}).
+//
+// # Why a custom router
+//
+// Go 1.22 added method matching ("GET /path") and {name}/{name...}
+// placeholders to http.ServeMux, covering most of what we previously used
+// gorilla/mux for. But two ServeMux behaviors make it inconvenient to use
+// directly in the test server:
+//
+//   - Exact and wildcard patterns conflict when they cover the same
+//     request under different methods. ServeMux treats `GET /x` as
+//     matching both GET and HEAD, so it overlaps with `HEAD /{path...}`
+//     and panics at registration. Test fixtures register both kinds of
+//     routes side by side, so we keep exact paths in our own map and
+//     only delegate wildcards to ServeMux. Exact lookup runs first;
+//     misses fall through to ServeMux, which also lets a wildcard
+//     handler serve methods that the exact registration doesn't cover.
+//
+//   - ServeMux panics on duplicate pattern registration. Router silently
+//     drops the later registration — first wins. Two callers rely on this:
+//     AddDefaultHandlers (libs/testserver/handlers.go) installs fallback
+//     handlers that any test stub for the same pattern can override, and
+//     startLocalServer (acceptance/internal/prepare_server.go) iterates
+//     test.toml stubs in reverse so leaf-directory configs register first
+//     and win over inherited parent stubs.
+//
+// Router also clears req.URL.RawPath before dispatch so percent-encoded
+// slashes (%2F) match literal slashes in patterns; workspace file paths
+// in tests routinely contain encoded slashes.
+type Router struct {
+	mux      *http.ServeMux
+	exact    map[string]map[string]HandlerFunc
+	wildcard map[string]bool
+
+	// Dispatch is invoked when a route matches. vars holds the path values for
+	// wildcard routes and is nil for exact routes.
+	Dispatch func(w http.ResponseWriter, r *http.Request, h HandlerFunc, vars map[string]string)
+	// NotFound is invoked when no route matches.
+	NotFound http.HandlerFunc
+}
+
+func NewRouter() *Router {
+	r := &Router{
+		mux:      http.NewServeMux(),
+		exact:    map[string]map[string]HandlerFunc{},
+		wildcard: map[string]bool{},
+	}
+	r.mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		if r.NotFound != nil {
+			r.NotFound(w, req)
+		}
+	})
+	return r
+}
+
+// Handle registers a handler for method+path. First registration wins;
+// duplicate (method, path) registrations are ignored.
+func (r *Router) Handle(method, path string, handler HandlerFunc) {
+	if !strings.Contains(path, "{") {
+		if r.exact[path] == nil {
+			r.exact[path] = map[string]HandlerFunc{}
+		}
+		if _, ok := r.exact[path][method]; !ok {
+			r.exact[path][method] = handler
+		}
+		return
+	}
+	pattern := method + " " + path
+	if r.wildcard[pattern] {
+		return
+	}
+	r.wildcard[pattern] = true
+	names := wildcardNames(path)
+	r.mux.HandleFunc(pattern, func(w http.ResponseWriter, req *http.Request) {
+		vars := make(map[string]string, len(names))
+		for _, name := range names {
+			vars[name] = req.PathValue(name)
+		}
+		if r.Dispatch != nil {
+			r.Dispatch(w, req, handler, vars)
+		}
+	})
+}
+
+// ServeHTTP routes a request to the registered handler, falling back to
+// NotFound if no route matches.
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Force ServeMux to match against the decoded path; see the type doc.
+	req.URL.RawPath = ""
+	if methods, ok := r.exact[req.URL.Path]; ok {
+		if h, ok := methods[req.Method]; ok {
+			if r.Dispatch != nil {
+				r.Dispatch(w, req, h, nil)
+			}
+			return
+		}
+	}
+	r.mux.ServeHTTP(w, req)
+}
+
+// wildcardNames extracts wildcard parameter names from a path pattern,
+// e.g. "/api/{id}/files/{path...}" returns ["id", "path"].
+func wildcardNames(path string) []string {
+	var names []string
+	for _, part := range strings.Split(path, "/") {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			name := part[1 : len(part)-1]
+			name = strings.TrimSuffix(name, "...")
+			names = append(names, name)
+		}
+	}
+	return names
+}

--- a/libs/testserver/router.go
+++ b/libs/testserver/router.go
@@ -113,7 +113,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // e.g. "/api/{id}/files/{path...}" returns ["id", "path"].
 func wildcardNames(path string) []string {
 	var names []string
-	for _, part := range strings.Split(path, "/") {
+	for part := range strings.SplitSeq(path, "/") {
 		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
 			name := part[1 : len(part)-1]
 			name = strings.TrimSuffix(name, "...")

--- a/libs/testserver/router_test.go
+++ b/libs/testserver/router_test.go
@@ -1,0 +1,137 @@
+package testserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/stretchr/testify/assert"
+)
+
+type capture struct {
+	handler  string
+	vars     map[string]string
+	notFound bool
+}
+
+func newRouter(t *testing.T) (*testserver.Router, *capture) {
+	t.Helper()
+	c := &capture{}
+	r := testserver.NewRouter()
+	r.Dispatch = func(w http.ResponseWriter, req *http.Request, h testserver.HandlerFunc, vars map[string]string) {
+		c.vars = vars
+		c.handler = h(testserver.Request{}).(string)
+	}
+	r.NotFound = func(w http.ResponseWriter, req *http.Request) {
+		c.notFound = true
+	}
+	return r, c
+}
+
+func handlerNamed(name string) testserver.HandlerFunc {
+	return func(req testserver.Request) any { return name }
+}
+
+func TestRouterExactMatch(t *testing.T) {
+	r, c := newRouter(t)
+	r.Handle("GET", "/foo", handlerNamed("foo-get"))
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/foo", nil))
+	assert.Equal(t, "foo-get", c.handler)
+	assert.Nil(t, c.vars)
+}
+
+func TestRouterWildcardMatch(t *testing.T) {
+	r, c := newRouter(t)
+	r.Handle("GET", "/items/{id}", handlerNamed("item-get"))
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/items/42", nil))
+	assert.Equal(t, "item-get", c.handler)
+	assert.Equal(t, map[string]string{"id": "42"}, c.vars)
+}
+
+func TestRouterCatchAllWildcard(t *testing.T) {
+	r, c := newRouter(t)
+	r.Handle("GET", "/files/{path...}", handlerNamed("files-get"))
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/files/a/b/c", nil))
+	assert.Equal(t, "files-get", c.handler)
+	assert.Equal(t, map[string]string{"path": "a/b/c"}, c.vars)
+}
+
+func TestRouterMultipleWildcards(t *testing.T) {
+	r, c := newRouter(t)
+	r.Handle("GET", "/items/{id}/files/{path...}", handlerNamed("nested"))
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/items/42/files/a/b", nil))
+	assert.Equal(t, "nested", c.handler)
+	assert.Equal(t, map[string]string{"id": "42", "path": "a/b"}, c.vars)
+}
+
+func TestRouterExactBeforeWildcard(t *testing.T) {
+	r, c := newRouter(t)
+	r.Handle("GET", "/foo", handlerNamed("exact"))
+	r.Handle("HEAD", "/{path...}", handlerNamed("wildcard-head"))
+
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/foo", nil))
+	assert.Equal(t, "exact", c.handler)
+
+	c.handler = ""
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("HEAD", "/foo", nil))
+	assert.Equal(t, "wildcard-head", c.handler)
+}
+
+func TestRouterFirstRegistrationWins(t *testing.T) {
+	t.Run("exact", func(t *testing.T) {
+		r, c := newRouter(t)
+		r.Handle("GET", "/foo", handlerNamed("first"))
+		r.Handle("GET", "/foo", handlerNamed("second"))
+
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/foo", nil))
+		assert.Equal(t, "first", c.handler)
+	})
+
+	t.Run("wildcard", func(t *testing.T) {
+		r, c := newRouter(t)
+		r.Handle("GET", "/items/{id}", handlerNamed("first"))
+		r.Handle("GET", "/items/{id}", handlerNamed("second"))
+
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/items/42", nil))
+		assert.Equal(t, "first", c.handler)
+	})
+}
+
+func TestRouterNotFound(t *testing.T) {
+	r, c := newRouter(t)
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/missing", nil))
+	assert.True(t, c.notFound)
+}
+
+func TestRouterMethodNotAllowed(t *testing.T) {
+	t.Run("exact", func(t *testing.T) {
+		r, c := newRouter(t)
+		r.Handle("GET", "/foo", handlerNamed("foo-get"))
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/foo", nil))
+		assert.True(t, c.notFound, "wrong method on exact path should hit NotFound")
+		assert.Empty(t, c.handler)
+	})
+
+	t.Run("wildcard", func(t *testing.T) {
+		r, c := newRouter(t)
+		r.Handle("GET", "/items/{id}", handlerNamed("item-get"))
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/items/42", nil))
+		assert.True(t, c.notFound, "wrong method on wildcard path should hit NotFound")
+		assert.Empty(t, c.handler)
+	})
+}
+
+func TestRouterPercentEncodedSlash(t *testing.T) {
+	r, c := newRouter(t)
+	r.Handle("GET", "/files/{path...}", handlerNamed("files-get"))
+
+	req := httptest.NewRequest("GET", "/files/a%2Fb%2Fc", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	assert.Equal(t, "files-get", c.handler)
+	assert.Equal(t, "a/b/c", c.vars["path"])
+}

--- a/libs/testserver/router_test.go
+++ b/libs/testserver/router_test.go
@@ -37,7 +37,7 @@ func TestRouterExactMatch(t *testing.T) {
 	r, c := newRouter(t)
 	r.Handle("GET", "/foo", handlerNamed("foo-get"))
 
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/foo", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/foo", nil))
 	assert.Equal(t, "foo-get", c.handler)
 	assert.Nil(t, c.vars)
 }
@@ -46,7 +46,7 @@ func TestRouterWildcardMatch(t *testing.T) {
 	r, c := newRouter(t)
 	r.Handle("GET", "/items/{id}", handlerNamed("item-get"))
 
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/items/42", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/items/42", nil))
 	assert.Equal(t, "item-get", c.handler)
 	assert.Equal(t, map[string]string{"id": "42"}, c.vars)
 }
@@ -55,7 +55,7 @@ func TestRouterCatchAllWildcard(t *testing.T) {
 	r, c := newRouter(t)
 	r.Handle("GET", "/files/{path...}", handlerNamed("files-get"))
 
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/files/a/b/c", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/files/a/b/c", nil))
 	assert.Equal(t, "files-get", c.handler)
 	assert.Equal(t, map[string]string{"path": "a/b/c"}, c.vars)
 }
@@ -64,7 +64,7 @@ func TestRouterMultipleWildcards(t *testing.T) {
 	r, c := newRouter(t)
 	r.Handle("GET", "/items/{id}/files/{path...}", handlerNamed("nested"))
 
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/items/42/files/a/b", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/items/42/files/a/b", nil))
 	assert.Equal(t, "nested", c.handler)
 	assert.Equal(t, map[string]string{"id": "42", "path": "a/b"}, c.vars)
 }
@@ -74,11 +74,11 @@ func TestRouterExactBeforeWildcard(t *testing.T) {
 	r.Handle("GET", "/foo", handlerNamed("exact"))
 	r.Handle("HEAD", "/{path...}", handlerNamed("wildcard-head"))
 
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/foo", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/foo", nil))
 	assert.Equal(t, "exact", c.handler)
 
 	c.handler = ""
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("HEAD", "/foo", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodHead, "/foo", nil))
 	assert.Equal(t, "wildcard-head", c.handler)
 }
 
@@ -88,7 +88,7 @@ func TestRouterFirstRegistrationWins(t *testing.T) {
 		r.Handle("GET", "/foo", handlerNamed("first"))
 		r.Handle("GET", "/foo", handlerNamed("second"))
 
-		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/foo", nil))
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/foo", nil))
 		assert.Equal(t, "first", c.handler)
 	})
 
@@ -97,14 +97,14 @@ func TestRouterFirstRegistrationWins(t *testing.T) {
 		r.Handle("GET", "/items/{id}", handlerNamed("first"))
 		r.Handle("GET", "/items/{id}", handlerNamed("second"))
 
-		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/items/42", nil))
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/items/42", nil))
 		assert.Equal(t, "first", c.handler)
 	})
 }
 
 func TestRouterNotFound(t *testing.T) {
 	r, c := newRouter(t)
-	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/missing", nil))
+	r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/missing", nil))
 	assert.True(t, c.notFound)
 }
 
@@ -112,7 +112,7 @@ func TestRouterMethodNotAllowed(t *testing.T) {
 	t.Run("exact", func(t *testing.T) {
 		r, c := newRouter(t)
 		r.Handle("GET", "/foo", handlerNamed("foo-get"))
-		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/foo", nil))
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/foo", nil))
 		assert.True(t, c.notFound, "wrong method on exact path should hit NotFound")
 		assert.Empty(t, c.handler)
 	})
@@ -120,7 +120,7 @@ func TestRouterMethodNotAllowed(t *testing.T) {
 	t.Run("wildcard", func(t *testing.T) {
 		r, c := newRouter(t)
 		r.Handle("GET", "/items/{id}", handlerNamed("item-get"))
-		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/items/42", nil))
+		r.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/items/42", nil))
 		assert.True(t, c.notFound, "wrong method on wildcard path should hit NotFound")
 		assert.Empty(t, c.handler)
 	})
@@ -130,7 +130,7 @@ func TestRouterPercentEncodedSlash(t *testing.T) {
 	r, c := newRouter(t)
 	r.Handle("GET", "/files/{path...}", handlerNamed("files-get"))
 
-	req := httptest.NewRequest("GET", "/files/a%2Fb%2Fc", nil)
+	req := httptest.NewRequest(http.MethodGet, "/files/a%2Fb%2Fc", nil)
 	r.ServeHTTP(httptest.NewRecorder(), req)
 	assert.Equal(t, "files-get", c.handler)
 	assert.Equal(t, "a/b/c", c.vars["path"])

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 
 	"github.com/databricks/cli/internal/testutil"
-	"github.com/gorilla/mux"
 )
 
 const testPidKey = "test-pid"
@@ -38,9 +37,12 @@ func ExtractPidFromHeaders(headers http.Header) int {
 
 type Server struct {
 	*httptest.Server
-	Router *mux.Router
 
 	t testutil.TestingT
+
+	mux             *http.ServeMux
+	wildcardMethods map[string]bool                   // "METHOD /pattern" -> registered
+	exactRoutes     map[string]map[string]HandlerFunc // path -> method -> handler
 
 	fakeWorkspaces map[string]*FakeWorkspace
 	fakeOidc       *FakeOidc
@@ -83,7 +85,6 @@ func NewRequest(t testutil.TestingT, r *http.Request, fakeWorkspace *FakeWorkspa
 		URL:       r.URL,
 		Headers:   r.Header,
 		Body:      body,
-		Vars:      mux.Vars(r),
 		Workspace: fakeWorkspace,
 		Context:   r.Context(),
 	}
@@ -200,17 +201,43 @@ func getHeaders(value []byte) http.Header {
 }
 
 func New(t testutil.TestingT) *Server {
-	router := mux.NewRouter()
-	server := httptest.NewServer(router)
-	t.Cleanup(server.Close)
+	mux := http.NewServeMux()
 
 	s := &Server{
-		Server:         server,
-		Router:         router,
-		t:              t,
-		fakeWorkspaces: map[string]*FakeWorkspace{},
-		fakeOidc:       &FakeOidc{url: server.URL},
+		t:               t,
+		mux:             mux,
+		wildcardMethods: map[string]bool{},
+		exactRoutes:     map[string]map[string]HandlerFunc{},
+		fakeWorkspaces:  map[string]*FakeWorkspace{},
 	}
+
+	// Exact (non-wildcard) routes are kept out of ServeMux to avoid
+	// conflicts between method-specific exact paths and wildcard patterns
+	// (e.g., GET on an exact path vs HEAD on a wildcard that covers it).
+	//
+	// When an exact path is registered for one method but a request arrives
+	// for a different method, it intentionally falls through to ServeMux.
+	// This lets wildcard handlers serve methods not covered by the exact
+	// registration (e.g., a stub registers GET /exact, but HEAD /exact
+	// falls through to the wildcard HEAD handler).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Clear RawPath so ServeMux matches decoded paths; without this,
+		// percent-encoded slashes (%2F) would not match literal slashes.
+		if r.URL.RawPath != "" {
+			r.URL.RawPath = ""
+		}
+		if methods, ok := s.exactRoutes[r.URL.Path]; ok {
+			if handler, ok := methods[r.Method]; ok {
+				s.serve(w, r, handler, nil)
+				return
+			}
+		}
+		mux.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	s.Server = server
+	s.fakeOidc = &FakeOidc{url: server.URL}
 
 	t.Cleanup(func() {
 		for _, ws := range s.fakeWorkspaces {
@@ -218,46 +245,8 @@ func New(t testutil.TestingT) *Server {
 		}
 	})
 
-	// Set up the not found handler as fallback
-	notFoundFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		pattern := r.Method + " " + r.URL.Path
-		bodyBytes, err := io.ReadAll(r.Body)
-		var body string
-		if err != nil {
-			body = fmt.Sprintf("failed to read the body: %s", err)
-		} else {
-			body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
-		}
-
-		t.Errorf(`No handler for URL: %s
-Body: %s
-
-For acceptance tests, add this to test.toml:
-[[Server]]
-Pattern = %q
-Response.Body = '<response body here>'
-# Response.StatusCode = <response code if not 200>
-`, r.URL, body, pattern)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotImplemented)
-
-		resp := map[string]string{
-			"message": "No stub found for pattern: " + pattern,
-		}
-
-		respBytes, err := json.Marshal(resp)
-		if err != nil {
-			t.Errorf("JSON encoding error: %s", err)
-			respBytes = []byte("{\"message\": \"JSON encoding error\"}")
-		}
-
-		if _, err := w.Write(respBytes); err != nil {
-			t.Errorf("Response write error: %s", err)
-		}
-	})
-	router.NotFoundHandler = notFoundFunc
-	router.MethodNotAllowedHandler = notFoundFunc
+	// Register a catch-all handler as fallback for unmatched routes.
+	mux.HandleFunc("/", s.handleNotFound)
 
 	// Register a default handler for the SDK's host metadata discovery endpoint.
 	// The SDK resolves this during config initialization (as of v0.126.0) to
@@ -291,48 +280,136 @@ func (s *Server) getWorkspaceForToken(token string) *FakeWorkspace {
 
 type HandlerFunc func(req Request) any
 
+// Handle registers a handler for the given method and path pattern.
+// First registration wins: subsequent calls with the same method+path are
+// ignored. Exact paths are stored in a map checked before ServeMux;
+// wildcard paths are registered with ServeMux using method-specific patterns.
 func (s *Server) Handle(method, path string, handler HandlerFunc) {
-	s.Router.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		// Each test uses unique DATABRICKS_TOKEN, we simulate each token having
-		// it's own fake fakeWorkspace to avoid interference between tests.
-		fakeWorkspace := s.getWorkspaceForToken(getToken(r))
+	if !strings.Contains(path, "{") {
+		s.handleExact(method, path, handler)
+	} else {
+		s.handleWildcard(method, path, handler)
+	}
+}
 
-		request := NewRequest(s.t, r, fakeWorkspace)
+func (s *Server) handleExact(method, path string, handler HandlerFunc) {
+	if s.exactRoutes[path] == nil {
+		s.exactRoutes[path] = map[string]HandlerFunc{}
+	}
+	if _, exists := s.exactRoutes[path][method]; !exists {
+		s.exactRoutes[path][method] = handler
+	}
+}
 
-		if s.RequestCallback != nil {
-			s.RequestCallback(&request)
+func (s *Server) handleWildcard(method, path string, handler HandlerFunc) {
+	pattern := method + " " + path
+	if s.wildcardMethods[pattern] {
+		return
+	}
+	s.wildcardMethods[pattern] = true
+
+	names := wildcardNames(path)
+	s.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		vars := make(map[string]string, len(names))
+		for _, name := range names {
+			vars[name] = r.PathValue(name)
 		}
+		s.serve(w, r, handler, vars)
+	})
+}
 
-		var resp EncodedResponse
-
-		if bytes.Contains(request.Body, []byte("INJECT_ERROR")) {
-			resp = EncodedResponse{
-				StatusCode: 500,
-				Body:       []byte("INJECTED"),
-			}
-		} else {
-			respAny := handler(request)
-			if respAny == nil && request.Context.Err() != nil {
-				return
-			}
-			resp = normalizeResponse(s.t, respAny)
+// wildcardNames extracts wildcard parameter names from a path pattern,
+// e.g. "/api/{id}/files/{path...}" returns ["id", "path"].
+func wildcardNames(path string) []string {
+	var names []string
+	for _, part := range strings.Split(path, "/") {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			name := part[1 : len(part)-1]
+			name = strings.TrimSuffix(name, "...")
+			names = append(names, name)
 		}
+	}
+	return names
+}
 
-		for k, v := range resp.Headers {
-			w.Header()[k] = v
+// serve is the common request handling logic for both exact and wildcard routes.
+func (s *Server) serve(w http.ResponseWriter, r *http.Request, handler HandlerFunc, vars map[string]string) {
+	fakeWorkspace := s.getWorkspaceForToken(getToken(r))
+
+	request := NewRequest(s.t, r, fakeWorkspace)
+	request.Vars = vars
+
+	if s.RequestCallback != nil {
+		s.RequestCallback(&request)
+	}
+
+	var resp EncodedResponse
+
+	if bytes.Contains(request.Body, []byte("INJECT_ERROR")) {
+		resp = EncodedResponse{
+			StatusCode: 500,
+			Body:       []byte("INJECTED"),
 		}
-
-		w.WriteHeader(resp.StatusCode)
-
-		if s.ResponseCallback != nil {
-			s.ResponseCallback(&request, &resp)
-		}
-
-		if _, err := w.Write(resp.Body); err != nil {
-			s.t.Errorf("Failed to write response: %s", err)
+	} else {
+		respAny := handler(request)
+		if respAny == nil && request.Context.Err() != nil {
 			return
 		}
-	}).Methods(method)
+		resp = normalizeResponse(s.t, respAny)
+	}
+
+	for k, v := range resp.Headers {
+		w.Header()[k] = v
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	if s.ResponseCallback != nil {
+		s.ResponseCallback(&request, &resp)
+	}
+
+	if _, err := w.Write(resp.Body); err != nil {
+		s.t.Errorf("Failed to write response: %s", err)
+		return
+	}
+}
+
+func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
+	pattern := r.Method + " " + r.URL.Path
+	bodyBytes, err := io.ReadAll(r.Body)
+	var body string
+	if err != nil {
+		body = fmt.Sprintf("failed to read the body: %s", err)
+	} else {
+		body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
+	}
+
+	s.t.Errorf(`No handler for URL: %s
+Body: %s
+
+For acceptance tests, add this to test.toml:
+[[Server]]
+Pattern = %q
+Response.Body = '<response body here>'
+# Response.StatusCode = <response code if not 200>
+`, r.URL, body, pattern)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented)
+
+	resp := map[string]string{
+		"message": "No stub found for pattern: " + pattern,
+	}
+
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		s.t.Errorf("JSON encoding error: %s", err)
+		respBytes = []byte("{\"message\": \"JSON encoding error\"}")
+	}
+
+	if _, err := w.Write(respBytes); err != nil {
+		s.t.Errorf("Response write error: %s", err)
+	}
 }
 
 func getToken(r *http.Request) string {

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 
 	"github.com/databricks/cli/internal/testutil"
-	"github.com/gorilla/mux"
 )
 
 const testPidKey = "test-pid"
@@ -39,9 +38,12 @@ func ExtractPidFromHeaders(headers http.Header) int {
 
 type Server struct {
 	*httptest.Server
-	Router *mux.Router
 
 	t testutil.TestingT
+
+	mux             *http.ServeMux
+	wildcardMethods map[string]bool                   // "METHOD /pattern" -> registered
+	exactRoutes     map[string]map[string]HandlerFunc // path -> method -> handler
 
 	fakeWorkspaces map[string]*FakeWorkspace
 	fakeOidc       *FakeOidc
@@ -84,7 +86,6 @@ func NewRequest(t testutil.TestingT, r *http.Request, fakeWorkspace *FakeWorkspa
 		URL:       r.URL,
 		Headers:   r.Header,
 		Body:      body,
-		Vars:      mux.Vars(r),
 		Workspace: fakeWorkspace,
 		Context:   r.Context(),
 	}
@@ -201,17 +202,43 @@ func getHeaders(value []byte) http.Header {
 }
 
 func New(t testutil.TestingT) *Server {
-	router := mux.NewRouter()
-	server := httptest.NewServer(router)
-	t.Cleanup(server.Close)
+	mux := http.NewServeMux()
 
 	s := &Server{
-		Server:         server,
-		Router:         router,
-		t:              t,
-		fakeWorkspaces: map[string]*FakeWorkspace{},
-		fakeOidc:       &FakeOidc{url: server.URL},
+		t:               t,
+		mux:             mux,
+		wildcardMethods: map[string]bool{},
+		exactRoutes:     map[string]map[string]HandlerFunc{},
+		fakeWorkspaces:  map[string]*FakeWorkspace{},
 	}
+
+	// Exact (non-wildcard) routes are kept out of ServeMux to avoid
+	// conflicts between method-specific exact paths and wildcard patterns
+	// (e.g., GET on an exact path vs HEAD on a wildcard that covers it).
+	//
+	// When an exact path is registered for one method but a request arrives
+	// for a different method, it intentionally falls through to ServeMux.
+	// This lets wildcard handlers serve methods not covered by the exact
+	// registration (e.g., a stub registers GET /exact, but HEAD /exact
+	// falls through to the wildcard HEAD handler).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Clear RawPath so ServeMux matches decoded paths; without this,
+		// percent-encoded slashes (%2F) would not match literal slashes.
+		if r.URL.RawPath != "" {
+			r.URL.RawPath = ""
+		}
+		if methods, ok := s.exactRoutes[r.URL.Path]; ok {
+			if handler, ok := methods[r.Method]; ok {
+				s.serve(w, r, handler, nil)
+				return
+			}
+		}
+		mux.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	s.Server = server
+	s.fakeOidc = &FakeOidc{url: server.URL}
 
 	t.Cleanup(func() {
 		for _, ws := range s.fakeWorkspaces {
@@ -219,46 +246,8 @@ func New(t testutil.TestingT) *Server {
 		}
 	})
 
-	// Set up the not found handler as fallback
-	notFoundFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		pattern := r.Method + " " + r.URL.Path
-		bodyBytes, err := io.ReadAll(r.Body)
-		var body string
-		if err != nil {
-			body = fmt.Sprintf("failed to read the body: %s", err)
-		} else {
-			body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
-		}
-
-		t.Errorf(`No handler for URL: %s
-Body: %s
-
-For acceptance tests, add this to test.toml:
-[[Server]]
-Pattern = %q
-Response.Body = '<response body here>'
-# Response.StatusCode = <response code if not 200>
-`, r.URL, body, pattern)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotImplemented)
-
-		resp := map[string]string{
-			"message": "No stub found for pattern: " + pattern,
-		}
-
-		respBytes, err := json.Marshal(resp)
-		if err != nil {
-			t.Errorf("JSON encoding error: %s", err)
-			respBytes = []byte("{\"message\": \"JSON encoding error\"}")
-		}
-
-		if _, err := w.Write(respBytes); err != nil {
-			t.Errorf("Response write error: %s", err)
-		}
-	})
-	router.NotFoundHandler = notFoundFunc
-	router.MethodNotAllowedHandler = notFoundFunc
+	// Register a catch-all handler as fallback for unmatched routes.
+	mux.HandleFunc("/", s.handleNotFound)
 
 	// Register a default handler for the SDK's host metadata discovery endpoint.
 	// The SDK resolves this during config initialization (as of v0.126.0) to
@@ -292,46 +281,134 @@ func (s *Server) getWorkspaceForToken(token string) *FakeWorkspace {
 
 type HandlerFunc func(req Request) any
 
+// Handle registers a handler for the given method and path pattern.
+// First registration wins: subsequent calls with the same method+path are
+// ignored. Exact paths are stored in a map checked before ServeMux;
+// wildcard paths are registered with ServeMux using method-specific patterns.
 func (s *Server) Handle(method, path string, handler HandlerFunc) {
-	s.Router.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		// Each test uses unique DATABRICKS_TOKEN, we simulate each token having
-		// it's own fake fakeWorkspace to avoid interference between tests.
-		fakeWorkspace := s.getWorkspaceForToken(getToken(r))
+	if !strings.Contains(path, "{") {
+		s.handleExact(method, path, handler)
+	} else {
+		s.handleWildcard(method, path, handler)
+	}
+}
 
-		request := NewRequest(s.t, r, fakeWorkspace)
+func (s *Server) handleExact(method, path string, handler HandlerFunc) {
+	if s.exactRoutes[path] == nil {
+		s.exactRoutes[path] = map[string]HandlerFunc{}
+	}
+	if _, exists := s.exactRoutes[path][method]; !exists {
+		s.exactRoutes[path][method] = handler
+	}
+}
 
-		if s.RequestCallback != nil {
-			s.RequestCallback(&request)
+func (s *Server) handleWildcard(method, path string, handler HandlerFunc) {
+	pattern := method + " " + path
+	if s.wildcardMethods[pattern] {
+		return
+	}
+	s.wildcardMethods[pattern] = true
+
+	names := wildcardNames(path)
+	s.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		vars := make(map[string]string, len(names))
+		for _, name := range names {
+			vars[name] = r.PathValue(name)
 		}
+		s.serve(w, r, handler, vars)
+	})
+}
 
-		var resp EncodedResponse
-
-		if bytes.Contains(request.Body, []byte("INJECT_ERROR")) {
-			resp = EncodedResponse{
-				StatusCode: 500,
-				Body:       []byte("INJECTED"),
-			}
-		} else {
-			respAny := handler(request)
-			if respAny == nil && request.Context.Err() != nil {
-				return
-			}
-			resp = normalizeResponse(s.t, respAny)
+// wildcardNames extracts wildcard parameter names from a path pattern,
+// e.g. "/api/{id}/files/{path...}" returns ["id", "path"].
+func wildcardNames(path string) []string {
+	var names []string
+	for _, part := range strings.Split(path, "/") {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			name := part[1 : len(part)-1]
+			name = strings.TrimSuffix(name, "...")
+			names = append(names, name)
 		}
+	}
+	return names
+}
 
-		maps.Copy(w.Header(), resp.Headers)
+// serve is the common request handling logic for both exact and wildcard routes.
+func (s *Server) serve(w http.ResponseWriter, r *http.Request, handler HandlerFunc, vars map[string]string) {
+	fakeWorkspace := s.getWorkspaceForToken(getToken(r))
 
-		w.WriteHeader(resp.StatusCode)
+	request := NewRequest(s.t, r, fakeWorkspace)
+	request.Vars = vars
 
-		if s.ResponseCallback != nil {
-			s.ResponseCallback(&request, &resp)
+	if s.RequestCallback != nil {
+		s.RequestCallback(&request)
+	}
+
+	var resp EncodedResponse
+
+	if bytes.Contains(request.Body, []byte("INJECT_ERROR")) {
+		resp = EncodedResponse{
+			StatusCode: 500,
+			Body:       []byte("INJECTED"),
 		}
-
-		if _, err := w.Write(resp.Body); err != nil {
-			s.t.Errorf("Failed to write response: %s", err)
+	} else {
+		respAny := handler(request)
+		if respAny == nil && request.Context.Err() != nil {
 			return
 		}
-	}).Methods(method)
+		resp = normalizeResponse(s.t, respAny)
+	}
+
+	maps.Copy(w.Header(), resp.Headers)
+
+	w.WriteHeader(resp.StatusCode)
+
+	if s.ResponseCallback != nil {
+		s.ResponseCallback(&request, &resp)
+	}
+
+	if _, err := w.Write(resp.Body); err != nil {
+		s.t.Errorf("Failed to write response: %s", err)
+		return
+	}
+}
+
+func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
+	pattern := r.Method + " " + r.URL.Path
+	bodyBytes, err := io.ReadAll(r.Body)
+	var body string
+	if err != nil {
+		body = fmt.Sprintf("failed to read the body: %s", err)
+	} else {
+		body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
+	}
+
+	s.t.Errorf(`No handler for URL: %s
+Body: %s
+
+For acceptance tests, add this to test.toml:
+[[Server]]
+Pattern = %q
+Response.Body = '<response body here>'
+# Response.StatusCode = <response code if not 200>
+`, r.URL, body, pattern)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented)
+
+	resp := map[string]string{
+		"message": "No stub found for pattern: " + pattern,
+	}
+
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		s.t.Errorf("JSON encoding error: %s", err)
+		respBytes = []byte("{\"message\": \"JSON encoding error\"}")
+	}
+
+	if _, err := w.Write(respBytes); err != nil {
+		s.t.Errorf("Response write error: %s", err)
+	}
 }
 
 func getToken(r *http.Request) string {

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -38,12 +38,9 @@ func ExtractPidFromHeaders(headers http.Header) int {
 
 type Server struct {
 	*httptest.Server
+	*Router
 
 	t testutil.TestingT
-
-	mux             *http.ServeMux
-	wildcardMethods map[string]bool                   // "METHOD /pattern" -> registered
-	exactRoutes     map[string]map[string]HandlerFunc // path -> method -> handler
 
 	fakeWorkspaces map[string]*FakeWorkspace
 	fakeOidc       *FakeOidc
@@ -202,43 +199,18 @@ func getHeaders(value []byte) http.Header {
 }
 
 func New(t testutil.TestingT) *Server {
-	mux := http.NewServeMux()
-
-	s := &Server{
-		t:               t,
-		mux:             mux,
-		wildcardMethods: map[string]bool{},
-		exactRoutes:     map[string]map[string]HandlerFunc{},
-		fakeWorkspaces:  map[string]*FakeWorkspace{},
-	}
-
-	// Exact (non-wildcard) routes are kept out of ServeMux to avoid
-	// conflicts between method-specific exact paths and wildcard patterns
-	// (e.g., GET on an exact path vs HEAD on a wildcard that covers it).
-	//
-	// When an exact path is registered for one method but a request arrives
-	// for a different method, it intentionally falls through to ServeMux.
-	// This lets wildcard handlers serve methods not covered by the exact
-	// registration (e.g., a stub registers GET /exact, but HEAD /exact
-	// falls through to the wildcard HEAD handler).
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Clear RawPath so ServeMux matches decoded paths; without this,
-		// percent-encoded slashes (%2F) would not match literal slashes.
-		if r.URL.RawPath != "" {
-			r.URL.RawPath = ""
-		}
-		if methods, ok := s.exactRoutes[r.URL.Path]; ok {
-			if handler, ok := methods[r.Method]; ok {
-				s.serve(w, r, handler, nil)
-				return
-			}
-		}
-		mux.ServeHTTP(w, r)
-	}))
+	router := NewRouter()
+	server := httptest.NewServer(router)
 	t.Cleanup(server.Close)
 
-	s.Server = server
-	s.fakeOidc = &FakeOidc{url: server.URL}
+	s := &Server{
+		Server:         server,
+		Router:         router,
+		t:              t,
+		fakeWorkspaces: map[string]*FakeWorkspace{},
+		fakeOidc:       &FakeOidc{url: server.URL},
+	}
+	router.Dispatch = s.serve
 
 	t.Cleanup(func() {
 		for _, ws := range s.fakeWorkspaces {
@@ -246,8 +218,45 @@ func New(t testutil.TestingT) *Server {
 		}
 	})
 
-	// Register a catch-all handler as fallback for unmatched routes.
-	mux.HandleFunc("/", s.handleNotFound)
+	// Set up the not found handler as fallback
+	notFoundFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pattern := r.Method + " " + r.URL.Path
+		bodyBytes, err := io.ReadAll(r.Body)
+		var body string
+		if err != nil {
+			body = fmt.Sprintf("failed to read the body: %s", err)
+		} else {
+			body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
+		}
+
+		t.Errorf(`No handler for URL: %s
+Body: %s
+
+For acceptance tests, add this to test.toml:
+[[Server]]
+Pattern = %q
+Response.Body = '<response body here>'
+# Response.StatusCode = <response code if not 200>
+`, r.URL, body, pattern)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+
+		resp := map[string]string{
+			"message": "No stub found for pattern: " + pattern,
+		}
+
+		respBytes, err := json.Marshal(resp)
+		if err != nil {
+			t.Errorf("JSON encoding error: %s", err)
+			respBytes = []byte("{\"message\": \"JSON encoding error\"}")
+		}
+
+		if _, err := w.Write(respBytes); err != nil {
+			t.Errorf("Response write error: %s", err)
+		}
+	})
+	router.NotFound = notFoundFunc
 
 	// Register a default handler for the SDK's host metadata discovery endpoint.
 	// The SDK resolves this during config initialization (as of v0.126.0) to
@@ -279,62 +288,9 @@ func (s *Server) getWorkspaceForToken(token string) *FakeWorkspace {
 	return s.fakeWorkspaces[token]
 }
 
-type HandlerFunc func(req Request) any
-
-// Handle registers a handler for the given method and path pattern.
-// First registration wins: subsequent calls with the same method+path are
-// ignored. Exact paths are stored in a map checked before ServeMux;
-// wildcard paths are registered with ServeMux using method-specific patterns.
-func (s *Server) Handle(method, path string, handler HandlerFunc) {
-	if !strings.Contains(path, "{") {
-		s.handleExact(method, path, handler)
-	} else {
-		s.handleWildcard(method, path, handler)
-	}
-}
-
-func (s *Server) handleExact(method, path string, handler HandlerFunc) {
-	if s.exactRoutes[path] == nil {
-		s.exactRoutes[path] = map[string]HandlerFunc{}
-	}
-	if _, exists := s.exactRoutes[path][method]; !exists {
-		s.exactRoutes[path][method] = handler
-	}
-}
-
-func (s *Server) handleWildcard(method, path string, handler HandlerFunc) {
-	pattern := method + " " + path
-	if s.wildcardMethods[pattern] {
-		return
-	}
-	s.wildcardMethods[pattern] = true
-
-	names := wildcardNames(path)
-	s.mux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
-		vars := make(map[string]string, len(names))
-		for _, name := range names {
-			vars[name] = r.PathValue(name)
-		}
-		s.serve(w, r, handler, vars)
-	})
-}
-
-// wildcardNames extracts wildcard parameter names from a path pattern,
-// e.g. "/api/{id}/files/{path...}" returns ["id", "path"].
-func wildcardNames(path string) []string {
-	var names []string
-	for _, part := range strings.Split(path, "/") {
-		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
-			name := part[1 : len(part)-1]
-			name = strings.TrimSuffix(name, "...")
-			names = append(names, name)
-		}
-	}
-	return names
-}
-
-// serve is the common request handling logic for both exact and wildcard routes.
 func (s *Server) serve(w http.ResponseWriter, r *http.Request, handler HandlerFunc, vars map[string]string) {
+	// Each test uses unique DATABRICKS_TOKEN, we simulate each token having
+	// it's own fake fakeWorkspace to avoid interference between tests.
 	fakeWorkspace := s.getWorkspaceForToken(getToken(r))
 
 	request := NewRequest(s.t, r, fakeWorkspace)
@@ -370,44 +326,6 @@ func (s *Server) serve(w http.ResponseWriter, r *http.Request, handler HandlerFu
 	if _, err := w.Write(resp.Body); err != nil {
 		s.t.Errorf("Failed to write response: %s", err)
 		return
-	}
-}
-
-func (s *Server) handleNotFound(w http.ResponseWriter, r *http.Request) {
-	pattern := r.Method + " " + r.URL.Path
-	bodyBytes, err := io.ReadAll(r.Body)
-	var body string
-	if err != nil {
-		body = fmt.Sprintf("failed to read the body: %s", err)
-	} else {
-		body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
-	}
-
-	s.t.Errorf(`No handler for URL: %s
-Body: %s
-
-For acceptance tests, add this to test.toml:
-[[Server]]
-Pattern = %q
-Response.Body = '<response body here>'
-# Response.StatusCode = <response code if not 200>
-`, r.URL, body, pattern)
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusNotImplemented)
-
-	resp := map[string]string{
-		"message": "No stub found for pattern: " + pattern,
-	}
-
-	respBytes, err := json.Marshal(resp)
-	if err != nil {
-		s.t.Errorf("JSON encoding error: %s", err)
-		respBytes = []byte("{\"message\": \"JSON encoding error\"}")
-	}
-
-	if _, err := w.Write(respBytes); err != nil {
-		s.t.Errorf("Response write error: %s", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the `gorilla/mux` dependency by switching `libs/testserver` to Go 1.22's enhanced `net/http.ServeMux`, which added method-based routing (`"GET /items/{id}"`), path wildcards (`{id}`), and rest wildcards (`{path...}`) — the same features we used gorilla for. See the [Go 1.22 release notes](https://go.dev/doc/go1.22#enhanced_routing_patterns).
- Replace gorilla's `{path:.*}` regex wildcards with stdlib `{path...}` rest wildcards, and `mux.Vars(r)` with `r.PathValue()`.
- Exact (non-wildcard) paths are dispatched via a map lookup before reaching ServeMux. This avoids a ServeMux limitation where registering method-specific exact paths alongside method-specific wildcard patterns panics due to Go's implicit GET→HEAD handling creating unresolvable precedence. When an exact path has no handler for the request method, it falls through to ServeMux where a wildcard handler can serve it (e.g., a stub registers `GET /exact/path`, but `HEAD` falls through to a wildcard `HEAD` handler).
- Wildcard patterns in `test.toml` stubs must now use the same placeholder names as the default handlers they coexist with — ServeMux panics on structurally identical patterns with different wildcard names. Two stubs updated: `{name}` → `{full_name}`.
- Extract the routing logic into a `Router` type with its own tests (`libs/testserver/router.go` + `router_test.go`); `Server` embeds it. The package doc on `Router` explains why the wrapper exists on top of stdlib ServeMux.

## Test plan

- [x] Unit tests pass (`libs/testserver`, `bundle/direct/dresources`, `acceptance/internal`)
- [x] Acceptance selftests pass
- [x] Full CI

This pull request was AI-assisted by Isaac.