### PR TITLE
acceptance: clean up vector_search_endpoints min_qps tests

### DIFF
--- a/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.plan.direct.json
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.plan.direct.json
@@ -1,0 +1,15 @@
+{
+  "plan": {
+    "resources.vector_search_endpoints.my_endpoint": {
+      "action": "update",
+      "changes": {
+        "min_qps": {
+          "action": "update",
+          "old": 1,
+          "new": 1,
+          "remote": 5
+        }
+      }
+    }
+  }
+}

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/script
@@ -16,6 +16,7 @@ trace $CLI vector-search-endpoints patch-endpoint "${endpoint_name}" --min-qps 5
 
 title "Plan detects drift and proposes update"
 trace $CLI bundle plan | contains.py "Plan: 0 to add, 1 to change, 0 to delete, 0 unchanged"
+$CLI bundle plan --output json | jq '{plan: .plan | map_values({action, changes})}' > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 
 title "Deploy restores min_qps to 1"
 rm -f out.requests.txt

--- a/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/output.txt
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/output.txt
@@ -6,7 +6,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> print_requests.py --keep //vector-search/endpoints //permissions
+>>> print_requests.py //vector-search/endpoints //permissions
 
 >>> [CLI] vector-search-endpoints get-endpoint vs-endpoint-[UNIQUE_NAME]
 {
@@ -29,7 +29,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> print_requests.py --keep //vector-search/endpoints //permissions
+>>> print_requests.py //vector-search/endpoints //permissions
 
 >>> [CLI] vector-search-endpoints get-endpoint vs-endpoint-[UNIQUE_NAME]
 {

--- a/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/script
@@ -8,8 +8,7 @@ trap cleanup EXIT
 
 print_requests() {
     local name=$1
-    trace print_requests.py --keep '//vector-search/endpoints' '//permissions' > out.requests.${name}.$DATABRICKS_BUNDLE_ENGINE.json
-    rm -f out.requests.txt
+    trace print_requests.py '//vector-search/endpoints' '//permissions' > out.requests.${name}.$DATABRICKS_BUNDLE_ENGINE.json
 }
 
 title "Initial deployment"


### PR DESCRIPTION
## Changes

Address review nits on #4887:

- **`update/min_qps/script`**: drop redundant `--keep` + manual `rm` pair in `print_requests()`. `print_requests.py` already deletes `out.requests.txt` when `--keep` is omitted, so the pair was a no-op. ([thread](https://github.com/databricks/cli/pull/4887#discussion_r3109611312))
- **`drift/min_qps/script`**: record `bundle plan --output json` alongside the existing `contains.py` summary check, so the test pins down that `min_qps` is the *only* field detected as changed (old=1, new=1, remote=5), not just the overall count. ([thread](https://github.com/databricks/cli/pull/4887#discussion_r3109644992))

Not in this PR: the [`recreated_same_name` badness thread](https://github.com/databricks/cli/pull/4887#discussion_r3109631848) — that requires real behavior change (storing `endpoint_uuid` in state and comparing it via `OverrideChangeDesc`, similar to `dashboards.go`'s etag pattern), so it'll get its own follow-up PR.

## Tests

- `go test ./acceptance -run TestAccept/bundle/resources/vector_search_endpoints/update/min_qps`
- `go test ./acceptance -run TestAccept/bundle/resources/vector_search_endpoints/drift/min_qps`