### PR TITLE
Treat deleted resources as not running in fail-on-active-runs check

### DIFF
--- a/bundle/statemgmt/check_running_resources.go
+++ b/bundle/statemgmt/check_running_resources.go
@@ -11,6 +11,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
 	"golang.org/x/sync/errgroup"
@@ -76,7 +77,6 @@ func checkAnyResourceRunning(ctx context.Context, w *databricks.WorkspaceClient,
 		if resourceType == "jobs" {
 			errs.Go(func() error {
 				isRunning, err := IsJobRunning(errCtx, w, id)
-				// If there's an error retrieving the job, we assume it's not running
 				if err != nil {
 					return err
 				}
@@ -91,7 +91,7 @@ func checkAnyResourceRunning(ctx context.Context, w *databricks.WorkspaceClient,
 			errs.Go(func() error {
 				isRunning, err := IsPipelineRunning(errCtx, w, id)
 				if err != nil {
-					return nil //nolint:nilerr // assume not running if pipeline check fails
+					return err
 				}
 				if isRunning {
 					return &ErrResourceIsRunning{resourceType: "pipeline", resourceId: id}
@@ -111,6 +111,9 @@ func IsJobRunning(ctx context.Context, w *databricks.WorkspaceClient, jobId stri
 	}
 
 	runs, err := w.Jobs.ListRunsAll(ctx, jobs.ListRunsRequest{JobId: int64(id), ActiveOnly: true})
+	if apierr.IsMissing(err) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
@@ -120,6 +123,9 @@ func IsJobRunning(ctx context.Context, w *databricks.WorkspaceClient, jobId stri
 
 func IsPipelineRunning(ctx context.Context, w *databricks.WorkspaceClient, pipelineId string) (bool, error) {
 	resp, err := w.Pipelines.Get(ctx, pipelines.GetPipelineRequest{PipelineId: pipelineId})
+	if apierr.IsMissing(err) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}

--- a/bundle/statemgmt/check_running_resources_test.go
+++ b/bundle/statemgmt/check_running_resources_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/pipelines"
@@ -81,6 +82,37 @@ func TestIsAnyResourceRunningWithAPIFailure(t *testing.T) {
 	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
 		PipelineId: "123",
 	}).Return(nil, errors.New("API failure")).Once()
+
+	err := checkAnyResourceRunning(t.Context(), m.WorkspaceClient, resources)
+	require.ErrorContains(t, err, "API failure")
+}
+
+func TestIsAnyResourceRunningWithDeletedJob(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	resources := ExportedResourcesMap{
+		"resources.jobs.job1": {ID: "123"},
+	}
+
+	jobsApi := m.GetMockJobsAPI()
+	jobsApi.EXPECT().ListRunsAll(mock.Anything, jobs.ListRunsRequest{
+		JobId:      123,
+		ActiveOnly: true,
+	}).Return(nil, &apierr.APIError{StatusCode: 404}).Once()
+
+	err := checkAnyResourceRunning(t.Context(), m.WorkspaceClient, resources)
+	require.NoError(t, err)
+}
+
+func TestIsAnyResourceRunningWithDeletedPipeline(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	resources := ExportedResourcesMap{
+		"resources.pipelines.pipeline1": {ID: "123"},
+	}
+
+	pipelineApi := m.GetMockPipelinesAPI()
+	pipelineApi.EXPECT().Get(mock.Anything, pipelines.GetPipelineRequest{
+		PipelineId: "123",
+	}).Return(nil, &apierr.APIError{StatusCode: 404}).Once()
 
 	err := checkAnyResourceRunning(t.Context(), m.WorkspaceClient, resources)
 	require.NoError(t, err)


### PR DESCRIPTION
Since #1163, the pipeline branch of `checkAnyResourceRunning` has swallowed errors while the jobs branch propagated them — an asymmetry with no apparent reasoning for it. #4997 flagged this with `nilerr` and annotated it as intentional, but it reads as a latent bug. This PR replaces the `//nolint` with what the original comments probably meant: `apierr.IsMissing` maps 404s to "not running" in both `IsJobRunning` and `IsPipelineRunning`, and genuine errors propagate on both branches.

This pull request and its description were written by Isaac.