### PR TITLE
acc: Make run_as/job_default test run only on direct

### DIFF
--- a/acceptance/bundle/run_as/job_default/databricks.yml.tmpl
+++ b/acceptance/bundle/run_as/job_default/databricks.yml.tmpl
@@ -1,5 +1,5 @@
 bundle:
-  name: "run_as_job_default"
+  name: "run_as_job_default_$UNIQUE_NAME"
 
 resources:
   jobs:

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -2,4 +2,4 @@ Local = false
 Cloud = true
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/job_default/output.txt
+++ b/acceptance/bundle/run_as/job_default/output.txt
@@ -8,37 +8,7 @@ Deployment complete!
 
 >>> print_requests.py //jobs
 {
-  "method": "POST",
-  "path": "/api/2.2/jobs/create",
-  "body": {
-    "deployment": {
-      "kind": "BUNDLE",
-      "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/state/metadata.json"
-    },
-    "edit_mode": "UI_LOCKED",
-    "format": "MULTI_TASK",
-    "max_concurrent_runs": 1,
-    "name": "Untitled",
-    "queue": {
-      "enabled": true
-    },
-    "run_as": {
-      "user_name": "deco-test-user@databricks.com"
-    },
-    "tasks": [
-      {
-        "new_cluster": {
-          "node_type_id": "[NODE_TYPE_ID]",
-          "num_workers": 1,
-          "spark_version": "13.3.x-snapshot-scala2.12"
-        },
-        "notebook_task": {
-          "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/files/test"
-        },
-        "task_key": "task_one"
-      }
-    ]
-  }
+  "user_name": "deco-test-user@databricks.com"
 }
 
 >>> [CLI] jobs get [NUMID]
@@ -59,39 +29,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> print_requests.py //jobs
-{
-  "method": "POST",
-  "path": "/api/2.2/jobs/reset",
-  "body": {
-    "job_id": [NUMID],
-    "new_settings": {
-      "deployment": {
-        "kind": "BUNDLE",
-        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/state/metadata.json"
-      },
-      "edit_mode": "UI_LOCKED",
-      "format": "MULTI_TASK",
-      "max_concurrent_runs": 1,
-      "name": "Untitled",
-      "queue": {
-        "enabled": true
-      },
-      "tasks": [
-        {
-          "new_cluster": {
-            "node_type_id": "[NODE_TYPE_ID]",
-            "num_workers": 1,
-            "spark_version": "13.3.x-snapshot-scala2.12"
-          },
-          "notebook_task": {
-            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/files/test"
-          },
-          "task_key": "task_one"
-        }
-      ]
-    }
-  }
-}
+null
 
 >>> [CLI] jobs get [NUMID]
 {

--- a/acceptance/bundle/run_as/job_default/output.txt
+++ b/acceptance/bundle/run_as/job_default/output.txt
@@ -1,14 +1,44 @@
 
 === Deploy with run_as
 >>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
 
 >>> print_requests.py //jobs
 {
-  "user_name": "deco-test-user@databricks.com"
+  "method": "POST",
+  "path": "/api/2.2/jobs/create",
+  "body": {
+    "deployment": {
+      "kind": "BUNDLE",
+      "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default/state/metadata.json"
+    },
+    "edit_mode": "UI_LOCKED",
+    "format": "MULTI_TASK",
+    "max_concurrent_runs": 1,
+    "name": "Untitled",
+    "queue": {
+      "enabled": true
+    },
+    "run_as": {
+      "user_name": "deco-test-user@databricks.com"
+    },
+    "tasks": [
+      {
+        "new_cluster": {
+          "node_type_id": "[NODE_TYPE_ID]",
+          "num_workers": 1,
+          "spark_version": "13.3.x-snapshot-scala2.12"
+        },
+        "notebook_task": {
+          "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default/files/test"
+        },
+        "task_key": "task_one"
+      }
+    ]
+  }
 }
 
 >>> [CLI] jobs get [NUMID]
@@ -23,13 +53,45 @@ update jobs.job_with_run_as
 Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged
 
 >>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
 
 >>> print_requests.py //jobs
-null
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/reset",
+  "body": {
+    "job_id": [NUMID],
+    "new_settings": {
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "max_concurrent_runs": 1,
+      "name": "Untitled",
+      "queue": {
+        "enabled": true
+      },
+      "tasks": [
+        {
+          "new_cluster": {
+            "node_type_id": "[NODE_TYPE_ID]",
+            "num_workers": 1,
+            "spark_version": "13.3.x-snapshot-scala2.12"
+          },
+          "notebook_task": {
+            "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default/files/test"
+          },
+          "task_key": "task_one"
+        }
+      ]
+    }
+  }
+}
 
 >>> [CLI] jobs get [NUMID]
 {
@@ -40,7 +102,7 @@ null
 The following resources will be deleted:
   delete resources.jobs.job_with_run_as
 
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/run_as_job_default_[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/run_as/job_default/script
+++ b/acceptance/bundle/run_as/job_default/script
@@ -8,7 +8,7 @@ trap cleanup EXIT
 
 title "Deploy with run_as"
 trace $CLI bundle deploy
-trace print_requests.py //jobs | contains.py "!GET" "POST" | jq '.body.run_as'
+trace print_requests.py //jobs | contains.py "!GET" "POST"
 JOB_ID=$($CLI bundle summary -o json | jq -r '.resources.jobs.job_with_run_as.id')
 trace $CLI jobs get $JOB_ID | jq -r '.settings.run_as'
 
@@ -18,5 +18,5 @@ update_file.py databricks.yml "run_as:
 title "Remove run_as and redeploy"
 trace $CLI bundle plan
 trace $CLI bundle deploy
-trace print_requests.py //jobs | contains.py "!GET" "POST" | jq '.body.run_as'
+trace print_requests.py //jobs | contains.py "!GET" "POST"
 trace $CLI jobs get $JOB_ID | jq -r '.settings.run_as'

--- a/acceptance/bundle/run_as/job_default/script
+++ b/acceptance/bundle/run_as/job_default/script
@@ -8,7 +8,7 @@ trap cleanup EXIT
 
 title "Deploy with run_as"
 trace $CLI bundle deploy
-trace print_requests.py //jobs | contains.py "!GET" "POST"
+trace print_requests.py //jobs | contains.py "!GET" "POST" | jq '.body.run_as'
 JOB_ID=$($CLI bundle summary -o json | jq -r '.resources.jobs.job_with_run_as.id')
 trace $CLI jobs get $JOB_ID | jq -r '.settings.run_as'
 
@@ -18,5 +18,5 @@ update_file.py databricks.yml "run_as:
 title "Remove run_as and redeploy"
 trace $CLI bundle plan
 trace $CLI bundle deploy
-trace print_requests.py //jobs | contains.py "!GET" "POST"
+trace print_requests.py //jobs | contains.py "!GET" "POST" | jq '.body.run_as'
 trace $CLI jobs get $JOB_ID | jq -r '.settings.run_as'

--- a/acceptance/bundle/run_as/job_default/test.toml
+++ b/acceptance/bundle/run_as/job_default/test.toml
@@ -5,4 +5,4 @@ Cloud = true
 RecordRequests = true
 
 [EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]


### PR DESCRIPTION
## Changes
Make run_as/job_default test run only on direct

## Why
This test on TF causes a permanent drift and differnce in the output. But for this test there is not real reason to run it on both direct and TF.
See the difference (`source` field is included) here: 

https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/24552546859/job/71781373042

```
 --- bundle/run_as/job_default/output.txt
          +++ /tmp/TestAcceptbundlerun_asjob_defaultDATABRICKS_BUNDLE_ENGINE=te1133212625/001/output.txt
          @@ -33,7 +33,8 @@
                     "spark_version": "13.3.x-snapshot-scala2.12"
                   },
                   "notebook_task": {
          -          "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/files/test"
          +          "notebook_path": "/Workspace/Users/[USERNAME]/.bundle/run_as_job_default/default/files/test",
          +          "source": "***"
                   },
                   "task_key": "task_one"
                 }
```

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
