### PR TITLE
Archive gotestsum JSON for unit and acc tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -150,8 +150,15 @@ jobs:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}
         run: go tool -modfile=tools/task/go.mod task cover
 
-      - name: Analyze slow tests
-        run: go tool -modfile=tools/task/go.mod task slowest
+      - name: Upload gotestsum JSON output
+        # Always upload so we can inspect timing even if tests fail.
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-output-${{ matrix.os.name }}-${{ matrix.deployment }}
+          path: test-output.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Check out.test.toml files are up to date
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -564,13 +564,15 @@ tasks:
 
   cover:
     desc: Run tests with coverage
+    generates:
+      - test-output.json
     cmds:
       - rm -fr ./acceptance/build/cover/
       - |
         VERBOSE_TEST=1 {{.GO_TOOL}} gotestsum \
           --format ${GOTESTSUM_FORMAT:-pkgname-and-test-fails} \
           --no-summary=skipped \
-          --jsonfile test-output.json \
+          --jsonfile test-output-unit.json \
           --rerun-fails \
           --packages "{{.TEST_PACKAGES}}" \
           -- -coverprofile=coverage.txt -timeout=${LOCAL_TIMEOUT:-30m}
@@ -578,10 +580,11 @@ tasks:
         VERBOSE_TEST=1 CLI_GOCOVERDIR=build/cover {{.GO_TOOL}} gotestsum \
           --format ${GOTESTSUM_FORMAT:-pkgname-and-test-fails} \
           --no-summary=skipped \
-          --jsonfile test-output.json \
+          --jsonfile test-output-acc.json \
           --rerun-fails \
           --packages ./acceptance/... \
           -- -timeout=${LOCAL_TIMEOUT:-30m}{{if .ACCEPTANCE_TEST_FILTER}} -run "{{.ACCEPTANCE_TEST_FILTER}}"{{end}}
+      - cat test-output-unit.json test-output-acc.json > test-output.json
       - rm -fr ./acceptance/build/cover-merged/
       - mkdir -p acceptance/build/cover-merged/
       - "go tool covdata merge -i $(printf '%s,' acceptance/build/cover/* | sed 's/,$//') -o acceptance/build/cover-merged/"


### PR DESCRIPTION
## Summary

`task cover` (push-to-main path) wrote both the unit and acceptance gotestsum runs to the same `test-output.json`, so the acc run overwrote the unit run. Mirror what `task test` already does:

- Each gotestsum run writes its own per-run JSON (`test-output-unit.json`, `test-output-acc.json`).
- A trailing `cat` step concatenates them into `test-output.json`, so `task cover` and `task test` produce the same artifact.

Upload `test-output.json` as a per-matrix-entry artifact (`test-output-<os>-<deployment>`) so we can run `gotestsum tool slowest` or ad-hoc queries against the full per-test timing set offline.

This pull request and its description were written by Isaac.