### PR TITLE
integration: Loosen dashboard-conflict assertion to ErrResourceConflict

### DIFF
--- a/integration/assumptions/dashboard_assumptions_test.go
+++ b/integration/assumptions/dashboard_assumptions_test.go
@@ -71,7 +71,11 @@ func TestDashboardAssumptions_WorkspaceImport(t *testing.T) {
 				SerializedDashboard: string(dashboardPayload),
 			},
 		})
-		require.ErrorIs(t, err, apierr.ErrResourceAlreadyExists)
+		// Lakeview returns the generic gRPC error_code ALREADY_EXISTS, not
+		// Databricks' RESOURCE_ALREADY_EXISTS, so the SDK unwraps to
+		// ErrAlreadyExists rather than ErrResourceAlreadyExists. Assert the
+		// common 409 parent to stay resilient to either code.
+		require.ErrorIs(t, err, apierr.ErrResourceConflict)
 	}
 
 	// Retrieve the dashboard object and confirm that only select fields were updated by the import.


### PR DESCRIPTION
## Why

Nightly integration run had `TestDashboardAssumptions_WorkspaceImport` failing with:

```
Target error should be in err chain:
expected: "operation was rejected due a conflict with an existing resource"
in chain: "Unable to register dashboard [...] A node of same type DASHBOARD_V3 with name 'New Dashboard.lvdash.json' already exists under parent ..."
          "operation was rejected due a conflict with an existing resource"
          "maps to all HTTP 409 (Conflict) responses"
```

The test asserted `errors.Is(err, apierr.ErrResourceAlreadyExists)`. The SDK has **two** sentinels with identical messages but distinct pointers:

- `ErrAlreadyExists` &mdash; mapped from `error_code: ALREADY_EXISTS` (gRPC canonical)
- `ErrResourceAlreadyExists` &mdash; mapped from `error_code: RESOURCE_ALREADY_EXISTS` (Databricks-specific)

Both inherit from `ErrResourceConflict`. `APIError.Unwrap()` prefers `errorCodeMapping[ErrorCode]` over the status-code fallback, so when Lakeview returns 409 with `error_code: ALREADY_EXISTS` the chain lands on `ErrAlreadyExists` and `errors.Is(err, ErrResourceAlreadyExists)` is false (even though the printed message looks identical &mdash; they're separate `wrapError` instances with the same string).

## Changes

**Before:** asserted `ErrResourceAlreadyExists`, which only matches when the backend returns `error_code: RESOURCE_ALREADY_EXISTS`.

**Now:** asserts `ErrResourceConflict`, the common 409 parent. The test only needs to confirm that re-creating a dashboard with a taken name surfaces a 409, and this stays correct regardless of which exact `error_code` string the backend happens to emit.

An inline comment documents the two SDK sentinels so the next reader does not have to rediscover this.

## Test plan

- [x] `go vet ./integration/assumptions/...` passes
- [x] `go test -c -o /dev/null ./integration/assumptions/` compiles
- [x] `make checks` passes
- [ ] Nightly `TestDashboardAssumptions_WorkspaceImport` passes on cloud