### PR TITLE
Truncate file lists in maintainer-approval comments

### DIFF
--- a/.github/workflows/maintainer-approval.js
+++ b/.github/workflows/maintainer-approval.js
@@ -261,6 +261,13 @@ async function selectRoundRobin(github, owner, repo, eligibleOwners, prAuthor) {
 
 // --- Comment builders ---
 
+function fmtFileList(files) {
+  if (files.length < 4) {
+    return `Files: ${files.map(f => `\`${f}\``).join(", ")}`;
+  }
+  return `${files.length} files changed`;
+}
+
 function buildPendingPerGroupComment(groups, scores, dirScores, approvedBy, maintainers, prAuthor) {
   const authorLower = (prAuthor || "").toLowerCase();
   const lines = [MARKER, "## Approval status: pending", ""];
@@ -274,7 +281,7 @@ function buildPendingPerGroupComment(groups, scores, dirScores, approvedBy, main
     } else {
       lines.push(`### \`${pattern}\` - needs approval`);
     }
-    lines.push(`Files: ${files.map(f => `\`${f}\``).join(", ")}`);
+    lines.push(fmtFileList(files));
 
     const teams = owners.filter(o => o.includes("/"));
     const individuals = owners.filter(o => !o.includes("/") && o.toLowerCase() !== authorLower);
@@ -301,7 +308,7 @@ function buildPendingPerGroupComment(groups, scores, dirScores, approvedBy, main
   const starGroup = groups.get("*");
   if (starGroup) {
     lines.push("### General files (require maintainer)");
-    lines.push(`Files: ${starGroup.files.map(f => `\`${f}\``).join(", ")}`);
+    lines.push(fmtFileList(starGroup.files));
 
     const maintainerSet = new Set(maintainers.map(m => m.toLowerCase()));
     const maintainerScores = Object.entries(scores)

--- a/.github/workflows/maintainer-approval.test.js
+++ b/.github/workflows/maintainer-approval.test.js
@@ -515,4 +515,47 @@ describe("maintainer-approval", () => {
     assert.ok(body.includes("approved by `@jefferycheng1`"));
     assert.ok(body.includes("needs approval"));
   });
+
+  it("lists individual files when fewer than 4 in a group", async () => {
+    const github = makeGithub({
+      reviews: [],
+      files: [
+        { filename: "cmd/pipelines/foo.go" },
+        { filename: "bundle/config.go" },
+        { filename: "bundle/deploy.go" },
+      ],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._comments.length, 1);
+    const body = github._comments[0].body;
+    assert.ok(body.includes("Files:"), "should list individual files");
+    assert.ok(body.includes("`bundle/config.go`"));
+    assert.ok(body.includes("`bundle/deploy.go`"));
+  });
+
+  it("shows file count instead of listing when 4 or more files in a group", async () => {
+    const github = makeGithub({
+      reviews: [],
+      files: [
+        { filename: "cmd/pipelines/foo.go" },
+        { filename: "bundle/a.go" },
+        { filename: "bundle/b.go" },
+        { filename: "bundle/c.go" },
+        { filename: "bundle/d.go" },
+      ],
+    });
+    const core = makeCore();
+    const context = makeContext();
+
+    await runModule({ github, context, core });
+
+    assert.equal(github._comments.length, 1);
+    const body = github._comments[0].body;
+    assert.ok(body.includes("4 files changed"), "should show count for bundle group");
+    assert.ok(!body.includes("`bundle/a.go`"), "should not list individual bundle files");
+  });
 });


### PR DESCRIPTION
## Why

The maintainer-approval bot comments list every single file in each ownership group. For PRs that touch many files (e.g. codegen updates), this makes the comment extremely verbose and hard to scan.

## Changes

When an ownership group has 4 or more files, the comment now shows "N files changed" instead of listing every file path. Groups with fewer than 4 files still list them individually.

## Test plan

- Added test for < 4 files (individual listing preserved)
- Added test for >= 4 files (count shown instead)
- All 22 tests pass: `node --test .github/workflows/maintainer-approval.test.js`

This pull request was AI-assisted by Isaac.