### PR TITLE
Bump Go toolchain to 1.25.9

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,5 +13,6 @@
 ### Dependency updates
 
 * Bump `github.com/databricks/databricks-sdk-go` from v0.126.0 to v0.127.0 ([#4984](https://github.com/databricks/cli/pull/4984)).
+* Bump Go toolchain to 1.25.9 ([#5004](https://github.com/databricks/cli/pull/5004))
 
 ### API Changes

--- a/bundle/internal/tf/codegen/go.mod
+++ b/bundle/internal/tf/codegen/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/bundle/internal/tf/codegen
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.9
 
 require (
 	github.com/hashicorp/go-version v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.9
 
 require (
 	dario.cat/mergo v1.0.2 // BSD-3-Clause

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/databricks/cli/tools
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.9
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.25.7 to 1.25.9 across all three `go.mod` files.

Notable upstream fixes ([release notes](https://go.dev/doc/devel/release#go1.25.minor)):
- `crypto/tls` and `crypto/x509` security fixes
- `html/template` security fixes
- `archive/tar` security fix
- `os` package security fixes
- Compiler and runtime bug fixes

This pull request and its description were written by Isaac.