### PR TITLE
acceptance: skip pydabs_1000_tasks in migrate + continue_293 invariants

### DIFF
--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -11,3 +11,7 @@ EnvMatrixExclude.no_vector_search_endpoint = ["INPUT_CONFIG=vector_search_endpoi
 
 # Dotted pipeline configuration keys are not supported on v0.293.0
 EnvMatrixExclude.no_pipeline_config_dots = ["INPUT_CONFIG=pipeline_config_dots.yml.tmpl"]
+
+# The 1000-task scale case is covered by no_drift. Running it here adds ~1.5 min
+# per variant (two full deploys at 1000 tasks) without incremental coverage.
+EnvMatrixExclude.no_pydabs_1000_tasks = ["INPUT_CONFIG=job_pydabs_1000_tasks.yml.tmpl"]

--- a/acceptance/bundle/invariant/migrate/test.toml
+++ b/acceptance/bundle/invariant/migrate/test.toml
@@ -19,3 +19,7 @@ EnvMatrixExclude.no_grant_ref = ["INPUT_CONFIG=schema_grant_ref.yml.tmpl"]
 
 # SQL warehouses currently failing with migration with permanent drift. TODO: fix this.
 EnvMatrixExclude.no_sql_warehouse = ["INPUT_CONFIG=sql_warehouse.yml.tmpl"]
+
+# The 1000-task scale case is covered by no_drift. Running it here adds ~1.5 min
+# per variant (deploy + migrate + plan at 1000 tasks) without incremental coverage.
+EnvMatrixExclude.no_pydabs_1000_tasks = ["INPUT_CONFIG=job_pydabs_1000_tasks.yml.tmpl"]


### PR DESCRIPTION
Drop `job_pydabs_1000_tasks` from the `migrate` and `continue_293` invariants — they are the top-2 slowest acceptance tests on `*/direct` jobs. `no_drift` still runs the same 1000-task config every PR, so the deploy + plan path stays covered at scale.

We do lose some coverage: scale-specific bugs in the terraform→direct state migration path (`migrate`) or in v0.293.0-state back-compat (`continue_293`) wouldn't be caught at 1000 tasks anymore. Both invariants still run their full set of other configs every PR. Given how heavy these two tests are, the trade-off is worth it.

The real fix is to make the 1000-task case fast in principle, but that's a separate effort. This PR buys back PR-CI time today; speeding up the underlying path is what makes the dropped coverage cheap to restore later.

Measured savings vs main:

- linux/direct: 8m47s → 5m20s
- macos/direct: 11m9s → 8m19s
- windows/direct: 25m44s → 24m15s

This pull request and its description were written by Isaac.