### PR TITLE
Add workflow to refresh jsonschema_for_docs.json after each release

### DIFF
--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -21,6 +21,8 @@ on:
 
 permissions:
   contents: write
+  # Required by setup-jfrog (GOPROXY exchange).
+  id-token: write
 
 jobs:
   update-schema-docs:
@@ -38,6 +40,9 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -1,15 +1,12 @@
 name: update-schema-docs
 
-# Regenerate bundle/schema/jsonschema_for_docs.json after every release.
+# Regenerate bundle/schema/jsonschema_for_docs.json after every release and
+# publish it to the `docgen` branch.
 #
-# bundle/internal/schema/since_version.go computes `x-since-version` annotations
+# bundle/internal/schema/since_version.go derives `x-since-version` annotations
 # from the list of `v*` git tags that exist when the schema is generated. The
-# committed file is therefore stale by one release as soon as the next tag is
-# pushed: fields shipped in that tag don't get stamped until the file is
-# regenerated against a tag list that includes it.
-#
-# This workflow runs on every `v*` tag push, regenerates the file from `main`,
-# and pushes the updated file directly to `main`.
+# `docgen` branch is therefore stale by one release as soon as the next tag is
+# pushed; this workflow keeps it current.
 
 on:
   push:
@@ -17,10 +14,6 @@ on:
       - "v*"
 
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Release tag this run is updating annotations for (e.g. v0.299.0). Used in the commit message only."
-        required: false
 
 permissions:
   contents: write
@@ -35,10 +28,9 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # The commit lands on main, not the tagged commit, so check main out
-          # directly. fetch-depth: 0 + fetch-tags: true ensure since_version.go
-          # can resolve `git show <tag>:bundle/schema/jsonschema.json` for every
-          # historical release.
+          # Regen runs against `main`. fetch-depth: 0 + fetch-tags: true ensure
+          # since_version.go can resolve `git show <tag>:bundle/schema/jsonschema.json`
+          # for every historical release.
           ref: main
           fetch-depth: 0
           fetch-tags: true
@@ -55,49 +47,67 @@ jobs:
         id: tag
         env:
           GITHUB_REF: ${{ github.ref }}
-          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             tag="${GITHUB_REF#refs/tags/}"
           else
-            tag="${INPUT_TAG:-manual}"
+            tag=$(git tag --list 'v*' --sort=-version:refname | head -n 1)
+          fi
+          if [ -z "$tag" ]; then
+            echo "Could not determine a v* tag to publish for." >&2
+            exit 1
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Publishing for tag $tag"
 
       - name: Regenerate jsonschema_for_docs.json
         run: go tool -modfile=tools/task/go.mod task --force generate-schema-docs
 
-      - name: Show diff
-        run: git diff -- bundle/schema/jsonschema_for_docs.json
-
       # Fail loudly if regeneration touches anything other than the docs schema.
       # Anything else (annotations.yml, untracked files, ...) is a bug in the
-      # generator, not something we want to silently push to main.
-      - name: Assert only jsonschema_for_docs.json changed
-        id: check
+      # generator, not something we want to silently publish.
+      - name: Assert only jsonschema_for_docs.json changed on main
         run: |
           changed=$(git status --porcelain)
+          expected=" M bundle/schema/jsonschema_for_docs.json"
           if [ -z "$changed" ]; then
-            echo "No changes; skipping commit."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Regeneration produced no diff against main."
             exit 0
           fi
-          expected=" M bundle/schema/jsonschema_for_docs.json"
           if [ "$changed" != "$expected" ]; then
             echo "Expected only bundle/schema/jsonschema_for_docs.json to be modified."
             echo "Actual git status --porcelain:"
             echo "$changed"
             exit 1
           fi
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push to main
-        if: steps.check.outputs.skip != 'true'
+      - name: Capture regenerated file
+        run: |
+          mkdir -p "$RUNNER_TEMP/regen"
+          cp bundle/schema/jsonschema_for_docs.json "$RUNNER_TEMP/regen/jsonschema_for_docs.json"
+
+      - name: Check out docgen worktree
+        run: |
+          git fetch origin docgen
+          git worktree add "$RUNNER_TEMP/docgen" origin/docgen
+
+      - name: Stage regenerated file on docgen
+        working-directory: ${{ runner.temp }}/docgen
+        run: |
+          mkdir -p bundle/schema
+          cp "$RUNNER_TEMP/regen/jsonschema_for_docs.json" bundle/schema/jsonschema_for_docs.json
+          git add bundle/schema/jsonschema_for_docs.json
+
+      - name: Commit and push to docgen
+        working-directory: ${{ runner.temp }}/docgen
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
+          if git diff --cached --quiet; then
+            echo "docgen already up to date for ${TAG}; nothing to commit."
+            exit 0
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add bundle/schema/jsonschema_for_docs.json
-          git commit -m "Update jsonschema_for_docs.json since-versions for ${TAG}"
-          git push origin HEAD:main
+          git commit -m "Update jsonschema_for_docs.json for ${TAG}"
+          git push origin HEAD:docgen

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -55,10 +55,11 @@ jobs:
       - name: Determine release tag
         id: tag
         env:
-          GITHUB_REF: ${{ github.ref }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            tag="${GITHUB_REF#refs/tags/}"
+          if [ "$REF_TYPE" = "tag" ]; then
+            tag="$REF_NAME"
           else
             tag=$(git tag --list 'v*' --sort=-version:refname | head -n 1)
           fi

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -110,7 +110,7 @@ jobs:
         working-directory: ${{ runner.temp }}/docgen
         env:
           TAG: ${{ steps.tag.outputs.tag }}
-        run: |
+        run: |-
           if git diff --cached --quiet; then
             echo "docgen already up to date for ${TAG}; nothing to commit."
             exit 0

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -1,0 +1,103 @@
+name: update-schema-docs
+
+# Regenerate bundle/schema/jsonschema_for_docs.json after every release.
+#
+# bundle/internal/schema/since_version.go computes `x-since-version` annotations
+# from the list of `v*` git tags that exist when the schema is generated. The
+# committed file is therefore stale by one release as soon as the next tag is
+# pushed: fields shipped in that tag don't get stamped until the file is
+# regenerated against a tag list that includes it.
+#
+# This workflow runs on every `v*` tag push, regenerates the file from `main`,
+# and pushes the updated file directly to `main`.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag this run is updating annotations for (e.g. v0.299.0). Used in the commit message only."
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  update-schema-docs:
+    runs-on:
+      group: databricks-protected-runner-group-large
+      labels: linux-ubuntu-latest-large
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The commit lands on main, not the tagged commit, so check main out
+          # directly. fetch-depth: 0 + fetch-tags: true ensure since_version.go
+          # can resolve `git show <tag>:bundle/schema/jsonschema.json` for every
+          # historical release.
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: |
+            go.sum
+            bundle/internal/schema/*.*
+
+      - name: Determine release tag
+        id: tag
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          else
+            tag="${INPUT_TAG:-manual}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate jsonschema_for_docs.json
+        run: go tool -modfile=tools/task/go.mod task --force generate-schema-docs
+
+      - name: Show diff
+        run: git diff -- bundle/schema/jsonschema_for_docs.json
+
+      # Fail loudly if regeneration touches anything other than the docs schema.
+      # Anything else (annotations.yml, untracked files, ...) is a bug in the
+      # generator, not something we want to silently push to main.
+      - name: Assert only jsonschema_for_docs.json changed
+        id: check
+        run: |
+          changed=$(git status --porcelain)
+          if [ -z "$changed" ]; then
+            echo "No changes; skipping commit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          expected=" M bundle/schema/jsonschema_for_docs.json"
+          if [ "$changed" != "$expected" ]; then
+            echo "Expected only bundle/schema/jsonschema_for_docs.json to be modified."
+            echo "Actual git status --porcelain:"
+            echo "$changed"
+            exit 1
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push to main
+        if: steps.check.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bundle/schema/jsonschema_for_docs.json
+          git commit -m "Update jsonschema_for_docs.json since-versions for ${TAG}"
+          git push origin HEAD:main

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -12,10 +12,6 @@ on:
   push:
     tags:
       - "v*"
-    # TEMP: drives end-to-end test on the PR branch (workflow_dispatch is
-    # unavailable until the file lands on main). Remove before merging.
-    branches:
-      - workflow/update-schema-docs-on-release
 
   workflow_dispatch:
 

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -12,6 +12,10 @@ on:
   push:
     tags:
       - "v*"
+    # TEMP: drives end-to-end test on the PR branch (workflow_dispatch is
+    # unavailable until the file lands on main). Remove before merging.
+    branches:
+      - workflow/update-schema-docs-on-release
 
   workflow_dispatch:
 

--- a/.github/workflows/update-schema-docs.yml
+++ b/.github/workflows/update-schema-docs.yml
@@ -11,7 +11,7 @@ name: update-schema-docs
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
   workflow_dispatch:
 
@@ -57,10 +57,12 @@ jobs:
           if [ "$REF_TYPE" = "tag" ]; then
             tag="$REF_NAME"
           else
-            tag=$(git tag --list 'v*' --sort=-version:refname | head -n 1)
+            # git tag --list uses fnmatch (no `+`), so post-filter with grep
+            # to match the same shape as the trigger above.
+            tag=$(git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
           fi
           if [ -z "$tag" ]; then
-            echo "Could not determine a v* tag to publish for." >&2
+            echo "Could not determine a release tag to publish for." >&2
             exit 1
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- New `.github/workflows/update-schema-docs.yml` triggers on `v*` tag pushes (and manual `workflow_dispatch`, which auto-detects the latest `v*` tag).
- Regenerates `bundle/schema/jsonschema_for_docs.json` from `main` (full tag history is required so `since_version.go` can stamp `x-since-version`), asserts only that file changed, and pushes the result to the dedicated `docgen` branch. `main` is never modified.
- `docgen` was bootstrapped as an orphan branch containing only `README.md`; the workflow adds `bundle/schema/jsonschema_for_docs.json` and updates it on every release.

## Why
`bundle/internal/schema/since_version.go` derives `x-since-version` from `git tag --list 'v*'` at generation time, so the committed file becomes stale the moment the next tag is pushed. This workflow keeps a clean publish branch (`docgen`) current automatically, decoupled from main.

## End-to-end test
Triggered the workflow via a temporary branch trigger, verified the file landed on `docgen` with up-to-date since-versions:

```
$ curl -sfL https://raw.githubusercontent.com/databricks/cli/docgen/bundle/schema/jsonschema_for_docs.json \
    | grep -o '"x-since-version": *"v[^"]*"' | sort | uniq -c | sort -rn | head -5
 631 "x-since-version": "v0.229.0"
  54 "x-since-version": "v0.298.0"
  46 "x-since-version": "v0.287.0"
  46 "x-since-version": "v0.279.0"
  31 "x-since-version": "v0.260.0"
```

Subsequent run (no schema change) correctly logs `docgen already up to date for v0.299.0; nothing to commit.`
