### PR TITLE
Move tool.uv.dev-dependencies (deprecated) to dependency-groups.dev

### DIFF
--- a/python/codegen/pyproject.toml
+++ b/python/codegen/pyproject.toml
@@ -11,7 +11,7 @@ testpaths = [
     "codegen_tests",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
   "pytest==8.3.3",
 ]


### PR DESCRIPTION
## Summary

- Move `python/codegen/pyproject.toml` off the deprecated `[tool.uv] dev-dependencies` key onto the [PEP 735](https://peps.python.org/pep-0735) `[dependency-groups] dev` table.
- See https://docs.astral.sh/uv/concepts/projects/dependencies/#legacy-dev-dependencies for the upstream deprecation note.
- `uv.lock` does not need regeneration: uv represents both forms with the same `[package.dev-dependencies]` / `[package.metadata.requires-dev]` structure.

## Test plan

- [ ] `uv lock --check` in `python/codegen/` passes (lockfile still consistent with `pyproject.toml`).

This pull request and its description were written by Isaac.