### PR TITLE
Enable allow-parallel-runners in golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,6 @@
 version: "2"
+run:
+  allow-parallel-runners: true
 linters:
   default: none
   enable:


### PR DESCRIPTION
## Summary
- Adds `allow-parallel-runners: true` under the `run` section in `.golangci.yaml` to permit parallel test runner execution with golangci-lint.

## Test plan
- [ ] Verify `make lint` still passes

This pull request was AI-assisted by Isaac.