### PR TITLE
direct: Make update mask fixed for apps

### DIFF
--- a/acceptance/bundle/resources/apps/lifecycle-started/output.txt
+++ b/acceptance/bundle/resources/apps/lifecycle-started/output.txt
@@ -84,7 +84,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_2",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
   }
 }
 
@@ -112,7 +112,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_3",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -15,7 +15,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "description"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
   },
   "method": "POST",
   "path": "/api/2.0/apps/myappname/update"

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -163,9 +163,14 @@ func (r *ResourceApp) DoCreate(ctx context.Context, config *AppState) (string, *
 }
 
 var UpdateMaskFields = []string{
-	"description", "budget_policy_id", "usage_policy_id", "resources",
-	"user_api_scopes", "compute_size", "compute_min_instances", "compute_max_instances",
-	"git_repository", "telemetry_export_destinations",
+	"description",
+	"budget_policy_id",
+	"usage_policy_id",
+	"resources",
+	"user_api_scopes",
+	"compute_size",
+	"git_repository",
+	"telemetry_export_destinations",
 }
 
 func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState, entry *PlanEntry) (*AppRemote, error) {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -173,6 +173,8 @@ var UpdateMaskFields = []string{
 	"telemetry_export_destinations",
 }
 
+var updateMask = strings.Join(UpdateMaskFields, ",")
+
 func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState, entry *PlanEntry) (*AppRemote, error) {
 	// Deploy-only fields (source_code_path, config,
 	// git_source, lifecycle) are not part of apps.App and thus excluded from the request body.
@@ -180,7 +182,7 @@ func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState,
 		request := apps.AsyncUpdateAppRequest{
 			App:        &config.App,
 			AppName:    id,
-			UpdateMask: strings.Join(UpdateMaskFields, ","),
+			UpdateMask: updateMask,
 		}
 		updateWaiter, err := r.client.Apps.CreateUpdate(ctx, request)
 		if err != nil {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -163,23 +162,20 @@ func (r *ResourceApp) DoCreate(ctx context.Context, config *AppState) (string, *
 	return app.Name, nil, nil
 }
 
+var UpdateMaskFields = []string{
+	"description", "budget_policy_id", "usage_policy_id", "resources",
+	"user_api_scopes", "compute_size", "compute_min_instances", "compute_max_instances",
+	"git_repository", "telemetry_export_destinations",
+}
+
 func (r *ResourceApp) DoUpdate(ctx context.Context, id string, config *AppState, entry *PlanEntry) (*AppRemote, error) {
 	// Deploy-only fields (source_code_path, config,
 	// git_source, lifecycle) are not part of apps.App and thus excluded from the request body.
 	if hasAppChanges(entry) {
-		fieldPaths := collectUpdatePathsWithPrefix(entry.Changes, "")
-		slices.Sort(fieldPaths)
-		for i, fieldPath := range fieldPaths {
-			fieldPaths[i] = truncateAtIndex(fieldPath)
-		}
-		fieldPaths = slices.DeleteFunc(fieldPaths, func(p string) bool {
-			return deployOnlyFields[p]
-		})
-		updateMask := strings.Join(fieldPaths, ",")
 		request := apps.AsyncUpdateAppRequest{
 			App:        &config.App,
 			AppName:    id,
-			UpdateMask: updateMask,
+			UpdateMask: strings.Join(UpdateMaskFields, ","),
 		}
 		updateWaiter, err := r.client.Apps.CreateUpdate(ctx, request)
 		if err != nil {

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -152,8 +152,8 @@ func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 	// iterate over all apps.App fields using reflection and ensure that UpdateMaskFields contains all of them.
 	app := apps.App{}
 	fields := reflect.TypeOf(app)
-	allFields := make([]string, 0)
-	for i := 0; i < fields.NumField(); i++ {
+	var allFields []string
+	for i := range fields.NumField() {
 		field := fields.Field(i)
 		jsonTag := field.Tag.Get("json")
 		if jsonTag == "" || jsonTag == "-" {

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -124,32 +124,29 @@ func TestAppDoCreate_RetriesWhenGetReturnsNotFound(t *testing.T) {
 	assert.Equal(t, 1, getCallCount, "expected Get to be called once to check app state")
 }
 
-var nonUpdatableFields = []string{
-	"id",
-	"url",
-	"updater",
-	"create_time",
-	"update_time",
-	"space",
-	"service_principal_name",
-	"service_principal_id",
-	"service_principal_client_id",
-	"oauth2_app_client_id",
-	"oauth2_app_integration_id",
-	"pending_deployment",
-	"active_deployment",
-	"app_status",
-	"compute_status",
-	"creator",
-	"default_source_code_path",
-	"effective_budget_policy_id",
-	"effective_usage_policy_id",
-	"effective_user_api_scopes",
-	"name",
-}
-
 func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 	// iterate over all apps.App fields using reflection and ensure that UpdateMaskFields contains all of them.
+	config := GetGeneratedResourceConfig("apps")
+	require.NotNil(t, config)
+	var nonUpdatableFields []string
+	for _, field := range config.IgnoreRemoteChanges {
+		nonUpdatableFields = append(nonUpdatableFields, field.Field.String())
+	}
+
+	for _, field := range config.RecreateOnChanges {
+		nonUpdatableFields = append(nonUpdatableFields, field.Field.String())
+	}
+
+	config = GetResourceConfig("apps")
+	require.NotNil(t, config)
+	for _, field := range config.IgnoreRemoteChanges {
+		nonUpdatableFields = append(nonUpdatableFields, field.Field.String())
+	}
+
+	for _, field := range config.RecreateOnChanges {
+		nonUpdatableFields = append(nonUpdatableFields, field.Field.String())
+	}
+
 	app := apps.App{}
 	fields := reflect.TypeOf(app)
 	var allFields []string

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -1,6 +1,9 @@
 package dresources
 
 import (
+	"reflect"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/databricks/cli/libs/testserver"
@@ -119,4 +122,29 @@ func TestAppDoCreate_RetriesWhenGetReturnsNotFound(t *testing.T) {
 	assert.Equal(t, "test-app", name)
 	assert.Equal(t, 2, createCallCount, "expected Create to be called twice")
 	assert.Equal(t, 1, getCallCount, "expected Get to be called once to check app state")
+}
+
+var nonUpdatableFields = []string{
+	"id", "url", "updater", "create_time",
+	"update_time", "space", "service_principal_name", "service_principal_id",
+	"service_principal_client_id", "oauth2_app_client_id", "oauth2_app_integration_id", "pending_deployment",
+	"active_deployment", "app_status", "compute_status", "creator", "default_source_code_path",
+	"effective_budget_policy_id", "effective_usage_policy_id", "effective_user_api_scopes", "name",
+}
+
+func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
+	// iterate over all apps.App fields using reflection and ensure that UpdateMaskFields contains all of them.
+	app := apps.App{}
+	fields := reflect.TypeOf(app)
+	for i := 0; i < fields.NumField(); i++ {
+		field := fields.Field(i)
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "" || jsonTag == "-" {
+			continue
+		}
+		jsonTag = strings.TrimSuffix(jsonTag, ",omitempty")
+		if !slices.Contains(nonUpdatableFields, jsonTag) {
+			assert.Contains(t, UpdateMaskFields, jsonTag, "field %s is not in UpdateMaskFields and not marked as non-updatable", jsonTag)
+		}
+	}
 }

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -125,17 +125,34 @@ func TestAppDoCreate_RetriesWhenGetReturnsNotFound(t *testing.T) {
 }
 
 var nonUpdatableFields = []string{
-	"id", "url", "updater", "create_time",
-	"update_time", "space", "service_principal_name", "service_principal_id",
-	"service_principal_client_id", "oauth2_app_client_id", "oauth2_app_integration_id", "pending_deployment",
-	"active_deployment", "app_status", "compute_status", "creator", "default_source_code_path",
-	"effective_budget_policy_id", "effective_usage_policy_id", "effective_user_api_scopes", "name",
+	"id",
+	"url",
+	"updater",
+	"create_time",
+	"update_time",
+	"space",
+	"service_principal_name",
+	"service_principal_id",
+	"service_principal_client_id",
+	"oauth2_app_client_id",
+	"oauth2_app_integration_id",
+	"pending_deployment",
+	"active_deployment",
+	"app_status",
+	"compute_status",
+	"creator",
+	"default_source_code_path",
+	"effective_budget_policy_id",
+	"effective_usage_policy_id",
+	"effective_user_api_scopes",
+	"name",
 }
 
 func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 	// iterate over all apps.App fields using reflection and ensure that UpdateMaskFields contains all of them.
 	app := apps.App{}
 	fields := reflect.TypeOf(app)
+	allFields := make([]string, 0)
 	for i := 0; i < fields.NumField(); i++ {
 		field := fields.Field(i)
 		jsonTag := field.Tag.Get("json")
@@ -143,8 +160,13 @@ func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 			continue
 		}
 		jsonTag = strings.TrimSuffix(jsonTag, ",omitempty")
+		allFields = append(allFields, jsonTag)
 		if !slices.Contains(nonUpdatableFields, jsonTag) {
 			assert.Contains(t, UpdateMaskFields, jsonTag, "field %s is not in UpdateMaskFields and not marked as non-updatable", jsonTag)
 		}
+	}
+
+	for _, field := range UpdateMaskFields {
+		assert.Contains(t, allFields, field, "field %s is in UpdateMaskFields but not in apps.App struct", field)
 	}
 }

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -385,6 +385,9 @@ resources:
       # drift detection applies (e.g. detecting out-of-band stop).
       - field: lifecycle
       - field: lifecycle.started
+    ignore_remote_changes:
+      - field: space # This field is not yet supported by Update APIs but exposed in the API spec. TODO: fix when update APIs supports it.
+        reason: managed
 
   secret_scopes:
     backend_defaults:


### PR DESCRIPTION
## Changes
Make update mask fixed for apps

## Why
This is to avoid issues when we try to pass field which update API can't support

## Tests
Added a test which check the completness of the set of the fields using reflection.

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
