### PR TITLE
ci: set TASK_CONCURRENCY=1 for Windows runners

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -88,6 +88,9 @@ jobs:
       id-token: write
       contents: read
 
+    env:
+      TASK_CONCURRENCY: ${{ matrix.os.name == 'windows' && '1' || '' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -228,6 +231,9 @@ jobs:
       id-token: write
       contents: read
 
+    env:
+      TASK_CONCURRENCY: ${{ matrix.os.name == 'windows' && '1' || '' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -276,6 +282,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+
+    env:
+      TASK_CONCURRENCY: ${{ matrix.os.name == 'windows' && '1' || '' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why
A couple races in practice:

> - Run 1 (codegen failed): race on ~/go/pkg/mod/cache/download/.../v0.2.2.partial during module download —
>    "Access is denied"
> - Run 2 (test-acc failed): race on AppData\Local\go-build\...\gotestsum.exe during fork/exec — "file is
>   being used by another process"
