### PR TITLE
Fix lint issues in tools and codegen

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,6 +57,7 @@ linters:
             - "**"
             - "!**/bundle/docsgen/**"
             - "!**/bundle/internal/schema/**"
+            - "!**/bundle/internal/tf/codegen/**"
             - "!**/bundle/internal/validation/**"
           deny:
             - pkg: "log$"

--- a/acceptance/install_terraform.py
+++ b/acceptance/install_terraform.py
@@ -41,7 +41,7 @@ def retrieve(url, path):
 
 def read_version(path):
     for line in path.open():
-        if "ProviderVersion" in line:
+        if "ProviderVersion" in line and not line.lstrip().startswith("//"):
             # Expecting 'const ProviderVersion = "1.64.1"'
             items = line.strip().split()
             assert len(items) >= 3, items

--- a/acceptance/install_terraform.py
+++ b/acceptance/install_terraform.py
@@ -41,7 +41,7 @@ def retrieve(url, path):
 
 def read_version(path):
     for line in path.open():
-        if "ProviderVersion" in line and not line.lstrip().startswith("//"):
+        if line.startswith("const ProviderVersion"):
             # Expecting 'const ProviderVersion = "1.64.1"'
             items = line.strip().split()
             assert len(items) >= 3, items

--- a/bundle/internal/tf/codegen/generator/generator.go
+++ b/bundle/internal/tf/codegen/generator/generator.go
@@ -1,3 +1,4 @@
+// Package generator produces Go types from the Terraform provider schema.
 package generator
 
 import (
@@ -31,7 +32,7 @@ func (c *collection) Generate(path string) error {
 		return err
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return tmpl.Execute(f, c)
 }
@@ -50,12 +51,13 @@ func (r *root) Generate(path string) error {
 		return err
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return tmpl.Execute(f, r)
 }
 
-func Run(ctx context.Context, schema *tfjson.ProviderSchema, checksums *schemapkg.ProviderChecksums, path string) error {
+// Run generates Go type files under path for every resource and data source in schema.
+func Run(_ context.Context, schema *tfjson.ProviderSchema, checksums *schemapkg.ProviderChecksums, path string) error {
 	// Generate types for resources
 	var resources []*namedBlock
 	for _, k := range slices.Sorted(maps.Keys(schema.ResourceSchemas)) {

--- a/bundle/internal/tf/codegen/generator/named_block.go
+++ b/bundle/internal/tf/codegen/generator/named_block.go
@@ -53,7 +53,7 @@ func (b *namedBlock) Generate(path string) error {
 		return err
 	}
 
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	tmpl := template.Must(template.ParseFiles("./templates/block.go.tmpl"))
 	return tmpl.Execute(f, w)

--- a/bundle/internal/tf/codegen/generator/walker.go
+++ b/bundle/internal/tf/codegen/generator/walker.go
@@ -138,7 +138,7 @@ func nestedField(name []string, k string, isRef bool) field {
 		fieldTypePrefix = "[]"
 	}
 	fieldType := fmt.Sprintf("%s%s", fieldTypePrefix, strings.Join(append(name, strcase.ToCamel(k)), ""))
-	fieldTag := fmt.Sprintf("%s,omitempty", k)
+	fieldTag := k + ",omitempty"
 
 	return field{
 		Name: fieldName,
@@ -195,7 +195,7 @@ func (w *walker) walk(block *tfjson.SchemaBlock, name []string) error {
 			return fmt.Errorf("both required and optional are set for attribute %s", k)
 		}
 		if !v.Required {
-			fieldTag = fmt.Sprintf("%s,omitempty", fieldTag)
+			fieldTag += ",omitempty"
 		}
 
 		// Append to list of fields for type.

--- a/bundle/internal/tf/codegen/generator/walker.go
+++ b/bundle/internal/tf/codegen/generator/walker.go
@@ -190,12 +190,12 @@ func (w *walker) walk(block *tfjson.SchemaBlock, name []string) error {
 		fieldName := strcase.ToCamel(k)
 		attributePath := buildAttributePath(name, k)
 		fieldType := processAttributeType(v.AttributeType, w.resourceName, attributePath)
-		fieldTag := k
 		if v.Required && v.Optional {
 			return fmt.Errorf("both required and optional are set for attribute %s", k)
 		}
-		if !v.Required {
-			fieldTag += ",omitempty"
+		fieldTag := k + ",omitempty"
+		if v.Required {
+			fieldTag = k
 		}
 
 		// Append to list of fields for type.

--- a/bundle/internal/tf/codegen/generator/walker.go
+++ b/bundle/internal/tf/codegen/generator/walker.go
@@ -193,9 +193,11 @@ func (w *walker) walk(block *tfjson.SchemaBlock, name []string) error {
 		if v.Required && v.Optional {
 			return fmt.Errorf("both required and optional are set for attribute %s", k)
 		}
-		fieldTag := k + ",omitempty"
+		var fieldTag string
 		if v.Required {
 			fieldTag = k
+		} else {
+			fieldTag = k + ",omitempty"
 		}
 
 		// Append to list of fields for type.

--- a/bundle/internal/tf/codegen/main.go
+++ b/bundle/internal/tf/codegen/main.go
@@ -1,3 +1,4 @@
+// Command codegen generates Go types from the Databricks Terraform provider schema.
 package main
 
 import (

--- a/bundle/internal/tf/codegen/schema/checksum.go
+++ b/bundle/internal/tf/codegen/schema/checksum.go
@@ -33,7 +33,7 @@ func FetchProviderChecksums(version string) (*ProviderChecksums, error) {
 	if err != nil {
 		return nil, fmt.Errorf("downloading SHA256SUMS for provider v%s: %w", version, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("downloading SHA256SUMS for provider v%s: HTTP %s", version, resp.Status)
@@ -94,7 +94,7 @@ func verifyProviderChecksum(version, platform, expectedChecksum string) error {
 	if err != nil {
 		return fmt.Errorf("downloading provider archive for checksum verification: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("downloading provider archive for checksum verification: HTTP %s", resp.Status)

--- a/bundle/internal/tf/codegen/schema/generate.go
+++ b/bundle/internal/tf/codegen/schema/generate.go
@@ -85,6 +85,7 @@ func (s *Schema) generateSchema(ctx context.Context, execPath string) error {
 	return os.WriteFile(s.ProviderSchemaFile, buf, 0o644)
 }
 
+// Generate produces the provider schema JSON file on disk.
 func (s *Schema) Generate(ctx context.Context) error {
 	var err error
 

--- a/bundle/internal/tf/codegen/schema/load.go
+++ b/bundle/internal/tf/codegen/schema/load.go
@@ -9,7 +9,8 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func (s *Schema) Load(ctx context.Context) (*tfjson.ProviderSchema, error) {
+// Load reads the provider schema JSON file and returns the Databricks provider schema.
+func (s *Schema) Load(_ context.Context) (*tfjson.ProviderSchema, error) {
 	buf, err := os.ReadFile(s.ProviderSchemaFile)
 	if err != nil {
 		return nil, err

--- a/bundle/internal/tf/codegen/schema/schema.go
+++ b/bundle/internal/tf/codegen/schema/schema.go
@@ -1,3 +1,5 @@
+// Package schema fetches and loads the Terraform provider schema used by
+// the codegen step.
 package schema
 
 import (
@@ -10,14 +12,17 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
+// DatabricksProvider is the fully qualified Terraform provider address.
 const DatabricksProvider = "registry.terraform.io/databricks/databricks"
 
+// Schema describes the on-disk location of the provider schema artifacts.
 type Schema struct {
 	WorkingDir string
 
 	ProviderSchemaFile string
 }
 
+// New creates a Schema rooted at ./tmp under the current working directory.
 func New() (*Schema, error) {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -36,6 +41,7 @@ func New() (*Schema, error) {
 	}, nil
 }
 
+// Load returns the parsed provider schema, fetching and generating it if needed.
 func Load(ctx context.Context) (*tfjson.ProviderSchema, error) {
 	s, err := New()
 	if err != nil {

--- a/bundle/internal/tf/codegen/schema/version.go
+++ b/bundle/internal/tf/codegen/schema/version.go
@@ -1,3 +1,4 @@
 package schema
 
+// ProviderVersion is the version of the Databricks Terraform provider used for codegen.
 const ProviderVersion = "1.113.0"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,6 +4,8 @@ go 1.25.0
 
 toolchain go1.25.9
 
+require github.com/stretchr/testify v1.11.1
+
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
@@ -180,7 +182,6 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tetafro/godot v1.5.4 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect

--- a/tools/testmask/main.go
+++ b/tools/testmask/main.go
@@ -1,3 +1,5 @@
+// Command testmask reads Taskfile.yml to decide which CI jobs should run
+// based on the set of files changed in a PR.
 package main
 
 import (

--- a/tools/testrunner/main.go
+++ b/tools/testrunner/main.go
@@ -127,7 +127,7 @@ func downloadConfig(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
@@ -155,7 +155,7 @@ func checkFailures(config *Config, jsonFile string, originalExitCode int) int {
 		fmt.Printf("testrunner: failed to open JSON file %s: %v\n", jsonFile, err)
 		return originalExitCode
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	unexpectedFailures := map[string]bool{}
@@ -202,10 +202,9 @@ func checkFailures(config *Config, jsonFile string, originalExitCode int) int {
 
 	if len(unexpectedFailures) == 0 {
 		return 0
-	} else {
-		fmt.Printf("testrunner: %d test failures were not expected\n", len(unexpectedFailures))
-		return originalExitCode
 	}
+	fmt.Printf("testrunner: %d test failures were not expected\n", len(unexpectedFailures))
+	return originalExitCode
 }
 
 // CI Config Format
@@ -330,9 +329,8 @@ func (r ConfigRule) matches(packageName, testName string) bool {
 	// Check test pattern
 	if r.TestPrefix {
 		return matchesPathPrefix(testName, r.TestPattern) || matchesPathPrefix(r.TestPattern, testName)
-	} else {
-		return testName == r.TestPattern || matchesPathPrefix(r.TestPattern, testName)
 	}
+	return testName == r.TestPattern || matchesPathPrefix(r.TestPattern, testName)
 }
 
 // matchesPathPrefix returns true if s matches pattern or starts with pattern + "/"

--- a/tools/testrunner/main.go
+++ b/tools/testrunner/main.go
@@ -117,7 +117,7 @@ func main() {
 }
 
 func downloadConfig(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", repoConfigURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, repoConfigURL, nil)
 	if err != nil {
 		return "", err
 	}

--- a/tools/testrunner/main_test.go
+++ b/tools/testrunner/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigRuleMatches(t *testing.T) {
@@ -59,7 +60,7 @@ func TestConfigRuleMatches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input+"_"+tt.packageName+"_"+tt.testcase, func(t *testing.T) {
 			rule, err := parseConfigRule(tt.input, tt.input)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			result := rule.matches(tt.packageName, tt.testcase)
 			assert.Equal(t, tt.match, result)
 		})

--- a/tools/testrunner/main_test.go
+++ b/tools/testrunner/main_test.go
@@ -36,9 +36,9 @@ func TestConfigRuleMatches(t *testing.T) {
 		{"libs/ *", "libs/auth", "AnyTest", true},
 
 		// Path prefix edge cases
-		{"TestAccept/ TestAccept/", "TestAccept", "TestAccept", true},
-		{"TestAccept/ TestAccept/", "TestAccept/bundle", "TestAccept/deploy", true},
-		{"TestAccept/ TestAccept/", "TestAcceptSomething", "TestAcceptSomething", false},
+		{"TestAccept/ TestAccept/", "TestAccept", "TestAccept", true},                    //nolint:dupword
+		{"TestAccept/ TestAccept/", "TestAccept/bundle", "TestAccept/deploy", true},      //nolint:dupword
+		{"TestAccept/ TestAccept/", "TestAcceptSomething", "TestAcceptSomething", false}, //nolint:dupword
 
 		// Empty values cases
 		{"* TestDeploy", "", "TestDeploy", true},


### PR DESCRIPTION
## Changes
Fix lint & mod tidy issues in tools and codegen -- those have their own go.mod so not checked by our regular linting.

I have a follow up PR to run those linters.

## Tests
```
! sh -c 'cd bundle/internal/tf/codegen && ../../../../tools/golangci-lint run --config ../../../../.golangci.yaml --disable gocritic ./...'
  ⎿  0 issues.

! cd tools && ./golangci-lint run --config ../.golangci.yaml --disable gocritic ./...
  ⎿  0 issues.
```
