### PR TITLE
acceptance: fix vector_search_endpoint permissions config to use existing principal

### DIFF
--- a/acceptance/bundle/invariant/configs/vector_search_endpoint.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/vector_search_endpoint.yml.tmpl
@@ -12,4 +12,4 @@ resources:
       endpoint_type: STANDARD
       permissions:
         - level: CAN_USE
-          user_name: viewer@example.com
+          group_name: users


### PR DESCRIPTION
## Summary

The invariant test config used \`user_name: viewer@example.com\`, which doesn't exist in the cloud workspaces. The Permissions Set API silently drops the unknown user, so a Read after deploy returns an ACL without that entry — the no_drift invariant then sees a phantom update and the test fails on aws-prod-ucws.

Pre-existing bug from #4887, not caught earlier because deploy itself was failing on the 50-char endpoint name limit (#5108) before reaching the no_drift check.

### Failure shape (before this fix)

\`\`\`
"resources.vector_search_endpoints.bar.permissions": {
  "action": "update",
  "new_state": {
    "value": {
      "__embed__": [
        { "level": "CAN_USE", "user_name": "viewer@example.com" },
        { "level": "CAN_MANAGE", "service_principal_name": "[USERNAME]" }
      ]
    }
  },
  "remote_state": {
    "__embed__": [
      { "level": "CAN_MANAGE", "service_principal_name": "[USERNAME]" }
    ]
  },
  ...
}
\`\`\`

### Change

Use \`group_name: users\` (always present in every workspace) to match the pattern used by the other \`*_with_permissions\` invariant configs (\`job_with_permissions\`, \`model_with_permissions\`, \`secret_scope_with_permissions\`).

## Test plan

- [x] Local: \`go test ./acceptance -run 'TestAccept/bundle/invariant/no_drift/DATABRICKS_BUNDLE_ENGINE=direct/INPUT_CONFIG=vector_search_endpoint'\` passes
- [x] Cloud: same target passes on aws-prod-ucws

This pull request was AI-assisted by Isaac.