### PR TITLE
Replace `os.IsNotExist` and friends with `errors.Is`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,6 +60,12 @@ linters:
           msg: Use slices.Sort from the standard library instead.
         - pattern: 'sort\.Float64s'
           msg: Use slices.Sort from the standard library instead.
+        - pattern: 'os\.IsNotExist'
+          msg: Use errors.Is(err, fs.ErrNotExist) instead.
+        - pattern: 'os\.IsExist'
+          msg: Use errors.Is(err, fs.ErrExist) instead.
+        - pattern: 'os\.IsPermission'
+          msg: Use errors.Is(err, fs.ErrPermission) instead.
       analyze-types: true
     copyloopvar:
       check-alias: true

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"os"
@@ -1486,7 +1487,7 @@ func setupTerraform(t *testing.T, cwd, buildDir string, repls *testdiff.Replacem
 
 func loadUserReplacements(t *testing.T, repls *testdiff.ReplacementsContext, tmpDir string) {
 	b, err := os.ReadFile(filepath.Join(tmpDir, userReplacementsFilename))
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return
 	}
 	require.NoError(t, err)

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"errors"
 	"hash/fnv"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -181,7 +183,7 @@ func FindConfigs(t *testing.T, dir string) []string {
 
 		dir = filepath.Dir(dir)
 
-		if err == nil || os.IsNotExist(err) {
+		if err == nil || errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 

--- a/bundle/direct/dstate/state.go
+++ b/bundle/direct/dstate/state.go
@@ -3,7 +3,9 @@ package dstate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,7 +120,7 @@ func (db *DeploymentState) Open(path string) error {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// Create new database with serial=0, will be incremented to 1 in Finalize()
 			db.Data = NewDatabase("", 0)
 			db.Path = path

--- a/bundle/docsgen/main.go
+++ b/bundle/docsgen/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path"
@@ -30,7 +32,7 @@ func main() {
 	outputDir := path.Join(docsDir, "output")
 	templatesDir := path.Join(docsDir, "templates")
 
-	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
+	if _, err := os.Stat(outputDir); errors.Is(err, fs.ErrNotExist) {
 		if err := os.MkdirAll(outputDir, 0o755); err != nil {
 			log.Fatal(err)
 		}

--- a/bundle/statemgmt/state_pull.go
+++ b/bundle/statemgmt/state_pull.go
@@ -59,7 +59,7 @@ func (s *StateDesc) HasRemoteTerraformState() bool {
 func localRead(ctx context.Context, fullPath string, engine engine.EngineType) *StateDesc {
 	content, err := os.ReadFile(fullPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, fs.ErrNotExist) {
 			logdiag.LogError(ctx, fmt.Errorf("reading %s: %w", filepath.ToSlash(fullPath), err))
 		}
 		return nil

--- a/cmd/apps/dev.go
+++ b/cmd/apps/dev.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/url"
 	"os"
@@ -144,7 +145,7 @@ Examples:
 			ctx := cmd.Context()
 
 			// Validate client path early (before any network calls)
-			if _, err := os.Stat(clientPath); os.IsNotExist(err) {
+			if _, err := os.Stat(clientPath); errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("client directory not found: %s", clientPath)
 			}
 

--- a/cmd/apps/import.go
+++ b/cmd/apps/import.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -171,7 +172,7 @@ Examples:
 			// Check if output directory already exists
 			if _, err := os.Stat(outputDir); err == nil {
 				return fmt.Errorf("directory '%s' already exists. Please remove it or choose a different output directory", outputDir)
-			} else if !os.IsNotExist(err) {
+			} else if !errors.Is(err, fs.ErrNotExist) {
 				return fmt.Errorf("failed to check if directory exists: %w", err)
 			}
 

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -791,10 +791,10 @@ func runCreate(ctx context.Context, opts createOptions) error {
 
 	// Check for generic subdirectory first (default for multi-template repos)
 	templateDir := filepath.Join(resolvedPath, "generic")
-	if _, err := os.Stat(templateDir); os.IsNotExist(err) {
+	if _, err := os.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
 		// Fall back to the provided path directly
 		templateDir = resolvedPath
-		if _, err := os.Stat(templateDir); os.IsNotExist(err) {
+		if _, err := os.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("template not found at %s (also checked %s/generic)", resolvedPath, resolvedPath)
 		}
 	}

--- a/cmd/apps/manifest.go
+++ b/cmd/apps/manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -46,9 +47,9 @@ func runManifestOnly(ctx context.Context, templatePath, branch, version string) 
 	}
 
 	templateDir := filepath.Join(resolvedPath, "generic")
-	if _, err := os.Stat(templateDir); os.IsNotExist(err) {
+	if _, err := os.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
 		templateDir = resolvedPath
-		if _, err := os.Stat(templateDir); os.IsNotExist(err) {
+		if _, err := os.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("template not found at %s (also checked %s/generic)", resolvedPath, resolvedPath)
 		}
 	}

--- a/cmd/labs/project/installer.go
+++ b/cmd/labs/project/installer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -110,7 +111,7 @@ func (i *installer) Install(ctx context.Context) error {
 		}
 	}
 
-	if _, err := os.Stat(i.LibDir()); os.IsNotExist(err) {
+	if _, err := os.Stat(i.LibDir()); errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("no local installation found: %w", err)
 	}
 	err = i.setupPythonVirtualEnvironment(ctx, w)

--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net/http"
 	"os"
@@ -452,7 +453,7 @@ func agentSkillsDirForScope(ctx context.Context, agent *agents.Agent, scope, cwd
 // a symlink pointing to canonicalDir. This preserves skills installed by other tools.
 func backupThirdPartySkill(ctx context.Context, destDir, canonicalDir, skillName, agentName string) error {
 	fi, err := os.Lstat(destDir)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	if err != nil {

--- a/experimental/aitools/lib/installer/installer_test.go
+++ b/experimental/aitools/lib/installer/installer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -127,7 +128,7 @@ func TestBackupThirdPartySkillRegularDir(t *testing.T) {
 
 	// destDir should no longer exist.
 	_, err = os.Stat(destDir)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 
 	// Backup should contain the original file.
 	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "databricks-skill-backup-databricks-*", "databricks", "custom.md"))
@@ -161,7 +162,7 @@ func TestBackupThirdPartySkillSymlinkToOtherTarget(t *testing.T) {
 
 	// destDir (the symlink) should no longer exist.
 	_, err = os.Lstat(destDir)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 
 	// Original target should be untouched.
 	content, err := os.ReadFile(filepath.Join(otherDir, "other.md"))
@@ -182,7 +183,7 @@ func TestBackupThirdPartySkillRegularFile(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = os.Stat(destDir)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 // --- InstallSkillsForAgents tests ---

--- a/experimental/aitools/lib/installer/uninstall.go
+++ b/experimental/aitools/lib/installer/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,7 +95,7 @@ func UninstallSkillsOpts(ctx context.Context, opts UninstallOptions) error {
 		// Clean up orphaned symlinks and delete state file.
 		cleanOrphanedSymlinks(ctx, baseDir, scope, cwd)
 		stateFile := filepath.Join(baseDir, stateFileName)
-		if err := os.Remove(stateFile); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(stateFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("failed to remove state file: %w", err)
 		}
 	} else {
@@ -130,7 +131,7 @@ func removeSymlinksFromAgents(ctx context.Context, skillName, canonicalDir, scop
 
 		// Use Lstat to detect symlinks (Stat follows them).
 		fi, err := os.Lstat(destDir)
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 		if err != nil {

--- a/experimental/aitools/lib/installer/uninstall_test.go
+++ b/experimental/aitools/lib/installer/uninstall_test.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,9 +37,9 @@ func TestUninstallRemovesSkillDirectories(t *testing.T) {
 
 	// Skill directories should be gone.
 	_, err = os.Stat(filepath.Join(globalDir, "databricks-sql"))
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 	_, err = os.Stat(filepath.Join(globalDir, "databricks-jobs"))
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 
 	assert.Contains(t, stderr.String(), "Uninstalled 2 skills.")
 }
@@ -80,11 +81,11 @@ func TestUninstallRemovesSymlinks(t *testing.T) {
 	for _, agentDir := range []string{".claude", ".cursor"} {
 		sqlLink := filepath.Join(tmp, agentDir, "skills", "databricks-sql")
 		_, err := os.Lstat(sqlLink)
-		assert.True(t, os.IsNotExist(err), "symlink should be removed from %s", agentDir)
+		assert.ErrorIs(t, err, fs.ErrNotExist, "symlink should be removed from %s", agentDir)
 
 		jobsLink := filepath.Join(tmp, agentDir, "skills", "databricks-jobs")
 		_, err = os.Lstat(jobsLink)
-		assert.True(t, os.IsNotExist(err), "symlink should be removed from %s", agentDir)
+		assert.ErrorIs(t, err, fs.ErrNotExist, "symlink should be removed from %s", agentDir)
 	}
 }
 
@@ -110,7 +111,7 @@ func TestUninstallCleansOrphanedSymlinks(t *testing.T) {
 
 	// Orphaned symlink should be removed.
 	_, err = os.Lstat(orphanLink)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func TestUninstallDeletesStateFile(t *testing.T) {
@@ -127,7 +128,7 @@ func TestUninstallDeletesStateFile(t *testing.T) {
 
 	// State file should be gone.
 	_, err = os.Stat(filepath.Join(globalDir, ".state.json"))
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func TestUninstallNoStateReturnsError(t *testing.T) {
@@ -190,7 +191,7 @@ func TestUninstallHandlesBrokenSymlinksToCanonicalDir(t *testing.T) {
 
 	// Symlink pointing to canonical dir should be removed.
 	_, err = os.Lstat(link)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 	assert.Contains(t, stderr.String(), "Uninstalled 1 skill.")
 }
 
@@ -266,7 +267,7 @@ func TestUninstallSelectiveRemovesOnlyNamedSkills(t *testing.T) {
 
 	// databricks-sql should be gone.
 	_, err = os.Stat(filepath.Join(globalDir, "databricks-sql"))
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 
 	// databricks-jobs should still exist.
 	_, err = os.Stat(filepath.Join(globalDir, "databricks-jobs"))
@@ -303,7 +304,7 @@ func TestUninstallSelectiveDuplicateNamesDeduplicates(t *testing.T) {
 
 	// databricks-sql should be gone.
 	_, err = os.Stat(filepath.Join(globalDir, "databricks-sql"))
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 
 	// databricks-jobs should still exist.
 	_, err = os.Stat(filepath.Join(globalDir, "databricks-jobs"))
@@ -329,5 +330,5 @@ func TestUninstallSelectiveAllRemovesStateFile(t *testing.T) {
 
 	// State file should be gone since all skills were removed.
 	_, err = os.Stat(filepath.Join(globalDir, ".state.json"))
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }

--- a/experimental/ssh/internal/fileutil/backup.go
+++ b/experimental/ssh/internal/fileutil/backup.go
@@ -2,6 +2,8 @@ package fileutil
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -23,10 +25,10 @@ func BackupFile(ctx context.Context, path string, data []byte) error {
 	latestBak := path + SuffixLatestBak
 	var bakPath string
 	_, statErr := os.Stat(originalBak)
-	if statErr != nil && !os.IsNotExist(statErr) {
+	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
 		return statErr
 	}
-	if os.IsNotExist(statErr) {
+	if errors.Is(statErr, fs.ErrNotExist) {
 		bakPath = originalBak
 	} else {
 		bakPath = latestBak

--- a/experimental/ssh/internal/fileutil/backup_test.go
+++ b/experimental/ssh/internal/fileutil/backup_test.go
@@ -1,6 +1,7 @@
 package fileutil_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,7 +20,7 @@ func TestBackupFile_EmptyData(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = os.Stat(path + fileutil.SuffixOriginalBak)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func TestBackupFile_FirstBackup(t *testing.T) {
@@ -35,7 +36,7 @@ func TestBackupFile_FirstBackup(t *testing.T) {
 	assert.Equal(t, data, content)
 
 	_, err = os.Stat(path + fileutil.SuffixLatestBak)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func TestBackupFile_SubsequentBackup(t *testing.T) {

--- a/experimental/ssh/internal/keys/keys.go
+++ b/experimental/ssh/internal/keys/keys.go
@@ -6,7 +6,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -51,7 +53,7 @@ func generateSSHKeyPair() ([]byte, []byte, error) {
 
 func SaveSSHKeyPair(keyPath string, privateKeyBytes, publicKeyBytes []byte) error {
 	err := os.RemoveAll(filepath.Dir(keyPath))
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("failed to remove existing key directory: %w", err)
 	}
 

--- a/experimental/ssh/internal/server/sshd.go
+++ b/experimental/ssh/internal/server/sshd.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -28,7 +30,7 @@ func prepareSSHDConfig(ctx context.Context, client *databricks.WorkspaceClient, 
 	sshDir := path.Join(homeDir, opts.ConfigDir)
 
 	err = os.RemoveAll(sshDir)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return "", fmt.Errorf("failed to remove existing SSH directory: %w", err)
 	}
 

--- a/experimental/ssh/internal/sshconfig/sshconfig.go
+++ b/experimental/ssh/internal/sshconfig/sshconfig.go
@@ -2,7 +2,9 @@ package sshconfig
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +44,7 @@ func GetMainConfigPathOrDefault(ctx context.Context, configPath string) (string,
 
 func EnsureMainConfigExists(configPath string) error {
 	_, err := os.Stat(configPath)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		sshDir := filepath.Dir(configPath)
 		err = os.MkdirAll(sshDir, 0o700)
 		if err != nil {
@@ -152,7 +154,7 @@ func HostConfigExists(ctx context.Context, hostName string) (bool, error) {
 		return false, err
 	}
 	_, err = os.Stat(configPath)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
 	}
 	if err != nil {

--- a/experimental/ssh/internal/vscode/settings.go
+++ b/experimental/ssh/internal/vscode/settings.go
@@ -3,7 +3,9 @@ package vscode
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -76,7 +78,7 @@ func CheckAndUpdateSettings(ctx context.Context, ide, connectionName string) err
 
 	settings, err := loadSettings(settingsPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return handleMissingFile(ctx, ide, connectionName, settingsPath)
 		}
 		return fmt.Errorf("failed to load settings: %w", err)

--- a/experimental/ssh/internal/vscode/settings_test.go
+++ b/experimental/ssh/internal/vscode/settings_test.go
@@ -3,6 +3,7 @@ package vscode
 import (
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -193,7 +194,7 @@ func TestLoadSettings_NotExists(t *testing.T) {
 
 	_, err := loadSettings(settingsPath)
 	assert.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func TestValidateSettings_Complete(t *testing.T) {

--- a/libs/apps/initializer/python_pip.go
+++ b/libs/apps/initializer/python_pip.go
@@ -2,6 +2,8 @@ package initializer
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,7 +114,7 @@ func (i *InitializerPythonPip) createVenv(ctx context.Context, workDir string) e
 // installDependencies installs dependencies from requirements.txt.
 func (i *InitializerPythonPip) installDependencies(ctx context.Context, workDir string) error {
 	requirementsPath := filepath.Join(workDir, "requirements.txt")
-	if _, err := os.Stat(requirementsPath); os.IsNotExist(err) {
+	if _, err := os.Stat(requirementsPath); errors.Is(err, fs.ErrNotExist) {
 		log.Debugf(ctx, "No requirements.txt found, skipping dependency installation")
 		return nil
 	}
@@ -126,7 +128,7 @@ func (i *InitializerPythonPip) installDependencies(ctx context.Context, workDir 
 	}
 
 	// Check if pip exists in venv
-	if _, err := os.Stat(pipPath); os.IsNotExist(err) {
+	if _, err := os.Stat(pipPath); errors.Is(err, fs.ErrNotExist) {
 		cmdio.LogString(ctx, "⚠ pip not found in virtual environment. Please install dependencies manually.")
 		return nil
 	}

--- a/libs/apps/manifest/manifest.go
+++ b/libs/apps/manifest/manifest.go
@@ -3,7 +3,9 @@ package manifest
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"maps"
 	"os"
 	"path/filepath"
@@ -88,7 +90,7 @@ func Load(templateDir string) (*Manifest, error) {
 	path := filepath.Join(templateDir, ManifestFileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("manifest file not found: %s", path)
 		}
 		return nil, fmt.Errorf("read manifest: %w", err)

--- a/libs/apps/runlocal/spec.go
+++ b/libs/apps/runlocal/spec.go
@@ -2,7 +2,9 @@ package runlocal
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +38,7 @@ func ReadAppSpecFile(config *Config) (*AppSpec, error) {
 	for _, file := range config.AppSpecFiles {
 		// Read the yaml file
 		yamlFile, err := os.ReadFile(filepath.Join(config.AppPath, file))
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			continue
 		}
 

--- a/libs/cache/file_cache_test.go
+++ b/libs/cache/file_cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -224,13 +225,13 @@ func TestFileCacheCleanupExpiredFiles(t *testing.T) {
 
 	// Check results
 	_, err = os.Stat(expiredFile)
-	assert.True(t, os.IsNotExist(err), "Expired file should be deleted")
+	assert.ErrorIs(t, err, fs.ErrNotExist, "Expired file should be deleted")
 
 	_, err = os.Stat(validFile)
-	assert.False(t, os.IsNotExist(err), "Valid file should still exist")
+	assert.NotErrorIs(t, err, fs.ErrNotExist, "Valid file should still exist")
 
 	_, err = os.Stat(nonCacheFile)
-	assert.False(t, os.IsNotExist(err), "Non-cache file should be ignored")
+	assert.NotErrorIs(t, err, fs.ErrNotExist, "Non-cache file should be ignored")
 }
 
 func TestFileCacheInvalidJSON(t *testing.T) {

--- a/libs/completion/install_test.go
+++ b/libs/completion/install_test.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -135,7 +136,7 @@ func TestInstallFishCreatesDirectory(t *testing.T) {
 	fishDir := filepath.Join(home, ".config", "fish", "completions")
 
 	_, err := os.Stat(fishDir)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 
 	_, _, err = Install(t.Context(), Fish, home)
 	require.NoError(t, err)

--- a/libs/completion/uninstall.go
+++ b/libs/completion/uninstall.go
@@ -1,7 +1,9 @@
 package completion
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"regexp"
 	"strings"
@@ -25,7 +27,7 @@ func Uninstall(shell Shell, homeDir string) (filePath string, wasInstalled bool,
 // manager or created by the user.
 func uninstallFish(filePath string) (string, bool, error) {
 	content, err := os.ReadFile(filePath)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return filePath, false, nil
 	}
 	if err != nil {
@@ -45,7 +47,7 @@ func uninstallFish(filePath string) (string, bool, error) {
 // uninstallRC handles the RC file model: find and remove the marker block.
 func uninstallRC(filePath string) (string, bool, error) {
 	info, err := os.Stat(filePath)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return filePath, false, nil
 	}
 	if err != nil {

--- a/libs/completion/uninstall_test.go
+++ b/libs/completion/uninstall_test.go
@@ -1,6 +1,7 @@
 package completion
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -110,7 +111,7 @@ func TestUninstallFish(t *testing.T) {
 	assert.Equal(t, fishPath, filePath)
 
 	_, err = os.Stat(fishPath)
-	assert.True(t, os.IsNotExist(err))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }
 
 func TestUninstallFishForeignFile(t *testing.T) {

--- a/libs/sync/gitignore.go
+++ b/libs/sync/gitignore.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -12,7 +14,7 @@ func WriteGitIgnore(ctx context.Context, dir string) {
 	gitignorePath := filepath.Join(dir, ".databricks", ".gitignore")
 	file, err := os.OpenFile(gitignorePath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
-		if os.IsExist(err) {
+		if errors.Is(err, fs.ErrExist) {
 			return
 		}
 		log.Debugf(ctx, "Failed to create %s: %s", gitignorePath, err)

--- a/libs/template/reader.go
+++ b/libs/template/reader.go
@@ -221,7 +221,7 @@ func loadSchemaAndResolveTemplateDir(path string) (*jsonschema.Schema, fs.FS, er
 	templateDir := filepath.Join(path, schema.TemplateDir)
 
 	// Check if the referenced template directory exists
-	if _, err := os.Stat(templateDir); os.IsNotExist(err) {
+	if _, err := os.Stat(templateDir); errors.Is(err, fs.ErrNotExist) {
 		return nil, nil, fmt.Errorf("template directory %s not found", templateDir)
 	}
 

--- a/libs/testdiff/golden.go
+++ b/libs/testdiff/golden.go
@@ -2,7 +2,9 @@ package testdiff
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -19,7 +21,7 @@ func init() {
 func ReadFile(t testutil.TestingT, ctx context.Context, filename string) string {
 	t.Helper()
 	data, err := os.ReadFile(filename)
-	if os.IsNotExist(err) {
+	if errors.Is(err, fs.ErrNotExist) {
 		return ""
 	}
 	assert.NoError(t, err, "Failed to read %s", filename)


### PR DESCRIPTION
## Summary

- Replace all uses of `os.IsNotExist`, `os.IsExist`, and `os.IsPermission` with their `errors.Is` equivalents (`errors.Is(err, fs.ErrNotExist)`, etc.)
- Add `forbidigo` linter rules to reject future use of these functions
- The [Go documentation](https://pkg.go.dev/os#IsNotExist) recommends `errors.Is` because it unwraps the error chain, while the `os.Is*` functions only recognize errors returned by the `os` package directly

## Test plan

- [x] `go build ./...` passes
- [x] `make lint` passes with 0 issues

This pull request was AI-assisted by Isaac.