### PR TITLE
Also skip server-side test subtrees on macOS (follow-up to #5072)

### DIFF
--- a/acceptance/bundle/deployment/bind/alert/out.test.toml
+++ b/acceptance/bundle/deployment/bind/alert/out.test.toml
@@ -1,6 +1,10 @@
 Local = false
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   aws = false
 

--- a/acceptance/bundle/deployment/bind/catalog/out.test.toml
+++ b/acceptance/bundle/deployment/bind/catalog/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/cluster/out.test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresCluster = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/database_instance/out.test.toml
+++ b/acceptance/bundle/deployment/bind/database_instance/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/experiment/out.test.toml
+++ b/acceptance/bundle/deployment/bind/experiment/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/external_location/out.test.toml
+++ b/acceptance/bundle/deployment/bind/external_location/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
@@ -1,5 +1,9 @@
 Local = false
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
+++ b/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/registered-model/out.test.toml
+++ b/acceptance/bundle/deployment/bind/registered-model/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/schema/out.test.toml
+++ b/acceptance/bundle/deployment/bind/schema/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
+++ b/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
+++ b/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/test.toml
+++ b/acceptance/bundle/deployment/bind/test.toml
@@ -1,0 +1,3 @@
+# Bind exercises server-side state binding via bundle deploy cycles; OS-agnostic.
+GOOS.windows = false
+GOOS.darwin = false

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/volume/out.test.toml
+++ b/acceptance/bundle/deployment/bind/volume/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/deployment/unbind/grants/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/grants/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/job/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/permissions/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/permissions/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/python-job/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/test.toml
+++ b/acceptance/bundle/deployment/unbind/test.toml
@@ -1,0 +1,3 @@
+# Unbind exercises server-side state binding via bundle deploy cycles; OS-agnostic.
+GOOS.windows = false
+GOOS.darwin = false

--- a/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/create_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/create_error/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/grant_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/grant_ref/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/id_chain/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_chain/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_star/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_star/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_self/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_self/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/permission_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/permission_ref/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/test.toml
+++ b/acceptance/bundle/resource_deps/test.toml
@@ -4,3 +4,8 @@ Ignore = [
     ".databricks",
     ".gitignore",
 ]
+
+# Resource dependency tests exercise server-side resolution via bundle deploy;
+# the CLI behavior under test is OS-agnostic. Linux coverage is sufficient.
+GOOS.windows = false
+GOOS.darwin = false

--- a/acceptance/bundle/resources/alerts/basic/out.test.toml
+++ b/acceptance/bundle/resources/alerts/basic/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/out.test.toml
@@ -1,5 +1,9 @@
 Local = false
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/config-drift/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/default_description/out.test.toml
+++ b/acceptance/bundle/resources/apps/default_description/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,5 +1,9 @@
 Local = false
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/resource-refs/out.test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/update/out.test.toml
+++ b/acceptance/bundle/resources/apps/update/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   aws = false
   azure = false

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 CloudSlow = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-name/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-name/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/destroy/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresWarehouse = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
@@ -4,6 +4,10 @@ CloudSlow = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   gcp = false
 

--- a/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
@@ -3,6 +3,10 @@ Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   gcp = false
 

--- a/acceptance/bundle/resources/experiments/basic/out.test.toml
+++ b/acceptance/bundle/resources/experiments/basic/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/external_locations/out.test.toml
+++ b/acceptance/bundle/resources/external_locations/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/catalogs/out.test.toml
+++ b/acceptance/bundle/resources/grants/catalogs/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/registered_models/out.test.toml
+++ b/acceptance/bundle/resources/grants/registered_models/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/volumes/out.test.toml
+++ b/acceptance/bundle/resources/grants/volumes/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/independent/out.test.toml
+++ b/acceptance/bundle/resources/independent/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/big_id/out.test.toml
+++ b/acceptance/bundle/resources/jobs/big_id/out.test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]
   READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,5 +1,9 @@
 Local = false
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/create-error/out.test.toml
+++ b/acceptance/bundle/resources/jobs/create-error/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/delete_job/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_job/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/delete_task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_task/out.test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
   READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -2,5 +2,9 @@ Local = false
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/num_workers/out.test.toml
+++ b/acceptance/bundle/resources/jobs/num_workers/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
+++ b/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
   READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -2,5 +2,9 @@ Local = false
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update/out.test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
   READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
@@ -2,5 +2,9 @@ Local = false
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/basic/out.test.toml
+++ b/acceptance/bundle/resources/models/basic/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -3,6 +3,7 @@ Cloud = true
 RequiresWarehouse = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [CloudEnvs]

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -4,6 +4,7 @@ CloudSlow = true
 RunsOnDbr = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [CloudEnvs]

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [CloudEnvs]

--- a/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.test.toml
@@ -3,6 +3,7 @@ Cloud = true
 RequiresUnityCatalog = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/local/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/local/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -3,6 +3,7 @@ Cloud = true
 RunsOnDbr = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [CloudEnvs]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -3,6 +3,7 @@ Cloud = true
 RunsOnDbr = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [CloudEnvs]

--- a/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/out.test.toml
@@ -3,6 +3,7 @@ Cloud = false
 Phase = 1
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/permissions/test.toml
+++ b/acceptance/bundle/resources/permissions/test.toml
@@ -1,9 +1,3 @@
 Phase = 1
 RecordRequests = true
 Ignore = ['.databricks']
-
-# Skip on Windows -- permissions tests exercise server-side logic via bundle
-# deploy/update cycles; the CLI behavior under test is OS-agnostic and fully
-# covered by the linux and macos runs. The directory accumulates ~17m of
-# cumulative Windows test time with no incremental signal.
-GOOS.windows = false

--- a/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/quality_monitors/create/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/create/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/basic/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/recreate/out.test.toml
+++ b/acceptance/bundle/resources/schemas/recreate/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/update/out.test.toml
+++ b/acceptance/bundle/resources/schemas/update/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   gcp = false
 

--- a/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   gcp = false
 

--- a/acceptance/bundle/resources/sql_warehouses/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 CloudSlow = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
@@ -3,6 +3,10 @@ Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   gcp = false
 

--- a/acceptance/bundle/resources/test.toml
+++ b/acceptance/bundle/resources/test.toml
@@ -1,1 +1,8 @@
 RecordRequests = true
+
+# Resource tests exercise server-side behavior through bundle deploy/update
+# cycles; the CLI behavior under test is OS-agnostic. Linux runs cover it
+# fully, so the windows and macos matrix entries don't add signal and
+# dominate per-OS wall-clock (~2.3x linux time per test on windows).
+GOOS.windows = false
+GOOS.darwin = false

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/out.test.toml
@@ -2,5 +2,9 @@ Local = true
 Cloud = false
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
+++ b/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/change-comment/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-comment/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-name/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -3,5 +3,9 @@ Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
@@ -2,6 +2,10 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [CloudEnvs]
   azure = false
   gcp = false

--- a/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/dashboard_embed/out.test.toml
+++ b/acceptance/bundle/run_as/dashboard_embed/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_override/out.test.toml
+++ b/acceptance/bundle/run_as/empty_override/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_sp/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
+++ b/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,5 +1,9 @@
 Local = false
 Cloud = true
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/model_serving_different/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_different/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/model_serving_matching/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_matching/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/out.test.toml
+++ b/acceptance/bundle/run_as/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
@@ -1,5 +1,9 @@
 Local = true
 Cloud = false
 
+[GOOS]
+  darwin = false
+  windows = false
+
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/test.toml
+++ b/acceptance/bundle/run_as/test.toml
@@ -1,0 +1,4 @@
+# run_as tests exercise server-side identity impersonation through bundle
+# deploy; CLI behavior under test is OS-agnostic.
+GOOS.windows = false
+GOOS.darwin = false

--- a/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/templates/default-python/combinations/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/test.toml
@@ -1,10 +1,11 @@
 Cloud = true
 
-# Skip on Windows -- 18 matrix variants at ~1m7s each cost ~20m of cumulative
-# Windows test time. Linux/macOS runs cover the full matrix; seeing the
-# single `templates/default-python/classic` test succeed on Windows is enough
-# signal that the template machinery works there.
+# 18 matrix variants at ~1m7s each cost ~20m of cumulative time on windows
+# alone. The CLI behavior is OS-agnostic; linux covers the full matrix. On
+# windows/macos the `classic/` smoke is enough to prove the template
+# machinery works.
 GOOS.windows = false
+GOOS.darwin = false
 
 Ignore = ["input.json"]
 

--- a/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = true
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,10 +1,11 @@
 Cloud = true
 Timeout = '1m'
 
-# Skip on Windows -- 5 Python versions x ~1m each = ~5m of cumulative Windows
-# test time. Linux/macOS runs already cover all 5 versions; the classic-template
-# path is smoke-tested on Windows by `templates/default-python/classic`.
+# 5 Python versions x ~1m each. Linux runs cover all 5 versions; on
+# windows/macos the classic-template path is smoke-tested by
+# `templates/default-python/classic`.
 GOOS.windows = false
+GOOS.darwin = false
 
 Ignore = [
     '.venv',

--- a/acceptance/bundle/templates/default-python/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/serverless/out.test.toml
@@ -2,6 +2,7 @@ Local = true
 Cloud = false
 
 [GOOS]
+  darwin = false
   windows = false
 
 [EnvMatrix]

--- a/acceptance/bundle/templates/default-python/serverless/test.toml
+++ b/acceptance/bundle/templates/default-python/serverless/test.toml
@@ -1,5 +1,6 @@
 RecordRequests = true
 
-# Skip on Windows -- serverless-template coverage on Linux/macOS is sufficient;
-# the Windows smoke for template machinery is covered by `classic/`.
+# Serverless-template coverage on linux is sufficient; the windows/macos
+# smoke for template machinery is covered by `classic/`.
 GOOS.windows = false
+GOOS.darwin = false


### PR DESCRIPTION
## Summary

Stacks on #5072. Two changes:

### 1. Also skip on macOS
The subtrees skipped on Windows in #5072 exercise server-side logic via bundle deploy/update cycles; none of them exercise OS-specific CLI behavior. Linux gives full coverage. Extending the skip to macOS removes redundant CI minutes and trims macOS/terraform wall-clock.

### 2. More subtrees that match the same pattern

Gotestsum profiling (PR #5068) shows Windows runs at ~2.1-2.4x Linux per test uniformly. After the #5072 cuts the remaining big contributors to windows/terraform are still all server-side:

| Directory | Windows cumulative | Linux cumulative | Ratio |
|---|---|---|---|
| `bundle/resources/jobs` | 486s | 231s | 2.1× |
| `bundle/deployment/bind` | 441s | 209s | 2.1× |
| `bundle/resources/model_serving_endpoints` | 376s | 173s | 2.2× |
| `bundle/resources/dashboards` | 369s | 175s | 2.1× |
| `bundle/resources/clusters` | 311s | 152s | 2.0× |
| `bundle/resources/pipelines` | 251s | 104s | 2.4× |
| `bundle/resources/grants` | 250s | 120s | 2.1× |
| `bundle/run_as/pipelines` | 178s | 72s | 2.5× |
| `bundle/resources/postgres_*` | 469s | 191s | 2.5× |
| `bundle/resource_deps/*` | ~300s | ~120s | ~2.5× |

None of these exercise Windows/macOS-specific CLI behavior — they're all server-side resource management through bundle deploy. Linux coverage is sufficient.

### Changes

- `GOOS.windows = false; GOOS.darwin = false` hoisted to `bundle/resources/test.toml` (covers all resources/, subsumes the permissions-specific entry from #5072).
- Same pair added to existing `test.toml` files for `templates/default-python/{combinations,integration_classic,serverless}` (replaces the Windows-only skip from #5072).
- New `test.toml` files for `bundle/deployment/bind/`, `bundle/deployment/unbind/`, `bundle/run_as/`.
- Same pair added to `bundle/resource_deps/test.toml`.
- `out.test.toml` files regenerated via `make generate-out-test-toml`.

## Expected impact (stacked on #5072)

- windows/terraform: **~23m → ~12-15m** (from ~3500s additional cumulative cut at ~4-5x parallelism)
- macos/terraform: **~12m → ~7-9m**
- linux/terraform: unchanged (full coverage)

## Test plan

- [ ] windows/terraform and macos/terraform still pass
- [ ] Linux timings unchanged
- [ ] Wall-clock delta matches expectation

This pull request and its description were written by Isaac.