### PR TITLE
Make --name flag optional for ssh connect

### DIFF
--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -85,6 +85,9 @@ the SSH server and handling the connection proxy.
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		wsClient := cmdctx.WorkspaceClient(ctx)
+		if connectionName == "" && clusterID == "" && !proxyMode {
+			connectionName = client.GenerateDefaultConnectionName(wsClient.Config.Host, accelerator)
+		}
 		opts := client.ClientOptions{
 			Profile:              wsClient.Config.Profile,
 			ClusterID:            clusterID,

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -134,7 +134,7 @@ func GenerateDefaultConnectionName(host, accelerator string) string {
 		acc := strings.ToLower(strings.ReplaceAll(accelerator, "_", "-"))
 		return fmt.Sprintf("databricks-%s-%s", acc, hashStr)
 	}
-	return fmt.Sprintf("databricks-ssh-%s", hashStr)
+	return fmt.Sprintf("databricks-cpu-%s", hashStr)
 }
 
 func (o *ClientOptions) IsServerlessMode() bool {

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -134,7 +134,7 @@ func GenerateDefaultConnectionName(host, accelerator string) string {
 		acc := strings.ToLower(strings.ReplaceAll(accelerator, "_", "-"))
 		return fmt.Sprintf("databricks-%s-%s", acc, hashStr)
 	}
-	return fmt.Sprintf("databricks-cpu-%s", hashStr)
+	return "databricks-cpu-" + hashStr
 }
 
 func (o *ClientOptions) IsServerlessMode() bool {

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -2,8 +2,10 @@ package client
 
 import (
 	"context"
+	"crypto/md5"
 	_ "embed"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -119,6 +121,20 @@ func (o *ClientOptions) Validate() error {
 		return fmt.Errorf("environment version must be >= %d, got %d", minEnvironmentVersion, o.EnvironmentVersion)
 	}
 	return nil
+}
+
+// GenerateDefaultConnectionName creates a deterministic connection name from
+// the workspace host and accelerator type. The name includes a hash of the
+// workspace host so that different workspaces produce different names,
+// avoiding SSH known_hosts conflicts.
+func GenerateDefaultConnectionName(host, accelerator string) string {
+	h := md5.Sum([]byte(host))
+	hashStr := hex.EncodeToString(h[:4])
+	if accelerator != "" {
+		acc := strings.ToLower(strings.ReplaceAll(accelerator, "_", "-"))
+		return fmt.Sprintf("databricks-%s-%s", acc, hashStr)
+	}
+	return fmt.Sprintf("databricks-ssh-%s", hashStr)
 }
 
 func (o *ClientOptions) IsServerlessMode() bool {

--- a/experimental/ssh/internal/client/client_test.go
+++ b/experimental/ssh/internal/client/client_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 	"time"
 
@@ -104,6 +105,67 @@ func TestValidate(t *testing.T) {
 				assert.EqualError(t, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestGenerateDefaultConnectionName(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		accelerator string
+		want        string
+	}{
+		{
+			name: "no accelerator",
+			host: "https://my-workspace.cloud.databricks.com",
+			want: "databricks-ssh-961dabbd",
+		},
+		{
+			name:        "GPU_1xA10 accelerator",
+			host:        "https://my-workspace.cloud.databricks.com",
+			accelerator: "GPU_1xA10",
+			want:        "databricks-gpu-1xa10-961dabbd",
+		},
+		{
+			name:        "GPU_8xH100 accelerator",
+			host:        "https://my-workspace.cloud.databricks.com",
+			accelerator: "GPU_8xH100",
+			want:        "databricks-gpu-8xh100-961dabbd",
+		},
+		{
+			name: "different host produces different name",
+			host: "https://other-workspace.cloud.databricks.com",
+			want: "databricks-ssh-e8a8ec19",
+		},
+		{
+			name: "deterministic for same input",
+			host: "https://my-workspace.cloud.databricks.com",
+			want: "databricks-ssh-961dabbd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.GenerateDefaultConnectionName(tt.host, tt.accelerator)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGenerateDefaultConnectionNameMatchesRegex(t *testing.T) {
+	hosts := []string{
+		"https://workspace1.cloud.databricks.com",
+		"https://workspace2.azuredatabricks.net",
+		"https://workspace3.gcp.databricks.com",
+	}
+	accelerators := []string{"", "GPU_1xA10", "GPU_8xH100"}
+	nameRegex := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+	for _, host := range hosts {
+		for _, acc := range accelerators {
+			name := client.GenerateDefaultConnectionName(host, acc)
+			assert.Regexp(t, nameRegex, name, "host=%q accelerator=%q name=%q", host, acc, name)
+		}
 	}
 }
 

--- a/experimental/ssh/internal/client/client_test.go
+++ b/experimental/ssh/internal/client/client_test.go
@@ -118,7 +118,7 @@ func TestGenerateDefaultConnectionName(t *testing.T) {
 		{
 			name: "no accelerator",
 			host: "https://my-workspace.cloud.databricks.com",
-			want: "databricks-ssh-961dabbd",
+			want: "databricks-cpu-961dabbd",
 		},
 		{
 			name:        "GPU_1xA10 accelerator",
@@ -135,12 +135,12 @@ func TestGenerateDefaultConnectionName(t *testing.T) {
 		{
 			name: "different host produces different name",
 			host: "https://other-workspace.cloud.databricks.com",
-			want: "databricks-ssh-e8a8ec19",
+			want: "databricks-cpu-e8a8ec19",
 		},
 		{
 			name: "deterministic for same input",
 			host: "https://my-workspace.cloud.databricks.com",
-			want: "databricks-ssh-961dabbd",
+			want: "databricks-cpu-961dabbd",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Auto-generate a deterministic connection name when neither `--name` nor `--cluster` is provided to `ssh connect`
- Name format: `databricks-ssh-<hash>` (no accelerator) or `databricks-<accelerator>-<hash>` (with accelerator), where `<hash>` is derived from the workspace host URL
- Different workspaces produce different names, avoiding SSH `known_hosts` conflicts

Supersedes #4701 with a simpler approach: deterministic names eliminate the need for session tracking, reconnection prompts, and stale session cleanup. The existing `ensureSSHServerIsRunning` flow naturally handles reconnection when the remote compute goes away.

## Test plan
- [x] Unit tests for `GenerateDefaultConnectionName` (determinism, workspace differentiation, accelerator variants)
- [x] Unit tests verifying all generated names match the `connectionNameRegex`
- [x] Existing validation and proxy command tests pass
- [x] Build succeeds (`go build ./...`)
- [x] Manually tested with `./cli ssh connect --ide vscode -p dogfood --releases-dir=./dist` to start a new connection an reconnect 
- [x] Manually tested with `./cli ssh connect --ide vscode -p dogfood --releases-dir=./dist --name mysession` to start a new connection an reconnect

This pull request was AI-assisted by Isaac.