### PR TITLE
Bump agent skills to v0.1.5

### DIFF
--- a/experimental/aitools/lib/installer/installer.go
+++ b/experimental/aitools/lib/installer/installer.go
@@ -27,7 +27,7 @@ const (
 	skillsRepoOwner      = "databricks"
 	skillsRepoName       = "databricks-agent-skills"
 	skillsRepoPath       = "skills"
-	defaultSkillsRepoRef = "v0.1.4"
+	defaultSkillsRepoRef = "v0.1.5"
 )
 
 // fetchFileFn is the function used to download individual skill files.


### PR DESCRIPTION
## Why

Pull in the latest agent skills release: https://github.com/databricks/databricks-agent-skills/releases/tag/v0.1.5

## Changes

Bumps the default `databricks-agent-skills` repo ref used by the experimental `aitools` command from v0.1.4 to v0.1.5. Tests reference `defaultSkillsRepoRef` (refactored in #4968), so no test updates are needed. `aitools` is experimental, so no `NEXT_CHANGELOG.md` entry.

## Test plan

- [x] `make checks` passes
- [x] `go test ./experimental/aitools/...` passes