### PR TITLE
Remove Slow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,29 +74,16 @@ checks: tidy ws links
 install-pythons:
 	uv python install 3.9 3.10 3.11 3.12 3.13
 
-# Run short unit and acceptance tests (testing.Short() is true).
 .PHONY: test
 test: test-unit test-acc
-
-# Run all unit and acceptance tests.
-.PHONY: test-slow
-test-slow: test-slow-unit test-slow-acc
 
 .PHONY: test-unit
 test-unit:
 	${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -timeout=${LOCAL_TIMEOUT} -short
 
-.PHONY: test-slow-unit
-test-slow-unit:
-	${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -timeout=${LOCAL_TIMEOUT}
-
 .PHONY: test-acc
 test-acc:
 	${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -short -run ${ACCEPTANCE_TEST_FILTER}
-
-.PHONY: test-slow-acc
-test-slow-acc:
-	${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -run ${ACCEPTANCE_TEST_FILTER}
 
 # Updates acceptance test output (local tests)
 .PHONY: test-update

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ test: test-unit test-acc
 
 .PHONY: test-unit
 test-unit:
-	${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -timeout=${LOCAL_TIMEOUT} -short
+	${GOTESTSUM_CMD} --packages "${TEST_PACKAGES}" -- -timeout=${LOCAL_TIMEOUT}
 
 .PHONY: test-acc
 test-acc:
-	${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -short -run ${ACCEPTANCE_TEST_FILTER}
+	${GOTESTSUM_CMD} --packages ./acceptance/... -- -timeout=${LOCAL_TIMEOUT} -run ${ACCEPTANCE_TEST_FILTER}
 
 # Updates acceptance test output (local tests)
 .PHONY: test-update

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -513,10 +513,6 @@ func getSkipReason(config *internal.TestConfig, configPath string) string {
 		return "Disabled because RunsOnDbr is not set in " + configPath
 	}
 
-	if isTruePtr(config.Slow) && testing.Short() {
-		return "Disabled via Slow setting in " + configPath
-	}
-
 	isEnabled, isPresent := config.GOOS[runtime.GOOS]
 	if isPresent && !isEnabled {
 		return fmt.Sprintf("Disabled via GOOS.%s setting in %s", runtime.GOOS, configPath)

--- a/acceptance/bundle/upload/timeout/test.toml
+++ b/acceptance/bundle/upload/timeout/test.toml
@@ -1,4 +1,3 @@
-Slow = true
 Timeout = "3m"
 
 [[Server]]

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -45,9 +45,6 @@ type TestConfig struct {
 	// If true, run this test when running locally with a testserver
 	Local *bool
 
-	// If true, this test will not be run in -short mode (which is default for make test / PR)
-	Slow *bool
-
 	// If true, run this test when running with cloud env configured
 	Cloud *bool
 

--- a/acceptance/selftest/slow/out.test.toml
+++ b/acceptance/selftest/slow/out.test.toml
@@ -1,5 +1,0 @@
-Local = true
-Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/slow/output.txt
+++ b/acceptance/selftest/slow/output.txt
@@ -1,1 +1,0 @@
-Skipped in -short mode

--- a/acceptance/selftest/slow/script
+++ b/acceptance/selftest/slow/script
@@ -1,1 +1,0 @@
-echo "Skipped in -short mode"

--- a/acceptance/selftest/slow/test.toml
+++ b/acceptance/selftest/slow/test.toml
@@ -1,1 +1,0 @@
-Slow = true


### PR DESCRIPTION
## Changes
- Remove Slow tests support from acceptance test runner, Makefile.
- The only test that was using it is upload/timeout - this will be updated to be faster [in separate PR.](https://github.com/databricks/cli/pull/5040)

## Why
Split between short and fast tests adds complexity to Makefile and makes it possible to miss failures. Better strategy is not to have slow tests.