### PR TITLE
direct: apps: mark compute_size as backend_default

### DIFF
--- a/acceptance/bundle/generate/app_not_yet_deployed/output.txt
+++ b/acceptance/bundle/generate/app_not_yet_deployed/output.txt
@@ -5,6 +5,7 @@
     "message":"Application is running.",
     "state":"RUNNING"
   },
+  "compute_size":"MEDIUM",
   "compute_status": {
     "message":"App compute is active.",
     "state":"ACTIVE"

--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -5,6 +5,3 @@ EnvMatrixExclude.no_grant_ref = ["INPUT_CONFIG=schema_grant_ref.yml.tmpl"]
 
 # Model permissions did not work until 0.297.0 https://github.com/databricks/cli/pull/4941
 EnvMatrixExclude.no_model_with_permissions = ["INPUT_CONFIG=model_with_permissions.yml.tmpl"]
-
-# LOG.deploy: Error: cannot update resources.apps.foo: updating id=app-dnppf7fm4zalnocu4yav774xpy: Invalid update mask. Only description, budget_policy_id, usage_policy_id, resources, user_api_scopes, compute_size, compute_min_instances, compute_max_instances, git_repository, telemetry_export_destinations are allowed. Supplied update mask: * (400 INVALID_PARAMETER_VALUE)
-EnvMatrixExclude.no_app = ["INPUT_CONFIG=app.yml"]

--- a/acceptance/bundle/resources/apps/config-drift/out.plan.direct.json
+++ b/acceptance/bundle/resources/apps/config-drift/out.plan.direct.json
@@ -35,6 +35,11 @@
       "state": "RUNNING"
     }
   },
+  "compute_size": {
+    "action": "skip",
+    "reason": "backend_default",
+    "remote": "MEDIUM"
+  },
   "compute_status": {
     "action": "skip",
     "reason": "spec:output_only",

--- a/acceptance/bundle/resources/apps/create_already_exists/output.txt
+++ b/acceptance/bundle/resources/apps/create_already_exists/output.txt
@@ -5,6 +5,7 @@
     "message":"Application is running.",
     "state":"RUNNING"
   },
+  "compute_size":"MEDIUM",
   "compute_status": {
     "message":"App compute is active.",
     "state":"ACTIVE"

--- a/acceptance/cmd/workspace/apps/output.txt
+++ b/acceptance/cmd/workspace/apps/output.txt
@@ -6,6 +6,7 @@
     "message":"Application is running.",
     "state":"RUNNING"
   },
+  "compute_size":"MEDIUM",
   "compute_status": {
     "message":"App compute is active.",
     "state":"ACTIVE"
@@ -37,6 +38,7 @@
     "message":"Application is running.",
     "state":"RUNNING"
   },
+  "compute_size":"MEDIUM",
   "compute_status": {
     "message":"App compute is active.",
     "state":"ACTIVE"

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -376,6 +376,8 @@ resources:
       - field: name
         reason: immutable
     backend_defaults:
+      # Backend sets it "MEDIUM" when not specified in the config
+      - field: compute_size
       # lifecycle.started is derived from remote compute status in RemapState, so the
       # remote side always has a value. When the user omits lifecycle from config,
       # both old and new are nil and backend_defaults correctly skips the remote value.

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -226,6 +226,10 @@ func (s *FakeWorkspace) AppsUpsert(req Request, name string) Response {
 	app.Url = name + "-123.cloud.databricksapps.com"
 	app.Id = strconv.Itoa(len(s.Apps) + 1000)
 
+	if app.ComputeSize == "" {
+		app.ComputeSize = "MEDIUM"
+	}
+
 	// Assign a service principal to the app, mimicking the real platform.
 	if app.ServicePrincipalClientId == "" {
 		app.ServicePrincipalClientId = nextUUID()


### PR DESCRIPTION
## Changes
For apps, mark compute_size as backend_default.

## Why
Backend sets it to "MEDIUM", causing drift.

## Tests
Update testserver to set compute_size default to "MEDIUM", same as cloud, this makes invariant test apps.yml fail locally same as on cloud. This PR then fixes both local and cloud.