### PR TITLE
Use `WaitGroup.Go` for remaining manual Add/Done patterns

### DIFF
--- a/libs/dagrun/dagrun.go
+++ b/libs/dagrun/dagrun.go
@@ -179,9 +179,8 @@ func (g *Graph) Run(pool int, runUnit func(node string, failedDependency *string
 	done := make(chan doneResult, len(in))
 
 	var wg sync.WaitGroup
-	wg.Add(pool)
 	for range pool {
-		go runWorkerLoop(&wg, ready, done, runUnit)
+		wg.Go(func() { runWorkerLoop(ready, done, runUnit) })
 	}
 
 	for _, n := range initial {
@@ -229,8 +228,7 @@ type task struct {
 	failedFrom *string
 }
 
-func runWorkerLoop(wg *sync.WaitGroup, ready <-chan task, done chan<- doneResult, runUnit func(string, *string) bool) {
-	defer wg.Done()
+func runWorkerLoop(ready <-chan task, done chan<- doneResult, runUnit func(string, *string) bool) {
 	for t := range ready {
 		success := runUnit(t.n, t.failedFrom)
 		if t.failedFrom != nil {

--- a/libs/filer/workspace_files_cache.go
+++ b/libs/filer/workspace_files_cache.go
@@ -206,8 +206,7 @@ func newWorkspaceFilesReadaheadCache(ctx context.Context, f Filer) *cache {
 	}
 
 	for range kNumCacheWorkers {
-		c.wg.Add(1)
-		go c.work(ctx)
+		c.wg.Go(func() { c.work(ctx) })
 	}
 
 	return c
@@ -215,8 +214,6 @@ func newWorkspaceFilesReadaheadCache(ctx context.Context, f Filer) *cache {
 
 // work until the queue is closed.
 func (c *cache) work(ctx context.Context) {
-	defer c.wg.Done()
-
 	for e := range c.queue {
 		e.execute(ctx, c)
 	}

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -121,11 +121,9 @@ func New(ctx context.Context, opts SyncOptions) (*Sync, error) {
 	if opts.OutputHandler != nil {
 		ch := make(chan Event, MaxRequestsInFlight)
 		notifier = &ChannelNotifier{ch}
-		outputWaitGroup.Add(1)
-		go func() {
-			defer outputWaitGroup.Done()
+		outputWaitGroup.Go(func() {
 			opts.OutputHandler(ctx, ch)
-		}()
+		})
 	} else {
 		notifier = &NopNotifier{}
 	}


### PR DESCRIPTION
## Summary
- Replace remaining `wg.Add`/`wg.Done`/`go` patterns with `wg.Go(...)` in `libs/dagrun`, `libs/filer`, and `libs/sync`
- These weren't caught by the `use-waitgroup-go` revive rule because they call `Done()` inside separate functions rather than inline

## Test plan
- [x] `go test ./libs/dagrun/ ./libs/filer/ ./libs/sync/` passes

This pull request was AI-assisted by Isaac.