### PR TITLE
Remove Makefile (use ./task directly)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-default:
-	./task
-
-# Delegates every make target to the equivalent ./task target.
-# Intentional semantic changes from the old Makefile:
-#   make fmt  → ./task fmt  (full format, was incremental; use make fmt-q for incremental)
-#   make lint → ./task lint (full lint,   was incremental; use make lint-q for incremental)
-.DEFAULT:
-	@./task "$@"

--- a/experimental/ssh/README.md
+++ b/experimental/ssh/README.md
@@ -19,7 +19,7 @@ databricks ssh connect --cluster=id
 
 ## Development
 ```shell
-make build snapshot-release
+./task build snapshot-release
 ./cli ssh connect --cluster=<id> --releases-dir=./dist --debug # or modify ssh config accordingly
 ```
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -33,5 +33,5 @@ go test ./integration/...
 Alternatively:
 
 ```bash
-make integration
+./task integration
 ```

--- a/tools/bench_parse.py
+++ b/tools/bench_parse.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Parses output of benchmark runs (e.g. "make bench100") and prints a summary table.
+Parses output of benchmark runs (e.g. "./task bench-100") and prints a summary table.
 """
 
 import sys


### PR DESCRIPTION
Drop the Makefile and route every remaining caller through \`./task\` directly.

#5050 introduced \`./task\` and kept the Makefile as a thin shim. eng-dev-ecosystem #1273 was the last external consumer; it now calls \`go tool task\` directly, so the shim has no callers left and can go.

The shim was also broken: \`make integration\` was silently exiting 0 because \`integration/\` is a real directory (\`.DEFAULT\` doesn't apply when the target name matches a file/directory). That's how cli-isolated-nightly stopped producing \`output.json\` for ~5 days.

### Diff

- Delete \`Makefile\`.
- \`integration/README.md\`: \`make integration\` → \`./task integration\`.
- \`experimental/ssh/README.md\`: \`make build snapshot-release\` → \`./task build snapshot-release\`.
- \`tools/bench_parse.py\`: docstring example.

No CI changes needed — \`.github/workflows/\` already calls \`./task\`.

This pull request was AI-assisted by Isaac.