### PR TITLE
experimental/ssh: improve --help copy and surface serverless flags

### DIFF
--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -12,11 +12,20 @@ import (
 func newConnectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "Connect to Databricks compute via SSH",
+		Short: "Connect to Databricks serverless or dedicated compute via SSH",
 		Long: `Connect to Databricks compute via SSH.
 
 This command establishes an SSH connection to Databricks compute, setting up
 the SSH server and handling the connection proxy.
+
+Connect to serverless (no cluster ID needed):
+  databricks ssh connect
+  databricks ssh connect --accelerator=GPU_1xA10            # serverless GPU
+  databricks ssh connect --environment-version=4            # custom serverless environment
+  databricks ssh connect --ide=cursor                       # launch Cursor remote window on connect
+
+Connect to a dedicated cluster:
+  databricks ssh connect --cluster=<cluster-id>
 
 ` + disclaimer,
 	}
@@ -43,12 +52,9 @@ the SSH server and handling the connection proxy.
 	cmd.Flags().IntVar(&maxClients, "max-clients", defaultMaxClients, "Maximum number of SSH clients")
 	cmd.Flags().BoolVar(&autoStartCluster, "auto-start-cluster", true, "Automatically start the cluster if it is not running")
 
-	cmd.Flags().StringVar(&connectionName, "name", "", "Connection name (for serverless compute)")
-	cmd.Flags().MarkHidden("name")
-	cmd.Flags().StringVar(&accelerator, "accelerator", "", "GPU accelerator type (GPU_1xA10 or GPU_8xH100)")
-	cmd.Flags().MarkHidden("accelerator")
-	cmd.Flags().StringVar(&ide, "ide", "", "Open remote IDE window (vscode or cursor)")
-	cmd.Flags().MarkHidden("ide")
+	cmd.Flags().StringVar(&connectionName, "name", "", "Connection name to reuse across sessions (serverless only)")
+	cmd.Flags().StringVar(&accelerator, "accelerator", "", "Serverless GPU accelerator type (GPU_1xA10 or GPU_8xH100)")
+	cmd.Flags().StringVar(&ide, "ide", "", "Open a remote IDE window on connect (vscode or cursor)")
 
 	cmd.Flags().BoolVar(&proxyMode, "proxy", false, "ProxyCommand mode")
 	cmd.Flags().MarkHidden("proxy")
@@ -69,8 +75,7 @@ the SSH server and handling the connection proxy.
 	cmd.Flags().BoolVar(&skipSettingsCheck, "skip-settings-check", false, "Skip checking and updating IDE settings")
 	cmd.Flags().MarkHidden("skip-settings-check")
 
-	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for serverless compute")
-	cmd.Flags().MarkHidden("environment-version")
+	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Serverless environment version to use for the session")
 
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 

--- a/experimental/ssh/cmd/setup.go
+++ b/experimental/ssh/cmd/setup.go
@@ -14,11 +14,14 @@ import (
 func newSetupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Setup SSH configuration for Databricks compute",
-		Long: `Setup SSH configuration for Databricks compute.
+		Short: "Setup SSH configuration for a Databricks dedicated cluster",
+		Long: `Setup SSH configuration for a Databricks dedicated cluster.
 
-This command configures SSH to connect to Databricks compute by adding
-an SSH host configuration to your SSH config file.
+This command configures SSH to connect to a Databricks dedicated cluster by
+adding an SSH host configuration to your SSH config file. After running setup,
+you can connect with ` + "`ssh <name>`" + ` directly.
+
+For serverless connections, use ` + "`databricks ssh connect`" + ` (no setup step needed).
 
 ` + disclaimer,
 	}

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -20,9 +20,12 @@ func New() *cobra.Command {
 SSH commands let you setup and establish ssh connections to Databricks compute.
 
 Common workflows:
-  databricks ssh connect --cluster=<cluster-id> --profile=<profile-name>  # connect to a cluster without any setup
-  databricks ssh setup --name=my-compute --cluster=<cluster-id>           # update local ssh config
-  ssh my-compute                                                          # connect to the compute using ssh client
+  databricks ssh connect                                          # connect to serverless compute
+  databricks ssh connect --cluster=<cluster-id>                   # connect to a dedicated cluster
+  databricks ssh setup --name=my-compute --cluster=<cluster-id>   # update local ssh config for a dedicated cluster
+  ssh my-compute                                                  # connect using the ssh client (after setup)
+
+Use ` + "`databricks ssh connect --help`" + ` to see flags for serverless GPUs and serverless environment versions.
 
 ` + disclaimer,
 	}

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/databricks/cli/experimental/ssh/internal/keys"
 	"github.com/databricks/cli/experimental/ssh/internal/proxy"
+	"github.com/databricks/cli/experimental/ssh/internal/sessions"
 	"github.com/databricks/cli/experimental/ssh/internal/sshconfig"
 	"github.com/databricks/cli/experimental/ssh/internal/vscode"
 	sshWorkspace "github.com/databricks/cli/experimental/ssh/internal/workspace"
@@ -104,11 +105,11 @@ type ClientOptions struct {
 }
 
 func (o *ClientOptions) Validate() error {
-	if !o.ProxyMode && o.ClusterID == "" && o.ConnectionName == "" {
-		return errors.New("please provide --cluster flag with the cluster ID, or --name flag with the connection name (for serverless compute)")
+	if !o.ProxyMode && o.ClusterID == "" && o.ConnectionName == "" && o.Accelerator == "" {
+		return errors.New("please provide --cluster or --accelerator flag")
 	}
-	if o.Accelerator != "" && o.ConnectionName == "" {
-		return errors.New("--accelerator flag can only be used with serverless compute (--name flag)")
+	if o.Accelerator != "" && o.ClusterID != "" {
+		return errors.New("--accelerator flag can only be used with serverless compute, not with --cluster")
 	}
 	if o.Accelerator != "" && o.Accelerator != "GPU_1xA10" && o.Accelerator != "GPU_8xH100" {
 		return fmt.Errorf("invalid accelerator value: %q, expected %q or %q", o.Accelerator, "GPU_1xA10", "GPU_8xH100")
@@ -140,7 +141,7 @@ func GenerateDefaultConnectionName(host, accelerator string) string {
 }
 
 func (o *ClientOptions) IsServerlessMode() bool {
-	return o.ClusterID == "" && o.ConnectionName != ""
+	return o.ClusterID == "" && (o.ConnectionName != "" || o.Accelerator != "")
 }
 
 // SessionIdentifier returns the unique identifier for the session.
@@ -220,9 +221,17 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		cancel()
 	}()
 
+	// For serverless without explicit --name: auto-generate or reconnect to existing session.
+	if opts.IsServerlessMode() && opts.ConnectionName == "" && !opts.ProxyMode {
+		err := resolveServerlessSession(ctx, client, &opts)
+		if err != nil {
+			return err
+		}
+	}
+
 	sessionID := opts.SessionIdentifier()
 	if sessionID == "" {
-		return errors.New("either --cluster or --name must be provided")
+		return errors.New("either --cluster or --accelerator must be provided")
 	}
 
 	if !opts.ProxyMode {
@@ -354,6 +363,20 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		cmdio.LogString(ctx, "Connected!")
 	}
 
+	// Persist the session for future reconnects.
+	if opts.IsServerlessMode() && !opts.ProxyMode {
+		err = sessions.Add(ctx, sessions.Session{
+			Name:          opts.ConnectionName,
+			Accelerator:   opts.Accelerator,
+			WorkspaceHost: client.Config.Host,
+			CreatedAt:     time.Now(),
+			ClusterID:     clusterID,
+		})
+		if err != nil {
+			log.Warnf(ctx, "Failed to save session state: %v", err)
+		}
+	}
+
 	if opts.ProxyMode {
 		return runSSHProxy(ctx, client, serverPort, clusterID, opts)
 	} else if opts.IDE != "" {
@@ -406,7 +429,12 @@ func ensureSSHConfigEntry(ctx context.Context, configPath, hostName, userName, k
 		return fmt.Errorf("failed to generate ProxyCommand: %w", err)
 	}
 
-	hostConfig := sshconfig.GenerateHostConfig(hostName, userName, keyPath, proxyCommand)
+	var hostConfig string
+	if opts.IsServerlessMode() {
+		hostConfig = sshconfig.GenerateServerlessHostConfig(hostName, userName, keyPath, proxyCommand)
+	} else {
+		hostConfig = sshconfig.GenerateHostConfig(hostName, userName, keyPath, proxyCommand)
+	}
 
 	_, err = sshconfig.CreateOrUpdateHostConfig(ctx, hostName, hostConfig, true)
 	if err != nil {
@@ -575,15 +603,22 @@ func spawnSSHClient(ctx context.Context, userName, privateKeyPath string, server
 
 	hostName := opts.SessionIdentifier()
 
+	hostKeyChecking := "StrictHostKeyChecking=accept-new"
+	if opts.IsServerlessMode() {
+		hostKeyChecking = "StrictHostKeyChecking=no"
+	}
+
 	sshArgs := []string{
 		"-l", userName,
 		"-i", privateKeyPath,
 		"-o", "IdentitiesOnly=yes",
-		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", hostKeyChecking,
 		"-o", "ConnectTimeout=360",
 		"-o", "ProxyCommand=" + proxyCommand,
 	}
-	if opts.UserKnownHostsFile != "" {
+	if opts.IsServerlessMode() {
+		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile=/dev/null")
+	} else if opts.UserKnownHostsFile != "" {
 		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
 	}
 	sshArgs = append(sshArgs, hostName)
@@ -726,4 +761,98 @@ func ensureSSHServerIsRunning(ctx context.Context, client *databricks.WorkspaceC
 	}
 
 	return userName, serverPort, effectiveClusterID, nil
+}
+
+// resolveServerlessSession handles auto-generation and reconnection for serverless sessions.
+// It checks local state for existing sessions matching the workspace and accelerator,
+// probes them to see if they're still alive, and prompts the user to reconnect or create new.
+func resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceClient, opts *ClientOptions) error {
+	version := build.GetInfo().Version
+
+	matching, err := sessions.FindMatching(ctx, client.Config.Host, opts.Accelerator)
+	if err != nil {
+		log.Warnf(ctx, "Failed to load session state: %v", err)
+	}
+
+	// Probe sessions to find alive ones (limit to 5 most recent to avoid latency).
+	const maxProbe = 5
+	if len(matching) > maxProbe {
+		matching = matching[len(matching)-maxProbe:]
+	}
+
+	var alive []sessions.Session
+	for _, s := range matching {
+		_, _, _, probeErr := getServerMetadata(ctx, client, s.Name, s.ClusterID, version, opts.Liteswap)
+		if probeErr == nil {
+			alive = append(alive, s)
+		} else {
+			cleanupStaleSession(ctx, client, s, version)
+		}
+	}
+
+	if len(alive) > 0 && cmdio.IsPromptSupported(ctx) {
+		choices := make([]string, 0, len(alive)+1)
+		for _, s := range alive {
+			choices = append(choices, fmt.Sprintf("Reconnect to %s (started %s)", s.Name, s.CreatedAt.Format(time.RFC822)))
+		}
+		choices = append(choices, "Create new session")
+
+		choice, choiceErr := cmdio.AskSelect(ctx, "Found existing sessions:", choices)
+		if choiceErr != nil {
+			return fmt.Errorf("failed to prompt user: %w", choiceErr)
+		}
+
+		for i, s := range alive {
+			if choice == choices[i] {
+				opts.ConnectionName = s.Name
+				cmdio.LogString(ctx, fmt.Sprintf("Reconnecting to session: %s", s.Name))
+				return nil
+			}
+		}
+	}
+
+	// No alive session selected — generate a new name.
+	opts.ConnectionName = sessions.GenerateSessionName(opts.Accelerator)
+	cmdio.LogString(ctx, fmt.Sprintf("Creating new session: %s", opts.ConnectionName))
+	return nil
+}
+
+// cleanupStaleSession removes all local and remote artifacts for a stale session.
+func cleanupStaleSession(ctx context.Context, client *databricks.WorkspaceClient, s sessions.Session, version string) {
+	// Remove local SSH keys.
+	keyPath, err := keys.GetLocalSSHKeyPath(ctx, s.Name, "")
+	if err == nil {
+		os.RemoveAll(filepath.Dir(keyPath))
+	}
+
+	// Remove SSH config entry.
+	if err := sshconfig.RemoveHostConfig(ctx, s.Name); err != nil {
+		log.Debugf(ctx, "Failed to remove SSH config for %s: %v", s.Name, err)
+	}
+
+	// Delete secret scope (best-effort).
+	me, err := client.CurrentUser.Me(ctx)
+	if err == nil {
+		scopeName := fmt.Sprintf("%s-%s-ssh-tunnel-keys", me.UserName, s.Name)
+		deleteErr := client.Secrets.DeleteScope(ctx, workspace.DeleteScope{Scope: scopeName})
+		if deleteErr != nil {
+			log.Debugf(ctx, "Failed to delete secret scope %s: %v", scopeName, deleteErr)
+		}
+	}
+
+	// Remove workspace content directory (best-effort).
+	contentDir, err := sshWorkspace.GetWorkspaceContentDir(ctx, client, version, s.Name)
+	if err == nil {
+		deleteErr := client.Workspace.Delete(ctx, workspace.Delete{Path: contentDir, Recursive: true})
+		if deleteErr != nil {
+			log.Debugf(ctx, "Failed to delete workspace content for %s: %v", s.Name, deleteErr)
+		}
+	}
+
+	// Remove from local state.
+	if err := sessions.Remove(ctx, s.Name); err != nil {
+		log.Debugf(ctx, "Failed to remove session %s from state: %v", s.Name, err)
+	}
+
+	log.Infof(ctx, "Cleaned up stale session: %s", s.Name)
 }

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -821,10 +821,11 @@ func (o *ClientOptions) resolveServerlessSession(ctx context.Context, client *da
 
 // cleanupStaleSession removes all local and remote artifacts for a stale session.
 func cleanupStaleSession(ctx context.Context, client *databricks.WorkspaceClient, s sessions.Session, version string) {
-	// Remove local SSH keys.
+	// Remove local SSH keys (only the session-specific files, not the shared directory).
 	keyPath, err := keys.GetLocalSSHKeyPath(ctx, s.Name, "")
 	if err == nil {
-		os.RemoveAll(filepath.Dir(keyPath))
+		os.Remove(keyPath)
+		os.Remove(keyPath + ".pub")
 	}
 
 	// Remove SSH config entry.

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -805,7 +805,7 @@ func resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceC
 		for i, s := range alive {
 			if choice == choices[i] {
 				opts.ConnectionName = s.Name
-				cmdio.LogString(ctx, fmt.Sprintf("Reconnecting to session: %s", s.Name))
+				cmdio.LogString(ctx, "Reconnecting to session: "+s.Name)
 				return nil
 			}
 		}
@@ -813,7 +813,7 @@ func resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceC
 
 	// No alive session selected — generate a new name.
 	opts.ConnectionName = sessions.GenerateSessionName(opts.Accelerator)
-	cmdio.LogString(ctx, fmt.Sprintf("Creating new session: %s", opts.ConnectionName))
+	cmdio.LogString(ctx, "Creating new session: "+opts.ConnectionName)
 	return nil
 }
 

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -223,8 +223,7 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 
 	// For serverless without explicit --name: auto-generate or reconnect to existing session.
 	if opts.IsServerlessMode() && opts.ConnectionName == "" && !opts.ProxyMode {
-		err := resolveServerlessSession(ctx, client, &opts)
-		if err != nil {
+		if err := opts.resolveServerlessSession(ctx, client); err != nil {
 			return err
 		}
 	}
@@ -365,10 +364,16 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 
 	// Persist the session for future reconnects.
 	if opts.IsServerlessMode() && !opts.ProxyMode {
+		currentUser, userErr := client.CurrentUser.Me(ctx)
+		sessionUserName := ""
+		if userErr == nil {
+			sessionUserName = currentUser.UserName
+		}
 		err = sessions.Add(ctx, sessions.Session{
 			Name:          opts.ConnectionName,
 			Accelerator:   opts.Accelerator,
 			WorkspaceHost: client.Config.Host,
+			UserName:      sessionUserName,
 			CreatedAt:     time.Now(),
 			ClusterID:     clusterID,
 		})
@@ -429,12 +434,7 @@ func ensureSSHConfigEntry(ctx context.Context, configPath, hostName, userName, k
 		return fmt.Errorf("failed to generate ProxyCommand: %w", err)
 	}
 
-	var hostConfig string
-	if opts.IsServerlessMode() {
-		hostConfig = sshconfig.GenerateServerlessHostConfig(hostName, userName, keyPath, proxyCommand)
-	} else {
-		hostConfig = sshconfig.GenerateHostConfig(hostName, userName, keyPath, proxyCommand)
-	}
+	hostConfig := sshconfig.GenerateHostConfig(hostName, userName, keyPath, proxyCommand)
 
 	_, err = sshconfig.CreateOrUpdateHostConfig(ctx, hostName, hostConfig, true)
 	if err != nil {
@@ -603,22 +603,15 @@ func spawnSSHClient(ctx context.Context, userName, privateKeyPath string, server
 
 	hostName := opts.SessionIdentifier()
 
-	hostKeyChecking := "StrictHostKeyChecking=accept-new"
-	if opts.IsServerlessMode() {
-		hostKeyChecking = "StrictHostKeyChecking=no"
-	}
-
 	sshArgs := []string{
 		"-l", userName,
 		"-i", privateKeyPath,
 		"-o", "IdentitiesOnly=yes",
-		"-o", hostKeyChecking,
+		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "ConnectTimeout=360",
 		"-o", "ProxyCommand=" + proxyCommand,
 	}
-	if opts.IsServerlessMode() {
-		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile=/dev/null")
-	} else if opts.UserKnownHostsFile != "" {
+	if opts.UserKnownHostsFile != "" {
 		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
 	}
 	sshArgs = append(sshArgs, hostName)
@@ -764,12 +757,17 @@ func ensureSSHServerIsRunning(ctx context.Context, client *databricks.WorkspaceC
 }
 
 // resolveServerlessSession handles auto-generation and reconnection for serverless sessions.
-// It checks local state for existing sessions matching the workspace and accelerator,
+// It checks local state for existing sessions matching the workspace, accelerator, and user,
 // probes them to see if they're still alive, and prompts the user to reconnect or create new.
-func resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceClient, opts *ClientOptions) error {
+func (opts *ClientOptions) resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceClient) error {
 	version := build.GetInfo().Version
 
-	matching, err := sessions.FindMatching(ctx, client.Config.Host, opts.Accelerator)
+	me, err := client.CurrentUser.Me(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get current user: %w", err)
+	}
+
+	matching, err := sessions.FindMatching(ctx, client.Config.Host, opts.Accelerator, me.UserName)
 	if err != nil {
 		log.Warnf(ctx, "Failed to load session state: %v", err)
 	}
@@ -785,8 +783,12 @@ func resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceC
 		_, _, _, probeErr := getServerMetadata(ctx, client, s.Name, s.ClusterID, version, opts.Liteswap)
 		if probeErr == nil {
 			alive = append(alive, s)
-		} else {
+		} else if errors.Is(probeErr, errServerMetadata) {
+			// Only clean up when the server is definitively gone (metadata endpoint returns not-found).
+			// Transient errors (network, auth) should not trigger cleanup.
 			cleanupStaleSession(ctx, client, s, version)
+		} else {
+			log.Warnf(ctx, "Transient error probing session %s, skipping: %v", s.Name, probeErr)
 		}
 	}
 
@@ -812,7 +814,7 @@ func resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceC
 	}
 
 	// No alive session selected — generate a new name.
-	opts.ConnectionName = sessions.GenerateSessionName(opts.Accelerator)
+	opts.ConnectionName = sessions.GenerateSessionName(opts.Accelerator, client.Config.Host)
 	cmdio.LogString(ctx, "Creating new session: "+opts.ConnectionName)
 	return nil
 }

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -759,7 +759,7 @@ func ensureSSHServerIsRunning(ctx context.Context, client *databricks.WorkspaceC
 // resolveServerlessSession handles auto-generation and reconnection for serverless sessions.
 // It checks local state for existing sessions matching the workspace, accelerator, and user,
 // probes them to see if they're still alive, and prompts the user to reconnect or create new.
-func (opts *ClientOptions) resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceClient) error {
+func (o *ClientOptions) resolveServerlessSession(ctx context.Context, client *databricks.WorkspaceClient) error {
 	version := build.GetInfo().Version
 
 	me, err := client.CurrentUser.Me(ctx)
@@ -767,7 +767,7 @@ func (opts *ClientOptions) resolveServerlessSession(ctx context.Context, client 
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
 
-	matching, err := sessions.FindMatching(ctx, client.Config.Host, opts.Accelerator, me.UserName)
+	matching, err := sessions.FindMatching(ctx, client.Config.Host, o.Accelerator, me.UserName)
 	if err != nil {
 		log.Warnf(ctx, "Failed to load session state: %v", err)
 	}
@@ -780,7 +780,7 @@ func (opts *ClientOptions) resolveServerlessSession(ctx context.Context, client 
 
 	var alive []sessions.Session
 	for _, s := range matching {
-		_, _, _, probeErr := getServerMetadata(ctx, client, s.Name, s.ClusterID, version, opts.Liteswap)
+		_, _, _, probeErr := getServerMetadata(ctx, client, s.Name, s.ClusterID, version, o.Liteswap)
 		if probeErr == nil {
 			alive = append(alive, s)
 		} else if errors.Is(probeErr, errServerMetadata) {
@@ -806,7 +806,7 @@ func (opts *ClientOptions) resolveServerlessSession(ctx context.Context, client 
 
 		for i, s := range alive {
 			if choice == choices[i] {
-				opts.ConnectionName = s.Name
+				o.ConnectionName = s.Name
 				cmdio.LogString(ctx, "Reconnecting to session: "+s.Name)
 				return nil
 			}
@@ -814,8 +814,8 @@ func (opts *ClientOptions) resolveServerlessSession(ctx context.Context, client 
 	}
 
 	// No alive session selected — generate a new name.
-	opts.ConnectionName = sessions.GenerateSessionName(opts.Accelerator, client.Config.Host)
-	cmdio.LogString(ctx, "Creating new session: "+opts.ConnectionName)
+	o.ConnectionName = sessions.GenerateSessionName(o.Accelerator, client.Config.Host)
+	cmdio.LogString(ctx, "Creating new session: "+o.ConnectionName)
 	return nil
 }
 

--- a/experimental/ssh/internal/client/client_test.go
+++ b/experimental/ssh/internal/client/client_test.go
@@ -68,8 +68,9 @@ func TestValidate(t *testing.T) {
 			wantErr: `invalid accelerator value: "CPU_1x", expected "GPU_1xA10" or "GPU_8xH100"`,
 		},
 		{
-			name: "both cluster ID and connection name",
-			opts: client.ClientOptions{ClusterID: "abc-123", ConnectionName: "my-conn", Accelerator: "GPU_1xA10"},
+			name:    "both cluster ID and connection name",
+			opts:    client.ClientOptions{ClusterID: "abc-123", ConnectionName: "my-conn", Accelerator: "GPU_1xA10"},
+			wantErr: `--accelerator flag can only be used with serverless compute, not with --cluster`,
 		},
 		{
 			name:    "proxy mode with invalid connection name",

--- a/experimental/ssh/internal/client/client_test.go
+++ b/experimental/ssh/internal/client/client_test.go
@@ -19,9 +19,9 @@ func TestValidate(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "no cluster or connection name",
+			name:    "no cluster or connection name or accelerator",
 			opts:    client.ClientOptions{},
-			wantErr: "please provide --cluster flag with the cluster ID, or --name flag with the connection name (for serverless compute)",
+			wantErr: "please provide --cluster or --accelerator flag",
 		},
 		{
 			name: "proxy mode skips cluster/name check",
@@ -32,9 +32,13 @@ func TestValidate(t *testing.T) {
 			opts: client.ClientOptions{ClusterID: "abc-123"},
 		},
 		{
-			name:    "accelerator without connection name",
+			name:    "accelerator with cluster ID",
 			opts:    client.ClientOptions{ClusterID: "abc-123", Accelerator: "GPU_1xA10"},
-			wantErr: "--accelerator flag can only be used with serverless compute (--name flag)",
+			wantErr: "--accelerator flag can only be used with serverless compute, not with --cluster",
+		},
+		{
+			name: "accelerator only (auto-generate session name)",
+			opts: client.ClientOptions{Accelerator: "GPU_1xA10"},
 		},
 		{
 			name: "connection name without accelerator",

--- a/experimental/ssh/internal/sessions/namegen.go
+++ b/experimental/ssh/internal/sessions/namegen.go
@@ -1,0 +1,28 @@
+package sessions
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+// acceleratorPrefixes maps known accelerator types to short human-readable prefixes.
+var acceleratorPrefixes = map[string]string{
+	"GPU_1xA10":  "gpu-a10",
+	"GPU_8xH100": "gpu-h100",
+}
+
+// GenerateSessionName creates a human-readable session name from the accelerator type.
+// Format: <prefix>-<random_hex>, e.g. "gpu-a10-f3a2b1c0".
+func GenerateSessionName(accelerator string) string {
+	prefix, ok := acceleratorPrefixes[accelerator]
+	if !ok {
+		prefix = strings.ToLower(strings.ReplaceAll(accelerator, "_", "-"))
+	}
+
+	date := time.Now().Format("20060102")
+	b := make([]byte, 3)
+	_, _ = rand.Read(b)
+	return "databricks-" + prefix + "-" + date + "-" + hex.EncodeToString(b)
+}

--- a/experimental/ssh/internal/sessions/namegen.go
+++ b/experimental/ssh/internal/sessions/namegen.go
@@ -1,8 +1,10 @@
 package sessions
 
 import (
+	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -13,16 +15,26 @@ var acceleratorPrefixes = map[string]string{
 	"GPU_8xH100": "gpu-h100",
 }
 
-// GenerateSessionName creates a human-readable session name from the accelerator type.
-// Format: <prefix>-<random_hex>, e.g. "gpu-a10-f3a2b1c0".
-func GenerateSessionName(accelerator string) string {
+// GenerateSessionName creates a human-readable session name from the accelerator type
+// and workspace host. The workspace host is hashed into the name to avoid SSH known_hosts
+// conflicts when connecting to different workspaces.
+// Format: databricks-<prefix>-<date>-<workspace_hash><random_hex>.
+func GenerateSessionName(accelerator, workspaceHost string) string {
 	prefix, ok := acceleratorPrefixes[accelerator]
 	if !ok {
 		prefix = strings.ToLower(strings.ReplaceAll(accelerator, "_", "-"))
 	}
 
 	date := time.Now().Format("20060102")
+
+	// Include a short hash of the workspace host to avoid known_hosts conflicts
+	// when connecting to different workspaces.
+	wsHash := md5.Sum([]byte(workspaceHost))
+	wsHashStr := hex.EncodeToString(wsHash[:])[:4]
+
 	b := make([]byte, 3)
-	_, _ = rand.Read(b)
-	return "databricks-" + prefix + "-" + date + "-" + hex.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("crypto/rand.Read failed: %v", err))
+	}
+	return "databricks-" + prefix + "-" + date + "-" + wsHashStr + hex.EncodeToString(b)
 }

--- a/experimental/ssh/internal/sessions/sessions.go
+++ b/experimental/ssh/internal/sessions/sessions.go
@@ -9,13 +9,21 @@ import (
 	"time"
 
 	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/log"
 )
 
 const (
 	stateFileName = "ssh-tunnel-sessions.json"
+	lockFileName  = "ssh-tunnel-sessions.lock"
 
 	// Sessions older than this are considered expired and cleaned up automatically.
 	sessionMaxAge = 24 * time.Hour
+
+	// Lock acquisition parameters.
+	lockRetryInterval = 100 * time.Millisecond
+	lockTimeout       = 5 * time.Second
+	// Locks older than this are considered stale and can be broken.
+	lockMaxAge = 30 * time.Second
 )
 
 // Session represents a tracked SSH tunnel session.
@@ -33,12 +41,55 @@ type SessionStore struct {
 	Sessions []Session `json:"sessions"`
 }
 
-func getStateFilePath(ctx context.Context) (string, error) {
+func getStateDir(ctx context.Context) (string, error) {
 	homeDir, err := env.UserHomeDir(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	return filepath.Join(homeDir, ".databricks", stateFileName), nil
+	return filepath.Join(homeDir, ".databricks"), nil
+}
+
+func getStateFilePath(ctx context.Context) (string, error) {
+	dir, err := getStateDir(ctx)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, stateFileName), nil
+}
+
+// acquireLock acquires an exclusive file lock for the session store.
+// Returns an unlock function that must be called when done.
+func acquireLock(ctx context.Context) (unlock func(), err error) {
+	dir, err := getStateDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	lockPath := filepath.Join(dir, lockFileName)
+	deadline := time.Now().Add(lockTimeout)
+
+	for {
+		f, createErr := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if createErr == nil {
+			f.Close()
+			return func() { os.Remove(lockPath) }, nil
+		}
+
+		// Break stale locks from crashed processes.
+		if info, statErr := os.Stat(lockPath); statErr == nil && time.Since(info.ModTime()) > lockMaxAge {
+			log.Debugf(ctx, "Breaking stale session lock (age: %v)", time.Since(info.ModTime()))
+			os.Remove(lockPath)
+			continue
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for session store lock")
+		}
+		time.Sleep(lockRetryInterval)
+	}
 }
 
 // Load reads the session store from disk. Returns an empty store if the file does not exist.
@@ -63,8 +114,8 @@ func Load(ctx context.Context) (*SessionStore, error) {
 	return &store, nil
 }
 
-// Save writes the session store to disk atomically.
-func Save(ctx context.Context, store *SessionStore) error {
+// save writes the session store to disk atomically. Caller must hold the lock.
+func save(ctx context.Context, store *SessionStore) error {
 	path, err := getStateFilePath(ctx)
 	if err != nil {
 		return err
@@ -79,12 +130,23 @@ func Save(ctx context.Context, store *SessionStore) error {
 		return fmt.Errorf("failed to marshal session state: %w", err)
 	}
 
-	// Atomic write: write to temp file, then rename.
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+	// Atomic write: write to unique temp file, then rename.
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), ".sessions-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
 		return fmt.Errorf("failed to write session state file: %w", err)
 	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
 	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
 		return fmt.Errorf("failed to rename session state file: %w", err)
 	}
 	return nil
@@ -92,6 +154,12 @@ func Save(ctx context.Context, store *SessionStore) error {
 
 // Add persists a new session to the store, replacing any existing session with the same name.
 func Add(ctx context.Context, s Session) error {
+	unlock, err := acquireLock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire session store lock: %w", err)
+	}
+	defer unlock()
+
 	store, err := Load(ctx)
 	if err != nil {
 		return err
@@ -110,11 +178,17 @@ func Add(ctx context.Context, s Session) error {
 		store.Sessions = append(store.Sessions, s)
 	}
 
-	return Save(ctx, store)
+	return save(ctx, store)
 }
 
 // Remove deletes a session by name.
 func Remove(ctx context.Context, name string) error {
+	unlock, err := acquireLock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire session store lock: %w", err)
+	}
+	defer unlock()
+
 	store, err := Load(ctx)
 	if err != nil {
 		return err
@@ -127,12 +201,18 @@ func Remove(ctx context.Context, name string) error {
 		}
 	}
 	store.Sessions = filtered
-	return Save(ctx, store)
+	return save(ctx, store)
 }
 
 // FindMatching returns non-expired sessions that match the given workspace host, accelerator,
 // and user name. Expired sessions are pruned from the store on disk.
 func FindMatching(ctx context.Context, workspaceHost, accelerator, userName string) ([]Session, error) {
+	unlock, err := acquireLock(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire session store lock: %w", err)
+	}
+	defer unlock()
+
 	store, err := Load(ctx)
 	if err != nil {
 		return nil, err
@@ -152,8 +232,7 @@ func FindMatching(ctx context.Context, workspaceHost, accelerator, userName stri
 	}
 	if pruned {
 		store.Sessions = active
-		// Best-effort save; don't fail the operation if pruning fails.
-		_ = Save(ctx, store)
+		_ = save(ctx, store)
 	}
 
 	var result []Session

--- a/experimental/ssh/internal/sessions/sessions.go
+++ b/experimental/ssh/internal/sessions/sessions.go
@@ -1,0 +1,147 @@
+package sessions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/databricks/cli/libs/env"
+)
+
+const (
+	stateFileName = "ssh-tunnel-sessions.json"
+
+	// Sessions older than this are considered expired and cleaned up automatically.
+	sessionMaxAge = 24 * time.Hour
+)
+
+// Session represents a tracked SSH tunnel session.
+type Session struct {
+	Name          string    `json:"name"`
+	Accelerator   string    `json:"accelerator"`
+	WorkspaceHost string    `json:"workspace_host"`
+	CreatedAt     time.Time `json:"created_at"`
+	ClusterID     string    `json:"cluster_id,omitempty"`
+}
+
+// SessionStore holds all tracked sessions.
+type SessionStore struct {
+	Sessions []Session `json:"sessions"`
+}
+
+func getStateFilePath(ctx context.Context) (string, error) {
+	homeDir, err := env.UserHomeDir(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".databricks", stateFileName), nil
+}
+
+// Load reads the session store from disk. Returns an empty store if the file does not exist.
+func Load(ctx context.Context) (*SessionStore, error) {
+	path, err := getStateFilePath(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &SessionStore{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session state file: %w", err)
+	}
+
+	var store SessionStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("failed to parse session state file: %w", err)
+	}
+	return &store, nil
+}
+
+// Save writes the session store to disk atomically.
+func Save(ctx context.Context, store *SessionStore) error {
+	path, err := getStateFilePath(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session state: %w", err)
+	}
+
+	// Atomic write: write to temp file, then rename.
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write session state file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to rename session state file: %w", err)
+	}
+	return nil
+}
+
+// Add persists a new session to the store, replacing any existing session with the same name.
+func Add(ctx context.Context, s Session) error {
+	store, err := Load(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Replace existing session with the same name.
+	found := false
+	for i, existing := range store.Sessions {
+		if existing.Name == s.Name {
+			store.Sessions[i] = s
+			found = true
+			break
+		}
+	}
+	if !found {
+		store.Sessions = append(store.Sessions, s)
+	}
+
+	return Save(ctx, store)
+}
+
+// Remove deletes a session by name.
+func Remove(ctx context.Context, name string) error {
+	store, err := Load(ctx)
+	if err != nil {
+		return err
+	}
+
+	filtered := store.Sessions[:0]
+	for _, s := range store.Sessions {
+		if s.Name != name {
+			filtered = append(filtered, s)
+		}
+	}
+	store.Sessions = filtered
+	return Save(ctx, store)
+}
+
+// FindMatching returns non-expired sessions that match the given workspace host and accelerator.
+func FindMatching(ctx context.Context, workspaceHost, accelerator string) ([]Session, error) {
+	store, err := Load(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cutoff := time.Now().Add(-sessionMaxAge)
+	var result []Session
+	for _, s := range store.Sessions {
+		if s.WorkspaceHost == workspaceHost && s.Accelerator == accelerator && s.CreatedAt.After(cutoff) {
+			result = append(result, s)
+		}
+	}
+	return result, nil
+}

--- a/experimental/ssh/internal/sessions/sessions.go
+++ b/experimental/ssh/internal/sessions/sessions.go
@@ -23,6 +23,7 @@ type Session struct {
 	Name          string    `json:"name"`
 	Accelerator   string    `json:"accelerator"`
 	WorkspaceHost string    `json:"workspace_host"`
+	UserName      string    `json:"user_name,omitempty"`
 	CreatedAt     time.Time `json:"created_at"`
 	ClusterID     string    `json:"cluster_id,omitempty"`
 }
@@ -129,17 +130,35 @@ func Remove(ctx context.Context, name string) error {
 	return Save(ctx, store)
 }
 
-// FindMatching returns non-expired sessions that match the given workspace host and accelerator.
-func FindMatching(ctx context.Context, workspaceHost, accelerator string) ([]Session, error) {
+// FindMatching returns non-expired sessions that match the given workspace host, accelerator,
+// and user name. Expired sessions are pruned from the store on disk.
+func FindMatching(ctx context.Context, workspaceHost, accelerator, userName string) ([]Session, error) {
 	store, err := Load(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	cutoff := time.Now().Add(-sessionMaxAge)
-	var result []Session
+
+	// Prune expired sessions from the store.
+	active := store.Sessions[:0]
+	pruned := false
 	for _, s := range store.Sessions {
-		if s.WorkspaceHost == workspaceHost && s.Accelerator == accelerator && s.CreatedAt.After(cutoff) {
+		if s.CreatedAt.After(cutoff) {
+			active = append(active, s)
+		} else {
+			pruned = true
+		}
+	}
+	if pruned {
+		store.Sessions = active
+		// Best-effort save; don't fail the operation if pruning fails.
+		_ = Save(ctx, store)
+	}
+
+	var result []Session
+	for _, s := range active {
+		if s.WorkspaceHost == workspaceHost && s.Accelerator == accelerator && s.UserName == userName {
 			result = append(result, s)
 		}
 	}

--- a/experimental/ssh/internal/sessions/sessions_test.go
+++ b/experimental/ssh/internal/sessions/sessions_test.go
@@ -1,0 +1,183 @@
+package sessions
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+
+	store, err := Load(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, store.Sessions)
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	store := &SessionStore{
+		Sessions: []Session{
+			{
+				Name:          "gpu-a10-abcd1234",
+				Accelerator:   "GPU_1xA10",
+				WorkspaceHost: "https://test.databricks.com",
+				CreatedAt:     time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+				ClusterID:     "0310-120000-abc",
+			},
+		},
+	}
+
+	err := Save(t.Context(), store)
+	require.NoError(t, err)
+
+	loaded, err := Load(t.Context())
+	require.NoError(t, err)
+	require.Len(t, loaded.Sessions, 1)
+	assert.Equal(t, "gpu-a10-abcd1234", loaded.Sessions[0].Name)
+	assert.Equal(t, "GPU_1xA10", loaded.Sessions[0].Accelerator)
+	assert.Equal(t, "https://test.databricks.com", loaded.Sessions[0].WorkspaceHost)
+	assert.Equal(t, "0310-120000-abc", loaded.Sessions[0].ClusterID)
+}
+
+func TestAddAndRemove(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	ctx := t.Context()
+
+	err := Add(ctx, Session{Name: "sess-1", Accelerator: "GPU_1xA10", WorkspaceHost: "https://a.com"})
+	require.NoError(t, err)
+
+	err = Add(ctx, Session{Name: "sess-2", Accelerator: "GPU_8xH100", WorkspaceHost: "https://b.com"})
+	require.NoError(t, err)
+
+	store, err := Load(ctx)
+	require.NoError(t, err)
+	assert.Len(t, store.Sessions, 2)
+
+	err = Remove(ctx, "sess-1")
+	require.NoError(t, err)
+
+	store, err = Load(ctx)
+	require.NoError(t, err)
+	require.Len(t, store.Sessions, 1)
+	assert.Equal(t, "sess-2", store.Sessions[0].Name)
+}
+
+func TestRemoveNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	err := Remove(t.Context(), "no-such-session")
+	assert.NoError(t, err)
+}
+
+func TestFindMatching(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	ctx := t.Context()
+	host := "https://test.databricks.com"
+
+	now := time.Now()
+
+	err := Add(ctx, Session{Name: "s1", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: now})
+	require.NoError(t, err)
+	err = Add(ctx, Session{Name: "s2", Accelerator: "GPU_8xH100", WorkspaceHost: host, CreatedAt: now})
+	require.NoError(t, err)
+	err = Add(ctx, Session{Name: "s3", Accelerator: "GPU_1xA10", WorkspaceHost: "https://other.com", CreatedAt: now})
+	require.NoError(t, err)
+	err = Add(ctx, Session{Name: "s4", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: now})
+	require.NoError(t, err)
+
+	matches, err := FindMatching(ctx, host, "GPU_1xA10")
+	require.NoError(t, err)
+	assert.Len(t, matches, 2)
+	assert.Equal(t, "s1", matches[0].Name)
+	assert.Equal(t, "s4", matches[1].Name)
+
+	matches, err = FindMatching(ctx, host, "GPU_8xH100")
+	require.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "s2", matches[0].Name)
+
+	matches, err = FindMatching(ctx, host, "GPU_4xA100")
+	require.NoError(t, err)
+	assert.Empty(t, matches)
+}
+
+func TestFindMatchingExpiresOldSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	ctx := t.Context()
+	host := "https://test.databricks.com"
+
+	err := Add(ctx, Session{Name: "old", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: time.Now().Add(-25 * time.Hour)})
+	require.NoError(t, err)
+	err = Add(ctx, Session{Name: "recent", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: time.Now()})
+	require.NoError(t, err)
+
+	matches, err := FindMatching(ctx, host, "GPU_1xA10")
+	require.NoError(t, err)
+	require.Len(t, matches, 1)
+	assert.Equal(t, "recent", matches[0].Name)
+}
+
+func TestStateFilePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	path, err := getStateFilePath(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmpDir, ".databricks", stateFileName), path)
+}
+
+// connectionNameRegex mirrors the regex in client.go.
+var connectionNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+func TestGenerateSessionName(t *testing.T) {
+	tests := []struct {
+		accelerator    string
+		wantPrefix     string
+		wantDatePrefix string
+	}{
+		{"GPU_1xA10", "databricks-gpu-a10-", "databricks-gpu-a10-20"},
+		{"GPU_8xH100", "databricks-gpu-h100-", "databricks-gpu-h100-20"},
+		{"UNKNOWN_TYPE", "databricks-unknown-type-", "databricks-unknown-type-20"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.accelerator, func(t *testing.T) {
+			name := GenerateSessionName(tt.accelerator)
+			assert.True(t, len(name) > len(tt.wantPrefix), "name should be longer than prefix")
+			assert.Equal(t, tt.wantPrefix, name[:len(tt.wantPrefix)])
+			// Verify date component is present (starts with "20" for 2000s dates).
+			assert.Equal(t, tt.wantDatePrefix, name[:len(tt.wantDatePrefix)])
+			assert.True(t, connectionNameRegex.MatchString(name), "generated name %q must match connection name regex", name)
+		})
+	}
+}
+
+func TestGenerateSessionNameUniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for range 100 {
+		name := GenerateSessionName("GPU_1xA10")
+		assert.False(t, seen[name], "duplicate name generated: %s", name)
+		seen[name] = true
+	}
+}

--- a/experimental/ssh/internal/sessions/sessions_test.go
+++ b/experimental/ssh/internal/sessions/sessions_test.go
@@ -19,24 +19,20 @@ func TestLoadEmpty(t *testing.T) {
 	assert.Empty(t, store.Sessions)
 }
 
-func TestSaveAndLoad(t *testing.T) {
+func TestAddAndLoad(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir)
 
-	store := &SessionStore{
-		Sessions: []Session{
-			{
-				Name:          "gpu-a10-abcd1234",
-				Accelerator:   "GPU_1xA10",
-				WorkspaceHost: "https://test.databricks.com",
-				CreatedAt:     time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
-				ClusterID:     "0310-120000-abc",
-			},
-		},
+	s := Session{
+		Name:          "gpu-a10-abcd1234",
+		Accelerator:   "GPU_1xA10",
+		WorkspaceHost: "https://test.databricks.com",
+		CreatedAt:     time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		ClusterID:     "0310-120000-abc",
 	}
 
-	err := Save(t.Context(), store)
+	err := Add(t.Context(), s)
 	require.NoError(t, err)
 
 	loaded, err := Load(t.Context())

--- a/experimental/ssh/internal/sessions/sessions_test.go
+++ b/experimental/ssh/internal/sessions/sessions_test.go
@@ -164,7 +164,7 @@ func TestGenerateSessionName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.accelerator, func(t *testing.T) {
 			name := GenerateSessionName(tt.accelerator)
-			assert.True(t, len(name) > len(tt.wantPrefix), "name should be longer than prefix")
+			assert.Greater(t, len(name), len(tt.wantPrefix), "name should be longer than prefix")
 			assert.Equal(t, tt.wantPrefix, name[:len(tt.wantPrefix)])
 			// Verify date component is present (starts with "20" for 2000s dates).
 			assert.Equal(t, tt.wantDatePrefix, name[:len(tt.wantDatePrefix)])

--- a/experimental/ssh/internal/sessions/sessions_test.go
+++ b/experimental/ssh/internal/sessions/sessions_test.go
@@ -90,32 +90,41 @@ func TestFindMatching(t *testing.T) {
 
 	ctx := t.Context()
 	host := "https://test.databricks.com"
+	user := "alice@example.com"
 
 	now := time.Now()
 
-	err := Add(ctx, Session{Name: "s1", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: now})
+	err := Add(ctx, Session{Name: "s1", Accelerator: "GPU_1xA10", WorkspaceHost: host, UserName: user, CreatedAt: now})
 	require.NoError(t, err)
-	err = Add(ctx, Session{Name: "s2", Accelerator: "GPU_8xH100", WorkspaceHost: host, CreatedAt: now})
+	err = Add(ctx, Session{Name: "s2", Accelerator: "GPU_8xH100", WorkspaceHost: host, UserName: user, CreatedAt: now})
 	require.NoError(t, err)
-	err = Add(ctx, Session{Name: "s3", Accelerator: "GPU_1xA10", WorkspaceHost: "https://other.com", CreatedAt: now})
+	err = Add(ctx, Session{Name: "s3", Accelerator: "GPU_1xA10", WorkspaceHost: "https://other.com", UserName: user, CreatedAt: now})
 	require.NoError(t, err)
-	err = Add(ctx, Session{Name: "s4", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: now})
+	err = Add(ctx, Session{Name: "s4", Accelerator: "GPU_1xA10", WorkspaceHost: host, UserName: user, CreatedAt: now})
+	require.NoError(t, err)
+	err = Add(ctx, Session{Name: "s5", Accelerator: "GPU_1xA10", WorkspaceHost: host, UserName: "bob@example.com", CreatedAt: now})
 	require.NoError(t, err)
 
-	matches, err := FindMatching(ctx, host, "GPU_1xA10")
+	matches, err := FindMatching(ctx, host, "GPU_1xA10", user)
 	require.NoError(t, err)
 	assert.Len(t, matches, 2)
 	assert.Equal(t, "s1", matches[0].Name)
 	assert.Equal(t, "s4", matches[1].Name)
 
-	matches, err = FindMatching(ctx, host, "GPU_8xH100")
+	matches, err = FindMatching(ctx, host, "GPU_8xH100", user)
 	require.NoError(t, err)
 	assert.Len(t, matches, 1)
 	assert.Equal(t, "s2", matches[0].Name)
 
-	matches, err = FindMatching(ctx, host, "GPU_4xA100")
+	matches, err = FindMatching(ctx, host, "GPU_4xA100", user)
 	require.NoError(t, err)
 	assert.Empty(t, matches)
+
+	// Different user should not see alice's sessions
+	matches, err = FindMatching(ctx, host, "GPU_1xA10", "bob@example.com")
+	require.NoError(t, err)
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "s5", matches[0].Name)
 }
 
 func TestFindMatchingExpiresOldSessions(t *testing.T) {
@@ -125,16 +134,22 @@ func TestFindMatchingExpiresOldSessions(t *testing.T) {
 
 	ctx := t.Context()
 	host := "https://test.databricks.com"
+	user := "alice@example.com"
 
-	err := Add(ctx, Session{Name: "old", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: time.Now().Add(-25 * time.Hour)})
+	err := Add(ctx, Session{Name: "old", Accelerator: "GPU_1xA10", WorkspaceHost: host, UserName: user, CreatedAt: time.Now().Add(-25 * time.Hour)})
 	require.NoError(t, err)
-	err = Add(ctx, Session{Name: "recent", Accelerator: "GPU_1xA10", WorkspaceHost: host, CreatedAt: time.Now()})
+	err = Add(ctx, Session{Name: "recent", Accelerator: "GPU_1xA10", WorkspaceHost: host, UserName: user, CreatedAt: time.Now()})
 	require.NoError(t, err)
 
-	matches, err := FindMatching(ctx, host, "GPU_1xA10")
+	matches, err := FindMatching(ctx, host, "GPU_1xA10", user)
 	require.NoError(t, err)
 	require.Len(t, matches, 1)
 	assert.Equal(t, "recent", matches[0].Name)
+
+	// Verify expired sessions were pruned from disk.
+	store, err := Load(ctx)
+	require.NoError(t, err)
+	assert.Len(t, store.Sessions, 1, "expired sessions should be pruned from disk")
 }
 
 func TestStateFilePath(t *testing.T) {
@@ -151,6 +166,7 @@ func TestStateFilePath(t *testing.T) {
 var connectionNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
 func TestGenerateSessionName(t *testing.T) {
+	host := "https://test.databricks.com"
 	tests := []struct {
 		accelerator    string
 		wantPrefix     string
@@ -163,7 +179,7 @@ func TestGenerateSessionName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.accelerator, func(t *testing.T) {
-			name := GenerateSessionName(tt.accelerator)
+			name := GenerateSessionName(tt.accelerator, host)
 			assert.Greater(t, len(name), len(tt.wantPrefix), "name should be longer than prefix")
 			assert.Equal(t, tt.wantPrefix, name[:len(tt.wantPrefix)])
 			// Verify date component is present (starts with "20" for 2000s dates).
@@ -173,10 +189,20 @@ func TestGenerateSessionName(t *testing.T) {
 	}
 }
 
+func TestGenerateSessionNameDiffersByWorkspace(t *testing.T) {
+	name1 := GenerateSessionName("GPU_1xA10", "https://workspace-a.databricks.com")
+	name2 := GenerateSessionName("GPU_1xA10", "https://workspace-b.databricks.com")
+	// The workspace hash portion (after the date-) should differ.
+	// Names have format: databricks-gpu-a10-YYYYMMDD-<wshash><random>
+	// Extract after the date prefix to compare workspace hash parts.
+	assert.NotEqual(t, name1, name2, "names for different workspaces should differ")
+}
+
 func TestGenerateSessionNameUniqueness(t *testing.T) {
+	host := "https://test.databricks.com"
 	seen := make(map[string]bool)
 	for range 100 {
-		name := GenerateSessionName("GPU_1xA10")
+		name := GenerateSessionName("GPU_1xA10", host)
 		assert.False(t, seen[name], "duplicate name generated: %s", name)
 		seen[name] = true
 	}

--- a/experimental/ssh/internal/sshconfig/sshconfig.go
+++ b/experimental/ssh/internal/sshconfig/sshconfig.go
@@ -216,30 +216,13 @@ func RemoveHostConfig(ctx context.Context, hostName string) error {
 
 // GenerateHostConfig generates an SSH host config block.
 func GenerateHostConfig(hostName, userName, identityFile, proxyCommand string) string {
-	return generateHostConfig(hostName, userName, identityFile, proxyCommand, false)
-}
-
-// GenerateServerlessHostConfig generates an SSH host config block for serverless compute.
-// It disables strict host key checking since serverless containers generate fresh keys each time,
-// and identity is already verified through Databricks authentication and Driver Proxy.
-func GenerateServerlessHostConfig(hostName, userName, identityFile, proxyCommand string) string {
-	return generateHostConfig(hostName, userName, identityFile, proxyCommand, true)
-}
-
-func generateHostConfig(hostName, userName, identityFile, proxyCommand string, serverless bool) string {
-	hostKeyChecking := "StrictHostKeyChecking accept-new"
-	knownHostsLine := ""
-	if serverless {
-		hostKeyChecking = "StrictHostKeyChecking no"
-		knownHostsLine = "    UserKnownHostsFile /dev/null\n"
-	}
 	return fmt.Sprintf(`
 Host %s
     User %s
     ConnectTimeout 360
-    %s
-%s    IdentitiesOnly yes
+    StrictHostKeyChecking accept-new
+    IdentitiesOnly yes
     IdentityFile %q
     ProxyCommand %s
-`, hostName, userName, hostKeyChecking, knownHostsLine, identityFile, proxyCommand)
+`, hostName, userName, identityFile, proxyCommand)
 }

--- a/experimental/ssh/internal/sshconfig/sshconfig.go
+++ b/experimental/ssh/internal/sshconfig/sshconfig.go
@@ -201,14 +201,45 @@ func PromptRecreateConfig(ctx context.Context, hostName string) (bool, error) {
 	return response, nil
 }
 
+// RemoveHostConfig deletes the SSH config file for a given host name.
+func RemoveHostConfig(ctx context.Context, hostName string) error {
+	configPath, err := GetHostConfigPath(ctx, hostName)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(configPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// GenerateHostConfig generates an SSH host config block.
 func GenerateHostConfig(hostName, userName, identityFile, proxyCommand string) string {
+	return generateHostConfig(hostName, userName, identityFile, proxyCommand, false)
+}
+
+// GenerateServerlessHostConfig generates an SSH host config block for serverless compute.
+// It disables strict host key checking since serverless containers generate fresh keys each time,
+// and identity is already verified through Databricks authentication and Driver Proxy.
+func GenerateServerlessHostConfig(hostName, userName, identityFile, proxyCommand string) string {
+	return generateHostConfig(hostName, userName, identityFile, proxyCommand, true)
+}
+
+func generateHostConfig(hostName, userName, identityFile, proxyCommand string, serverless bool) string {
+	hostKeyChecking := "StrictHostKeyChecking accept-new"
+	knownHostsLine := ""
+	if serverless {
+		hostKeyChecking = "StrictHostKeyChecking no"
+		knownHostsLine = "    UserKnownHostsFile /dev/null\n"
+	}
 	return fmt.Sprintf(`
 Host %s
     User %s
     ConnectTimeout 360
-    StrictHostKeyChecking accept-new
-    IdentitiesOnly yes
+    %s
+%s    IdentitiesOnly yes
     IdentityFile %q
     ProxyCommand %s
-`, hostName, userName, identityFile, proxyCommand)
+`, hostName, userName, hostKeyChecking, knownHostsLine, identityFile, proxyCommand)
 }


### PR DESCRIPTION
## Summary

- **`databricks ssh`**: common-workflows examples now lead with serverless (no flags), with the dedicated-cluster path as a follow-up.
- **`databricks ssh connect`**: Long description groups example invocations by serverless vs dedicated. Unhides `--name`, `--accelerator`, `--ide`, `--environment-version` so users can discover them via `--help`.
- **`databricks ssh setup`**: tightened Short/Long to clarify it's for dedicated clusters; users on serverless should just use `connect`.

CUJ: https://docs.google.com/document/d/1WnIg2vrnPR98cMay8OTY1zJ4yWcKBAHdZUXi5AhYylU/edit?tab=t.7erhv6e67uw#heading=h.kj99al6d2ch
Tracked at DECO-27026 (under epic DECO-27015 FY27Q2 P0 [IDE-Remote] CLI UX).

## Test plan

- [ ] Run `databricks ssh --help` and verify serverless examples appear first
- [ ] Run `databricks ssh connect --help` and verify `--name`, `--accelerator`, `--ide`, `--environment-version` are visible (not hidden)
- [ ] Run `databricks ssh setup --help` and verify it references dedicated clusters and points users to `connect` for serverless

This pull request and its description were written by Isaac.