### PR TITLE
auth describe: show U2M token storage location and source

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### CLI
 
+* `databricks auth describe` now reports where U2M (`databricks-cli`) tokens are stored: `plaintext` (`~/.databricks/token-cache.json`) or `secure` (OS keyring), and the source of the choice (env var, config setting, or default).
+
 ### Bundles
 
 * Fixed `--force-pull` on `bundle summary` and `bundle open` so the flag bypasses the local state cache and reads state from the workspace.

--- a/acceptance/cmd/auth/describe/u2m-json-output/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-json-output/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-json-output/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-json-output/output.txt
@@ -1,0 +1,8 @@
+
+>>> [CLI] auth describe --profile u2m-profile --output json
+Warn: [hostmetadata] failed to fetch host metadata for https://u2m-profile.databricks.test, will skip for 1m0s
+{
+  "mode": "plaintext",
+  "location": "~/.databricks/token-cache.json",
+  "source": "default"
+}

--- a/acceptance/cmd/auth/describe/u2m-json-output/script
+++ b/acceptance/cmd/auth/describe/u2m-json-output/script
@@ -1,0 +1,16 @@
+sethome "./home"
+
+unset DATABRICKS_HOST
+unset DATABRICKS_TOKEN
+unset DATABRICKS_CONFIG_PROFILE
+unset DATABRICKS_AUTH_STORAGE
+
+cat > "./home/.databrickscfg" <<ENDCFG
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli
+ENDCFG
+
+# Filter to just the new token_storage object so the assertion is focused
+# and doesn't churn when other fields evolve.
+trace $CLI auth describe --profile u2m-profile --output json | jq '.token_storage'

--- a/acceptance/cmd/auth/describe/u2m-json-output/test.toml
+++ b/acceptance/cmd/auth/describe/u2m-json-output/test.toml
@@ -1,0 +1,3 @@
+Ignore = [
+    "home"
+]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/output.txt
@@ -1,0 +1,12 @@
+
+>>> [CLI] auth describe --profile u2m-profile
+Warn: [hostmetadata] failed to fetch host metadata for https://u2m-profile.databricks.test, will skip for 1m0s
+Unable to authenticate: error getting token: cache: token not found
+Token storage: plaintext, ~/.databricks/token-cache.json (from auth_storage in [__settings__] section of home/.databrickscfg)
+-----
+Current configuration:
+  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
+  ✓ profile: u2m-profile (from --profile flag)
+  ✓ databricks_cli_path: [CLI]
+  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
+  ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/script
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/script
@@ -1,0 +1,17 @@
+sethome "./home"
+
+unset DATABRICKS_HOST
+unset DATABRICKS_TOKEN
+unset DATABRICKS_CONFIG_PROFILE
+unset DATABRICKS_AUTH_STORAGE
+
+cat > "./home/.databrickscfg" <<ENDCFG
+[__settings__]
+auth_storage = plaintext
+
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli
+ENDCFG
+
+trace $CLI auth describe --profile u2m-profile

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/test.toml
@@ -1,0 +1,3 @@
+Ignore = [
+    "home"
+]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-default/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-default/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-default/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-default/output.txt
@@ -1,0 +1,12 @@
+
+>>> [CLI] auth describe --profile u2m-profile
+Warn: [hostmetadata] failed to fetch host metadata for https://u2m-profile.databricks.test, will skip for 1m0s
+Unable to authenticate: error getting token: cache: token not found
+Token storage: plaintext, ~/.databricks/token-cache.json (from default)
+-----
+Current configuration:
+  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
+  ✓ profile: u2m-profile (from --profile flag)
+  ✓ databricks_cli_path: [CLI]
+  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
+  ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-default/script
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-default/script
@@ -1,0 +1,14 @@
+sethome "./home"
+
+unset DATABRICKS_HOST
+unset DATABRICKS_TOKEN
+unset DATABRICKS_CONFIG_PROFILE
+unset DATABRICKS_AUTH_STORAGE
+
+cat > "./home/.databrickscfg" <<ENDCFG
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli
+ENDCFG
+
+trace $CLI auth describe --profile u2m-profile

--- a/acceptance/cmd/auth/describe/u2m-plaintext-default/test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-default/test.toml
@@ -1,0 +1,3 @@
+Ignore = [
+    "home"
+]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/out.test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/output.txt
@@ -1,0 +1,12 @@
+
+>>> [CLI] auth describe --profile u2m-profile
+Warn: [hostmetadata] failed to fetch host metadata for https://u2m-profile.databricks.test, will skip for 1m0s
+Unable to authenticate: error getting token: cache: token not found
+Token storage: plaintext, ~/.databricks/token-cache.json (from DATABRICKS_AUTH_STORAGE environment variable)
+-----
+Current configuration:
+  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
+  ✓ profile: u2m-profile (from --profile flag)
+  ✓ databricks_cli_path: [CLI]
+  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
+  ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/script
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/script
@@ -1,0 +1,15 @@
+sethome "./home"
+
+unset DATABRICKS_HOST
+unset DATABRICKS_TOKEN
+unset DATABRICKS_CONFIG_PROFILE
+
+export DATABRICKS_AUTH_STORAGE=plaintext
+
+cat > "./home/.databrickscfg" <<ENDCFG
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli
+ENDCFG
+
+trace $CLI auth describe --profile u2m-profile

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/test.toml
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/test.toml
@@ -1,0 +1,3 @@
+Ignore = [
+    "home"
+]

--- a/cmd/auth/describe.go
+++ b/cmd/auth/describe.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 
 	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/auth/storage"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/spf13/cobra"
 )
@@ -21,10 +23,16 @@ var authTemplate = `{{"Host:" | bold}} {{.Status.Details.Host}}
 {{"User:" | bold}} {{.Status.Username}}
 {{- end}}
 {{"Authenticated with:" | bold}} {{.Status.Details.AuthType}}
+{{- if .Status.TokenStorage}}
+{{"Token storage:" | bold}} {{.Status.TokenStorage.Mode}}, {{.Status.TokenStorage.Location}} {{ printf "(from %s)" .Status.TokenStorage.Source | italic}}
+{{- end}}
 -----
 ` + configurationTemplate
 
 var errorTemplate = `Unable to authenticate: {{.Status.Error}}
+{{- if .Status.TokenStorage}}
+{{"Token storage:" | bold}} {{.Status.TokenStorage.Mode}}, {{.Status.TokenStorage.Location}} {{ printf "(from %s)" .Status.TokenStorage.Source | italic}}
+{{- end}}
 -----
 ` + configurationTemplate
 
@@ -80,10 +88,12 @@ func getAuthStatus(cmd *cobra.Command, args []string, showSensitive bool, fn try
 	cfg, isAccount, err := fn(cmd, args)
 	ctx := cmd.Context()
 	if err != nil {
+		details := getAuthDetails(cmd, cfg, showSensitive)
 		return &authStatus{ //nolint:nilerr // error is returned in the authStatus struct
-			Status:  "error",
-			Error:   err,
-			Details: getAuthDetails(cmd, cfg, showSensitive),
+			Status:       "error",
+			Error:        err,
+			Details:      details,
+			TokenStorage: resolveTokenStorageInfo(ctx, details.AuthType),
 		}, nil
 	}
 
@@ -93,18 +103,22 @@ func getAuthStatus(cmd *cobra.Command, args []string, showSensitive bool, fn try
 		// Doing a simple API call to check if the auth is valid
 		_, err := a.Workspaces.List(ctx)
 		if err != nil {
+			details := getAuthDetails(cmd, cfg, showSensitive)
 			return &authStatus{ //nolint:nilerr // error is returned in the authStatus struct
-				Status:  "error",
-				Error:   err,
-				Details: getAuthDetails(cmd, cfg, showSensitive),
+				Status:       "error",
+				Error:        err,
+				Details:      details,
+				TokenStorage: resolveTokenStorageInfo(ctx, details.AuthType),
 			}, nil
 		}
 
+		details := getAuthDetails(cmd, a.Config, showSensitive)
 		status := authStatus{
-			Status:    "success",
-			Details:   getAuthDetails(cmd, a.Config, showSensitive),
-			AccountID: a.Config.AccountID,
-			Username:  a.Config.Username,
+			Status:       "success",
+			Details:      details,
+			AccountID:    a.Config.AccountID,
+			Username:     a.Config.Username,
+			TokenStorage: resolveTokenStorageInfo(ctx, details.AuthType),
 		}
 
 		return &status, nil
@@ -113,17 +127,21 @@ func getAuthStatus(cmd *cobra.Command, args []string, showSensitive bool, fn try
 	w := cmdctx.WorkspaceClient(ctx)
 	me, err := w.CurrentUser.Me(ctx)
 	if err != nil {
+		details := getAuthDetails(cmd, cfg, showSensitive)
 		return &authStatus{ //nolint:nilerr // error is returned in the authStatus struct
-			Status:  "error",
-			Error:   err,
-			Details: getAuthDetails(cmd, cfg, showSensitive),
+			Status:       "error",
+			Error:        err,
+			Details:      details,
+			TokenStorage: resolveTokenStorageInfo(ctx, details.AuthType),
 		}, nil
 	}
 
+	details := getAuthDetails(cmd, w.Config, showSensitive)
 	status := authStatus{
-		Status:   "success",
-		Details:  getAuthDetails(cmd, w.Config, showSensitive),
-		Username: me.UserName,
+		Status:       "success",
+		Details:      details,
+		Username:     me.UserName,
+		TokenStorage: resolveTokenStorageInfo(ctx, details.AuthType),
 	}
 
 	return &status, nil
@@ -153,11 +171,56 @@ func render(ctx context.Context, cmd *cobra.Command, status *authStatus, templat
 }
 
 type authStatus struct {
-	Status    string             `json:"status"`
-	Error     error              `json:"error,omitempty"`
-	Username  string             `json:"username,omitempty"`
-	AccountID string             `json:"account_id,omitempty"`
-	Details   config.AuthDetails `json:"details"`
+	Status       string             `json:"status"`
+	Error        error              `json:"error,omitempty"`
+	Username     string             `json:"username,omitempty"`
+	AccountID    string             `json:"account_id,omitempty"`
+	Details      config.AuthDetails `json:"details"`
+	TokenStorage *tokenStorageInfo  `json:"token_storage,omitempty"`
+}
+
+// tokenStorageInfo describes where the U2M (databricks-cli) token cache lives
+// and which precedence level produced that choice. Populated only when the
+// active auth type is "databricks-cli"; other auth types do not use the
+// CLI's U2M token cache and the field is omitted.
+type tokenStorageInfo struct {
+	Mode     string `json:"mode"`
+	Location string `json:"location"`
+	Source   string `json:"source"`
+}
+
+const (
+	plaintextLocation = "~/.databricks/token-cache.json"
+	secureLocation    = "OS keyring (service: databricks-cli)"
+)
+
+// resolveTokenStorageInfo returns storage info for the U2M token cache, or
+// nil if the active auth type does not use the cache. Resolver errors are
+// logged at debug level and treated as "no info available" rather than
+// failing describe; the user-visible auth status is more important than
+// secondary metadata about where a token would have been stored.
+func resolveTokenStorageInfo(ctx context.Context, authType string) *tokenStorageInfo {
+	if authType != authTypeDatabricksCLI {
+		return nil
+	}
+	mode, source, err := storage.ResolveStorageModeWithSource(ctx, "")
+	if err != nil {
+		log.Debugf(ctx, "auth describe: resolve storage mode: %v", err)
+		return nil
+	}
+	info := &tokenStorageInfo{
+		Mode:   string(mode),
+		Source: source.String(),
+	}
+	switch mode {
+	case storage.StorageModePlaintext:
+		info.Location = plaintextLocation
+	case storage.StorageModeSecure:
+		info.Location = secureLocation
+	default:
+		return nil
+	}
+	return info
 }
 
 func getAuthDetails(cmd *cobra.Command, cfg *config.Config, showSensitive bool) config.AuthDetails {

--- a/cmd/auth/describe.go
+++ b/cmd/auth/describe.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/auth/storage"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/config"
@@ -210,7 +212,7 @@ func resolveTokenStorageInfo(ctx context.Context, authType string) *tokenStorage
 	}
 	info := &tokenStorageInfo{
 		Mode:   string(mode),
-		Source: source.String(),
+		Source: storageSourceLabel(ctx, source),
 	}
 	switch mode {
 	case storage.StorageModePlaintext:
@@ -221,6 +223,35 @@ func resolveTokenStorageInfo(ctx context.Context, authType string) *tokenStorage
 		return nil
 	}
 	return info
+}
+
+// storageSourceLabel returns a user-facing label for source. For
+// StorageSourceConfig, it appends the resolved config file path
+// (DATABRICKS_CONFIG_FILE or <home>/.databrickscfg) so the output matches
+// the SDK's config.Source style ("from <path> config file") rather than
+// hardcoding ".databrickscfg" when a custom path is in use.
+func storageSourceLabel(ctx context.Context, source storage.StorageSource) string {
+	if source != storage.StorageSourceConfig {
+		return source.String()
+	}
+	return "auth_storage in [__settings__] section of " + resolvedConfigPath(ctx)
+}
+
+// resolvedConfigPath returns the path the storage-mode resolver loaded from
+// for [__settings__].auth_storage: DATABRICKS_CONFIG_FILE if set, otherwise
+// <home>/.databrickscfg. Falls back to "~/.databrickscfg" only when the home
+// directory cannot be determined (rare; describe should not crash on this
+// secondary metadata path).
+func resolvedConfigPath(ctx context.Context) string {
+	if path := env.Get(ctx, "DATABRICKS_CONFIG_FILE"); path != "" {
+		return path
+	}
+	home, err := env.UserHomeDir(ctx)
+	if err != nil {
+		log.Debugf(ctx, "auth describe: resolve home dir: %v", err)
+		return "~/.databrickscfg"
+	}
+	return filepath.ToSlash(filepath.Join(home, ".databrickscfg"))
 }
 
 func getAuthDetails(cmd *cobra.Command, cfg *config.Config, showSensitive bool) config.AuthDetails {

--- a/cmd/auth/describe_test.go
+++ b/cmd/auth/describe_test.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/databricks/cli/libs/auth/storage"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -222,4 +224,116 @@ func TestGetAccountAuthStatus(t *testing.T) {
 	require.Equal(t, "my-profile", status.Details.Configuration["profile"].Value)
 	require.Equal(t, "--profile flag", status.Details.Configuration["profile"].Source.String())
 	require.False(t, status.Details.Configuration["profile"].AuthTypeMismatch)
+}
+
+func TestResolveTokenStorageInfo(t *testing.T) {
+	cases := []struct {
+		name     string
+		authType string
+		envValue string
+		want     *tokenStorageInfo
+	}{
+		{
+			name:     "non-databricks-cli auth has no token storage",
+			authType: "pat",
+			want:     nil,
+		},
+		{
+			name:     "databricks-cli with default plaintext",
+			authType: authTypeDatabricksCLI,
+			want: &tokenStorageInfo{
+				Mode:     "plaintext",
+				Location: plaintextLocation,
+				Source:   "default",
+			},
+		},
+		{
+			name:     "databricks-cli with secure from env",
+			authType: authTypeDatabricksCLI,
+			envValue: "secure",
+			want: &tokenStorageInfo{
+				Mode:     "secure",
+				Location: secureLocation,
+				Source:   "DATABRICKS_AUTH_STORAGE environment variable",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(storage.EnvVar, tc.envValue)
+			t.Setenv("DATABRICKS_CONFIG_FILE", t.TempDir()+"/.databrickscfg")
+
+			got := resolveTokenStorageInfo(t.Context(), tc.authType)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGetWorkspaceAuthStatus_U2M_PopulatesTokenStorage(t *testing.T) {
+	ctx := t.Context()
+	m := mocks.NewMockWorkspaceClient(t)
+	ctx = cmdctx.SetWorkspaceClient(ctx, m.WorkspaceClient)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	currentUserApi := m.GetMockCurrentUserAPI()
+	currentUserApi.EXPECT().Me(mock.Anything).Return(&iam.User{UserName: "u2m-user"}, nil)
+
+	cmd.Flags().String("host", "", "")
+	cmd.Flags().String("profile", "", "")
+	require.NoError(t, cmd.Flag("profile").Value.Set("u2m-profile"))
+	cmd.Flag("profile").Changed = true
+
+	cfg := &config.Config{Profile: "u2m-profile"}
+	m.WorkspaceClient.Config = cfg
+	t.Setenv(storage.EnvVar, "secure")
+	t.Setenv("DATABRICKS_CONFIG_FILE", t.TempDir()+"/.databrickscfg")
+	require.NoError(t, config.ConfigAttributes.Configure(cfg))
+
+	status, err := getAuthStatus(cmd, []string{}, false, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
+		require.NoError(t, config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
+			"host":      "https://test.test",
+			"auth_type": authTypeDatabricksCLI,
+		}))
+		return cfg, false, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.NotNil(t, status.TokenStorage)
+	assert.Equal(t, "secure", status.TokenStorage.Mode)
+	assert.Equal(t, secureLocation, status.TokenStorage.Location)
+	assert.Equal(t, "DATABRICKS_AUTH_STORAGE environment variable", status.TokenStorage.Source)
+}
+
+func TestGetWorkspaceAuthStatus_NonU2M_OmitsTokenStorage(t *testing.T) {
+	ctx := t.Context()
+	m := mocks.NewMockWorkspaceClient(t)
+	ctx = cmdctx.SetWorkspaceClient(ctx, m.WorkspaceClient)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+
+	currentUserApi := m.GetMockCurrentUserAPI()
+	currentUserApi.EXPECT().Me(mock.Anything).Return(&iam.User{UserName: "pat-user"}, nil)
+
+	cmd.Flags().String("host", "", "")
+	cmd.Flags().String("profile", "", "")
+
+	cfg := &config.Config{}
+	m.WorkspaceClient.Config = cfg
+	require.NoError(t, config.ConfigAttributes.Configure(cfg))
+
+	status, err := getAuthStatus(cmd, []string{}, false, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
+		require.NoError(t, config.ConfigAttributes.ResolveFromStringMap(cfg, map[string]string{
+			"host":      "https://test.test",
+			"token":     "pat-token",
+			"auth_type": "pat",
+		}))
+		return cfg, false, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.Nil(t, status.TokenStorage)
 }

--- a/cmd/auth/describe_test.go
+++ b/cmd/auth/describe_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/libs/auth/storage"
@@ -268,6 +269,32 @@ func TestResolveTokenStorageInfo(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestStorageSourceLabel_ConfigUsesResolvedPath(t *testing.T) {
+	ctx := t.Context()
+	t.Setenv("DATABRICKS_CONFIG_FILE", "/custom/path/.databrickscfg")
+	got := storageSourceLabel(ctx, storage.StorageSourceConfig)
+	assert.Equal(t, "auth_storage in [__settings__] section of /custom/path/.databrickscfg", got)
+}
+
+func TestStorageSourceLabel_ConfigDefaultsToHome(t *testing.T) {
+	ctx := t.Context()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DATABRICKS_CONFIG_FILE", "")
+	got := storageSourceLabel(ctx, storage.StorageSourceConfig)
+	expected := "auth_storage in [__settings__] section of " + filepath.ToSlash(filepath.Join(home, ".databrickscfg"))
+	assert.Equal(t, expected, got)
+}
+
+func TestStorageSourceLabel_NonConfigDelegatesToSource(t *testing.T) {
+	ctx := t.Context()
+	t.Setenv("DATABRICKS_CONFIG_FILE", "/should/not/appear")
+	assert.Equal(t, "default", storageSourceLabel(ctx, storage.StorageSourceDefault))
+	assert.Equal(t, "DATABRICKS_AUTH_STORAGE environment variable", storageSourceLabel(ctx, storage.StorageSourceEnvVar))
+	assert.Equal(t, "command-line override", storageSourceLabel(ctx, storage.StorageSourceOverride))
 }
 
 func TestGetWorkspaceAuthStatus_U2M_PopulatesTokenStorage(t *testing.T) {

--- a/libs/auth/storage/cache.go
+++ b/libs/auth/storage/cache.go
@@ -106,11 +106,11 @@ func resolveCacheWith(ctx context.Context, override StorageMode, f cacheFactorie
 // resolveCacheForLoginWith is the pure form of ResolveCacheForLogin. It takes
 // the factory set as a parameter so tests can inject stubs.
 func resolveCacheForLoginWith(ctx context.Context, override StorageMode, f cacheFactories) (cache.TokenCache, StorageMode, error) {
-	mode, explicit, err := ResolveStorageModeWithSource(ctx, override)
+	mode, source, err := ResolveStorageModeWithSource(ctx, override)
 	if err != nil {
 		return nil, "", err
 	}
-	return applyLoginFallback(ctx, mode, explicit, f)
+	return applyLoginFallback(ctx, mode, source.Explicit(), f)
 }
 
 // applyLoginFallback realizes the login-time fallback rules given an already-

--- a/libs/auth/storage/mode.go
+++ b/libs/auth/storage/mode.go
@@ -38,6 +38,43 @@ const (
 // EnvVar is the environment variable that selects the storage mode.
 const EnvVar = "DATABRICKS_AUTH_STORAGE"
 
+// StorageSource identifies which precedence level produced the resolved
+// storage mode. Callers use it both to decide whether the user explicitly
+// asked for a mode (everything except StorageSourceDefault) and to surface
+// where the choice came from in user-facing output.
+type StorageSource int
+
+const (
+	// StorageSourceDefault is the zero value: no override, env, or config
+	// was set, so the resolver fell through to the built-in default.
+	StorageSourceDefault StorageSource = iota
+	StorageSourceOverride
+	StorageSourceEnvVar
+	StorageSourceConfig
+)
+
+// Explicit reports whether the source came from a user-supplied input
+// (override flag, env var, or config) rather than the built-in default.
+func (s StorageSource) Explicit() bool {
+	return s != StorageSourceDefault
+}
+
+// String returns a human-readable label for the source, matching the style
+// used by the SDK's config.Source.String() (e.g. "DATABRICKS_HOST environment
+// variable", "--profile flag").
+func (s StorageSource) String() string {
+	switch s {
+	case StorageSourceOverride:
+		return "--auth-storage flag"
+	case StorageSourceEnvVar:
+		return EnvVar + " environment variable"
+	case StorageSourceConfig:
+		return "auth_storage in [__settings__] section of .databrickscfg"
+	default:
+		return "default"
+	}
+}
+
 // ParseMode parses raw as a StorageMode. Whitespace is trimmed and matching
 // is case-insensitive. Empty or unrecognized input returns StorageModeUnknown;
 // callers decide whether that is an error (user-supplied value) or a
@@ -70,32 +107,31 @@ func ResolveStorageMode(ctx context.Context, override StorageMode) (StorageMode,
 }
 
 // ResolveStorageModeWithSource is like ResolveStorageMode but also reports
-// whether the resolved mode came from an explicit user choice (override flag,
-// env var, or config) versus the built-in default. Callers use this to honor
-// "I want secure" strictly: when the user explicitly asked for secure storage
-// but it cannot be provided, the right move is to error out, not to silently
-// downgrade.
-func ResolveStorageModeWithSource(ctx context.Context, override StorageMode) (StorageMode, bool, error) {
+// which precedence level produced the resolved mode. Callers use the source
+// both to honor "I want secure" strictly (when source.Explicit() is true and
+// secure cannot be provided, error out instead of silently downgrading) and
+// to surface where the choice came from in user-facing output.
+func ResolveStorageModeWithSource(ctx context.Context, override StorageMode) (StorageMode, StorageSource, error) {
 	if override != StorageModeUnknown {
-		return override, true, nil
+		return override, StorageSourceOverride, nil
 	}
 
 	if raw := env.Get(ctx, EnvVar); raw != "" {
 		mode, err := parseFromSource(raw, EnvVar)
-		return mode, true, err
+		return mode, StorageSourceEnvVar, err
 	}
 
 	configPath := env.Get(ctx, "DATABRICKS_CONFIG_FILE")
 	raw, err := databrickscfg.GetConfiguredAuthStorage(ctx, configPath)
 	if err != nil {
-		return "", false, fmt.Errorf("read auth_storage setting: %w", err)
+		return "", StorageSourceDefault, fmt.Errorf("read auth_storage setting: %w", err)
 	}
 	if raw != "" {
 		mode, err := parseFromSource(raw, "auth_storage")
-		return mode, true, err
+		return mode, StorageSourceConfig, err
 	}
 
-	return StorageModePlaintext, false, nil
+	return StorageModePlaintext, StorageSourceDefault, nil
 }
 
 func parseFromSource(raw, source string) (StorageMode, error) {

--- a/libs/auth/storage/mode.go
+++ b/libs/auth/storage/mode.go
@@ -61,15 +61,22 @@ func (s StorageSource) Explicit() bool {
 
 // String returns a human-readable label for the source, matching the style
 // used by the SDK's config.Source.String() (e.g. "DATABRICKS_HOST environment
-// variable", "--profile flag").
+// variable").
+//
+// The label for StorageSourceConfig intentionally does not name a specific
+// config file: callers that know the resolved path (e.g. auth describe)
+// should append it themselves to match the SDK's "from <path> config file"
+// convention. The label for StorageSourceOverride is generic because no
+// CLI command currently exposes a storage-mode flag; if one is added in
+// the future, that command can replace the label at the call site.
 func (s StorageSource) String() string {
 	switch s {
 	case StorageSourceOverride:
-		return "--auth-storage flag"
+		return "command-line override"
 	case StorageSourceEnvVar:
 		return EnvVar + " environment variable"
 	case StorageSourceConfig:
-		return "auth_storage in [__settings__] section of .databrickscfg"
+		return "auth_storage in [__settings__] section of config file"
 	default:
 		return "default"
 	}

--- a/libs/auth/storage/mode_test.go
+++ b/libs/auth/storage/mode_test.go
@@ -205,7 +205,7 @@ func TestStorageSource_Explicit(t *testing.T) {
 
 func TestStorageSource_String(t *testing.T) {
 	assert.Equal(t, "default", StorageSourceDefault.String())
-	assert.Equal(t, "--auth-storage flag", StorageSourceOverride.String())
+	assert.Equal(t, "command-line override", StorageSourceOverride.String())
 	assert.Equal(t, "DATABRICKS_AUTH_STORAGE environment variable", StorageSourceEnvVar.String())
-	assert.Equal(t, "auth_storage in [__settings__] section of .databrickscfg", StorageSourceConfig.String())
+	assert.Equal(t, "auth_storage in [__settings__] section of config file", StorageSourceConfig.String())
 }

--- a/libs/auth/storage/mode_test.go
+++ b/libs/auth/storage/mode_test.go
@@ -131,36 +131,36 @@ func TestResolveStorageMode_SkipsConfigReadWhenOverrideOrEnvSet(t *testing.T) {
 
 func TestResolveStorageModeWithSource(t *testing.T) {
 	cases := []struct {
-		name         string
-		override     StorageMode
-		envValue     string
-		configBody   string
-		wantMode     StorageMode
-		wantExplicit bool
-		wantErrSub   string
+		name       string
+		override   StorageMode
+		envValue   string
+		configBody string
+		wantMode   StorageMode
+		wantSource StorageSource
+		wantErrSub string
 	}{
 		{
-			name:         "default is not explicit",
-			wantMode:     StorageModePlaintext,
-			wantExplicit: false,
+			name:       "default",
+			wantMode:   StorageModePlaintext,
+			wantSource: StorageSourceDefault,
 		},
 		{
-			name:         "override is explicit",
-			override:     StorageModeSecure,
-			wantMode:     StorageModeSecure,
-			wantExplicit: true,
+			name:       "override",
+			override:   StorageModeSecure,
+			wantMode:   StorageModeSecure,
+			wantSource: StorageSourceOverride,
 		},
 		{
-			name:         "env is explicit",
-			envValue:     "secure",
-			wantMode:     StorageModeSecure,
-			wantExplicit: true,
+			name:       "env",
+			envValue:   "secure",
+			wantMode:   StorageModeSecure,
+			wantSource: StorageSourceEnvVar,
 		},
 		{
-			name:         "config is explicit",
-			configBody:   "[__settings__]\nauth_storage = secure\n",
-			wantMode:     StorageModeSecure,
-			wantExplicit: true,
+			name:       "config",
+			configBody: "[__settings__]\nauth_storage = secure\n",
+			wantMode:   StorageModeSecure,
+			wantSource: StorageSourceConfig,
 		},
 		{
 			name:       "invalid env is rejected",
@@ -183,7 +183,7 @@ func TestResolveStorageModeWithSource(t *testing.T) {
 			t.Setenv("DATABRICKS_CONFIG_FILE", cfgPath)
 			t.Setenv(EnvVar, tc.envValue)
 
-			mode, explicit, err := ResolveStorageModeWithSource(t.Context(), tc.override)
+			mode, source, err := ResolveStorageModeWithSource(t.Context(), tc.override)
 			if tc.wantErrSub != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErrSub)
@@ -191,7 +191,21 @@ func TestResolveStorageModeWithSource(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantMode, mode)
-			assert.Equal(t, tc.wantExplicit, explicit)
+			assert.Equal(t, tc.wantSource, source)
 		})
 	}
+}
+
+func TestStorageSource_Explicit(t *testing.T) {
+	assert.False(t, StorageSourceDefault.Explicit())
+	assert.True(t, StorageSourceOverride.Explicit())
+	assert.True(t, StorageSourceEnvVar.Explicit())
+	assert.True(t, StorageSourceConfig.Explicit())
+}
+
+func TestStorageSource_String(t *testing.T) {
+	assert.Equal(t, "default", StorageSourceDefault.String())
+	assert.Equal(t, "--auth-storage flag", StorageSourceOverride.String())
+	assert.Equal(t, "DATABRICKS_AUTH_STORAGE environment variable", StorageSourceEnvVar.String())
+	assert.Equal(t, "auth_storage in [__settings__] section of .databrickscfg", StorageSourceConfig.String())
 }


### PR DESCRIPTION
## Why

Users have no way to tell where the CLI is storing their U2M (`databricks-cli`) token. As we move toward making secure storage the default at GA, users need to confirm whether their tokens live in the OS keyring or in `~/.databricks/token-cache.json`, and which precedence level produced that choice. `gh auth status` does this with a `(keyring)` or `(/path/to/hosts.yml)` suffix; we want the same.

## Changes

Before: `databricks auth describe` showed host, user, auth type, and a "Current configuration" block, with no information about U2M token storage.

Now: For profiles using `auth_type = databricks-cli`, output adds:

```
Token storage: plaintext, ~/.databricks/token-cache.json (from default)
```

or

```
Token storage: secure, OS keyring (service: databricks-cli) (from DATABRICKS_AUTH_STORAGE environment variable)
```

The `(from ...)` clause matches the existing config-attribute annotation style. Other auth types (PAT, M2M, OIDC, Azure, etc.) do not use the U2M cache and the line is omitted entirely (no field in JSON either).

JSON output adds a `token_storage: { mode, location, source }` object alongside `details`.

Implementation:

- `libs/auth/storage/mode.go`: `ResolveStorageModeWithSource` now returns a typed `StorageSource` (`Default | Override | EnvVar | Config`) instead of an opaque bool. `StorageSource.String()` produces user-facing labels matching `config.Source.String()` style.
- `libs/auth/storage/cache.go`: only existing in-repo caller updated to use `source.Explicit()`.
- `cmd/auth/describe.go`: new `tokenStorageInfo` struct + `resolveTokenStorageInfo` helper. Templates conditionally render the new line. Only resolves when `auth_type == "databricks-cli"`; resolver errors are debug-logged and treated as "no info available" rather than failing describe.

No probing of either backend at describe time. The describe command already makes a live API call that validates the token works; double-probing would add a 3-second hang on Linux without Secret Service for no extra signal. Following up with a `--check-token` flag is a separate change if there's appetite for it.

## Test plan

- [x] Unit tests for `StorageSource.String()` and `.Explicit()`
- [x] Updated `TestResolveStorageModeWithSource` for the new return type
- [x] New `TestResolveTokenStorageInfo` table test covering U2M+default, U2M+env, and non-U2M
- [x] New `TestGetWorkspaceAuthStatus_U2M_PopulatesTokenStorage` and `TestGetWorkspaceAuthStatus_NonU2M_OmitsTokenStorage`
- [x] New acceptance tests at `acceptance/cmd/auth/describe/u2m-plaintext-default/` and `u2m-plaintext-env/`
- [x] Existing PAT acceptance test (`default-profile/`) still passes unchanged
- [x] Manual smoke: built CLI, ran describe with U2M+default, U2M+secure-env, and PAT profiles. Output is correct in both text and JSON.
- [x] `./task checks` and `./task lint-q` clean

Secure-storage acceptance tests are intentionally omitted: they would actually query the OS keyring on macOS (potential prompt) or hit the 3s timeout on Linux CI without Secret Service. Unit tests cover the secure path on any platform.