### PR TITLE
Remove no-op `promptui.SearchPrompt` assignment in warehouse picker

### DIFF
--- a/libs/databrickscfg/cfgpickers/warehouses.go
+++ b/libs/databrickscfg/cfgpickers/warehouses.go
@@ -15,7 +15,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/httpclient"
 	"github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/fatih/color"
-	"github.com/manifoldco/promptui"
 )
 
 var ErrNoCompatibleWarehouses = errors.New("no compatible warehouses")
@@ -225,7 +224,6 @@ func SelectWarehouse(ctx context.Context, w *databricks.WorkspaceClient, descrip
 	if description != "" {
 		cmdio.LogString(ctx, description)
 	}
-	promptui.SearchPrompt = "Search: "
 	warehouseId, err := cmdio.SelectOrdered(ctx, items, "warehouse\n")
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

`SelectWarehouse` in `libs/databrickscfg/cfgpickers/warehouses.go` contains:

```go
promptui.SearchPrompt = "Search: "
```

This assigns the package-level global to its own default. promptui declares it [here](https://github.com/manifoldco/promptui/blob/v0.9.0/select.go#L184) as `var SearchPrompt = "Search: "` — byte-identical to what we set. The line is the only write to `promptui.SearchPrompt` in the repo.

It was introduced in #4170 alongside the template-init warehouse picker. The original warehouse picker (`AskForWarehouse`, added in #956) never had it, which suggests it's copy-paste residue rather than a deliberate override.

## Test plan

- [x] `go build ./libs/databrickscfg/cfgpickers/`
- [x] No behavior change expected — value matches promptui's default

This pull request and its description were written by Isaac.