### PR TITLE
Add X-Databricks-Org-Id header to filer API calls for SPOG hosts

### DIFF
--- a/bundle/deploy/filer.go
+++ b/bundle/deploy/filer.go
@@ -25,6 +25,19 @@ type stateFiler struct {
 	root      filer.WorkspaceRootPath
 }
 
+// orgIDHeaders returns headers with X-Databricks-Org-Id set if a workspace ID
+// is configured. SPOG hosts require this header to route requests to the
+// correct workspace.
+func (s stateFiler) orgIDHeaders() map[string]string {
+	wsID := s.apiClient.Config.WorkspaceID
+	if wsID == "" {
+		return nil
+	}
+	return map[string]string{
+		"X-Databricks-Org-Id": wsID,
+	}
+}
+
 func (s stateFiler) Delete(ctx context.Context, path string, mode ...filer.DeleteMode) error {
 	return s.filer.Delete(ctx, path, mode...)
 }
@@ -50,7 +63,7 @@ func (s stateFiler) Read(ctx context.Context, path string) (io.ReadCloser, error
 
 	var buf bytes.Buffer
 	urlPath := "/api/2.0/workspace-files/" + url.PathEscape(strings.TrimLeft(absPath, "/"))
-	err = s.apiClient.Do(ctx, http.MethodGet, urlPath, nil, nil, nil, &buf)
+	err = s.apiClient.Do(ctx, http.MethodGet, urlPath, s.orgIDHeaders(), nil, nil, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -109,6 +109,19 @@ func NewFilesClient(w *databricks.WorkspaceClient, root string) (Filer, error) {
 	}, nil
 }
 
+// orgIDHeaders returns headers with X-Databricks-Org-Id set if a workspace ID
+// is configured. SPOG hosts require this header to route requests to the
+// correct workspace.
+func (w *FilesClient) orgIDHeaders() map[string]string {
+	wsID := w.workspaceClient.Config.WorkspaceID
+	if wsID == "" {
+		return nil
+	}
+	return map[string]string{
+		"X-Databricks-Org-Id": wsID,
+	}
+}
+
 func (w *FilesClient) urlPath(name string) (string, string, error) {
 	absPath, err := w.root.Join(name)
 	if err != nil {
@@ -148,6 +161,9 @@ func (w *FilesClient) Write(ctx context.Context, name string, reader io.Reader, 
 	overwrite := slices.Contains(mode, OverwriteIfExists)
 	urlPath = fmt.Sprintf("%s?overwrite=%t", urlPath, overwrite)
 	headers := map[string]string{"Content-Type": "application/octet-stream"}
+	if wsID := w.workspaceClient.Config.WorkspaceID; wsID != "" {
+		headers["X-Databricks-Org-Id"] = wsID
+	}
 	err = w.apiClient.Do(ctx, http.MethodPut, urlPath, headers, nil, reader, nil)
 
 	// Return early on success.
@@ -176,7 +192,7 @@ func (w *FilesClient) Read(ctx context.Context, name string) (io.ReadCloser, err
 	}
 
 	var reader io.ReadCloser
-	err = w.apiClient.Do(ctx, http.MethodGet, urlPath, nil, nil, nil, &reader)
+	err = w.apiClient.Do(ctx, http.MethodGet, urlPath, w.orgIDHeaders(), nil, nil, &reader)
 
 	// Return early on success.
 	if err == nil {

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -122,6 +122,22 @@ type WorkspaceFilesClient struct {
 	root WorkspaceRootPath
 }
 
+// orgIDHeaders returns headers with X-Databricks-Org-Id set if a workspace ID
+// is configured. SPOG hosts require this header to route requests to the
+// correct workspace.
+func (w *WorkspaceFilesClient) orgIDHeaders() map[string]string {
+	if w.workspaceClient == nil || w.workspaceClient.Config == nil {
+		return nil
+	}
+	wsID := w.workspaceClient.Config.WorkspaceID
+	if wsID == "" {
+		return nil
+	}
+	return map[string]string{
+		"X-Databricks-Org-Id": wsID,
+	}
+}
+
 func NewWorkspaceFilesClient(w *databricks.WorkspaceClient, root string) (Filer, error) {
 	apiClient, err := client.New(w.Config)
 	if err != nil {
@@ -156,7 +172,7 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 		return err
 	}
 
-	err = w.apiClient.Do(ctx, http.MethodPost, urlPath, nil, nil, body, nil)
+	err = w.apiClient.Do(ctx, http.MethodPost, urlPath, w.orgIDHeaders(), nil, body, nil)
 
 	// Return early on success.
 	if err == nil {
@@ -337,7 +353,7 @@ func (w *WorkspaceFilesClient) Stat(ctx context.Context, name string) (fs.FileIn
 		ctx,
 		http.MethodGet,
 		"/api/2.0/workspace/get-status",
-		nil,
+		w.orgIDHeaders(),
 		nil,
 		map[string]string{
 			"path":               absPath,

--- a/libs/filer/workspace_files_client_test.go
+++ b/libs/filer/workspace_files_client_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +57,42 @@ func TestWorkspaceFilesDirEntry(t *testing.T) {
 	assert.True(t, i0.IsDir())
 	assert.False(t, i1.IsDir())
 	assert.True(t, i2.IsDir())
+}
+
+func TestWorkspaceFilesClientOrgIDHeaders(t *testing.T) {
+	tests := []struct {
+		name        string
+		workspaceID string
+		expect      map[string]string
+	}{
+		{
+			name:        "with workspace ID",
+			workspaceID: "7474644166319138",
+			expect:      map[string]string{"X-Databricks-Org-Id": "7474644166319138"},
+		},
+		{
+			name:        "without workspace ID",
+			workspaceID: "",
+			expect:      nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &WorkspaceFilesClient{
+				workspaceClient: &databricks.WorkspaceClient{
+					Config: &config.Config{
+						WorkspaceID: tc.workspaceID,
+					},
+				},
+			}
+			assert.Equal(t, tc.expect, w.orgIDHeaders())
+		})
+	}
+
+	t.Run("nil workspace client", func(t *testing.T) {
+		w := &WorkspaceFilesClient{}
+		assert.Nil(t, w.orgIDHeaders())
+	})
 }
 
 func TestWorkspaceFilesClient_wsfsUnmarshal(t *testing.T) {


### PR DESCRIPTION
## Why

`databricks bundle deploy` fails on SPOG hosts with "Unable to load OAuth Config" errors. SPOG hosts serve multiple workspaces from a single URL and require the `X-Databricks-Org-Id` header to route API requests to the correct workspace.

The SDK's generated service methods (`impl.go`) include this header when `WorkspaceID` is configured. However, the CLI's filer code makes direct `apiClient.Do()` calls that bypass the generated services and don't include the header. This causes `bundle deploy` to fail when reading state files (terraform.tfstate, resources.json) and writing deployment artifacts.

## Changes

Before: Direct `apiClient.Do()` calls in three filer implementations passed `nil` for the headers parameter, missing the workspace routing header. Running `bundle deploy` on a SPOG workspace like `https://db-deco-test.databricks.com/?o=7474644166319138` failed with:

```
Error: reading terraform.tfstate: opening: Unable to load OAuth Config (400 UNKNOWN)
```

Now: All direct API calls include `X-Databricks-Org-Id` when a `WorkspaceID` is configured:

- `libs/filer/workspace_files_client.go` - `Write()` and `Stat()` methods
- `libs/filer/files_client.go` - `Write()` and `Read()` methods
- `bundle/deploy/filer.go` - `stateFiler.Read()` (reads terraform.tfstate and resources.json)

Each client gets an `orgIDHeaders()` helper that returns the header map when `WorkspaceID` is set, or `nil` otherwise.

**Note:** This PR fixes the CLI-side direct API calls. The SDK also has hand-written extension methods (`Workspace.Download()` and `Workspace.Upload()` in `service/workspace/ext_utilities.go`) that make direct `client.Do()` calls without the header. databricks/databricks-sdk-go#1634 fixes this at the SDK transport level so all calls automatically include the header when `WorkspaceID` is configured. Full SPOG `bundle deploy` support requires both this PR and the SDK fix.

## Test plan

- [x] Unit tests for `orgIDHeaders()` (workspace ID set, empty, nil client)
- [x] Existing filer and deploy tests pass
- [x] `make checks` passes