### PR TITLE
acceptance: skip integration_whl/wrapper{,_custom_params} on AWS

### DIFF
--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 CloudSlow = true
+CloudEnvs.aws = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/wrapper/test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/test.toml
@@ -1,2 +1,7 @@
-# Temporarily disabling due to DBR release breakage.
+# This test exercises the trampoline workaround for DBR <13.1 (PR #635), which
+# requires booking a cluster on Spark 12.2.x-scala2.12. The AWS test workspaces
+# have legacy access disabled, so 12.2.x is rejected with INVALID_PARAMETER_VALUE
+# ("legacy access is disabled in your workspace. Please use Databricks Runtime
+# 13.3 LTS or above"). GCP was previously disabled due to a DBR release breakage.
+CloudEnvs.aws = false
 CloudEnvs.gcp = false

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
 CloudSlow = true
+CloudEnvs.aws = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/test.toml
@@ -1,2 +1,7 @@
-# Temporarily disabling due to DBR release breakage.
+# This test exercises the trampoline workaround for DBR <13.1 (PR #635), which
+# requires booking a cluster on Spark 12.2.x-scala2.12. The AWS test workspaces
+# have legacy access disabled, so 12.2.x is rejected with INVALID_PARAMETER_VALUE
+# ("legacy access is disabled in your workspace. Please use Databricks Runtime
+# 13.3 LTS or above"). GCP was previously disabled due to a DBR release breakage.
+CloudEnvs.aws = false
 CloudEnvs.gcp = false


### PR DESCRIPTION
## Summary

The `wrapper` and `wrapper_custom_params` tests pin Spark to `12.2.x-scala2.12` to exercise the trampoline workaround for DBR <13.1 ([PR #635](https://github.com/databricks/cli/pull/635)). The AWS test workspaces have disabled legacy access, so 12.2.x is rejected at job submission time:

```
INVALID_PARAMETER_VALUE: Spark version 12.2.x-scala2.12 isn't supported because legacy
access is disabled in your workspace. Please use Databricks Runtime 13.3 LTS or above
when any legacy features are disabled.
```

Bumping the runtime would defeat the purpose of the test (the trampoline only triggers for DBR <13.1). Restrict the test matrix to Azure where 12.2.x is still bookable. GCP was already excluded for an unrelated DBR release issue.

The trampoline itself is covered by unit tests in `bundle/trampoline/` and acceptance tests under `acceptance/bundle/trampoline/`.

## Test plan

- [ ] Confirm next nightly: wrapper and wrapper_custom_params no longer in the failures list on aws-prod-is or aws-prod-ucws-is.
- [ ] They continue to pass on Azure (azure-prod-is, azure-prod-ucws-is) where they had been passing before.

This pull request was AI-assisted by Isaac.