### PR TITLE
Simplify cluster-id flag handling in cmd/bundle

### DIFF
--- a/cmd/bundle/deploy.go
+++ b/cmd/bundle/deploy.go
@@ -50,11 +50,7 @@ See https://docs.databricks.com/en/dev-tools/bundles/index.html for more informa
 				b.Config.Bundle.Deployment.Lock.Force = forceLock
 				b.AutoApprove = autoApprove
 
-				if cmd.Flag("compute-id").Changed {
-					b.Config.Bundle.ClusterId = clusterId
-				}
-
-				if cmd.Flag("cluster-id").Changed {
+				if cmd.Flag("compute-id").Changed || cmd.Flag("cluster-id").Changed {
 					b.Config.Bundle.ClusterId = clusterId
 				}
 				if cmd.Flag("fail-on-active-runs").Changed {

--- a/cmd/bundle/plan.go
+++ b/cmd/bundle/plan.go
@@ -41,18 +41,11 @@ It is useful for previewing changes before running 'bundle deploy'.`,
 			PreDeployChecks: true,
 		}
 
-		// Only add InitFunc if we need to set force or cluster ID
-		if force || cmd.Flag("compute-id").Changed || cmd.Flag("cluster-id").Changed {
-			opts.InitFunc = func(b *bundle.Bundle) {
-				b.Config.Bundle.Force = force
+		opts.InitFunc = func(b *bundle.Bundle) {
+			b.Config.Bundle.Force = force
 
-				if cmd.Flag("compute-id").Changed {
-					b.Config.Bundle.ClusterId = clusterId
-				}
-
-				if cmd.Flag("cluster-id").Changed {
-					b.Config.Bundle.ClusterId = clusterId
-				}
+			if cmd.Flag("compute-id").Changed || cmd.Flag("cluster-id").Changed {
+				b.Config.Bundle.ClusterId = clusterId
 			}
 		}
 


### PR DESCRIPTION
## Changes
- Merge duplicate `--compute-id` / `--cluster-id` flag checks into a single condition in `deploy.go` and `plan.go`, since both flags bind to the same variable.
- Make `InitFunc` assignment in `plan.go` unconditional, matching `deploy.go`.

## Why
Both flags write to the same `clusterId` variable, so checking them separately is redundant. Aligning `plan.go` with `deploy.go` reduces the chance of future divergence.

## Tests
No new tests — behavior-preserving refactor.