### PR TITLE
Fix template permission tests to be umask-independent

### DIFF
--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -68,19 +68,6 @@ func AssertFileContents(t TestingT, path, expected string) bool {
 	return assert.Equal(t, expected, actual)
 }
 
-// AssertFilePermissions asserts that the file at path has the expected permissions.
-func AssertFilePermissions(t TestingT, path string, expected os.FileMode) bool {
-	fi := StatFile(t, path)
-	assert.False(t, fi.Mode().IsDir(), "expected a file, got a directory")
-	return assert.Equal(t, expected, fi.Mode().Perm(), "expected 0%o, got 0%o", expected, fi.Mode().Perm())
-}
-
-// AssertDirPermissions asserts that the file at path has the expected permissions.
-func AssertDirPermissions(t TestingT, path string, expected os.FileMode) bool {
-	fi := StatFile(t, path)
-	assert.True(t, fi.Mode().IsDir(), "expected a directory, got a file")
-	return assert.Equal(t, expected, fi.Mode().Perm(), "expected 0%o, got 0%o", expected, fi.Mode().Perm())
-}
 
 // AssertFileOwnerExec asserts whether the owner executable bit is set for the file at path.
 func AssertFileOwnerExec(t TestingT, path string, executable bool) bool {

--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -68,7 +68,6 @@ func AssertFileContents(t TestingT, path, expected string) bool {
 	return assert.Equal(t, expected, actual)
 }
 
-
 // AssertFileOwnerExec asserts whether the owner executable bit is set for the file at path.
 func AssertFileOwnerExec(t TestingT, path string, executable bool) bool {
 	fi := StatFile(t, path)

--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -81,3 +81,19 @@ func AssertDirPermissions(t TestingT, path string, expected os.FileMode) bool {
 	assert.True(t, fi.Mode().IsDir(), "expected a directory, got a file")
 	return assert.Equal(t, expected, fi.Mode().Perm(), "expected 0%o, got 0%o", expected, fi.Mode().Perm())
 }
+
+// AssertFileOwnerExec asserts whether the owner executable bit is set for the file at path.
+func AssertFileOwnerExec(t TestingT, path string, executable bool) bool {
+	fi := StatFile(t, path)
+	assert.False(t, fi.Mode().IsDir(), "expected a file, got a directory")
+	ownerExec := fi.Mode().Perm()&0o100 != 0
+	return assert.Equal(t, executable, ownerExec, "expected owner exec bit %v for %s, got mode 0%o", executable, path, fi.Mode().Perm())
+}
+
+// AssertDirOwnerExec asserts whether the owner executable bit is set for the directory at path.
+func AssertDirOwnerExec(t TestingT, path string, executable bool) bool {
+	fi := StatFile(t, path)
+	assert.True(t, fi.Mode().IsDir(), "expected a directory, got a file")
+	ownerExec := fi.Mode().Perm()&0o100 != 0
+	return assert.Equal(t, executable, ownerExec, "expected owner exec bit %v for %s, got mode 0%o", executable, path, fi.Mode().Perm())
+}

--- a/libs/template/file_test.go
+++ b/libs/template/file_test.go
@@ -14,9 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testInMemoryFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
+func testInMemoryFile(t *testing.T, ctx context.Context, executable bool) {
 	tmpDir := t.TempDir()
 
+	perm := fs.FileMode(0o644)
+	if executable {
+		perm = 0o755
+	}
 	f := &inMemoryFile{
 		perm:    perm,
 		relPath: "a/b/c",
@@ -29,11 +33,16 @@ func testInMemoryFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
 	assert.NoError(t, err)
 
 	testutil.AssertFileContents(t, filepath.Join(tmpDir, "a/b/c"), "123")
-	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "a/b/c"), perm)
+	testutil.AssertFileOwnerExec(t, filepath.Join(tmpDir, "a/b/c"), executable)
 }
 
-func testCopyFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
+func testCopyFile(t *testing.T, ctx context.Context, executable bool) {
 	tmpDir := t.TempDir()
+
+	perm := fs.FileMode(0o644)
+	if executable {
+		perm = 0o755
+	}
 	err := os.WriteFile(filepath.Join(tmpDir, "source"), []byte("qwerty"), perm)
 	require.NoError(t, err)
 
@@ -50,7 +59,7 @@ func testCopyFile(t *testing.T, ctx context.Context, perm fs.FileMode) {
 	assert.NoError(t, err)
 
 	testutil.AssertFileContents(t, filepath.Join(tmpDir, "source"), "qwerty")
-	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "source"), perm)
+	testutil.AssertFileOwnerExec(t, filepath.Join(tmpDir, "source"), executable)
 }
 
 func TestTemplateInMemoryFilePersistToDisk(t *testing.T) {
@@ -58,7 +67,7 @@ func TestTemplateInMemoryFilePersistToDisk(t *testing.T) {
 		t.SkipNow()
 	}
 	ctx := t.Context()
-	testInMemoryFile(t, ctx, 0o755)
+	testInMemoryFile(t, ctx, true)
 }
 
 func TestTemplateInMemoryFilePersistToDiskForWindows(t *testing.T) {
@@ -68,7 +77,7 @@ func TestTemplateInMemoryFilePersistToDiskForWindows(t *testing.T) {
 	// we have separate tests for windows because of differences in valid
 	// fs.FileMode values we can use for different operating systems.
 	ctx := t.Context()
-	testInMemoryFile(t, ctx, 0o666)
+	testInMemoryFile(t, ctx, false)
 }
 
 func TestTemplateCopyFilePersistToDisk(t *testing.T) {
@@ -76,7 +85,7 @@ func TestTemplateCopyFilePersistToDisk(t *testing.T) {
 		t.SkipNow()
 	}
 	ctx := t.Context()
-	testCopyFile(t, ctx, 0o644)
+	testCopyFile(t, ctx, false)
 }
 
 func TestTemplateCopyFilePersistToDiskForWindows(t *testing.T) {
@@ -86,5 +95,5 @@ func TestTemplateCopyFilePersistToDiskForWindows(t *testing.T) {
 	// we have separate tests for windows because of differences in valid
 	// fs.FileMode values we can use for different operating systems.
 	ctx := t.Context()
-	testCopyFile(t, ctx, 0o666)
+	testCopyFile(t, ctx, false)
 }

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -159,13 +159,11 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Git only tracks the executable bit, and permissions on disk depend on
-	// umask at checkout. Normalize to canonical 0o755 for executable files
-	// and 0o644 for regular files so output is independent of the environment.
-	var perm fs.FileMode = 0o644
-	if info.Mode().Perm()&0o100 != 0 {
-		perm = 0o755
-	}
+	perm := info.Mode().Perm()
+
+	// Always include the write bit for the owner of the file.
+	// It does not make sense to have a file that is not writable by the owner.
+	perm |= 0o200
 
 	// Execute relative path template to get destination path for the file
 	relPath, err := r.executeTemplate(relPathTemplate)

--- a/libs/template/renderer.go
+++ b/libs/template/renderer.go
@@ -159,11 +159,13 @@ func (r *renderer) computeFile(relPathTemplate string) (file, error) {
 	if err != nil {
 		return nil, err
 	}
-	perm := info.Mode().Perm()
-
-	// Always include the write bit for the owner of the file.
-	// It does not make sense to have a file that is not writable by the owner.
-	perm |= 0o200
+	// Git only tracks the executable bit, and permissions on disk depend on
+	// umask at checkout. Normalize to canonical 0o755 for executable files
+	// and 0o644 for regular files so output is independent of the environment.
+	var perm fs.FileMode = 0o644
+	if info.Mode().Perm()&0o100 != 0 {
+		perm = 0o755
+	}
 
 	// Execute relative path template to get destination path for the file
 	relPath, err := r.executeTemplate(relPathTemplate)

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -494,56 +494,6 @@ func TestRendererReadsPermissionsBits(t *testing.T) {
 	assert.Equal(t, getPermissions(r, "not-a-script"), fs.FileMode(0o644))
 }
 
-// TestRendererNormalizesPermissions guards the canonicalization policy in
-// computeFile: source perms are collapsed to 0o755 when the owner-exec bit is
-// set and 0o644 otherwise, so rendered output is independent of the umask at
-// checkout time.
-func TestRendererNormalizesPermissions(t *testing.T) {
-	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
-		t.SkipNow()
-	}
-
-	tests := []struct {
-		name         string
-		filename     string
-		sourcePerm   os.FileMode
-		expectedPerm fs.FileMode
-	}{
-		{"owner-exec restrictive", "exec.sh", 0o700, 0o755},
-		{"owner-rw restrictive", "data.txt", 0o600, 0o644},
-		{"group-restricted executable", "script", 0o750, 0o755},
-		{"group-restricted regular", "config", 0o640, 0o644},
-		{"read-only regular", "readonly", 0o444, 0o644},
-		{"group-exec without owner-exec", "quirky", 0o410, 0o644},
-	}
-
-	ctx := t.Context()
-	ctx = cmdctx.SetWorkspaceClient(ctx, nil)
-	helpers := loadHelpers(ctx)
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			templateDir := filepath.Join(tmpDir, "template")
-			require.NoError(t, os.Mkdir(templateDir, 0o755))
-
-			srcPath := filepath.Join(templateDir, tc.filename)
-			require.NoError(t, os.WriteFile(srcPath, []byte("content"), 0o644))
-			require.NoError(t, os.Chmod(srcPath, tc.sourcePerm))
-
-			r, err := newRenderer(ctx, nil, helpers, os.DirFS(tmpDir), "template", "library")
-			require.NoError(t, err)
-
-			require.NoError(t, r.walk())
-			require.Len(t, r.files, 1)
-
-			cf, ok := r.files[0].(*copyFile)
-			require.True(t, ok, "expected copyFile, got %T", r.files[0])
-			assert.Equal(t, tc.expectedPerm, cf.perm)
-		})
-	}
-}
-
 func TestRendererErrorOnConflictingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	ctx := t.Context()

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func assertBuiltinTemplateValid(t *testing.T, template string, settings map[string]any, target string, isServicePrincipal, build bool, tempDir string) {
 	ctx := dbr.MockRuntime(t.Context(), dbr.Environment{})
 

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -27,20 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	defaultFilePermissions fs.FileMode
-	defaultDirPermissions  fs.FileMode
-)
-
-func init() {
-	if runtime.GOOS == "windows" {
-		defaultFilePermissions = fs.FileMode(0o666)
-		defaultDirPermissions = fs.FileMode(0o777)
-	} else {
-		defaultFilePermissions = fs.FileMode(0o644)
-		defaultDirPermissions = fs.FileMode(0o755)
-	}
-}
 
 func assertBuiltinTemplateValid(t *testing.T, template string, settings map[string]any, target string, isServicePrincipal, build bool, tempDir string) {
 	ctx := dbr.MockRuntime(t.Context(), dbr.Environment{})
@@ -73,8 +59,8 @@ func assertBuiltinTemplateValid(t *testing.T, template string, settings map[stri
 	require.NoError(t, err)
 
 	// Verify permissions on file and directory
-	testutil.AssertFilePermissions(t, filepath.Join(tempDir, "my_project/README.md"), defaultFilePermissions)
-	testutil.AssertDirPermissions(t, filepath.Join(tempDir, "my_project/resources"), defaultDirPermissions)
+	testutil.AssertFileOwnerExec(t, filepath.Join(tempDir, "my_project/README.md"), false)
+	testutil.AssertDirOwnerExec(t, filepath.Join(tempDir, "my_project/resources"), true)
 
 	b, err := bundle.Load(ctx, filepath.Join(tempDir, "my_project"))
 	require.NoError(t, err)
@@ -319,9 +305,9 @@ func TestRendererPersistToDisk(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(tmpDir, "mno"))
 
 	testutil.AssertFileContents(t, filepath.Join(tmpDir, "a/b/d"), "123")
-	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "a/b/d"), fs.FileMode(0o444))
+	testutil.AssertFileOwnerExec(t, filepath.Join(tmpDir, "a/b/d"), false)
 	testutil.AssertFileContents(t, filepath.Join(tmpDir, "mmnn"), "456")
-	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "mmnn"), fs.FileMode(0o444))
+	testutil.AssertFileOwnerExec(t, filepath.Join(tmpDir, "mmnn"), false)
 }
 
 func TestRendererWalk(t *testing.T) {
@@ -490,8 +476,8 @@ func TestRendererReadsPermissionsBits(t *testing.T) {
 	}
 
 	assert.Len(t, r.files, 2)
-	assert.Equal(t, getPermissions(r, "script.sh"), fs.FileMode(0o755))
-	assert.Equal(t, getPermissions(r, "not-a-script"), fs.FileMode(0o644))
+	assert.NotZero(t, getPermissions(r, "script.sh")&0o100, "expected owner exec bit set for script.sh")
+	assert.Zero(t, getPermissions(r, "not-a-script")&0o100, "expected owner exec bit not set for not-a-script")
 }
 
 func TestRendererErrorOnConflictingFile(t *testing.T) {
@@ -589,8 +575,8 @@ func TestRendererFileTreeRendering(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert files and directories are correctly materialized.
-	testutil.AssertDirPermissions(t, filepath.Join(tmpDir, "my_directory"), defaultDirPermissions)
-	testutil.AssertFilePermissions(t, filepath.Join(tmpDir, "my_directory", "my_file"), defaultFilePermissions)
+	testutil.AssertDirOwnerExec(t, filepath.Join(tmpDir, "my_directory"), true)
+	testutil.AssertFileOwnerExec(t, filepath.Join(tmpDir, "my_directory", "my_file"), false)
 }
 
 func TestRendererSubTemplateInPath(t *testing.T) {

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -494,6 +494,56 @@ func TestRendererReadsPermissionsBits(t *testing.T) {
 	assert.Equal(t, getPermissions(r, "not-a-script"), fs.FileMode(0o644))
 }
 
+// TestRendererNormalizesPermissions guards the canonicalization policy in
+// computeFile: source perms are collapsed to 0o755 when the owner-exec bit is
+// set and 0o644 otherwise, so rendered output is independent of the umask at
+// checkout time.
+func TestRendererNormalizesPermissions(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.SkipNow()
+	}
+
+	tests := []struct {
+		name         string
+		filename     string
+		sourcePerm   os.FileMode
+		expectedPerm fs.FileMode
+	}{
+		{"owner-exec restrictive", "exec.sh", 0o700, 0o755},
+		{"owner-rw restrictive", "data.txt", 0o600, 0o644},
+		{"group-restricted executable", "script", 0o750, 0o755},
+		{"group-restricted regular", "config", 0o640, 0o644},
+		{"read-only regular", "readonly", 0o444, 0o644},
+		{"group-exec without owner-exec", "quirky", 0o410, 0o644},
+	}
+
+	ctx := t.Context()
+	ctx = cmdctx.SetWorkspaceClient(ctx, nil)
+	helpers := loadHelpers(ctx)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			templateDir := filepath.Join(tmpDir, "template")
+			require.NoError(t, os.Mkdir(templateDir, 0o755))
+
+			srcPath := filepath.Join(templateDir, tc.filename)
+			require.NoError(t, os.WriteFile(srcPath, []byte("content"), 0o644))
+			require.NoError(t, os.Chmod(srcPath, tc.sourcePerm))
+
+			r, err := newRenderer(ctx, nil, helpers, os.DirFS(tmpDir), "template", "library")
+			require.NoError(t, err)
+
+			require.NoError(t, r.walk())
+			require.Len(t, r.files, 1)
+
+			cf, ok := r.files[0].(*copyFile)
+			require.True(t, ok, "expected copyFile, got %T", r.files[0])
+			assert.Equal(t, tc.expectedPerm, cf.perm)
+		})
+	}
+}
+
 func TestRendererErrorOnConflictingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	ctx := t.Context()


### PR DESCRIPTION
## Tests
In libs/template unit tests, instead of checking exact permission, test for presence of executable bit for the owner.

## Why
On arca I have stricter umask which results in test failures.