### PR TITLE
Prepare NEXT_CHANGELOG for v0.298.0

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -2,23 +2,19 @@
 
 ## Release v0.298.0
 
-### Notable Changes
-
 ### CLI
-
-* Added `--limit` flag to all paginated list commands for client-side result capping ([#4984](https://github.com/databricks/cli/pull/4984)).
+* Added `--limit` flag to all paginated list commands for client-side result capping ([#4984](https://github.com/databricks/cli/pull/4984)). On `jobs list` and `jobs list-runs` the former API page-size flag was renamed to `--page-size` (hidden) to avoid collision.
 * Accept `yes` in addition to `y` for confirmation prompts, and show `[y/N]` to indicate that no is the default.
 * Deprecated `auth env`. The command is hidden from help listings and prints a deprecation warning to stderr; it will be removed in a future release.
 
 ### Bundles
 * Remove `experimental-jobs-as-code` template, superseded by `pydabs` ([#4999](https://github.com/databricks/cli/pull/4999)).
-* engine/direct: Added support for Vector Search Endpoints ([#4887](https://github.com/databricks/cli/pull/4887))
-* engine/direct: Exclude deploy-only fields (e.g. `lifecycle`) from the Apps update mask so requests that change both `description` and `lifecycle.started` in the same deploy no longer fail with `INVALID_PARAMETER_VALUE`.
-* engine/direct: Fix phantom diffs from `depends_on` reordering in job tasks ([#4990](https://github.com/databricks/cli/pull/4990))
+* Prompt before destroying or recreating Lakebase resources (database instances, synced database tables, postgres projects and branches) ([#5052](https://github.com/databricks/cli/pull/5052)).
+* Treat deleted resources as not running in the `fail-on-active-runs` check ([#5044](https://github.com/databricks/cli/pull/5044)).
+* engine/direct: Added support for Vector Search Endpoints ([#4887](https://github.com/databricks/cli/pull/4887)).
+* engine/direct: Exclude deploy-only fields (e.g. `lifecycle`) from the Apps update mask so requests that change both `description` and `lifecycle.started` in the same deploy no longer fail with `INVALID_PARAMETER_VALUE` ([#5042](https://github.com/databricks/cli/pull/5042), [#5051](https://github.com/databricks/cli/pull/5051)).
+* engine/direct: Fix phantom diffs from `depends_on` reordering in job tasks ([#4990](https://github.com/databricks/cli/pull/4990)).
 
 ### Dependency updates
-
 * Bump `github.com/databricks/databricks-sdk-go` from v0.126.0 to v0.128.0 ([#4984](https://github.com/databricks/cli/pull/4984), [#5031](https://github.com/databricks/cli/pull/5031)).
-* Bump Go toolchain to 1.25.9 ([#5004](https://github.com/databricks/cli/pull/5004))
-
-### API Changes
+* Bump Go toolchain to 1.25.9 ([#5004](https://github.com/databricks/cli/pull/5004)).


### PR DESCRIPTION
## Summary
- Add Lakebase destroy/recreate prompt (#5052) and fail-on-active-runs deleted-resource fix (#5044) to the Bundles section.
- Note the `jobs list` / `jobs list-runs` `--page-size` rename that came with the repo-wide `--limit` flag from the SDK v0.127.0 bump.
- Attribute the Apps update-mask change to #5042 and #5051 (the follow-up that made the mask a fixed allowlist).
- Clean up inconsistencies: drop the empty `Notable Changes` and `API Changes` sections, normalize trailing periods, and tighten blank lines under section headers.