### PR TITLE
Deprecate `auth env`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Added `--limit` flag to all paginated list commands for client-side result capping ([#4984](https://github.com/databricks/cli/pull/4984)).
 * Accept `yes` in addition to `y` for confirmation prompts, and show `[y/N]` to indicate that no is the default.
+* Deprecated `auth env`. The command is hidden from help listings and prints a deprecation warning to stderr; it will be removed in a future release.
 
 ### Bundles
 * Remove `experimental-jobs-as-code` template, superseded by `pydabs` ([#4999](https://github.com/databricks/cli/pull/4999)).

--- a/cmd/auth/env.go
+++ b/cmd/auth/env.go
@@ -93,8 +93,12 @@ func loadFromDatabricksCfg(ctx context.Context, cfg *config.Config) error {
 
 func newEnvCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "env",
-		Short: "Get env",
+		Use:    "env",
+		Short:  "Get env (deprecated)",
+		Hidden: true,
+		Long: `Get env.
+
+Deprecated: this command will be removed in a future release.`,
 	}
 
 	var host string
@@ -103,6 +107,8 @@ func newEnvCommand() *cobra.Command {
 	cmd.Flags().StringVar(&profile, "profile", profile, "Profile to get auth env for")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		fmt.Fprintln(cmd.ErrOrStderr(), "Warning: 'databricks auth env' is deprecated and will be removed in a future release.")
+
 		cfg := &config.Config{
 			Host:    host,
 			Profile: profile,


### PR DESCRIPTION
## Why

`auth env` has never really fit the rest of the CLI. It has its own custom auth resolution (local `--host`/`--profile` flags, manual ini scanning) instead of going through the standard auth chain, and it overlaps with what callers can get from the SDK directly. Rather than invest more in maintaining it, we want to signal that it's on its way out so users stop depending on it.

## Changes

Deprecate the command:

- `Hidden: true` — no longer shows up under `databricks auth --help` (still invokable, `--help` still works).
- Prints `Warning: 'databricks auth env' is deprecated and will be removed in a future release.` to stderr on every invocation.
- Long help and `Short` mention the deprecation.

Behavior is otherwise unchanged. JSON output shape, flags, and resolution logic all stay identical so anything currently scripting against the command keeps working until the removal PR.

Replaces #4904, which mixed this deprecation with a larger refactor.

## Test plan

- [x] `make checks` clean
- [x] `go test ./cmd/auth/...` passes
- [x] `databricks auth env --help` still works and shows the "Deprecated" note
- [x] `databricks auth env` no longer appears under `databricks auth --help`
- [x] Running the command prints the warning to stderr and the JSON env output to stdout unchanged