### PR TITLE
acceptance: fix UV_PYTHON_INSTALL_DIR to use actual managed Python directory

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -275,8 +275,9 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("UV_CACHE_DIR", uvCache)
 
 	// UV_CACHE_DIR only applies to packages but not Python installations.
-	// UV_PYTHON_INSTALL_DIR ensures we cache Python downloads as well
-	uvInstall := filepath.Join(uvCache, "python_installs")
+	// UV_PYTHON_INSTALL_DIR points to the actual managed Python directory so
+	// uv finds pre-installed versions without falling back to system PATH search.
+	uvInstall := getUVPythonInstallDir(t)
 	t.Setenv("UV_PYTHON_INSTALL_DIR", uvInstall)
 
 	cloudEnv := os.Getenv("CLOUD_ENV")
@@ -1270,6 +1271,20 @@ func getUVDefaultCacheDir(t *testing.T) string {
 	} else {
 		return cacheDir + "/uv"
 	}
+}
+
+// getUVPythonInstallDir returns the directory where uv stores managed Python installations.
+// Must be called before HOME is overridden in tests, so that uv resolves the real install path.
+func getUVPythonInstallDir(t *testing.T) string {
+	cmd := exec.Command("uv", "python", "dir")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Logf("uv python dir failed: %v; falling back to cache-based path", err)
+		cacheDir, err2 := os.UserCacheDir()
+		require.NoError(t, err2)
+		return filepath.Join(cacheDir, "uv", "python_installs")
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func RunCommand(t *testing.T, args []string, dir string, env []string) {


### PR DESCRIPTION
## Summary
- `UV_PYTHON_INSTALL_DIR` was set to a subdirectory of the uv cache dir (`~/Library/Caches/uv/python_installs` on macOS), which is empty on machines where uv stores managed Pythons in the default XDG data dir (`~/.local/share/uv/python`)
- With `UV_OFFLINE=true`, uv couldn't find the requested Python version there and fell back to scanning PATH, where it encountered `/usr/local/bin/python` (Python 2.7) and failed with: _"Python executable does not support `-I` flag"_
- Fix: use `uv python dir` to resolve the actual install directory, so tests find pre-installed managed Pythons without touching system Python

## Test plan
- [ ] Ran `go test ./acceptance -run 'TestAccept/bundle/templates/default-python/integration_classic/DATABRICKS_BUNDLE_ENGINE=terraform'` — all 5 `UV_PYTHON` variants pass

This pull request was AI-assisted by Isaac.