### PR TITLE
Use configured HTTP transport for SSH metadata fetch

### DIFF
--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -454,7 +454,8 @@ func getServerMetadata(ctx context.Context, client *databricks.WorkspaceClient, 
 	if err := client.Config.Authenticate(req); err != nil {
 		return 0, "", "", err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	httpClient := &http.Client{Transport: client.Config.HTTPTransport}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return 0, "", "", err
 	}


### PR DESCRIPTION
## Summary
- `getServerMetadata` in `experimental/ssh` was using `http.DefaultClient` for the driver proxy metadata request, bypassing workspace TLS and proxy configuration from `client.Config`.
- Replace with `&http.Client{Transport: client.Config.HTTPTransport}` to respect custom TLS certs and proxy settings.

## Test plan
- [ ] Verify SSH connect works with default config
- [ ] Verify SSH connect works behind corporate proxy with custom TLS certs