### PR TITLE
Expose bundle deploy flags on apps deploy

### DIFF
--- a/acceptance/apps/deploy/bundle-no-args-with-flags/app/app.py
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/app/app.py
@@ -1,0 +1,2 @@
+# Minimal app for testing
+print("Hello from app")

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/databricks.yml
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/databricks.yml
@@ -1,0 +1,8 @@
+bundle:
+  name: test-bundle
+
+resources:
+  apps:
+    myapp:
+      name: myapp
+      source_code_path: ./app

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/out.test.toml
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/output.txt
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/output.txt
@@ -1,0 +1,25 @@
+
+>>> [CLI] apps deploy --skip-validation --auto-approve --force-lock --fail-on-active-runs
+Deploying project...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+✓ Getting the status of the app myapp
+✓ App is in RUNNING state
+✓ App compute is in STOPPED state
+✓ Starting the app myapp
+✓ App is starting...
+✓ App is started!
+✓ Deployment succeeded
+You can access the app at myapp-123.cloud.databricksapps.com
+✔ Deployment complete!
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.apps.myapp
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/script
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/script
@@ -1,0 +1,6 @@
+# Test: apps deploy in a bundle directory with bundle-style deploy flags
+# Expected: flags are accepted and the bundle deploy pipeline completes
+
+trace $CLI apps deploy --skip-validation --auto-approve --force-lock --fail-on-active-runs
+
+trace $CLI bundle destroy --auto-approve

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/test.toml
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/test.toml
@@ -1,0 +1,37 @@
+Local = true
+Cloud = false
+
+Ignore = [
+    '.databricks',
+]
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+
+[[Server]]
+Pattern = "POST /api/2.0/apps/myapp/deployments"
+Response.Body = '''
+{
+  "deployment_id": "dep-123",
+  "source_code_path": "/Workspace/apps/myapp",
+  "mode": "SNAPSHOT",
+  "status": {
+    "state": "SUCCEEDED",
+    "message": "Deployment succeeded"
+  }
+}
+'''
+
+[[Server]]
+Pattern = "GET /api/2.0/apps/myapp/deployments/dep-123"
+Response.Body = '''
+{
+  "deployment_id": "dep-123",
+  "source_code_path": "/Workspace/apps/myapp",
+  "mode": "SNAPSHOT",
+  "status": {
+    "state": "SUCCEEDED",
+    "message": "Deployment succeeded"
+  }
+}
+'''

--- a/cmd/apps/deploy_bundle.go
+++ b/cmd/apps/deploy_bundle.go
@@ -33,19 +33,40 @@ func hasBundleConfig() bool {
 	return err == nil
 }
 
+// bundleDeployOptions holds the flags that configure the bundle-aware deploy path.
+// The fields mirror the flags on `bundle deploy` plus the apps-specific validation
+// controls (skip-validation, skip-tests).
+type bundleDeployOptions struct {
+	force            bool
+	forceLock        bool
+	failOnActiveRuns bool
+	autoApprove      bool
+	verbose          bool
+	clusterId        string
+	readPlanPath     string
+	skipValidation   bool
+	skipTests        bool
+}
+
 // BundleDeployOverrideWithWrapper creates a deploy override function that uses
 // the provided error wrapper for API fallback errors.
 func BundleDeployOverrideWithWrapper(wrapError ErrorWrapper) func(*cobra.Command, *apps.CreateAppDeploymentRequest) {
 	return func(deployCmd *cobra.Command, deployReq *apps.CreateAppDeploymentRequest) {
-		var (
-			force          bool
-			skipValidation bool
-			skipTests      bool
-		)
+		var opts bundleDeployOptions
 
-		deployCmd.Flags().BoolVar(&force, "force", false, "Force-override Git branch validation")
-		deployCmd.Flags().BoolVar(&skipValidation, "skip-validation", false, "Skip project validation (build, typecheck, lint)")
-		deployCmd.Flags().BoolVar(&skipTests, "skip-tests", true, "Skip running tests during validation")
+		deployCmd.Flags().BoolVar(&opts.force, "force", false, "Force-override Git branch validation.")
+		deployCmd.Flags().BoolVar(&opts.forceLock, "force-lock", false, "Force acquisition of deployment lock.")
+		deployCmd.Flags().BoolVar(&opts.failOnActiveRuns, "fail-on-active-runs", false, "Fail if there are running jobs or pipelines in the deployment.")
+		deployCmd.Flags().StringVar(&opts.clusterId, "compute-id", "", "Override cluster in the deployment with the given compute ID.")
+		deployCmd.Flags().StringVarP(&opts.clusterId, "cluster-id", "c", "", "Override cluster in the deployment with the given cluster ID.")
+		deployCmd.Flags().BoolVar(&opts.autoApprove, "auto-approve", false, "Skip interactive approvals that might be required for deployment.")
+		deployCmd.Flags().MarkDeprecated("compute-id", "use --cluster-id instead")
+		deployCmd.Flags().BoolVar(&opts.verbose, "verbose", false, "Enable verbose output.")
+		deployCmd.Flags().StringVar(&opts.readPlanPath, "plan", "", "Path to a JSON plan file to apply instead of planning (direct engine only).")
+		// Verbose currently only affects file sync output; it's used by the vscode extension.
+		deployCmd.Flags().MarkHidden("verbose")
+		deployCmd.Flags().BoolVar(&opts.skipValidation, "skip-validation", false, "Skip project validation (build, typecheck, lint)")
+		deployCmd.Flags().BoolVar(&opts.skipTests, "skip-tests", true, "Skip running tests during validation")
 
 		makeArgsOptionalWithBundle(deployCmd, "deploy [APP_NAME]")
 
@@ -54,7 +75,7 @@ func BundleDeployOverrideWithWrapper(wrapError ErrorWrapper) func(*cobra.Command
 			if len(args) == 0 {
 				b := root.TryConfigureBundle(cmd)
 				if b != nil {
-					return runBundleDeploy(cmd, force, skipValidation, skipTests)
+					return runBundleDeploy(cmd, opts)
 				}
 			}
 
@@ -91,12 +112,21 @@ Examples:
   databricks apps deploy --skip-validation
 
   # Force deploy (override git branch validation)
-  databricks apps deploy --force`
+  databricks apps deploy --force
+
+  # Skip interactive approval prompts
+  databricks apps deploy --auto-approve
+
+  # Force-acquire the deployment lock if a previous run left it stale
+  databricks apps deploy --force-lock
+
+  # Override the cluster used for job resources in the bundle
+  databricks apps deploy --cluster-id 0123-456789-abcdef01`
 	}
 }
 
 // runBundleDeploy executes the enhanced deployment flow for project directories.
-func runBundleDeploy(cmd *cobra.Command, force, skipValidation, skipTests bool) error {
+func runBundleDeploy(cmd *cobra.Command, opts bundleDeployOptions) error {
 	ctx := cmd.Context()
 
 	workDir, err := os.Getwd()
@@ -105,13 +135,13 @@ func runBundleDeploy(cmd *cobra.Command, force, skipValidation, skipTests bool) 
 	}
 
 	// Step 1: Validate project (unless skipped)
-	if !skipValidation {
+	if !opts.skipValidation {
 		validator := validation.GetProjectValidator(workDir)
 		if validator != nil {
-			opts := validation.ValidateOptions{
-				SkipTests: skipTests,
+			vopts := validation.ValidateOptions{
+				SkipTests: opts.skipTests,
 			}
-			result, err := validator.Validate(ctx, workDir, opts)
+			result, err := validator.Validate(ctx, workDir, vopts)
 			if err != nil {
 				return fmt.Errorf("validation error: %w", err)
 			}
@@ -132,7 +162,19 @@ func runBundleDeploy(cmd *cobra.Command, force, skipValidation, skipTests bool) 
 	cmdio.LogString(ctx, "Deploying project...")
 	b, err := utils.ProcessBundle(cmd, utils.ProcessOptions{
 		InitFunc: func(b *bundle.Bundle) {
-			b.Config.Bundle.Force = force
+			b.Config.Bundle.Force = opts.force
+			b.Config.Bundle.Deployment.Lock.Force = opts.forceLock
+			b.AutoApprove = opts.autoApprove
+
+			if cmd.Flag("compute-id").Changed {
+				b.Config.Bundle.ClusterId = opts.clusterId
+			}
+			if cmd.Flag("cluster-id").Changed {
+				b.Config.Bundle.ClusterId = opts.clusterId
+			}
+			if cmd.Flag("fail-on-active-runs").Changed {
+				b.Config.Bundle.Deployment.FailOnActiveRuns = opts.failOnActiveRuns
+			}
 		},
 		// Context is already initialized by the workspace command's PreRunE
 		SkipInitContext: true,
@@ -140,6 +182,8 @@ func runBundleDeploy(cmd *cobra.Command, force, skipValidation, skipTests bool) 
 		FastValidate:    true,
 		Build:           true,
 		Deploy:          true,
+		Verbose:         opts.verbose,
+		ReadPlanPath:    opts.readPlanPath,
 	})
 	if err != nil {
 		return fmt.Errorf("deploy failed: %w", err)

--- a/cmd/apps/deploy_bundle.go
+++ b/cmd/apps/deploy_bundle.go
@@ -33,9 +33,7 @@ func hasBundleConfig() bool {
 	return err == nil
 }
 
-// bundleDeployOptions holds the flags that configure the bundle-aware deploy path.
-// The fields mirror the flags on `bundle deploy` plus the apps-specific validation
-// controls (skip-validation, skip-tests).
+// bundleDeployOptions holds flags for the bundle-aware deploy path.
 type bundleDeployOptions struct {
 	force            bool
 	forceLock        bool
@@ -46,6 +44,24 @@ type bundleDeployOptions struct {
 	readPlanPath     string
 	skipValidation   bool
 	skipTests        bool
+}
+
+// applyDeployFlags writes the deploy flag values onto the bundle config.
+// Flags that override bundle YAML are only applied when explicitly set by the user.
+func applyDeployFlags(cmd *cobra.Command, b *bundle.Bundle, opts bundleDeployOptions) {
+	b.Config.Bundle.Force = opts.force
+	b.Config.Bundle.Deployment.Lock.Force = opts.forceLock
+	b.AutoApprove = opts.autoApprove
+
+	if cmd.Flag("compute-id").Changed {
+		b.Config.Bundle.ClusterId = opts.clusterId
+	}
+	if cmd.Flag("cluster-id").Changed {
+		b.Config.Bundle.ClusterId = opts.clusterId
+	}
+	if cmd.Flag("fail-on-active-runs").Changed {
+		b.Config.Bundle.Deployment.FailOnActiveRuns = opts.failOnActiveRuns
+	}
 }
 
 // BundleDeployOverrideWithWrapper creates a deploy override function that uses
@@ -63,7 +79,7 @@ func BundleDeployOverrideWithWrapper(wrapError ErrorWrapper) func(*cobra.Command
 		deployCmd.Flags().MarkDeprecated("compute-id", "use --cluster-id instead")
 		deployCmd.Flags().BoolVar(&opts.verbose, "verbose", false, "Enable verbose output.")
 		deployCmd.Flags().StringVar(&opts.readPlanPath, "plan", "", "Path to a JSON plan file to apply instead of planning (direct engine only).")
-		// Verbose currently only affects file sync output; it's used by the vscode extension.
+		// Verbose flag currently only affects file sync output, it's used by the vscode extension
 		deployCmd.Flags().MarkHidden("verbose")
 		deployCmd.Flags().BoolVar(&opts.skipValidation, "skip-validation", false, "Skip project validation (build, typecheck, lint)")
 		deployCmd.Flags().BoolVar(&opts.skipTests, "skip-tests", true, "Skip running tests during validation")
@@ -162,19 +178,7 @@ func runBundleDeploy(cmd *cobra.Command, opts bundleDeployOptions) error {
 	cmdio.LogString(ctx, "Deploying project...")
 	b, err := utils.ProcessBundle(cmd, utils.ProcessOptions{
 		InitFunc: func(b *bundle.Bundle) {
-			b.Config.Bundle.Force = opts.force
-			b.Config.Bundle.Deployment.Lock.Force = opts.forceLock
-			b.AutoApprove = opts.autoApprove
-
-			if cmd.Flag("compute-id").Changed {
-				b.Config.Bundle.ClusterId = opts.clusterId
-			}
-			if cmd.Flag("cluster-id").Changed {
-				b.Config.Bundle.ClusterId = opts.clusterId
-			}
-			if cmd.Flag("fail-on-active-runs").Changed {
-				b.Config.Bundle.Deployment.FailOnActiveRuns = opts.failOnActiveRuns
-			}
+			applyDeployFlags(cmd, b, opts)
 		},
 		// Context is already initialized by the workspace command's PreRunE
 		SkipInitContext: true,

--- a/cmd/apps/deploy_bundle_test.go
+++ b/cmd/apps/deploy_bundle_test.go
@@ -1,0 +1,141 @@
+package apps
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/apps"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBundleDeployOverrideWithWrapper(t *testing.T) {
+	mockWrapper := func(cmd *cobra.Command, appName string, err error) error {
+		return err
+	}
+
+	overrideFunc := BundleDeployOverrideWithWrapper(mockWrapper)
+	assert.NotNil(t, overrideFunc)
+
+	cmd := &cobra.Command{}
+	deployReq := &apps.CreateAppDeploymentRequest{}
+
+	overrideFunc(cmd, deployReq)
+
+	assert.Equal(t, "deploy [APP_NAME]", cmd.Use)
+}
+
+func TestBundleDeployOverrideFlags(t *testing.T) {
+	mockWrapper := func(cmd *cobra.Command, appName string, err error) error {
+		return err
+	}
+
+	cmd := &cobra.Command{}
+	deployReq := &apps.CreateAppDeploymentRequest{}
+
+	overrideFunc := BundleDeployOverrideWithWrapper(mockWrapper)
+	overrideFunc(cmd, deployReq)
+
+	tests := []struct {
+		name       string
+		defaultVal string
+	}{
+		{"force", "false"},
+		{"force-lock", "false"},
+		{"fail-on-active-runs", "false"},
+		{"compute-id", ""},
+		{"cluster-id", ""},
+		{"auto-approve", "false"},
+		{"verbose", "false"},
+		{"plan", ""},
+		{"skip-validation", "false"},
+		{"skip-tests", "true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := cmd.Flags().Lookup(tc.name)
+			require.NotNil(t, flag, "flag %q should be registered", tc.name)
+			assert.Equal(t, tc.defaultVal, flag.DefValue)
+		})
+	}
+}
+
+func TestBundleDeployOverrideDeprecatedAndHiddenFlags(t *testing.T) {
+	mockWrapper := func(cmd *cobra.Command, appName string, err error) error {
+		return err
+	}
+
+	cmd := &cobra.Command{}
+	deployReq := &apps.CreateAppDeploymentRequest{}
+
+	overrideFunc := BundleDeployOverrideWithWrapper(mockWrapper)
+	overrideFunc(cmd, deployReq)
+
+	computeID := cmd.Flags().Lookup("compute-id")
+	require.NotNil(t, computeID)
+	assert.NotEmpty(t, computeID.Deprecated, "compute-id should be deprecated")
+
+	verbose := cmd.Flags().Lookup("verbose")
+	require.NotNil(t, verbose)
+	assert.True(t, verbose.Hidden, "verbose should be hidden")
+}
+
+func TestBundleDeployOverrideClusterIDShorthand(t *testing.T) {
+	mockWrapper := func(cmd *cobra.Command, appName string, err error) error {
+		return err
+	}
+
+	cmd := &cobra.Command{}
+	deployReq := &apps.CreateAppDeploymentRequest{}
+
+	overrideFunc := BundleDeployOverrideWithWrapper(mockWrapper)
+	overrideFunc(cmd, deployReq)
+
+	flag := cmd.Flags().Lookup("cluster-id")
+	require.NotNil(t, flag)
+	assert.Equal(t, "c", flag.Shorthand)
+}
+
+func TestBundleDeployOverrideHelpText(t *testing.T) {
+	mockWrapper := func(cmd *cobra.Command, appName string, err error) error {
+		return err
+	}
+
+	cmd := &cobra.Command{}
+	deployReq := &apps.CreateAppDeploymentRequest{}
+
+	overrideFunc := BundleDeployOverrideWithWrapper(mockWrapper)
+	overrideFunc(cmd, deployReq)
+
+	assert.NotEmpty(t, cmd.Long)
+	assert.Contains(t, cmd.Long, "app deployment")
+	assert.Contains(t, cmd.Long, "project directory")
+	assert.Contains(t, cmd.Long, "databricks.yml")
+	assert.Contains(t, cmd.Long, "--auto-approve")
+	assert.Contains(t, cmd.Long, "--force-lock")
+}
+
+func TestBundleDeployOverrideErrorWrapping(t *testing.T) {
+	wrapperCalled := false
+	mockWrapper := func(cmd *cobra.Command, appName string, err error) error {
+		wrapperCalled = true
+		assert.Equal(t, "test-app", appName)
+		return err
+	}
+
+	cmd := &cobra.Command{
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("api error")
+		},
+	}
+	deployReq := &apps.CreateAppDeploymentRequest{AppName: "test-app"}
+
+	overrideFunc := BundleDeployOverrideWithWrapper(mockWrapper)
+	overrideFunc(cmd, deployReq)
+
+	err := cmd.RunE(cmd, []string{"test-app"})
+	assert.Error(t, err)
+	assert.True(t, wrapperCalled)
+}

--- a/cmd/apps/deploy_bundle_test.go
+++ b/cmd/apps/deploy_bundle_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/databricks/cli/bundle"
 	"github.com/databricks/databricks-sdk-go/service/apps"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -115,6 +116,76 @@ func TestBundleDeployOverrideHelpText(t *testing.T) {
 	assert.Contains(t, cmd.Long, "databricks.yml")
 	assert.Contains(t, cmd.Long, "--auto-approve")
 	assert.Contains(t, cmd.Long, "--force-lock")
+}
+
+func TestApplyDeployFlags(t *testing.T) {
+	noopWrapper := func(cmd *cobra.Command, appName string, err error) error { return err }
+
+	tests := []struct {
+		name      string
+		args      []string
+		opts      bundleDeployOptions
+		assertion func(*testing.T, *bundle.Bundle)
+	}{
+		{
+			name: "force, forceLock, autoApprove always apply",
+			opts: bundleDeployOptions{force: true, forceLock: true, autoApprove: true},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.True(t, b.Config.Bundle.Force)
+				assert.True(t, b.Config.Bundle.Deployment.Lock.Force)
+				assert.True(t, b.AutoApprove)
+			},
+		},
+		{
+			name: "clusterId ignored when cluster-id flag unchanged",
+			opts: bundleDeployOptions{clusterId: "should-not-leak"},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.Empty(t, b.Config.Bundle.ClusterId)
+			},
+		},
+		{
+			name: "clusterId applies when --cluster-id is set",
+			args: []string{"--cluster-id=my-cluster"},
+			opts: bundleDeployOptions{clusterId: "my-cluster"},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.Equal(t, "my-cluster", b.Config.Bundle.ClusterId)
+			},
+		},
+		{
+			name: "clusterId applies when --compute-id is set",
+			args: []string{"--compute-id=my-compute"},
+			opts: bundleDeployOptions{clusterId: "my-compute"},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.Equal(t, "my-compute", b.Config.Bundle.ClusterId)
+			},
+		},
+		{
+			name:      "failOnActiveRuns ignored when flag unchanged",
+			opts:      bundleDeployOptions{failOnActiveRuns: true},
+			assertion: func(t *testing.T, b *bundle.Bundle) { assert.False(t, b.Config.Bundle.Deployment.FailOnActiveRuns) },
+		},
+		{
+			name: "failOnActiveRuns applies when --fail-on-active-runs is set",
+			args: []string{"--fail-on-active-runs"},
+			opts: bundleDeployOptions{failOnActiveRuns: true},
+			assertion: func(t *testing.T, b *bundle.Bundle) {
+				assert.True(t, b.Config.Bundle.Deployment.FailOnActiveRuns)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "deploy"}
+			BundleDeployOverrideWithWrapper(noopWrapper)(cmd, &apps.CreateAppDeploymentRequest{})
+			require.NoError(t, cmd.ParseFlags(tc.args))
+
+			b := &bundle.Bundle{}
+			applyDeployFlags(cmd, b, tc.opts)
+
+			tc.assertion(t, b)
+		})
+	}
 }
 
 func TestBundleDeployOverrideErrorWrapping(t *testing.T) {


### PR DESCRIPTION
## Why

When `apps deploy` runs from a bundle directory without an `APP_NAME`, it runs the same deployment pipeline as `bundle deploy`. But the apps-deploy wrapper only forwarded `--force`, `--skip-validation`, and `--skip-tests`, so users couldn't:

- skip confirmation prompts in CI (`--auto-approve`)
- break a stale deploy lock left by a killed previous run (`--force-lock`)
- pin a specific cluster for job resources in the bundle (`--cluster-id`)
- fail fast when active runs are in the way (`--fail-on-active-runs`)

This mirrors `apps delete`, which already exposes `--auto-approve` and `--force-lock`.

## Changes

Before: `apps deploy` in a bundle directory exposed `--force`, `--skip-validation`, `--skip-tests` only.

Now: it exposes the full `bundle deploy` flag set in addition: `--force-lock`, `--auto-approve`, `--fail-on-active-runs`, `--cluster-id` / `-c` (plus the deprecated `--compute-id` alias), `--verbose` (hidden, for the vscode extension), and `--plan`.

Implementation:

- Collapsed the positional flag args on `runBundleDeploy` into a `bundleDeployOptions` struct since there are now ten flags.
- Registered the new flags on the deploy command and wired each one into the same `bundle.Config` field that `bundle deploy` uses (`Bundle.Force`, `Bundle.Deployment.Lock.Force`, `Bundle.Deployment.FailOnActiveRuns`, `Bundle.ClusterId`, `AutoApprove`) and into `ProcessOptions.Verbose` / `ProcessOptions.ReadPlanPath`.
- Only applied `--cluster-id` / `--compute-id` / `--fail-on-active-runs` when the user actually set them, so we don't stomp bundle YAML defaults.

The direct-API fallback path (when `APP_NAME` is provided or there's no `databricks.yml`) ignores the new flags, matching the existing pattern in `apps delete`.

Heads-up for review: `apps deploy` now has both `--force` (Git branch override) and `--force-lock` (deployment lock), same as `bundle deploy`. That's intentional parity, not a rename.

## Test plan

- [x] New unit tests in `cmd/apps/deploy_bundle_test.go` assert every flag is registered with the right default, that `--compute-id` is marked deprecated, that `--verbose` is marked hidden, and that `-c` is the shorthand for `--cluster-id`.
- [x] New acceptance test `acceptance/apps/deploy/bundle-no-args-with-flags` runs `apps deploy --skip-validation --auto-approve --force-lock --fail-on-active-runs` against the mock server and confirms it completes successfully on both the terraform and direct engines.
- [x] Re-ran all existing `acceptance/apps/deploy/*` tests to confirm no regressions.
- [x] `make checks` and `make lint` clean.