### PR TITLE
Add tag input to release-build workflow_dispatch

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -91,6 +91,13 @@ jobs:
       - name: Hide snapshot tag to outsmart GoReleaser
         run: git tag -d snapshot || true
 
+      # Overlay scripts from the workflow ref so goreleaser hooks resolve
+      # correctly even when building an older tag that predates them.
+      - name: Sync workflow scripts to working directory
+        run: |
+          mkdir -p .github/scripts
+          cp -r .workflow-actions/.github/scripts/. .github/scripts/
+
       # Use --snapshot for branch builds (non-tag refs).
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -37,8 +37,18 @@ jobs:
           fetch-tags: true
           ref: ${{ inputs.tag || github.ref }}
 
+      # Check out the workflow's own ref into a side directory so local
+      # composite actions (e.g. setup-jfrog) are available even when the
+      # built ref is an older tag that predates them.
+      - name: Checkout workflow ref for local actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          path: .workflow-actions
+          sparse-checkout: .github
+
       - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
+        uses: ./.workflow-actions/.github/actions/setup-jfrog
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -122,8 +132,18 @@ jobs:
           fetch-tags: true
           ref: ${{ inputs.tag || github.ref }}
 
+      # Check out the workflow's own ref into a side directory so local
+      # composite actions (e.g. setup-jfrog) are available even when the
+      # built ref is an older tag that predates them.
+      - name: Checkout workflow ref for local actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          path: .workflow-actions
+          sparse-checkout: .github
+
       - name: Setup JFrog
-        uses: ./.github/actions/setup-jfrog
+        uses: ./.workflow-actions/.github/actions/setup-jfrog
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -38,14 +38,16 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       # Check out the workflow's own ref into a side directory so local
-      # composite actions (e.g. setup-jfrog) are available even when the
-      # built ref is an older tag that predates them.
+      # composite actions (e.g. setup-jfrog) and the goreleaser config are
+      # available even when the built ref is an older tag that predates them.
       - name: Checkout workflow ref for local actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
           path: .workflow-actions
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            .goreleaser.yaml
 
       - name: Setup JFrog
         uses: ./.workflow-actions/.github/actions/setup-jfrog
@@ -94,7 +96,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2.14.3
-          args: release --skip=publish --skip=docker ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
+          args: release --skip=publish --config .workflow-actions/.goreleaser.yaml --skip=docker ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
 
       - name: Verify Windows binary signatures
         run: |
@@ -133,14 +135,16 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       # Check out the workflow's own ref into a side directory so local
-      # composite actions (e.g. setup-jfrog) are available even when the
-      # built ref is an older tag that predates them.
+      # composite actions (e.g. setup-jfrog) and the goreleaser config are
+      # available even when the built ref is an older tag that predates them.
       - name: Checkout workflow ref for local actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
           path: .workflow-actions
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            .goreleaser.yaml
 
       - name: Setup JFrog
         uses: ./.workflow-actions/.github/actions/setup-jfrog

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -94,7 +94,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2.14.3
-          args: release --skip=publish ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
+          args: release --skip=publish --skip=docker ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
 
       - name: Verify Windows binary signatures
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,6 +10,11 @@ on:
       - "bugbash-*"
 
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v1.2.3). Leave empty for a snapshot build of the current ref."
+        type: string
+        required: false
 
 jobs:
   cli:
@@ -30,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog
@@ -78,7 +84,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2.14.3
-          args: release --skip=publish ${{ !startsWith(github.ref, 'refs/tags/') && '--snapshot' || '' }}
+          args: release --skip=publish ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
 
       - name: Verify Windows binary signatures
         run: |
@@ -114,6 +120,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup JFrog
         uses: ./.github/actions/setup-jfrog

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -97,10 +97,13 @@ jobs:
 
       # Overlay scripts from the workflow ref so goreleaser hooks resolve
       # correctly even when building an older tag that predates them.
+      # Register both injected paths in .git/info/exclude so goreleaser's
+      # dirty-state check does not flag them as untracked files.
       - name: Sync workflow scripts to working directory
         run: |
           mkdir -p .github/scripts
           cp -r .workflow-actions/.github/scripts/. .github/scripts/
+          printf '.workflow-actions/\n.github/scripts/\n' >> .git/info/exclude
 
       # Use --snapshot for branch builds (non-tag refs).
       - name: Run GoReleaser

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -107,7 +107,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2.14.3
-          args: release ${{ !inputs.publish && '--skip=publish' || '' }} --config .workflow-actions/.goreleaser.yaml --skip=docker ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
+          args: release ${{ !inputs.publish && '--skip=publish' || '' }} --config .workflow-actions/.goreleaser.yaml --skip=docker ${{ (!startsWith(github.ref, 'refs/tags/') && !inputs.tag) && '--snapshot' || '' }}
 
       - name: Verify Windows binary signatures
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -31,7 +31,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -108,6 +108,8 @@ jobs:
         with:
           version: v2.14.3
           args: release ${{ !inputs.publish && '--skip=publish' || '' }} --config .workflow-actions/.goreleaser.yaml --skip=docker ${{ (!startsWith(github.ref, 'refs/tags/') && !inputs.tag) && '--snapshot' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Verify Windows binary signatures
         run: |
@@ -135,7 +137,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,6 +15,10 @@ on:
         description: "Tag to build (e.g. v1.2.3). Leave empty for a snapshot build of the current ref."
         type: string
         required: false
+      publish:
+        description: "Publish release artifacts to the GitHub release."
+        type: boolean
+        default: false
 
 jobs:
   cli:
@@ -103,7 +107,7 @@ jobs:
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2.14.3
-          args: release --skip=publish --config .workflow-actions/.goreleaser.yaml --skip=docker ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
+          args: release ${{ !inputs.publish && '--skip=publish' || '' }} --config .workflow-actions/.goreleaser.yaml --skip=docker ${{ (startsWith(github.ref, 'refs/tags/') || inputs.tag) && '' || '--snapshot' }}
 
       - name: Verify Windows binary signatures
         run: |


### PR DESCRIPTION
## Summary
- Adds an optional `tag` input to the `workflow_dispatch` trigger of `release-build.yml`.
- Both `cli` and `wheel` jobs now check out the given tag when provided.
- GoReleaser omits `--snapshot` when a tag is dispatched, producing versioned binaries for that tag.