### PR TITLE
Add lint rule to prevent use of stdlib `log` package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,6 +34,15 @@ linters:
           deny:
             - pkg: "github.com/databricks/cli/experimental"
               desc: "must not import experimental/ packages; use an interface or move the dependency"
+        no-stdlib-log:
+          files:
+            - "**"
+            - "!**/bundle/docsgen/**"
+            - "!**/bundle/internal/schema/**"
+            - "!**/bundle/internal/validation/**"
+          deny:
+            - pkg: "log$"
+              desc: "use libs/log instead of the standard library log package"
     forbidigo:
       forbid:
         - pattern: 'term\.IsTerminal'

--- a/libs/appproxy/appproxy.go
+++ b/libs/appproxy/appproxy.go
@@ -3,11 +3,12 @@ package appproxy
 import (
 	"context"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/databricks/cli/libs/log"
 )
 
 type Proxy struct {
@@ -122,7 +123,7 @@ func (p *Proxy) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		// If the error is not EOF, then there was a problem
 		if err != io.EOF {
 			// Log the error and perform cleanup
-			log.Printf("Error copying messages: %v", err)
+			log.Warnf(r.Context(), "error copying messages: %v", err)
 			middlewareConn.Close()
 			targetServerConn.Close()
 		}


### PR DESCRIPTION
## Summary
- Add a `depguard` rule that blocks `import "log"` and points to `libs/log`
- Migrate the single existing violation in `libs/appproxy`
- Exclude build tools (`docsgen`, `schema`, `validation`) that use `log.Fatal`

This pull request was AI-assisted by Isaac.