### PR TITLE
Improve auth token error formatting for easier copy-paste

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Release v1.1.0
 
-### Notable Changes
-
 ### CLI
+
+* Improve `auth token` error formatting for easier copy-paste of login commands ([#5115](https://github.com/databricks/cli/pull/5115)).
 
 ### Bundles
 * The error reported when a direct-only resource (catalogs, external locations, vector search endpoints) is used with the terraform engine now also suggests setting `bundle.engine: direct` in `databricks.yml`, in addition to the `DATABRICKS_BUNDLE_ENGINE` environment variable ([#5295](https://github.com/databricks/cli/pull/5295)).

--- a/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/output.txt
+++ b/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/output.txt
@@ -2,6 +2,6 @@ Error: A new access token could not be retrieved because the refresh token is in
 
 To reauthenticate, run the following command:
 
-  $ databricks auth login --profile test-profile --workspace-id [NUMID]
+  $ databricks auth login --profile test-profile
 
 Exit code: 1

--- a/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/output.txt
+++ b/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/output.txt
@@ -1,4 +1,7 @@
-Error: A new access token could not be retrieved because the refresh token is invalid. To reauthenticate, run the following command:
-  $ databricks auth login --profile test-profile
+Error: A new access token could not be retrieved because the refresh token is invalid.
+
+To reauthenticate, run the following command:
+
+  $ databricks auth login --profile test-profile --workspace-id [NUMID]
 
 Exit code: 1

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -26,9 +26,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func helpfulError(ctx context.Context, profile string, persistentAuth u2m.OAuthArgument) string {
-	loginMsg := auth.BuildLoginCommand(ctx, profile, persistentAuth)
-	return fmt.Sprintf("Try logging in again with `%s` before retrying. If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new", loginMsg)
+func helpfulError(ctx context.Context, profile, workspaceID string, persistentAuth u2m.OAuthArgument) string {
+	loginMsg := auth.BuildLoginCommand(ctx, profile, workspaceID, persistentAuth)
+	return fmt.Sprintf("To reauthenticate, run the following command:\n\n  $ %s\n\nIf this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new", loginMsg)
 }
 
 func newTokenCommand(authArguments *auth.AuthArguments) *cobra.Command {
@@ -268,8 +268,8 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 	allArgs = append(allArgs, u2m.WithOAuthArgument(oauthArgument))
 	persistentAuth, err := u2m.NewPersistentAuth(ctx, allArgs...)
 	if err != nil {
-		helpMsg := helpfulError(ctx, args.profileName, oauthArgument)
-		return nil, fmt.Errorf("%w. %s", err, helpMsg)
+		helpMsg := helpfulError(ctx, args.profileName, args.authArguments.WorkspaceID, oauthArgument)
+		return nil, fmt.Errorf("%w.\n\n%s", err, helpMsg)
 	}
 	var t *oauth2.Token
 	if args.forceRefresh {
@@ -302,11 +302,11 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 			}
 			err = errors.New("cache: " + compatSubstring)
 		}
-		if rewritten, rewrittenErr := auth.RewriteAuthError(ctx, args.authArguments.Host, args.authArguments.AccountID, args.profileName, err); rewritten {
+		if rewritten, rewrittenErr := auth.RewriteAuthError(ctx, args.authArguments.Host, args.authArguments.AccountID, args.authArguments.WorkspaceID, args.profileName, err); rewritten {
 			return nil, rewrittenErr
 		}
-		helpMsg := helpfulError(ctx, args.profileName, oauthArgument)
-		return nil, fmt.Errorf("%w. %s", err, helpMsg)
+		helpMsg := helpfulError(ctx, args.profileName, args.authArguments.WorkspaceID, oauthArgument)
+		return nil, fmt.Errorf("%w.\n\n%s", err, helpMsg)
 	}
 	return t, nil
 }

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -302,7 +302,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 			}
 			err = errors.New("cache: " + compatSubstring)
 		}
-		if rewritten, rewrittenErr := auth.RewriteAuthError(ctx, args.authArguments.Host, args.authArguments.AccountID, args.authArguments.WorkspaceID, args.profileName, err); rewritten {
+		if rewritten, rewrittenErr := auth.RewriteAuthError(ctx, args.authArguments.Host, args.authArguments.AccountID, args.authArguments.WorkspaceID, args.authArguments.DiscoveryURL, args.profileName, err); rewritten {
 			return nil, rewrittenErr
 		}
 		helpMsg := helpfulError(ctx, args.profileName, args.authArguments.WorkspaceID, oauthArgument)

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -247,8 +247,9 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
 			},
-			wantErr: `A new access token could not be retrieved because the refresh token is invalid. To reauthenticate, run the following command:
-  $ databricks auth login --profile expired`,
+			wantErr: "A new access token could not be retrieved because the refresh token is invalid.\n\n" +
+				"To reauthenticate, run the following command:\n\n" +
+				"  $ databricks auth login --profile expired",
 		},
 		{
 			name: "prints helpful login message on refresh failure when host is specified",
@@ -268,8 +269,9 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
 			},
-			wantErr: `A new access token could not be retrieved because the refresh token is invalid. To reauthenticate, run the following command:
-  $ databricks auth login --profile expired`,
+			wantErr: "A new access token could not be retrieved because the refresh token is invalid.\n\n" +
+				"To reauthenticate, run the following command:\n\n" +
+				"  $ databricks auth login --profile expired",
 		},
 		{
 			name: "prints helpful login message on invalid response",
@@ -286,8 +288,10 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureInvalidResponse}}),
 				},
 			},
-			wantErr: "token refresh: oauth2: cannot parse json: invalid character 'N' looking for beginning of value. Try logging in again with " +
-				"`databricks auth login --profile active` before retrying. If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new",
+			wantErr: "token refresh: oauth2: cannot parse json: invalid character 'N' looking for beginning of value.\n\n" +
+				"To reauthenticate, run the following command:\n\n" +
+				"  $ databricks auth login --profile active\n\n" +
+				"If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new",
 		},
 		{
 			name: "prints helpful login message on other error response",
@@ -304,8 +308,10 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureOtherError}}),
 				},
 			},
-			wantErr: "token refresh: Databricks is down (error code: other_error). Try logging in again with " +
-				"`databricks auth login --profile active` before retrying. If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new",
+			wantErr: "token refresh: Databricks is down (error code: other_error).\n\n" +
+				"To reauthenticate, run the following command:\n\n" +
+				"  $ databricks auth login --profile active\n\n" +
+				"If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new",
 		},
 		{
 			name: "succeeds with profile",
@@ -423,8 +429,9 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
-			wantErr: "cache: databricks OAuth is not configured for this host. " +
-				"Try logging in again with `databricks auth login --host https://nonexistent.cloud.databricks.com` before retrying. " +
+			wantErr: "cache: databricks OAuth is not configured for this host.\n\n" +
+				"To reauthenticate, run the following command:\n\n" +
+				"  $ databricks auth login --host https://nonexistent.cloud.databricks.com\n\n" +
 				"If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new",
 		},
 		{
@@ -851,8 +858,9 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
 			},
-			wantErr: `A new access token could not be retrieved because the refresh token is invalid. To reauthenticate, run the following command:
-  $ databricks auth login --profile valid-token`,
+			wantErr: "A new access token could not be retrieved because the refresh token is invalid.\n\n" +
+				"To reauthenticate, run the following command:\n\n" +
+				"  $ databricks auth login --profile valid-token",
 		},
 	}
 	for _, c := range cases {

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -367,7 +367,7 @@ func emptyHttpRequest(ctx context.Context) *http.Request {
 }
 
 func renderError(ctx context.Context, cfg *config.Config, err error) error {
-	if rewritten, newErr := auth.RewriteAuthError(ctx, cfg.Host, cfg.AccountID, cfg.WorkspaceID, cfg.Profile, err); rewritten {
+	if rewritten, newErr := auth.RewriteAuthError(ctx, cfg.Host, cfg.AccountID, cfg.WorkspaceID, cfg.DiscoveryURL, cfg.Profile, err); rewritten {
 		return newErr
 	}
 	return err

--- a/cmd/root/auth.go
+++ b/cmd/root/auth.go
@@ -367,7 +367,7 @@ func emptyHttpRequest(ctx context.Context) *http.Request {
 }
 
 func renderError(ctx context.Context, cfg *config.Config, err error) error {
-	if rewritten, newErr := auth.RewriteAuthError(ctx, cfg.Host, cfg.AccountID, cfg.Profile, err); rewritten {
+	if rewritten, newErr := auth.RewriteAuthError(ctx, cfg.Host, cfg.AccountID, cfg.WorkspaceID, cfg.Profile, err); rewritten {
 		return newErr
 	}
 	return err

--- a/libs/auth/error.go
+++ b/libs/auth/error.go
@@ -141,14 +141,14 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 
 	case AuthTypePat:
 		if cfg.Profile != "" {
-			fmt.Fprintf(b, "\n  - Regenerate your access token or run: databricks auth login --profile %s", cfg.Profile)
+			fmt.Fprintf(b, "\n  - Regenerate your access token or run: %s", BuildLoginCommand(ctx, cfg.Profile, "", nil))
 		} else {
 			fmt.Fprint(b, "\n  - Regenerate your access token")
 		}
 
 	case AuthTypeBasic:
 		if cfg.Profile != "" {
-			fmt.Fprintf(b, "\n  - Check your username/password or run: databricks auth login --profile %s", cfg.Profile)
+			fmt.Fprintf(b, "\n  - Check your username/password or run: %s", BuildLoginCommand(ctx, cfg.Profile, "", nil))
 		} else {
 			fmt.Fprint(b, "\n  - Check your username and password")
 		}

--- a/libs/auth/error.go
+++ b/libs/auth/error.go
@@ -54,13 +54,19 @@ func AuthTypeDisplayName(authType string) string {
 
 // RewriteAuthError rewrites the error message for invalid refresh token error.
 // It returns whether the error was rewritten and the rewritten error.
-func RewriteAuthError(ctx context.Context, host, accountId, workspaceId, profile string, err error) (bool, error) {
+//
+// discoveryURL is required so unified/SPOG hosts are recognized: without it,
+// ToOAuthArgument falls back to host-shape heuristics and the suggested
+// reauth command would drop --account-id / --workspace-id for hosts that
+// actually need them (see HasUnifiedHostSignal).
+func RewriteAuthError(ctx context.Context, host, accountId, workspaceId, discoveryURL, profile string, err error) (bool, error) {
 	target := &u2m.InvalidRefreshTokenError{}
 	if errors.As(err, &target) {
 		oauthArgument, err := AuthArguments{
-			Host:        host,
-			AccountID:   accountId,
-			WorkspaceID: workspaceId,
+			Host:         host,
+			AccountID:    accountId,
+			WorkspaceID:  workspaceId,
+			DiscoveryURL: discoveryURL,
 		}.ToOAuthArgument()
 		if err != nil {
 			return false, err

--- a/libs/auth/error.go
+++ b/libs/auth/error.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/databricks/cli/libs/shellquote"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/credentials/u2m"
@@ -53,18 +54,20 @@ func AuthTypeDisplayName(authType string) string {
 
 // RewriteAuthError rewrites the error message for invalid refresh token error.
 // It returns whether the error was rewritten and the rewritten error.
-func RewriteAuthError(ctx context.Context, host, accountId, profile string, err error) (bool, error) {
+func RewriteAuthError(ctx context.Context, host, accountId, workspaceId, profile string, err error) (bool, error) {
 	target := &u2m.InvalidRefreshTokenError{}
 	if errors.As(err, &target) {
 		oauthArgument, err := AuthArguments{
-			Host:      host,
-			AccountID: accountId,
+			Host:        host,
+			AccountID:   accountId,
+			WorkspaceID: workspaceId,
 		}.ToOAuthArgument()
 		if err != nil {
 			return false, err
 		}
-		msg := `A new access token could not be retrieved because the refresh token is invalid. To reauthenticate, run the following command:
-  $ ` + BuildLoginCommand(ctx, profile, oauthArgument)
+		msg := "A new access token could not be retrieved because the refresh token is invalid.\n\n" +
+			"To reauthenticate, run the following command:\n\n" +
+			"  $ " + BuildLoginCommand(ctx, profile, workspaceId, oauthArgument)
 		return true, errors.New(msg)
 	}
 	return false, err
@@ -118,9 +121,11 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 	switch strings.ToLower(cfg.AuthType) {
 	case AuthTypeDatabricksCli:
 		// When profile is set, BuildLoginCommand uses --profile and ignores
-		// the OAuthArgument, so skip the conversion entirely.
+		// the OAuthArgument, so skip the conversion entirely. Route through
+		// the helper so this branch picks up shell-quoting on the profile name
+		// and emits --workspace-id consistently with the host-based branch.
 		if cfg.Profile != "" {
-			fmt.Fprintf(b, "\n  - Re-authenticate: databricks auth login --profile %s", cfg.Profile)
+			fmt.Fprintf(b, "\n  - Re-authenticate: %s", BuildLoginCommand(ctx, cfg.Profile, cfg.WorkspaceID, nil))
 			return
 		}
 		oauthArg, argErr := AuthArguments{
@@ -133,7 +138,7 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 			fmt.Fprint(b, "\n  - Re-authenticate: databricks auth login")
 			return
 		}
-		fmt.Fprintf(b, "\n  - Re-authenticate: %s", BuildLoginCommand(ctx, "", oauthArg))
+		fmt.Fprintf(b, "\n  - Re-authenticate: %s", BuildLoginCommand(ctx, "", cfg.WorkspaceID, oauthArg))
 
 	case AuthTypePat:
 		if cfg.Profile != "" {
@@ -160,8 +165,23 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 	}
 }
 
-// BuildLoginCommand builds the login command for the given OAuth argument or profile.
-func BuildLoginCommand(ctx context.Context, profile string, arg u2m.OAuthArgument) string {
+// BuildLoginCommand builds the login command for the given OAuth argument or
+// profile. Each argument is shell-quoted so the rendered command is safe to
+// copy-paste even when host, profile, or account-id values contain spaces or
+// shell metacharacters.
+//
+// workspaceID, when non-empty and not the WorkspaceIDNone sentinel, is
+// emitted as --workspace-id for unified hosts so the suggested reauth
+// targets the same workspace the failing call resolved against (the
+// information the OAuthArgument otherwise drops). It is also re-emitted on
+// the profile path so the suggested reauth pins the same workspace_id the
+// failing call resolved against, even if the profile's persisted value has
+// drifted.
+//
+// For AccountOAuthArgument and WorkspaceOAuthArgument, workspaceID is
+// intentionally ignored: account args target the account API, and workspace
+// args already identify a workspace via --host.
+func BuildLoginCommand(ctx context.Context, profile, workspaceID string, arg u2m.OAuthArgument) string {
 	cmd := []string{
 		"databricks",
 		"auth",
@@ -169,19 +189,36 @@ func BuildLoginCommand(ctx context.Context, profile string, arg u2m.OAuthArgumen
 	}
 	if profile != "" {
 		cmd = append(cmd, "--profile", profile)
+		if isExplicitWorkspaceID(workspaceID) {
+			cmd = append(cmd, "--workspace-id", workspaceID)
+		}
 	} else {
 		switch arg := arg.(type) {
 		case u2m.UnifiedOAuthArgument:
 			// Discovery handles unified-host routing from --host + --account-id,
 			// so we no longer suggest --experimental-is-unified-host here.
 			cmd = append(cmd, "--host", arg.GetHost(), "--account-id", arg.GetAccountId())
+			if isExplicitWorkspaceID(workspaceID) {
+				cmd = append(cmd, "--workspace-id", workspaceID)
+			}
 		case u2m.AccountOAuthArgument:
 			cmd = append(cmd, "--host", arg.GetAccountHost(), "--account-id", arg.GetAccountId())
 		case u2m.WorkspaceOAuthArgument:
 			cmd = append(cmd, "--host", arg.GetWorkspaceHost())
 		}
 	}
-	return strings.Join(cmd, " ")
+	quoted := make([]string, len(cmd))
+	for i, c := range cmd {
+		quoted[i] = shellquote.BashArg(c)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// isExplicitWorkspaceID reports whether workspaceID names a real workspace
+// (not the "none" sentinel persisted to .databrickscfg when the user
+// explicitly skipped workspace selection).
+func isExplicitWorkspaceID(workspaceID string) bool {
+	return workspaceID != "" && workspaceID != WorkspaceIDNone
 }
 
 // BuildDescribeCommand builds the describe command for the given config.
@@ -190,7 +227,7 @@ func BuildLoginCommand(ctx context.Context, profile string, arg u2m.OAuthArgumen
 // automatically.
 func BuildDescribeCommand(cfg *config.Config) string {
 	if cfg.Profile != "" {
-		return "databricks auth describe --profile " + cfg.Profile
+		return "databricks auth describe --profile " + shellquote.BashArg(cfg.Profile)
 	}
 	return "databricks auth describe"
 }

--- a/libs/auth/error.go
+++ b/libs/auth/error.go
@@ -122,10 +122,9 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 	case AuthTypeDatabricksCli:
 		// When profile is set, BuildLoginCommand uses --profile and ignores
 		// the OAuthArgument, so skip the conversion entirely. Route through
-		// the helper so this branch picks up shell-quoting on the profile name
-		// and emits --workspace-id consistently with the host-based branch.
+		// the helper so this branch picks up shell-quoting on the profile name.
 		if cfg.Profile != "" {
-			fmt.Fprintf(b, "\n  - Re-authenticate: %s", BuildLoginCommand(ctx, cfg.Profile, cfg.WorkspaceID, nil))
+			fmt.Fprintf(b, "\n  - Re-authenticate: %s", BuildLoginCommand(ctx, cfg.Profile, "", nil))
 			return
 		}
 		oauthArg, argErr := AuthArguments{
@@ -173,14 +172,15 @@ func writeReauthSteps(ctx context.Context, cfg *config.Config, b *strings.Builde
 // workspaceID, when non-empty and not the WorkspaceIDNone sentinel, is
 // emitted as --workspace-id for unified hosts so the suggested reauth
 // targets the same workspace the failing call resolved against (the
-// information the OAuthArgument otherwise drops). It is also re-emitted on
-// the profile path so the suggested reauth pins the same workspace_id the
-// failing call resolved against, even if the profile's persisted value has
-// drifted.
+// information the OAuthArgument otherwise drops).
+//
+// On the profile path workspaceID is ignored: `auth login --profile foo`
+// already picks up the profile's stored workspace_id, so re-emitting it
+// would be redundant.
 //
 // For AccountOAuthArgument and WorkspaceOAuthArgument, workspaceID is
-// intentionally ignored: account args target the account API, and workspace
-// args already identify a workspace via --host.
+// also intentionally ignored: account args target the account API, and
+// workspace args already identify a workspace via --host.
 func BuildLoginCommand(ctx context.Context, profile, workspaceID string, arg u2m.OAuthArgument) string {
 	cmd := []string{
 		"databricks",
@@ -189,9 +189,6 @@ func BuildLoginCommand(ctx context.Context, profile, workspaceID string, arg u2m
 	}
 	if profile != "" {
 		cmd = append(cmd, "--profile", profile)
-		if isExplicitWorkspaceID(workspaceID) {
-			cmd = append(cmd, "--workspace-id", workspaceID)
-		}
 	} else {
 		switch arg := arg.(type) {
 		case u2m.UnifiedOAuthArgument:

--- a/libs/auth/error_test.go
+++ b/libs/auth/error_test.go
@@ -36,11 +36,14 @@ func TestBuildLoginCommand_AppendsWorkspaceID(t *testing.T) {
 		assert.Equal(t, "databricks auth login --profile dev", BuildLoginCommand(ctx, "dev", WorkspaceIDNone, nil))
 	})
 
+	// Use a .test TLD with an explicit DiscoveryURL so ToOAuthArgument never
+	// triggers a real .well-known resolution (which can stall CI for ~5min
+	// per call on networks that can't fast-fail public lookups). See PR #5125.
 	t.Run("unified host path emits --workspace-id when set", func(t *testing.T) {
 		oauthArg, err := AuthArguments{
-			Host:         "https://unified.cloud.databricks.com",
+			Host:         "https://unified.cloud.databricks.test",
 			AccountID:    "acc-123",
-			DiscoveryURL: "https://unified.cloud.databricks.com/oidc/accounts/acc-123/.well-known/oauth-authorization-server",
+			DiscoveryURL: "https://unified.cloud.databricks.test/oidc/accounts/acc-123/.well-known/oauth-authorization-server",
 		}.ToOAuthArgument()
 		require.NoError(t, err)
 
@@ -51,19 +54,21 @@ func TestBuildLoginCommand_AppendsWorkspaceID(t *testing.T) {
 
 	t.Run("workspace host path omits --workspace-id even when provided", func(t *testing.T) {
 		oauthArg, err := AuthArguments{
-			Host: "https://adb-123.azuredatabricks.net",
+			Host:         "https://adb-123.azuredatabricks.test",
+			DiscoveryURL: "https://adb-123.azuredatabricks.test/oidc/.well-known/oauth-authorization-server",
 		}.ToOAuthArgument()
 		require.NoError(t, err)
 
 		cmd := BuildLoginCommand(ctx, "", "ws-456", oauthArg)
-		assert.Contains(t, cmd, "--host https://adb-123.azuredatabricks.net")
+		assert.Contains(t, cmd, "--host https://adb-123.azuredatabricks.test")
 		assert.NotContains(t, cmd, "--workspace-id")
 	})
 
 	t.Run("account host path omits --workspace-id even when provided", func(t *testing.T) {
 		oauthArg, err := AuthArguments{
-			Host:      "https://accounts.cloud.databricks.com",
-			AccountID: "acc-123",
+			Host:         "https://accounts.cloud.databricks.test",
+			AccountID:    "acc-123",
+			DiscoveryURL: "https://accounts.cloud.databricks.test/oidc/accounts/acc-123/.well-known/oauth-authorization-server",
 		}.ToOAuthArgument()
 		require.NoError(t, err)
 

--- a/libs/auth/error_test.go
+++ b/libs/auth/error_test.go
@@ -25,6 +25,66 @@ func TestBuildDescribeCommand(t *testing.T) {
 	)
 }
 
+func TestBuildLoginCommand_AppendsWorkspaceID(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("profile path emits --workspace-id when set", func(t *testing.T) {
+		cmd := BuildLoginCommand(ctx, "dev", "12345", nil)
+		assert.Equal(t, "databricks auth login --profile dev --workspace-id 12345", cmd)
+	})
+
+	t.Run("profile path omits --workspace-id when empty", func(t *testing.T) {
+		cmd := BuildLoginCommand(ctx, "dev", "", nil)
+		assert.Equal(t, "databricks auth login --profile dev", cmd)
+	})
+
+	t.Run("profile path omits --workspace-id for the 'none' sentinel", func(t *testing.T) {
+		cmd := BuildLoginCommand(ctx, "dev", WorkspaceIDNone, nil)
+		assert.Equal(t, "databricks auth login --profile dev", cmd)
+	})
+
+	t.Run("unified host path emits --workspace-id when set", func(t *testing.T) {
+		oauthArg, err := AuthArguments{
+			Host:         "https://unified.cloud.databricks.com",
+			AccountID:    "acc-123",
+			DiscoveryURL: "https://unified.cloud.databricks.com/oidc/accounts/acc-123/.well-known/oauth-authorization-server",
+		}.ToOAuthArgument()
+		require.NoError(t, err)
+
+		cmd := BuildLoginCommand(ctx, "", "ws-456", oauthArg)
+		assert.Contains(t, cmd, "--account-id acc-123")
+		assert.Contains(t, cmd, "--workspace-id ws-456")
+	})
+
+	t.Run("workspace host path omits --workspace-id even when provided", func(t *testing.T) {
+		oauthArg, err := AuthArguments{
+			Host: "https://adb-123.azuredatabricks.net",
+		}.ToOAuthArgument()
+		require.NoError(t, err)
+
+		cmd := BuildLoginCommand(ctx, "", "ws-456", oauthArg)
+		assert.Contains(t, cmd, "--host https://adb-123.azuredatabricks.net")
+		assert.NotContains(t, cmd, "--workspace-id")
+	})
+
+	t.Run("account host path omits --workspace-id even when provided", func(t *testing.T) {
+		oauthArg, err := AuthArguments{
+			Host:      "https://accounts.cloud.databricks.com",
+			AccountID: "acc-123",
+		}.ToOAuthArgument()
+		require.NoError(t, err)
+
+		cmd := BuildLoginCommand(ctx, "", "ws-456", oauthArg)
+		assert.Contains(t, cmd, "--account-id acc-123")
+		assert.NotContains(t, cmd, "--workspace-id")
+	})
+
+	t.Run("profile path shell-quotes profile names with spaces", func(t *testing.T) {
+		cmd := BuildLoginCommand(ctx, "weird name", "", nil)
+		assert.Equal(t, "databricks auth login --profile 'weird name'", cmd)
+	})
+}
+
 func TestAuthTypeDisplayName(t *testing.T) {
 	assert.Equal(t, "Personal Access Token (pat)", AuthTypeDisplayName("pat"))
 	assert.Equal(t, "OAuth (databricks-cli)", AuthTypeDisplayName("databricks-cli"))
@@ -241,7 +301,7 @@ func TestEnrichAuthError(t *testing.T) {
 				"\nHost:      https://unified.cloud.databricks.com" +
 				"\nAuth type: OAuth (databricks-cli)" +
 				"\n\nNext steps:" +
-				"\n  - Re-authenticate: databricks auth login --host https://unified.cloud.databricks.com --account-id acc-123" +
+				"\n  - Re-authenticate: databricks auth login --host https://unified.cloud.databricks.com --account-id acc-123 --workspace-id ws-456" +
 				"\n  - Check your identity: databricks auth describe" +
 				"\n  - Consider setting up a profile: databricks auth login --profile <name>",
 		},

--- a/libs/auth/error_test.go
+++ b/libs/auth/error_test.go
@@ -139,6 +139,22 @@ func TestEnrichAuthError(t *testing.T) {
 				"\n  - Check your identity: databricks auth describe --profile dev",
 		},
 		{
+			name: "401 with profile needing shell-quoting and pat auth",
+			cfg: &config.Config{
+				Host:     "https://my-workspace.cloud.databricks.com",
+				Profile:  "weird name",
+				AuthType: AuthTypePat,
+			},
+			statusCode: 401,
+			wantMsg: "test error message\n" +
+				"\nProfile:   weird name" +
+				"\nHost:      https://my-workspace.cloud.databricks.com" +
+				"\nAuth type: Personal Access Token (pat)" +
+				"\n\nNext steps:" +
+				"\n  - Regenerate your access token or run: databricks auth login --profile 'weird name'" +
+				"\n  - Check your identity: databricks auth describe --profile 'weird name'",
+		},
+		{
 			name: "401 with profile and pat auth",
 			cfg: &config.Config{
 				Host:     "https://my-workspace.cloud.databricks.com",

--- a/libs/auth/error_test.go
+++ b/libs/auth/error_test.go
@@ -28,19 +28,12 @@ func TestBuildDescribeCommand(t *testing.T) {
 func TestBuildLoginCommand_AppendsWorkspaceID(t *testing.T) {
 	ctx := t.Context()
 
-	t.Run("profile path emits --workspace-id when set", func(t *testing.T) {
-		cmd := BuildLoginCommand(ctx, "dev", "12345", nil)
-		assert.Equal(t, "databricks auth login --profile dev --workspace-id 12345", cmd)
-	})
-
-	t.Run("profile path omits --workspace-id when empty", func(t *testing.T) {
-		cmd := BuildLoginCommand(ctx, "dev", "", nil)
-		assert.Equal(t, "databricks auth login --profile dev", cmd)
-	})
-
-	t.Run("profile path omits --workspace-id for the 'none' sentinel", func(t *testing.T) {
-		cmd := BuildLoginCommand(ctx, "dev", WorkspaceIDNone, nil)
-		assert.Equal(t, "databricks auth login --profile dev", cmd)
+	t.Run("profile path never emits --workspace-id", func(t *testing.T) {
+		// `auth login --profile foo` already picks up the profile's stored
+		// workspace_id, so we don't re-emit it regardless of value.
+		assert.Equal(t, "databricks auth login --profile dev", BuildLoginCommand(ctx, "dev", "", nil))
+		assert.Equal(t, "databricks auth login --profile dev", BuildLoginCommand(ctx, "dev", "12345", nil))
+		assert.Equal(t, "databricks auth login --profile dev", BuildLoginCommand(ctx, "dev", WorkspaceIDNone, nil))
 	})
 
 	t.Run("unified host path emits --workspace-id when set", func(t *testing.T) {


### PR DESCRIPTION
> Replaces #4602 — re-opened from an upstream branch (was previously from a fork, which blocked CI from running properly). Original PR was approved by @andrewnester and @simonfaltum.

## Changes

Format the `auth token` error message across multiple lines so the
suggested `databricks auth login` command is on its own line and easy
to copy-paste.

**Before:**
```
Error: cache: databricks OAuth is not configured for this host. Try logging in again with `databricks auth login --host https://example.com` before retrying. If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new
```

**After:**
```
Error: cache: databricks OAuth is not configured for this host.

To reauthenticate, run the following command:

  $ databricks auth login --host https://example.com

If this fails, please report this issue to the Databricks CLI maintainers at https://github.com/databricks/cli/issues/new
```

## Why

When auth fails, the suggested login command was printed on the same line as the error and config details, making it difficult to select and copy. This follows the same multi-line pattern already used by `RewriteAuthError` for invalid refresh token errors.

## Tests

- Unit tests updated and passing (`go test ./cmd/auth/ -run TestToken_loadToken`)
- Acceptance test golden file updated and passing (`go test ./acceptance/... -run TestAccept/cmd/auth/token`)