### PR TITLE
direct: Pass changed fields into update mask for apps instead of wildcard

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bundles
 * Added support for lifecycle.started option for apps ([#4672](https://github.com/databricks/cli/pull/4672))
 * engine/direct: Fix permissions for resources.models ([#4941](https://github.com/databricks/cli/pull/4941))
+* direct: Pass changed fields into update mask for apps instead of wildcard ([#4963](https://github.com/databricks/cli/pull/4963))
 
 ### Dependency updates
 

--- a/acceptance/bundle/apps/compute_size/out.update.direct.txt
+++ b/acceptance/bundle/apps/compute_size/out.update.direct.txt
@@ -7,5 +7,5 @@ Deployment complete!
 
 >>> [CLI] apps get app-[UNIQUE_NAME]
 {
-  "compute_size": "LARGE"
+  "compute_size": "MEDIUM"
 }

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -15,7 +15,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "*"
+    "update_mask": "description"
   },
   "method": "POST",
   "path": "/api/2.0/apps/myappname/update"

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/databricks/cli/bundle/appdeploy"
@@ -162,13 +164,19 @@ func (r *ResourceApp) DoCreate(ctx context.Context, config *AppState) (string, *
 }
 
 func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState, entry *PlanEntry) (*AppRemote, error) {
-	// Use "*" to update all App API fields. Deploy-only fields (source_code_path, config,
+	// Deploy-only fields (source_code_path, config,
 	// git_source, lifecycle) are not part of apps.App and thus excluded from the request body.
 	if hasAppChanges(entry) {
+		fieldPaths := collectUpdatePathsWithPrefix(entry.Changes, "")
+		sort.Strings(fieldPaths)
+		for i, fieldPath := range fieldPaths {
+			fieldPaths[i] = truncateAtIndex(fieldPath)
+		}
+		updateMask := strings.Join(fieldPaths, ",")
 		request := apps.AsyncUpdateAppRequest{
 			App:        &config.App,
 			AppName:    id,
-			UpdateMask: "*",
+			UpdateMask: updateMask,
 		}
 		updateWaiter, err := r.client.Apps.CreateUpdate(ctx, request)
 		if err != nil {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -168,7 +168,7 @@ func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState,
 	// git_source, lifecycle) are not part of apps.App and thus excluded from the request body.
 	if hasAppChanges(entry) {
 		fieldPaths := collectUpdatePathsWithPrefix(entry.Changes, "")
-		sort.Strings(fieldPaths)
+		slices.Sort(fieldPaths)
 		for i, fieldPath := range fieldPaths {
 			fieldPaths[i] = truncateAtIndex(fieldPath)
 		}


### PR DESCRIPTION
## Changes
Pass changed fields into update mask for apps instead of wildcard

## Why
Apps Update API does not support "*" for update mask yet.

## Tests
Existing (Cloud) tests pass

```
DATABRICKS_BUNDLE_ENGINE=direct go test ./acceptance -v -run TestAccept/bundle/run/app-with-job
=== RUN   TestAccept
   ...
--- PASS: TestAccept (32.48s)
    --- SKIP: TestAccept/bundle/run_as (0.00s)
    --- PASS: TestAccept/bundle/run/app-with-job (0.00s)
        --- PASS: TestAccept/bundle/run/app-with-job/DATABRICKS_BUNDLE_ENGINE=direct (294.22s)
        --- PASS: TestAccept/bundle/run/app-with-job/DATABRICKS_BUNDLE_ENGINE=terraform (299.11s)
```