### PR TITLE
fix: guard against nil target entries in bundle debug list-targets

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bundles
 * Validate that resource keys do not contain variable references ([#5169](https://github.com/databricks/cli/pull/5169))
 * engine/direct: Drop the deployment state entry on a recreate before the follow-up `Create`, so a `Create` failure no longer leaves a broken state with `invalid state: empty id` on the next `bundle plan` ([#5173](https://github.com/databricks/cli/pull/5173)).
+* `bundle debug list-targets`: skip nil entries in the targets map instead of panicking when a target is declared with a null value ([#5203](https://github.com/databricks/cli/pull/5203)).
 
 ### Dependency updates
 

--- a/cmd/bundle/debug/list_targets.go
+++ b/cmd/bundle/debug/list_targets.go
@@ -35,6 +35,12 @@ func collectTargets(targets map[string]*config.Target) []targetInfo {
 	result := make([]targetInfo, 0, len(names))
 	for _, name := range names {
 		t := targets[name]
+		// YAML decoding can leave a nil entry in the map when a target is
+		// declared with a null value. Skip rather than dereference and panic.
+		if t == nil {
+			result = append(result, targetInfo{Name: name})
+			continue
+		}
 		info := targetInfo{
 			Name:    name,
 			Default: t.Default,


### PR DESCRIPTION
## Summary
- `bundle debug list-targets` panics with a nil pointer dereference at `cmd/bundle/debug/list_targets.go:40` when the targets map contains a nil `*config.Target`.
- YAML decoding can leave such an entry when a target is declared with a null value; `collectTargets` then dereferences `t.Default`/`t.Mode` without a nil check.
- Skip nil entries while still listing the target name so the command no longer crashes.

## Test plan
- [ ] `./task test` passes.
- [ ] Manual: a `databricks.yml` with a null-valued target lists its name and exits 0 instead of panicking.