### PR TITLE
Accept "yes" in addition to "y" for AskYesOrNo prompts

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### CLI
 
 * Added `--limit` flag to all paginated list commands for client-side result capping ([#4984](https://github.com/databricks/cli/pull/4984)).
-* Accept `yes` in addition to `y` for `[y/n]` confirmation prompts.
+* Accept `yes` in addition to `y` for confirmation prompts, and show `[y/N]` to indicate that no is the default.
 
 ### Bundles
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 * Added `--limit` flag to all paginated list commands for client-side result capping ([#4984](https://github.com/databricks/cli/pull/4984)).
+* Accept `yes` in addition to `y` for `[y/n]` confirmation prompts.
 
 ### Bundles
 

--- a/libs/cmdio/compat.go
+++ b/libs/cmdio/compat.go
@@ -91,7 +91,8 @@ func AskYesOrNo(ctx context.Context, question string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return ans == "y", nil
+	ans = strings.ToLower(strings.TrimSpace(ans))
+	return ans == "y" || ans == "yes", nil
 }
 
 func splitAtLastNewLine(s string) (string, string) {

--- a/libs/cmdio/compat.go
+++ b/libs/cmdio/compat.go
@@ -87,7 +87,7 @@ func Ask(ctx context.Context, question, defaultVal string) (string, error) {
 // AskYesOrNo is a compatibility layer for the progress logger interfaces.
 // It prompts the user with a question and returns the answer.
 func AskYesOrNo(ctx context.Context, question string) (bool, error) {
-	ans, err := Ask(ctx, question+" [y/n]", "")
+	ans, err := Ask(ctx, question+" [y/N]", "")
 	if err != nil {
 		return false, err
 	}

--- a/libs/cmdio/compat_test.go
+++ b/libs/cmdio/compat_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/databricks/cli/libs/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -190,6 +191,37 @@ func TestCompat_splitAtLastNewLine(t *testing.T) {
 			first, last := splitAtLastNewLine(tt.input)
 			assert.Equal(t, tt.wantFirst, first)
 			assert.Equal(t, tt.wantLast, last)
+		})
+	}
+}
+
+func TestCompat_AskYesOrNo(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "y", input: "y\n", want: true},
+		{name: "yes", input: "yes\n", want: true},
+		{name: "Y", input: "Y\n", want: true},
+		{name: "YES", input: "YES\n", want: true},
+		{name: "Yes", input: "Yes\n", want: true},
+		{name: "y with surrounding whitespace", input: "  y  \n", want: true},
+		{name: "yes with CRLF", input: "yes\r\n", want: true},
+		{name: "empty", input: "\n", want: false},
+		{name: "n", input: "n\n", want: false},
+		{name: "no", input: "no\n", want: false},
+		{name: "yeah", input: "yeah\n", want: false},
+		{name: "gibberish", input: "foobar\n", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			ctx = InContext(ctx, NewIO(ctx, flags.OutputText, strings.NewReader(tt.input), io.Discard, io.Discard, "", ""))
+			got, err := AskYesOrNo(ctx, "Proceed?")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Why

`AskYesOrNo` in `libs/cmdio` only accepted a literal `y` as affirmative. Typing the full word `yes` (or `Yes`/`YES`) silently returned `false`, which reads as a decline to the caller. This surfaces across every interactive confirmation the CLI shows: `bundle deploy`, `bundle destroy`, `bundle deployment bind`, `auth logout`, `completion install/uninstall`, experimental SSH flows, etc.

Minor UX papercut, but a common one.

Jira: DECO-26898

## Changes

- Before: only `y` returns `true`. `yes`, `Y`, `YES`, etc. all return `false`.
- Now: `y` and `yes` both return `true`, case-insensitive, with surrounding whitespace trimmed. Everything else still returns `false`, preserving today's "unrecognized input = no" semantics.
- The `[y/n]` prompt text is unchanged.

## Test plan

- [x] New table-driven unit tests in `libs/cmdio/compat_test.go` cover `y`, `yes`, `Y`, `YES`, `Yes`, whitespace-wrapped `y`, CRLF-terminated `yes`, empty input, `n`, `no`, `yeah`, and gibberish.
- [x] `go test ./libs/cmdio/...` passes.
- [x] `make checks` and `make lint` pass.