### PR TITLE
Update scala environment_version and dbr_version

### DIFF
--- a/acceptance/bundle/templates/default-scala/output/my_default_scala/build.sbt
+++ b/acceptance/bundle/templates/default-scala/output/my_default_scala/build.sbt
@@ -6,7 +6,7 @@ name := "my_default_scala"
 organization := "com.examples"
 version := "0.1"
 
-libraryDependencies += "com.databricks" %% "databricks-connect" % "17.0.+"
+libraryDependencies += "com.databricks" %% "databricks-connect" % "17.3.+"
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "2.0.16"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test

--- a/acceptance/bundle/templates/default-scala/output/my_default_scala/resources/my_default_scala.job.yml
+++ b/acceptance/bundle/templates/default-scala/output/my_default_scala/resources/my_default_scala.job.yml
@@ -22,6 +22,6 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4-scala-preview"
+            environment_version: "4"
             java_dependencies:
               - ${workspace.artifact_path}/.internal/my_default_scala-assembly-0.1.jar

--- a/libs/template/templates/default-scala/library/template_variables.tmpl
+++ b/libs/template/templates/default-scala/library/template_variables.tmpl
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{ define `dbr_version` -}}
-    17.0
+    17.3
 {{- end }}
 
 {{ define `scala_major_minor_version` -}}

--- a/libs/template/templates/default-scala/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/default-scala/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -31,7 +31,7 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4-scala-preview"
+            environment_version: "4"
             java_dependencies:
               - ${workspace.artifact_path}/.internal/{{.project_name}}-assembly-{{template `version` .}}.jar
 {{- else}}


### PR DESCRIPTION
## Changes
Sync cli code with changes in https://github.com/databricks/bundle-examples/pull/152.

Same as #5172 — reopened from an upstream branch so CI can obtain the JFrog OIDC token.

## Tests
Updated `acceptance/bundle/templates/default-scala` golden files via `./task test-update-templates`.

This pull request and its description were written by Isaac.