### PR TITLE
acceptance: skip default-python classic-compute tests on UC envs

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -554,6 +554,10 @@ func getSkipReason(config *internal.TestConfig, configPath string) string {
 			return fmt.Sprintf("Disabled via RequiresUnityCatalog setting in %s (TEST_METASTORE_ID is empty)", configPath)
 		}
 
+		if isTruePtr(config.SkipOnUnityCatalog) && os.Getenv("TEST_METASTORE_ID") != "" {
+			return fmt.Sprintf("Disabled via SkipOnUnityCatalog setting in %s (TEST_METASTORE_ID is set)", configPath)
+		}
+
 		if isTruePtr(config.RequiresWarehouse) && os.Getenv("TEST_DEFAULT_WAREHOUSE_ID") == "" {
 			return fmt.Sprintf("Disabled via RequiresWarehouse setting in %s (TEST_DEFAULT_WAREHOUSE_ID is empty)", configPath)
 		}

--- a/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
@@ -1,6 +1,6 @@
 Local = true
 Cloud = true
-RequiresUnityCatalog = true
+SkipOnUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DLT = ["yes", "no"]
 EnvMatrix.NBOOK = ["yes", "no"]

--- a/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DLT = ["yes", "no"]
 EnvMatrix.NBOOK = ["yes", "no"]

--- a/acceptance/bundle/templates/default-python/combinations/classic/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/test.toml
@@ -1,6 +1,8 @@
 Env.SERVERLESS = "no"
 
-# The pipeline resource falls back to a hive_metastore catalog when no UC
-# catalog is detected, so gate classic combinations on UC. The serverless
-# variant hardcodes "catalog: main" and is unaffected.
+# The pipeline yaml omits "catalog:" when default_catalog resolves to "" or
+# "hive_metastore" (helper reads metastore.DefaultCatalogName). Without an
+# explicit catalog, DLT falls back to (disabled) hive_metastore. Gate classic
+# combinations on a real UC default catalog; the serverless variant is
+# unaffected because it hardcodes "catalog: main".
 RequiresUnityCatalog = true

--- a/acceptance/bundle/templates/default-python/combinations/classic/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/test.toml
@@ -5,4 +5,8 @@ Env.SERVERLESS = "no"
 # explicit catalog, DLT falls back to (disabled) hive_metastore. Gate classic
 # combinations on a real UC default catalog; the serverless variant is
 # unaffected because it hardcodes "catalog: main".
+#
+# Known UC API inconsistency: on our test workspaces, metastore.DefaultCatalogName
+# is "hive_metastore" even though no such catalog exists. Drop this gate once UC
+# fixes that.
 RequiresUnityCatalog = true

--- a/acceptance/bundle/templates/default-python/combinations/classic/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/test.toml
@@ -1,11 +1,6 @@
 Env.SERVERLESS = "no"
 
-# The default-python template's pipeline resource defaults to a hive_metastore
-# catalog when no UC catalog is detected on the workspace. Several test
-# workspaces have HMS disabled, so the deploy fails with
-# "Hive Metastore is not enabled for this workspace; please publish to Unity
-# Catalog." Restrict the classic-compute combinations to UC-enabled
-# workspaces where default_catalog resolves to a real UC catalog. The
-# serverless variant is unaffected because the template hardcodes
-# "catalog: main" for serverless pipelines without UC.
+# The pipeline resource falls back to a hive_metastore catalog when no UC
+# catalog is detected, so gate classic combinations on UC. The serverless
+# variant hardcodes "catalog: main" and is unaffected.
 RequiresUnityCatalog = true

--- a/acceptance/bundle/templates/default-python/combinations/classic/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/test.toml
@@ -2,11 +2,11 @@ Env.SERVERLESS = "no"
 
 # The pipeline yaml omits "catalog:" when default_catalog resolves to "" or
 # "hive_metastore" (helper reads metastore.DefaultCatalogName). Without an
-# explicit catalog, DLT falls back to (disabled) hive_metastore. Gate classic
-# combinations on a real UC default catalog; the serverless variant is
+# explicit catalog, DLT falls back to (disabled) hive_metastore. Skip classic
+# combinations on UC envs where this misfires; the serverless variant is
 # unaffected because it hardcodes "catalog: main".
 #
 # Known UC API inconsistency: on our test workspaces, metastore.DefaultCatalogName
-# is "hive_metastore" even though no such catalog exists. Drop this gate once UC
+# is "hive_metastore" even though no such catalog exists. Drop this skip once UC
 # fixes that.
-RequiresUnityCatalog = true
+SkipOnUnityCatalog = true

--- a/acceptance/bundle/templates/default-python/combinations/classic/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/test.toml
@@ -1,1 +1,11 @@
 Env.SERVERLESS = "no"
+
+# The default-python template's pipeline resource defaults to a hive_metastore
+# catalog when no UC catalog is detected on the workspace. Several test
+# workspaces have HMS disabled, so the deploy fails with
+# "Hive Metastore is not enabled for this workspace; please publish to Unity
+# Catalog." Restrict the classic-compute combinations to UC-enabled
+# workspaces where default_catalog resolves to a real UC catalog. The
+# serverless variant is unaffected because the template hardcodes
+# "catalog: main" for serverless pipelines without UC.
+RequiresUnityCatalog = true

--- a/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
@@ -1,5 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.UV_PYTHON = [
   "3.9",

--- a/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.test.toml
@@ -1,6 +1,6 @@
 Local = true
 Cloud = true
-RequiresUnityCatalog = true
+SkipOnUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.UV_PYTHON = [
   "3.9",

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,10 +1,6 @@
 Cloud = true
-# The default-python template's pipeline resource defaults to a hive_metastore
-# catalog when no UC catalog is detected on the workspace. Several test
-# workspaces have HMS disabled, so the deploy fails with
-# "Hive Metastore is not enabled for this workspace; please publish to Unity
-# Catalog." Restrict to UC-enabled workspaces where default_catalog resolves
-# to a real UC catalog and the pipeline gets a proper "catalog:" field.
+# The pipeline resource falls back to a hive_metastore catalog when no UC
+# catalog is detected, so gate on UC to get a real UC catalog instead.
 RequiresUnityCatalog = true
 Timeout = '1m'
 

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,4 +1,11 @@
 Cloud = true
+# The default-python template's pipeline resource defaults to a hive_metastore
+# catalog when no UC catalog is detected on the workspace. Several test
+# workspaces have HMS disabled, so the deploy fails with
+# "Hive Metastore is not enabled for this workspace; please publish to Unity
+# Catalog." Restrict to UC-enabled workspaces where default_catalog resolves
+# to a real UC catalog and the pipeline gets a proper "catalog:" field.
+RequiresUnityCatalog = true
 Timeout = '1m'
 
 Ignore = [

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,13 +1,13 @@
 Cloud = true
 # The pipeline yaml omits "catalog:" when default_catalog resolves to "" or
 # "hive_metastore" (helper reads metastore.DefaultCatalogName). Without an
-# explicit catalog, DLT falls back to (disabled) hive_metastore. Gate on a
-# real UC default catalog.
+# explicit catalog, DLT falls back to (disabled) hive_metastore. Skip on UC
+# envs where this misfires.
 #
 # Known UC API inconsistency: on our test workspaces, metastore.DefaultCatalogName
-# is "hive_metastore" even though no such catalog exists. Drop this gate once UC
+# is "hive_metastore" even though no such catalog exists. Drop this skip once UC
 # fixes that.
-RequiresUnityCatalog = true
+SkipOnUnityCatalog = true
 Timeout = '1m'
 
 Ignore = [

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -3,6 +3,10 @@ Cloud = true
 # "hive_metastore" (helper reads metastore.DefaultCatalogName). Without an
 # explicit catalog, DLT falls back to (disabled) hive_metastore. Gate on a
 # real UC default catalog.
+#
+# Known UC API inconsistency: on our test workspaces, metastore.DefaultCatalogName
+# is "hive_metastore" even though no such catalog exists. Drop this gate once UC
+# fixes that.
 RequiresUnityCatalog = true
 Timeout = '1m'
 

--- a/acceptance/bundle/templates/default-python/integration_classic/test.toml
+++ b/acceptance/bundle/templates/default-python/integration_classic/test.toml
@@ -1,6 +1,8 @@
 Cloud = true
-# The pipeline resource falls back to a hive_metastore catalog when no UC
-# catalog is detected, so gate on UC to get a real UC catalog instead.
+# The pipeline yaml omits "catalog:" when default_catalog resolves to "" or
+# "hive_metastore" (helper reads metastore.DefaultCatalogName). Without an
+# explicit catalog, DLT falls back to (disabled) hive_metastore. Gate on a
+# real UC default catalog.
 RequiresUnityCatalog = true
 Timeout = '1m'
 

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -55,6 +55,9 @@ type TestConfig struct {
 	// If true and Cloud=true, run this test only if unity catalog is available in the cloud environment
 	RequiresUnityCatalog *bool
 
+	// If true and Cloud=true, skip this test when Unity Catalog is available in the cloud environment
+	SkipOnUnityCatalog *bool
+
 	// If true and Cloud=true, run this test only if a default test cluster is available in the cloud environment
 	RequiresCluster *bool
 

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -19,6 +19,7 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	writeBool(&buf, "Cloud", config.Cloud)
 	writeBool(&buf, "CloudSlow", config.CloudSlow)
 	writeBool(&buf, "RequiresUnityCatalog", config.RequiresUnityCatalog)
+	writeBool(&buf, "SkipOnUnityCatalog", config.SkipOnUnityCatalog)
 	writeBool(&buf, "RequiresCluster", config.RequiresCluster)
 	writeBool(&buf, "RequiresWarehouse", config.RequiresWarehouse)
 	writeBool(&buf, "RunsOnDbr", config.RunsOnDbr)


### PR DESCRIPTION
## Summary

`default-python` classic-compute template tests fail on UC test workspaces because the pipeline template ([source](https://github.com/databricks/cli/blob/main/libs/template/templates/default/template/%7B%7B.project_name%7D%7D/resources/%7B%7B.project_name%7D%7D_etl.pipeline.yml.tmpl#L12)) omits `catalog:` when `default_catalog` resolves to `""` or `"hive_metastore"` — which it does on `*-prod-ucws-is`, where the metastore-assignment carries the legacy literal `default_catalog_name = "hive_metastore"`. Without an explicit catalog, DLT falls back to `hive_metastore`, which fails on UC-only workspaces with `Hive Metastore is not enabled for this workspace`.

The HMS-disable on UC workspaces might not have been rolled out to all workspaces yet (same dynamic as #5106's note that `RESOURCE_ALREADY_EXISTS` has not been rolled out to all workspaces yet). The same workspace can pass one nightly and fail the next as the rollout progresses, so a defensive skip is appropriate even when current samples happen to be green.

This PR adds a `SkipOnUnityCatalog` test config field (inverse of `RequiresUnityCatalog`) and sets it on `integration_classic` and `combinations/classic`. Coverage is preserved on non-UC envs. Drop the skip once UC reconciles `default_catalog_name` (filed with \`#eng-unity-catalog\`).

The `serverless` variant of `combinations` is unaffected — the template hardcodes `catalog: main` there.

## Test plan

- [x] \`out.test.toml\` regenerated; passes locally.
- [ ] Next nightly: classic-compute runs on non-UC, skips on UC; serverless unchanged.

This pull request was AI-assisted by Isaac.