### PR TITLE
filer: detect notebook already-exists across both error formats

### DIFF
--- a/integration/libs/filer/filer_test.go
+++ b/integration/libs/filer/filer_test.go
@@ -443,7 +443,7 @@ func TestFilerWorkspaceNotebook(t *testing.T) {
 			// Assert uploading a second time fails due to overwrite mode missing
 			err = f.Write(ctx, tc.name, strings.NewReader(tc.content2))
 			require.ErrorIs(t, err, fs.ErrExist)
-			assert.Regexp(t, `file already exists: .*/`+tc.nameWithoutExt+`$`, err.Error())
+			assert.Regexp(t, `file already exists: .*/`+tc.name+`$`, err.Error())
 
 			// Try uploading the notebook again with overwrite flag. This time it should succeed.
 			err = f.Write(ctx, tc.name, strings.NewReader(tc.content2), filer.OverwriteIfExists)

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -209,30 +208,14 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 		return fileAlreadyExistsError{absPath}
 	}
 
-	// This API returns 400 if the file already exists, when the object type is notebook.
-	// We match both the historical "Path (<path>) already exists." format and the newer
-	// "RESOURCE_ALREADY_EXISTS: <path> ..." format because the new format has not been
-	// rolled out to all workspaces yet. The error_code field is empty in the JSON body
-	// for both formats, so we anchor on markers in the message rather than using
-	// errors.Is(apierr.ErrResourceAlreadyExists).
-	notebookExistsRegexes := []*regexp.Regexp{
-		regexp.MustCompile(`Path \((.*)\) already exists\.`),
-		regexp.MustCompile(`RESOURCE_ALREADY_EXISTS: (\S+)`),
-	}
-	if aerr.StatusCode == http.StatusBadRequest {
-		for _, regex := range notebookExistsRegexes {
-			if !regex.MatchString(aerr.Message) {
-				continue
-			}
-			// Parse file path from regex capture group
-			matches := regex.FindStringSubmatch(aerr.Message)
-			if len(matches) == 2 {
-				return fileAlreadyExistsError{matches[1]}
-			}
-
-			// Default to path specified to filer.Write if regex capture fails
-			return fileAlreadyExistsError{absPath}
-		}
+	// This API returns 400 if the file already exists when the object type is notebook.
+	// Both the historical "Path (<path>) already exists." format and the newer
+	// "RESOURCE_ALREADY_EXISTS: <path> already exists. ..." format end with the same
+	// "already exists." marker; the JSON error_code is empty in both. The new format
+	// might not have been rolled out to all workspaces yet, so we anchor on the shared
+	// marker and return absPath rather than parsing the message.
+	if aerr.StatusCode == http.StatusBadRequest && strings.Contains(aerr.Message, "already exists.") {
+		return fileAlreadyExistsError{absPath}
 	}
 
 	// This API returns StatusForbidden when you have read access but don't have write access to a file

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -209,8 +209,10 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 		return fileAlreadyExistsError{absPath}
 	}
 
-	// This API returns 400 if the file already exists, when the object type is notebook
-	regex := regexp.MustCompile(`Path \((.*)\) already exists.`)
+	// This API returns 400 if the file already exists, when the object type is notebook.
+	// The error_code field is empty in the JSON body, so we anchor on the
+	// RESOURCE_ALREADY_EXISTS marker that the API embeds in the message instead.
+	regex := regexp.MustCompile(`RESOURCE_ALREADY_EXISTS: (\S+)`)
 	if aerr.StatusCode == http.StatusBadRequest && regex.MatchString(aerr.Message) {
 		// Parse file path from regex capture group
 		matches := regex.FindStringSubmatch(aerr.Message)

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -210,18 +210,29 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 	}
 
 	// This API returns 400 if the file already exists, when the object type is notebook.
-	// The error_code field is empty in the JSON body, so we anchor on the
-	// RESOURCE_ALREADY_EXISTS marker that the API embeds in the message instead.
-	regex := regexp.MustCompile(`RESOURCE_ALREADY_EXISTS: (\S+)`)
-	if aerr.StatusCode == http.StatusBadRequest && regex.MatchString(aerr.Message) {
-		// Parse file path from regex capture group
-		matches := regex.FindStringSubmatch(aerr.Message)
-		if len(matches) == 2 {
-			return fileAlreadyExistsError{matches[1]}
-		}
+	// We match both the historical "Path (<path>) already exists." format and the newer
+	// "RESOURCE_ALREADY_EXISTS: <path> ..." format because the new format has not been
+	// rolled out to all workspaces yet. The error_code field is empty in the JSON body
+	// for both formats, so we anchor on markers in the message rather than using
+	// errors.Is(apierr.ErrResourceAlreadyExists).
+	notebookExistsRegexes := []*regexp.Regexp{
+		regexp.MustCompile(`Path \((.*)\) already exists\.`),
+		regexp.MustCompile(`RESOURCE_ALREADY_EXISTS: (\S+)`),
+	}
+	if aerr.StatusCode == http.StatusBadRequest {
+		for _, regex := range notebookExistsRegexes {
+			if !regex.MatchString(aerr.Message) {
+				continue
+			}
+			// Parse file path from regex capture group
+			matches := regex.FindStringSubmatch(aerr.Message)
+			if len(matches) == 2 {
+				return fileAlreadyExistsError{matches[1]}
+			}
 
-		// Default to path specified to filer.Write if regex capture fails
-		return fileAlreadyExistsError{absPath}
+			// Default to path specified to filer.Write if regex capture fails
+			return fileAlreadyExistsError{absPath}
+		}
 	}
 
 	// This API returns StatusForbidden when you have read access but don't have write access to a file


### PR DESCRIPTION
## Summary

The Workspace files import-file API used to return `Path (<path>) already exists.` for notebook conflicts. The format has changed on some workspaces to `RESOURCE_ALREADY_EXISTS: <path> already exists. ...`. The original regex no longer matched the new format, so `fs.ErrExist` was not returned — breaking `TestImportDirDoesNotOverwrite` and 8 `TestFilerWorkspaceNotebook` subtests on every cloud.

The new format might not have been rolled out to all workspaces yet (see [databricks-sdk-go#1639](https://github.com/databricks/databricks-sdk-go/pull/1639)), and the JSON `error_code` is empty in both. Both messages end with `already exists.`, so we anchor on that substring and return the request `absPath` in the error rather than parsing the message.

The integration test assertion is updated to expect the path with extension (`tc.name`) instead of without (`tc.nameWithoutExt`), since `absPath` is the request path.

## Test plan

- [x] `go test ./libs/filer/...` passes locally
- [x] `TestFilerWorkspaceNotebook` passes on aws-prod-ucws (new format)
- [ ] Verify a workspace still emitting the old format also passes (best-effort — single substring match handles both)

This pull request was AI-assisted by Isaac.