### PR TITLE
Enable `usestdlibvars` linter and fix all violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,6 +20,7 @@ linters:
     - copyloopvar
     - forbidigo
     - depguard
+    - usestdlibvars
   settings:
     depguard:
       rules:

--- a/bundle/direct/dresources/postgres_endpoint.go
+++ b/bundle/direct/dresources/postgres_endpoint.go
@@ -3,6 +3,7 @@ package dresources
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"time"
 
@@ -180,7 +181,7 @@ func (r *ResourcePostgresEndpoint) DoDelete(ctx context.Context, id string) erro
 		if err != nil {
 			// Check if this is a reconciliation in progress error
 			var apiErr *apierr.APIError
-			if errors.As(err, &apiErr) && apiErr.StatusCode == 409 &&
+			if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict &&
 				strings.Contains(apiErr.Message, "reconciliation") {
 				// Check if we've exceeded the timeout
 				if time.Now().After(deadline) {

--- a/cmd/bundle/generate/alert.go
+++ b/cmd/bundle/generate/alert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -81,7 +82,7 @@ After generation, you can deploy this alert to other targets using:
 		if err != nil {
 			// Check if it's a not found error to provide a better message
 			var apiErr *apierr.APIError
-			if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
 				return fmt.Errorf("alert with ID %s not found", alertID)
 			}
 			return err

--- a/cmd/labs/github/github.go
+++ b/cmd/labs/github/github.go
@@ -56,7 +56,7 @@ func getPagedBytes(ctx context.Context, method, url string, body io.Reader) (*pa
 		url = strings.Replace(url, gitHubUserContent, uco, 1)
 	}
 	log.Tracef(ctx, "%s %s", method, url)
-	req, err := http.NewRequestWithContext(ctx, "GET", url, body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func getPagedBytes(ctx context.Context, method, url string, body io.Reader) (*pa
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode == 404 {
+	if res.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
 	if res.StatusCode >= 400 {

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -439,7 +439,7 @@ func getServerMetadata(ctx context.Context, client *databricks.WorkspaceClient, 
 	}
 	metadataURL := fmt.Sprintf("%s/driver-proxy-api/o/%d/%s/%d/metadata", client.Config.Host, workspaceID, effectiveClusterID, wsMetadata.Port)
 	log.Debugf(ctx, "Metadata URL: %s", metadataURL)
-	req, err := http.NewRequestWithContext(ctx, "GET", metadataURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return 0, "", "", err
 	}

--- a/experimental/ssh/internal/client/websockets.go
+++ b/experimental/ssh/internal/client/websockets.go
@@ -15,7 +15,7 @@ func createWebsocketConnection(ctx context.Context, client *databricks.Workspace
 		return nil, fmt.Errorf("failed to get proxy URL: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/libs/appproxy/appproxy_test.go
+++ b/libs/appproxy/appproxy_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func sendTestRequest(t *testing.T, url, path string) (int, []byte) {
-	req, err := http.NewRequest("GET", url+path, bytes.NewBufferString("{'test': 'value'}"))
+	req, err := http.NewRequest(http.MethodGet, url+path, bytes.NewBufferString("{'test': 'value'}"))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 

--- a/libs/apps/vite/bridge.go
+++ b/libs/apps/vite/bridge.go
@@ -133,7 +133,7 @@ func NewBridge(ctx context.Context, w *databricks.WorkspaceClient, appName strin
 }
 
 func (vb *Bridge) getAuthHeaders(wsURL string) (http.Header, error) {
-	req, err := http.NewRequestWithContext(vb.ctx, "GET", wsURL, nil)
+	req, err := http.NewRequestWithContext(vb.ctx, http.MethodGet, wsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/libs/auth/credentials_test.go
+++ b/libs/auth/credentials_test.go
@@ -176,7 +176,7 @@ func TestCLICredentialsConfigure(t *testing.T) {
 			}
 
 			// Verify the credentials provider sets the correct Bearer token.
-			req, err := http.NewRequest("GET", tt.cfg.Host, nil)
+			req, err := http.NewRequest(http.MethodGet, tt.cfg.Host, nil)
 			if err != nil {
 				t.Fatalf("creating request: %v", err)
 			}

--- a/libs/testproxy/server.go
+++ b/libs/testproxy/server.go
@@ -62,7 +62,7 @@ func New(t testutil.TestingT) *ProxyServer {
 func (s *ProxyServer) reqBody(r testserver.Request) any {
 	// The SDK expects the query parameters to be specified in the "request body"
 	// argument for GET, DELETE, and HEAD requests in the .Do method.
-	if r.Method == "GET" || r.Method == "DELETE" || r.Method == "HEAD" {
+	if r.Method == http.MethodGet || r.Method == http.MethodDelete || r.Method == http.MethodHead {
 		queryParams := make(map[string]any)
 		for k, v := range r.URL.Query() {
 			queryParams[k] = v[0]

--- a/libs/testserver/postgres_test.go
+++ b/libs/testserver/postgres_test.go
@@ -19,7 +19,7 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	baseURL := server.URL
 
 	// Create project
-	createReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects?project_id=test-project", nil)
+	createReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=test-project", nil)
 	createReq.Header.Set("Authorization", "Bearer test-token")
 	createReq.Header.Set("Content-Type", "application/json")
 	createResp, err := client.Do(createReq)
@@ -32,7 +32,7 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	createResp.Body.Close()
 
 	// Get project
-	getReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/test-project", nil)
+	getReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/test-project", nil)
 	getReq.Header.Set("Authorization", "Bearer test-token")
 	getResp, err := client.Do(getReq)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	getResp.Body.Close()
 
 	// List projects
-	listReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects", nil)
+	listReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects", nil)
 	listReq.Header.Set("Authorization", "Bearer test-token")
 	listResp, err := client.Do(listReq)
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	listResp.Body.Close()
 
 	// Delete project
-	deleteReq, _ := http.NewRequest("DELETE", baseURL+"/api/2.0/postgres/projects/test-project", nil)
+	deleteReq, _ := http.NewRequest(http.MethodDelete, baseURL+"/api/2.0/postgres/projects/test-project", nil)
 	deleteReq.Header.Set("Authorization", "Bearer test-token")
 	deleteResp, err := client.Do(deleteReq)
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	deleteResp.Body.Close()
 
 	// Verify project is deleted
-	getReq2, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/test-project", nil)
+	getReq2, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/test-project", nil)
 	getReq2.Header.Set("Authorization", "Bearer test-token")
 	getResp2, err := client.Do(getReq2)
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestPostgresProjectNotFound(t *testing.T) {
 	client := &http.Client{}
 	baseURL := server.URL
 
-	getReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/nonexistent", nil)
+	getReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/nonexistent", nil)
 	getReq.Header.Set("Authorization", "Bearer test-token")
 	getResp, err := client.Do(getReq)
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestPostgresProjectDuplicate(t *testing.T) {
 	baseURL := server.URL
 
 	// Create project
-	createReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects?project_id=dup-project", nil)
+	createReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=dup-project", nil)
 	createReq.Header.Set("Authorization", "Bearer test-token")
 	createResp, err := client.Do(createReq)
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestPostgresProjectDuplicate(t *testing.T) {
 	createResp.Body.Close()
 
 	// Try to create duplicate
-	createReq2, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects?project_id=dup-project", nil)
+	createReq2, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=dup-project", nil)
 	createReq2.Header.Set("Authorization", "Bearer test-token")
 	createResp2, err := client.Do(createReq2)
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestPostgresBranchCRUD(t *testing.T) {
 	baseURL := server.URL
 
 	// Create project first
-	createProjReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects?project_id=branch-test-project", nil)
+	createProjReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=branch-test-project", nil)
 	createProjReq.Header.Set("Authorization", "Bearer test-token")
 	createProjResp, err := client.Do(createProjReq)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestPostgresBranchCRUD(t *testing.T) {
 	createProjResp.Body.Close()
 
 	// Create branch
-	createBranchReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects/branch-test-project/branches?branch_id=main", nil)
+	createBranchReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects/branch-test-project/branches?branch_id=main", nil)
 	createBranchReq.Header.Set("Authorization", "Bearer test-token")
 	createBranchResp, err := client.Do(createBranchReq)
 	require.NoError(t, err)
@@ -135,7 +135,7 @@ func TestPostgresBranchCRUD(t *testing.T) {
 	createBranchResp.Body.Close()
 
 	// Get branch
-	getBranchReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/branch-test-project/branches/main", nil)
+	getBranchReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/branch-test-project/branches/main", nil)
 	getBranchReq.Header.Set("Authorization", "Bearer test-token")
 	getBranchResp, err := client.Do(getBranchReq)
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestPostgresBranchCRUD(t *testing.T) {
 	getBranchResp.Body.Close()
 
 	// List branches
-	listBranchReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/branch-test-project/branches", nil)
+	listBranchReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/branch-test-project/branches", nil)
 	listBranchReq.Header.Set("Authorization", "Bearer test-token")
 	listBranchResp, err := client.Do(listBranchReq)
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestPostgresBranchCRUD(t *testing.T) {
 	listBranchResp.Body.Close()
 
 	// Delete branch
-	deleteBranchReq, _ := http.NewRequest("DELETE", baseURL+"/api/2.0/postgres/projects/branch-test-project/branches/main", nil)
+	deleteBranchReq, _ := http.NewRequest(http.MethodDelete, baseURL+"/api/2.0/postgres/projects/branch-test-project/branches/main", nil)
 	deleteBranchReq.Header.Set("Authorization", "Bearer test-token")
 	deleteBranchResp, err := client.Do(deleteBranchReq)
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestPostgresBranchNotFoundWhenProjectNotExists(t *testing.T) {
 	baseURL := server.URL
 
 	// Try to create branch without project
-	createBranchReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects/nonexistent/branches?branch_id=main", nil)
+	createBranchReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects/nonexistent/branches?branch_id=main", nil)
 	createBranchReq.Header.Set("Authorization", "Bearer test-token")
 	createBranchResp, err := client.Do(createBranchReq)
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestPostgresEndpointCRUD(t *testing.T) {
 	baseURL := server.URL
 
 	// Create project first
-	createProjReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects?project_id=endpoint-test-project", nil)
+	createProjReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=endpoint-test-project", nil)
 	createProjReq.Header.Set("Authorization", "Bearer test-token")
 	createProjResp, err := client.Do(createProjReq)
 	require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestPostgresEndpointCRUD(t *testing.T) {
 	createProjResp.Body.Close()
 
 	// Create branch
-	createBranchReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches?branch_id=main", nil)
+	createBranchReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches?branch_id=main", nil)
 	createBranchReq.Header.Set("Authorization", "Bearer test-token")
 	createBranchResp, err := client.Do(createBranchReq)
 	require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestPostgresEndpointCRUD(t *testing.T) {
 	createBranchResp.Body.Close()
 
 	// Create endpoint
-	createEpReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints?endpoint_id=rw-endpoint", nil)
+	createEpReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints?endpoint_id=rw-endpoint", nil)
 	createEpReq.Header.Set("Authorization", "Bearer test-token")
 	createEpResp, err := client.Do(createEpReq)
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestPostgresEndpointCRUD(t *testing.T) {
 	createEpResp.Body.Close()
 
 	// Get endpoint
-	getEpReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints/rw-endpoint", nil)
+	getEpReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints/rw-endpoint", nil)
 	getEpReq.Header.Set("Authorization", "Bearer test-token")
 	getEpResp, err := client.Do(getEpReq)
 	require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestPostgresEndpointCRUD(t *testing.T) {
 	getEpResp.Body.Close()
 
 	// List endpoints
-	listEpReq, _ := http.NewRequest("GET", baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints", nil)
+	listEpReq, _ := http.NewRequest(http.MethodGet, baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints", nil)
 	listEpReq.Header.Set("Authorization", "Bearer test-token")
 	listEpResp, err := client.Do(listEpReq)
 	require.NoError(t, err)
@@ -240,7 +240,7 @@ func TestPostgresEndpointCRUD(t *testing.T) {
 	listEpResp.Body.Close()
 
 	// Delete endpoint
-	deleteEpReq, _ := http.NewRequest("DELETE", baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints/rw-endpoint", nil)
+	deleteEpReq, _ := http.NewRequest(http.MethodDelete, baseURL+"/api/2.0/postgres/projects/endpoint-test-project/branches/main/endpoints/rw-endpoint", nil)
 	deleteEpReq.Header.Set("Authorization", "Bearer test-token")
 	deleteEpResp, err := client.Do(deleteEpReq)
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestPostgresEndpointNotFoundWhenBranchNotExists(t *testing.T) {
 	baseURL := server.URL
 
 	// Create project first
-	createProjReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects?project_id=ep-test-project", nil)
+	createProjReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=ep-test-project", nil)
 	createProjReq.Header.Set("Authorization", "Bearer test-token")
 	createProjResp, err := client.Do(createProjReq)
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestPostgresEndpointNotFoundWhenBranchNotExists(t *testing.T) {
 	createProjResp.Body.Close()
 
 	// Try to create endpoint without branch
-	createEpReq, _ := http.NewRequest("POST", baseURL+"/api/2.0/postgres/projects/ep-test-project/branches/nonexistent/endpoints?endpoint_id=rw-endpoint", nil)
+	createEpReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects/ep-test-project/branches/nonexistent/endpoints?endpoint_id=rw-endpoint", nil)
 	createEpReq.Header.Set("Authorization", "Bearer test-token")
 	createEpResp, err := client.Do(createEpReq)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Enable the `usestdlibvars` golangci-lint linter, which detects places where Go standard library constants should be used instead of literal values
- Auto-fixed all violations: HTTP method strings (`"GET"`, `"POST"`, etc.) replaced with `http.Method*` constants, and HTTP status codes (`404`, `409`) replaced with `http.Status*` constants

## Test plan
- [x] `make checks fmt lint` passes
- [x] All unit tests pass (5025 tests)
- [x] No new acceptance test failures