### PR TITLE
sync: add --concurrency flag

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### CLI
 
+* Add `--concurrency` flag to `databricks sync` and `databricks bundle sync` to control the number of parallel requests to the workspace (default 20). Useful when uploading many medium-sized files where the previous fixed concurrency could trigger stream timeouts ([#5197](https://github.com/databricks/cli/pull/5197)).
+
 ### Bundles
 
 ### Dependency updates

--- a/acceptance/bundle/help/bundle-sync/output.txt
+++ b/acceptance/bundle/help/bundle-sync/output.txt
@@ -15,6 +15,7 @@ Usage:
   databricks bundle sync [flags]
 
 Flags:
+      --concurrency int     number of parallel requests to the workspace (default 20)
       --dry-run             simulate sync execution without making actual changes
       --full                perform full synchronization (default is incremental)
   -h, --help                help for sync

--- a/acceptance/cmd/sync-without-args/output.txt
+++ b/acceptance/cmd/sync-without-args/output.txt
@@ -6,16 +6,17 @@ Usage:
   databricks sync [flags] SRC DST
 
 Flags:
-      --dry-run               simulate sync execution without making actual changes
-      --exclude strings       patterns to exclude from sync (can be specified multiple times)
-      --exclude-from string   file containing patterns to exclude from sync (one pattern per line)
-      --full                  perform full synchronization (default is incremental)
-  -h, --help                  help for sync
-      --include strings       patterns to include in sync (can be specified multiple times)
-      --include-from string   file containing patterns to include to sync (one pattern per line)
-      --interval duration     file system polling interval (for --watch) (default 1s)
-      --output type           type of output format (default text)
-      --watch                 watch local file system for changes
+      --dry-run                       simulate sync execution without making actual changes
+      --exclude strings               patterns to exclude from sync (can be specified multiple times)
+      --exclude-from string           file containing patterns to exclude from sync (one pattern per line)
+      --full                          perform full synchronization (default is incremental)
+  -h, --help                          help for sync
+      --include strings               patterns to include in sync (can be specified multiple times)
+      --include-from string           file containing patterns to include to sync (one pattern per line)
+      --interval duration             file system polling interval (for --watch) (default 1s)
+      --max-concurrent-requests int   maximum number of concurrent requests to the workspace (default 20)
+      --output type                   type of output format (default text)
+      --watch                         watch local file system for changes
 
 Global Flags:
       --debug            enable debug logging

--- a/acceptance/cmd/sync-without-args/output.txt
+++ b/acceptance/cmd/sync-without-args/output.txt
@@ -6,17 +6,17 @@ Usage:
   databricks sync [flags] SRC DST
 
 Flags:
-      --dry-run                       simulate sync execution without making actual changes
-      --exclude strings               patterns to exclude from sync (can be specified multiple times)
-      --exclude-from string           file containing patterns to exclude from sync (one pattern per line)
-      --full                          perform full synchronization (default is incremental)
-  -h, --help                          help for sync
-      --include strings               patterns to include in sync (can be specified multiple times)
-      --include-from string           file containing patterns to include to sync (one pattern per line)
-      --interval duration             file system polling interval (for --watch) (default 1s)
-      --max-concurrent-requests int   maximum number of concurrent requests to the workspace (default 20)
-      --output type                   type of output format (default text)
-      --watch                         watch local file system for changes
+      --concurrency int       number of parallel requests to the workspace (default 20)
+      --dry-run               simulate sync execution without making actual changes
+      --exclude strings       patterns to exclude from sync (can be specified multiple times)
+      --exclude-from string   file containing patterns to exclude from sync (one pattern per line)
+      --full                  perform full synchronization (default is incremental)
+  -h, --help                  help for sync
+      --include strings       patterns to include in sync (can be specified multiple times)
+      --include-from string   file containing patterns to include to sync (one pattern per line)
+      --interval duration     file system polling interval (for --watch) (default 1s)
+      --output type           type of output format (default text)
+      --watch                 watch local file system for changes
 
 Global Flags:
       --debug            enable debug logging

--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -16,12 +17,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var errInvalidConcurrency = errors.New("--concurrency must be at least 1")
+
 type syncFlags struct {
-	interval time.Duration
-	full     bool
-	watch    bool
-	output   flags.Output
-	dryRun   bool
+	interval    time.Duration
+	full        bool
+	watch       bool
+	output      flags.Output
+	dryRun      bool
+	concurrency int
+}
+
+func (f *syncFlags) validate() error {
+	if f.concurrency < 1 {
+		return errInvalidConcurrency
+	}
+	return nil
 }
 
 func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) (*sync.SyncOptions, error) {
@@ -48,6 +59,7 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) 
 	opts.Full = f.full
 	opts.PollInterval = f.interval
 	opts.DryRun = f.dryRun
+	opts.Concurrency = f.concurrency
 	return opts, nil
 }
 
@@ -74,8 +86,13 @@ Use 'databricks bundle deploy' for full resource deployment.`,
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
 	cmd.Flags().Var(&f.output, "output", "type of the output format")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "simulate sync execution without making actual changes")
+	cmd.Flags().IntVar(&f.concurrency, "concurrency", sync.MaxRequestsInFlight, "number of parallel requests to the workspace")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := f.validate(); err != nil {
+			return err
+		}
+
 		b, err := utils.ProcessBundle(cmd, utils.ProcessOptions{})
 		if err != nil {
 			return err

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -26,15 +26,23 @@ import (
 
 type syncFlags struct {
 	// project files polling interval
-	interval    time.Duration
-	full        bool
-	watch       bool
-	output      flags.Output
-	exclude     []string
-	include     []string
-	dryRun      bool
-	excludeFrom string
-	includeFrom string
+	interval              time.Duration
+	full                  bool
+	watch                 bool
+	output                flags.Output
+	exclude               []string
+	include               []string
+	dryRun                bool
+	excludeFrom           string
+	includeFrom           string
+	maxConcurrentRequests int
+}
+
+func (f *syncFlags) validate() error {
+	if f.maxConcurrentRequests < 1 {
+		return fmt.Errorf("--max-concurrent-requests must be >= 1, got %d", f.maxConcurrentRequests)
+	}
+	return nil
 }
 
 func readPatternsFile(filePath string) ([]string, error) {
@@ -89,6 +97,7 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 	opts.Include = append(opts.Include, f.include...)
 	opts.Include = append(opts.Include, includePatterns...)
 	opts.DryRun = f.dryRun
+	opts.MaxConcurrentRequests = f.maxConcurrentRequests
 	return opts, nil
 }
 
@@ -161,8 +170,9 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		SnapshotBasePath: filepath.Join(args[0], ".databricks"),
 		WorkspaceClient:  client,
 
-		OutputHandler: outputHandler,
-		DryRun:        f.dryRun,
+		OutputHandler:         outputHandler,
+		DryRun:                f.dryRun,
+		MaxConcurrentRequests: f.maxConcurrentRequests,
 	}
 	return &opts, nil
 }
@@ -187,6 +197,7 @@ func New() *cobra.Command {
 	cmd.Flags().StringVar(&f.excludeFrom, "exclude-from", "", "file containing patterns to exclude from sync (one pattern per line)")
 	cmd.Flags().StringVar(&f.includeFrom, "include-from", "", "file containing patterns to include to sync (one pattern per line)")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "simulate sync execution without making actual changes")
+	cmd.Flags().IntVar(&f.maxConcurrentRequests, "max-concurrent-requests", sync.MaxRequestsInFlight, "maximum number of concurrent requests to the workspace")
 
 	// Wrapper for [root.MustWorkspaceClient] that disables loading authentication configuration from a bundle.
 	mustWorkspaceClient := func(cmd *cobra.Command, args []string) error {
@@ -196,6 +207,10 @@ func New() *cobra.Command {
 
 	cmd.PreRunE = mustWorkspaceClient
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := f.validate(); err != nil {
+			return err
+		}
+
 		var opts *sync.SyncOptions
 		var err error
 

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -24,23 +24,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var errInvalidConcurrency = errors.New("--concurrency must be at least 1")
+
 type syncFlags struct {
 	// project files polling interval
-	interval              time.Duration
-	full                  bool
-	watch                 bool
-	output                flags.Output
-	exclude               []string
-	include               []string
-	dryRun                bool
-	excludeFrom           string
-	includeFrom           string
-	maxConcurrentRequests int
+	interval    time.Duration
+	full        bool
+	watch       bool
+	output      flags.Output
+	exclude     []string
+	include     []string
+	dryRun      bool
+	excludeFrom string
+	includeFrom string
+	concurrency int
 }
 
 func (f *syncFlags) validate() error {
-	if f.maxConcurrentRequests < 1 {
-		return fmt.Errorf("--max-concurrent-requests must be >= 1, got %d", f.maxConcurrentRequests)
+	if f.concurrency < 1 {
+		return errInvalidConcurrency
 	}
 	return nil
 }
@@ -97,7 +99,7 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 	opts.Include = append(opts.Include, f.include...)
 	opts.Include = append(opts.Include, includePatterns...)
 	opts.DryRun = f.dryRun
-	opts.MaxConcurrentRequests = f.maxConcurrentRequests
+	opts.Concurrency = f.concurrency
 	return opts, nil
 }
 
@@ -170,9 +172,9 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		SnapshotBasePath: filepath.Join(args[0], ".databricks"),
 		WorkspaceClient:  client,
 
-		OutputHandler:         outputHandler,
-		DryRun:                f.dryRun,
-		MaxConcurrentRequests: f.maxConcurrentRequests,
+		OutputHandler: outputHandler,
+		DryRun:        f.dryRun,
+		Concurrency:   f.concurrency,
 	}
 	return &opts, nil
 }
@@ -197,7 +199,7 @@ func New() *cobra.Command {
 	cmd.Flags().StringVar(&f.excludeFrom, "exclude-from", "", "file containing patterns to exclude from sync (one pattern per line)")
 	cmd.Flags().StringVar(&f.includeFrom, "include-from", "", "file containing patterns to include to sync (one pattern per line)")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "simulate sync execution without making actual changes")
-	cmd.Flags().IntVar(&f.maxConcurrentRequests, "max-concurrent-requests", sync.MaxRequestsInFlight, "maximum number of concurrent requests to the workspace")
+	cmd.Flags().IntVar(&f.concurrency, "concurrency", sync.MaxRequestsInFlight, "number of parallel requests to the workspace")
 
 	// Wrapper for [root.MustWorkspaceClient] that disables loading authentication configuration from a bundle.
 	mustWorkspaceClient := func(cmd *cobra.Command, args []string) error {

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -40,13 +40,6 @@ type syncFlags struct {
 	concurrency int
 }
 
-func (f *syncFlags) validate() error {
-	if f.concurrency < 1 {
-		return errInvalidConcurrency
-	}
-	return nil
-}
-
 func readPatternsFile(filePath string) ([]string, error) {
 	if filePath == "" {
 		return nil, nil
@@ -207,12 +200,13 @@ func New() *cobra.Command {
 		return root.MustWorkspaceClient(cmd, args)
 	}
 
-	cmd.PreRunE = mustWorkspaceClient
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := f.validate(); err != nil {
-			return err
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if f.concurrency < 1 {
+			return errInvalidConcurrency
 		}
-
+		return mustWorkspaceClient(cmd, args)
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		var opts *sync.SyncOptions
 		var err error
 

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -67,17 +67,6 @@ func TestSyncOptionsFromArgs(t *testing.T) {
 	assert.Equal(t, 7, opts.Concurrency)
 }
 
-func TestSyncFlagsValidate(t *testing.T) {
-	f := syncFlags{concurrency: 1}
-	require.NoError(t, f.validate())
-
-	f.concurrency = 0
-	require.ErrorIs(t, f.validate(), errInvalidConcurrency)
-
-	f.concurrency = -3
-	require.ErrorIs(t, f.validate(), errInvalidConcurrency)
-}
-
 func TestExcludeFromFlag(t *testing.T) {
 	// Create a temporary directory
 	tempDir := t.TempDir()

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -32,12 +32,13 @@ func TestSyncOptionsFromBundle(t *testing.T) {
 		},
 	}
 
-	f := syncFlags{}
+	f := syncFlags{maxConcurrentRequests: 5}
 	opts, err := f.syncOptionsFromBundle(New(), []string{}, b)
 	require.NoError(t, err)
 	assert.Equal(t, tempDir, opts.LocalRoot.Native())
 	assert.Equal(t, "/Users/jane@doe.com/path", opts.RemotePath)
 	assert.Equal(t, filepath.Join(tempDir, ".databricks", "bundle", "default"), opts.SnapshotBasePath)
+	assert.Equal(t, 5, opts.MaxConcurrentRequests)
 	assert.NotNil(t, opts.WorkspaceClient)
 }
 
@@ -56,13 +57,25 @@ func TestSyncOptionsFromArgs(t *testing.T) {
 	local := t.TempDir()
 	remote := "/remote"
 
-	f := syncFlags{}
+	f := syncFlags{maxConcurrentRequests: 7}
 	cmd := New()
 	cmd.SetContext(cmdctx.SetWorkspaceClient(t.Context(), nil))
 	opts, err := f.syncOptionsFromArgs(cmd, []string{local, remote})
 	require.NoError(t, err)
 	assert.Equal(t, local, opts.LocalRoot.Native())
 	assert.Equal(t, remote, opts.RemotePath)
+	assert.Equal(t, 7, opts.MaxConcurrentRequests)
+}
+
+func TestSyncFlagsValidate(t *testing.T) {
+	f := syncFlags{maxConcurrentRequests: 1}
+	require.NoError(t, f.validate())
+
+	f.maxConcurrentRequests = 0
+	require.ErrorContains(t, f.validate(), "--max-concurrent-requests must be >= 1")
+
+	f.maxConcurrentRequests = -3
+	require.ErrorContains(t, f.validate(), "--max-concurrent-requests must be >= 1")
 }
 
 func TestExcludeFromFlag(t *testing.T) {

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -32,13 +32,13 @@ func TestSyncOptionsFromBundle(t *testing.T) {
 		},
 	}
 
-	f := syncFlags{maxConcurrentRequests: 5}
+	f := syncFlags{concurrency: 5}
 	opts, err := f.syncOptionsFromBundle(New(), []string{}, b)
 	require.NoError(t, err)
 	assert.Equal(t, tempDir, opts.LocalRoot.Native())
 	assert.Equal(t, "/Users/jane@doe.com/path", opts.RemotePath)
 	assert.Equal(t, filepath.Join(tempDir, ".databricks", "bundle", "default"), opts.SnapshotBasePath)
-	assert.Equal(t, 5, opts.MaxConcurrentRequests)
+	assert.Equal(t, 5, opts.Concurrency)
 	assert.NotNil(t, opts.WorkspaceClient)
 }
 
@@ -57,25 +57,25 @@ func TestSyncOptionsFromArgs(t *testing.T) {
 	local := t.TempDir()
 	remote := "/remote"
 
-	f := syncFlags{maxConcurrentRequests: 7}
+	f := syncFlags{concurrency: 7}
 	cmd := New()
 	cmd.SetContext(cmdctx.SetWorkspaceClient(t.Context(), nil))
 	opts, err := f.syncOptionsFromArgs(cmd, []string{local, remote})
 	require.NoError(t, err)
 	assert.Equal(t, local, opts.LocalRoot.Native())
 	assert.Equal(t, remote, opts.RemotePath)
-	assert.Equal(t, 7, opts.MaxConcurrentRequests)
+	assert.Equal(t, 7, opts.Concurrency)
 }
 
 func TestSyncFlagsValidate(t *testing.T) {
-	f := syncFlags{maxConcurrentRequests: 1}
+	f := syncFlags{concurrency: 1}
 	require.NoError(t, f.validate())
 
-	f.maxConcurrentRequests = 0
-	require.ErrorContains(t, f.validate(), "--max-concurrent-requests must be >= 1")
+	f.concurrency = 0
+	require.ErrorIs(t, f.validate(), errInvalidConcurrency)
 
-	f.maxConcurrentRequests = -3
-	require.ErrorContains(t, f.validate(), "--max-concurrent-requests must be >= 1")
+	f.concurrency = -3
+	require.ErrorIs(t, f.validate(), errInvalidConcurrency)
 }
 
 func TestExcludeFromFlag(t *testing.T) {

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -44,7 +44,7 @@ type SyncOptions struct {
 
 	DryRun bool
 
-	MaxConcurrentRequests int
+	Concurrency int
 }
 
 type Sync struct {
@@ -98,8 +98,8 @@ func New(ctx context.Context, opts SyncOptions) (*Sync, error) {
 		return nil, errors.New("failed to resolve host for snapshot")
 	}
 
-	if opts.MaxConcurrentRequests <= 0 {
-		opts.MaxConcurrentRequests = MaxRequestsInFlight
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = MaxRequestsInFlight
 	}
 
 	// For full sync, we start with an empty snapshot.

--- a/libs/sync/sync.go
+++ b/libs/sync/sync.go
@@ -43,6 +43,8 @@ type SyncOptions struct {
 	OutputHandler OutputHandler
 
 	DryRun bool
+
+	MaxConcurrentRequests int
 }
 
 type Sync struct {
@@ -94,6 +96,10 @@ func New(ctx context.Context, opts SyncOptions) (*Sync, error) {
 	opts.Host = opts.WorkspaceClient.Config.Host
 	if opts.Host == "" {
 		return nil, errors.New("failed to resolve host for snapshot")
+	}
+
+	if opts.MaxConcurrentRequests <= 0 {
+		opts.MaxConcurrentRequests = MaxRequestsInFlight
 	}
 
 	// For full sync, we start with an empty snapshot.

--- a/libs/sync/watchdog.go
+++ b/libs/sync/watchdog.go
@@ -110,7 +110,7 @@ func groupRunParallel(ctx context.Context, paths []string, limit int, fn func(co
 
 func (s *Sync) applyDiff(ctx context.Context, d diff) error {
 	var err error
-	limit := s.MaxConcurrentRequests
+	limit := s.Concurrency
 
 	// Delete files in parallel.
 	err = groupRunParallel(ctx, d.delete, limit, s.applyDelete)

--- a/libs/sync/watchdog.go
+++ b/libs/sync/watchdog.go
@@ -96,9 +96,9 @@ func groupRunSingle(ctx context.Context, group *errgroup.Group, fn func(context.
 	})
 }
 
-func groupRunParallel(ctx context.Context, paths []string, fn func(context.Context, string) error) error {
+func groupRunParallel(ctx context.Context, paths []string, limit int, fn func(context.Context, string) error) error {
 	group, ctx := errgroup.WithContext(ctx)
-	group.SetLimit(MaxRequestsInFlight)
+	group.SetLimit(limit)
 
 	for _, path := range paths {
 		groupRunSingle(ctx, group, fn, path)
@@ -110,16 +110,17 @@ func groupRunParallel(ctx context.Context, paths []string, fn func(context.Conte
 
 func (s *Sync) applyDiff(ctx context.Context, d diff) error {
 	var err error
+	limit := s.MaxConcurrentRequests
 
 	// Delete files in parallel.
-	err = groupRunParallel(ctx, d.delete, s.applyDelete)
+	err = groupRunParallel(ctx, d.delete, limit, s.applyDelete)
 	if err != nil {
 		return err
 	}
 
 	// Delete directories ordered by depth from leaf to root.
 	for _, group := range d.groupedRmdir() {
-		err = groupRunParallel(ctx, group, s.applyRmdir)
+		err = groupRunParallel(ctx, group, limit, s.applyRmdir)
 		if err != nil {
 			return err
 		}
@@ -127,14 +128,14 @@ func (s *Sync) applyDiff(ctx context.Context, d diff) error {
 
 	// Create directories (leafs only because intermediates are created automatically).
 	for _, group := range d.groupedMkdir() {
-		err = groupRunParallel(ctx, group, s.applyMkdir)
+		err = groupRunParallel(ctx, group, limit, s.applyMkdir)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Put files in parallel.
-	err = groupRunParallel(ctx, d.put, s.applyPut)
+	err = groupRunParallel(ctx, d.put, limit, s.applyPut)
 
 	return err
 }


### PR DESCRIPTION
## Changes
Expose the previously-hardcoded request concurrency cap as a `--concurrency` flag on `databricks sync` and `databricks bundle sync`. Defaults to the existing limit (20) so behavior is unchanged when the flag is omitted; values < 1 are rejected.

The flag name matches `databricks fs cp --concurrency` (#4132).

## Why
When uploading multiple files ~5mb size, high concurrency can trigger stream timeouts.

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->