### PR TITLE
direct: Exclude deploy-only fields from Apps update mask

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bundles
 * Remove `experimental-jobs-as-code` template, superseded by `pydabs` ([#4999](https://github.com/databricks/cli/pull/4999)).
 * engine/direct: Added support for Vector Search Endpoints ([#4887](https://github.com/databricks/cli/pull/4887))
+* engine/direct: Exclude deploy-only fields (e.g. `lifecycle`) from the Apps update mask so requests that change both `description` and `lifecycle.started` in the same deploy no longer fail with `INVALID_PARAMETER_VALUE`.
 
 ### Dependency updates
 

--- a/acceptance/bundle/resources/apps/lifecycle-started/output.txt
+++ b/acceptance/bundle/resources/apps/lifecycle-started/output.txt
@@ -70,7 +70,23 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> print_requests.py //deployments
+>>> print_requests.py //apps
+{
+  "method": "POST",
+  "path": "/api/2.0/apps/[UNIQUE_NAME]/stop",
+  "body": {}
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/apps/[UNIQUE_NAME]/update",
+  "body": {
+    "app": {
+      "description": "MY_APP_DESCRIPTION_2",
+      "name": "[UNIQUE_NAME]"
+    },
+    "update_mask": "description"
+  }
+}
 
 >>> errcode [CLI] apps get [UNIQUE_NAME]
 "STOPPED"
@@ -87,7 +103,23 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> print_requests.py //deployments
+>>> print_requests.py //apps
+{
+  "method": "POST",
+  "path": "/api/2.0/apps/[UNIQUE_NAME]/update",
+  "body": {
+    "app": {
+      "description": "MY_APP_DESCRIPTION_3",
+      "name": "[UNIQUE_NAME]"
+    },
+    "update_mask": "description"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/apps/[UNIQUE_NAME]/start",
+  "body": {}
+}
 {
   "method": "POST",
   "path": "/api/2.0/apps/[UNIQUE_NAME]/deployments",

--- a/acceptance/bundle/resources/apps/lifecycle-started/script
+++ b/acceptance/bundle/resources/apps/lifecycle-started/script
@@ -31,7 +31,7 @@ title "Stop app externally, then deploy with started=false: app stays stopped"
 trace update_file.py databricks.yml "started: true" "started: false"
 trace update_file.py databricks.yml MY_APP_DESCRIPTION MY_APP_DESCRIPTION_2
 trace errcode $CLI bundle deploy
-trace print_requests.py //deployments
+trace print_requests.py //apps
 rm -f out.requests.txt
 { trace errcode $CLI apps get $UNIQUE_NAME | jq '.compute_status.state'; } || true
 
@@ -39,6 +39,6 @@ title "Deploy with started=true: compute restarted and code deployed"
 trace update_file.py databricks.yml "started: false" "started: true"
 trace update_file.py databricks.yml MY_APP_DESCRIPTION_2 MY_APP_DESCRIPTION_3
 trace errcode $CLI bundle deploy
-trace print_requests.py //deployments
+trace print_requests.py //apps
 rm -f out.requests.txt
 { trace errcode $CLI apps get $UNIQUE_NAME | jq '.compute_status.state'; } || true

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -172,6 +172,9 @@ func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState,
 		for i, fieldPath := range fieldPaths {
 			fieldPaths[i] = truncateAtIndex(fieldPath)
 		}
+		fieldPaths = slices.DeleteFunc(fieldPaths, func(p string) bool {
+			return deployOnlyFields[p]
+		})
 		updateMask := strings.Join(fieldPaths, ",")
 		request := apps.AsyncUpdateAppRequest{
 			App:        &config.App,


### PR DESCRIPTION
## Why

When an Apps resource changes both `description` and `lifecycle.started` in the same deploy, the direct engine produces an `update_mask` of `"description,lifecycle"`. The Apps Update API rejects it:

```
Error: cannot update resources.apps.myapp: updating id=...: Invalid update mask.
Only description, budget_policy_id, usage_policy_id, resources, user_api_scopes,
compute_size, compute_min_instances, compute_max_instances, git_repository,
telemetry_export_destinations are allowed.
Supplied update mask: description, lifecycle
(400 INVALID_PARAMETER_VALUE)
```

`lifecycle` is a deploy-only field managed by the CLI (via start/stop + the Deployments API), not by the App Update endpoint.

This surfaced in the nightly run `lifecycle-started/DATABRICKS_BUNDLE_ENGINE=direct` acceptance test. Locally the mock server does not validate the update mask, so the bug slipped through.

## Changes

Before: `DoUpdate` collected every `Update` path in the plan entry, truncated each to its top-level field, and joined them into the mask. Deploy-only fields (`source_code_path`, `config`, `git_source`, `lifecycle`) leaked into the mask whenever they changed alongside a real App field.

Now: filter `deployOnlyFields` out of the collected paths before building the mask. The `hasAppChanges` gate already applies the same filter to decide whether to call Update at all; this matches the mask to the same set of fields.

Also updated `lifecycle-started` acceptance test to print `//apps` instead of only `//deployments` for the two steps that toggle `started` and change `description` together, so the `update_mask` now appears in the recorded output. Without the fix the mask shows `"description,lifecycle"`; with the fix it shows `"description"` only.

## Test plan

- [x] `go test ./bundle/direct/...` passes
- [x] `go test ./acceptance -run 'TestAccept/bundle/resources/apps/'` passes (all engines)
- [x] `make checks` passes
- [ ] Nightly `lifecycle-started/direct` + related tests pass on cloud