### PR TITLE
Ship bundle JSON schema with the CLI release artifact

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -124,9 +124,6 @@ jobs:
             echo
           done
 
-      # goreleaser's release.extra_files only runs in the publish stage, which
-      # this workflow skips. Stage the bundle JSON schema into dist/ so it is
-      # picked up by upload-artifact and travels with the binaries.
       - name: Stage bundle JSON schema for upload
         run: cp bundle/schema/jsonschema.json dist/
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -124,6 +124,12 @@ jobs:
             echo
           done
 
+      # goreleaser's release.extra_files only runs in the publish stage, which
+      # this workflow skips. Stage the bundle JSON schema into dist/ so it is
+      # picked up by upload-artifact and travels with the binaries.
+      - name: Stage bundle JSON schema for upload
+        run: cp bundle/schema/jsonschema.json dist/
+
       - name: Upload artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -132,6 +138,7 @@ jobs:
             dist/*.zip
             dist/*.tar.gz
             dist/*SHA256SUMS*
+            dist/jsonschema.json
 
   wheel:
     runs-on:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,7 +66,3 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-
-release:
-  extra_files:
-    - glob: bundle/schema/jsonschema.json


### PR DESCRIPTION
## Changes

- Stage `bundle/schema/jsonschema.json` into `dist/` before the `upload-artifact` step in `.github/workflows/release-build.yml` and add it to the upload globs so it travels with the `cli` artifact.
- Drop the now-unused `release.extra_files` block from `.goreleaser.yaml` (originally added in #5083).

## Why

- #5083 added `release.extra_files` to ship the JSON schema with the GitHub release. The `release-build` workflow runs goreleaser with `--skip=publish`, so goreleaser's `release.extra_files` block (which only fires in the publish stage) is never reached.
- The actual GitHub release is now created by an internal workflow, which uploads whatever is in the `cli` artifact. The previous `upload-artifact` globs (`*.zip`, `*.tar.gz`, `*SHA256SUMS*`) excluded the schema entirely, so it never made it onto the release.
- Snapshot publishing only uploads `*.tar.gz` and `*.zip`, so the schema will appear on tagged releases but not on the snapshot release.

## Tests

- Will verify by triggering `release-build` via `workflow_dispatch` after merge and confirming the `cli` artifact contains `jsonschema.json`.
- After the next tagged release runs, verify `jsonschema.json` is attached to the GitHub release on `databricks/cli`.

Downloaded cli.zip artifacts from https://github.com/databricks/cli/actions/runs/25161591061
```
% ls -1
databricks_cli_0.299.1-dev+0f8bffb39_SHA256SUMS
databricks_cli_darwin_amd64.tar.gz
databricks_cli_darwin_amd64.zip
databricks_cli_darwin_arm64.tar.gz
databricks_cli_darwin_arm64.zip
databricks_cli_linux_amd64.tar.gz
databricks_cli_linux_amd64.zip
databricks_cli_linux_arm64.tar.gz
databricks_cli_linux_arm64.zip
databricks_cli_windows_amd64.tar.gz
databricks_cli_windows_amd64.zip
databricks_cli_windows_arm64.tar.gz
databricks_cli_windows_arm64.zip
jsonschema.json
```

_This PR was written by Claude Code._