### PR TITLE
acc: Format out.test.toml in diff-friendly and copypaste-friendly way

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -372,8 +372,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 
 			// Generate materialized config for this test.
 			// We do this before skipping the test, so the configs are generated for all tests.
-			materializedConfig, err := internal.GenerateMaterializedConfig(config)
-			require.NoError(t, err)
+			materializedConfig := internal.GenerateMaterializedConfig(&config)
 			outPath := filepath.Join(dir, internal.MaterializedConfigFile)
 			if existing, _ := os.ReadFile(outPath); string(existing) != materializedConfig {
 				testutil.WriteFile(t, outPath, materializedConfig)

--- a/acceptance/apps/deploy/bundle-no-args-with-flags/out.test.toml
+++ b/acceptance/apps/deploy/bundle-no-args-with-flags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/bundle-no-args/out.test.toml
+++ b/acceptance/apps/deploy/bundle-no-args/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/bundle-with-appname/out.test.toml
+++ b/acceptance/apps/deploy/bundle-with-appname/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/no-bundle-no-args/out.test.toml
+++ b/acceptance/apps/deploy/no-bundle-no-args/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/apps/deploy/no-bundle-with-appname/out.test.toml
+++ b/acceptance/apps/deploy/no-bundle-with-appname/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/bundle_and_profile/out.test.toml
+++ b/acceptance/auth/bundle_and_profile/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/basic/out.test.toml
+++ b/acceptance/auth/credentials/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/oauth/out.test.toml
+++ b/acceptance/auth/credentials/oauth/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/credentials/pat/out.test.toml
+++ b/acceptance/auth/credentials/pat/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/auth/host-metadata-cache/out.test.toml
+++ b/acceptance/auth/host-metadata-cache/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/app_yaml/out.test.toml
+++ b/acceptance/bundle/apps/app_yaml/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/artifact_and_app_same_path/out.test.toml
+++ b/acceptance/bundle/apps/artifact_and_app_same_path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/compute_size/out.test.toml
+++ b/acceptance/bundle/apps/compute_size/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/git_source/out.test.toml
+++ b/acceptance/bundle/apps/git_source/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/job_permissions/out.test.toml
+++ b/acceptance/bundle/apps/job_permissions/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/job_permissions_warning/out.test.toml
+++ b/acceptance/bundle/apps/job_permissions_warning/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/apps/value_from_warning/out.test.toml
+++ b/acceptance/bundle/apps/value_from_warning/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_for_volumes/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_for_volumes/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_for_workspace/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_for_workspace/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_upload_with_no_library_reference/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_upload_with_no_library_reference/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifacts_dynamic_version/out.test.toml
+++ b/acceptance/bundle/artifacts/artifacts_dynamic_version/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/build_and_files/out.test.toml
+++ b/acceptance/bundle/artifacts/build_and_files/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/build_and_files_whl/out.test.toml
+++ b/acceptance/bundle/artifacts/build_and_files_whl/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/glob_exact_whl/out.test.toml
+++ b/acceptance/bundle/artifacts/glob_exact_whl/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_in_files/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_in_files/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_in_files_in_include/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_in_files_in_include/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/globs_invalid/out.test.toml
+++ b/acceptance/bundle/artifacts/globs_invalid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/issue_3109/out.test.toml
+++ b/acceptance/bundle/artifacts/issue_3109/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/nil_artifacts/out.test.toml
+++ b/acceptance/bundle/artifacts/nil_artifacts/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/same_name_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/same_name_libraries/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/bash/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/bash/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/basic/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/cmd/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/cmd/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  darwin = false
-  linux = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.darwin = false
+GOOS.linux = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/default/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/default/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/err-bash/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/err-bash/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/err-sh/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/err-sh/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/invalid/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/invalid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/shell/sh/out.test.toml
+++ b/acceptance/bundle/artifacts/shell/sh/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/unique_name_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/unique_name_libraries/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/upload_multiple_libraries/out.test.toml
+++ b/acceptance/bundle/artifacts/upload_multiple_libraries/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_change_version/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_change_version/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_dbfs/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_dbfs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_dynamic/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_dynamic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_explicit/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_explicit/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit_custom_path/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit_custom_path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_implicit_notebook/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_implicit_notebook/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_multiple/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_multiple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_no_cleanup/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_no_cleanup/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_multiple/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_multiple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_prebuilt_outside_dynamic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/whl_via_environment_key/out.test.toml
+++ b/acceptance/bundle/artifacts/whl_via_environment_key/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/benchmarks/deploy/out.test.toml
+++ b/acceptance/bundle/benchmarks/deploy/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/benchmarks/plan/out.test.toml
+++ b/acceptance/bundle/benchmarks/plan/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/benchmarks/validate/out.test.toml
+++ b/acceptance/bundle/benchmarks/validate/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/id/out.test.toml
+++ b/acceptance/bundle/bundle_tag/id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url_ref/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/config-remote-sync/cli_defaults/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/cli_defaults/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/config_edits/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/flushed_cache/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/flushed_cache/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/formatting_preserved/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_fields/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_multiple_tasks/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_params_variables/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_params_variables/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/job_pipeline_task/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_files/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/multiple_resources/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/output_json/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_json/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/output_no_changes/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/pipeline_fields/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/target_override/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/target_override/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/validation_errors/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/validation_errors/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/debug/list-targets/out.test.toml
+++ b/acceptance/bundle/debug/list-targets/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/debug/out.test.toml
+++ b/acceptance/bundle/debug/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/empty-bundle/out.test.toml
+++ b/acceptance/bundle/deploy/empty-bundle/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = ["", "true"]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = ["", "true"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/experimental-python/out.test.toml
+++ b/acceptance/bundle/deploy/experimental-python/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/deploy/fail-on-active-runs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/mlops-stacks/out.test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/pipeline-config-dots/out.test.toml
+++ b/acceptance/bundle/deploy/pipeline-config-dots/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/python-notebook/out.test.toml
+++ b/acceptance/bundle/deploy/python-notebook/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/readplan/basic/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/cli-version-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/cli-version-mismatch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/invalid-plan/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/invalid-plan/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/lineage-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/lineage-mismatch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/plan-not-found/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/plan-not-found/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/plan-version-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/plan-version-mismatch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/serial-mismatch/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/serial-mismatch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/readplan/terraform-error/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/terraform-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deploy/readplan/unknown-field/out.test.toml
+++ b/acceptance/bundle/deploy/readplan/unknown-field/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
+++ b/acceptance/bundle/deploy/snapshot-comparison/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/deployment/bind/alert/out.test.toml
+++ b/acceptance/bundle/deployment/bind/alert/out.test.toml
@@ -1,8 +1,4 @@
 Local = false
 Cloud = true
-
-[CloudEnvs]
-  aws = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.aws = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/catalog/out.test.toml
+++ b/acceptance/bundle/deployment/bind/catalog/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/cluster/out.test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresCluster = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/database_instance/out.test.toml
+++ b/acceptance/bundle/deployment/bind/database_instance/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/experiment/out.test.toml
+++ b/acceptance/bundle/deployment/bind/experiment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/external_location/out.test.toml
+++ b/acceptance/bundle/deployment/bind/external_location/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = []
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
+++ b/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/registered-model/out.test.toml
+++ b/acceptance/bundle/deployment/bind/registered-model/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/schema/out.test.toml
+++ b/acceptance/bundle/deployment/bind/schema/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
+++ b/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
+++ b/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/volume/out.test.toml
+++ b/acceptance/bundle/deployment/bind/volume/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = []
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/deployment/unbind/grants/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/grants/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/permissions/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/python-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/all-resources/out.test.toml
+++ b/acceptance/bundle/destroy/all-resources/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/environments/dependencies/out.test.toml
+++ b/acceptance/bundle/environments/dependencies/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/experimental/skip_name_prefix_for_schema/out.test.toml
+++ b/acceptance/bundle/experimental/skip_name_prefix_for_schema/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/alert/out.test.toml
+++ b/acceptance/bundle/generate/alert/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/alert_existing_id_not_found/out.test.toml
+++ b/acceptance/bundle/generate/alert_existing_id_not_found/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/app_not_yet_deployed/out.test.toml
+++ b/acceptance/bundle/generate/app_not_yet_deployed/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/app_subfolders/out.test.toml
+++ b/acceptance/bundle/generate/app_subfolders/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/auto-bind/out.test.toml
+++ b/acceptance/bundle/generate/auto-bind/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/generate/dashboard-inplace/out.test.toml
+++ b/acceptance/bundle/generate/dashboard-inplace/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard/out.test.toml
+++ b/acceptance/bundle/generate/dashboard/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard_existing_id_not_found/out.test.toml
+++ b/acceptance/bundle/generate/dashboard_existing_id_not_found/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard_existing_path_nominal/out.test.toml
+++ b/acceptance/bundle/generate/dashboard_existing_path_nominal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/dashboard_existing_path_not_found/out.test.toml
+++ b/acceptance/bundle/generate/dashboard_existing_path_not_found/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/git_job/out.test.toml
+++ b/acceptance/bundle/generate/git_job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/ipynb_job/out.test.toml
+++ b/acceptance/bundle/generate/ipynb_job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/lakeflow_pipelines/out.test.toml
+++ b/acceptance/bundle/generate/lakeflow_pipelines/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline/out.test.toml
+++ b/acceptance/bundle/generate/pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline_with_sql/out.test.toml
+++ b/acceptance/bundle/generate/pipeline_with_sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/python_job/out.test.toml
+++ b/acceptance/bundle/generate/python_job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/git-permerror/out.test.toml
+++ b/acceptance/bundle/git-permerror/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-deploy/out.test.toml
+++ b/acceptance/bundle/help/bundle-deploy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-deployment-migrate/out.test.toml
+++ b/acceptance/bundle/help/bundle-deployment-migrate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-deployment/out.test.toml
+++ b/acceptance/bundle/help/bundle-deployment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-destroy/out.test.toml
+++ b/acceptance/bundle/help/bundle-destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate-dashboard/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate-dashboard/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate-job/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate-pipeline/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-generate/out.test.toml
+++ b/acceptance/bundle/help/bundle-generate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-init/out.test.toml
+++ b/acceptance/bundle/help/bundle-init/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-open/out.test.toml
+++ b/acceptance/bundle/help/bundle-open/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-run/out.test.toml
+++ b/acceptance/bundle/help/bundle-run/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-schema/out.test.toml
+++ b/acceptance/bundle/help/bundle-schema/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-summary/out.test.toml
+++ b/acceptance/bundle/help/bundle-summary/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-sync/out.test.toml
+++ b/acceptance/bundle/help/bundle-sync/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle-validate/out.test.toml
+++ b/acceptance/bundle/help/bundle-validate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/help/bundle/out.test.toml
+++ b/acceptance/bundle/help/bundle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/glob_in_root_path/out.test.toml
+++ b/acceptance/bundle/includes/glob_in_root_path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/include_outside_root/out.test.toml
+++ b/acceptance/bundle/includes/include_outside_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/non_yaml_in_include/out.test.toml
+++ b/acceptance/bundle/includes/non_yaml_in_include/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/includes/yml_outside_root/out.test.toml
+++ b/acceptance/bundle/includes/yml_outside_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/base/out.test.toml
+++ b/acceptance/bundle/integration_whl/base/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  DATA_SECURITY_MODE = ["USER_ISOLATION", "SINGLE_USER"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATA_SECURITY_MODE = ["USER_ISOLATION", "SINGLE_USER"]

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -1,7 +1,42 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
-  INPUT_CONFIG = ["alert.yml.tmpl", "app.yml.tmpl", "catalog.yml.tmpl", "cluster.yml.tmpl", "dashboard.yml.tmpl", "database_catalog.yml.tmpl", "database_instance.yml.tmpl", "experiment.yml.tmpl", "external_location.yml.tmpl", "job.yml.tmpl", "job_pydabs_10_tasks.yml.tmpl", "job_pydabs_1000_tasks.yml.tmpl", "job_cross_resource_ref.yml.tmpl", "job_permission_ref.yml.tmpl", "job_with_depends_on.yml.tmpl", "job_with_permissions.yml.tmpl", "job_with_task.yml.tmpl", "model.yml.tmpl", "model_with_permissions.yml.tmpl", "model_serving_endpoint.yml.tmpl", "pipeline.yml.tmpl", "pipeline_config_dots.yml.tmpl", "postgres_branch.yml.tmpl", "postgres_endpoint.yml.tmpl", "postgres_project.yml.tmpl", "registered_model.yml.tmpl", "schema.yml.tmpl", "schema_grant_ref.yml.tmpl", "schema_with_grants.yml.tmpl", "secret_scope.yml.tmpl", "secret_scope_default_backend_type.yml.tmpl", "secret_scope_with_permissions.yml.tmpl", "sql_warehouse.yml.tmpl", "synced_database_table.yml.tmpl", "vector_search_endpoint.yml.tmpl", "volume.yml.tmpl"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.INPUT_CONFIG = [
+  "alert.yml.tmpl",
+  "app.yml.tmpl",
+  "catalog.yml.tmpl",
+  "cluster.yml.tmpl",
+  "dashboard.yml.tmpl",
+  "database_catalog.yml.tmpl",
+  "database_instance.yml.tmpl",
+  "experiment.yml.tmpl",
+  "external_location.yml.tmpl",
+  "job.yml.tmpl",
+  "job_pydabs_10_tasks.yml.tmpl",
+  "job_pydabs_1000_tasks.yml.tmpl",
+  "job_cross_resource_ref.yml.tmpl",
+  "job_permission_ref.yml.tmpl",
+  "job_with_depends_on.yml.tmpl",
+  "job_with_permissions.yml.tmpl",
+  "job_with_task.yml.tmpl",
+  "model.yml.tmpl",
+  "model_with_permissions.yml.tmpl",
+  "model_serving_endpoint.yml.tmpl",
+  "pipeline.yml.tmpl",
+  "pipeline_config_dots.yml.tmpl",
+  "postgres_branch.yml.tmpl",
+  "postgres_endpoint.yml.tmpl",
+  "postgres_project.yml.tmpl",
+  "registered_model.yml.tmpl",
+  "schema.yml.tmpl",
+  "schema_grant_ref.yml.tmpl",
+  "schema_with_grants.yml.tmpl",
+  "secret_scope.yml.tmpl",
+  "secret_scope_default_backend_type.yml.tmpl",
+  "secret_scope_with_permissions.yml.tmpl",
+  "sql_warehouse.yml.tmpl",
+  "synced_database_table.yml.tmpl",
+  "vector_search_endpoint.yml.tmpl",
+  "volume.yml.tmpl"
+]

--- a/acceptance/bundle/invariant/migrate/out.test.toml
+++ b/acceptance/bundle/invariant/migrate/out.test.toml
@@ -1,7 +1,42 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
-  INPUT_CONFIG = ["alert.yml.tmpl", "app.yml.tmpl", "catalog.yml.tmpl", "cluster.yml.tmpl", "dashboard.yml.tmpl", "database_catalog.yml.tmpl", "database_instance.yml.tmpl", "experiment.yml.tmpl", "external_location.yml.tmpl", "job.yml.tmpl", "job_pydabs_10_tasks.yml.tmpl", "job_pydabs_1000_tasks.yml.tmpl", "job_cross_resource_ref.yml.tmpl", "job_permission_ref.yml.tmpl", "job_with_depends_on.yml.tmpl", "job_with_permissions.yml.tmpl", "job_with_task.yml.tmpl", "model.yml.tmpl", "model_with_permissions.yml.tmpl", "model_serving_endpoint.yml.tmpl", "pipeline.yml.tmpl", "pipeline_config_dots.yml.tmpl", "postgres_branch.yml.tmpl", "postgres_endpoint.yml.tmpl", "postgres_project.yml.tmpl", "registered_model.yml.tmpl", "schema.yml.tmpl", "schema_grant_ref.yml.tmpl", "schema_with_grants.yml.tmpl", "secret_scope.yml.tmpl", "secret_scope_default_backend_type.yml.tmpl", "secret_scope_with_permissions.yml.tmpl", "sql_warehouse.yml.tmpl", "synced_database_table.yml.tmpl", "vector_search_endpoint.yml.tmpl", "volume.yml.tmpl"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.INPUT_CONFIG = [
+  "alert.yml.tmpl",
+  "app.yml.tmpl",
+  "catalog.yml.tmpl",
+  "cluster.yml.tmpl",
+  "dashboard.yml.tmpl",
+  "database_catalog.yml.tmpl",
+  "database_instance.yml.tmpl",
+  "experiment.yml.tmpl",
+  "external_location.yml.tmpl",
+  "job.yml.tmpl",
+  "job_pydabs_10_tasks.yml.tmpl",
+  "job_pydabs_1000_tasks.yml.tmpl",
+  "job_cross_resource_ref.yml.tmpl",
+  "job_permission_ref.yml.tmpl",
+  "job_with_depends_on.yml.tmpl",
+  "job_with_permissions.yml.tmpl",
+  "job_with_task.yml.tmpl",
+  "model.yml.tmpl",
+  "model_with_permissions.yml.tmpl",
+  "model_serving_endpoint.yml.tmpl",
+  "pipeline.yml.tmpl",
+  "pipeline_config_dots.yml.tmpl",
+  "postgres_branch.yml.tmpl",
+  "postgres_endpoint.yml.tmpl",
+  "postgres_project.yml.tmpl",
+  "registered_model.yml.tmpl",
+  "schema.yml.tmpl",
+  "schema_grant_ref.yml.tmpl",
+  "schema_with_grants.yml.tmpl",
+  "secret_scope.yml.tmpl",
+  "secret_scope_default_backend_type.yml.tmpl",
+  "secret_scope_with_permissions.yml.tmpl",
+  "sql_warehouse.yml.tmpl",
+  "synced_database_table.yml.tmpl",
+  "vector_search_endpoint.yml.tmpl",
+  "volume.yml.tmpl"
+]

--- a/acceptance/bundle/invariant/no_drift/out.test.toml
+++ b/acceptance/bundle/invariant/no_drift/out.test.toml
@@ -1,7 +1,42 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
-  INPUT_CONFIG = ["alert.yml.tmpl", "app.yml.tmpl", "catalog.yml.tmpl", "cluster.yml.tmpl", "dashboard.yml.tmpl", "database_catalog.yml.tmpl", "database_instance.yml.tmpl", "experiment.yml.tmpl", "external_location.yml.tmpl", "job.yml.tmpl", "job_pydabs_10_tasks.yml.tmpl", "job_pydabs_1000_tasks.yml.tmpl", "job_cross_resource_ref.yml.tmpl", "job_permission_ref.yml.tmpl", "job_with_depends_on.yml.tmpl", "job_with_permissions.yml.tmpl", "job_with_task.yml.tmpl", "model.yml.tmpl", "model_with_permissions.yml.tmpl", "model_serving_endpoint.yml.tmpl", "pipeline.yml.tmpl", "pipeline_config_dots.yml.tmpl", "postgres_branch.yml.tmpl", "postgres_endpoint.yml.tmpl", "postgres_project.yml.tmpl", "registered_model.yml.tmpl", "schema.yml.tmpl", "schema_grant_ref.yml.tmpl", "schema_with_grants.yml.tmpl", "secret_scope.yml.tmpl", "secret_scope_default_backend_type.yml.tmpl", "secret_scope_with_permissions.yml.tmpl", "sql_warehouse.yml.tmpl", "synced_database_table.yml.tmpl", "vector_search_endpoint.yml.tmpl", "volume.yml.tmpl"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.INPUT_CONFIG = [
+  "alert.yml.tmpl",
+  "app.yml.tmpl",
+  "catalog.yml.tmpl",
+  "cluster.yml.tmpl",
+  "dashboard.yml.tmpl",
+  "database_catalog.yml.tmpl",
+  "database_instance.yml.tmpl",
+  "experiment.yml.tmpl",
+  "external_location.yml.tmpl",
+  "job.yml.tmpl",
+  "job_pydabs_10_tasks.yml.tmpl",
+  "job_pydabs_1000_tasks.yml.tmpl",
+  "job_cross_resource_ref.yml.tmpl",
+  "job_permission_ref.yml.tmpl",
+  "job_with_depends_on.yml.tmpl",
+  "job_with_permissions.yml.tmpl",
+  "job_with_task.yml.tmpl",
+  "model.yml.tmpl",
+  "model_with_permissions.yml.tmpl",
+  "model_serving_endpoint.yml.tmpl",
+  "pipeline.yml.tmpl",
+  "pipeline_config_dots.yml.tmpl",
+  "postgres_branch.yml.tmpl",
+  "postgres_endpoint.yml.tmpl",
+  "postgres_project.yml.tmpl",
+  "registered_model.yml.tmpl",
+  "schema.yml.tmpl",
+  "schema_grant_ref.yml.tmpl",
+  "schema_with_grants.yml.tmpl",
+  "secret_scope.yml.tmpl",
+  "secret_scope_default_backend_type.yml.tmpl",
+  "secret_scope_with_permissions.yml.tmpl",
+  "sql_warehouse.yml.tmpl",
+  "synced_database_table.yml.tmpl",
+  "vector_search_endpoint.yml.tmpl",
+  "volume.yml.tmpl"
+]

--- a/acceptance/bundle/libraries/maven/out.test.toml
+++ b/acceptance/bundle/libraries/maven/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/outside_of_bundle_root/out.test.toml
+++ b/acceptance/bundle/libraries/outside_of_bundle_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/libraries/pypi/out.test.toml
+++ b/acceptance/bundle/libraries/pypi/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/lifecycle/started-validation/out.test.toml
+++ b/acceptance/bundle/lifecycle/started-validation/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/lifecycle/started/out.test.toml
+++ b/acceptance/bundle/lifecycle/started/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/local_state_staleness/out.test.toml
+++ b/acceptance/bundle/local_state_staleness/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/migrate/basic/out.test.toml
+++ b/acceptance/bundle/migrate/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/dashboards/out.test.toml
+++ b/acceptance/bundle/migrate/dashboards/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/default-python/out.test.toml
+++ b/acceptance/bundle/migrate/default-python/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/engine-config-direct/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-direct/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/grants/out.test.toml
+++ b/acceptance/bundle/migrate/grants/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/permissions/out.test.toml
+++ b/acceptance/bundle/migrate/permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/profile_arg/out.test.toml
+++ b/acceptance/bundle/migrate/profile_arg/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/runas/out.test.toml
+++ b/acceptance/bundle/migrate/runas/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/var_arg/out.test.toml
+++ b/acceptance/bundle/migrate/var_arg/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/multi_profile/auto_select/out.test.toml
+++ b/acceptance/bundle/multi_profile/auto_select/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/env_auth_skip/out.test.toml
+++ b/acceptance/bundle/multi_profile/env_auth_skip/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/no_workspace_profiles/out.test.toml
+++ b/acceptance/bundle/multi_profile/no_workspace_profiles/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/multi_profile/non_interactive_error/out.test.toml
+++ b/acceptance/bundle/multi_profile/non_interactive_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/open/out.test.toml
+++ b/acceptance/bundle/open/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  linux = false
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.linux = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/clusters/out.test.toml
+++ b/acceptance/bundle/override/clusters/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/job_cluster/out.test.toml
+++ b/acceptance/bundle/override/job_cluster/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/job_cluster_var/out.test.toml
+++ b/acceptance/bundle/override/job_cluster_var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/job_tasks/out.test.toml
+++ b/acceptance/bundle/override/job_tasks/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/merge-string-map/out.test.toml
+++ b/acceptance/bundle/override/merge-string-map/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/override/pipeline_cluster/out.test.toml
+++ b/acceptance/bundle/override/pipeline_cluster/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/fallback/out.test.toml
+++ b/acceptance/bundle/paths/fallback/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/git_source_jobs/out.test.toml
+++ b/acceptance/bundle/paths/git_source_jobs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/invalid_pipeline_globs/out.test.toml
+++ b/acceptance/bundle/paths/invalid_pipeline_globs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/nominal/out.test.toml
+++ b/acceptance/bundle/paths/nominal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/outside_root_no_sync/out.test.toml
+++ b/acceptance/bundle/paths/outside_root_no_sync/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipeline_expected_file_got_notebook/out.test.toml
+++ b/acceptance/bundle/paths/pipeline_expected_file_got_notebook/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipeline_globs/out.test.toml
+++ b/acceptance/bundle/paths/pipeline_globs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipeline_root_path_doesnotexist/out.test.toml
+++ b/acceptance/bundle/paths/pipeline_root_path_doesnotexist/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipelines_glob_include_and_root_path/out.test.toml
+++ b/acceptance/bundle/paths/pipelines_glob_include_and_root_path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/pipelines_root_path_outside_sync_root/out.test.toml
+++ b/acceptance/bundle/paths/pipelines_root_path_outside_sync_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/relative_path_outside_root/out.test.toml
+++ b/acceptance/bundle/paths/relative_path_outside_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/paths/relative_path_translation/out.test.toml
+++ b/acceptance/bundle/paths/relative_path_translation/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/plan/no_upload/out.test.toml
+++ b/acceptance/bundle/plan/no_upload/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/presets/preset_vs_dev_mode/out.test.toml
+++ b/acceptance/bundle/presets/preset_vs_dev_mode/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/python/experimental-compatibility-both-equal/out.test.toml
+++ b/acceptance/bundle/python/experimental-compatibility-both-equal/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/experimental-compatibility-both-error/out.test.toml
+++ b/acceptance/bundle/python/experimental-compatibility-both-error/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/experimental-compatibility/out.test.toml
+++ b/acceptance/bundle/python/experimental-compatibility/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/grants-aliases/out.test.toml
+++ b/acceptance/bundle/python/grants-aliases/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["current"]

--- a/acceptance/bundle/python/mutator-ordering/out.test.toml
+++ b/acceptance/bundle/python/mutator-ordering/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/pipelines-support/out.test.toml
+++ b/acceptance/bundle/python/pipelines-support/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/resolve-variable/out.test.toml
+++ b/acceptance/bundle/python/resolve-variable/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/resource-loading/out.test.toml
+++ b/acceptance/bundle/python/resource-loading/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/restricted-execution/out.test.toml
+++ b/acceptance/bundle/python/restricted-execution/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/schemas-support/out.test.toml
+++ b/acceptance/bundle/python/schemas-support/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["current"]

--- a/acceptance/bundle/python/unicode-support/out.test.toml
+++ b/acceptance/bundle/python/unicode-support/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/python/volumes-support/out.test.toml
+++ b/acceptance/bundle/python/volumes-support/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  PYDAB_VERSION = ["0.266.0", "current"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.PYDAB_VERSION = ["0.266.0", "current"]

--- a/acceptance/bundle/quality_monitor/out.test.toml
+++ b/acceptance/bundle/quality_monitor/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/refschema/out.test.toml
+++ b/acceptance/bundle/refschema/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/create_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/create_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/grant_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/grant_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/id_chain/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_chain/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_star/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_star/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_self/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_self/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/permission_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/permission_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/basic/out.test.toml
+++ b/acceptance/bundle/resources/alerts/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/config-drift/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/default_description/out.test.toml
+++ b/acceptance/bundle/resources/apps/default_description/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/resource-refs/out.test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/update/out.test.toml
+++ b/acceptance/bundle/resources/apps/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
-
-[CloudEnvs]
-  aws = false
-  azure = false
-  gcp = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.aws = false
+CloudEnvs.azure = false
+CloudEnvs.gcp = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -2,6 +2,4 @@ Local = false
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-name/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/destroy/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
@@ -2,6 +2,4 @@ Local = false
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
@@ -3,9 +3,5 @@ Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
@@ -2,9 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/experiments/basic/out.test.toml
+++ b/acceptance/bundle/resources/experiments/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/external_locations/out.test.toml
+++ b/acceptance/bundle/resources/external_locations/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/catalogs/out.test.toml
+++ b/acceptance/bundle/resources/grants/catalogs/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/registered_models/out.test.toml
+++ b/acceptance/bundle/resources/grants/registered_models/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/volumes/out.test.toml
+++ b/acceptance/bundle/resources/grants/volumes/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/independent/out.test.toml
+++ b/acceptance/bundle/resources/independent/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/alert-task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/alert-task/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/big_id/out.test.toml
+++ b/acceptance/bundle/resources/jobs/big_id/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/create-error/out.test.toml
+++ b/acceptance/bundle/resources/jobs/create-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/delete_job/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/delete_task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_task/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/num_workers/out.test.toml
+++ b/acceptance/bundle/resources/jobs/num_workers/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
+++ b/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/basic/out.test.toml
+++ b/acceptance/bundle/resources/models/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -1,9 +1,5 @@
 Local = false
 Cloud = true
 RequiresWarehouse = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -2,9 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -1,10 +1,6 @@
 Local = false
 Cloud = true
 RunsOnDbr = false
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -1,10 +1,6 @@
 Local = false
 Cloud = true
 RunsOnDbr = false
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 Phase = 1
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/quality_monitors/create/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/create/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/basic/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/recreate/out.test.toml
+++ b/acceptance/bundle/resources/schemas/recreate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/update/out.test.toml
+++ b/acceptance/bundle/resources/schemas/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/sql_warehouses/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 CloudSlow = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
@@ -2,9 +2,5 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = false
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/min_qps/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/min_qps/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
+++ b/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/change-comment/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-comment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -2,6 +2,4 @@ Local = false
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
@@ -1,10 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  azure = false
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+CloudEnvs.azure = false
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/app-with-job/out.test.toml
+++ b/acceptance/bundle/run/app-with-job/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 CloudSlow = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/basic/out.test.toml
+++ b/acceptance/bundle/run/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/diagnostics/out.test.toml
+++ b/acceptance/bundle/run/diagnostics/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/basic/out.test.toml
+++ b/acceptance/bundle/run/inline-script/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/cwd/out.test.toml
+++ b/acceptance/bundle/run/inline-script/cwd/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/profile-is-passed/from_flag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/no-auth/out.test.toml
+++ b/acceptance/bundle/run/inline-script/no-auth/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/no-bundle/out.test.toml
+++ b/acceptance/bundle/run/inline-script/no-bundle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/inline-script/no-separator/out.test.toml
+++ b/acceptance/bundle/run/inline-script/no-separator/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/jobs/partial_run/out.test.toml
+++ b/acceptance/bundle/run/jobs/partial_run/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/no-state/out.test.toml
+++ b/acceptance/bundle/run/no-state/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/refresh-flags/out.test.toml
+++ b/acceptance/bundle/run/refresh-flags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/basic/out.test.toml
+++ b/acceptance/bundle/run/scripts/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/cwd/out.test.toml
+++ b/acceptance/bundle/run/scripts/cwd/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/profile-is-passed/from_flag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.test.toml
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/exit_code/out.test.toml
+++ b/acceptance/bundle/run/scripts/exit_code/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/io/out.test.toml
+++ b/acceptance/bundle/run/scripts/io/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/no-auth/out.test.toml
+++ b/acceptance/bundle/run/scripts/no-auth/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/no-interpolation/out.test.toml
+++ b/acceptance/bundle/run/scripts/no-interpolation/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/no_content/out.test.toml
+++ b/acceptance/bundle/run/scripts/no_content/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/shell/envvar/out.test.toml
+++ b/acceptance/bundle/run/scripts/shell/envvar/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/shell/math/out.test.toml
+++ b/acceptance/bundle/run/scripts/shell/math/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_name_root/out.test.toml
+++ b/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_name_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_subconfigurations/out.test.toml
+++ b/acceptance/bundle/run/scripts/unique_keys/duplicate_resource_and_script_subconfigurations/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/scripts/unique_keys/duplicate_script_names_in_subconfiguration/out.test.toml
+++ b/acceptance/bundle/run/scripts/unique_keys/duplicate_script_names_in_subconfiguration/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run/state-wiped/out.test.toml
+++ b/acceptance/bundle/run/state-wiped/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/dashboard_embed/out.test.toml
+++ b/acceptance/bundle/run_as/dashboard_embed/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_override/out.test.toml
+++ b/acceptance/bundle/run_as/empty_override/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_sp/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
+++ b/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/model_serving_different/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_different/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/model_serving_matching/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_matching/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/out.test.toml
+++ b/acceptance/bundle/run_as/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/out.test.toml
+++ b/acceptance/bundle/scripts/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/scripts/restricted-execution/out.test.toml
+++ b/acceptance/bundle/scripts/restricted-execution/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/bad_env/out.test.toml
+++ b/acceptance/bundle/state/bad_env/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/bad_json_local/out.test.toml
+++ b/acceptance/bundle/state/bad_json_local/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/basic/out.test.toml
+++ b/acceptance/bundle/state/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/engine_mismatch/out.test.toml
+++ b/acceptance/bundle/state/engine_mismatch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/future_version/out.test.toml
+++ b/acceptance/bundle/state/future_version/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/lineage_different/out.test.toml
+++ b/acceptance/bundle/state/lineage_different/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/permission_level_migration/out.test.toml
+++ b/acceptance/bundle/state/permission_level_migration/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/same_serial/out.test.toml
+++ b/acceptance/bundle/state/same_serial/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/state_present/out.test.toml
+++ b/acceptance/bundle/state/state_present/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
+++ b/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/summary/modified_status/out.test.toml
+++ b/acceptance/bundle/summary/modified_status/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  VARIANT = ["empty_resources.yml", "no_resources.yml"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.VARIANT = ["empty_resources.yml", "no_resources.yml"]

--- a/acceptance/bundle/summary/show-full-config/out.test.toml
+++ b/acceptance/bundle/summary/show-full-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/sync/dryrun/out.test.toml
+++ b/acceptance/bundle/sync/dryrun/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/sync/out.test.toml
+++ b/acceptance/bundle/sync/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/syncroot/dotdot-git/out.test.toml
+++ b/acceptance/bundle/syncroot/dotdot-git/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/syncroot/dotdot-nogit/out.test.toml
+++ b/acceptance/bundle/syncroot/dotdot-nogit/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error-message/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error-message/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-mode/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-mode/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/helper_upper_lower/out.test.toml
+++ b/acceptance/bundle/templates-machinery/helper_upper_lower/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/helper_username/out.test.toml
+++ b/acceptance/bundle/templates-machinery/helper_username/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/helpers-error/out.test.toml
+++ b/acceptance/bundle/templates-machinery/helpers-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/number-precision/out.test.toml
+++ b/acceptance/bundle/templates-machinery/number-precision/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/wrong-path/out.test.toml
+++ b/acceptance/bundle/templates-machinery/wrong-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/wrong-url/out.test.toml
+++ b/acceptance/bundle/templates-machinery/wrong-url/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/dbt-sql/out.test.toml
+++ b/acceptance/bundle/templates/dbt-sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-minimal/out.test.toml
+++ b/acceptance/bundle/templates/default-minimal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/azure-government/out.test.toml
+++ b/acceptance/bundle/templates/default-python/azure-government/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/classic/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
 Phase = 1
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
@@ -1,9 +1,7 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  DLT = ["yes", "no"]
-  NBOOK = ["yes", "no"]
-  PY = ["yes", "no"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DLT = ["yes", "no"]
+EnvMatrix.NBOOK = ["yes", "no"]
+EnvMatrix.PY = ["yes", "no"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
@@ -1,9 +1,7 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  DLT = ["yes", "no"]
-  NBOOK = ["yes", "no"]
-  PY = ["yes", "no"]
-  READPLAN = ["", "1"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DLT = ["yes", "no"]
+EnvMatrix.NBOOK = ["yes", "no"]
+EnvMatrix.PY = ["yes", "no"]
+EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/templates/default-python/fail-missing-uv/out.test.toml
+++ b/acceptance/bundle/templates/default-python/fail-missing-uv/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  UV_PYTHON = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.UV_PYTHON = [
+  "3.9",
+  "3.10",
+  "3.11",
+  "3.12",
+  "3.13"
+]

--- a/acceptance/bundle/templates/default-python/no-uc/out.test.toml
+++ b/acceptance/bundle/templates/default-python/no-uc/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/serverless-customcatalog/out.test.toml
+++ b/acceptance/bundle/templates/default-python/serverless-customcatalog/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 Phase = 1
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-python/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/serverless/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-scala/out.test.toml
+++ b/acceptance/bundle/templates/default-scala/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/default-sql/out.test.toml
+++ b/acceptance/bundle/templates/default-sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/lakeflow-pipelines/python/out.test.toml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/python/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/lakeflow-pipelines/sql/out.test.toml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/pydabs/check-consistency/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/check-consistency/out.test.toml
@@ -1,9 +1,7 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  INCLUDE_JOB = ["yes", "no"]
-  INCLUDE_PIPELINE = ["yes", "no"]
-  INCLUDE_PYTHON = ["yes", "no"]
-  SERVERLESS = ["yes", "no"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.INCLUDE_JOB = ["yes", "no"]
+EnvMatrix.INCLUDE_PIPELINE = ["yes", "no"]
+EnvMatrix.INCLUDE_PYTHON = ["yes", "no"]
+EnvMatrix.SERVERLESS = ["yes", "no"]

--- a/acceptance/bundle/templates/pydabs/check-formatting/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/check-formatting/out.test.toml
@@ -1,9 +1,7 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  INCLUDE_JOB = ["yes", "no"]
-  INCLUDE_PIPELINE = ["yes", "no"]
-  INCLUDE_PYTHON = ["yes", "no"]
-  SERVERLESS = ["yes", "no"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.INCLUDE_JOB = ["yes", "no"]
+EnvMatrix.INCLUDE_PIPELINE = ["yes", "no"]
+EnvMatrix.INCLUDE_PYTHON = ["yes", "no"]
+EnvMatrix.SERVERLESS = ["yes", "no"]

--- a/acceptance/bundle/templates/pydabs/deploy-classic/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/deploy-classic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/pydabs/init-classic/out.test.toml
+++ b/acceptance/bundle/templates/pydabs/init-classic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/custom-template/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/custom-template/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/dbt-sql/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/dbt-sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/default-python/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/default-python/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates/telemetry/default-sql/out.test.toml
+++ b/acceptance/bundle/templates/telemetry/default-sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/trampoline/warning_message/out.test.toml
+++ b/acceptance/bundle/trampoline/warning_message/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/trampoline/warning_message_with_new_spark/out.test.toml
+++ b/acceptance/bundle/trampoline/warning_message_with_new_spark/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/trampoline/warning_message_with_old_spark/out.test.toml
+++ b/acceptance/bundle/trampoline/warning_message_with_old_spark/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/undefined_resources/out.test.toml
+++ b/acceptance/bundle/undefined_resources/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/upload/internal_server_error/out.test.toml
+++ b/acceptance/bundle/upload/internal_server_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/upload/timeout/out.test.toml
+++ b/acceptance/bundle/upload/timeout/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/out.test.toml
+++ b/acceptance/bundle/user_agent/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 Phase = 1
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/user_agent/simple/out.test.toml
+++ b/acceptance/bundle/user_agent/simple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/catalog_requires_direct_mode/out.test.toml
+++ b/acceptance/bundle/validate/catalog_requires_direct_mode/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/validate/dashboard_defaults/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dashboard_required_name/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_required_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dashboard_required_warehouse_id/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_required_warehouse_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/definitions_yaml_anchors/out.test.toml
+++ b/acceptance/bundle/validate/definitions_yaml_anchors/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/empty_def/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/empty_def/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/empty_dict/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/empty_dict/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/null/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/null/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/with_grants/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/with_grants/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/with_permissions/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/with_permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/engine-config-valid/out.test.toml
+++ b/acceptance/bundle/validate/engine-config-valid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/enum/out.test.toml
+++ b/acceptance/bundle/validate/enum/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/enum_resource_refs/out.test.toml
+++ b/acceptance/bundle/validate/enum_resource_refs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/include_locations/out.test.toml
+++ b/acceptance/bundle/validate/include_locations/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/invalid-engine-bundle/out.test.toml
+++ b/acceptance/bundle/validate/invalid-engine-bundle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/invalid-engine-target/out.test.toml
+++ b/acceptance/bundle/validate/invalid-engine-target/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/job-references/out.test.toml
+++ b/acceptance/bundle/validate/job-references/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_both_fields_error/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_both_fields_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_conversion/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_conversion/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/models/missing_name/out.test.toml
+++ b/acceptance/bundle/validate/models/missing_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/models/user_id/out.test.toml
+++ b/acceptance/bundle/validate/models/user_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/no_dashboard_etag/out.test.toml
+++ b/acceptance/bundle/validate/no_dashboard_etag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/permissions/out.test.toml
+++ b/acceptance/bundle/validate/permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_max_concurrent_runs/out.test.toml
+++ b/acceptance/bundle/validate/presets_max_concurrent_runs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_name_prefix/out.test.toml
+++ b/acceptance/bundle/validate/presets_name_prefix/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.test.toml
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/presets_tags/out.test.toml
+++ b/acceptance/bundle/validate/presets_tags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/required/out.test.toml
+++ b/acceptance/bundle/validate/required/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/strict/out.test.toml
+++ b/acceptance/bundle/validate/strict/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/sync_patterns/out.test.toml
+++ b/acceptance/bundle/validate/sync_patterns/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/var_in_bundle_name/out.test.toml
+++ b/acceptance/bundle/validate/var_in_bundle_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/volume_defaults/out.test.toml
+++ b/acceptance/bundle/validate/volume_defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/arg-repeat/out.test.toml
+++ b/acceptance/bundle/variables/arg-repeat/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cross-ref/out.test.toml
+++ b/acceptance/bundle/variables/complex-cross-ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cycle-self/out.test.toml
+++ b/acceptance/bundle/variables/complex-cycle-self/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cycle/out.test.toml
+++ b/acceptance/bundle/variables/complex-cycle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-simple/out.test.toml
+++ b/acceptance/bundle/variables/complex-simple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive-deep/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive-deep/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive-deeper/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive-deeper/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-with-var-reference/out.test.toml
+++ b/acceptance/bundle/variables/complex-with-var-reference/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-within-complex/out.test.toml
+++ b/acceptance/bundle/variables/complex-within-complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex/out.test.toml
+++ b/acceptance/bundle/variables/complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex_multiple_files/out.test.toml
+++ b/acceptance/bundle/variables/complex_multiple_files/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/cycle/out.test.toml
+++ b/acceptance/bundle/variables/cycle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/double_underscore/out.test.toml
+++ b/acceptance/bundle/variables/double_underscore/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/empty/out.test.toml
+++ b/acceptance/bundle/variables/empty/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/env_overrides/out.test.toml
+++ b/acceptance/bundle/variables/env_overrides/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/file-defaults/out.test.toml
+++ b/acceptance/bundle/variables/file-defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/git-branch/out.test.toml
+++ b/acceptance/bundle/variables/git-branch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/host/out.test.toml
+++ b/acceptance/bundle/variables/host/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/int/out.test.toml
+++ b/acceptance/bundle/variables/int/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/issue_2436/out.test.toml
+++ b/acceptance/bundle/variables/issue_2436/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/issue_3039_lookup_with_ref/out.test.toml
+++ b/acceptance/bundle/variables/issue_3039_lookup_with_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/lookup/out.test.toml
+++ b/acceptance/bundle/variables/lookup/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/prepend-workspace-var/out.test.toml
+++ b/acceptance/bundle/variables/prepend-workspace-var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-builtin/out.test.toml
+++ b/acceptance/bundle/variables/resolve-builtin/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-empty/out.test.toml
+++ b/acceptance/bundle/variables/resolve-empty/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-field-within-complex/out.test.toml
+++ b/acceptance/bundle/variables/resolve-field-within-complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-nonstrings/out.test.toml
+++ b/acceptance/bundle/variables/resolve-nonstrings/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-resources-fields/out.test.toml
+++ b/acceptance/bundle/variables/resolve-resources-fields/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-vars-in-root-path/out.test.toml
+++ b/acceptance/bundle/variables/resolve-vars-in-root-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/vanilla/out.test.toml
+++ b/acceptance/bundle/variables/vanilla/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/var_in_var/out.test.toml
+++ b/acceptance/bundle/variables/var_in_var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/variable_overrides_in_target/out.test.toml
+++ b/acceptance/bundle/variables/variable_overrides_in_target/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/without_definition/out.test.toml
+++ b/acceptance/bundle/variables/without_definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_file/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_file/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_resource/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_resource/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_root/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_root/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/invalid_state/out.test.toml
+++ b/acceptance/bundle/volume_path/invalid_state/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/volume_path/valid/out.test.toml
+++ b/acceptance/bundle/volume_path/valid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cache/clear/out.test.toml
+++ b/acceptance/cache/clear/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cache/simple/out.test.toml
+++ b/acceptance/cache/simple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/account/account-help/out.test.toml
+++ b/acceptance/cmd/account/account-help/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/default-profile/out.test.toml
+++ b/acceptance/cmd/auth/describe/default-profile/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/configure-serverless/out.test.toml
+++ b/acceptance/cmd/auth/login/configure-serverless/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/custom-config-file/out.test.toml
+++ b/acceptance/cmd/auth/login/custom-config-file/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/discovery/out.test.toml
+++ b/acceptance/cmd/auth/login/discovery/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/host-arg-overrides-profile/out.test.toml
+++ b/acceptance/cmd/auth/login/host-arg-overrides-profile/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/host-from-profile/out.test.toml
+++ b/acceptance/cmd/auth/login/host-from-profile/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/nominal/out.test.toml
+++ b/acceptance/cmd/auth/login/nominal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/preserve-fields/out.test.toml
+++ b/acceptance/cmd/auth/login/preserve-fields/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/login/with-scopes/out.test.toml
+++ b/acceptance/cmd/auth/login/with-scopes/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/default-profile/out.test.toml
+++ b/acceptance/cmd/auth/logout/default-profile/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/delete-clears-default/out.test.toml
+++ b/acceptance/cmd/auth/logout/delete-clears-default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/delete-pat-token-profile/out.test.toml
+++ b/acceptance/cmd/auth/logout/delete-pat-token-profile/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/error-cases/out.test.toml
+++ b/acceptance/cmd/auth/logout/error-cases/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/last-non-default/out.test.toml
+++ b/acceptance/cmd/auth/logout/last-non-default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/ordering-preserved/out.test.toml
+++ b/acceptance/cmd/auth/logout/ordering-preserved/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/stale-account-id-workspace-host/out.test.toml
+++ b/acceptance/cmd/auth/logout/stale-account-id-workspace-host/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/token-only-shared-host/out.test.toml
+++ b/acceptance/cmd/auth/logout/token-only-shared-host/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/logout/token-only/out.test.toml
+++ b/acceptance/cmd/auth/logout/token-only/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/profiles/out.test.toml
+++ b/acceptance/cmd/auth/profiles/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/profiles/spog-account/out.test.toml
+++ b/acceptance/cmd/auth/profiles/spog-account/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/env-overrides-config/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/env-overrides-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/invalid-config/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/invalid-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/invalid-env/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/invalid-env/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/storage-modes/plaintext-env-default/out.test.toml
+++ b/acceptance/cmd/auth/storage-modes/plaintext-env-default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/switch/nominal/out.test.toml
+++ b/acceptance/cmd/auth/switch/nominal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/out.test.toml
+++ b/acceptance/cmd/auth/token/force-refresh-invalid-refresh-token/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/force-refresh-no-cache/out.test.toml
+++ b/acceptance/cmd/auth/token/force-refresh-no-cache/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/force-refresh-success/out.test.toml
+++ b/acceptance/cmd/auth/token/force-refresh-success/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/no-args-no-profiles/out.test.toml
+++ b/acceptance/cmd/auth/token/no-args-no-profiles/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/no-args-with-profiles/out.test.toml
+++ b/acceptance/cmd/auth/token/no-args-with-profiles/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/token/out.test.toml
+++ b/acceptance/cmd/auth/token/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/completion/out.test.toml
+++ b/acceptance/cmd/completion/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/cmd/configure/clears-oauth-on-pat/out.test.toml
+++ b/acceptance/cmd/configure/clears-oauth-on-pat/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/out.test.toml
+++ b/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/dir-to-dir/out.test.toml
+++ b/acceptance/cmd/fs/cp/dir-to-dir/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/file-to-dir/out.test.toml
+++ b/acceptance/cmd/fs/cp/file-to-dir/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/file-to-file/out.test.toml
+++ b/acceptance/cmd/fs/cp/file-to-file/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/fs/cp/input-validation/out.test.toml
+++ b/acceptance/cmd/fs/cp/input-validation/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/patchwhl/out.test.toml
+++ b/acceptance/cmd/patchwhl/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/argument-errors/out.test.toml
+++ b/acceptance/cmd/psql/argument-errors/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/completions/out.test.toml
+++ b/acceptance/cmd/psql/completions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/failing-connection/out.test.toml
+++ b/acceptance/cmd/psql/failing-connection/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/not-available/out.test.toml
+++ b/acceptance/cmd/psql/not-available/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/postgres/out.test.toml
+++ b/acceptance/cmd/psql/postgres/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/psql/simple/out.test.toml
+++ b/acceptance/cmd/psql/simple/out.test.toml
@@ -1,8 +1,4 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync-from-file/out.test.toml
+++ b/acceptance/cmd/sync-from-file/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync-without-args/out.test.toml
+++ b/acceptance/cmd/sync-without-args/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync/dryrun/out.test.toml
+++ b/acceptance/cmd/sync/dryrun/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/sync/out.test.toml
+++ b/acceptance/cmd/sync/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/unknown-subcommand/out.test.toml
+++ b/acceptance/cmd/unknown-subcommand/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/apps/out.test.toml
+++ b/acceptance/cmd/workspace/apps/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local-node/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/cmd/workspace/apps/run-local/out.test.toml
+++ b/acceptance/cmd/workspace/apps/run-local/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/cmd/workspace/create-scope/out.test.toml
+++ b/acceptance/cmd/workspace/create-scope/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/database/update-database-instance/out.test.toml
+++ b/acceptance/cmd/workspace/database/update-database-instance/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/export-dir-file-size-limit/out.test.toml
+++ b/acceptance/cmd/workspace/export-dir-file-size-limit/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/export-dir-skip-experiments/out.test.toml
+++ b/acceptance/cmd/workspace/export-dir-skip-experiments/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/queries/out.test.toml
+++ b/acceptance/cmd/workspace/queries/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/query-history/out.test.toml
+++ b/acceptance/cmd/workspace/query-history/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/workspace/secrets/out.test.toml
+++ b/acceptance/cmd/workspace/secrets/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/experimental/open/out.test.toml
+++ b/acceptance/experimental/open/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = []
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/help/out.test.toml
+++ b/acceptance/help/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -15,18 +15,13 @@ const MaterializedConfigFile = "out.test.toml"
 func GenerateMaterializedConfig(config *TestConfig) string {
 	var buf strings.Builder
 
-	writeBool := func(key string, v *bool) {
-		if v != nil {
-			fmt.Fprintf(&buf, "%s = %v\n", key, *v)
-		}
-	}
-	writeBool("Local", config.Local)
-	writeBool("Cloud", config.Cloud)
-	writeBool("CloudSlow", config.CloudSlow)
-	writeBool("RequiresUnityCatalog", config.RequiresUnityCatalog)
-	writeBool("RequiresCluster", config.RequiresCluster)
-	writeBool("RequiresWarehouse", config.RequiresWarehouse)
-	writeBool("RunsOnDbr", config.RunsOnDbr)
+	writeBool(&buf, "Local", config.Local)
+	writeBool(&buf, "Cloud", config.Cloud)
+	writeBool(&buf, "CloudSlow", config.CloudSlow)
+	writeBool(&buf, "RequiresUnityCatalog", config.RequiresUnityCatalog)
+	writeBool(&buf, "RequiresCluster", config.RequiresCluster)
+	writeBool(&buf, "RequiresWarehouse", config.RequiresWarehouse)
+	writeBool(&buf, "RunsOnDbr", config.RunsOnDbr)
 	if config.Phase != 0 {
 		fmt.Fprintf(&buf, "Phase = %d\n", config.Phase)
 	}
@@ -42,6 +37,12 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	}
 
 	return buf.String()
+}
+
+func writeBool(buf *strings.Builder, key string, v *bool) {
+	if v != nil {
+		fmt.Fprintf(buf, "%s = %v\n", key, *v)
+	}
 }
 
 // writeTomlStringArray writes a TOML string array. Arrays with more than 3 elements

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -1,9 +1,11 @@
 package internal
 
 import (
-	"bytes"
-
-	"github.com/BurntSushi/toml"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
 )
 
 const MaterializedConfigFile = "out.test.toml"
@@ -23,7 +25,7 @@ type MaterializedConfig struct {
 }
 
 // GenerateMaterializedConfig creates a TOML representation of the configuration fields
-// that determine where and how a test is executed
+// that determine where and how a test is executed.
 func GenerateMaterializedConfig(config TestConfig) (string, error) {
 	var phase *int
 	if config.Phase != 0 {
@@ -44,13 +46,69 @@ func GenerateMaterializedConfig(config TestConfig) (string, error) {
 		EnvMatrix:            config.EnvMatrix,
 	}
 
-	var buf bytes.Buffer
-	encoder := toml.NewEncoder(&buf)
-	err := encoder.Encode(materialized)
-	if err != nil {
-		return "", err
+	return encodeMaterializedConfig(materialized), nil
+}
+
+func encodeMaterializedConfig(c MaterializedConfig) string {
+	var buf strings.Builder
+
+	writeBool := func(key string, v *bool) {
+		if v != nil {
+			fmt.Fprintf(&buf, "%s = %v\n", key, *v)
+		}
+	}
+	writeBool("Local", c.Local)
+	writeBool("Cloud", c.Cloud)
+	writeBool("CloudSlow", c.CloudSlow)
+	writeBool("RequiresUnityCatalog", c.RequiresUnityCatalog)
+	writeBool("RequiresCluster", c.RequiresCluster)
+	writeBool("RequiresWarehouse", c.RequiresWarehouse)
+	writeBool("RunsOnDbr", c.RunsOnDbr)
+	if c.Phase != nil {
+		fmt.Fprintf(&buf, "Phase = %d\n", *c.Phase)
 	}
 
-	// Add newline at the end of the TOML
-	return buf.String(), nil
+	for _, k := range slices.Sorted(maps.Keys(c.GOOS)) {
+		fmt.Fprintf(&buf, "GOOS.%s = %v\n", k, c.GOOS[k])
+	}
+	for _, k := range slices.Sorted(maps.Keys(c.CloudEnvs)) {
+		fmt.Fprintf(&buf, "CloudEnvs.%s = %v\n", k, c.CloudEnvs[k])
+	}
+	for _, k := range slices.Sorted(maps.Keys(c.EnvMatrix)) {
+		writeTomlStringArray(&buf, "EnvMatrix."+k, c.EnvMatrix[k])
+	}
+
+	return buf.String()
+}
+
+// writeTomlStringArray writes a TOML string array. Arrays with more than 3 elements
+// use one element per line for readability.
+func writeTomlStringArray(buf *strings.Builder, key string, vals []string) {
+	if len(vals) > 3 {
+		fmt.Fprintf(buf, "%s = [\n", key)
+		for i, v := range vals {
+			if i < len(vals)-1 {
+				fmt.Fprintf(buf, "  %s,\n", tomlQuote(v))
+			} else {
+				fmt.Fprintf(buf, "  %s\n", tomlQuote(v))
+			}
+		}
+		buf.WriteString("]\n")
+		return
+	}
+	fmt.Fprintf(buf, "%s = [", key)
+	for i, v := range vals {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(tomlQuote(v))
+	}
+	buf.WriteString("]\n")
+}
+
+// tomlQuote returns a TOML basic string literal for s using JSON encoding,
+// whose escape sequences (\", \\, \n, \r, \t, \uXXXX) are all valid in TOML.
+func tomlQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -12,7 +12,7 @@ const MaterializedConfigFile = "out.test.toml"
 
 // GenerateMaterializedConfig creates a TOML representation of the configuration fields
 // that determine where and how a test is executed.
-func GenerateMaterializedConfig(config TestConfig) (string, error) {
+func GenerateMaterializedConfig(config *TestConfig) string {
 	var buf strings.Builder
 
 	writeBool := func(key string, v *bool) {
@@ -41,7 +41,7 @@ func GenerateMaterializedConfig(config TestConfig) (string, error) {
 		writeTomlStringArray(&buf, "EnvMatrix."+k, config.EnvMatrix[k])
 	}
 
-	return buf.String(), nil
+	return buf.String()
 }
 
 // writeTomlStringArray writes a TOML string array. Arrays with more than 3 elements

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -10,46 +10,9 @@ import (
 
 const MaterializedConfigFile = "out.test.toml"
 
-type MaterializedConfig struct {
-	GOOS                 map[string]bool     `toml:"GOOS,omitempty"`
-	CloudEnvs            map[string]bool     `toml:"CloudEnvs,omitempty"`
-	Local                *bool               `toml:"Local,omitempty"`
-	Cloud                *bool               `toml:"Cloud,omitempty"`
-	CloudSlow            *bool               `toml:"CloudSlow,omitempty"`
-	RequiresUnityCatalog *bool               `toml:"RequiresUnityCatalog,omitempty"`
-	RequiresCluster      *bool               `toml:"RequiresCluster,omitempty"`
-	RequiresWarehouse    *bool               `toml:"RequiresWarehouse,omitempty"`
-	RunsOnDbr            *bool               `toml:"RunsOnDbr,omitempty"`
-	Phase                *int                `toml:"Phase,omitempty"`
-	EnvMatrix            map[string][]string `toml:"EnvMatrix,omitempty"`
-}
-
 // GenerateMaterializedConfig creates a TOML representation of the configuration fields
 // that determine where and how a test is executed.
 func GenerateMaterializedConfig(config TestConfig) (string, error) {
-	var phase *int
-	if config.Phase != 0 {
-		phase = &config.Phase
-	}
-
-	materialized := MaterializedConfig{
-		GOOS:                 config.GOOS,
-		CloudEnvs:            config.CloudEnvs,
-		Local:                config.Local,
-		Cloud:                config.Cloud,
-		CloudSlow:            config.CloudSlow,
-		RequiresUnityCatalog: config.RequiresUnityCatalog,
-		RequiresCluster:      config.RequiresCluster,
-		RequiresWarehouse:    config.RequiresWarehouse,
-		RunsOnDbr:            config.RunsOnDbr,
-		Phase:                phase,
-		EnvMatrix:            config.EnvMatrix,
-	}
-
-	return encodeMaterializedConfig(materialized), nil
-}
-
-func encodeMaterializedConfig(c MaterializedConfig) string {
 	var buf strings.Builder
 
 	writeBool := func(key string, v *bool) {
@@ -57,28 +20,28 @@ func encodeMaterializedConfig(c MaterializedConfig) string {
 			fmt.Fprintf(&buf, "%s = %v\n", key, *v)
 		}
 	}
-	writeBool("Local", c.Local)
-	writeBool("Cloud", c.Cloud)
-	writeBool("CloudSlow", c.CloudSlow)
-	writeBool("RequiresUnityCatalog", c.RequiresUnityCatalog)
-	writeBool("RequiresCluster", c.RequiresCluster)
-	writeBool("RequiresWarehouse", c.RequiresWarehouse)
-	writeBool("RunsOnDbr", c.RunsOnDbr)
-	if c.Phase != nil {
-		fmt.Fprintf(&buf, "Phase = %d\n", *c.Phase)
+	writeBool("Local", config.Local)
+	writeBool("Cloud", config.Cloud)
+	writeBool("CloudSlow", config.CloudSlow)
+	writeBool("RequiresUnityCatalog", config.RequiresUnityCatalog)
+	writeBool("RequiresCluster", config.RequiresCluster)
+	writeBool("RequiresWarehouse", config.RequiresWarehouse)
+	writeBool("RunsOnDbr", config.RunsOnDbr)
+	if config.Phase != 0 {
+		fmt.Fprintf(&buf, "Phase = %d\n", config.Phase)
 	}
 
-	for _, k := range slices.Sorted(maps.Keys(c.GOOS)) {
-		fmt.Fprintf(&buf, "GOOS.%s = %v\n", k, c.GOOS[k])
+	for _, k := range slices.Sorted(maps.Keys(config.GOOS)) {
+		fmt.Fprintf(&buf, "GOOS.%s = %v\n", k, config.GOOS[k])
 	}
-	for _, k := range slices.Sorted(maps.Keys(c.CloudEnvs)) {
-		fmt.Fprintf(&buf, "CloudEnvs.%s = %v\n", k, c.CloudEnvs[k])
+	for _, k := range slices.Sorted(maps.Keys(config.CloudEnvs)) {
+		fmt.Fprintf(&buf, "CloudEnvs.%s = %v\n", k, config.CloudEnvs[k])
 	}
-	for _, k := range slices.Sorted(maps.Keys(c.EnvMatrix)) {
-		writeTomlStringArray(&buf, "EnvMatrix."+k, c.EnvMatrix[k])
+	for _, k := range slices.Sorted(maps.Keys(config.EnvMatrix)) {
+		writeTomlStringArray(&buf, "EnvMatrix."+k, config.EnvMatrix[k])
 	}
 
-	return buf.String()
+	return buf.String(), nil
 }
 
 // writeTomlStringArray writes a TOML string array. Arrays with more than 3 elements

--- a/acceptance/panic/out.test.toml
+++ b/acceptance/panic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/databricks-cli-help/out.test.toml
+++ b/acceptance/pipelines/databricks-cli-help/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/auto-approve/out.test.toml
+++ b/acceptance/pipelines/deploy/auto-approve/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/create-pipeline/out.test.toml
+++ b/acceptance/pipelines/deploy/create-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/fail-on-active-runs/out.test.toml
+++ b/acceptance/pipelines/deploy/fail-on-active-runs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/force-lock/out.test.toml
+++ b/acceptance/pipelines/deploy/force-lock/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/oss-spark-error/out.test.toml
+++ b/acceptance/pipelines/deploy/oss-spark-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/render-diagnostics-warning/out.test.toml
+++ b/acceptance/pipelines/deploy/render-diagnostics-warning/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/deploy/var-flag/out.test.toml
+++ b/acceptance/pipelines/deploy/var-flag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/destroy/auto-approve/out.test.toml
+++ b/acceptance/pipelines/destroy/auto-approve/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/destroy/destroy-pipeline/out.test.toml
+++ b/acceptance/pipelines/destroy/destroy-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/destroy/force-lock/out.test.toml
+++ b/acceptance/pipelines/destroy/force-lock/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/no-wait/out.test.toml
+++ b/acceptance/pipelines/dry-run/no-wait/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/dry-run/restart/out.test.toml
+++ b/acceptance/pipelines/dry-run/restart/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/e2e/out.test.toml
+++ b/acceptance/pipelines/e2e/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/bad-path/out.test.toml
+++ b/acceptance/pipelines/generate/bad-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/discover-spark-pipeline-yml/out.test.toml
+++ b/acceptance/pipelines/generate/discover-spark-pipeline-yml/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/fail-overwrite/out.test.toml
+++ b/acceptance/pipelines/generate/fail-overwrite/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/simple/out.test.toml
+++ b/acceptance/pipelines/generate/simple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/generate/unknown-attribute/out.test.toml
+++ b/acceptance/pipelines/generate/unknown-attribute/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/init/error-cases/out.test.toml
+++ b/acceptance/pipelines/init/error-cases/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/init/python/out.test.toml
+++ b/acceptance/pipelines/init/python/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/init/sql/out.test.toml
+++ b/acceptance/pipelines/init/sql/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/open/completion/out.test.toml
+++ b/acceptance/pipelines/open/completion/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/open/open-after-deployment/out.test.toml
+++ b/acceptance/pipelines/open/open-after-deployment/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  linux = false
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.linux = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/completion/out.test.toml
+++ b/acceptance/pipelines/run/completion/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/no-wait/out.test.toml
+++ b/acceptance/pipelines/run/no-wait/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/refresh-flags/out.test.toml
+++ b/acceptance/pipelines/run/refresh-flags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/restart/out.test.toml
+++ b/acceptance/pipelines/run/restart/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/run-info/out.test.toml
+++ b/acceptance/pipelines/run/run-info/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/run/run-pipeline/out.test.toml
+++ b/acceptance/pipelines/run/run-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/pipelines/stop/out.test.toml
+++ b/acceptance/pipelines/stop/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/IsServicePrincipal/out.test.toml
+++ b/acceptance/selftest/IsServicePrincipal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/acc_repls/out.test.toml
+++ b/acceptance/selftest/acc_repls/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/add_repl/out.test.toml
+++ b/acceptance/selftest/add_repl/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/basic/out.test.toml
+++ b/acceptance/selftest/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/benchmark/out.test.toml
+++ b/acceptance/selftest/benchmark/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/contains/out.test.toml
+++ b/acceptance/selftest/contains/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/diff/out.test.toml
+++ b/acceptance/selftest/diff/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/envmatrix/inner/out.test.toml
+++ b/acceptance/selftest/envmatrix/inner/out.test.toml
@@ -1,9 +1,7 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  B_REGULAR_VAR = ["hello"]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  FIRST = ["one111", "two222"]
-  SECOND = ["variantA", "variantB"]
-  THIRD = ["three $FIRST"]
+EnvMatrix.B_REGULAR_VAR = ["hello"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.FIRST = ["one111", "two222"]
+EnvMatrix.SECOND = ["variantA", "variantB"]
+EnvMatrix.THIRD = ["three $FIRST"]

--- a/acceptance/selftest/envmatrix/out.test.toml
+++ b/acceptance/selftest/envmatrix/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  FIRST = ["overriden-in-inner"]
-  THIRD = ["three $FIRST"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.FIRST = ["overriden-in-inner"]
+EnvMatrix.THIRD = ["three $FIRST"]

--- a/acceptance/selftest/envmatrix_empty/out.test.toml
+++ b/acceptance/selftest/envmatrix_empty/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = []
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/selftest/envmatrix_mixed/out.test.toml
+++ b/acceptance/selftest/envmatrix_mixed/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = []
-  FIRST = ["alpha", "beta"]
-  SECOND = []
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+EnvMatrix.FIRST = ["alpha", "beta"]
+EnvMatrix.SECOND = []

--- a/acceptance/selftest/envoutput/out.test.toml
+++ b/acceptance/selftest/envoutput/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/gen_config/out.test.toml
+++ b/acceptance/selftest/gen_config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/inject_error/out.test.toml
+++ b/acceptance/selftest/inject_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/currentuser/out.test.toml
+++ b/acceptance/selftest/kill_caller/currentuser/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/multi_pattern/out.test.toml
+++ b/acceptance/selftest/kill_caller/multi_pattern/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/multiple/out.test.toml
+++ b/acceptance/selftest/kill_caller/multiple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/kill_caller/workspace/out.test.toml
+++ b/acceptance/selftest/kill_caller/workspace/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/log/out.test.toml
+++ b/acceptance/selftest/log/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/basic/out.test.toml
+++ b/acceptance/selftest/record_cloud/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/error/out.test.toml
+++ b/acceptance/selftest/record_cloud/error/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
+++ b/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/volume-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/volume-io/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = true
 RequiresUnityCatalog = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
@@ -1,5 +1,3 @@
 Local = false
 Cloud = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/server/out.test.toml
+++ b/acceptance/selftest/server/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
-  VARIABLE_A = ["one", "two"]
-  VARIABLE_B = ["HELLO", "WORLD"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.VARIABLE_A = ["one", "two"]
+EnvMatrix.VARIABLE_B = ["HELLO", "WORLD"]

--- a/acceptance/selftest/skip/out.test.toml
+++ b/acceptance/selftest/skip/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/subset_ancestor_engine/child/out.test.toml
+++ b/acceptance/selftest/subset_ancestor_engine/child/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/testlog/out.test.toml
+++ b/acceptance/selftest/testlog/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/timeout/out.test.toml
+++ b/acceptance/selftest/timeout/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/timestamp/out.test.toml
+++ b/acceptance/selftest/timestamp/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/trap/out.test.toml
+++ b/acceptance/selftest/trap/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/ssh/connect-serverless-gpu/out.test.toml
+++ b/acceptance/ssh/connect-serverless-gpu/out.test.toml
@@ -1,9 +1,5 @@
 Local = false
 Cloud = false
 RequiresUnityCatalog = true
-
-[CloudEnvs]
-  gcp = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+CloudEnvs.gcp = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/ssh/connection/out.test.toml
+++ b/acceptance/ssh/connection/out.test.toml
@@ -1,6 +1,4 @@
 Local = false
 Cloud = false
 RequiresCluster = true
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/telemetry/failure/out.test.toml
+++ b/acceptance/telemetry/failure/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/partial-success/out.test.toml
+++ b/acceptance/telemetry/partial-success/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/skipped/out.test.toml
+++ b/acceptance/telemetry/skipped/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/success/out.test.toml
+++ b/acceptance/telemetry/success/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/telemetry/timeout/out.test.toml
+++ b/acceptance/telemetry/timeout/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/jobs/create-error/out.test.toml
+++ b/acceptance/workspace/jobs/create-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/jobs/create/out.test.toml
+++ b/acceptance/workspace/jobs/create/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/lakeview/publish/out.test.toml
+++ b/acceptance/workspace/lakeview/publish/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/create_with_provider/out.test.toml
+++ b/acceptance/workspace/repos/create_with_provider/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/create_without_provider/out.test.toml
+++ b/acceptance/workspace/repos/create_without_provider/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/delete_by_path/out.test.toml
+++ b/acceptance/workspace/repos/delete_by_path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/get_errors/out.test.toml
+++ b/acceptance/workspace/repos/get_errors/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/workspace/repos/update/out.test.toml
+++ b/acceptance/workspace/repos/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]


### PR DESCRIPTION
## Changes
- Uses dotted key syntax (EnvMatrix.KEY, GOOS.KEY) instead of [Section] headers. Sections affects all entries below them, dotted-syntax is context-safe.
- Formats string arrays with more than 3 elements one per line.

## Why
Make diffs like this more readable: https://github.com/databricks/cli/pull/5146/changes#diff-821bc7cc7ab24c784a8c7952ad1a7a7334beb0094fe3b0967559098ae0a8f439