### PR TITLE
acceptance: strip display_name from user ACL entries on UCWS

### DIFF
--- a/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.permissions_create.json
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.permissions_create.json
@@ -28,7 +28,6 @@
           "permission_level": "CAN_MANAGE_RUN"
         }
       ],
-      "display_name": "test-dabs-1@databricks.com",
       "user_name": "test-dabs-1@databricks.com"
     },
     {
@@ -38,7 +37,6 @@
           "permission_level": "CAN_VIEW"
         }
       ],
-      "display_name": "test-dabs-2@databricks.com",
       "user_name": "test-dabs-2@databricks.com"
     },
     {

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.permissions_update.json
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/out.permissions_update.json
@@ -28,7 +28,6 @@
           "permission_level": "CAN_VIEW"
         }
       ],
-      "display_name": "test-dabs-2@databricks.com",
       "user_name": "test-dabs-2@databricks.com"
     },
     {

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/script
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/cloud/script
@@ -25,7 +25,9 @@ sort_acl_requests() {
 }
 
 sort_acl() {
-    jq '.access_control_list |= if . != null then sort_by(.all_permissions[0].permission_level, (.group_name // ""), (.user_name != null), (.service_principal_name != null)) else . end'
+    # ucws workspaces omit display_name on user entries while non-ucws workspaces echo it back as user_name.
+    # Strip display_name on user entries to make output stable across workspace types.
+    jq '.access_control_list |= if . != null then sort_by(.all_permissions[0].permission_level, (.group_name // ""), (.user_name != null), (.service_principal_name != null)) | map(if .user_name != null then del(.display_name) else . end) else . end'
 }
 
 trace $CLI bundle deploy


### PR DESCRIPTION
## Summary

aws-ucws workspaces don't echo \`display_name\` back on user permission entries while non-ucws workspaces do. The expected fixtures had \`display_name\`, so the test diverged on aws-ucws.

- Update the script's \`sort_acl\` jq pipeline to \`del(.display_name)\` on entries with \`user_name\` (service principal entries keep it)
- Update expected files to match

## Test plan

- [x] Verified \`TestAccept/bundle/resources/permissions/jobs/delete_one/cloud\` passes on aws-prod-ucws

This pull request was AI-assisted by Isaac.