### PR TITLE
acceptance: add default_branch to postgres project test outputs

### DIFF
--- a/acceptance/bundle/resources/postgres_projects/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/basic/output.txt
@@ -31,6 +31,7 @@ Deployment complete!
   "name": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
+    "default_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
     "default_endpoint_settings": {
       "autoscaling_limit_max_cu": 4,
       "autoscaling_limit_min_cu": 0.5,

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
@@ -3,6 +3,7 @@
   "name": "[MY_PROJECT_ID_2]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
+    "default_branch": "[MY_PROJECT_ID_2]/branches/production",
     "default_endpoint_settings": {
       "autoscaling_limit_max_cu": 4,
       "autoscaling_limit_min_cu": 0.5,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -5,6 +5,7 @@
     "name": "[MY_PROJECT_ID]",
     "status": {
       "branch_logical_size_limit_bytes": [NUMID],
+      "default_branch": "[MY_PROJECT_ID]/branches/production",
       "default_endpoint_settings": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -18,6 +18,7 @@
     "name": "[MY_PROJECT_ID]",
     "status": {
       "branch_logical_size_limit_bytes": [NUMID],
+      "default_branch": "[MY_PROJECT_ID]/branches/production",
       "default_endpoint_settings": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -18,6 +18,7 @@
     "name": "[MY_PROJECT_ID]",
     "status": {
       "branch_logical_size_limit_bytes": [NUMID],
+      "default_branch": "[MY_PROJECT_ID]/branches/production",
       "default_endpoint_settings": {
         "autoscaling_limit_max_cu": 4,
         "autoscaling_limit_min_cu": 0.5,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
@@ -29,6 +29,7 @@ Deployment complete!
   "name": "[MY_PROJECT_ID]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
+    "default_branch": "[MY_PROJECT_ID]/branches/production",
     "default_endpoint_settings": {
       "autoscaling_limit_max_cu": 4,
       "autoscaling_limit_min_cu": 0.5,
@@ -100,6 +101,7 @@ Deployment complete!
   "name": "[MY_PROJECT_ID]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
+    "default_branch": "[MY_PROJECT_ID]/branches/production",
     "default_endpoint_settings": {
       "autoscaling_limit_max_cu": 4,
       "autoscaling_limit_min_cu": 0.5,
@@ -138,6 +140,7 @@ Deployment complete!
   "name": "[MY_PROJECT_ID]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
+    "default_branch": "[MY_PROJECT_ID]/branches/production",
     "default_endpoint_settings": {
       "autoscaling_limit_max_cu": 4,
       "autoscaling_limit_min_cu": 0.5,

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -74,6 +74,7 @@ func (s *FakeWorkspace) PostgresProjectCreate(req Request, projectID string) Res
 	// Copy spec fields to status (API returns status as materialized view)
 	if project.Spec != nil {
 		project.Status = &postgres.ProjectStatus{
+			DefaultBranch:               name + "/branches/production",
 			DisplayName:                 project.Spec.DisplayName,
 			PgVersion:                   project.Spec.PgVersion,
 			HistoryRetentionDuration:    project.Spec.HistoryRetentionDuration,


### PR DESCRIPTION
## Summary

The Lakebase postgres API now returns `\"default_branch\": \"<project>/branches/production\"` in `ProjectStatus`. Update the testserver mock to populate the field on project create and regenerate the affected acceptance test outputs (basic, recreate, update_display_name) so the tests pass against both the local testserver and a real cloud workspace.

This was failing in nightly runs on aws-prod-ucws.

## Test plan

- [x] \`go test ./acceptance -run TestAccept/bundle/resources/postgres_projects\` passes locally
- [x] Verified all 8 subtests pass on aws-prod-ucws

This pull request was AI-assisted by Isaac.