### PR TITLE
Prompt before destroying Lakebase resources

### DIFF
--- a/acceptance/bundle/resources/database_catalogs/basic/output.txt
+++ b/acceptance/bundle/resources/database_catalogs/basic/output.txt
@@ -47,6 +47,10 @@ The following resources will be deleted:
   delete resources.database_catalogs.my_catalog
   delete resources.database_instances.my_instance
 
+This action will result in the deletion of the following Lakebase database instances.
+All data stored in them will be permanently lost:
+  delete resources.database_instances.my_instance
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-catalog-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/database_instances/single-instance/output.txt
+++ b/acceptance/bundle/resources/database_instances/single-instance/output.txt
@@ -59,6 +59,10 @@ Resources:
 The following resources will be deleted:
   delete resources.database_instances.my_database
 
+This action will result in the deletion of the following Lakebase database instances.
+All data stored in them will be permanently lost:
+  delete resources.database_instances.my_database
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-single-instance-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/output.txt
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/output.txt
@@ -61,6 +61,10 @@ Warning: unknown field: instance_profile_arn
 The following resources will be deleted:
   delete resources.database_instances.foo
 
+This action will result in the deletion of the following Lakebase database instances.
+All data stored in them will be permanently lost:
+  delete resources.database_instances.foo
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
 
 Deleting files...

--- a/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/output.txt
+++ b/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/output.txt
@@ -29,6 +29,10 @@ Deployment complete!
 The following resources will be deleted:
   delete resources.postgres_projects.foo
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.foo
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_branches/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/basic/output.txt
@@ -69,6 +69,14 @@ The following resources will be deleted:
   delete resources.postgres_branches.main
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.main
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-branch-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_branches/recreate/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/recreate/output.txt
@@ -64,6 +64,10 @@ resources:
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-branch-recreate-[UNIQUE_NAME]/default/files...
+
+This action will result in the deletion or recreation of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  recreate resources.postgres_branches.main
 Deploying resources...
 Updating deployment state...
 Deployment complete!
@@ -74,6 +78,14 @@ Deployment complete!
 The following resources will be deleted:
   delete resources.postgres_branches.main
   delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.main
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-branch-recreate-[UNIQUE_NAME]/default
 

--- a/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
@@ -154,6 +154,14 @@ The following resources will be deleted:
   delete resources.postgres_branches.dev_branch
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.dev_branch
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/update-postgres-branch-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
@@ -87,6 +87,14 @@ The following resources will be deleted:
   delete resources.postgres_endpoints.custom
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.main
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-endpoint-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/output.txt
@@ -147,6 +147,14 @@ The following resources will be deleted:
   delete resources.postgres_endpoints.my_endpoint
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.main
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-endpoint-recreate-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
@@ -187,6 +187,14 @@ The following resources will be deleted:
   delete resources.postgres_endpoints.my_endpoint
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:
+  delete resources.postgres_branches.main
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/update-postgres-endpoint-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_projects/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/basic/output.txt
@@ -64,6 +64,10 @@ Resources:
 The following resources will be deleted:
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-single-project-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/postgres_projects/recreate/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/output.txt
@@ -51,6 +51,10 @@ resources:
 
 >>> [CLI] bundle deploy --auto-approve
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-recreate-[UNIQUE_NAME]/default/files...
+
+This action will result in the deletion or recreation of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  recreate resources.postgres_projects.my_project
 Deploying resources...
 Updating deployment state...
 Deployment complete!
@@ -59,6 +63,10 @@ Deployment complete!
 === Destroy and verify cleanup
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
+  delete resources.postgres_projects.my_project
+
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
   delete resources.postgres_projects.my_project
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-postgres-recreate-[UNIQUE_NAME]/default

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
@@ -157,6 +157,10 @@ Deployment complete!
 The following resources will be deleted:
   delete resources.postgres_projects.my_project
 
+This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:
+  delete resources.postgres_projects.my_project
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/update-postgres-project-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/acceptance/bundle/resources/synced_database_tables/basic/output.txt
+++ b/acceptance/bundle/resources/synced_database_tables/basic/output.txt
@@ -50,6 +50,14 @@ The following resources will be deleted:
   delete resources.database_instances.my_instance
   delete resources.synced_database_tables.my_synced_table
 
+This action will result in the deletion of the following Lakebase database instances.
+All data stored in them will be permanently lost:
+  delete resources.database_instances.my_instance
+
+This action will result in the deletion of the following synced database tables.
+The synced data in the destination database will be lost (the source table is preserved):
+  delete resources.synced_database_tables.my_synced_table
+
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/deploy-lakebase-synced-table-[UNIQUE_NAME]/default
 
 Deleting files...

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -39,9 +39,15 @@ func approvalForDeploy(ctx context.Context, b *bundle.Bundle, plan *deployplan.P
 	pipelineActions := filterGroup(actions, "pipelines", types...)
 	volumeActions := filterGroup(actions, "volumes", types...)
 	dashboardActions := filterGroup(actions, "dashboards", types...)
+	databaseInstanceActions := filterGroup(actions, "database_instances", types...)
+	syncedDatabaseTableActions := filterGroup(actions, "synced_database_tables", types...)
+	postgresProjectActions := filterGroup(actions, "postgres_projects", types...)
+	postgresBranchActions := filterGroup(actions, "postgres_branches", types...)
 
 	// We don't need to display any prompts in this case.
-	if len(schemaActions) == 0 && len(pipelineActions) == 0 && len(volumeActions) == 0 && len(dashboardActions) == 0 {
+	if len(schemaActions) == 0 && len(pipelineActions) == 0 && len(volumeActions) == 0 && len(dashboardActions) == 0 &&
+		len(databaseInstanceActions) == 0 && len(syncedDatabaseTableActions) == 0 &&
+		len(postgresProjectActions) == 0 && len(postgresBranchActions) == 0 {
 		return true, nil
 	}
 
@@ -76,6 +82,38 @@ func approvalForDeploy(ctx context.Context, b *bundle.Bundle, plan *deployplan.P
 	if len(dashboardActions) != 0 {
 		cmdio.LogString(ctx, deleteOrRecreateDashboardMessage)
 		for _, action := range dashboardActions {
+			cmdio.Log(ctx, action)
+		}
+	}
+
+	// One or more database instances is being deleted or recreated.
+	if len(databaseInstanceActions) != 0 {
+		cmdio.LogString(ctx, deleteOrRecreateDatabaseInstanceMessage)
+		for _, action := range databaseInstanceActions {
+			cmdio.Log(ctx, action)
+		}
+	}
+
+	// One or more synced database tables is being deleted or recreated.
+	if len(syncedDatabaseTableActions) != 0 {
+		cmdio.LogString(ctx, deleteOrRecreateSyncedDatabaseTableMessage)
+		for _, action := range syncedDatabaseTableActions {
+			cmdio.Log(ctx, action)
+		}
+	}
+
+	// One or more Lakebase projects is being deleted or recreated.
+	if len(postgresProjectActions) != 0 {
+		cmdio.LogString(ctx, deleteOrRecreatePostgresProjectMessage)
+		for _, action := range postgresProjectActions {
+			cmdio.Log(ctx, action)
+		}
+	}
+
+	// One or more Lakebase branches is being deleted or recreated.
+	if len(postgresBranchActions) != 0 {
+		cmdio.LogString(ctx, deleteOrRecreatePostgresBranchMessage)
+		for _, action := range postgresBranchActions {
 			cmdio.Log(ctx, action)
 		}
 	}

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -54,6 +54,10 @@ func approvalForDestroy(ctx context.Context, b *bundle.Bundle, plan *deployplan.
 	schemaActions := filterGroup(deleteActions, "schemas", deployplan.Delete)
 	pipelineActions := filterGroup(deleteActions, "pipelines", deployplan.Delete)
 	volumeActions := filterGroup(deleteActions, "volumes", deployplan.Delete)
+	databaseInstanceActions := filterGroup(deleteActions, "database_instances", deployplan.Delete)
+	syncedDatabaseTableActions := filterGroup(deleteActions, "synced_database_tables", deployplan.Delete)
+	postgresProjectActions := filterGroup(deleteActions, "postgres_projects", deployplan.Delete)
+	postgresBranchActions := filterGroup(deleteActions, "postgres_branches", deployplan.Delete)
 
 	if len(schemaActions) > 0 {
 		cmdio.LogString(ctx, deleteSchemaMessage)
@@ -74,6 +78,38 @@ func approvalForDestroy(ctx context.Context, b *bundle.Bundle, plan *deployplan.
 	if len(volumeActions) > 0 {
 		cmdio.LogString(ctx, deleteVolumeMessage)
 		for _, a := range volumeActions {
+			cmdio.Log(ctx, a)
+		}
+		cmdio.LogString(ctx, "")
+	}
+
+	if len(databaseInstanceActions) > 0 {
+		cmdio.LogString(ctx, deleteDatabaseInstanceMessage)
+		for _, a := range databaseInstanceActions {
+			cmdio.Log(ctx, a)
+		}
+		cmdio.LogString(ctx, "")
+	}
+
+	if len(syncedDatabaseTableActions) > 0 {
+		cmdio.LogString(ctx, deleteSyncedDatabaseTableMessage)
+		for _, a := range syncedDatabaseTableActions {
+			cmdio.Log(ctx, a)
+		}
+		cmdio.LogString(ctx, "")
+	}
+
+	if len(postgresProjectActions) > 0 {
+		cmdio.LogString(ctx, deletePostgresProjectMessage)
+		for _, a := range postgresProjectActions {
+			cmdio.Log(ctx, a)
+		}
+		cmdio.LogString(ctx, "")
+	}
+
+	if len(postgresBranchActions) > 0 {
+		cmdio.LogString(ctx, deletePostgresBranchMessage)
+		for _, a := range postgresBranchActions {
 			cmdio.Log(ctx, a)
 		}
 		cmdio.LogString(ctx, "")

--- a/bundle/phases/messages.go
+++ b/bundle/phases/messages.go
@@ -20,6 +20,22 @@ is removed from the catalog, but the underlying files are not deleted:`
 	deleteOrRecreateDashboardMessage = `
 This action will result in the deletion or recreation of the following dashboards.
 This will result in changed IDs and permanent URLs of the dashboards that will be recreated:`
+
+	deleteOrRecreateDatabaseInstanceMessage = `
+This action will result in the deletion or recreation of the following Lakebase database instances.
+All data stored in them will be permanently lost:`
+
+	deleteOrRecreateSyncedDatabaseTableMessage = `
+This action will result in the deletion or recreation of the following synced database tables.
+The synced data in the destination database will be lost (the source table is preserved):`
+
+	deleteOrRecreatePostgresProjectMessage = `
+This action will result in the deletion or recreation of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:`
+
+	deleteOrRecreatePostgresBranchMessage = `
+This action will result in the deletion or recreation of the following Lakebase branches.
+All data stored in them will be permanently lost:`
 )
 
 // Messages for bundle destroy.
@@ -33,4 +49,16 @@ Streaming Tables (STs) and Materialized Views (MVs) managed by them:`
 For managed volumes, the files stored in the volume are also deleted from your
 cloud tenant within 30 days. For external volumes, the metadata about the volume
 is removed from the catalog, but the underlying files are not deleted:`
+
+	deleteDatabaseInstanceMessage = `This action will result in the deletion of the following Lakebase database instances.
+All data stored in them will be permanently lost:`
+
+	deleteSyncedDatabaseTableMessage = `This action will result in the deletion of the following synced database tables.
+The synced data in the destination database will be lost (the source table is preserved):`
+
+	deletePostgresProjectMessage = `This action will result in the deletion of the following Lakebase projects along with
+all their branches, databases, and endpoints. All data stored in them will be permanently lost:`
+
+	deletePostgresBranchMessage = `This action will result in the deletion of the following Lakebase branches.
+All data stored in them will be permanently lost:`
 )


### PR DESCRIPTION
## Summary
Extend the deploy/destroy data-loss warning to cover `database_instances`, `synced_database_tables`, `postgres_projects`, and `postgres_branches`. Deleting or recreating any of these can result in permanent data loss.

Note: the output here is not optimal and deserves attention. I'm mirroring existing patterns in this PR.

This pull request and its description were written by Isaac.