### PR TITLE
Add X-Databricks-Org-Id header to telemetry API calls for SPOG hosts

### DIFF
--- a/acceptance/telemetry/failure/out.requests.txt
+++ b/acceptance/telemetry/failure/out.requests.txt
@@ -6,6 +6,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",
@@ -23,6 +26,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",
@@ -40,6 +46,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",

--- a/acceptance/telemetry/partial-success/out.requests.txt
+++ b/acceptance/telemetry/partial-success/out.requests.txt
@@ -6,6 +6,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",
@@ -23,6 +26,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",
@@ -40,6 +46,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",

--- a/acceptance/telemetry/success/out.requests.txt
+++ b/acceptance/telemetry/success/out.requests.txt
@@ -14,6 +14,9 @@
     ],
     "User-Agent": [
       "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/selftest_send-telemetry cmd-exec-id/[CMD-EXEC-ID] interactive/none auth/pat"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",

--- a/acceptance/telemetry/test.toml
+++ b/acceptance/telemetry/test.toml
@@ -1,4 +1,4 @@
-IncludeRequestHeaders = ["Authorization"]
+IncludeRequestHeaders = ["Authorization", "X-Databricks-Org-Id"]
 RecordRequests = true
 
 Local = true

--- a/acceptance/telemetry/timeout/out.requests.txt
+++ b/acceptance/telemetry/timeout/out.requests.txt
@@ -6,6 +6,9 @@
   "headers": {
     "Authorization": [
       "Bearer [DATABRICKS_TOKEN]"
+    ],
+    "X-Databricks-Org-Id": [
+      "[NUMID]"
     ]
   },
   "method": "POST",

--- a/libs/telemetry/logger.go
+++ b/libs/telemetry/logger.go
@@ -171,9 +171,23 @@ func Upload(ctx context.Context, ec protos.ExecutionContext) error {
 	return errors.New("failed to upload telemetry logs after three attempts")
 }
 
+// orgIDHeaders returns headers with X-Databricks-Org-Id set if a workspace ID
+// is configured. SPOG hosts require this header to route requests to the
+// correct workspace; without it, telemetry is recorded in a central shard
+// instead of the correct workspace.
+func orgIDHeaders(apiClient *client.DatabricksClient) map[string]string {
+	wsID := apiClient.Config.WorkspaceID
+	if wsID == "" {
+		return nil
+	}
+	return map[string]string{
+		"X-Databricks-Org-Id": wsID,
+	}
+}
+
 func attempt(ctx context.Context, apiClient *client.DatabricksClient, protoLogs []string) (*ResponseBody, error) {
 	resp := &ResponseBody{}
-	err := apiClient.Do(ctx, http.MethodPost, "/telemetry-ext", nil, nil, RequestBody{
+	err := apiClient.Do(ctx, http.MethodPost, "/telemetry-ext", orgIDHeaders(apiClient), nil, RequestBody{
 		UploadTime: time.Now().UnixMilli(),
 		// There is a bug in the `/telemetry-ext` API which requires us to
 		// send an empty array for the `Items` field. Otherwise the API returns

--- a/libs/telemetry/logger_test.go
+++ b/libs/telemetry/logger_test.go
@@ -7,10 +7,63 @@ import (
 	"github.com/databricks/cli/libs/telemetry/protos"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOrgIDHeaders(t *testing.T) {
+	tests := []struct {
+		name        string
+		workspaceID string
+		expect      map[string]string
+	}{
+		{
+			name:        "with workspace ID",
+			workspaceID: "7474644166319138",
+			expect:      map[string]string{"X-Databricks-Org-Id": "7474644166319138"},
+		},
+		{
+			name:        "without workspace ID",
+			workspaceID: "",
+			expect:      nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			apiClient := &client.DatabricksClient{
+				Config: &config.Config{WorkspaceID: tc.workspaceID},
+			}
+			assert.Equal(t, tc.expect, orgIDHeaders(apiClient))
+		})
+	}
+}
+
+func TestTelemetryUploadSendsOrgIDHeader(t *testing.T) {
+	server := testserver.New(t)
+	t.Cleanup(server.Close)
+
+	const workspaceID = "7474644166319138"
+	var gotHeader string
+	server.Handle("POST", "/telemetry-ext", func(req testserver.Request) any {
+		gotHeader = req.Headers.Get("X-Databricks-Org-Id")
+		return ResponseBody{NumProtoSuccess: 1}
+	})
+
+	ctx := WithNewLogger(t.Context())
+	Log(ctx, protos.DatabricksCliLog{
+		CliTestEvent: &protos.CliTestEvent{Name: protos.DummyCliEnumValue1},
+	})
+	ctx = cmdctx.SetConfigUsed(ctx, &config.Config{
+		Host:        server.URL,
+		Token:       "token",
+		WorkspaceID: workspaceID,
+	})
+
+	require.NoError(t, Upload(ctx, protos.ExecutionContext{}))
+	assert.Equal(t, workspaceID, gotHeader)
+}
 
 func TestTelemetryUploadRetriesOnPartialSuccess(t *testing.T) {
 	server := testserver.New(t)

--- a/libs/telemetry/logger_test.go
+++ b/libs/telemetry/logger_test.go
@@ -7,63 +7,10 @@ import (
 	"github.com/databricks/cli/libs/telemetry/protos"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/databricks/databricks-sdk-go/client"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestOrgIDHeaders(t *testing.T) {
-	tests := []struct {
-		name        string
-		workspaceID string
-		expect      map[string]string
-	}{
-		{
-			name:        "with workspace ID",
-			workspaceID: "7474644166319138",
-			expect:      map[string]string{"X-Databricks-Org-Id": "7474644166319138"},
-		},
-		{
-			name:        "without workspace ID",
-			workspaceID: "",
-			expect:      nil,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			apiClient := &client.DatabricksClient{
-				Config: &config.Config{WorkspaceID: tc.workspaceID},
-			}
-			assert.Equal(t, tc.expect, orgIDHeaders(apiClient))
-		})
-	}
-}
-
-func TestTelemetryUploadSendsOrgIDHeader(t *testing.T) {
-	server := testserver.New(t)
-	t.Cleanup(server.Close)
-
-	const workspaceID = "7474644166319138"
-	var gotHeader string
-	server.Handle("POST", "/telemetry-ext", func(req testserver.Request) any {
-		gotHeader = req.Headers.Get("X-Databricks-Org-Id")
-		return ResponseBody{NumProtoSuccess: 1}
-	})
-
-	ctx := WithNewLogger(t.Context())
-	Log(ctx, protos.DatabricksCliLog{
-		CliTestEvent: &protos.CliTestEvent{Name: protos.DummyCliEnumValue1},
-	})
-	ctx = cmdctx.SetConfigUsed(ctx, &config.Config{
-		Host:        server.URL,
-		Token:       "token",
-		WorkspaceID: workspaceID,
-	})
-
-	require.NoError(t, Upload(ctx, protos.ExecutionContext{}))
-	assert.Equal(t, workspaceID, gotHeader)
-}
 
 func TestTelemetryUploadRetriesOnPartialSuccess(t *testing.T) {
 	server := testserver.New(t)


### PR DESCRIPTION
## Why

SPOG hosts serve multiple workspaces from a single URL and require the `X-Databricks-Org-Id` header to route requests to the correct workspace. Without it, telemetry recorded by `/telemetry-ext` lands in a central shard rather than the user's workspace.

The CLI's telemetry code makes a direct `apiClient.Do()` call to `/telemetry-ext` that bypasses the SDK's generated service methods (which set this header from `cfg.WorkspaceID`) and was passing `nil` for headers.

This mirrors the fix already applied for filer in #4985. SDK PR databricks/databricks-sdk-go#1634 only patched `Workspace.Download()` / `Workspace.Upload()`; it is not a transport-level visitor, so direct `apiClient.Do()` callers in the CLI still need to set the header explicitly.

## Changes

- `libs/telemetry/logger.go`: add `orgIDHeaders(apiClient)` helper that returns `{"X-Databricks-Org-Id": cfg.WorkspaceID}` when set, `nil` otherwise; pass it to `apiClient.Do()` in `attempt()`.
- `acceptance/telemetry/test.toml`: append `X-Databricks-Org-Id` to `IncludeRequestHeaders` so the existing telemetry acceptance tests capture the header on `POST /telemetry-ext`. The header value is resolved from `.well-known/databricks-config` via the SDK and now flows into the recorded request, giving end-to-end coverage.

## Test plan

- [x] `go test ./acceptance -run TestAccept/telemetry` passes; `out.requests.txt` for success/partial-success/failure/timeout now includes `X-Databricks-Org-Id`.
- [x] `go test ./libs/telemetry/...` passes.

This pull request was AI-assisted by Isaac.