### PR TITLE
Add --auto-approve to experimental prompt sites

### DIFF
--- a/cmd/apps/dev.go
+++ b/cmd/apps/dev.go
@@ -113,9 +113,10 @@ func startViteDevServer(ctx context.Context, appURL string, port int) (*exec.Cmd
 
 func newDevRemoteCmd() *cobra.Command {
 	var (
-		appName    string
-		clientPath string
-		port       int
+		appName     string
+		clientPath  string
+		port        int
+		autoApprove bool
 	)
 
 	cmd := &cobra.Command{
@@ -174,7 +175,7 @@ Examples:
 				appName = selected
 			}
 
-			bridge := vite.NewBridge(ctx, w, appName, port)
+			bridge := vite.NewBridge(ctx, w, appName, port, autoApprove)
 
 			// Validate app exists and get domain before starting Vite
 			var appDomain *url.URL
@@ -234,6 +235,7 @@ Examples:
 	cmd.Flags().StringVar(&appName, "name", "", "Name of the app to connect to (prompts if not provided)")
 	cmd.Flags().StringVar(&clientPath, "client-path", "./client", "Path to the Vite client directory")
 	cmd.Flags().IntVar(&port, "port", vitePort, "Port to run the Vite server on")
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Automatically approve every viewer connection. Anyone with the shareable dev URL will be trusted for the life of the session; use only in trusted environments.")
 
 	return cmd
 }

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -76,6 +76,7 @@ func newInitCmd() *cobra.Command {
 		deploy       bool
 		run          string
 		setValues    []string
+		autoApprove  bool
 	)
 
 	cmd := &cobra.Command{
@@ -160,6 +161,7 @@ Environment variables:
 				runChanged:     cmd.Flags().Changed("run"),
 				pluginsChanged: cmd.Flags().Changed("features") || cmd.Flags().Changed("plugins"),
 				setValues:      setValues,
+				autoApprove:    autoApprove,
 			})
 		},
 	}
@@ -178,6 +180,7 @@ Environment variables:
 	_ = cmd.Flags().MarkHidden("plugins")
 	cmd.Flags().BoolVar(&deploy, "deploy", false, "Deploy the app after creation")
 	cmd.Flags().StringVar(&run, "run", "", "Run the app after creation (none, dev, dev-remote)")
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts for optional resources. Optional resources are only configured when their values are provided via --set.")
 
 	return cmd
 }
@@ -198,6 +201,7 @@ type createOptions struct {
 	runChanged     bool     // true if --run flag was explicitly set
 	pluginsChanged bool     // true if --plugins flag was explicitly set
 	setValues      []string // --set plugin.resourceKey.field=value pairs
+	autoApprove    bool     // true if --auto-approve flag was set
 }
 
 // parseSetValues parses --set key=value pairs into the resourceValues map.
@@ -332,7 +336,9 @@ func parseDeployAndRunFlags(deploy bool, run string) (bool, prompt.RunMode, erro
 
 // promptForPluginsAndDeps prompts for plugins and their resource dependencies using the manifest.
 // skipDeployRunPrompt indicates whether to skip prompting for deploy/run (because flags were provided).
-func promptForPluginsAndDeps(ctx context.Context, m *manifest.Manifest, preSelectedPlugins []string, skipDeployRunPrompt bool) (*prompt.CreateProjectConfig, error) {
+// When autoApprove is true, the optional-resource confirmation is skipped and optional
+// resources are not configured unless their values were provided explicitly.
+func promptForPluginsAndDeps(ctx context.Context, m *manifest.Manifest, preSelectedPlugins []string, skipDeployRunPrompt, autoApprove bool) (*prompt.CreateProjectConfig, error) {
 	config := &prompt.CreateProjectConfig{
 		Dependencies: make(map[string]string),
 		Features:     preSelectedPlugins, // Reuse Features field for plugin names
@@ -394,14 +400,18 @@ func promptForPluginsAndDeps(ctx context.Context, m *manifest.Manifest, preSelec
 		}
 	}
 
-	// Step 3: Prompt for optional plugin resource dependencies
-	for _, r := range optionalResources {
-		values, err := promptForResource(ctx, r, theme, false)
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range values {
-			config.Dependencies[k] = v
+	// Step 3: Prompt for optional plugin resource dependencies.
+	// With --auto-approve, optional resources are skipped here; they're only
+	// configured when their values are supplied via --set (merged later).
+	if !autoApprove {
+		for _, r := range optionalResources {
+			values, err := promptForResource(ctx, r, theme, false)
+			if err != nil {
+				return nil, err
+			}
+			for k, v := range values {
+				config.Dependencies[k] = v
+			}
 		}
 	}
 
@@ -830,7 +840,7 @@ func runCreate(ctx context.Context, opts createOptions) error {
 
 	if isInteractive && !opts.pluginsChanged && !flagsMode {
 		// Interactive mode without --plugins flag: prompt for plugins, dependencies, description
-		config, err := promptForPluginsAndDeps(ctx, m, selectedPlugins, skipDeployRunPrompt)
+		config, err := promptForPluginsAndDeps(ctx, m, selectedPlugins, skipDeployRunPrompt, opts.autoApprove)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -201,7 +201,7 @@ type createOptions struct {
 	runChanged     bool     // true if --run flag was explicitly set
 	pluginsChanged bool     // true if --plugins flag was explicitly set
 	setValues      []string // --set plugin.resourceKey.field=value pairs
-	autoApprove    bool     // true if --auto-approve flag was set
+	autoApprove    bool
 }
 
 // parseSetValues parses --set key=value pairs into the resourceValues map.
@@ -336,8 +336,6 @@ func parseDeployAndRunFlags(deploy bool, run string) (bool, prompt.RunMode, erro
 
 // promptForPluginsAndDeps prompts for plugins and their resource dependencies using the manifest.
 // skipDeployRunPrompt indicates whether to skip prompting for deploy/run (because flags were provided).
-// When autoApprove is true, the optional-resource confirmation is skipped and optional
-// resources are not configured unless their values were provided explicitly.
 func promptForPluginsAndDeps(ctx context.Context, m *manifest.Manifest, preSelectedPlugins []string, skipDeployRunPrompt, autoApprove bool) (*prompt.CreateProjectConfig, error) {
 	config := &prompt.CreateProjectConfig{
 		Dependencies: make(map[string]string),

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -36,6 +36,7 @@ the SSH server and handling the connection proxy.
 	var liteswap string
 	var skipSettingsCheck bool
 	var environmentVersion int
+	var autoApprove bool
 
 	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks cluster ID (for dedicated clusters)")
 	cmd.Flags().DurationVar(&shutdownDelay, "shutdown-delay", defaultShutdownDelay, "Delay before shutting down the server after the last client disconnects")
@@ -70,6 +71,8 @@ the SSH server and handling the connection proxy.
 
 	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for serverless compute")
 	cmd.Flags().MarkHidden("environment-version")
+
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		// CLI in the proxy mode is executed by the ssh client and can't prompt for input
@@ -110,6 +113,7 @@ the SSH server and handling the connection proxy.
 			SkipSettingsCheck:    skipSettingsCheck,
 			EnvironmentVersion:   environmentVersion,
 			AdditionalArgs:       args,
+			AutoApprove:          autoApprove,
 		}
 		if err := opts.Validate(); err != nil {
 			return err

--- a/experimental/ssh/cmd/setup.go
+++ b/experimental/ssh/cmd/setup.go
@@ -28,6 +28,7 @@ an SSH host configuration to your SSH config file.
 	var sshConfigPath string
 	var shutdownDelay time.Duration
 	var autoStartCluster bool
+	var autoApprove bool
 
 	cmd.Flags().StringVar(&hostName, "name", "", "Host name to use in SSH config")
 	cmd.MarkFlagRequired("name")
@@ -35,6 +36,7 @@ an SSH host configuration to your SSH config file.
 	cmd.Flags().BoolVar(&autoStartCluster, "auto-start-cluster", true, "Automatically start the cluster when establishing the ssh connection")
 	cmd.Flags().StringVar(&sshConfigPath, "ssh-config", "", "Path to SSH config file (default ~/.ssh/config)")
 	cmd.Flags().DurationVar(&shutdownDelay, "shutdown-delay", defaultShutdownDelay, "SSH server will terminate after this delay if there are no active connections")
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, recreating existing SSH host configs without asking")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		// We want to avoid the situation where the setup command works because it pulls the auth config from a bundle,
@@ -53,6 +55,7 @@ an SSH host configuration to your SSH config file.
 			SSHConfigPath:    sshConfigPath,
 			ShutdownDelay:    shutdownDelay,
 			Profile:          wsClient.Config.Profile,
+			AutoApprove:      autoApprove,
 		}
 		clientOpts := client.ClientOptions{
 			ClusterID:        setupOpts.ClusterID,

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -245,9 +245,7 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 	// desired server ports (or socket connection mode) for the connection to go through
 	// (as the majority of the localhost ports on the remote side are blocked by iptable rules).
 	// Plus the platform (always linux), and extensions (python and jupyter), to make the initial experience smoother.
-	// --auto-approve lets non-interactive callers run this path; without it we still
-	// fall back to the prompt-supported short-circuit so existing behavior is preserved.
-	if opts.IDE != "" && opts.IsServerlessMode() && !opts.ProxyMode && !opts.SkipSettingsCheck && (cmdio.IsPromptSupported(ctx) || opts.AutoApprove) {
+	if opts.IDE != "" && opts.IsServerlessMode() && !opts.ProxyMode && !opts.SkipSettingsCheck {
 		err := vscode.CheckAndUpdateSettings(ctx, opts.IDE, opts.ConnectionName, opts.AutoApprove)
 		if err != nil {
 			cmdio.LogString(ctx, fmt.Sprintf("Failed to update IDE settings: %v", err))

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -99,6 +99,8 @@ type ClientOptions struct {
 	SkipSettingsCheck bool
 	// Environment version for serverless compute.
 	EnvironmentVersion int
+	// If true, skip confirmation prompts for IDE extension install and IDE settings updates.
+	AutoApprove bool
 }
 
 func (o *ClientOptions) Validate() error {
@@ -234,7 +236,7 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		if err := vscode.CheckIDECommand(opts.IDE); err != nil {
 			return err
 		}
-		if err := vscode.CheckIDESSHExtension(ctx, opts.IDE); err != nil {
+		if err := vscode.CheckIDESSHExtension(ctx, opts.IDE, opts.AutoApprove); err != nil {
 			return err
 		}
 	}
@@ -243,12 +245,17 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 	// desired server ports (or socket connection mode) for the connection to go through
 	// (as the majority of the localhost ports on the remote side are blocked by iptable rules).
 	// Plus the platform (always linux), and extensions (python and jupyter), to make the initial experience smoother.
-	if opts.IDE != "" && opts.IsServerlessMode() && !opts.ProxyMode && !opts.SkipSettingsCheck && cmdio.IsPromptSupported(ctx) {
-		err := vscode.CheckAndUpdateSettings(ctx, opts.IDE, opts.ConnectionName)
+	// --auto-approve lets non-interactive callers run this path; without it we still
+	// fall back to the prompt-supported short-circuit so existing behavior is preserved.
+	if opts.IDE != "" && opts.IsServerlessMode() && !opts.ProxyMode && !opts.SkipSettingsCheck && (cmdio.IsPromptSupported(ctx) || opts.AutoApprove) {
+		err := vscode.CheckAndUpdateSettings(ctx, opts.IDE, opts.ConnectionName, opts.AutoApprove)
 		if err != nil {
 			cmdio.LogString(ctx, fmt.Sprintf("Failed to update IDE settings: %v", err))
 			cmdio.LogString(ctx, vscode.GetManualInstructions(opts.IDE, opts.ConnectionName))
 			cmdio.LogString(ctx, "Use --skip-settings-check to bypass IDE settings verification.")
+			if opts.AutoApprove {
+				return fmt.Errorf("aborted: IDE settings need to be updated manually: %w", err)
+			}
 			shouldProceed, promptErr := cmdio.AskYesOrNo(ctx, "Do you want to proceed with the connection?")
 			if promptErr != nil {
 				return fmt.Errorf("failed to prompt user: %w", promptErr)

--- a/experimental/ssh/internal/setup/setup.go
+++ b/experimental/ssh/internal/setup/setup.go
@@ -30,6 +30,8 @@ type SetupOptions struct {
 	Profile string
 	// Proxy command to use for the SSH connection
 	ProxyCommand string
+	// Skip confirmation prompts (e.g. recreate existing host config without asking)
+	AutoApprove bool
 }
 
 func validateClusterAccess(ctx context.Context, client *databricks.WorkspaceClient, clusterID string) error {
@@ -112,13 +114,18 @@ func Setup(ctx context.Context, client *databricks.WorkspaceClient, opts SetupOp
 
 	recreate := false
 	if exists {
-		recreate, err = sshconfig.PromptRecreateConfig(ctx, opts.HostName)
-		if err != nil {
-			return err
-		}
-		if !recreate {
-			cmdio.LogString(ctx, fmt.Sprintf("Skipping setup for host '%s'", opts.HostName))
-			return nil
+		if opts.AutoApprove {
+			recreate = true
+			cmdio.LogString(ctx, fmt.Sprintf("Host '%s' already exists, recreating (--auto-approve)", opts.HostName))
+		} else {
+			recreate, err = sshconfig.PromptRecreateConfig(ctx, opts.HostName)
+			if err != nil {
+				return err
+			}
+			if !recreate {
+				cmdio.LogString(ctx, fmt.Sprintf("Skipping setup for host '%s'", opts.HostName))
+				return nil
+			}
 		}
 	}
 

--- a/experimental/ssh/internal/setup/setup_test.go
+++ b/experimental/ssh/internal/setup/setup_test.go
@@ -256,6 +256,54 @@ func TestSetup_SuccessfulWithNewConfigFile(t *testing.T) {
 	assert.Contains(t, hostConfigStr, "--profile=test-profile")
 }
 
+func TestSetup_AutoApproveRecreatesExistingHost(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	// Pre-seed an existing host config so PromptRecreateConfig would fire without --auto-approve.
+	hostConfigDir := filepath.Join(tmpDir, ".databricks", "ssh-tunnel-configs")
+	require.NoError(t, os.MkdirAll(hostConfigDir, 0o700))
+	existingHostConfig := filepath.Join(hostConfigDir, "test-host")
+	require.NoError(t, os.WriteFile(existingHostConfig, []byte("# stale\nHost test-host\n    User stale\n"), 0o600))
+
+	configPath := filepath.Join(tmpDir, "ssh_config")
+
+	m := mocks.NewMockWorkspaceClient(t)
+	clustersAPI := m.GetMockClustersAPI()
+	clustersAPI.EXPECT().Get(ctx, compute.GetClusterRequest{ClusterId: "cluster-123"}).Return(&compute.ClusterDetails{
+		DataSecurityMode: compute.DataSecurityModeSingleUser,
+	}, nil)
+
+	opts := SetupOptions{
+		HostName:      "test-host",
+		ClusterID:     "cluster-123",
+		SSHConfigPath: configPath,
+		SSHKeysDir:    tmpDir,
+		ShutdownDelay: 30 * time.Second,
+		AutoApprove:   true,
+	}
+
+	clientOpts := client.ClientOptions{
+		ClusterID:     opts.ClusterID,
+		ShutdownDelay: opts.ShutdownDelay,
+	}
+	proxyCommand, err := clientOpts.ToProxyCommand()
+	require.NoError(t, err)
+	opts.ProxyCommand = proxyCommand
+
+	err = Setup(ctx, m.WorkspaceClient, opts)
+	assert.NoError(t, err)
+
+	// Host config should be recreated (no longer contains the stale User).
+	content, err := os.ReadFile(existingHostConfig)
+	require.NoError(t, err)
+	s := string(content)
+	assert.NotContains(t, s, "User stale")
+	assert.Contains(t, s, "--cluster=cluster-123")
+}
+
 func TestSetup_SuccessfulWithExistingConfigFile(t *testing.T) {
 	ctx := cmdio.MockDiscard(t.Context())
 	tmpDir := t.TempDir()

--- a/experimental/ssh/internal/vscode/run.go
+++ b/experimental/ssh/internal/vscode/run.go
@@ -95,7 +95,8 @@ func isExtensionVersionAtLeast(version, minVersion string) bool {
 
 // CheckIDESSHExtension verifies that the required Remote SSH extension is installed
 // with a compatible version, and offers to install/update it if not.
-func CheckIDESSHExtension(ctx context.Context, option string) error {
+// When autoApprove is true, the extension is installed without asking.
+func CheckIDESSHExtension(ctx context.Context, option string, autoApprove bool) error {
 	ide := getIDE(option)
 
 	out, err := exec.CommandContext(ctx, ide.Command, "--list-extensions", "--show-versions").Output()
@@ -116,18 +117,22 @@ func CheckIDESSHExtension(ctx context.Context, option string) error {
 			ide.SSHExtensionName, version, ide.MinSSHExtensionVersion)
 	}
 
-	if !cmdio.IsPromptSupported(ctx) {
-		return fmt.Errorf("%s Install it with: %s --install-extension %s",
-			msg, ide.Command, ide.SSHExtensionID)
-	}
+	if !autoApprove {
+		if !cmdio.IsPromptSupported(ctx) {
+			return fmt.Errorf("%s Install it with: %s --install-extension %s, or pass --auto-approve",
+				msg, ide.Command, ide.SSHExtensionID)
+		}
 
-	shouldInstall, err := cmdio.AskYesOrNo(ctx, msg+" Would you like to install it?")
-	if err != nil {
-		return fmt.Errorf("failed to prompt user: %w", err)
-	}
-	if !shouldInstall {
-		return fmt.Errorf("%s Install it with: %s --install-extension %s",
-			msg, ide.Command, ide.SSHExtensionID)
+		shouldInstall, err := cmdio.AskYesOrNo(ctx, msg+" Would you like to install it?")
+		if err != nil {
+			return fmt.Errorf("failed to prompt user: %w", err)
+		}
+		if !shouldInstall {
+			return fmt.Errorf("%s Install it with: %s --install-extension %s",
+				msg, ide.Command, ide.SSHExtensionID)
+		}
+	} else {
+		cmdio.LogString(ctx, msg+" Installing automatically (--auto-approve).")
 	}
 
 	cmdio.LogString(ctx, fmt.Sprintf("Installing %q...", ide.SSHExtensionName))

--- a/experimental/ssh/internal/vscode/run_test.go
+++ b/experimental/ssh/internal/vscode/run_test.go
@@ -240,7 +240,7 @@ func TestCheckIDESSHExtension_UpToDate(t *testing.T) {
 	extensionOutput := "ms-python.python@2024.1.1\nms-vscode-remote.remote-ssh@0.123.0\n"
 	createFakeIDEExecutable(t, tmpDir, "code", extensionOutput)
 
-	err := CheckIDESSHExtension(ctx, VSCodeOption)
+	err := CheckIDESSHExtension(ctx, VSCodeOption, false)
 	assert.NoError(t, err)
 }
 
@@ -252,7 +252,7 @@ func TestCheckIDESSHExtension_ExactMinVersion(t *testing.T) {
 	extensionOutput := "ms-vscode-remote.remote-ssh@0.120.0\n"
 	createFakeIDEExecutable(t, tmpDir, "code", extensionOutput)
 
-	err := CheckIDESSHExtension(ctx, VSCodeOption)
+	err := CheckIDESSHExtension(ctx, VSCodeOption, false)
 	assert.NoError(t, err)
 }
 
@@ -264,7 +264,7 @@ func TestCheckIDESSHExtension_Missing(t *testing.T) {
 	extensionOutput := "ms-python.python@2024.1.1\n"
 	createFakeIDEExecutable(t, tmpDir, "code", extensionOutput)
 
-	err := CheckIDESSHExtension(ctx, VSCodeOption)
+	err := CheckIDESSHExtension(ctx, VSCodeOption, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"Remote - SSH"`)
 	assert.Contains(t, err.Error(), "not installed")
@@ -278,7 +278,7 @@ func TestCheckIDESSHExtension_Outdated(t *testing.T) {
 	extensionOutput := "ms-vscode-remote.remote-ssh@0.100.0\n"
 	createFakeIDEExecutable(t, tmpDir, "code", extensionOutput)
 
-	err := CheckIDESSHExtension(ctx, VSCodeOption)
+	err := CheckIDESSHExtension(ctx, VSCodeOption, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "0.100.0")
 	assert.Contains(t, err.Error(), ">= 0.120.0")
@@ -292,6 +292,31 @@ func TestCheckIDESSHExtension_Cursor(t *testing.T) {
 	extensionOutput := "anysphere.remote-ssh@1.0.32\n"
 	createFakeIDEExecutable(t, tmpDir, "cursor", extensionOutput)
 
-	err := CheckIDESSHExtension(ctx, CursorOption)
+	err := CheckIDESSHExtension(ctx, CursorOption, false)
 	assert.NoError(t, err)
+}
+
+func TestCheckIDESSHExtension_AutoApproveMissing_Installs(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+	ctx, _ := cmdio.NewTestContextWithStdout(t.Context())
+
+	// Fake `code` returns no extensions for --list-extensions, but succeeds for --install-extension.
+	createFakeIDEExecutable(t, tmpDir, "code", "")
+
+	err := CheckIDESSHExtension(ctx, VSCodeOption, true)
+	assert.NoError(t, err)
+}
+
+func TestCheckIDESSHExtension_NoPrompt_WithoutAutoApprove_Errors(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("PATH", tmpDir)
+	ctx, _ := cmdio.NewTestContextWithStdout(t.Context())
+
+	extensionOutput := "ms-python.python@2024.1.1\n"
+	createFakeIDEExecutable(t, tmpDir, "code", extensionOutput)
+
+	err := CheckIDESSHExtension(ctx, VSCodeOption, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--install-extension")
 }

--- a/experimental/ssh/internal/vscode/settings.go
+++ b/experimental/ssh/internal/vscode/settings.go
@@ -65,8 +65,12 @@ func logSkippingSettings(ctx context.Context, msg string) {
 	cmdio.LogString(ctx, msg+"\n\nWARNING: the connection might not work as expected\n")
 }
 
-func CheckAndUpdateSettings(ctx context.Context, ide, connectionName string) error {
-	if !cmdio.IsPromptSupported(ctx) {
+// CheckAndUpdateSettings verifies that the IDE settings file contains the
+// required entries for this SSH connection, and applies missing entries after
+// confirming with the user. When autoApprove is true, updates are applied
+// without prompting.
+func CheckAndUpdateSettings(ctx context.Context, ide, connectionName string, autoApprove bool) error {
+	if !cmdio.IsPromptSupported(ctx) && !autoApprove {
 		logSkippingSettings(ctx, "Skipping IDE settings check: prompts not supported")
 		return nil
 	}
@@ -79,7 +83,7 @@ func CheckAndUpdateSettings(ctx context.Context, ide, connectionName string) err
 	settings, err := loadSettings(settingsPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return handleMissingFile(ctx, ide, connectionName, settingsPath)
+			return handleMissingFile(ctx, ide, connectionName, settingsPath, autoApprove)
 		}
 		return fmt.Errorf("failed to load settings: %w", err)
 	}
@@ -90,13 +94,17 @@ func CheckAndUpdateSettings(ctx context.Context, ide, connectionName string) err
 		return nil
 	}
 
-	shouldUpdate, err := promptUserForUpdate(ctx, ide, connectionName, missing)
-	if err != nil {
-		return fmt.Errorf("failed to prompt user: %w", err)
-	}
-	if !shouldUpdate {
-		logSkippingSettings(ctx, "Skipping IDE settings update")
-		return nil
+	if !autoApprove {
+		shouldUpdate, err := promptUserForUpdate(ctx, ide, connectionName, missing)
+		if err != nil {
+			return fmt.Errorf("failed to prompt user: %w", err)
+		}
+		if !shouldUpdate {
+			logSkippingSettings(ctx, "Skipping IDE settings update")
+			return nil
+		}
+	} else {
+		cmdio.LogString(ctx, fmt.Sprintf("Applying %s settings for '%s' (--auto-approve)", getIDE(ide).Name, connectionName))
 	}
 
 	if data, err := os.ReadFile(settingsPath); err == nil {
@@ -249,20 +257,24 @@ func promptUserForUpdate(ctx context.Context, ide, connectionName string, missin
 	return strings.ToLower(ans) == "y", nil
 }
 
-func handleMissingFile(ctx context.Context, ide, connectionName, settingsPath string) error {
+func handleMissingFile(ctx context.Context, ide, connectionName, settingsPath string, autoApprove bool) error {
 	missing := &missingSettings{
 		portRange:      true,
 		platform:       true,
 		listenOnSocket: true,
 		extensions:     []string{pythonExtension, jupyterExtension, databricksExtension},
 	}
-	shouldCreate, err := promptUserForUpdate(ctx, ide, connectionName, missing)
-	if err != nil {
-		return fmt.Errorf("failed to prompt user: %w", err)
-	}
-	if !shouldCreate {
-		logSkippingSettings(ctx, "Skipping IDE settings creation")
-		return nil
+	if !autoApprove {
+		shouldCreate, err := promptUserForUpdate(ctx, ide, connectionName, missing)
+		if err != nil {
+			return fmt.Errorf("failed to prompt user: %w", err)
+		}
+		if !shouldCreate {
+			logSkippingSettings(ctx, "Skipping IDE settings creation")
+			return nil
+		}
+	} else {
+		cmdio.LogString(ctx, fmt.Sprintf("Creating %s settings for '%s' (--auto-approve)", getIDE(ide).Name, connectionName))
 	}
 
 	settingsDir := filepath.Dir(settingsPath)

--- a/experimental/ssh/internal/vscode/settings_test.go
+++ b/experimental/ssh/internal/vscode/settings_test.go
@@ -457,7 +457,7 @@ func TestCheckAndUpdateSettings_CreatesBackup(t *testing.T) {
 		_ = tst.Stdin.Flush()
 	}()
 
-	err = CheckAndUpdateSettings(ctx, "cursor", "my-host")
+	err = CheckAndUpdateSettings(ctx, "cursor", "my-host", false)
 	require.NoError(t, err)
 
 	originalBakContent, err := os.ReadFile(settingsPath + fileutil.SuffixOriginalBak)
@@ -473,7 +473,7 @@ func TestCheckAndUpdateSettings_CreatesBackup(t *testing.T) {
 		_ = tst.Stdin.Flush()
 	}()
 
-	err = CheckAndUpdateSettings(ctx, "cursor", "my-host-2")
+	err = CheckAndUpdateSettings(ctx, "cursor", "my-host-2", false)
 	require.NoError(t, err)
 
 	latestBakContent, err := os.ReadFile(settingsPath + fileutil.SuffixLatestBak)
@@ -484,6 +484,52 @@ func TestCheckAndUpdateSettings_CreatesBackup(t *testing.T) {
 	originalBakContent2, err := os.ReadFile(settingsPath + fileutil.SuffixOriginalBak)
 	require.NoError(t, err)
 	assert.Equal(t, originalContent, originalBakContent2)
+}
+
+func TestCheckAndUpdateSettings_AutoApproveWithoutPromptSupport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path setup differs on windows")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Default test context has PromptSupported=false; --auto-approve must still apply updates.
+	ctx, _ := cmdio.NewTestContextWithStdout(t.Context())
+
+	settingsPath, err := getDefaultSettingsPath(ctx, "cursor")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(settingsPath), 0o755))
+	require.NoError(t, os.WriteFile(settingsPath, []byte(`{}`), 0o600))
+
+	err = CheckAndUpdateSettings(ctx, "cursor", "my-host", true)
+	require.NoError(t, err)
+
+	updated, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), "my-host")
+	assert.Contains(t, string(updated), "29500-29505")
+}
+
+func TestCheckAndUpdateSettings_AutoApproveCreatesMissingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path setup differs on windows")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	ctx, _ := cmdio.NewTestContextWithStdout(t.Context())
+
+	settingsPath, err := getDefaultSettingsPath(ctx, "cursor")
+	require.NoError(t, err)
+
+	err = CheckAndUpdateSettings(ctx, "cursor", "my-host", true)
+	require.NoError(t, err)
+
+	created, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(created), "my-host")
 }
 
 func TestSaveSettings_Formatting(t *testing.T) {

--- a/libs/apps/vite/bridge.go
+++ b/libs/apps/vite/bridge.go
@@ -89,9 +89,13 @@ type Bridge struct {
 	port               int
 	keepaliveDone      chan struct{} // Signals keepalive goroutine to stop on reconnect
 	keepaliveMu        sync.Mutex    // Protects keepaliveDone
+	autoApprove        bool          // If true, approve every viewer connection without asking
 }
 
-func NewBridge(ctx context.Context, w *databricks.WorkspaceClient, appName string, port int) *Bridge {
+// NewBridge constructs a development bridge to a remote app. When autoApprove is
+// true, inbound connection requests from viewers are approved without prompting
+// on stdin.
+func NewBridge(ctx context.Context, w *databricks.WorkspaceClient, appName string, port int, autoApprove bool) *Bridge {
 	// Configure HTTP client optimized for local high-volume requests
 	transport := &http.Transport{
 		MaxIdleConns:        100,
@@ -113,6 +117,7 @@ func NewBridge(ctx context.Context, w *databricks.WorkspaceClient, appName strin
 		tunnelWriteChan:    make(chan prioritizedMessage, 100), // Buffered channel for async writes
 		connectionRequests: make(chan *BridgeMessage, 10),
 		port:               port,
+		autoApprove:        autoApprove,
 	}
 
 	b.stop = sync.OnceFunc(func() {
@@ -448,32 +453,38 @@ func (vb *Bridge) handleConnectionRequest(msg *BridgeMessage) error {
 	cmdio.LogString(vb.ctx, "")
 	cmdio.LogString(vb.ctx, "🔔 Connection Request")
 	cmdio.LogString(vb.ctx, "   User: "+msg.Viewer)
-	cmdio.LogString(vb.ctx, "   Approve this connection? (y/n)")
-
-	// Read from stdin with timeout to prevent indefinite blocking
-	inputChan := make(chan string, 1)
-	errChan := make(chan error, 1)
-
-	go func() {
-		reader := bufio.NewReader(os.Stdin)
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			errChan <- err
-			return
-		}
-		inputChan <- input
-	}()
 
 	var approved bool
-	select {
-	case input := <-inputChan:
-		approved = strings.ToLower(strings.TrimSpace(input)) == "y"
-	case err := <-errChan:
-		return fmt.Errorf("failed to read user input: %w", err)
-	case <-time.After(BridgeConnTimeout):
-		// Default to denying after timeout
-		cmdio.LogString(vb.ctx, "⏱️  Timeout waiting for response, denying connection")
-		approved = false
+	if vb.autoApprove {
+		cmdio.LogString(vb.ctx, "   Auto-approving (--auto-approve)")
+		approved = true
+	} else {
+		cmdio.LogString(vb.ctx, "   Approve this connection? (y/n)")
+
+		// Read from stdin with timeout to prevent indefinite blocking
+		inputChan := make(chan string, 1)
+		errChan := make(chan error, 1)
+
+		go func() {
+			reader := bufio.NewReader(os.Stdin)
+			input, err := reader.ReadString('\n')
+			if err != nil {
+				errChan <- err
+				return
+			}
+			inputChan <- input
+		}()
+
+		select {
+		case input := <-inputChan:
+			approved = strings.ToLower(strings.TrimSpace(input)) == "y"
+		case err := <-errChan:
+			return fmt.Errorf("failed to read user input: %w", err)
+		case <-time.After(BridgeConnTimeout):
+			// Default to denying after timeout
+			cmdio.LogString(vb.ctx, "⏱️  Timeout waiting for response, denying connection")
+			approved = false
+		}
 	}
 
 	response := BridgeMessage{

--- a/libs/apps/vite/bridge_test.go
+++ b/libs/apps/vite/bridge_test.go
@@ -152,7 +152,7 @@ func TestBridgeHandleMessage(t *testing.T) {
 
 	w := &databricks.WorkspaceClient{}
 
-	vb := NewBridge(ctx, w, "test-app", 5173)
+	vb := NewBridge(ctx, w, "test-app", 5173, false)
 
 	tests := []struct {
 		name        string
@@ -238,7 +238,7 @@ func TestBridgeHandleFileReadRequest(t *testing.T) {
 		defer resp.Body.Close()
 		defer conn.Close()
 
-		vb := NewBridge(ctx, w, "test-app", 5173)
+		vb := NewBridge(ctx, w, "test-app", 5173, false)
 		vb.tunnelConn = conn
 
 		go func() { _ = vb.tunnelWriter(ctx) }()
@@ -295,7 +295,7 @@ func TestBridgeHandleFileReadRequest(t *testing.T) {
 		defer resp.Body.Close()
 		defer conn.Close()
 
-		vb := NewBridge(ctx, w, "test-app", 5173)
+		vb := NewBridge(ctx, w, "test-app", 5173, false)
 		vb.tunnelConn = conn
 
 		go func() { _ = vb.tunnelWriter(ctx) }()
@@ -326,7 +326,7 @@ func TestBridgeStop(t *testing.T) {
 	ctx := cmdio.MockDiscard(t.Context())
 	w := &databricks.WorkspaceClient{}
 
-	vb := NewBridge(ctx, w, "test-app", 5173)
+	vb := NewBridge(ctx, w, "test-app", 5173, false)
 
 	// Call Stop multiple times to ensure it's idempotent
 	vb.Stop()
@@ -347,7 +347,7 @@ func TestNewBridge(t *testing.T) {
 	w := &databricks.WorkspaceClient{}
 	appName := "test-app"
 
-	vb := NewBridge(ctx, w, appName, 5173)
+	vb := NewBridge(ctx, w, appName, 5173, false)
 
 	assert.NotNil(t, vb)
 	assert.Equal(t, appName, vb.appName)
@@ -355,4 +355,66 @@ func TestNewBridge(t *testing.T) {
 	assert.NotNil(t, vb.stopChan)
 	assert.NotNil(t, vb.connectionRequests)
 	assert.Equal(t, 10, cap(vb.connectionRequests))
+	assert.False(t, vb.autoApprove)
+}
+
+func TestNewBridge_AutoApprove(t *testing.T) {
+	ctx := t.Context()
+	w := &databricks.WorkspaceClient{}
+
+	vb := NewBridge(ctx, w, "test-app", 5173, true)
+
+	assert.NotNil(t, vb)
+	assert.True(t, vb.autoApprove)
+}
+
+func TestBridgeHandleConnectionRequest_AutoApproveSkipsStdin(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	w := &databricks.WorkspaceClient{}
+
+	var received []byte
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("failed to upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("failed to read message: %v", err)
+			return
+		}
+		received = message
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[4:]
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	defer conn.Close()
+
+	vb := NewBridge(ctx, w, "test-app", 5173, true)
+	vb.tunnelConn = conn
+
+	go func() { _ = vb.tunnelWriter(ctx) }()
+
+	msg := &BridgeMessage{
+		Type:      "connection:request",
+		Viewer:    "alice@example.com",
+		RequestID: "req-auto",
+	}
+
+	require.NoError(t, vb.handleConnectionRequest(msg))
+
+	time.Sleep(100 * time.Millisecond)
+
+	var response BridgeMessage
+	require.NoError(t, json.Unmarshal(received, &response))
+	assert.Equal(t, "connection:response", response.Type)
+	assert.Equal(t, "req-auto", response.RequestID)
+	assert.True(t, response.Approved)
 }

--- a/libs/apps/vite/validate_dir_test.go
+++ b/libs/apps/vite/validate_dir_test.go
@@ -148,7 +148,7 @@ func TestBridgeHandleDirListRequest(t *testing.T) {
 		defer resp.Body.Close()
 		defer conn.Close()
 
-		vb := NewBridge(ctx, w, "test-app", 5173)
+		vb := NewBridge(ctx, w, "test-app", 5173, false)
 		vb.tunnelConn = conn
 
 		go func() { _ = vb.tunnelWriter(ctx) }()
@@ -213,7 +213,7 @@ func TestBridgeHandleDirListRequest(t *testing.T) {
 		defer resp.Body.Close()
 		defer conn.Close()
 
-		vb := NewBridge(ctx, w, "test-app", 5173)
+		vb := NewBridge(ctx, w, "test-app", 5173, false)
 		vb.tunnelConn = conn
 
 		go func() { _ = vb.tunnelWriter(ctx) }()


### PR DESCRIPTION
## Why

The rest of the CLI already exposes `--auto-approve` on confirmation prompts: `bundle deploy`, `bundle destroy`, `pipelines deploy`, `pipelines destroy`, `completion install`, `completion uninstall`, `auth logout`, and `apps delete` all have it. Five prompts in experimental commands do not, which is inconsistent and also blocks any non-interactive use of those commands (CI, scripts).

The five sites:

- `databricks ssh setup`: "Host already exists" prompt
- `databricks ssh connect`: required IDE extension install
- `databricks ssh connect`: IDE settings update
- `databricks apps dev-remote`: viewer connection request
- `databricks apps init`: optional resource confirmation

All five are in `Hidden: true` / experimental commands.

## Changes

Before: these prompts could not be bypassed, so these commands didn't match the `--auto-approve` convention the rest of the CLI has settled on.
Now: each of the four owning commands accepts `--auto-approve`, and the prompt is skipped when the flag is set.

Follows the same convention as the commands listed above: a bool flag on the command, threaded through the options struct, checked before the prompt. No new cmdio helper, no context-based capability, no new pattern - just applying the existing one to the last few places that didn't have it.

Behavior details:

- **`ssh setup --auto-approve`**: recreates an existing host config without prompting.
- **`ssh connect --auto-approve`**: installs the required IDE SSH extension and applies missing IDE settings without prompting. Also removes the `cmdio.IsPromptSupported` short-circuit on the settings path so the flag works in non-TTY contexts (the whole point).
- **`apps dev-remote --auto-approve`**: auto-approves every viewer connection for the life of the session. Help text flags the trust implication (anyone with the shareable dev URL is trusted). Intended for trusted environments only.
- **`apps init --auto-approve`**: skips the `Configure <optional resource>?` confirmation. Optional resources are only configured when their values are supplied via `--set plugin.resourceKey.field=value`.

No `NEXT_CHANGELOG.md` entry since all commands are experimental.

## Test plan

- [x] `make checks` clean
- [x] `make lint` clean
- [x] `go test ./experimental/ssh/... ./libs/apps/vite/... ./cmd/apps/...` passes
- [x] Unit tests added:
  - `TestSetup_AutoApproveRecreatesExistingHost`: Setup with AutoApprove=true recreates a pre-existing host config
  - `TestCheckIDESSHExtension_AutoApproveMissing_Installs`: extension is installed without a prompt
  - `TestCheckIDESSHExtension_NoPrompt_WithoutAutoApprove_Errors`: non-interactive without the flag still errors with install instructions
  - `TestCheckAndUpdateSettings_AutoApproveWithoutPromptSupport`: settings applied even when prompts are unsupported
  - `TestCheckAndUpdateSettings_AutoApproveCreatesMissingFile`: missing settings file is created
  - `TestNewBridge_AutoApprove`: bridge stores the flag
  - `TestBridgeHandleConnectionRequest_AutoApproveSkipsStdin`: connection request is approved without reading stdin
- [ ] Manual: `databricks ssh setup --name h --cluster <id>` twice; second run with `--auto-approve` recreates silently
- [ ] Manual: `databricks ssh connect --ide vscode --auto-approve` with the SSH extension missing: installs without a prompt
- [ ] Manual: `databricks apps dev-remote --name <app> --auto-approve`: external viewer opens the shareable URL and is approved without stdin interaction
- [ ] Manual: `databricks apps init --name x --features analytics --auto-approve`: optional resources are skipped when no `--set` supplied; honored when `--set` is supplied