### PR TITLE
Fix race condition between SSH client and ProxyCommand process

### DIFF
--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -268,27 +268,35 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		}
 	}
 
-	secretScopeName, err := keys.CreateKeysSecretScope(ctx, client, sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to create secret scope: %w", err)
-	}
+	// Proxy mode only proxies stdin/stdout over a WebSocket — it doesn't need
+	// SSH keys. Skipping key operations avoids a race where SaveSSHKeyPair
+	// deletes the key files that the SSH client (parent process) is reading.
+	var keyPath string
+	var secretScopeName string
+	if !opts.ProxyMode {
+		var err error
+		secretScopeName, err = keys.CreateKeysSecretScope(ctx, client, sessionID)
+		if err != nil {
+			return fmt.Errorf("failed to create secret scope: %w", err)
+		}
 
-	privateKeyBytes, publicKeyBytes, err := keys.CheckAndGenerateSSHKeyPairFromSecrets(ctx, client, secretScopeName, opts.ClientPrivateKeyName, opts.ClientPublicKeyName)
-	if err != nil {
-		return fmt.Errorf("failed to get or generate SSH key pair from secrets: %w", err)
-	}
+		privateKeyBytes, publicKeyBytes, err := keys.CheckAndGenerateSSHKeyPairFromSecrets(ctx, client, secretScopeName, opts.ClientPrivateKeyName, opts.ClientPublicKeyName)
+		if err != nil {
+			return fmt.Errorf("failed to get or generate SSH key pair from secrets: %w", err)
+		}
 
-	keyPath, err := keys.GetLocalSSHKeyPath(ctx, sessionID, opts.SSHKeysDir)
-	if err != nil {
-		return fmt.Errorf("failed to get local keys folder: %w", err)
-	}
+		keyPath, err = keys.GetLocalSSHKeyPath(ctx, sessionID, opts.SSHKeysDir)
+		if err != nil {
+			return fmt.Errorf("failed to get local keys folder: %w", err)
+		}
 
-	err = keys.SaveSSHKeyPair(keyPath, privateKeyBytes, publicKeyBytes)
-	if err != nil {
-		return fmt.Errorf("failed to save SSH key pair locally: %w", err)
+		err = keys.SaveSSHKeyPair(keyPath, privateKeyBytes, publicKeyBytes)
+		if err != nil {
+			return fmt.Errorf("failed to save SSH key pair locally: %w", err)
+		}
+		log.Infof(ctx, "Using SSH key: %s", keyPath)
+		log.Infof(ctx, "Secrets scope: %s, key name: %s", secretScopeName, opts.ClientPublicKeyName)
 	}
-	log.Infof(ctx, "Using SSH key: %s", keyPath)
-	log.Infof(ctx, "Secrets scope: %s, key name: %s", secretScopeName, opts.ClientPublicKeyName)
 
 	var userName string
 	var serverPort int
@@ -323,10 +331,11 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		if userName == "" {
 			return fmt.Errorf("remote user name is empty in the metadata: %s", opts.ServerMetadata)
 		}
-		serverPort, err = strconv.Atoi(metadata[1])
+		port, err := strconv.Atoi(metadata[1])
 		if err != nil {
 			return fmt.Errorf("cannot parse port from metadata: %s, %w", opts.ServerMetadata, err)
 		}
+		serverPort = port
 		if len(metadata) >= 3 {
 			clusterID = metadata[2]
 		} else {

--- a/experimental/ssh/internal/keys/keys.go
+++ b/experimental/ssh/internal/keys/keys.go
@@ -52,9 +52,13 @@ func generateSSHKeyPair() ([]byte, []byte, error) {
 }
 
 func SaveSSHKeyPair(keyPath string, privateKeyBytes, publicKeyBytes []byte) error {
-	err := os.RemoveAll(filepath.Dir(keyPath))
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("failed to remove existing key directory: %w", err)
+	// Remove only the specific key files, not the entire parent directory.
+	// Using os.RemoveAll on the parent would break concurrent sessions
+	// that store their keys in the same directory.
+	for _, f := range []string{keyPath, keyPath + ".pub"} {
+		if err := os.Remove(f); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("failed to remove existing key file %s: %w", f, err)
+		}
 	}
 
 	if err := os.MkdirAll(filepath.Dir(keyPath), 0o700); err != nil {

--- a/experimental/ssh/internal/keys/keys_test.go
+++ b/experimental/ssh/internal/keys/keys_test.go
@@ -1,0 +1,94 @@
+package keys_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/experimental/ssh/internal/keys"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveSSHKeyPairCreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "session1")
+
+	err := keys.SaveSSHKeyPair(keyPath, []byte("private"), []byte("public"))
+	require.NoError(t, err)
+
+	priv, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, "private", string(priv))
+
+	pub, err := os.ReadFile(keyPath + ".pub")
+	require.NoError(t, err)
+	assert.Equal(t, "public", string(pub))
+}
+
+func TestSaveSSHKeyPairOverwritesExistingFiles(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "session1")
+
+	err := keys.SaveSSHKeyPair(keyPath, []byte("old-private"), []byte("old-public"))
+	require.NoError(t, err)
+
+	err = keys.SaveSSHKeyPair(keyPath, []byte("new-private"), []byte("new-public"))
+	require.NoError(t, err)
+
+	priv, err := os.ReadFile(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, "new-private", string(priv))
+
+	pub, err := os.ReadFile(keyPath + ".pub")
+	require.NoError(t, err)
+	assert.Equal(t, "new-public", string(pub))
+}
+
+func TestSaveSSHKeyPairDoesNotDeleteOtherSessions(t *testing.T) {
+	dir := t.TempDir()
+
+	// Save keys for session1.
+	err := keys.SaveSSHKeyPair(filepath.Join(dir, "session1"), []byte("priv1"), []byte("pub1"))
+	require.NoError(t, err)
+
+	// Save keys for session2 in the same directory.
+	err = keys.SaveSSHKeyPair(filepath.Join(dir, "session2"), []byte("priv2"), []byte("pub2"))
+	require.NoError(t, err)
+
+	// session1 keys must still exist.
+	priv, err := os.ReadFile(filepath.Join(dir, "session1"))
+	require.NoError(t, err)
+	assert.Equal(t, "priv1", string(priv))
+
+	pub, err := os.ReadFile(filepath.Join(dir, "session1.pub"))
+	require.NoError(t, err)
+	assert.Equal(t, "pub1", string(pub))
+}
+
+func TestSaveSSHKeyPairCreatesParentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "nested", "dir", "session1")
+
+	err := keys.SaveSSHKeyPair(keyPath, []byte("private"), []byte("public"))
+	require.NoError(t, err)
+
+	_, err = os.ReadFile(keyPath)
+	require.NoError(t, err)
+}
+
+func TestSaveSSHKeyPairFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "session1")
+
+	err := keys.SaveSSHKeyPair(keyPath, []byte("private"), []byte("public"))
+	require.NoError(t, err)
+
+	info, err := os.Stat(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	info, err = os.Stat(keyPath + ".pub")
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}


### PR DESCRIPTION
## Summary

Additional take on #4988 

- **Skip key operations in proxy mode**: The ProxyCommand (proxy mode) process was unconditionally running key generation and `SaveSSHKeyPair`, which wiped the SSH keys directory while the parent SSH client was concurrently reading the identity file — causing "Permission denied (publickey)" errors. Proxy mode only proxies stdin/stdout over a WebSocket and never needs SSH keys.
- **Fix `SaveSSHKeyPair` to not wipe sibling sessions**: `os.RemoveAll(filepath.Dir(keyPath))` removed the entire `~/.databricks/ssh-tunnel-keys/` directory instead of just the current session's files, breaking concurrent connections to different clusters.
- **Add unit tests for `SaveSSHKeyPair`**: Including a regression test that verifies saving one session's keys does not delete another session's keys.

## Test plan

- [x] Existing unit tests pass (`go test ./experimental/ssh/internal/client/` and `go test ./experimental/ssh/internal/keys/`)
- [x] New `TestSaveSSHKeyPairDoesNotDeleteOtherSessions` validates the concurrent session fix
- [x] Linter passes (`make lint`)
- [ ] Manual test: `databricks ssh connect --cluster=<id>` should no longer intermittently fail with "Permission denied (publickey)"



This pull request was AI-assisted by Isaac.