### PR TITLE
Exclude continue_293 test on models with perms and apps

### DIFF
--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -1,5 +1,5 @@
 Local = true
-Cloud = false
+Cloud = true
 RequiresUnityCatalog = true
 
 [EnvMatrix]

--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -6,6 +6,5 @@ EnvMatrixExclude.no_grant_ref = ["INPUT_CONFIG=schema_grant_ref.yml.tmpl"]
 # Model permissions did not work until 0.297.0 https://github.com/databricks/cli/pull/4941
 EnvMatrixExclude.no_model_with_permissions = ["INPUT_CONFIG=model_with_permissions.yml.tmpl"]
 
-# apps updates were broken on direct until 0.297.0 https://github.com/databricks/cli/pull/4963
 # LOG.deploy: Error: cannot update resources.apps.foo: updating id=app-dnppf7fm4zalnocu4yav774xpy: Invalid update mask. Only description, budget_policy_id, usage_policy_id, resources, user_api_scopes, compute_size, compute_min_instances, compute_max_instances, git_repository, telemetry_export_destinations are allowed. Supplied update mask: * (400 INVALID_PARAMETER_VALUE)
 EnvMatrixExclude.no_app = ["INPUT_CONFIG=app.yml"]

--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -1,7 +1,11 @@
-Cloud = false
-Slow = true
-
 # $resources references to permissions and grants are not supported on v0.293.0
 EnvMatrixExclude.no_permission_ref = ["INPUT_CONFIG=job_permission_ref.yml.tmpl"]
 EnvMatrixExclude.no_cross_resource_ref = ["INPUT_CONFIG=job_cross_resource_ref.yml.tmpl"]
 EnvMatrixExclude.no_grant_ref = ["INPUT_CONFIG=schema_grant_ref.yml.tmpl"]
+
+# Model permissions did not work until 0.297.0 https://github.com/databricks/cli/pull/4941
+EnvMatrixExclude.no_model_with_permissions = ["INPUT_CONFIG=model_with_permissions.yml.tmpl"]
+
+# apps updates were broken on direct until 0.297.0 https://github.com/databricks/cli/pull/4963
+# LOG.deploy: Error: cannot update resources.apps.foo: updating id=app-dnppf7fm4zalnocu4yav774xpy: Invalid update mask. Only description, budget_policy_id, usage_policy_id, resources, user_api_scopes, compute_size, compute_min_instances, compute_max_instances, git_repository, telemetry_export_destinations are allowed. Supplied update mask: * (400 INVALID_PARAMETER_VALUE)
+EnvMatrixExclude.no_app = ["INPUT_CONFIG=app.yml"]


### PR DESCRIPTION
Also don't mark it as Slow so it runs on PRs and enable it on Cloud.
