### PR TITLE
Disable @-mentions in approval workflow comments

### DIFF
--- a/.github/workflows/maintainer-approval.js
+++ b/.github/workflows/maintainer-approval.js
@@ -203,9 +203,8 @@ function topDirs(ds, n = 3) {
 }
 
 function fmtReviewer(login, dirs) {
-  const mention = MENTION_REVIEWERS ? `@${login}` : login;
   const dirList = dirs.map((d) => `\`${d}/\``).join(", ");
-  return `- ${mention} -- recent work in ${dirList}`;
+  return `- ${fmtLogin(login)} -- recent work in ${dirList}`;
 }
 
 function selectReviewers(ss) {
@@ -221,12 +220,12 @@ function selectReviewers(ss) {
 }
 
 function fmtEligible(owners) {
-  if (MENTION_REVIEWERS) return owners.map((o) => `@${o}`).join(", ");
-  return owners.join(", ");
+  return owners.map((o) => fmtLogin(o)).join(", ");
 }
 
 function fmtLogin(login) {
-  return MENTION_REVIEWERS ? `@${login}` : login;
+  if (MENTION_REVIEWERS) return `@${login}`;
+  return `\`@${login}\``;
 }
 
 async function countRecentReviews(github, owner, repo, logins, days = 30) {

--- a/.github/workflows/maintainer-approval.js
+++ b/.github/workflows/maintainer-approval.js
@@ -96,7 +96,7 @@ async function checkPerPathApproval(files, rulesWithTeams, approverLogins, githu
 
 // --- Git history & scoring helpers ---
 
-const MENTION_REVIEWERS = true;
+const MENTION_REVIEWERS = false;
 const OWNERS_LINK = "[OWNERS](.github/OWNERS)";
 const MARKER = "<!-- MAINTAINER_APPROVAL -->";
 const STATUS_CONTEXT = "maintainer-approval";
@@ -225,6 +225,10 @@ function fmtEligible(owners) {
   return owners.join(", ");
 }
 
+function fmtLogin(login) {
+  return MENTION_REVIEWERS ? `@${login}` : login;
+}
+
 async function countRecentReviews(github, owner, repo, logins, days = 30) {
   const since = new Date(Date.now() - days * 86400000)
     .toISOString()
@@ -267,7 +271,7 @@ function buildPendingPerGroupComment(groups, scores, dirScores, approvedBy, main
 
     const approver = approvedBy.get(pattern);
     if (approver) {
-      lines.push(`### \`${pattern}\` - approved by @${approver}`);
+      lines.push(`### \`${pattern}\` - approved by ${fmtLogin(approver)}`);
     } else {
       lines.push(`### \`${pattern}\` - needs approval`);
     }
@@ -277,13 +281,13 @@ function buildPendingPerGroupComment(groups, scores, dirScores, approvedBy, main
     const individuals = owners.filter(o => !o.includes("/") && o.toLowerCase() !== authorLower);
 
     if (teams.length > 0) {
-      lines.push(`Teams: ${teams.map(t => `@${t}`).join(", ")}`);
+      lines.push(`Teams: ${teams.map(t => fmtLogin(t)).join(", ")}`);
     }
 
     if (!approver && individuals.length > 0) {
       const scored = individuals.map(o => [o, scores[o] || 0]).sort((a, b) => b[1] - a[1]);
       if (scored[0][1] > 0) {
-        lines.push(`Suggested: @${scored[0][0]}`);
+        lines.push(`Suggested: ${fmtLogin(scored[0][0])}`);
         const rest = scored.slice(1).map(([o]) => o);
         if (rest.length > 0) {
           lines.push(`Also eligible: ${fmtEligible(rest)}`);
@@ -320,7 +324,7 @@ function buildPendingPerGroupComment(groups, scores, dirScores, approvedBy, main
 
   const maintainerList = maintainers
     .filter(m => m.toLowerCase() !== authorLower)
-    .map(m => `@${m}`)
+    .map(m => fmtLogin(m))
     .join(", ");
 
   lines.push(
@@ -349,7 +353,7 @@ function buildSingleDomainPendingComment(sortedScores, dirScores, scoredCount, e
   } else if (roundRobinReviewer) {
     lines.push(
       "Could not determine reviewers from git history.",
-      `Round-robin suggestion: @${roundRobinReviewer}`,
+      `Round-robin suggestion: ${fmtLogin(roundRobinReviewer)}`,
       ""
     );
   }

--- a/.github/workflows/maintainer-approval.test.js
+++ b/.github/workflows/maintainer-approval.test.js
@@ -509,7 +509,7 @@ describe("maintainer-approval", () => {
     assert.ok(body.includes("## Approval status: pending"));
     assert.ok(body.includes("`/cmd/pipelines/`"));
     assert.ok(body.includes("`/bundle/`"));
-    assert.ok(body.includes("approved by @jefferycheng1"));
+    assert.ok(body.includes("approved by jefferycheng1"));
     assert.ok(body.includes("needs approval"));
   });
 });

--- a/.github/workflows/maintainer-approval.test.js
+++ b/.github/workflows/maintainer-approval.test.js
@@ -509,7 +509,7 @@ describe("maintainer-approval", () => {
     assert.ok(body.includes("## Approval status: pending"));
     assert.ok(body.includes("`/cmd/pipelines/`"));
     assert.ok(body.includes("`/bundle/`"));
-    assert.ok(body.includes("approved by jefferycheng1"));
+    assert.ok(body.includes("approved by `@jefferycheng1`"));
     assert.ok(body.includes("needs approval"));
   });
 });


### PR DESCRIPTION
## Why

The approval workflow comments currently @-mention everyone it suggests as a reviewer. This generates a lot of notification noise, especially on PRs that touch multiple ownership areas. The comments are useful for showing who should review, but the pings are disruptive.

## Changes

Before: approval comments used `@username` for all suggested reviewers, eligible owners, and maintainers, triggering GitHub notifications for each.

Now: all mentions are wrapped in backticks (`` `@username` ``), so they render as inline code on GitHub. This preserves the familiar `@` prefix for readability but prevents GitHub from treating them as mentions that trigger notifications.

All hardcoded `@` mentions in the comment templates are now routed through a single `fmtLogin` helper controlled by the existing `MENTION_REVIEWERS` flag.

### Example comment (cross-domain PR)

> ## Approval status: pending
>
> ### `/cmd/pipelines/` - approved by `@jefferycheng1`
> Files: `cmd/pipelines/foo.go`
>
> ### `/bundle/` - needs approval
> Files: `bundle/config.go`
> Eligible: `@bundleowner1`, `@bundleowner2`, `@bundleowner3`
>
> <sub>Any maintainer (`@maintainer1`, `@maintainer2`, `@maintainer3`) can approve all areas.
> See OWNERS for ownership rules.</sub>

## Test plan

- All 20 existing unit tests pass
- Ran a verification script against 5 scenarios (single domain, cross-domain partial approval, wildcard-only, team-owned paths, three domains mixed) confirming zero bare @-mentions in generated comments