### PR TITLE
acceptance: drop darwin-only gate from bundle open + force_pull_commands

### DIFF
--- a/acceptance/bin/echo_browser.py
+++ b/acceptance/bin/echo_browser.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Fake browser that prints the URL it was asked to open and exits.
+
+Used by acceptance tests that exercise commands which call libs/browser.Open
+but don't need to follow the URL (unlike auth tests, which use browser.py to
+close the OAuth callback loop). Setting BROWSER=echo_browser.py is portable
+across darwin/linux/windows because libs/browser routes through libs/exec.
+
+Usage: echo_browser.py <url>
+"""
+
+import sys
+
+if len(sys.argv) < 2:
+    sys.stderr.write("Usage: echo_browser.py <url>\n")
+    sys.exit(1)
+
+print(sys.argv[1])

--- a/acceptance/bundle/open/open
+++ b/acceptance/bundle/open/open
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "I AM BROWSER"

--- a/acceptance/bundle/open/out.test.toml
+++ b/acceptance/bundle/open/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOS.linux = false
-GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/open/output.txt
+++ b/acceptance/bundle/open/output.txt
@@ -17,11 +17,11 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
-=== Modify PATH so that real open is not run
-=== open after deployment. This will fail to open browser and complain, that's ok, we only want the message
+=== Use a fake browser that just prints the URL it would have opened
+=== open after deployment
 >>> [CLI] bundle open foo
 Opening browser at [DATABRICKS_URL]/jobs/[NUMID]?o=[NUMID]
-Error: exec: "open": cannot run executable found relative to current directory
+[DATABRICKS_URL]/jobs/[NUMID]?o=[NUMID]
 
 === test auto-completion handler
 >>> [CLI] __complete bundle open ,

--- a/acceptance/bundle/open/script
+++ b/acceptance/bundle/open/script
@@ -6,11 +6,11 @@ errcode trace $CLI bundle open foo
 
 errcode trace $CLI bundle deploy
 
-title "Modify PATH so that real open is not run"
-export PATH=.:$PATH
+title "Use a fake browser that just prints the URL it would have opened"
+export BROWSER="echo_browser.py"
 
-title "open after deployment. This will fail to open browser and complain, that's ok, we only want the message"
-musterr trace $CLI bundle open foo
+title "open after deployment"
+trace $CLI bundle open foo
 
 title "test auto-completion handler"
 trace $CLI __complete bundle open ,

--- a/acceptance/bundle/open/test.toml
+++ b/acceptance/bundle/open/test.toml
@@ -1,2 +1,0 @@
-GOOS.windows = false
-GOOS.linux = false

--- a/acceptance/bundle/state/force_pull_commands/open
+++ b/acceptance/bundle/state/force_pull_commands/open
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "I AM BROWSER"

--- a/acceptance/bundle/state/force_pull_commands/out.test.toml
+++ b/acceptance/bundle/state/force_pull_commands/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOS.linux = false
-GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/force_pull_commands/output.txt
+++ b/acceptance/bundle/state/force_pull_commands/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
-=== Modify PATH so that real open is not run
+=== Use a fake browser that just prints the URL it would have opened
 === bundle summary without --force-pull: no remote state read
 
 >>> [CLI] bundle summary
@@ -22,13 +22,11 @@ Deployment complete!
 
 >>> [CLI] bundle open foo
 Opening browser at [DATABRICKS_URL]/jobs/[NUMID]?o=[NUMID]
-Error: exec: "open": cannot run executable found relative to current directory
 
 === bundle open --force-pull: remote state read
 
 >>> [CLI] bundle open foo --force-pull
 Opening browser at [DATABRICKS_URL]/jobs/[NUMID]?o=[NUMID]
-Error: exec: "open": cannot run executable found relative to current directory
 {
   "method": "GET",
   "path": "/api/2.0/workspace-files/Workspace/Users/[USERNAME]/.bundle/force-pull-commands/default/state/STATE_FILENAME"

--- a/acceptance/bundle/state/force_pull_commands/script
+++ b/acceptance/bundle/state/force_pull_commands/script
@@ -1,8 +1,8 @@
 trace $CLI bundle deploy > /dev/null
 rm -f out.requests.txt
 
-title "Modify PATH so that real open is not run"
-export PATH=.:$PATH
+title "Use a fake browser that just prints the URL it would have opened"
+export BROWSER="echo_browser.py"
 
 # touch out.requests.txt before each print_requests.py call: the commands without
 # --force-pull make zero HTTP requests, so the file is never created and
@@ -19,11 +19,11 @@ touch out.requests.txt
 print_requests.py --get //workspace-files/
 
 title "bundle open without --force-pull: no remote state read\n"
-musterr trace $CLI bundle open foo > /dev/null
+trace $CLI bundle open foo > /dev/null
 touch out.requests.txt
 print_requests.py --get //workspace-files/
 
 title "bundle open --force-pull: remote state read\n"
-musterr trace $CLI bundle open foo --force-pull > /dev/null
+trace $CLI bundle open foo --force-pull > /dev/null
 touch out.requests.txt
 print_requests.py --get //workspace-files/

--- a/acceptance/bundle/state/force_pull_commands/test.toml
+++ b/acceptance/bundle/state/force_pull_commands/test.toml
@@ -2,11 +2,6 @@ Local = true
 Cloud = false
 RecordRequests = true
 
-# bundle open opens a browser; restrict to darwin to get stable output
-# (mirrors acceptance/bundle/open/test.toml).
-GOOS.windows = false
-GOOS.linux = false
-
 Ignore = [".databricks"]
 
 [EnvMatrix]


### PR DESCRIPTION
## Why

Follow-up to #5212. Both `acceptance/bundle/open` and `acceptance/bundle/state/force_pull_commands` are gated to darwin only (`GOOS.windows = false`, `GOOS.linux = false`) because they relied on `export PATH=.:$PATH` plus a local `open` stub to keep the real browser from launching. That trick is macOS-specific, and Go's `exec.LookPath` rejects results from `.` anyway, which is why the captured output included `Error: exec: "open": cannot run executable found relative to current directory`.

Pieter pointed out that `libs/browser` already honors `$BROWSER` and routes through `libs/exec`, so a fake browser command is portable across darwin/linux/windows.

## Changes

**Before:** `export PATH=.:$PATH` + local `open` script; tests gated to darwin; output captured a Go exec error as the assertion.

**Now:** `export BROWSER=echo_browser.py`; the stub prints the URL and exits 0; tests run on all three platforms; output shows a clean "Opening browser at <url>" line (and the echoed URL where stdout isn't redirected to /dev/null).

- New `acceptance/bin/echo_browser.py`: prints argv[1] and exits. Distinct from the existing `browser.py`, which performs an HTTP GET to close the OAuth callback loop in auth tests; that fetch would have polluted `out.requests.txt` in `force_pull_commands`.
- `acceptance/bundle/open/`: replace PATH trick with `BROWSER=echo_browser.py`, drop `musterr`, delete the local `open` stub, delete the test-local `test.toml` (was only setting GOOS overrides).
- `acceptance/bundle/state/force_pull_commands/`: same script swap, drop GOOS overrides from `test.toml`, delete local `open` stub.

## Test plan

- [x] `go test ./acceptance -run "TestAccept/bundle/open$" -v` passes on darwin (both `direct` and `terraform` engines)
- [x] `go test ./acceptance -run "TestAccept/bundle/state/force_pull_commands$" -v` passes on darwin (both engines)
- [x] `go test ./acceptance -run "TestAccept/bundle/state/" ` passes (no neighbors broken)
- [x] `./task checks`, `./task fmt`, `./task lint-q` clean
- [ ] Linux + Windows CI on this PR

This pull request and its description were written by Isaac.