### PR TITLE
Fix script output dropping last line without trailing newline

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 ### Bundles
+* Fix script output dropping last line without trailing newline (denik/random-bugfixes-4)
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### CLI
 
 ### Bundles
-* Fix script output dropping last line without trailing newline (denik/random-bugfixes-4)
+* Fix script output dropping last line without trailing newline ([#4995](https://github.com/databricks/cli/pull/4995))
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,5 +10,6 @@
 ### Bundles
 * Retry transient HTTP 5xx and 408 errors in direct deployment engine ([#5349](https://github.com/databricks/cli/pull/5349), [#5364](https://github.com/databricks/cli/pull/5364)).
 * Preserve `.designer.ipynb` suffix when translating notebook task paths so Lakeflow Designer files referenced from a `notebook_task` resolve correctly in the workspace ([#5370](https://github.com/databricks/cli/pull/5370)).
+* Fix script output dropping last line without trailing newline ([#4995](https://github.com/databricks/cli/pull/4995)).
 
 ### Dependency updates

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -761,6 +761,14 @@ func runTest(t *testing.T,
 	formatOutput(out, err)
 	require.NoError(t, out.Close())
 
+	// On script timeout the test directory holds partial state: the script was
+	// killed mid-run, so any "out.*" files (e.g. out.requests.txt) reflect an
+	// incomplete recording, and output.txt has only the prefix that streamed
+	// before the kill. Suppress OverwriteMode so `make test-update` does not
+	// taint committed reference files with this partial state.
+	timedOut := errors.Is(err, errScriptTimedOut)
+	overwrite := testdiff.OverwriteMode && !timedOut
+
 	loadUserReplacements(t, &repls, tmpDir)
 
 	printedRepls := false
@@ -773,7 +781,14 @@ func runTest(t *testing.T,
 			continue
 		}
 
-		doComparison(t, repls, dir, tmpDir, relPath, &printedRepls)
+		doComparison(t, repls, dir, tmpDir, relPath, &printedRepls, overwrite)
+	}
+
+	// On timeout, partial files left over by the killed script (e.g.
+	// out.requests.txt) should not be reported as unexpected nor written out;
+	// the timeout is the only failure that matters.
+	if timedOut {
+		return
 	}
 
 	// Make sure there are not unaccounted for new files
@@ -807,7 +822,7 @@ func runTest(t *testing.T,
 		if strings.HasPrefix(relPath, "out") {
 			// We have a new file starting with "out"
 			// Show the contents & support overwrite mode for it:
-			doComparison(t, repls, dir, tmpDir, relPath, &printedRepls)
+			doComparison(t, repls, dir, tmpDir, relPath, &printedRepls, overwrite)
 		}
 	}
 
@@ -880,7 +895,7 @@ func addEnvVar(t *testing.T, env []string, repls *testdiff.ReplacementsContext, 
 	return append(env, key+"="+newValue)
 }
 
-func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirNew, relPath string, printedRepls *bool) {
+func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirNew, relPath string, printedRepls *bool, overwrite bool) {
 	pathRef := filepath.Join(dirRef, relPath)
 	pathNew := filepath.Join(dirNew, relPath)
 	bufRef, okRef := tryReading(t, pathRef)
@@ -902,7 +917,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 	// The test did not produce an expected output file.
 	if okRef && !okNew {
 		t.Errorf("Missing output file: %s", relPath)
-		if testdiff.OverwriteMode {
+		if overwrite {
 			t.Logf("Removing output file: %s", relPath)
 			require.NoError(t, os.Remove(pathRef))
 		}
@@ -915,7 +930,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		if shouldShowDiff(pathNew, valueNew) {
 			testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		}
-		if testdiff.OverwriteMode {
+		if overwrite {
 			t.Logf("Writing output file: %s", relPath)
 			testutil.WriteFile(t, pathRef, valueNew)
 		}
@@ -924,7 +939,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 
 	// Compare the reference and new values.
 	equal := testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
-	if !equal && testdiff.OverwriteMode {
+	if !equal && overwrite {
 		t.Logf("Overwriting existing output file: %s", relPath)
 		testutil.WriteFile(t, pathRef, valueNew)
 	}
@@ -1361,6 +1376,24 @@ func isTruePtr(value *bool) bool {
 	return value != nil && *value
 }
 
+// errScriptTimedOut is returned when a test script is killed because it exceeded its timeout.
+// Callers can match it with errors.Is to suppress destructive side effects
+// (e.g. overwriting committed outputs with partial results).
+var errScriptTimedOut = errors.New("test script killed due to a timeout")
+
+// scriptTimeoutError carries the timeout duration for the user-facing message
+// while wrapping errScriptTimedOut so that errors.Is matches without the
+// sentinel's text appearing in the formatted output.
+type scriptTimeoutError struct {
+	timeout time.Duration
+}
+
+func (e scriptTimeoutError) Error() string {
+	return fmt.Sprintf("Test script killed due to a timeout (%s)", e.timeout)
+}
+
+func (scriptTimeoutError) Unwrap() error { return errScriptTimedOut }
+
 func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File, tail bool, timeout time.Duration) (string, error) {
 	r, w := io.Pipe()
 	cmd.Stdout = w
@@ -1368,7 +1401,7 @@ func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File, tail bool, timeout ti
 	processErrCh := make(chan error, 1)
 
 	cmd.Cancel = func() error {
-		processErrCh <- fmt.Errorf("Test script killed due to a timeout (%s)", timeout)
+		processErrCh <- scriptTimeoutError{timeout: timeout}
 		_ = cmd.Process.Kill()
 		_ = w.Close()
 		return nil

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -761,14 +761,6 @@ func runTest(t *testing.T,
 	formatOutput(out, err)
 	require.NoError(t, out.Close())
 
-	// On script timeout the test directory holds partial state: the script was
-	// killed mid-run, so any "out.*" files (e.g. out.requests.txt) reflect an
-	// incomplete recording, and output.txt has only the prefix that streamed
-	// before the kill. Suppress OverwriteMode so `make test-update` does not
-	// taint committed reference files with this partial state.
-	timedOut := errors.Is(err, errScriptTimedOut)
-	overwrite := testdiff.OverwriteMode && !timedOut
-
 	loadUserReplacements(t, &repls, tmpDir)
 
 	printedRepls := false
@@ -781,14 +773,7 @@ func runTest(t *testing.T,
 			continue
 		}
 
-		doComparison(t, repls, dir, tmpDir, relPath, &printedRepls, overwrite)
-	}
-
-	// On timeout, partial files left over by the killed script (e.g.
-	// out.requests.txt) should not be reported as unexpected nor written out;
-	// the timeout is the only failure that matters.
-	if timedOut {
-		return
+		doComparison(t, repls, dir, tmpDir, relPath, &printedRepls)
 	}
 
 	// Make sure there are not unaccounted for new files
@@ -822,7 +807,7 @@ func runTest(t *testing.T,
 		if strings.HasPrefix(relPath, "out") {
 			// We have a new file starting with "out"
 			// Show the contents & support overwrite mode for it:
-			doComparison(t, repls, dir, tmpDir, relPath, &printedRepls, overwrite)
+			doComparison(t, repls, dir, tmpDir, relPath, &printedRepls)
 		}
 	}
 
@@ -895,7 +880,7 @@ func addEnvVar(t *testing.T, env []string, repls *testdiff.ReplacementsContext, 
 	return append(env, key+"="+newValue)
 }
 
-func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirNew, relPath string, printedRepls *bool, overwrite bool) {
+func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirNew, relPath string, printedRepls *bool) {
 	pathRef := filepath.Join(dirRef, relPath)
 	pathNew := filepath.Join(dirNew, relPath)
 	bufRef, okRef := tryReading(t, pathRef)
@@ -917,7 +902,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 	// The test did not produce an expected output file.
 	if okRef && !okNew {
 		t.Errorf("Missing output file: %s", relPath)
-		if overwrite {
+		if testdiff.OverwriteMode {
 			t.Logf("Removing output file: %s", relPath)
 			require.NoError(t, os.Remove(pathRef))
 		}
@@ -930,7 +915,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		if shouldShowDiff(pathNew, valueNew) {
 			testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		}
-		if overwrite {
+		if testdiff.OverwriteMode {
 			t.Logf("Writing output file: %s", relPath)
 			testutil.WriteFile(t, pathRef, valueNew)
 		}
@@ -939,7 +924,7 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 
 	// Compare the reference and new values.
 	equal := testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
-	if !equal && overwrite {
+	if !equal && testdiff.OverwriteMode {
 		t.Logf("Overwriting existing output file: %s", relPath)
 		testutil.WriteFile(t, pathRef, valueNew)
 	}
@@ -1376,24 +1361,6 @@ func isTruePtr(value *bool) bool {
 	return value != nil && *value
 }
 
-// errScriptTimedOut is returned when a test script is killed because it exceeded its timeout.
-// Callers can match it with errors.Is to suppress destructive side effects
-// (e.g. overwriting committed outputs with partial results).
-var errScriptTimedOut = errors.New("test script killed due to a timeout")
-
-// scriptTimeoutError carries the timeout duration for the user-facing message
-// while wrapping errScriptTimedOut so that errors.Is matches without the
-// sentinel's text appearing in the formatted output.
-type scriptTimeoutError struct {
-	timeout time.Duration
-}
-
-func (e scriptTimeoutError) Error() string {
-	return fmt.Sprintf("Test script killed due to a timeout (%s)", e.timeout)
-}
-
-func (scriptTimeoutError) Unwrap() error { return errScriptTimedOut }
-
 func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File, tail bool, timeout time.Duration) (string, error) {
 	r, w := io.Pipe()
 	cmd.Stdout = w
@@ -1401,7 +1368,7 @@ func runWithLog(t *testing.T, cmd *exec.Cmd, out *os.File, tail bool, timeout ti
 	processErrCh := make(chan error, 1)
 
 	cmd.Cancel = func() error {
-		processErrCh <- scriptTimeoutError{timeout: timeout}
+		processErrCh <- fmt.Errorf("Test script killed due to a timeout (%s)", timeout)
 		_ = cmd.Process.Kill()
 		_ = w.Close()
 		return nil

--- a/acceptance/bundle/scripts/no-trailing-newline/databricks.yml
+++ b/acceptance/bundle/scripts/no-trailing-newline/databricks.yml
@@ -1,0 +1,6 @@
+bundle:
+  name: scripts_no_trailing_newline
+
+experimental:
+  scripts:
+    preinit: "python3 ./myscript.py"

--- a/acceptance/bundle/scripts/no-trailing-newline/myscript.py
+++ b/acceptance/bundle/scripts/no-trailing-newline/myscript.py
@@ -1,0 +1,5 @@
+import sys
+
+sys.stdout.write("line 1\n")
+sys.stdout.write("line 2\n")
+sys.stdout.write("line without newline")

--- a/acceptance/bundle/scripts/no-trailing-newline/out.test.toml
+++ b/acceptance/bundle/scripts/no-trailing-newline/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/no-trailing-newline/out.test.toml
+++ b/acceptance/bundle/scripts/no-trailing-newline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/no-trailing-newline/output.txt
+++ b/acceptance/bundle/scripts/no-trailing-newline/output.txt
@@ -1,0 +1,13 @@
+
+>>> [CLI] bundle validate
+Executing 'preinit' script
+line 1
+line 2
+line without newline
+Name: scripts_no_trailing_newline
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/scripts_no_trailing_newline/default
+
+Validation OK!

--- a/acceptance/bundle/scripts/no-trailing-newline/script
+++ b/acceptance/bundle/scripts/no-trailing-newline/script
@@ -1,0 +1,1 @@
+trace $CLI bundle validate

--- a/bundle/scripts/scripts.go
+++ b/bundle/scripts/scripts.go
@@ -51,10 +51,14 @@ func (m *script) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	cmdio.LogString(ctx, fmt.Sprintf("Executing '%s' script", m.scriptHook))
 
 	reader := bufio.NewReader(out)
-	line, err := reader.ReadString('\n')
-	for err == nil {
-		cmdio.LogString(ctx, strings.TrimSpace(line))
-		line, err = reader.ReadString('\n')
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			cmdio.LogString(ctx, strings.TrimSpace(line))
+		}
+		if err != nil {
+			break
+		}
 	}
 
 	err = cmd.Wait()

--- a/bundle/scripts/scripts_test.go
+++ b/bundle/scripts/scripts_test.go
@@ -1,0 +1,50 @@
+package scripts_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/scripts"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteOutputWithoutTrailingNewline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	dir := t.TempDir()
+	b := &bundle.Bundle{
+		BundleRootPath: dir,
+		Config: config.Root{
+			Experimental: &config.Experimental{
+				Scripts: map[config.ScriptHook]config.Command{
+					config.ScriptPreInit: "printf 'line1\nline2\nlast line without newline'",
+				},
+			},
+		},
+	}
+
+	ctx, stderr := cmdio.NewTestContextWithStderr(t.Context())
+	diags := bundle.Apply(ctx, b, scripts.Execute(config.ScriptPreInit))
+	require.NoError(t, diags.Error())
+
+	output := stderr.String()
+	assert.Contains(t, output, "line1")
+	assert.Contains(t, output, "line2")
+	assert.Contains(t, output, "last line without newline")
+}
+
+func TestExecuteNoScript(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{},
+	}
+
+	ctx, _ := cmdio.NewTestContextWithStderr(t.Context())
+	diags := bundle.Apply(ctx, b, scripts.Execute(config.ScriptPreInit))
+	require.NoError(t, diags.Error())
+}

--- a/bundle/scripts/scripts_test.go
+++ b/bundle/scripts/scripts_test.go
@@ -38,13 +38,3 @@ func TestExecuteOutputWithoutTrailingNewline(t *testing.T) {
 	assert.Contains(t, output, "line2")
 	assert.Contains(t, output, "last line without newline")
 }
-
-func TestExecuteNoScript(t *testing.T) {
-	b := &bundle.Bundle{
-		Config: config.Root{},
-	}
-
-	ctx, _ := cmdio.NewTestContextWithStderr(t.Context())
-	diags := bundle.Apply(ctx, b, scripts.Execute(config.ScriptPreInit))
-	require.NoError(t, diags.Error())
-}


### PR DESCRIPTION
## Changes
Fix `experimental.scripts` hooks silently dropping the last line of output when it doesn't end with a trailing newline (e.g. `printf "done"`).

## Tests
Added acceptance test at `acceptance/bundle/scripts/no-trailing-newline/` and unit tests for the script executor.

Running the acceptance test against the previous release demonstrates the bug:

```
$ go test ./acceptance -run 'TestAccept/bundle/scripts/no-trailing-newline' -useversion 0.296.0

--- Expected
+++ Actual (v0.296.0)
@@ -5,3 +5,2 @@
 line 2
-line without newline
 Name: scripts_no_trailing_newline
```

v0.296.0 drops "line without newline" because the last line has no trailing `\n`. The fix correctly includes it.