### PR TITLE
direct: reject variable references in resource map keys

### DIFF
--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -763,6 +763,17 @@ func (b *DeploymentBundle) makePlan(ctx context.Context, configRoot *config.Root
 				pat,
 				func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 					s := p.String()
+					// Resource keys are used as identifiers in plan paths and looked up
+					// via dyn.NewPathFromString, which splits on '.'. A variable reference
+					// in a resource key (e.g. resources.schemas.${var.schema}) cannot be
+					// resolved at this stage and would be split into multiple path
+					// components, causing a nil dereference downstream in PrepareState.
+					// Reject early with an actionable error.
+					for _, c := range p {
+						if dynvar.ContainsVariableReference(c.Key()) {
+							return v, fmt.Errorf("resource key %q cannot contain variable references; use a literal key and parameterize fields like 'name' instead", s)
+						}
+					}
 					resourceType := config.GetResourceTypeFromKey(s)
 					if resourceType == "" {
 						return v, fmt.Errorf("cannot parse resource key: %q", s)

--- a/bundle/direct/bundle_plan_test.go
+++ b/bundle/direct/bundle_plan_test.go
@@ -3,8 +3,13 @@ package direct
 import (
 	"testing"
 
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/bundle/direct/dresources"
+	"github.com/databricks/cli/bundle/direct/dstate"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDynPathToStructPath(t *testing.T) {
@@ -34,4 +39,29 @@ func TestDynPathToStructPath(t *testing.T) {
 		node := dynPathToStructPath(tc.path)
 		assert.Equal(t, tc.expected, node.String())
 	}
+}
+
+// TestMakePlanRejectsVariableInResourceKey verifies that a variable reference
+// in a resource map key (e.g. resources.schemas.${var.schema}) is rejected
+// with a clear error rather than panicking with a nil pointer dereference
+// inside PrepareState. Regression test for issue #5098.
+func TestMakePlanRejectsVariableInResourceKey(t *testing.T) {
+	rootCfg := config.Root{
+		Resources: config.Resources{
+			Schemas: map[string]*resources.Schema{
+				"${var.schema}": {},
+			},
+		},
+	}
+	require.NoError(t, rootCfg.Mutate(func(v dyn.Value) (dyn.Value, error) { return v, nil }))
+
+	db := dstate.NewDatabase("", 0)
+	adapters, err := dresources.InitAll(nil)
+	require.NoError(t, err)
+	b := &DeploymentBundle{Adapters: adapters}
+
+	_, err = b.makePlan(t.Context(), &rootCfg, &db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "${var.schema}")
+	assert.Contains(t, err.Error(), "cannot contain variable references")
 }


### PR DESCRIPTION
## Changes

When a resource is keyed by a variable reference (e.g. `resources.schemas.${var.schema}`), the literal `${var.foo}` survives the plan-time walk in `bundle/direct/bundle_plan.go`. The string is then re-parsed by `dyn.NewPathFromString`, which splits on `.` and produces a non-existent path. `Root.GetResourceConfig` returns `(nil, nil)` for that path, and the resulting nil `*resources.Schema` is dereferenced inside `PrepareState` (`bundle/direct/dresources/schema.go:22`), panicking with a nil pointer.

This change detects variable references in resource map keys during the `MapByPattern` walk in `makePlan` and returns an actionable error instead of crashing.

## Why

Closes #5098. The user expected either correct interpolation or a clear error; either way, panicking is wrong. Variable interpolation only applies to values, not to map keys, so the only correct behavior here is a validation error pointing at the offending key. Matches the `CLAUDE.md` rules "Reject incompatible inputs early with an actionable error" and "Where a panic is genuinely possible, validate at the entry point and return an error."

## Tests

- New regression test `TestMakePlanRejectsVariableInResourceKey` in `bundle/direct/bundle_plan_test.go` reproduces the issue's YAML scenario and asserts a clear error message instead of a panic. Without the fix, this test panics with the exact stack trace from the issue (`schema.go:22` nil deref); with the fix it returns `resource key "resources.schemas.${var.schema}" cannot contain variable references; use a literal key and parameterize fields like 'name' instead`.
- `go build ./...`
- `go test ./bundle/... -timeout 120s` passes (unrelated `TestClearWorkspaceClient` requires `~/.databrickscfg` and fails on `main` too).