### PR TITLE
Add changelog entry for alert_task.workspace_path translation

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Bundles
 
+* Translate relative paths in `alert_task.workspace_path` on job tasks to fully qualified workspace paths, matching the behavior of other task path fields. Applies to both regular tasks and `for_each_task` nested tasks ([#4836](https://github.com/databricks/cli/pull/4836)).
+
 ### Dependency updates
 
 * Added `github.com/zalando/go-keyring` as a new dependency (dormant until a later release enables experimental secure-storage for OAuth tokens).


### PR DESCRIPTION
## Summary
- Add `Bundles` changelog entry for [#4836](https://github.com/databricks/cli/pull/4836), which added relative path translation for `alert_task.workspace_path` in job tasks.

## Test plan
- [x] N/A — changelog-only change.

This pull request was AI-assisted by Isaac.