### PR TITLE
Fix nil pointer dereference in `doBuild` when shell detection fails

### DIFF
--- a/bundle/artifacts/build.go
+++ b/bundle/artifacts/build.go
@@ -84,16 +84,19 @@ func doBuild(ctx context.Context, artifactName string, a *config.Artifact) error
 	cmdio.LogString(ctx, fmt.Sprintf("Building %s...", artifactName))
 
 	var executor *exec.Executor
-	var err error
 	if a.Executable != "" {
+		var err error
 		executor, err = exec.NewCommandExecutorWithExecutable(a.Path, a.Executable)
+		if err != nil {
+			return err
+		}
 	} else {
+		var err error
 		executor, err = exec.NewCommandExecutor(a.Path)
+		if err != nil {
+			return err
+		}
 		a.Executable = executor.ShellType()
-	}
-
-	if err != nil {
-		return err
 	}
 
 	out, err := executor.Exec(ctx, a.BuildCommand)


### PR DESCRIPTION
Move error checks for `NewCommandExecutor` into the if/else branches so `executor.ShellType()` is only called after confirming success. If `findShell` fails, `executor` is nil and the dereference panics.

Found while reviewing error-handling lint rules.