### PR TITLE
testserver: 404 on permissions GET when V2 parent is gone

### DIFF
--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/output.txt
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/output.txt
@@ -38,9 +38,9 @@ Remote recreated endpoint UUID: [REMOTE_RECREATED_ENDPOINT_UUID]
 === Plan detects the UUID change and proposes recreate
 >>> [CLI] bundle plan
 recreate vector_search_endpoints.my_endpoint
-update vector_search_endpoints.my_endpoint.permissions
+create vector_search_endpoints.my_endpoint.permissions
 
-Plan: 1 to add, 1 to change, 1 to delete, 0 unchanged
+Plan: 2 to add, 0 to change, 1 to delete, 0 unchanged
 
 === Deploy recreates the endpoint and rebinds permissions to the new UUID
 >>> [CLI] bundle deploy

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/script
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/script
@@ -33,7 +33,7 @@ if [ "$original_endpoint_uuid" = "$remote_recreated_endpoint_uuid" ]; then
 fi
 
 title "Plan detects the UUID change and proposes recreate"
-trace $CLI bundle plan | contains.py "recreate vector_search_endpoints.my_endpoint" "update vector_search_endpoints.my_endpoint.permissions"
+trace $CLI bundle plan | contains.py "recreate vector_search_endpoints.my_endpoint" "create vector_search_endpoints.my_endpoint.permissions"
 
 title "Deploy recreates the endpoint and rebinds permissions to the new UUID"
 trace $CLI bundle deploy

--- a/libs/testserver/permissions.go
+++ b/libs/testserver/permissions.go
@@ -107,6 +107,19 @@ func (s *FakeWorkspace) GetPermissions(req Request) any {
 	}
 
 	responseObjectID := fmt.Sprintf("/%s/%s", requestObjectType, objectId)
+
+	// V2 permissions APIs cascade-delete ACLs with the parent, so the cloud
+	// returns 404 once the parent is gone. V1 APIs (jobs, pipelines, etc.)
+	// retain ACL data after delete via async/soft delete; for those, we
+	// fall through to the "empty ACL on miss" branch below, which is close
+	// enough. New V2 resources should add a case to permissionsParentExists.
+	if !s.permissionsParentExists(requestObjectType, objectId) {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": fmt.Sprintf("%s %s not found.", requestObjectType, objectId)},
+		}
+	}
+
 	permissions, exists := s.Permissions[responseObjectID]
 
 	if !exists {
@@ -121,6 +134,23 @@ func (s *FakeWorkspace) GetPermissions(req Request) any {
 	return Response{
 		Body: permissions,
 	}
+}
+
+// permissionsParentExists reports whether the parent object backing a
+// permissions request exists in workspace state. Returns true for resource
+// types without a parent-existence check wired up; V1 resources rely on
+// that fallback to keep their "empty ACL on miss" behavior.
+func (s *FakeWorkspace) permissionsParentExists(requestObjectType, objectId string) bool {
+	switch requestObjectType {
+	case "vector-search-endpoints":
+		for _, ep := range s.VectorSearchEndpoints {
+			if ep.Id == objectId {
+				return true
+			}
+		}
+		return false
+	}
+	return true
 }
 
 func (s *FakeWorkspace) SetPermissions(req Request) any {


### PR DESCRIPTION
## Changes

`testserver.GetPermissions` now returns 404 when the parent object backing
a permissions request is gone, defaulting to V2 permissions API behavior.
The check is wired up for `vector-search-endpoints` only; other resource
types fall through to the existing "empty ACL on miss" branch.

The acceptance test
`bundle/resources/vector_search_endpoints/drift/recreated_same_name`
now asserts `create` (instead of `update`) for the permissions resource
when the parent endpoint is recreated remotely with a different UUID, and
the recorded `output.txt` is regenerated to match.

## Why

The integration variant of the test was failing with:

```
recreate vector_search_endpoints.my_endpoint
-update vector_search_endpoints.my_endpoint.permissions
+create vector_search_endpoints.my_endpoint.permissions
-Plan: 1 to add, 1 to change, 1 to delete, 0 unchanged
+Plan: 2 to add, 0 to change, 1 to delete, 0 unchanged
```

I confirmed the cloud behavior end-to-end against dogfood-aws:

| Resource | After delete: GET permissions returns |
|----------|---------------------------------------|
| Jobs | 200 with full ACL data (incl. IS_OWNER) |
| Pipelines | 200 with full ACL data |
| Vector search endpoints | 404 "not found" |
| Experiments | 404 "does not exist" |

There is a known inconsistency in how the cloud permissions API handles
deletion across resource types: V2 resources (vector search, experiments)
cascade-delete ACLs immediately and return 404 on subsequent GETs, while
V1 resources (jobs, pipelines) retain ACL data after the parent is deleted
via async/soft delete. The testserver previously matched neither
behavior — it returned an empty ACL for any unknown object id. The new
default is V2; V1 resources keep their existing fall-through.

When more V2 resources gain coverage that exercises this path, they
should add a case to `permissionsParentExists`.

## Tests

- `go test ./acceptance -run 'TestAccept/bundle/resources/vector_search_endpoints'` — green.
- `go test ./acceptance -run 'TestAccept/bundle/resources/permissions'` — green.
- `go test ./libs/testserver/...` — green.
- `./task lint` and `./task fmt` — clean.

_This PR was written by Claude Code._