### PR TITLE
Reformat and extend AI-assistant rule files

### DIFF
--- a/.agent/rules/auto-generated-files.md
+++ b/.agent/rules/auto-generated-files.md
@@ -50,16 +50,17 @@ paths:
 
 ## Identification
 
-The files matching this rule glob pattern are most likely generated artifacts. Auto-generated files generally have a comment (if the file type allows for comments) at or near the top of the file indicating that they are generated, or their file name/path may indicate they are generated. You may also consult Makefile as starting point to determine if a file is auto-generated.
+Files matching this rule's glob pattern are most likely generated artifacts. Auto-generated files generally have a comment (when the file type allows it) at or near the top indicating they are generated, or their name or path signals it. You may also consult the Makefile as a starting point to determine if a file is auto-generated.
 
 ## Rules
 
-DO NOT "MANUALLY" EDIT THESE FILES!
+**RULE: Do not manually edit auto-generated files.**
 
-If a change is needed in any matched file:
-1. Find the source logic/template/annotation that drives the file.
-2. Run the appropriate generator/update command.
-3. Commit both the source change (if any) and regenerated outputs.
+**RULE: To change a generated file, edit the source and regenerate.**
+
+1. Find the source logic, template, or annotation that drives the file.
+2. Run the appropriate generator or update command.
+3. Commit both the source change (if any) and the regenerated outputs.
 
 ### Core generation commands
 
@@ -83,16 +84,19 @@ If a change is needed in any matched file:
 
 ### Acceptance and test generated outputs
 
-Acceptance outputs are generated and should not be hand-edited (except rare, intentional mass replacement when explicitly justified by repo guidance).
+**RULE: Do not hand-edit acceptance outputs.** Exception: rare, intentional mass replacement when explicitly justified by repo guidance.
 
-- Preferred regeneration:
-  - `make test-update`
-  - `make test-update-templates` (templates only)
-  - `make generate-out-test-toml` (only `out.test.toml`)
-- Typical generated files include:
-  - `acceptance/**/out*`
-  - `acceptance/**/output.txt`
-  - `acceptance/**/output.*.txt`
-  - `acceptance/**/output/**` (materialized template output trees)
+Regeneration commands:
 
-When touching acceptance sources (`databricks.yml`, scripts, templates, or test config), regenerate outputs instead of editing generated files directly.
+- `make test-update`
+- `make test-update-templates` (templates only)
+- `make generate-out-test-toml` (only `out.test.toml`)
+
+Typical generated files:
+
+- `acceptance/**/out*`
+- `acceptance/**/output.txt`
+- `acceptance/**/output.*.txt`
+- `acceptance/**/output/**` (materialized template output trees)
+
+**RULE: When touching acceptance sources, regenerate outputs instead of editing generated files.** Sources include `databricks.yml`, scripts, templates, and test config.

--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -52,7 +52,7 @@ type myKeyType int
 
 ### Lazy initialization
 
-**RULE: Use `sync.OnceValue` or `sync.OnceValues` for cached computations, not `sync.Once` with package variables.** The `sync.OnceValue[T]` family (Go 1.21+) removes the boilerplate and makes the cached result a first-class return value.
+**RULE: Use `sync.OnceValue`, `sync.OnceValues`, or `sync.OnceFunc` for one-time initialization, not `sync.Once` with package variables.** The `sync.OnceValue[T]` family (Go 1.21+) removes the boilerplate and makes the cached result a first-class return value. Use `sync.OnceFunc` when the initialization has side effects and no return value (the CLI already uses it in places like `libs/cmdio/spinner.go`).
 
 GOOD:
 
@@ -87,9 +87,7 @@ Caveats that apply to both: results are cached forever (including errors), and a
 
 ### Constructors
 
-**RULE: When a constructor has 4 or more parameters, group them into a struct.** Readability wins fast as the parameter list grows, and adding a field later does not ripple through every call site.
-
-GOOD:
+When a constructor's parameter list is long enough that callers forget the order or misread positional arguments, consider grouping dependencies into a struct. This is a judgment call. The CLI has many ordinary constructors with 4+ parameters, and that's fine when the arguments are obvious at the call site. The signal for switching is readability, not parameter count.
 
 ```go
 type ServiceDeps struct {
@@ -101,12 +99,6 @@ type ServiceDeps struct {
 }
 
 func NewService(deps ServiceDeps) *Service { ... }
-```
-
-BAD:
-
-```go
-func NewService(client HTTPClient, logger Logger, config Config, validator Validator, metrics MetricsCollector) *Service { ... }
 ```
 
 ### Configuration patterns

--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -52,24 +52,25 @@ type myKeyType int
 
 ### Control flow
 
-**RULE: For mutually exclusive, terminal branches, use `switch` instead of `if / else if`.** The branches read as clearly exclusive and Go flags a missing default when it matters.
+**RULE: When several branches are alternatives for the same decision, prefer `switch` over `if / else if`.** Same-decision means: you're dispatching on one value or one boolean question and each branch is a different answer to it. Ordered precedence chains (try this, else this, else this) are a different shape; leave those as early-return `if`s.
 
-GOOD:
+GOOD (alternatives for one decision):
 
 ```go
-switch {
-case override != "":
-	return override, nil
-case envValue != "":
-	return parseMode(envValue)
+switch mode {
+case modeText:
+	renderText(out, result)
+case modeJSON:
+	renderJSON(out, result)
 default:
-	return loadFromFile()
+	return fmt.Errorf("unknown mode %q", mode)
 }
 ```
 
-BAD:
+Also fine (ordered precedence, early-return style):
 
 ```go
+// see libs/auth/storage/mode.go#ResolveStorageMode
 if override != "" {
 	return override, nil
 }
@@ -98,7 +99,7 @@ return nil
 
 ### Determinism
 
-**RULE: When you build a slice by iterating over a map and the slice influences an API payload, update mask, log line, or anything a human might diff, sort it before returning.** Go maps have randomized iteration order, so the same input produces different outputs across runs. Non-deterministic update masks hit the wire with varying field order and non-deterministic test output creates flaky comparisons.
+**RULE: When you build a slice by iterating over a map and its order affects tests, logs, update masks, or the wire format, sort it before returning.** Go maps have randomized iteration order, so the same input produces different outputs across runs. Reviewers catch these when they produce flaky test output or noisy diffs in update masks. If the slice is purely internal and nothing downstream observes its order, sorting is unnecessary — some accepted code in `bundle/direct/dresources/` and `bundle/config/mutator/resourcemutator/` returns unsorted slices precisely because order doesn't matter there.
 
 GOOD:
 
@@ -123,7 +124,7 @@ return fieldPaths
 
 ### Environment variables
 
-**RULE: Use `github.com/databricks/cli/libs/env` for reading environment variables, not `os.Getenv`.** `env.Get(ctx, name)` and `env.Lookup(ctx, name)` can be overridden per-context in tests, so you don't have to mutate process-wide state to exercise a code path.
+**RULE: In library and product code, use `github.com/databricks/cli/libs/env` for reading environment variables, not `os.Getenv`.** `env.Get(ctx, name)` and `env.Lookup(ctx, name)` can be overridden per-context in tests, so you don't have to mutate process-wide state to exercise a code path. `os.Getenv` is still fine in `main`, tests, and acceptance/integration harnesses where no `ctx` is available and overrides aren't needed.
 
 GOOD:
 

--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -50,6 +50,65 @@ type myKeyType int
 
 **RULE: When integrating external tools or detecting environment variables, include source reference URLs as comments.** This lets future readers trace where the behavior came from.
 
+### Lazy initialization
+
+**RULE: Use `sync.OnceValue` or `sync.OnceValues` for cached computations, not `sync.Once` with package variables.** The `sync.OnceValue[T]` family (Go 1.21+) removes the boilerplate and makes the cached result a first-class return value.
+
+GOOD:
+
+```go
+var loadConfig = sync.OnceValues(func() (*Config, error) {
+	return parseConfigFile("config.yml")
+})
+
+func GetConfig() (*Config, error) {
+	return loadConfig()
+}
+```
+
+BAD:
+
+```go
+var (
+	config     *Config
+	configErr  error
+	configOnce sync.Once
+)
+
+func GetConfig() (*Config, error) {
+	configOnce.Do(func() {
+		config, configErr = parseConfigFile("config.yml")
+	})
+	return config, configErr
+}
+```
+
+Caveats that apply to both: results are cached forever (including errors), and a panic is rethrown on every subsequent call. Create a new instance if you need retry semantics.
+
+### Constructors
+
+**RULE: When a constructor has 4 or more parameters, group them into a struct.** Readability wins fast as the parameter list grows, and adding a field later does not ripple through every call site.
+
+GOOD:
+
+```go
+type ServiceDeps struct {
+	Client    HTTPClient
+	Logger    Logger
+	Config    Config
+	Validator Validator
+	Metrics   MetricsCollector
+}
+
+func NewService(deps ServiceDeps) *Service { ... }
+```
+
+BAD:
+
+```go
+func NewService(client HTTPClient, logger Logger, config Config, validator Validator, metrics MetricsCollector) *Service { ... }
+```
+
 ### Configuration patterns
 
 - Bundle config uses `dyn.Value` for dynamic typing

--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -46,9 +46,101 @@ BAD:
 type myKeyType int
 ```
 
-**RULE: Define magic strings as named constants at the top of the file.**
+**RULE: Define magic strings as named constants at the top of the file.** When a value is used in more than one place, define a package-level constant even if the literal is short. If a related value already has a constant in the same package, follow the existing pattern instead of introducing a parallel literal.
 
 **RULE: When integrating external tools or detecting environment variables, include source reference URLs as comments.** This lets future readers trace where the behavior came from.
+
+### Control flow
+
+**RULE: For mutually exclusive, terminal branches, use `switch` instead of `if / else if`.** The branches read as clearly exclusive and Go flags a missing default when it matters.
+
+GOOD:
+
+```go
+switch {
+case override != "":
+	return override, nil
+case envValue != "":
+	return parseMode(envValue)
+default:
+	return loadFromFile()
+}
+```
+
+BAD:
+
+```go
+if override != "" {
+	return override, nil
+}
+if envValue != "" {
+	return parseMode(envValue)
+}
+return loadFromFile()
+```
+
+**RULE: Collapse `if err != nil { return err }; return nil` to just `return err`.** The pattern is never doing anything useful in the intermediate step.
+
+GOOD:
+
+```go
+return someCall()
+```
+
+BAD:
+
+```go
+if err := someCall(); err != nil {
+	return err
+}
+return nil
+```
+
+### Determinism
+
+**RULE: When you build a slice by iterating over a map and the slice influences an API payload, update mask, log line, or anything a human might diff, sort it before returning.** Go maps have randomized iteration order, so the same input produces different outputs across runs. Non-deterministic update masks hit the wire with varying field order and non-deterministic test output creates flaky comparisons.
+
+GOOD:
+
+```go
+fieldPaths := make([]string, 0, len(changes))
+for p := range changes {
+	fieldPaths = append(fieldPaths, p)
+}
+slices.Sort(fieldPaths)
+return fieldPaths
+```
+
+BAD:
+
+```go
+fieldPaths := make([]string, 0, len(changes))
+for p := range changes {
+	fieldPaths = append(fieldPaths, p)
+}
+return fieldPaths
+```
+
+### Environment variables
+
+**RULE: Use `github.com/databricks/cli/libs/env` for reading environment variables, not `os.Getenv`.** `env.Get(ctx, name)` and `env.Lookup(ctx, name)` can be overridden per-context in tests, so you don't have to mutate process-wide state to exercise a code path.
+
+GOOD:
+
+```go
+import "github.com/databricks/cli/libs/env"
+
+token := env.Get(ctx, "DATABRICKS_TOKEN")
+if path, ok := env.Lookup(ctx, "DATABRICKS_CLI_PATH"); ok {
+	// use path
+}
+```
+
+BAD:
+
+```go
+token := os.Getenv("DATABRICKS_TOKEN")
+```
 
 ### Lazy initialization
 
@@ -137,3 +229,25 @@ cmdio.LogString(ctx, "...")
 ```
 
 **RULE: Always output file paths with forward slashes, even on Windows.** Use `filepath.ToSlash` so acceptance test output is stable between OSes.
+
+**RULE: Pick log levels deliberately.** Warn for things the user should know about and might act on. Debug for diagnostic signal a developer wants but a user shouldn't see by default. Error for actual failures that also surface as a returned error. A message that's warn-by-default but isn't user-actionable belongs at debug.
+
+GOOD:
+
+```go
+if err := w.Config.Authenticate(); err != nil {
+	// user can check their profile; worth warning
+	log.Warnf(ctx, "could not authenticate: %v", err)
+}
+
+if err := cleanupExpiredCacheEntries(ctx); err != nil {
+	// internal-only, user can't act on this
+	log.Debugf(ctx, "cache cleanup failed: %v", err)
+}
+```
+
+BAD:
+
+```go
+log.Warnf(ctx, "cache cleanup failed: %v", err) // noisy, not actionable
+```

--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -9,11 +9,9 @@ paths:
 
 ## General guidance
 
-Please make sure code that you author is consistent with the codebase and concise.
+Code you author should be consistent with the codebase and concise. The code should be self-documenting based on its function and variable names.
 
-The code should be self-documenting based on the code and function names.
-
-Functions should be documented with a doc comment as follows:
+**RULE: Document functions with a doc comment that starts with the function name and ends with a period.**
 
 ```go
 // SomeFunc does something.
@@ -22,21 +20,37 @@ func SomeFunc() {
 }
 ```
 
-Note how the comment starts with the name of the function and is followed by a period.
+**RULE: Avoid redundant and verbose comments.** Only add a comment if it complements the code rather than repeating it.
 
-Avoid redundant and verbose comments. Use terse comments and only add comments if it complements, not repeats the code.
+**RULE: Focus on making implementations as small and elegant as possible.** Avoid unnecessary loops and allocations. If dropping or relaxing a requirement would simplify things, ask the user about the trade-off.
 
-Focus on making implementation as small and elegant as possible. Avoid unnecessary loops and allocations. If you see an opportunity of making things simpler by dropping or relaxing some requirements, ask user about the trade-off.
+### Modern Go (1.24+) idioms
 
-Use modern idiomatic Golang features (version 1.24+). Specifically:
- - Use for-range for integer iteration where possible. Instead of for i:=0; i < X; i++ {} you must write for i := range X{}.
- - Use builtin min() and max() where possible (works on any type and any number of values).
- - Do not capture the for-range variable, since go 1.22 a new copy of the variable is created for each loop iteration.
- - Use empty struct types for context keys: `type myKeyType struct{}` (not `int`).
- - Define magic strings as named constants at the top of the file.
- - When integrating external tools or detecting environment variables, include source reference URLs as comments so they can be traced later.
+**RULE: Use `for i := range X` for integer iteration, not `for i := 0; i < X; i++`.**
 
-### Configuration Patterns
+**RULE: Use builtin `min()` and `max()` where possible.** They work on any type and any number of values.
+
+**RULE: Do not capture the for-range variable.** Since Go 1.22 a new copy is created each iteration, so the capture workaround is no longer needed.
+
+**RULE: Use empty struct types for context keys.**
+
+GOOD:
+
+```go
+type myKeyType struct{}
+```
+
+BAD:
+
+```go
+type myKeyType int
+```
+
+**RULE: Define magic strings as named constants at the top of the file.**
+
+**RULE: When integrating external tools or detecting environment variables, include source reference URLs as comments.** This lets future readers trace where the behavior came from.
+
+### Configuration patterns
 
 - Bundle config uses `dyn.Value` for dynamic typing
 - Config loading supports includes, variable interpolation, and target overrides
@@ -44,11 +58,15 @@ Use modern idiomatic Golang features (version 1.24+). Specifically:
 
 ## Context
 
-Always pass `context.Context` as a function argument; never store it in a struct. Storing context in a struct obscures the lifecycle and prevents callers from setting per-call deadlines, cancellation, and metadata (see https://go.dev/blog/context-and-structs). Do not use `context.Background()` outside of `main.go` files. In tests, use `t.Context()` (or `b.Context()` for benchmarks).
+**RULE: Always pass `context.Context` as a function argument; never store it in a struct.** Storing context in a struct obscures the lifecycle and prevents callers from setting per-call deadlines, cancellation, and metadata. See https://go.dev/blog/context-and-structs.
+
+**RULE: Do not use `context.Background()` outside of `main.go` files.**
+
+**RULE: In tests, use `t.Context()` (or `b.Context()` for benchmarks).**
 
 ## Logging
 
-Use the following for logging:
+**RULE: Use `github.com/databricks/cli/libs/log` for debug/info/warn/error logging.** The `ctx` variable must be passed in by the caller.
 
 ```go
 import "github.com/databricks/cli/libs/log"
@@ -59,10 +77,7 @@ log.Warnf(ctx, "...")
 log.Errorf(ctx, "...")
 ```
 
-Note that the 'ctx' variable here is something that should be passed in as
-an argument by the caller.
-
-Use cmdio.LogString to print to stdout:
+**RULE: Use `cmdio.LogString` to print to stdout.**
 
 ```go
 import "github.com/databricks/cli/libs/cmdio"
@@ -70,4 +85,4 @@ import "github.com/databricks/cli/libs/cmdio"
 cmdio.LogString(ctx, "...")
 ```
 
-Always output file path with forward slashes, even on Windows, so that acceptance test output is stable between OSes. Use filepath.ToSlash for this.
+**RULE: Always output file paths with forward slashes, even on Windows.** Use `filepath.ToSlash` so acceptance test output is stable between OSes.

--- a/.agent/rules/style-guide-py.md
+++ b/.agent/rules/style-guide-py.md
@@ -9,11 +9,18 @@ paths:
 
 ## General guidance
 
-When writing Python scripts, we bias for conciseness. We think of Python in this code base as scripts.
-- use Python 3.11
-- Do not catch exceptions to make nicer messages, only catch if you can add critical information
-- use pathlib.Path in almost all cases over os.path unless it makes code longer
-- Do not add redundant comments.
-- Try to keep your code small and the number of abstractions low.
-- After done, format your code with `ruff format -n <path>`
-- Use `#!/usr/bin/env python3` shebang.
+Python in this codebase is written as scripts. Bias for conciseness.
+
+**RULE: Use Python 3.11.**
+
+**RULE: Use `#!/usr/bin/env python3` as the shebang.**
+
+**RULE: Prefer `pathlib.Path` over `os.path`.** Exception: when it would make the code longer.
+
+**RULE: Do not catch exceptions just to add a nicer message.** Only catch if you can add critical information the caller can't produce.
+
+**RULE: Avoid redundant comments.**
+
+**RULE: Keep code small and minimize abstractions.**
+
+**RULE: Format with `ruff format -n <path>` before committing.**

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -36,7 +36,7 @@ func TestApplySomeChangeFixesThings(t *testing.T) {
 
 **RULE: Use table-driven tests for multiple similar cases.** Reviewers prefer this pattern over repeating near-identical test functions when the inputs differ but the logic is the same.
 
-**RULE: Extract values used in 2 or more tests into package-level `const` or `var` at the top of the test file.** Applies to URIs, IDs, names, error messages, expected results, and any complex test fixtures. Avoids drift when the value changes and makes the intent of each test clearer.
+**RULE: If a value is shared across tests and they must change together, extract it to a package-level `const` or `var`.** Think shared fixtures, identifiers that must stay in sync across tests, and expected error messages that the tests verify as a set. Repeated literals that happen to be the same (e.g. a header name like `"Authorization"` appearing inline in many tests) are fine to leave inline; forcing extraction there hurts readability without buying anything.
 
 When writing tests, don't include an explanation in each test case in your responses. Only the tests are needed.
 

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -10,6 +10,14 @@ description: Rules for the testing strategy of this repo
 - **Integration tests**: `integration/` directory, requires live Databricks workspace
 - **Acceptance tests**: `acceptance/` directory, uses mock HTTP server
 
+## Choosing a test level
+
+**RULE: For user-visible CLI output and mutator pipeline behavior, reach for acceptance tests first.** They exercise the full pipeline and capture the exact output the user sees. `cmd/...` commands and changes to `bundle/config/mutator/...` are the strongest candidates. Before adding a new acceptance test file, see if an existing nearby test can be extended.
+
+**Unit tests are still the right tool** for pure functions, utility code, parsing/formatting helpers, and anything you can meaningfully test without mocking the whole world. Don't force a unit into an acceptance test just because the code lives under `cmd/`, and don't add a mutator unit test that only duplicates what an acceptance test already covers.
+
+When in doubt: would the test fail in a useful way if a mutator earlier in the pipeline changed? If yes, the test wants to be an acceptance test.
+
 ## Unit tests
 
 **RULE: Each source file should have a corresponding test file.** If you add new functionality to a file, extend the test file to cover it.
@@ -54,6 +62,31 @@ Exception: mass string replacement when the change is predictable and much cheap
 
 **RULE: Add test artifacts (e.g. `.databricks`) to `Ignore` in `test.toml`.**
 
+**RULE: Commit static test inputs into the acceptance test directory; do not create them in `script` at test time.** If a file's content is dynamic, generating it in `script` is fine. For everything else, check it in and let the test read it directly; you won't need an `Ignore` entry because there's nothing to clean up.
+
+GOOD:
+
+```
+acceptance/cmd/fs/cp/file-to-dir/
+  script        # $CLI fs cp local.txt dbfs:/path/
+  test.toml
+  local.txt     # committed input
+  output.txt
+```
+
+BAD:
+
+```
+acceptance/cmd/fs/cp/file-to-dir/
+  script        # echo "contents" > local.txt; $CLI fs cp local.txt dbfs:/path/; rm local.txt
+  test.toml     # Ignore = ["local.txt"]
+  output.txt
+```
+
+**RULE: When output genuinely diverges between engines (terraform vs direct), split only the diverging file into per-engine variants.** Keep the rest of the output unified. Files named `output.$DATABRICKS_BUNDLE_ENGINE.txt` or `out.requests.$DATABRICKS_BUNDLE_ENGINE.json` are the allowed per-engine form.
+
+If the only reason for divergence is a server-side default that one engine sets and the other doesn't, set the field explicitly in `databricks.yml` so both engines produce identical output. Don't paper over it with per-engine files.
+
 ### Reference
 
 - Tests live in `acceptance/` with a nested directory structure.
@@ -67,6 +100,22 @@ Exception: mass string replacement when the change is predictable and much cheap
 - `script.prepare` files from parent directories are concatenated into the test script. Use them for shared bash helpers.
 
 ### Helper scripts
+
+**RULE: Use the `acceptance/bin/` helpers before reaching for inline `jq` or `grep` pipelines.** When a test needs to filter recorded requests, assert a substring is or isn't present, or register a dynamic replacement, the helpers handle sorting, URL query normalization, redaction hooks, and cross-platform path issues. Inline `jq` in an acceptance script is brittle and hard to read.
+
+GOOD:
+
+```bash
+trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to delete, 1 to update"
+trace print_requests.py //api/2.0/apps
+echo "$deployment_id:DEPLOYMENT_ID" >> ACC_REPLS
+```
+
+BAD:
+
+```bash
+{ trace jq 'select(.method == "POST" and .path == "/api/2.0/apps")' out.requests.txt; } || true
+```
 
 Available on `PATH` during test execution (from `acceptance/bin/`):
 

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -36,6 +36,8 @@ func TestApplySomeChangeFixesThings(t *testing.T) {
 
 **RULE: Use table-driven tests for multiple similar cases.** Reviewers prefer this pattern over repeating near-identical test functions when the inputs differ but the logic is the same.
 
+**RULE: Extract values used in 2 or more tests into package-level `const` or `var` at the top of the test file.** Applies to URIs, IDs, names, error messages, expected results, and any complex test fixtures. Avoids drift when the value changes and makes the intent of each test clearer.
+
 When writing tests, don't include an explanation in each test case in your responses. Only the tests are needed.
 
 ## Acceptance Tests

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -12,7 +12,7 @@ description: Rules for the testing strategy of this repo
 
 ## Choosing a test level
 
-**RULE: For user-visible CLI output and mutator pipeline behavior, reach for acceptance tests first.** They exercise the full pipeline and capture the exact output the user sees. `cmd/...` commands and changes to `bundle/config/mutator/...` are the strongest candidates. Before adding a new acceptance test file, see if an existing nearby test can be extended.
+**RULE: For user-visible CLI output and changes to the bundle mutator pipeline, reach for acceptance tests first.** They exercise the full pipeline and capture the exact output the user sees. `cmd/...` commands and anything under the mutator pipeline (`bundle/config/mutator/...` and `bundle/mutator/...`) are the strongest candidates. When the coverage overlaps with an existing test, extend the existing acceptance directory instead of creating a new one.
 
 **Unit tests are still the right tool** for pure functions, utility code, parsing/formatting helpers, and anything you can meaningfully test without mocking the whole world. Don't force a unit into an acceptance test just because the code lives under `cmd/`, and don't add a mutator unit test that only duplicates what an acceptance test already covers.
 

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -10,11 +10,14 @@ description: Rules for the testing strategy of this repo
 - **Integration tests**: `integration/` directory, requires live Databricks workspace
 - **Acceptance tests**: `acceptance/` directory, uses mock HTTP server
 
-Each file like process_target_mode_test.go should have a corresponding test file
-like process_target_mode_test.go. If you add new functionality to a file,
-the test file should be extended to cover the new functionality.
+## Unit tests
 
-Tests should look like the following:
+**RULE: Each source file should have a corresponding test file.** If you add new functionality to a file, extend the test file to cover it.
+
+**RULE: Place tests in the same package but with a `_test` suffix.** Test names start with `Test` and describe the function or module under test.
+
+**RULE: Use `require` for preconditions that would make the rest of the test meaningless on failure.** Use `assert` for expected values where the test can keep running after a failure.
+
 ```go
 package mutator_test
 
@@ -31,49 +34,59 @@ func TestApplySomeChangeFixesThings(t *testing.T) {
 }
 ```
 
-Notice that:
-- Tests are often in the same package but suffixed with _test.
-- The test names are prefixed with Test and are named after the function or module they are testing.
-- 'require' and 'require.NoError' are used to check for things that would cause the rest of the test case to fail.
-- 'assert' is used to check for expected values where the rest of the test is not expected to fail.
+**RULE: Use table-driven tests for multiple similar cases.** Reviewers prefer this pattern over repeating near-identical test functions when the inputs differ but the logic is the same.
 
-When writing tests, please don't include an explanation in each
-test case in your responses. I am just interested in the tests.
-
-Use table-driven tests when testing multiple similar cases (e.g., different inputs producing different outputs). Reviewers prefer this pattern over repeating near-identical test functions.
+When writing tests, don't include an explanation in each test case in your responses. Only the tests are needed.
 
 ## Acceptance Tests
 
-- Located in `acceptance/` with nested directory structure.
+**RULE: Never edit generated acceptance output files directly.** Files named `output.txt`, `out.test.toml`, `out.requests.txt`, or anything starting with `out` are regenerated. Use the `-update` flag to regenerate them.
+
+Exception: mass string replacement when the change is predictable and much cheaper than re-running the test suite.
+
+**RULE: All `EnvMatrix` variants MUST produce identical output files.** Filenames containing `$DATABRICKS_BUNDLE_ENGINE` (e.g. `output.direct.txt`) are the only per-engine exception.
+
+**RULE: Do not run `-update` while a divergent variant exists.** It is destructive: it overwrites with the last variant and breaks the others. To debug: run a single variant you consider correct with `-update`, then debug the other variant to find why it diverges.
+
+**RULE: Put common `test.toml` options in a parent directory.** Config is inherited from parents.
+
+**RULE: Add test artifacts (e.g. `.databricks`) to `Ignore` in `test.toml`.**
+
+### Reference
+
+- Tests live in `acceptance/` with a nested directory structure.
 - Each test directory contains `databricks.yml`, `script`, and `output.txt`.
 - Source files: `test.toml`, `script`, `script.prepare`, `databricks.yml`, etc.
-- Tests are configured via `test.toml`. Config schema and explanation is in `acceptance/internal/config.go`. Config is inherited from parent directories. Certain options are also dumped to `out.test.toml` so that inherited values are visible on PRs.
-- Generated output files start with `out`: `output.txt`, `out.test.toml`, `out.requests.txt`. Never edit these directly — use `-update` to regenerate. Exception: mass string replacement when the change is predictable and much cheaper than re-running the test suite.
+- Tests are configured via `test.toml`. Config schema and explanation is in `acceptance/internal/config.go`. Certain options are also dumped to `out.test.toml` so that inherited values are visible on PRs.
 - Run a single test: `go test ./acceptance -run TestAccept/bundle/<path>/<to>/<folder>`
-- Run a specific variant by appending EnvMatrix values to the test name: `go test ./acceptance -run 'TestAccept/.../DATABRICKS_BUNDLE_ENGINE=direct'`. When there are multiple EnvMatrix variables, they appear in alphabetical order.
+- Run a specific variant by appending `EnvMatrix` values to the test name: `go test ./acceptance -run 'TestAccept/.../DATABRICKS_BUNDLE_ENGINE=direct'`. When there are multiple `EnvMatrix` variables, they appear in alphabetical order.
 - Useful flags: `-v` for verbose output, `-tail` to follow test output (requires `-v`), `-logrequests` to log all HTTP requests/responses (requires `-v`).
 - Run tests on cloud: `deco env run -i -n aws-prod-ucws -- <go test command>` (requires `deco` tool and access to test env).
-- Use `-update` flag to regenerate expected output files. When a test fails because of stale output, re-run with `-update` instead of editing output files.
-- All EnvMatrix variants share the same output files — they MUST produce identical output. Exception: filenames containing `$DATABRICKS_BUNDLE_ENGINE` (e.g. `output.direct.txt`) are recorded per-engine.
-- `-update` with divergent variant outputs is destructive: overwrites with last variant, breaking others. To debug: run a single variant you consider correct with `-update`, then debug the other variant to find why it diverges.
-- `test.toml` is inherited — put common options into a parent directory.
-- Add test artifacts (e.g. `.databricks`) to `Ignore` in `test.toml`.
-- `script.prepare` files from parent directories are concatenated into the test script — use them for shared bash helpers.
+- `script.prepare` files from parent directories are concatenated into the test script. Use them for shared bash helpers.
 
-**Helper scripts** in `acceptance/bin/` are available on `PATH` during test execution:
-- `contains.py SUBSTR [!SUBSTR_NOT]` — passthrough filter (stdin→stdout) that checks substrings are present (or absent with `!` prefix). Errors are reported on stderr.
-- `print_requests.py //path [^//exclude] [--get] [--sort] [--keep]` — print recorded HTTP requests matching path filters. Requires `RecordRequests=true` in `test.toml`. Clears `out.requests.txt` afterwards unless `--keep`. Use `--get` to include GET requests (excluded by default). Use `^` prefix to exclude paths.
-- `replace_ids.py [-t TARGET]` — read deployment state and add `[NAME_ID]` replacements for all resource IDs.
-- `read_id.py [-t TARGET] NAME` — read ID of a single resource from state, print it, and add a `[NAME_ID]` replacement.
-- `add_repl.py VALUE REPLACEMENT` — add a custom replacement (VALUE will be replaced with `[REPLACEMENT]` in output).
-- `update_file.py FILENAME OLD NEW` — replace all occurrences of OLD with NEW in FILENAME. Errors if OLD is not found. Cannot be used on `output.txt`.
-- `find.py REGEX [--expect N]` — find files matching regex in current directory. `--expect N` to assert exact count.
-- `diff.py DIR1 DIR2` or `diff.py FILE1 FILE2` — recursive diff with test replacements applied.
-- `print_state.py [-t TARGET] [--backup]` — print deployment state (terraform or direct).
-- `edit_resource.py TYPE ID < script.py` — fetch resource by ID, execute Python on it (resource in `r`), then update it. TYPE is `jobs` or `pipelines`.
-- `gron.py` — flatten JSON into greppable discrete assignments (simpler than `jq` for searching JSON).
+### Helper scripts
+
+Available on `PATH` during test execution (from `acceptance/bin/`):
+
+- `contains.py SUBSTR [!SUBSTR_NOT]`: passthrough filter (stdin→stdout) that checks substrings are present (or absent with `!` prefix). Errors are reported on stderr.
+- `print_requests.py //path [^//exclude] [--get] [--sort] [--keep]`: print recorded HTTP requests matching path filters. Requires `RecordRequests=true` in `test.toml`. Clears `out.requests.txt` afterwards unless `--keep`. Use `--get` to include GET requests (excluded by default). Use `^` prefix to exclude paths.
+- `replace_ids.py [-t TARGET]`: read deployment state and add `[NAME_ID]` replacements for all resource IDs.
+- `read_id.py [-t TARGET] NAME`: read ID of a single resource from state, print it, and add a `[NAME_ID]` replacement.
+- `add_repl.py VALUE REPLACEMENT`: add a custom replacement (VALUE will be replaced with `[REPLACEMENT]` in output).
+- `update_file.py FILENAME OLD NEW`: replace all occurrences of OLD with NEW in FILENAME. Errors if OLD is not found. Cannot be used on `output.txt`.
+- `find.py REGEX [--expect N]`: find files matching regex in current directory. `--expect N` asserts an exact count.
+- `diff.py DIR1 DIR2` or `diff.py FILE1 FILE2`: recursive diff with test replacements applied.
+- `print_state.py [-t TARGET] [--backup]`: print deployment state (terraform or direct).
+- `edit_resource.py TYPE ID < script.py`: fetch resource by ID, execute Python on it (resource in `r`), then update it. TYPE is `jobs` or `pipelines`.
+- `gron.py`: flatten JSON into greppable discrete assignments (simpler than `jq` for searching JSON).
 - `jq` is also available for JSON processing.
 
-**Update workflow**: Run `make test-update` to regenerate outputs. Then run `make fmt` and `make lint` — if these modify files in `acceptance/`, there's an issue in source files. Fix the source, regenerate, and verify lint/fmt pass cleanly.
+### Update workflow
 
-**Template tests**: Tests in `acceptance/bundle/templates` include materialized templates in output directories. These directories follow the same `out` convention — everything starting with `out` is generated output. Sources are in `libs/template/templates/`. Use `make test-update-templates` to regenerate. If linters or formatters find issues in materialized templates, do not fix the output files — fix the source in `libs/template/templates/`, then regenerate.
+**RULE: Run `make test-update` to regenerate outputs, then `make fmt` and `make lint`.** If fmt or lint modify files in `acceptance/`, there's an issue in the source files. Fix the source, regenerate, and verify fmt/lint pass cleanly.
+
+### Template tests
+
+Tests in `acceptance/bundle/templates` include materialized templates in output directories. These directories follow the same `out` convention: everything starting with `out` is generated output. Sources are in `libs/template/templates/`.
+
+**RULE: Use `make test-update-templates` to regenerate materialized templates.** If linters or formatters find issues in materialized templates, do not fix the output files; fix the source in `libs/template/templates/` and regenerate.

--- a/.agent/skills/pr-checklist/SKILL.md
+++ b/.agent/skills/pr-checklist/SKILL.md
@@ -26,3 +26,12 @@ cd python && make codegen && make test && make lint && make docs
 make test-exp-aitools   # only if aitools code changed
 make test-exp-ssh       # only if ssh code changed
 ```
+
+## Final cleanup scan
+
+After the commands above pass, scrub the diff before pushing:
+
+- **Debug prints**: search for `fmt.Println`, `fmt.Printf`, and `log.Printf` calls that were added for debugging. Remove them. `rg 'fmt\.(Print|Printf|Println)' $(git diff --name-only origin/main -- '*.go')` is a starting point.
+- **Commented-out code**: delete it. If it's needed for reference, it lives in git history.
+- **TODOs without a ticket**: either add a ticket reference (e.g. `// TODO(DECO-1234): ...`) or remove the TODO. Un-tracked TODOs rot.
+- **Unintended files**: review `git status` and `git diff --stat` to confirm only the files you meant to change are staged.

--- a/.agent/skills/pr-checklist/SKILL.md
+++ b/.agent/skills/pr-checklist/SKILL.md
@@ -29,9 +29,15 @@ make test-exp-ssh       # only if ssh code changed
 
 ## Final cleanup scan
 
-After the commands above pass, scrub the diff before pushing:
+After the commands above pass, scrub the diff before pushing. The quick version: run `git diff @{u}` and read through what you added. Specifically:
 
-- **Debug prints**: search for `fmt.Println`, `fmt.Printf`, and `log.Printf` calls that were added for debugging. Remove them. `rg 'fmt\.(Print|Printf|Println)' $(git diff --name-only origin/main -- '*.go')` is a starting point.
+- **Debug prints**: look for newly added `fmt.Print`, `fmt.Printf`, `fmt.Println`, `log.Print`, `log.Printf`, `log.Println`, or bare `println(...)` calls. A regex that scans only added lines against your upstream branch:
+
+  ```bash
+  git diff @{u} -- '*.go' | rg '^\+.*\b(fmt|log)\.(Print|Printf|Println)\b|^\+.*\bprintln\('
+  ```
+
+  If you have no upstream yet, substitute the intended base (e.g. `origin/main`) for `@{u}`.
 - **Commented-out code**: delete it. If it's needed for reference, it lives in git history.
 - **TODOs without a ticket**: either add a ticket reference (e.g. `// TODO(DECO-1234): ...`) or remove the TODO. Un-tracked TODOs rot.
 - **Unintended files**: review `git status` and `git diff --stat` to confirm only the files you meant to change are staged.

--- a/.agent/skills/pr-checklist/SKILL.md
+++ b/.agent/skills/pr-checklist/SKILL.md
@@ -41,3 +41,24 @@ After the commands above pass, scrub the diff before pushing. The quick version:
 - **Commented-out code**: delete it. If it's needed for reference, it lives in git history.
 - **TODOs without a ticket**: either add a ticket reference (e.g. `// TODO(DECO-1234): ...`) or remove the TODO. Un-tracked TODOs rot.
 - **Unintended files**: review `git status` and `git diff --stat` to confirm only the files you meant to change are staged.
+
+## Changelog entry
+
+Add a `NEXT_CHANGELOG.md` entry when your change is user-visible. CI generates the real `CHANGELOG.md` from `NEXT_CHANGELOG.md` at release time, so never hand-edit `CHANGELOG.md` directly.
+
+**When to add an entry:**
+- New or changed CLI command, flag, or subcommand behavior
+- New or changed bundle config field, schema, or engine behavior
+- New direct dependency (annotate under `Dependency updates`)
+- Bug fix that users will notice
+
+**When to skip:**
+- Experimental commands (under `experimental/`): no entry until the feature graduates out of experimental
+- Pure refactors, internal renames, test-only changes, and doc-only changes
+- Auto-generated output changes without a corresponding user-facing change
+
+**How to add:**
+- Pick the right section (`CLI`, `Bundles`, `Dependency updates`) under the current `## Release vX.Y.Z` header.
+- One or two sentences, user-facing language, no Jira links.
+- Reference the PR number once it's open: after `gh pr create`, edit the entry to append ` (#NNNN)` or similar matching nearby entries.
+- Match the voice and tense of the existing entries in the file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 
 **RULE: When moving code from one place to another, don't unnecessarily change or omit parts.** Keep refactors separate from content changes so reviewers can tell them apart.
 
+**RULE: Do not modify or remove existing comments in code you didn't write.** Comments often encode non-obvious context (a bug reference, a workaround, a reason the code is shaped a certain way) that is lost if rewritten. Leave them alone unless the user explicitly asks for a change.
+
 # Development Commands
 
 ### Building and Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 
 # General Rules
 
-When moving code from one place to another, please don't unnecessarily change the code or omit parts.
+**RULE: When moving code from one place to another, don't unnecessarily change or omit parts.** Keep refactors separate from content changes so reviewers can tell them apart.
 
 # Development Commands
 
@@ -34,9 +34,10 @@ When moving code from one place to another, please don't unnecessarily change th
 
 ### Git Commands
 
-Use `git rm` to remove and `git mv` to rename files instead of directly modifying files on FS.
+**RULE: Use `git rm` to remove and `git mv` to rename files, instead of directly modifying files on the filesystem.**
 
-If asked to rebase, always prefix each git command with appropriate settings so that it never launches interactive editor:
+**RULE: When rebasing, prefix git commands so they never launch an interactive editor.**
+
 ```sh
 GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git fetch origin main &&
 GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git rebase origin/main
@@ -77,20 +78,39 @@ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git rebase or
 
 # Development Tips
 
-- Use `make test-update` to regenerate acceptance test outputs after changes
-- The CLI binary supports both `databricks` and `pipelines` command modes based on executable name
-- Comments should explain "why", not "what" — reviewers consistently reject comments that merely restate the code
+- Use `make test-update` to regenerate acceptance test outputs after changes.
+- The CLI binary supports both `databricks` and `pipelines` command modes based on executable name.
+
+**RULE: Comments should explain "why", not "what".** Reviewers consistently reject comments that merely restate the code.
 
 # Common Mistakes
 
-- Do NOT add dependencies without checking license compatibility.
-- Do NOT use `os.Exit()` outside of `main.go`.
-- Do NOT remove or skip failing tests to fix CI — fix the underlying issue.
-- Do NOT leave debug print statements (`fmt.Println`, `log.Printf` for debugging) in committed code — always scrub before committing.
+**RULE: Do not add dependencies without checking license compatibility.**
+
+**RULE: Do not use `os.Exit()` outside of `main.go`.** `main.go` owns the exit path; calling `os.Exit()` elsewhere skips deferred cleanup and complicates testing.
+
+**RULE: Do not remove or skip failing tests to fix CI.** Fix the underlying issue instead.
+
+**RULE: Do not leave debug print statements in committed code.** `fmt.Println`, `log.Printf`, or similar. Always scrub before committing.
 
 # Error Handling
 
-- Wrap errors with context: `fmt.Errorf("failed to deploy %s: %w", name, err)`
-- Use `logdiag.LogDiag` / `logdiag.LogError` for logging diagnostics.
-- Return early on errors; avoid deeply nested if-else chains.
-- Use `diag.Errorf` / `diag.Warningf` to create diagnostics with severity.
+**RULE: Wrap errors with context using `%w`.** Preserves the error chain so `errors.Is` and `errors.As` keep working upstream.
+
+GOOD:
+
+```go
+return fmt.Errorf("failed to deploy %s: %w", name, err)
+```
+
+BAD:
+
+```go
+return fmt.Errorf("failed to deploy %s: %s", name, err)
+```
+
+**RULE: Return early on errors; avoid deeply nested if-else chains.**
+
+**RULE: Use `logdiag.LogDiag` and `logdiag.LogError` for logging diagnostics.**
+
+**RULE: Use `diag.Errorf` and `diag.Warningf` to create diagnostics with severity.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ parentPath = "/Workspace" + parentPath
 
 # Common Mistakes
 
-**RULE: Do not add dependencies without checking license compatibility.**
+**RULE: When adding a direct Go dependency, annotate its license in `go.mod` and update `NOTICE`.** The allowed SPDX identifiers are enforced by `internal/build/license_test.go`: currently `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `MIT`, and `MPL-2.0`. Each direct `require` line in `go.mod` must have a matching SPDX suffix comment (e.g. `// MIT`), and a corresponding entry belongs in `NOTICE` under the appropriate license section. If a dep's license isn't on the allowlist, the test fails — discuss before adding.
 
 **RULE: Do not use `os.Exit()` outside of `main.go`.** `main.go` owns the exit path; calling `os.Exit()` elsewhere skips deferred cleanup and complicates testing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 This file provides guidance to AI assistants when working with code in this repository.
 
+Rules prefixed `**RULE:**` are mandatory. `GOOD:` and `BAD:` labels on code snippets mark patterns to follow and patterns to avoid. This convention is a common best practice for AI-assistant rule files and is used consistently across `AGENTS.md` and `.agent/rules/*.md`.
+
 # Project Overview
 
 This is the Databricks CLI, a command-line interface for interacting with Databricks workspaces and managing Declarative Automation Bundles (DABs), formerly known as Databricks Asset Bundles. The project is written in Go and follows a modular architecture.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 
 **RULE: Prefer simplicity over cleverness. Avoid speculative fallbacks and default values.** If you catch yourself adding a fallback branch "just in case," identify the correct path and use only that one. Reviewers in this repo reject speculative flexibility.
 
+**RULE: Keep each PR focused on one change.** If you notice an unrelated cleanup, bug fix, or refactor while making your primary change, leave it alone or put it in a separate PR. Reviewers consistently ask to split mixed PRs, especially when a dependency bump or schema diff rides along with a feature change.
+
+**RULE: Before adding a new helper, search the codebase for an existing one.** Common homes: `libs/` (shared utilities), `libs/databrickscfg/` (config), `libs/git/`, `libs/filer/`, `libs/cmdio/` (CLI I/O, spinners, prompts), `libs/env/` (env vars), `libs/testserver/`, `libs/structpath/` and `libs/dyn/` (path / dynamic values), `acceptance/bin/` (acceptance test helpers), `internal/mocks/` (generated mocks). A function that duplicates an existing name and signature in the same package is a compile error waiting to happen; grep before you name.
+
 # Development Commands
 
 ### Building and Testing
@@ -87,6 +91,22 @@ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git rebase or
 
 **RULE: Comments should explain "why", not "what".** Reviewers consistently reject comments that merely restate the code.
 
+**RULE: When code relies on a non-obvious invariant, workaround, or backend quirk, add a short comment stating the reason.** The inverse of the rule above: noise comments are bad, but missing comments are the single most common thing reviewers catch. Triggers include: API quirks (PATCH-like semantics, no get-by-name, stripped prefixes), fields intentionally included or excluded (output-only, etag, `ForceSendFields`), branches that look dead but are kept as guards, and tests where the expectation isn't obvious from the assertions.
+
+GOOD:
+
+```go
+// The Workspace API strips the "/Workspace" prefix from parent_path on GET,
+// so we re-add it here to match the local configuration.
+parentPath = "/Workspace" + parentPath
+```
+
+BAD:
+
+```go
+parentPath = "/Workspace" + parentPath
+```
+
 # Common Mistakes
 
 **RULE: Do not add dependencies without checking license compatibility.**
@@ -96,6 +116,10 @@ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true VISUAL=true GIT_PAGER=cat git rebase or
 **RULE: Do not remove or skip failing tests to fix CI.** Fix the underlying issue instead.
 
 **RULE: Do not leave debug print statements in committed code.** `fmt.Println`, `log.Printf`, or similar. Always scrub before committing.
+
+**RULE: Do not add defensive `nil` checks for values the caller or framework is documented to always provide.** If a check exists "just in case", either remove it or attach a comment explaining why the invariant might be violated. Direct engine resource methods (`DoCreate`, `DoUpdate`, `RemapState`, etc.) never receive nil receivers or state from the framework, so extra nil-guards there are dead code.
+
+Where a panic is genuinely possible (e.g. `reflect.Type.Elem()` on a non-pointer, division by an empty slice's length), validate at the entry point and return an error.
 
 # Error Handling
 
@@ -118,3 +142,43 @@ return fmt.Errorf("failed to deploy %s: %s", name, err)
 **RULE: Use `logdiag.LogDiag` and `logdiag.LogError` for logging diagnostics.**
 
 **RULE: Use `diag.Errorf` and `diag.Warningf` to create diagnostics with severity.**
+
+**RULE: Compare errors with `errors.Is` or `errors.As` against a sentinel or typed error. Never branch on `err.Error()` string content.** The SDK exposes sentinels like `apierr.ErrNotFound` and `apierr.ErrResourceDoesNotExist`; the CLI has its own helpers like `isResourceGone`. String-matching error messages breaks the moment the upstream wording changes.
+
+GOOD:
+
+```go
+import "github.com/databricks/databricks-sdk-go/apierr"
+
+if errors.Is(err, apierr.ErrResourceDoesNotExist) {
+	return nil
+}
+```
+
+BAD:
+
+```go
+if strings.Contains(err.Error(), "does not exist") {
+	return nil
+}
+```
+
+# CLI UX and validation
+
+**RULE: Reject incompatible inputs early with an actionable error. Never silently ignore a flag or config field the current mode can't honor.** If a flag is incompatible with another flag or with a mode, return an error at flag-parse or validation time that tells the user which flag pair is at fault and what to do. If a config field applies only to certain resource types or engines, return a validation error, not a warning that gets lost in log output.
+
+GOOD:
+
+```go
+if opts.Bind && opts.Resource != "dashboards" {
+	return fmt.Errorf("--bind is only supported for dashboards, got %q", opts.Resource)
+}
+```
+
+BAD:
+
+```go
+if opts.Bind && opts.Resource != "dashboards" {
+	// silently drop the flag; user can't tell why nothing happened
+}
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ if errors.Is(err, apierr.ErrResourceDoesNotExist) {
 BAD:
 
 ```go
-if strings.Contains(err.Error(), "does not exist") {
+if err != nil && strings.Contains(err.Error(), "does not exist") {
 	return nil
 }
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ parentPath = "/Workspace" + parentPath
 
 # Common Mistakes
 
-**RULE: When adding a direct Go dependency, annotate its license in `go.mod` and update `NOTICE`.** The allowed SPDX identifiers are enforced by `internal/build/license_test.go`: currently `Apache-2.0`, `BSD-2-Clause`, `BSD-3-Clause`, `MIT`, and `MPL-2.0`. Each direct `require` line in `go.mod` must have a matching SPDX suffix comment (e.g. `// MIT`), and a corresponding entry belongs in `NOTICE` under the appropriate license section. If a dep's license isn't on the allowlist, the test fails — discuss before adding.
+**RULE: When adding a direct Go dependency, annotate its license in `go.mod` and update `NOTICE`.** Before picking the SPDX identifier, read `internal/build/license_test.go` to see the current allowlist (the `spdxLicenses` map). That test is the source of truth and will fail CI if a direct `require` line lacks a matching SPDX suffix comment (e.g. `// MIT`). Also add a corresponding entry to `NOTICE` under the matching license section. If a dep's license isn't on the allowlist, discuss before adding.
 
 **RULE: Do not use `os.Exit()` outside of `main.go`.** `main.go` owns the exit path; calling `os.Exit()` elsewhere skips deferred cleanup and complicates testing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This is the Databricks CLI, a command-line interface for interacting with Databr
 
 **RULE: Do not modify or remove existing comments in code you didn't write.** Comments often encode non-obvious context (a bug reference, a workaround, a reason the code is shaped a certain way) that is lost if rewritten. Leave them alone unless the user explicitly asks for a change.
 
+**RULE: Prefer simplicity over cleverness. Avoid speculative fallbacks and default values.** If you catch yourself adding a fallback branch "just in case," identify the correct path and use only that one. Reviewers in this repo reject speculative flexibility.
+
 # Development Commands
 
 ### Building and Testing


### PR DESCRIPTION
## Why

The CLI repo's AI-assistant rules (`AGENTS.md`, `.agent/rules/*.md`, and the `pr-checklist` skill) are a load-bearing input to every Claude / Cursor session in this codebase, but they've been hard to scan and uneven in coverage. This PR:

1. Adopts a consistent `RULE: / GOOD: / BAD:` format that both agents and human reviewers can pattern-match on.
2. Lifts a small set of prescriptive rules informed by common AI-rules best practices and adapted to the CLI's stack.
3. Encodes patterns extracted from 6 months of real reviewer feedback on this repo so the same comments don't need to be made again on the next PR.

## Changes

**Before:** prose-style guidance with inconsistent framing; no explicit final cleanup step before push; no guidance on `sync.Once*`, `libs/env`, deterministic slices, helper-first development, error sentinels, or log level selection.

**Now:** every prescriptive statement is prefixed `RULE:`, code examples are labeled `GOOD:` / `BAD:` where both apply, and the pre-push checklist ends with an explicit cleanup scan.

Five commits:

1. `Reformat AI rules to RULE / GOOD / BAD pattern`: pure structural rewrite of `AGENTS.md` and `.agent/rules/*.md`. Minor rationale additions where a rule had no stated reason. No rules removed, no commands changed.
2. `Add new AI-assistant rules from best practices`: adds `sync.OnceValue` / `sync.OnceValues` / `sync.OnceFunc` preference; soft guidance on grouping many constructor params into a struct; shared test fixture extraction; don't-modify-comments-you-didn't-write; a final cleanup scan step in the `pr-checklist` skill.
3. `Address cursor review round 1`: softens two rules that were stricter than existing CLI style, fixes the cleanup-scan `rg` command, adds the `sync.OnceFunc` mention, adds a "prefer simplicity" rule.
4. `Add rules mined from 6 months of CLI PR reviews`: encodes 11 recurring patterns from 933 merged PRs and 1218 inline reviewer comments. Each new rule is backed by 3+ independent PR instances. Highlights: add-a-comment-when-the-why-isn't-obvious; keep PRs focused; search for existing helpers before hand-rolling; prefer acceptance tests for user-visible CLI output; use `libs/env` over `os.Getenv`; use `errors.Is`/`errors.As` over `strings.Contains(err.Error(), ...)`; reject incompatible CLI flags with actionable errors; pick log levels deliberately; and more.
5. `Address cursor review round 3`: softens the `switch` and determinism rules to avoid flagging accepted early-return patterns in code like `libs/auth/storage/mode.go`, scopes the `libs/env` rule to library/product code, and picks up some nits.

Deliberately **not** adopted: monorepo-specific content (`dberrors`, `fx`, `bazel`, `jsonnet` patterns); a blanket ban on table-driven tests (the opposite of this repo's preference); general Claude Code authoring meta-docs (not CLI-specific enough to justify the context cost).

Note: `.claude/rules/` and `.cursor/rules/*.mdc` are symlinks to `.agent/rules/` in this repo (and `CLAUDE.md` is a symlink to `AGENTS.md`), so only the source files are edited and the mirrors pick up changes transparently.

## Test plan

- [x] `make checks` passes.
- [x] Cursor review round 1 on the reformat + best-practices lifts: 3 important findings, addressed in commit 3.
- [x] Cursor review round 2: approved with nits.
- [x] Cursor review round 3 on the PR-mining additions: approved with nits, 2 important findings addressed in commit 5.
- [x] Verified symlinks in `.claude/rules/` and `.cursor/rules/` reflect edits to `.agent/rules/` sources.