### PR TITLE
bundle: add DATABRICKS_BUNDLE_HTTP_TIMEOUT_SECONDS; prop context to WorkspaceClient

### DIFF
--- a/acceptance/bundle/upload/timeout/output.txt
+++ b/acceptance/bundle/upload/timeout/output.txt
@@ -1,3 +1,3 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
-Error: Post "[DATABRICKS_URL]/api/2.0/workspace-files/import-file/Workspace%2FUsers%2F[USERNAME]%2F.bundle%2Ftest-bundle%2Fdefault%2Ffiles%2Ffile_to_upload.txt?overwrite=true": request timed out after 1m30s of inactivity
+Error: Post "[DATABRICKS_URL]/api/2.0/workspace-files/import-file/Workspace%2FUsers%2F[USERNAME]%2F.bundle%2Ftest-bundle%2Fdefault%2Ffiles%2Ffile_to_upload.txt?overwrite=true": request timed out after 5s of inactivity
 

--- a/acceptance/bundle/upload/timeout/test.toml
+++ b/acceptance/bundle/upload/timeout/test.toml
@@ -3,6 +3,6 @@ DATABRICKS_BUNDLE_HTTP_TIMEOUT_SECONDS = "5"
 
 [[Server]]
 # CLI aborts after a single attempt when the HTTP timeout fires.
-Delay = "6s"
+Delay = "30s"
 Pattern = "POST /api/2.0/workspace-files/import-file/Workspace/Users/tester@databricks.com/.bundle/test-bundle/default/files/file_to_upload.txt"
 Response.StatusCode = 200

--- a/acceptance/bundle/upload/timeout/test.toml
+++ b/acceptance/bundle/upload/timeout/test.toml
@@ -1,8 +1,8 @@
-Timeout = "3m"
+[Env]
+DATABRICKS_BUNDLE_HTTP_TIMEOUT_SECONDS = "5"
 
 [[Server]]
-# Client single timeout is 90s, retry timeout is 30m, API delay is 2m and test timeout is 3m, so we should see test killed with timeout.
-# Badness: actually what happens is CLI aborts after single attempt.
-Delay = "2m"
+# CLI aborts after a single attempt when the HTTP timeout fires.
+Delay = "6s"
 Pattern = "POST /api/2.0/workspace-files/import-file/Workspace/Users/tester@databricks.com/.bundle/test-bundle/default/files/file_to_upload.txt"
 Response.StatusCode = 200

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -221,9 +221,9 @@ func TryLoad(ctx context.Context) *Bundle {
 	return b
 }
 
-func (b *Bundle) initClientOnce() {
+func (b *Bundle) initClientOnce(ctx context.Context) {
 	b.getClient = sync.OnceValues(func() (*databricks.WorkspaceClient, error) {
-		w, err := b.Config.Workspace.Client()
+		w, err := b.Config.Workspace.Client(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("cannot resolve bundle auth configuration: %w", err)
 		}
@@ -231,15 +231,15 @@ func (b *Bundle) initClientOnce() {
 	})
 }
 
-func (b *Bundle) WorkspaceClientE() (*databricks.WorkspaceClient, error) {
+func (b *Bundle) WorkspaceClientE(ctx context.Context) (*databricks.WorkspaceClient, error) {
 	if b.getClient == nil {
-		b.initClientOnce()
+		b.initClientOnce(ctx)
 	}
 	return b.getClient()
 }
 
-func (b *Bundle) WorkspaceClient() *databricks.WorkspaceClient {
-	client, err := b.WorkspaceClientE()
+func (b *Bundle) WorkspaceClient(ctx context.Context) *databricks.WorkspaceClient {
+	client, err := b.WorkspaceClientE(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -257,8 +257,8 @@ func (b *Bundle) SetWorkpaceClient(w *databricks.WorkspaceClient) {
 
 // ClearWorkspaceClient resets the workspace client cache, allowing
 // WorkspaceClientE() to attempt client creation again on the next call.
-func (b *Bundle) ClearWorkspaceClient() {
-	b.initClientOnce()
+func (b *Bundle) ClearWorkspaceClient(ctx context.Context) {
+	b.initClientOnce(ctx)
 }
 
 // LocalStateDir returns directory to use for temporary files for this bundle without creating
@@ -346,8 +346,8 @@ func (b *Bundle) GetSyncIncludePatterns(ctx context.Context) ([]string, error) {
 //
 // This map can be used to configure authentication for tools that
 // we call into from this bundle context.
-func (b *Bundle) AuthEnv() (map[string]string, error) {
-	w, err := b.WorkspaceClientE()
+func (b *Bundle) AuthEnv(ctx context.Context) (map[string]string, error) {
+	w, err := b.WorkspaceClientE(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -179,25 +179,27 @@ func TestBundleGetResourceConfigJobsPointer(t *testing.T) {
 }
 
 func TestClearWorkspaceClient(t *testing.T) {
+	ctx := t.Context()
+
 	// First attempt: profile "profile-A" doesn't exist → error mentions "profile-A".
 	b := &Bundle{}
 	b.Config.Workspace.Host = "https://nonexistent.example.com"
 	b.Config.Workspace.Profile = "profile-A"
 
-	_, err1 := b.WorkspaceClientE()
+	_, err1 := b.WorkspaceClientE(ctx)
 	require.Error(t, err1)
 	assert.Contains(t, err1.Error(), "profile-A")
 
 	// Without retry, second call returns the same cached error (same object).
-	_, err1b := b.WorkspaceClientE()
+	_, err1b := b.WorkspaceClientE(ctx)
 	assert.Same(t, err1, err1b, "expected same cached error without retry")
 
 	// After retry, change the profile to "profile-B" and call again.
 	// If retry didn't re-execute, the error would still mention "profile-A".
-	b.ClearWorkspaceClient()
+	b.ClearWorkspaceClient(ctx)
 	b.Config.Workspace.Profile = "profile-B"
 
-	_, err2 := b.WorkspaceClientE()
+	_, err2 := b.WorkspaceClientE(ctx)
 	require.Error(t, err2)
 	assert.Contains(t, err2.Error(), "profile-B", "expected re-execution to pick up new profile")
 	assert.NotContains(t, err2.Error(), "profile-A", "stale cached error should not appear")

--- a/bundle/config/mutator/configure_wsfs.go
+++ b/bundle/config/mutator/configure_wsfs.go
@@ -51,7 +51,7 @@ func (m *configureWSFS) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagno
 	// If so, swap out vfs.Path instance of the sync root with one that
 	// makes all Workspace File System interactions extension aware.
 	p, err := vfs.NewFilerPath(ctx, root, func(path string) (filer.Filer, error) {
-		return filer.NewReadOnlyWorkspaceFilesExtensionsClient(ctx, b.WorkspaceClient(), path)
+		return filer.NewReadOnlyWorkspaceFilesExtensionsClient(ctx, b.WorkspaceClient(ctx), path)
 	})
 	if err != nil {
 		return diag.FromErr(err)

--- a/bundle/config/mutator/initialize_urls.go
+++ b/bundle/config/mutator/initialize_urls.go
@@ -25,12 +25,12 @@ func (m *initializeURLs) Name() string {
 }
 
 func (m *initializeURLs) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	workspaceId, err := b.WorkspaceClient().CurrentWorkspaceID(ctx)
+	workspaceId, err := b.WorkspaceClient(ctx).CurrentWorkspaceID(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	orgId := strconv.FormatInt(workspaceId, 10)
-	host := b.WorkspaceClient().Config.CanonicalHostName()
+	host := b.WorkspaceClient(ctx).Config.CanonicalHostName()
 	err = initializeForWorkspace(b, orgId, host)
 	if err != nil {
 		return diag.FromErr(err)

--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -24,7 +24,7 @@ func (m *loadGitDetails) Name() string {
 
 func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	var diags diag.Diagnostics
-	info, err := git.FetchRepositoryInfo(ctx, b.BundleRoot.Native(), b.WorkspaceClient())
+	info, err := git.FetchRepositoryInfo(ctx, b.BundleRoot.Native(), b.WorkspaceClient(ctx))
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			diags = append(diags, diag.WarningFromErr(err)...)

--- a/bundle/config/mutator/populate_current_user.go
+++ b/bundle/config/mutator/populate_current_user.go
@@ -27,7 +27,7 @@ func (m *populateCurrentUser) Apply(ctx context.Context, b *bundle.Bundle) diag.
 	if b.Config.Workspace.CurrentUser != nil {
 		return nil
 	}
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 
 	fingerprint := b.GetUserFingerprint(ctx)
 	me, err := cache.GetOrCompute(ctx, b.Cache, fingerprint, func(ctx context.Context) (*iam.User, error) {

--- a/bundle/config/mutator/resolve_lookup_variables.go
+++ b/bundle/config/mutator/resolve_lookup_variables.go
@@ -31,7 +31,7 @@ func (m *resolveLookupVariables) Apply(ctx context.Context, b *bundle.Bundle) di
 		}
 
 		errs.Go(func() error {
-			id, err := v.Lookup.Resolve(errCtx, b.WorkspaceClient())
+			id, err := v.Lookup.Resolve(errCtx, b.WorkspaceClient(errCtx))
 			if err != nil {
 				return fmt.Errorf("failed to resolve %s, err: %w", v.Lookup, err)
 			}

--- a/bundle/config/validate/folder_permissions.go
+++ b/bundle/config/validate/folder_permissions.go
@@ -53,7 +53,7 @@ func checkFolderPermission(ctx context.Context, b *bundle.Bundle, folderPath str
 		return nil
 	}
 
-	w := b.WorkspaceClient().Workspace
+	w := b.WorkspaceClient(ctx).Workspace
 	obj, err := getClosestExistingObject(ctx, w, folderPath)
 	if err != nil {
 		return diag.FromErr(err)

--- a/bundle/config/validate/validate_artifact_path.go
+++ b/bundle/config/validate/validate_artifact_path.go
@@ -96,7 +96,7 @@ func (v *validateArtifactPath) Apply(ctx context.Context, b *bundle.Bundle) diag
 		return wrapErrorMsg(err.Error())
 	}
 	volumeFullName := fmt.Sprintf("%s.%s.%s", catalogName, schemaName, volumeName)
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	_, err = w.Volumes.ReadByName(ctx, volumeFullName)
 
 	if errors.Is(err, apierr.ErrPermissionDenied) {

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
 
+	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/databricks/databricks-sdk-go"
@@ -12,8 +14,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 )
-
-const envHTTPTimeoutSeconds = "DATABRICKS_BUNDLE_HTTP_TIMEOUT_SECONDS"
 
 // Workspace defines configurables at the workspace level.
 type Workspace struct {
@@ -96,13 +96,13 @@ func (s User) MarshalJSON() ([]byte, error) {
 	return marshal.Marshal(s)
 }
 
-func (w *Workspace) Config() *config.Config {
+func (w *Workspace) Config(ctx context.Context) *config.Config {
 	// Once bundle deploy started, old deployment is partially destroyed, so we should do utmost to complete it.
 	// Having client-side timeouts that kill the deployment seems counter-productive. We should just keep on
 	// trying and the user should be the one interrupting it if they decide so.
 	// Default is 30s
 	httpTimeout := 90
-	if v := os.Getenv(envHTTPTimeoutSeconds); v != "" {
+	if v, ok := env.HTTPTimeoutSeconds(ctx); ok {
 		if n, err := strconv.Atoi(v); err == nil {
 			httpTimeout = n
 		}
@@ -166,13 +166,13 @@ func (w *Workspace) NormalizeHostURL() {
 	}
 }
 
-func (w *Workspace) Client() (*databricks.WorkspaceClient, error) {
+func (w *Workspace) Client(ctx context.Context) (*databricks.WorkspaceClient, error) {
 	// Extract query parameters (?o=, ?a=) from the host URL before building
 	// the SDK config. This ensures workspace_id and account_id are available
 	// for profile resolution during EnsureResolved().
 	w.NormalizeHostURL()
 
-	cfg := w.Config()
+	cfg := w.Config(ctx)
 
 	// If only the host is configured, we try and unambiguously match it to
 	// a profile in the user's databrickscfg file. Override the default loaders.

--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/databricks/cli/libs/auth"
 	"github.com/databricks/cli/libs/databrickscfg"
@@ -11,6 +12,8 @@ import (
 	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 )
+
+const envHTTPTimeoutSeconds = "DATABRICKS_BUNDLE_HTTP_TIMEOUT_SECONDS"
 
 // Workspace defines configurables at the workspace level.
 type Workspace struct {
@@ -94,12 +97,19 @@ func (s User) MarshalJSON() ([]byte, error) {
 }
 
 func (w *Workspace) Config() *config.Config {
+	// Once bundle deploy started, old deployment is partially destroyed, so we should do utmost to complete it.
+	// Having client-side timeouts that kill the deployment seems counter-productive. We should just keep on
+	// trying and the user should be the one interrupting it if they decide so.
+	// Default is 30s
+	httpTimeout := 90
+	if v := os.Getenv(envHTTPTimeoutSeconds); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			httpTimeout = n
+		}
+	}
+
 	cfg := &config.Config{
-		// Once bundle deploy started, old deployment is partially destroyed, so we should do utmost to complete it.
-		// Having client-side timeouts that kill the deployment seems counter-productive. We should just keep on
-		// trying and the user should be the one interrupting it if they decide so.
-		// Default is 30s
-		HTTPTimeoutSeconds: 90,
+		HTTPTimeoutSeconds: httpTimeout,
 
 		// Default is 5min
 		RetryTimeoutSeconds: 15 * 60,

--- a/bundle/config/workspace_test.go
+++ b/bundle/config/workspace_test.go
@@ -156,24 +156,22 @@ func TestWorkspaceClientNormalizesHostBeforeProfileResolution(t *testing.T) {
 }
 
 func TestWorkspaceConfigHTTPTimeout(t *testing.T) {
-	w := Workspace{}
-
-	t.Run("default", func(t *testing.T) {
-		cfg := w.Config(t.Context())
-		assert.Equal(t, 90, cfg.HTTPTimeoutSeconds)
-	})
-
-	t.Run("env var", func(t *testing.T) {
-		t.Setenv(env.HTTPTimeoutSecondsVariable, "5")
-		cfg := w.Config(t.Context())
-		assert.Equal(t, 5, cfg.HTTPTimeoutSeconds)
-	})
-
-	t.Run("invalid env var uses default", func(t *testing.T) {
-		t.Setenv(env.HTTPTimeoutSecondsVariable, "not-a-number")
-		cfg := w.Config(t.Context())
-		assert.Equal(t, 90, cfg.HTTPTimeoutSeconds)
-	})
+	for _, tc := range []struct {
+		envVal  string
+		want    int
+	}{
+		{"", 90},
+		{"5", 5},
+		{"not-a-number", 90},
+	} {
+		t.Run(tc.envVal, func(t *testing.T) {
+			if tc.envVal != "" {
+				t.Setenv(env.HTTPTimeoutSecondsVariable, tc.envVal)
+			}
+			w := Workspace{}
+			assert.Equal(t, tc.want, w.Config(t.Context()).HTTPTimeoutSeconds)
+		})
+	}
 }
 
 func TestWorkspaceVerifyProfileForHost(t *testing.T) {

--- a/bundle/config/workspace_test.go
+++ b/bundle/config/workspace_test.go
@@ -157,8 +157,8 @@ func TestWorkspaceClientNormalizesHostBeforeProfileResolution(t *testing.T) {
 
 func TestWorkspaceConfigHTTPTimeout(t *testing.T) {
 	for _, tc := range []struct {
-		envVal  string
-		want    int
+		envVal string
+		want   int
 	}{
 		{"", 90},
 		{"5", 5},

--- a/bundle/config/workspace_test.go
+++ b/bundle/config/workspace_test.go
@@ -154,6 +154,27 @@ func TestWorkspaceClientNormalizesHostBeforeProfileResolution(t *testing.T) {
 	assert.Equal(t, "ws2", client.Config.Profile)
 }
 
+func TestWorkspaceConfigHTTPTimeout(t *testing.T) {
+	w := Workspace{}
+
+	t.Run("default", func(t *testing.T) {
+		cfg := w.Config()
+		assert.Equal(t, 90, cfg.HTTPTimeoutSeconds)
+	})
+
+	t.Run("env var", func(t *testing.T) {
+		t.Setenv(envHTTPTimeoutSeconds, "5")
+		cfg := w.Config()
+		assert.Equal(t, 5, cfg.HTTPTimeoutSeconds)
+	})
+
+	t.Run("invalid env var uses default", func(t *testing.T) {
+		t.Setenv(envHTTPTimeoutSeconds, "not-a-number")
+		cfg := w.Config()
+		assert.Equal(t, 90, cfg.HTTPTimeoutSeconds)
+	})
+}
+
 func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 	// If both a workspace host and a profile are specified,
 	// verify that the host configured in the profile matches

--- a/bundle/config/workspace_test.go
+++ b/bundle/config/workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/databricks/databricks-sdk-go/config"
@@ -34,7 +35,7 @@ func TestWorkspaceResolveProfileFromHost(t *testing.T) {
 
 	t.Run("no config file", func(t *testing.T) {
 		setupWorkspaceTest(t)
-		_, err := w.Client()
+		_, err := w.Client(t.Context())
 		assert.NoError(t, err)
 	})
 
@@ -49,7 +50,7 @@ func TestWorkspaceResolveProfileFromHost(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		client, err := w.Client()
+		client, err := w.Client(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, "default", client.Config.Profile)
 	})
@@ -67,7 +68,7 @@ func TestWorkspaceResolveProfileFromHost(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
-		client, err := w.Client()
+		client, err := w.Client(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, "custom", client.Config.Profile)
 	})
@@ -149,7 +150,7 @@ func TestWorkspaceClientNormalizesHostBeforeProfileResolution(t *testing.T) {
 	w := Workspace{
 		Host: "https://spog.databricks.com/?o=222",
 	}
-	client, err := w.Client()
+	client, err := w.Client(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "ws2", client.Config.Profile)
 }
@@ -158,19 +159,19 @@ func TestWorkspaceConfigHTTPTimeout(t *testing.T) {
 	w := Workspace{}
 
 	t.Run("default", func(t *testing.T) {
-		cfg := w.Config()
+		cfg := w.Config(t.Context())
 		assert.Equal(t, 90, cfg.HTTPTimeoutSeconds)
 	})
 
 	t.Run("env var", func(t *testing.T) {
-		t.Setenv(envHTTPTimeoutSeconds, "5")
-		cfg := w.Config()
+		t.Setenv(env.HTTPTimeoutSecondsVariable, "5")
+		cfg := w.Config(t.Context())
 		assert.Equal(t, 5, cfg.HTTPTimeoutSeconds)
 	})
 
 	t.Run("invalid env var uses default", func(t *testing.T) {
-		t.Setenv(envHTTPTimeoutSeconds, "not-a-number")
-		cfg := w.Config()
+		t.Setenv(env.HTTPTimeoutSecondsVariable, "not-a-number")
+		cfg := w.Config(t.Context())
 		assert.Equal(t, 90, cfg.HTTPTimeoutSeconds)
 	})
 }
@@ -186,7 +187,7 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 
 	t.Run("no config file", func(t *testing.T) {
 		setupWorkspaceTest(t)
-		_, err := w.Client()
+		_, err := w.Client(t.Context())
 		assert.ErrorIs(t, err, fs.ErrNotExist)
 	})
 
@@ -200,7 +201,7 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = w.Client()
+		_, err = w.Client(t.Context())
 		assert.NoError(t, err)
 	})
 
@@ -214,7 +215,7 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = w.Client()
+		_, err = w.Client(t.Context())
 		assert.ErrorContains(t, err, "doesn’t match the host configured in the bundle")
 	})
 
@@ -230,7 +231,7 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
-		_, err = w.Client()
+		_, err = w.Client(t.Context())
 		assert.NoError(t, err)
 	})
 
@@ -246,7 +247,7 @@ func TestWorkspaceVerifyProfileForHost(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(home, "customcfg"))
-		_, err = w.Client()
+		_, err = w.Client(t.Context())
 		assert.ErrorContains(t, err, "doesn’t match the host configured in the bundle")
 	})
 }

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -139,7 +139,7 @@ func DetectChanges(ctx context.Context, b *bundle.Bundle, engine engine.EngineTy
 		}
 	}
 
-	plan, err := deployBundle.CalculatePlan(ctx, b.WorkspaceClient(), &b.Config)
+	plan, err := deployBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate plan: %w", err)
 	}
@@ -191,7 +191,7 @@ func ensureSnapshotAvailable(ctx context.Context, b *bundle.Bundle, engine engin
 
 	log.Debugf(ctx, "Resources state snapshot not found locally, pulling from remote")
 
-	f, err := deploy.StateFiler(b)
+	f, err := deploy.StateFiler(ctx, b)
 	if err != nil {
 		return fmt.Errorf("getting state filer: %w", err)
 	}

--- a/bundle/deploy/filer.go
+++ b/bundle/deploy/filer.go
@@ -16,7 +16,7 @@ import (
 )
 
 // FilerFactory is a function that returns a filer.Filer.
-type FilerFactory func(b *bundle.Bundle) (filer.Filer, error)
+type FilerFactory func(ctx context.Context, b *bundle.Bundle) (filer.Filer, error)
 
 type stateFiler struct {
 	filer filer.Filer
@@ -88,13 +88,13 @@ func (s stateFiler) Write(ctx context.Context, path string, reader io.Reader, mo
 // This API has a higher than 10 MB limits and allows to export large state files.
 // We don't use the same API for read because it doesn't correct get the file content for notebooks and returns
 // "File Not Found" error instead.
-func StateFiler(b *bundle.Bundle) (filer.Filer, error) {
-	f, err := filer.NewWorkspaceFilesClient(b.WorkspaceClient(), b.Config.Workspace.StatePath)
+func StateFiler(ctx context.Context, b *bundle.Bundle) (filer.Filer, error) {
+	f, err := filer.NewWorkspaceFilesClient(b.WorkspaceClient(ctx), b.Config.Workspace.StatePath)
 	if err != nil {
 		return nil, err
 	}
 
-	apiClient, err := client.New(b.WorkspaceClient().Config)
+	apiClient, err := client.New(b.WorkspaceClient(ctx).Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API client: %w", err)
 	}

--- a/bundle/deploy/files/delete.go
+++ b/bundle/deploy/files/delete.go
@@ -23,7 +23,7 @@ func (m *delete) Name() string {
 func (m *delete) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	cmdio.LogString(ctx, "Deleting files...")
 
-	err := b.WorkspaceClient().Workspace.Delete(ctx, workspace.Delete{ //nolint:staticcheck // Deprecated in SDK v0.127.0. Migration to WorkspaceHierarchyService tracked separately.
+	err := b.WorkspaceClient(ctx).Workspace.Delete(ctx, workspace.Delete{ //nolint:staticcheck // Deprecated in SDK v0.127.0. Migration to WorkspaceHierarchyService tracked separately.
 		Path:      b.Config.Workspace.RootPath,
 		Recursive: true,
 	})

--- a/bundle/deploy/files/sync.go
+++ b/bundle/deploy/files/sync.go
@@ -35,12 +35,12 @@ func GetSyncOptions(ctx context.Context, b *bundle.Bundle) (*sync.SyncOptions, e
 		Exclude:      b.Config.Sync.Exclude,
 
 		RemotePath: b.Config.Workspace.FilePath,
-		Host:       b.WorkspaceClient().Config.Host,
+		Host:       b.WorkspaceClient(ctx).Config.Host,
 
 		Full: false,
 
 		SnapshotBasePath: cacheDir,
-		WorkspaceClient:  b.WorkspaceClient(),
+		WorkspaceClient:  b.WorkspaceClient(ctx),
 	}
 
 	if b.Config.Workspace.CurrentUser != nil {

--- a/bundle/deploy/lock/acquire.go
+++ b/bundle/deploy/lock/acquire.go
@@ -22,10 +22,10 @@ func (m *acquire) Name() string {
 	return "lock:acquire"
 }
 
-func (m *acquire) init(b *bundle.Bundle) error {
+func (m *acquire) init(ctx context.Context, b *bundle.Bundle) error {
 	user := b.Config.Workspace.CurrentUser.UserName
 	dir := b.Config.Workspace.StatePath
-	l, err := locker.CreateLocker(user, dir, b.WorkspaceClient())
+	l, err := locker.CreateLocker(user, dir, b.WorkspaceClient(ctx))
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func (m *acquire) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 		return nil
 	}
 
-	err := m.init(b)
+	err := m.init(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/deploy/metadata/upload.go
+++ b/bundle/deploy/metadata/upload.go
@@ -28,7 +28,7 @@ func (m *upload) Name() string {
 }
 
 func (m *upload) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	f, err := filer.NewWorkspaceFilesClient(b.WorkspaceClient(), b.Config.Workspace.StatePath)
+	f, err := filer.NewWorkspaceFilesClient(b.WorkspaceClient(ctx), b.Config.Workspace.StatePath)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/deploy/resource_path_mkdir.go
+++ b/bundle/deploy/resource_path_mkdir.go
@@ -25,7 +25,7 @@ func (m *resourcePathMkdir) Apply(ctx context.Context, b *bundle.Bundle) diag.Di
 		return nil
 	}
 
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 
 	// Optimisitcally create the resource path. If it already exists ignore the error.
 	err := w.Workspace.MkdirsByPath(ctx, b.Config.Workspace.ResourcePath) //nolint:staticcheck // Deprecated in SDK v0.127.0. Migration to WorkspaceHierarchyService tracked separately.

--- a/bundle/deploy/state_pull.go
+++ b/bundle/deploy/state_pull.go
@@ -22,7 +22,7 @@ type statePull struct {
 }
 
 func (s *statePull) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	f, err := s.filerFactory(b)
+	f, err := s.filerFactory(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/deploy/state_pull_test.go
+++ b/bundle/deploy/state_pull_test.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/fs"
@@ -43,7 +44,7 @@ type statePullOpts struct {
 }
 
 func testStatePull(t *testing.T, opts statePullOpts) {
-	s := &statePull{func(b *bundle.Bundle) (filer.Filer, error) {
+	s := &statePull{func(_ context.Context, b *bundle.Bundle) (filer.Filer, error) {
 		f := mockfiler.NewMockFiler(t)
 
 		deploymentStateData, err := json.Marshal(DeploymentState{
@@ -248,7 +249,7 @@ func TestStatePullSnapshotExists(t *testing.T) {
 }
 
 func TestStatePullNoState(t *testing.T) {
-	s := &statePull{func(b *bundle.Bundle) (filer.Filer, error) {
+	s := &statePull{func(_ context.Context, b *bundle.Bundle) (filer.Filer, error) {
 		f := mockfiler.NewMockFiler(t)
 
 		f.EXPECT().Read(mock.Anything, DeploymentStateFileName).Return(nil, os.ErrNotExist)
@@ -421,7 +422,7 @@ func TestStatePullAndNotebookIsRemovedLocally(t *testing.T) {
 }
 
 func TestStatePullNewerDeploymentStateVersion(t *testing.T) {
-	s := &statePull{func(b *bundle.Bundle) (filer.Filer, error) {
+	s := &statePull{func(_ context.Context, b *bundle.Bundle) (filer.Filer, error) {
 		f := mockfiler.NewMockFiler(t)
 
 		deploymentStateData, err := json.Marshal(DeploymentState{

--- a/bundle/deploy/state_push.go
+++ b/bundle/deploy/state_push.go
@@ -19,7 +19,7 @@ func (s *statePush) Name() string {
 }
 
 func (s *statePush) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	f, err := s.filerFactory(b)
+	f, err := s.filerFactory(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/deploy/state_push_test.go
+++ b/bundle/deploy/state_push_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -15,7 +16,7 @@ import (
 )
 
 func TestStatePush(t *testing.T) {
-	s := &statePush{func(b *bundle.Bundle) (filer.Filer, error) {
+	s := &statePush{func(_ context.Context, b *bundle.Bundle) (filer.Filer, error) {
 		f := mockfiler.NewMockFiler(t)
 
 		f.EXPECT().Write(mock.Anything, DeploymentStateFileName, mock.MatchedBy(func(r *os.File) bool {

--- a/bundle/deploy/terraform/check_dashboards_modified_remotely.go
+++ b/bundle/deploy/terraform/check_dashboards_modified_remotely.go
@@ -87,7 +87,7 @@ func (l *checkDashboardsModifiedRemotely) Apply(ctx context.Context, b *bundle.B
 
 		path := dyn.MustPathFromString("resources.dashboards." + dashboard.Name)
 		loc := b.Config.GetLocation(path.String())
-		actual, err := b.WorkspaceClient().Lakeview.GetByDashboardId(ctx, dashboard.ID)
+		actual, err := b.WorkspaceClient(ctx).Lakeview.GetByDashboardId(ctx, dashboard.ID)
 		if err != nil {
 			diags = diags.Append(diag.Diagnostic{
 				Severity:  diag.Error,

--- a/bundle/deploy/terraform/init.go
+++ b/bundle/deploy/terraform/init.go
@@ -336,7 +336,7 @@ func Initialize(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 		return diag.FromErr(err)
 	}
 
-	environ, err := b.AuthEnv()
+	environ, err := b.AuthEnv(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/env/http_timeout.go
+++ b/bundle/env/http_timeout.go
@@ -1,0 +1,13 @@
+package env
+
+import "context"
+
+// HTTPTimeoutSecondsVariable names the environment variable that overrides the HTTP timeout for bundle operations.
+const HTTPTimeoutSecondsVariable = "DATABRICKS_BUNDLE_HTTP_TIMEOUT_SECONDS"
+
+// HTTPTimeoutSeconds returns the HTTP timeout override for bundle operations.
+func HTTPTimeoutSeconds(ctx context.Context) (string, bool) {
+	return get(ctx, []string{
+		HTTPTimeoutSecondsVariable,
+	})
+}

--- a/bundle/fingerprint.go
+++ b/bundle/fingerprint.go
@@ -16,17 +16,17 @@ func (f *UserFingerprint) IsEmpty() bool {
 
 func (b *Bundle) GetUserFingerprint(ctx context.Context) UserFingerprint {
 	return UserFingerprint{
-		Host:       b.WorkspaceClient().Config.Host,
-		AuthHeader: b.getAuthorizationHeader(),
+		Host:       b.WorkspaceClient(ctx).Config.Host,
+		AuthHeader: b.getAuthorizationHeader(ctx),
 	}
 }
 
 // getAuthorizationHeader extracts the Authorization header from the workspace client configuration.
 // If it fails to authenticate, it returns an empty string.
-func (b *Bundle) getAuthorizationHeader() string {
+func (b *Bundle) getAuthorizationHeader(ctx context.Context) string {
 	// Create a dummy request to extract the Authorization header
 	req := &http.Request{Header: http.Header{}}
-	if err := b.WorkspaceClient().Config.Authenticate(req); err != nil {
+	if err := b.WorkspaceClient(ctx).Config.Authenticate(req); err != nil {
 		return ""
 	}
 

--- a/bundle/libraries/filer.go
+++ b/bundle/libraries/filer.go
@@ -29,10 +29,10 @@ func GetFilerForLibraries(ctx context.Context, b *bundle.Bundle) (filer.Filer, s
 
 	switch {
 	case IsVolumesPath(artifactPath):
-		return filerForVolume(b, uploadPath)
+		return filerForVolume(ctx, b, uploadPath)
 
 	default:
-		return filerForWorkspace(b, uploadPath)
+		return filerForWorkspace(ctx, b, uploadPath)
 	}
 }
 
@@ -46,10 +46,10 @@ func GetFilerForLibrariesCleanup(ctx context.Context, b *bundle.Bundle) (filer.F
 
 	switch {
 	case IsVolumesPath(artifactPath):
-		return filerForVolume(b, artifactPath)
+		return filerForVolume(ctx, b, artifactPath)
 
 	default:
-		return filerForWorkspace(b, artifactPath)
+		return filerForWorkspace(ctx, b, artifactPath)
 	}
 }
 

--- a/bundle/libraries/filer_volume.go
+++ b/bundle/libraries/filer_volume.go
@@ -1,13 +1,15 @@
 package libraries
 
 import (
+	"context"
+
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/filer"
 )
 
-func filerForVolume(b *bundle.Bundle, uploadPath string) (filer.Filer, string, diag.Diagnostics) {
-	w := b.WorkspaceClient()
+func filerForVolume(ctx context.Context, b *bundle.Bundle, uploadPath string) (filer.Filer, string, diag.Diagnostics) {
+	w := b.WorkspaceClient(ctx)
 	f, err := filer.NewFilesClient(w, uploadPath)
 	return f, uploadPath, diag.FromErr(err)
 }

--- a/bundle/libraries/filer_workspace.go
+++ b/bundle/libraries/filer_workspace.go
@@ -1,12 +1,14 @@
 package libraries
 
 import (
+	"context"
+
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/filer"
 )
 
-func filerForWorkspace(b *bundle.Bundle, uploadPath string) (filer.Filer, string, diag.Diagnostics) {
-	f, err := filer.NewWorkspaceFilesClient(b.WorkspaceClient(), uploadPath)
+func filerForWorkspace(ctx context.Context, b *bundle.Bundle, uploadPath string) (filer.Filer, string, diag.Diagnostics) {
+	f, err := filer.NewWorkspaceFilesClient(b.WorkspaceClient(ctx), uploadPath)
 	return f, uploadPath, diag.FromErr(err)
 }

--- a/bundle/permissions/workspace_root.go
+++ b/bundle/permissions/workspace_root.go
@@ -54,7 +54,7 @@ func giveAccessForWorkspaceRoot(ctx context.Context, b *bundle.Bundle) error {
 		return nil
 	}
 
-	w := b.WorkspaceClient().Workspace
+	w := b.WorkspaceClient(ctx).Workspace
 	bundlePaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config.Workspace)
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/bundle/phases/bind.go
+++ b/bundle/phases/bind.go
@@ -41,7 +41,7 @@ func Bind(ctx context.Context, b *bundle.Bundle, opts *terraform.BindOptions, en
 		resourceKey := fmt.Sprintf("resources.%s.%s", groupName, opts.ResourceKey)
 		_, statePath := b.StateFilenameDirect(ctx)
 
-		result, err := b.DeploymentBundle.Bind(ctx, b.WorkspaceClient(), &b.Config, statePath, resourceKey, opts.ResourceId)
+		result, err := b.DeploymentBundle.Bind(ctx, b.WorkspaceClient(ctx), &b.Config, statePath, resourceKey, opts.ResourceId)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -103,7 +103,7 @@ func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, ta
 	cmdio.LogString(ctx, "Deploying resources...")
 
 	if targetEngine.IsDirect() {
-		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(), plan, direct.MigrateMode(false))
+		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan, direct.MigrateMode(false))
 		// Finalize state: write to disk even if deploy failed, so partial progress is saved.
 		// Skip for empty plans to avoid creating a state file when nothing was deployed.
 		if len(plan.Plan) > 0 {
@@ -185,7 +185,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 
 	if plan != nil {
 		// Initialize DeploymentBundle for applying the loaded plan
-		err := b.DeploymentBundle.InitForApply(ctx, b.WorkspaceClient(), plan)
+		err := b.DeploymentBundle.InitForApply(ctx, b.WorkspaceClient(ctx), plan)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return
@@ -219,7 +219,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 
 func RunPlan(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) *deployplan.Plan {
 	if engine.IsDirect() {
-		plan, err := b.DeploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(), &b.Config)
+		plan, err := b.DeploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return nil

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -20,7 +20,7 @@ import (
 )
 
 func assertRootPathExists(ctx context.Context, b *bundle.Bundle) (bool, error) {
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	_, err := w.Workspace.GetStatusByPath(ctx, b.Config.Workspace.RootPath) //nolint:staticcheck // Deprecated in SDK v0.127.0. Migration to WorkspaceHierarchyService tracked separately.
 
 	var aerr *apierr.APIError
@@ -96,7 +96,7 @@ func approvalForDestroy(ctx context.Context, b *bundle.Bundle, plan *deployplan.
 
 func destroyCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) {
 	if engine.IsDirect() {
-		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(), plan, direct.MigrateMode(false))
+		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan, direct.MigrateMode(false))
 		// Skip Finalize for empty plans to avoid creating a state file when nothing was destroyed.
 		if len(plan.Plan) > 0 {
 			if err := b.DeploymentBundle.StateDB.Finalize(); err != nil {
@@ -163,7 +163,7 @@ func Destroy(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) {
 
 	var plan *deployplan.Plan
 	if engine.IsDirect() {
-		plan, err = b.DeploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(), nil)
+		plan, err = b.DeploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), nil)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return

--- a/bundle/run/app.go
+++ b/bundle/run/app.go
@@ -53,7 +53,7 @@ func (a *appRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 	}
 
 	logProgress(ctx, "Getting the status of the app "+app.Name)
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 
 	// Check the status of the app first.
 	createdApp, err := w.Apps.Get(ctx, apps.GetAppRequest{Name: app.Name})
@@ -105,7 +105,7 @@ func isAppComputeStarting(app *apps.App) bool {
 func (a *appRunner) start(ctx context.Context) error {
 	app := a.app
 	b := a.bundle
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 
 	logProgress(ctx, "Starting the app "+app.Name)
 	wait, err := w.Apps.Start(ctx, apps.StartAppRequest{Name: app.Name})
@@ -137,7 +137,7 @@ func (a *appRunner) start(ctx context.Context) error {
 }
 
 func (a *appRunner) deploy(ctx context.Context) error {
-	w := a.bundle.WorkspaceClient()
+	w := a.bundle.WorkspaceClient(ctx)
 	config, err := a.resolvedConfig()
 	if err != nil {
 		return err
@@ -199,7 +199,7 @@ func (a *appRunner) Cancel(ctx context.Context) error {
 		return errors.New("app is not defined")
 	}
 
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 
 	logProgress(ctx, "Stopping app "+app.Name)
 	wait, err := w.Apps.Stop(ctx, apps.StopAppRequest{Name: app.Name})

--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -49,7 +49,7 @@ func isSuccess(task jobs.RunTask) bool {
 }
 
 func (r *jobRunner) logFailedTasks(ctx context.Context, runId int64) {
-	w := r.bundle.WorkspaceClient()
+	w := r.bundle.WorkspaceClient(ctx)
 	red := color.New(color.FgRed).SprintFunc()
 	green := color.New(color.FgGreen).SprintFunc()
 	yellow := color.New(color.FgYellow).SprintFunc()
@@ -146,7 +146,7 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 	// Include resource key in logger.
 	ctx = log.NewContext(ctx, log.GetLogger(ctx).With("resource", r.Key()))
 
-	w := r.bundle.WorkspaceClient()
+	w := r.bundle.WorkspaceClient(ctx)
 
 	monitor := &jobRunMonitor{
 		ctx: ctx,
@@ -191,7 +191,7 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 	// The task completed successfully.
 	case jobs.RunResultStateSuccess:
 		log.Infof(ctx, "Run has completed successfully!")
-		return output.GetJobOutput(ctx, r.bundle.WorkspaceClient(), waiter.RunId)
+		return output.GetJobOutput(ctx, r.bundle.WorkspaceClient(ctx), waiter.RunId)
 
 	// The run was stopped after reaching the timeout.
 	case jobs.RunResultStateTimedout:
@@ -245,7 +245,7 @@ func (r *jobRunner) convertPythonParams(opts *Options) error {
 }
 
 func (r *jobRunner) Cancel(ctx context.Context) error {
-	w := r.bundle.WorkspaceClient()
+	w := r.bundle.WorkspaceClient(ctx)
 	jobID, err := strconv.ParseInt(r.job.ID, 10, 64)
 	if err != nil {
 		return fmt.Errorf("job ID is not an integer: %s", r.job.ID)

--- a/bundle/run/pipeline.go
+++ b/bundle/run/pipeline.go
@@ -44,7 +44,7 @@ func (r *pipelineRunner) logEvent(ctx context.Context, event pipelines.PipelineE
 }
 
 func (r *pipelineRunner) logErrorEvent(ctx context.Context, pipelineId, updateId string) error {
-	w := r.bundle.WorkspaceClient()
+	w := r.bundle.WorkspaceClient(ctx)
 
 	// Note: For a 100 percent correct and complete solution we should use the
 	// w.Pipelines.ListPipelineEventsAll method to find all relevant events. However the
@@ -90,7 +90,7 @@ func (r *pipelineRunner) Run(ctx context.Context, opts *Options) (output.RunOutp
 
 	// Include resource key in logger.
 	ctx = log.NewContext(ctx, log.GetLogger(ctx).With("resource", r.Key()))
-	w := r.bundle.WorkspaceClient()
+	w := r.bundle.WorkspaceClient(ctx)
 
 	req, err := opts.Pipeline.toPayload(r.pipeline, pipelineID)
 	if err != nil {
@@ -165,7 +165,7 @@ func (r *pipelineRunner) Run(ctx context.Context, opts *Options) (output.RunOutp
 }
 
 func (r *pipelineRunner) Cancel(ctx context.Context) error {
-	w := r.bundle.WorkspaceClient()
+	w := r.bundle.WorkspaceClient(ctx)
 	wait, err := w.Pipelines.Stop(ctx, pipelines.StopRequest{
 		PipelineId: r.pipeline.ID,
 	})

--- a/bundle/statemgmt/check_running_resources.go
+++ b/bundle/statemgmt/check_running_resources.go
@@ -50,7 +50,7 @@ func (l *checkRunningResources) Apply(ctx context.Context, b *bundle.Bundle) dia
 		}
 	}
 
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	err = checkAnyResourceRunning(ctx, w, state)
 	if err != nil {
 		return diag.FromErr(err)

--- a/bundle/statemgmt/state_pull.go
+++ b/bundle/statemgmt/state_pull.go
@@ -220,7 +220,7 @@ func readStates(ctx context.Context, b *bundle.Bundle, alwaysPull AlwaysPull) []
 	terraformLocalState := localRead(ctx, localPathTerraform, engine.EngineTerraform)
 
 	if (directLocalState == nil && terraformLocalState == nil) || alwaysPull {
-		f, err := deploy.StateFiler(b)
+		f, err := deploy.StateFiler(ctx, b)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return nil

--- a/bundle/statemgmt/state_push.go
+++ b/bundle/statemgmt/state_push.go
@@ -17,7 +17,7 @@ import (
 
 // PushResourcesState uploads the local state file to the remote location.
 func PushResourcesState(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) {
-	f, err := deploy.StateFiler(b)
+	f, err := deploy.StateFiler(ctx, b)
 	if err != nil {
 		logdiag.LogError(ctx, err)
 		return
@@ -53,7 +53,7 @@ func PushResourcesState(ctx context.Context, b *bundle.Bundle, engine engine.Eng
 }
 
 func BackupRemoteTerraformState(ctx context.Context, b *bundle.Bundle) {
-	f, err := deploy.StateFiler(b)
+	f, err := deploy.StateFiler(ctx, b)
 	if err != nil {
 		logdiag.LogError(ctx, err)
 		return

--- a/bundle/statemgmt/upload_state_for_yaml_sync.go
+++ b/bundle/statemgmt/upload_state_for_yaml_sync.go
@@ -76,7 +76,7 @@ func (m *uploadStateForYamlSync) Apply(ctx context.Context, b *bundle.Bundle) di
 }
 
 func uploadState(ctx context.Context, b *bundle.Bundle) error {
-	f, err := deploy.StateFiler(b)
+	f, err := deploy.StateFiler(ctx, b)
 	if err != nil {
 		return fmt.Errorf("failed to get state filer: %w", err)
 	}
@@ -173,7 +173,7 @@ func (m *uploadStateForYamlSync) convertState(ctx context.Context, b *bundle.Bun
 		return false, fmt.Errorf("failed to create uninterpolated config: %w", err)
 	}
 
-	plan, err := deploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(), &uninterpolatedConfig)
+	plan, err := deploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &uninterpolatedConfig)
 	if err != nil {
 		return false, err
 	}
@@ -197,7 +197,7 @@ func (m *uploadStateForYamlSync) convertState(ctx context.Context, b *bundle.Bun
 		}
 	}
 
-	deploymentBundle.Apply(ctx, b.WorkspaceClient(), plan, direct.MigrateMode(true))
+	deploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan, direct.MigrateMode(true))
 	if err := deploymentBundle.StateDB.Finalize(); err != nil {
 		return false, err
 	}

--- a/bundle/trampoline/python_dbr_warning.go
+++ b/bundle/trampoline/python_dbr_warning.go
@@ -101,7 +101,7 @@ func hasIncompatibleWheelTasks(ctx context.Context, b *bundle.Bundle) diag.Diagn
 				}
 				version = cluster.SparkVersion
 			} else {
-				version, err = getSparkVersionForCluster(ctx, b.WorkspaceClient(), task.ExistingClusterId)
+				version, err = getSparkVersionForCluster(ctx, b.WorkspaceClient(ctx), task.ExistingClusterId)
 				// If there's error getting spark version for cluster, do not mark it as incompatible
 				if err != nil {
 					log.Warnf(ctx, "unable to get spark version for cluster %s, err: %s", task.ExistingClusterId, err.Error())

--- a/cmd/apps/import.go
+++ b/cmd/apps/import.go
@@ -321,7 +321,7 @@ func runImport(ctx context.Context, w *databricks.WorkspaceClient, appName, outp
 		}
 
 		// Verify the app exists
-		exists, err := resource.Exists(ctx, b.WorkspaceClient(), app.Name)
+		exists, err := resource.Exists(ctx, b.WorkspaceClient(ctx), app.Name)
 		if err != nil {
 			return fmt.Errorf("failed to verify app exists: %w", err)
 		}

--- a/cmd/bundle/deployment/bind_resource.go
+++ b/cmd/bundle/deployment/bind_resource.go
@@ -33,7 +33,7 @@ func BindResource(cmd *cobra.Command, resourceKey, resourceId string, autoApprov
 		return err
 	}
 
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	exists, err := resource.Exists(ctx, w, resourceId)
 	if err != nil {
 		return fmt.Errorf("failed to fetch the resource, err: %w", err)

--- a/cmd/bundle/deployment/migrate.go
+++ b/cmd/bundle/deployment/migrate.go
@@ -250,7 +250,7 @@ To start using direct engine, set "engine: direct" under bundle in your databric
 			return root.ErrAlreadyPrinted
 		}
 
-		plan, err := deploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(), &b.Config)
+		plan, err := deploymentBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ To start using direct engine, set "engine: direct" under bundle in your databric
 			}
 		}
 
-		deploymentBundle.Apply(ctx, b.WorkspaceClient(), plan, direct.MigrateMode(true))
+		deploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan, direct.MigrateMode(true))
 		if err := deploymentBundle.StateDB.Finalize(); err != nil {
 			logdiag.LogError(ctx, err)
 		}

--- a/cmd/bundle/generate/alert.go
+++ b/cmd/bundle/generate/alert.go
@@ -75,7 +75,7 @@ After generation, you can deploy this alert to other targets using:
 			return root.ErrAlreadyPrinted
 		}
 
-		w := b.WorkspaceClient()
+		w := b.WorkspaceClient(ctx)
 
 		// Get alert from Databricks
 		alert, err := w.AlertsV2.GetAlert(ctx, sql.GetAlertV2Request{Id: alertID})

--- a/cmd/bundle/generate/app.go
+++ b/cmd/bundle/generate/app.go
@@ -70,7 +70,7 @@ per target environment.`,
 			return root.ErrAlreadyPrinted
 		}
 
-		w := b.WorkspaceClient()
+		w := b.WorkspaceClient(ctx)
 		cmdio.LogString(ctx, fmt.Sprintf("Loading app '%s' configuration", appName))
 		app, err := w.Apps.Get(ctx, apps.GetAppRequest{Name: appName})
 		if err != nil {

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -82,7 +82,7 @@ func (d *dashboard) resolveID(ctx context.Context, b *bundle.Bundle) string {
 }
 
 func (d *dashboard) resolveFromPath(ctx context.Context, b *bundle.Bundle) string {
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	obj, err := w.Workspace.GetStatusByPath(ctx, d.existingPath) //nolint:staticcheck // Deprecated in SDK v0.127.0. Migration to WorkspaceHierarchyService tracked separately.
 	if err != nil {
 		if apierr.IsMissing(err) {
@@ -129,7 +129,7 @@ func (d *dashboard) resolveFromPath(ctx context.Context, b *bundle.Bundle) strin
 }
 
 func (d *dashboard) resolveFromID(ctx context.Context, b *bundle.Bundle) string {
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	obj, err := w.Lakeview.GetByDashboardId(ctx, d.existingID)
 	if err != nil {
 		if apierr.IsMissing(err) {
@@ -295,7 +295,7 @@ func (d *dashboard) updateDashboardForResource(ctx context.Context, b *bundle.Bu
 	// Overwrite the dashboard at the path referenced from the resource.
 	dashboardPath := resource.FilePath
 
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 
 	// Start polling the underlying dashboard for changes.
 	var etag string
@@ -331,7 +331,7 @@ func (d *dashboard) updateDashboardForResource(ctx context.Context, b *bundle.Bu
 }
 
 func (d *dashboard) generateForExisting(ctx context.Context, b *bundle.Bundle, dashboardID string) {
-	w := b.WorkspaceClient()
+	w := b.WorkspaceClient(ctx)
 	dashboard, err := w.Lakeview.GetByDashboardId(ctx, dashboardID)
 	if err != nil {
 		logdiag.LogError(ctx, err)

--- a/cmd/bundle/generate/job.go
+++ b/cmd/bundle/generate/job.go
@@ -74,7 +74,7 @@ After generation, you can deploy this job to other targets using:
 			return root.ErrAlreadyPrinted
 		}
 
-		w := b.WorkspaceClient()
+		w := b.WorkspaceClient(ctx)
 		job, err := w.Jobs.Get(ctx, jobs.GetJobRequest{JobId: jobId})
 		if err != nil {
 			return err

--- a/cmd/bundle/generate/pipeline.go
+++ b/cmd/bundle/generate/pipeline.go
@@ -73,7 +73,7 @@ like catalogs, schemas, and compute configurations per target.`,
 			return root.ErrAlreadyPrinted
 		}
 
-		w := b.WorkspaceClient()
+		w := b.WorkspaceClient(ctx)
 		pipeline, err := w.Pipelines.Get(ctx, pipelines.GetPipelineRequest{PipelineId: pipelineId})
 		if err != nil {
 			return err

--- a/cmd/labs/project/entrypoint.go
+++ b/cmd/labs/project/entrypoint.go
@@ -205,7 +205,7 @@ func (e *Entrypoint) getLoginConfig(cmd *cobra.Command) (*loginConfig, *config.C
 		b := root.TryConfigureBundle(cmd)
 		if b != nil {
 			log.Infof(ctx, "Using login configuration from Databricks Asset Bundle")
-			return &loginConfig{}, b.WorkspaceClient().Config, nil
+			return &loginConfig{}, b.WorkspaceClient(ctx).Config, nil
 		}
 	}
 	log.Debugf(ctx, "Using workspace-level login profile: %s", lc.WorkspaceProfile)

--- a/cmd/pipelines/history.go
+++ b/cmd/pipelines/history.go
@@ -52,7 +52,7 @@ func historyCommand() *cobra.Command {
 			return err
 		}
 
-		w := b.WorkspaceClient()
+		w := b.WorkspaceClient(ctx)
 
 		startTimePtr, err := parseTimeToUnixMillis(startTimeStr)
 		if err != nil {

--- a/cmd/pipelines/logs.go
+++ b/cmd/pipelines/logs.go
@@ -101,7 +101,7 @@ Example usage:
 			return err
 		}
 
-		w := b.WorkspaceClient()
+		w := b.WorkspaceClient(ctx)
 		if updateId == "" {
 			updateId, err = getMostRecentUpdateId(ctx, w, pipelineId)
 			if err != nil {

--- a/cmd/pipelines/run.go
+++ b/cmd/pipelines/run.go
@@ -331,7 +331,7 @@ Refreshes all tables in the pipeline unless otherwise specified.`,
 		// as runner.Run() returns an error if the pipeline doesn't complete successfully.
 		if ref.Description.SingularName == "pipeline" && runOutput != nil {
 			if pipelineOutput, ok := runOutput.(*bundlerunoutput.PipelineOutput); ok && pipelineOutput.UpdateId != "" {
-				w := b.WorkspaceClient()
+				w := b.WorkspaceClient(ctx)
 				err = fetchAndDisplayPipelineUpdate(ctx, w, ref.Resource.(*resources.Pipeline).ID, pipelineOutput.UpdateId)
 				if err != nil {
 					return fmt.Errorf("failed to fetch and display pipeline update: %w", err)

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -272,9 +272,9 @@ func MustWorkspaceClient(cmd *cobra.Command, args []string) error {
 		}
 
 		if b != nil {
-			ctx = cmdctx.SetConfigUsed(ctx, b.Config.Workspace.Config())
+			ctx = cmdctx.SetConfigUsed(ctx, b.Config.Workspace.Config(ctx))
 			cmd.SetContext(ctx)
-			client, err := b.WorkspaceClientE()
+			client, err := b.WorkspaceClientE(ctx)
 			if err != nil {
 				return err
 			}

--- a/cmd/root/bundle.go
+++ b/cmd/root/bundle.go
@@ -162,7 +162,7 @@ func configureBundle(cmd *cobra.Command, b *bundle.Bundle) {
 	//
 	// Note that just initializing a workspace client and loading auth configuration
 	// is a fast operation. It does not perform network I/O or invoke processes (for example the Azure CLI).
-	client, err := b.WorkspaceClientE()
+	client, err := b.WorkspaceClientE(ctx)
 	if err != nil {
 		names, isMulti := databrickscfg.AsMultipleProfiles(err)
 		if !isMulti {
@@ -177,8 +177,8 @@ func configureBundle(cmd *cobra.Command, b *bundle.Bundle) {
 		}
 
 		b.Config.Workspace.Profile = selected
-		b.ClearWorkspaceClient()
-		client, err = b.WorkspaceClientE()
+		b.ClearWorkspaceClient(ctx)
+		client, err = b.WorkspaceClientE(ctx)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return

--- a/libs/template/renderer_test.go
+++ b/libs/template/renderer_test.go
@@ -79,7 +79,7 @@ func assertBuiltinTemplateValid(t *testing.T, template string, settings map[stri
 
 	b.Tagging = tags.ForCloud(w.Config)
 	b.SetWorkpaceClient(w)
-	b.WorkspaceClient()
+	b.WorkspaceClient(ctx)
 
 	phases.Initialize(ctx, b)
 	diags = logdiag.FlushCollected(ctx)


### PR DESCRIPTION
Allows overriding the HTTP timeout for bundle operations. The acceptance test for upload timeout now uses a 5s timeout instead of 90s, reducing test runtime from ~2 minutes to ~6 seconds.

Co-authored-by: Isaac
