### PR TITLE
cmdio: drop unused PromptOptions.AllowEdit

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -56,8 +56,7 @@ func promptForAccountID(ctx context.Context) (string, error) {
 	}
 
 	return cmdio.RunPrompt(ctx, cmdio.PromptOptions{
-		Label:     "Databricks account ID",
-		AllowEdit: true,
+		Label: "Databricks account ID",
 	})
 }
 

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -33,8 +33,7 @@ func promptForProfile(ctx context.Context, defaultValue string) (string, error) 
 	}
 
 	result, err := cmdio.RunPrompt(ctx, cmdio.PromptOptions{
-		Label:     "Databricks profile name [" + defaultValue + "]",
-		AllowEdit: true,
+		Label: "Databricks profile name [" + defaultValue + "]",
 	})
 	if result == "" {
 		// Manually return the default value. We could use the prompt.Default
@@ -757,8 +756,7 @@ func promptForWorkspaceSelection(ctx context.Context, authArguments *auth.AuthAr
 // Returns empty string if the user provides no input.
 func promptForWorkspaceID(ctx context.Context) (string, error) {
 	result, err := cmdio.RunPrompt(ctx, cmdio.PromptOptions{
-		Label:     "Enter workspace ID (empty to skip)",
-		AllowEdit: true,
+		Label: "Enter workspace ID (empty to skip)",
 	})
 	if err != nil {
 		return "", err

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -28,8 +28,7 @@ func configureInteractive(cmd *cobra.Command, flags *configureFlags, cfg *config
 	// Ask user to specify the host if not already set.
 	if cfg.Host == "" {
 		out, err := cmdio.RunPrompt(ctx, cmdio.PromptOptions{
-			Label:     "Databricks workspace host (https://...)",
-			AllowEdit: true,
+			Label: "Databricks workspace host (https://...)",
 			Validate: func(input string) error {
 				normalized := normalizeHost(input)
 				return validateHost(normalized)

--- a/libs/cmdio/prompt.go
+++ b/libs/cmdio/prompt.go
@@ -18,9 +18,6 @@ type PromptOptions struct {
 	// (use '*' for password-style input).
 	Mask rune
 
-	// AllowEdit lets the user edit Default rather than overwriting it.
-	AllowEdit bool
-
 	// Validate, when set, is called on every keystroke; returning a non-nil
 	// error keeps the prompt open and shows the error to the user.
 	Validate func(input string) error
@@ -30,13 +27,12 @@ type PromptOptions struct {
 func RunPrompt(ctx context.Context, opts PromptOptions) (string, error) {
 	c := fromContext(ctx)
 	p := promptui.Prompt{
-		Label:     opts.Label,
-		Default:   opts.Default,
-		Mask:      opts.Mask,
-		AllowEdit: opts.AllowEdit,
-		Validate:  opts.Validate,
-		Stdin:     c.promptStdin(),
-		Stdout:    nopWriteCloser{c.err},
+		Label:    opts.Label,
+		Default:  opts.Default,
+		Mask:     opts.Mask,
+		Validate: opts.Validate,
+		Stdin:    c.promptStdin(),
+		Stdout:   nopWriteCloser{c.err},
 	}
 	return p.Run()
 }


### PR DESCRIPTION
## Summary

`AllowEdit` only affects how `promptui` renders a non-empty `Default`: with `AllowEdit:true` the default pre-fills the buffer; with `AllowEdit:false` it appears as a placeholder that's wiped on first keystroke. No caller in the repo sets `Default`, so the field has been a no-op everywhere it was passed. Drop it rather than carry an option that does nothing.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/configure/... ./cmd/auth/... ./libs/cmdio/...`
- [x] `go test ./libs/cmdio/... ./cmd/configure/... ./cmd/auth/...`

This pull request and its description were written by Isaac.