### PR TITLE
acceptance: fix force_pull_commands test on macOS

### DIFF
--- a/acceptance/bundle/state/force_pull_commands/out.test.toml
+++ b/acceptance/bundle/state/force_pull_commands/out.test.toml
@@ -1,9 +1,5 @@
 Local = true
 Cloud = false
-
-[GOOS]
-  linux = false
-  windows = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+GOOS.linux = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/force_pull_commands/script
+++ b/acceptance/bundle/state/force_pull_commands/script
@@ -4,18 +4,26 @@ rm -f out.requests.txt
 title "Modify PATH so that real open is not run"
 export PATH=.:$PATH
 
+# touch out.requests.txt before each print_requests.py call: the commands without
+# --force-pull make zero HTTP requests, so the file is never created and
+# print_requests.py would otherwise exit with "File not found".
+
 title "bundle summary without --force-pull: no remote state read\n"
 trace $CLI bundle summary > /dev/null
+touch out.requests.txt
 print_requests.py --get //workspace-files/
 
 title "bundle summary --force-pull: remote state read\n"
 trace $CLI bundle summary --force-pull > /dev/null
+touch out.requests.txt
 print_requests.py --get //workspace-files/
 
 title "bundle open without --force-pull: no remote state read\n"
 musterr trace $CLI bundle open foo > /dev/null
+touch out.requests.txt
 print_requests.py --get //workspace-files/
 
 title "bundle open --force-pull: remote state read\n"
 musterr trace $CLI bundle open foo --force-pull > /dev/null
+touch out.requests.txt
 print_requests.py --get //workspace-files/


### PR DESCRIPTION
## Why

The acceptance test added in #5028 was merged with CI red on every platform. Two follow-up issues:

1. **macOS**: the script bails at the first `print_requests.py` call because `bundle summary` without `--force-pull` makes zero HTTP requests, so `out.requests.txt` is never created after the `rm -f` earlier in the script. `print_requests.py` then exits with `File [TEST_TMP_DIR]/out.requests.txt not found`, and the rest of the script never runs. The test only runs on darwin (`GOOS.windows = false`, `GOOS.linux = false`), so this manifested as a macOS-only failure.
2. **Linux/Windows**: the post-test `git diff --exit-code` check fails because `out.test.toml` was checked in using the older `[GOOS]` / `[EnvMatrix]` table form, but the framework now serializes those keys in dotted form.

## Changes

**Before:** `bundle summary` (no `--force-pull`) makes 0 requests, file is missing, `print_requests.py` exits 1, the rest of the test never runs.

**Now:** `touch out.requests.txt` before each `print_requests.py` call so the helper sees an empty file and prints nothing, matching the expected output. Also regenerate `out.test.toml` so it matches the current serialization format.

## Test plan

- [x] `go test ./acceptance -run "TestAccept/bundle/state/force_pull_commands" -v` passes locally on darwin (both `direct` and `terraform` engines)
- [x] `go test ./acceptance -run "^TestAccept$" -only-out-test-toml` produces no further diff
- [x] `./task checks` clean

This pull request and its description were written by Isaac.