### PR TITLE
acceptance: shorten vector_search_endpoint test name to fit 50-char API limit

### DIFF
--- a/acceptance/bundle/invariant/configs/vector_search_endpoint.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/vector_search_endpoint.yml.tmpl
@@ -7,7 +7,8 @@ resources:
       name: test-endpoint-$UNIQUE_NAME
       endpoint_type: STANDARD
     bar:
-      name: test-endpoint-with-permissions-$UNIQUE_NAME
+      # Endpoint names must be < 50 chars, so keep this prefix short.
+      name: test-vse-perm-$UNIQUE_NAME
       endpoint_type: STANDARD
       permissions:
         - level: CAN_USE


### PR DESCRIPTION
## Summary

The vector search endpoint name \`test-endpoint-with-permissions-\$UNIQUE_NAME\` was 57 characters, exceeding the API's 50-character limit. Rename to \`test-vse-perm-\$UNIQUE_NAME\` (40 chars) so the no_drift invariant test passes on UCWS.

This was failing in nightly runs on aws-prod-ucws and azure-prod-ucws.

## Test plan

- [x] Verified \`TestAccept/bundle/invariant/no_drift/...vector_search_endpoint.yml.tmpl\` passes on aws-prod-ucws

This pull request was AI-assisted by Isaac.