### PR TITLE
direct: Rename RefreshOutput to ModelServingEndpointRemote

### DIFF
--- a/bundle/direct/dresources/model.go
+++ b/bundle/direct/dresources/model.go
@@ -16,7 +16,7 @@ type ResourceMlflowModel struct {
 // MlflowModelRemote wraps the API response with the numeric model ID.
 // The state ID for models is the model name (used for CRUD operations), but
 // the permissions API requires the numeric ID. This wrapper exposes the numeric
-// ID as model_id, analogous to RefreshOutput.EndpointId for serving endpoints.
+// ID as model_id, analogous to ModelServingEndpointRemote.EndpointId for serving endpoints.
 type MlflowModelRemote struct {
 	ml.ModelDatabricks
 	ModelId string `json:"model_id"`

--- a/bundle/direct/dresources/model_serving_endpoint.go
+++ b/bundle/direct/dresources/model_serving_endpoint.go
@@ -86,7 +86,7 @@ func configOutputToInput(output *serving.EndpointCoreConfigOutput) *serving.Endp
 	}
 }
 
-func (*ResourceModelServingEndpoint) RemapState(state *RefreshOutput) *serving.CreateServingEndpoint {
+func (*ResourceModelServingEndpoint) RemapState(state *ModelServingEndpointRemote) *serving.CreateServingEndpoint {
 	details := state.EndpointDetails
 	// Map the remote state (ServingEndpointDetailed) to the local state (CreateServingEndpoint)
 	// for proper comparison during diff calculation
@@ -107,23 +107,23 @@ func (*ResourceModelServingEndpoint) RemapState(state *RefreshOutput) *serving.C
 	}
 }
 
-type RefreshOutput struct {
+type ModelServingEndpointRemote struct {
 	EndpointDetails *serving.ServingEndpointDetailed `json:"endpoint_details"`
 	EndpointId      string                           `json:"endpoint_id"`
 }
 
-func (r *ResourceModelServingEndpoint) DoRead(ctx context.Context, id string) (*RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) DoRead(ctx context.Context, id string) (*ModelServingEndpointRemote, error) {
 	endpoint, err := r.client.ServingEndpoints.GetByName(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	return &RefreshOutput{
+	return &ModelServingEndpointRemote{
 		EndpointDetails: endpoint,
 		EndpointId:      endpoint.Id,
 	}, nil
 }
 
-func (r *ResourceModelServingEndpoint) DoCreate(ctx context.Context, config *serving.CreateServingEndpoint) (string, *RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) DoCreate(ctx context.Context, config *serving.CreateServingEndpoint) (string, *ModelServingEndpointRemote, error) {
 	waiter, err := r.client.ServingEndpoints.Create(ctx, *config)
 	if err != nil {
 		return "", nil, err
@@ -133,23 +133,23 @@ func (r *ResourceModelServingEndpoint) DoCreate(ctx context.Context, config *ser
 }
 
 // waitForEndpointReady waits for the serving endpoint to be ready (not updating)
-func (r *ResourceModelServingEndpoint) waitForEndpointReady(ctx context.Context, name string) (*RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) waitForEndpointReady(ctx context.Context, name string) (*ModelServingEndpointRemote, error) {
 	details, err := r.client.ServingEndpoints.WaitGetServingEndpointNotUpdating(ctx, name, 35*time.Minute, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return &RefreshOutput{
+	return &ModelServingEndpointRemote{
 		EndpointDetails: details,
 		EndpointId:      details.Id,
 	}, nil
 }
 
-func (r *ResourceModelServingEndpoint) WaitAfterCreate(ctx context.Context, config *serving.CreateServingEndpoint) (*RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) WaitAfterCreate(ctx context.Context, config *serving.CreateServingEndpoint) (*ModelServingEndpointRemote, error) {
 	return r.waitForEndpointReady(ctx, config.Name)
 }
 
-func (r *ResourceModelServingEndpoint) WaitAfterUpdate(ctx context.Context, config *serving.CreateServingEndpoint) (*RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) WaitAfterUpdate(ctx context.Context, config *serving.CreateServingEndpoint) (*ModelServingEndpointRemote, error) {
 	return r.waitForEndpointReady(ctx, config.Name)
 }
 
@@ -285,7 +285,7 @@ func (r *ResourceModelServingEndpoint) updateTags(ctx context.Context, id string
 	return nil
 }
 
-func (r *ResourceModelServingEndpoint) DoUpdate(ctx context.Context, id string, config *serving.CreateServingEndpoint, entry *PlanEntry) (*RefreshOutput, error) {
+func (r *ResourceModelServingEndpoint) DoUpdate(ctx context.Context, id string, config *serving.CreateServingEndpoint, entry *PlanEntry) (*ModelServingEndpointRemote, error) {
 	var err error
 
 	// Terraform makes these API calls sequentially. We do the same here.

--- a/bundle/direct/dresources/permissions.go
+++ b/bundle/direct/dresources/permissions.go
@@ -78,7 +78,7 @@ func PreparePermissionsInputConfig(inputConfig any, node string) (*structvar.Str
 	objectIdRef := prefix + "${" + baseNode + ".id}"
 	// For permissions, model serving endpoint uses its internal ID, which is different
 	// from its CRUD APIs which use the name.
-	// We have a wrapper struct [RefreshOutput] from which we read the internal ID
+	// We have a wrapper struct [ModelServingEndpointRemote] from which we read the internal ID
 	// in order to set the appropriate permissions.
 	if strings.HasPrefix(baseNode, "resources.model_serving_endpoints.") {
 		objectIdRef = prefix + "${" + baseNode + ".endpoint_id}"


### PR DESCRIPTION
## Summary

- Renames `RefreshOutput` to `ModelServingEndpointRemote` in `model_serving_endpoint.go`
- Follows the `<Resource>Remote` naming convention used by `JobRemote`, `PipelineRemote`, `AppRemote`, and `MlflowModelRemote`
- Updates comment references in `model.go` and `permissions.go`

## Test plan

- [ ] Existing unit tests cover the renamed type (no logic changed)

This pull request was AI-assisted by Claude.