### PR TITLE
Bump AppKit in the `apps init` flow to 0.24.0

### DIFF
--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -37,7 +37,7 @@ const (
 	appkitTemplateDir    = "template"
 	appkitDefaultBranch  = "main"
 	appkitTemplateTagPfx = "template-v"
-	appkitDefaultVersion = "template-v0.23.0"
+	appkitDefaultVersion = "template-v0.24.0"
 	defaultProfile       = "DEFAULT"
 )
 


### PR DESCRIPTION
## Summary
- Bumps default AppKit version from 0.23.0 to 0.24.0

## Test plan
- [x] `go test ./cmd/apps/...` passes

This pull request and its description were written by Isaac.