### PR TITLE
Move eng-apps-devex to OWNERTEAMS for approval resolution

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -16,10 +16,10 @@
 /acceptance/labs/           @alexott @nfx
 
 # Apps
-/cmd/apps/                  @databricks/eng-apps-devex
-/cmd/workspace/apps/        @databricks/eng-apps-devex
-/libs/apps/                 @databricks/eng-apps-devex
-/acceptance/apps/           @databricks/eng-apps-devex
+/cmd/apps/                  team:eng-apps-devex
+/cmd/workspace/apps/        team:eng-apps-devex
+/libs/apps/                 team:eng-apps-devex
+/acceptance/apps/           team:eng-apps-devex
 
 # Auth
 /cmd/auth/                  team:platform
@@ -60,4 +60,4 @@
 /internal/                  team:platform
 
 # Experimental
-/experimental/aitools/      @databricks/eng-apps-devex @lennartkats-db
+/experimental/aitools/      team:eng-apps-devex @lennartkats-db

--- a/.github/OWNERTEAMS
+++ b/.github/OWNERTEAMS
@@ -4,3 +4,4 @@
 
 team:bundle     @andrewnester @anton-107 @denik @janniklasrose @pietern @shreyas-goenka
 team:platform   @simonfaltum @renaudhartert-db @hectorcast-db @parthban-db @tanmay-db @Divyansh-db @tejaskochar-db @mihaimitrea-db @chrisst @rauchy
+team:eng-apps-devex @fjakobs @jamesbroadhead @Shridhad @atilafassina @keugenek @arsenyinfo @igrekun @pkosiec @MarioCadenas @pffigueiredo @ditadi @calvarjorge

--- a/.github/OWNERTEAMS
+++ b/.github/OWNERTEAMS
@@ -1,6 +1,15 @@
 # Team aliases for OWNERS file.
 # Use "team:<name>" in OWNERS to reference a team defined here.
 # Format: team:<name>  @member1 @member2 ...
+#
+# Keep these in sync with actual GitHub team rosters. GITHUB_TOKEN can't
+# resolve org team membership via the API, so this file is the source of
+# truth for the maintainer-approval workflow.
+#
+# GitHub team pages:
+#   bundle:          https://github.com/orgs/databricks/teams/cli-maintainers
+#   platform:        https://github.com/orgs/databricks/teams/cli-platform
+#   eng-apps-devex:  https://github.com/orgs/databricks/teams/eng-apps-devex
 
 team:bundle     @andrewnester @anton-107 @denik @janniklasrose @pietern @shreyas-goenka
 team:platform   @simonfaltum @renaudhartert-db @hectorcast-db @parthban-db @tanmay-db @Divyansh-db @tejaskochar-db @mihaimitrea-db @chrisst @rauchy

--- a/.github/workflows/maintainer-approval.test.js
+++ b/.github/workflows/maintainer-approval.test.js
@@ -8,18 +8,23 @@ const runModule = require("./maintainer-approval");
 
 // --- Test helpers ---
 
-function makeTmpOwners(content) {
+function makeTmpOwners(content, ownerTeamsContent) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "approval-test-"));
   const ghDir = path.join(tmpDir, ".github");
   fs.mkdirSync(ghDir);
   fs.writeFileSync(path.join(ghDir, "OWNERS"), content);
+  if (ownerTeamsContent) {
+    fs.writeFileSync(path.join(ghDir, "OWNERTEAMS"), ownerTeamsContent);
+  }
   return tmpDir;
 }
+
+const OWNERTEAMS_CONTENT = "team:eng-apps-devex @teamdev1 @teamdev2\n";
 
 const OWNERS_CONTENT = [
   "* @maintainer1 @maintainer2",
   "/cmd/pipelines/ @jefferycheng1 @kanterov",
-  "/cmd/apps/ @databricks/eng-apps-devex",
+  "/cmd/apps/ team:eng-apps-devex",
   "/bundle/ @bundleowner",
 ].join("\n");
 
@@ -121,7 +126,7 @@ describe("maintainer-approval", () => {
 
   before(() => {
     originalWorkspace = process.env.GITHUB_WORKSPACE;
-    tmpDir = makeTmpOwners(OWNERS_CONTENT);
+    tmpDir = makeTmpOwners(OWNERS_CONTENT, OWNERTEAMS_CONTENT);
     process.env.GITHUB_WORKSPACE = tmpDir;
   });
 
@@ -283,13 +288,12 @@ describe("maintainer-approval", () => {
     assert.equal(github._checkRuns.length, 0);
   });
 
-  it("team member approved -> success for team-owned path", async () => {
+  it("OWNERTEAMS member approved -> success for team-owned path", async () => {
     const github = makeGithub({
       reviews: [
         { state: "APPROVED", user: { login: "teamdev1" } },
       ],
       files: [{ filename: "cmd/apps/main.go" }],
-      teamMembers: { "eng-apps-devex": ["teamdev1"] },
     });
     const core = makeCore();
     const context = makeContext();
@@ -300,13 +304,12 @@ describe("maintainer-approval", () => {
     assert.equal(github._checkRuns[0].conclusion, "success");
   });
 
-  it("non-team-member approval for team-owned path -> pending", async () => {
+  it("non-OWNERTEAMS-member approval for team-owned path -> pending", async () => {
     const github = makeGithub({
       reviews: [
         { state: "APPROVED", user: { login: "outsider" } },
       ],
       files: [{ filename: "cmd/apps/main.go" }],
-      teamMembers: { "eng-apps-devex": [] },
     });
     const core = makeCore();
     const context = makeContext();


### PR DESCRIPTION
## Why

The `maintainer-approval` workflow uses `@databricks/eng-apps-devex` team references in OWNERS, then calls `teams.getMembershipForUserInOrg()` to check if a reviewer belongs to that team. This API requires `read:org` scope, which `GITHUB_TOKEN` doesn't support (it only has repository-scoped permissions). The API returns 404 for privacy reasons, the code silently treats that as "not a member", and team-based approvals never resolve.

This showed up on #4968 where arsenyinfo (a member of eng-apps-devex) approved, but the check stayed pending until a maintainer stepped in.

## Changes

We already have an `OWNERTEAMS` mechanism that expands `team:<name>` references to individual logins at parse time, no API calls needed. `team:bundle` and `team:platform` already use it. This PR adds `team:eng-apps-devex` to the same system:

- OWNERTEAMS: added `team:eng-apps-devex` with the full team roster (12 members)
- OWNERS: replaced all `@databricks/eng-apps-devex` references with `team:eng-apps-devex`
- Tests: updated to use `OWNERTEAMS`-based team resolution instead of mocking the GitHub API

## Test plan

- [x] All 20 existing maintainer-approval tests pass
- [x] Team member approval now resolves via OWNERTEAMS expansion (no API dependency)
- [x] Non-team-member approval correctly stays pending
- [x] `make ws` passes

This pull request was AI-assisted by Isaac.