### PR TITLE
acceptance: mark vector search endpoint tests as RequiresUnityCatalog

### DIFF
--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 
 Ignore = [
     ".databricks",

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 
 # Vector Search endpoints are only available in direct mode (no Terraform provider)
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = false
+RequiresUnityCatalog = true
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]


### PR DESCRIPTION
## Summary
- Adds `RequiresUnityCatalog = true` to vector search endpoint acceptance tests so they run against UC-enabled cloud environments.
    - Added it to all VS tests (including `Cloud = false`) in case we make them `Cloud = true` later

## Test plan
- [ ] CI acceptance tests pass
- [ ] Cloud run picks up the UC requirement correctly

This pull request and its description were written by Isaac.