### PR TITLE
test: cover nil target entries in bundle debug list-targets

### DIFF
--- a/acceptance/bundle/debug/list-targets/databricks.yml
+++ b/acceptance/bundle/debug/list-targets/databricks.yml
@@ -15,7 +15,7 @@ targets:
     mode: development
     workspace:
       host: https://dev.example.com
-  staging: {}
+  staging:
   prod:
     mode: production
     workspace:


### PR DESCRIPTION
## Summary
- Follow-up to #5203. Adds a unit test for `collectTargets` that exercises the nil-entry path so the regression is locked in.
- Test stays at the function level because no YAML pattern I tried produces a nil `*config.Target` entry through the loader pipeline (`staging:`, `staging: null`, `staging: ~`, `staging: {}` all yield non-nil entries). Direct unit coverage is the practical guard.

## Test plan
- [ ] `go test ./cmd/bundle/debug -run TestCollectTargetsHandlesNilEntries` passes.
- [ ] Reverting the nil guard in `collectTargets` makes the test fail with a nil pointer dereference.