### PR TITLE
tests: use .test TLD for bare-hostname fixtures

### DIFF
--- a/cmd/labs/project/testdata/installed-in-home/.databrickscfg
+++ b/cmd/labs/project/testdata/installed-in-home/.databrickscfg
@@ -1,5 +1,5 @@
 [workspace-profile]
-host = https://abc
+host = https://abc.test
 token = bcd
 cluster_id = cde
 warehouse_id = def

--- a/libs/databrickscfg/loader_test.go
+++ b/libs/databrickscfg/loader_test.go
@@ -26,7 +26,7 @@ func TestLoaderSkipsExistingAuth(t *testing.T) {
 		Loaders: []config.Loader{
 			ResolveProfileFromHost,
 		},
-		Host:  "https://foo",
+		Host:  "https://foo.test",
 		Token: "nonempty means pat auth",
 	}
 
@@ -40,7 +40,7 @@ func TestLoaderSkipsExplicitAuthType(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "testdata/databrickscfg",
-		Host:       "https://default",
+		Host:       "https://default.test",
 		AuthType:   "azure-cli",
 	}
 
@@ -57,7 +57,7 @@ func TestLoaderSkipsNonExistingConfigFile(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "idontexist",
-		Host:       "https://default",
+		Host:       "https://default.test",
 	}
 
 	err := cfg.EnsureResolved()
@@ -71,7 +71,7 @@ func TestLoaderErrorsOnInvalidFile(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "profile/testdata/badcfg",
-		Host:       "https://default",
+		Host:       "https://default.test",
 	}
 
 	err := cfg.EnsureResolved()
@@ -84,7 +84,7 @@ func TestLoaderSkipsNoMatchingHost(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "profile/testdata/databrickscfg",
-		Host:       "https://noneofthehostsmatch",
+		Host:       "https://noneofthehostsmatch.test",
 	}
 
 	err := cfg.EnsureResolved()
@@ -98,7 +98,7 @@ func TestLoaderMatchingHost(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "profile/testdata/databrickscfg",
-		Host:       "https://default",
+		Host:       "https://default.test",
 	}
 
 	err := cfg.EnsureResolved()
@@ -113,7 +113,7 @@ func TestLoaderMatchingHostWithQuery(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "profile/testdata/databrickscfg",
-		Host:       "https://query/?foo=bar",
+		Host:       "https://query.test/?foo=bar",
 	}
 
 	err := cfg.EnsureResolved()
@@ -128,12 +128,12 @@ func TestLoaderErrorsOnMultipleMatches(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "profile/testdata/databrickscfg",
-		Host:       "https://foo/bar",
+		Host:       "https://foo.test/bar",
 	}
 
 	err := cfg.EnsureResolved()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "https://foo: multiple profiles matched: foo1, foo2")
+	assert.ErrorContains(t, err, "https://foo.test: multiple profiles matched: foo1, foo2")
 }
 
 func TestAsMultipleProfilesExtractsNames(t *testing.T) {
@@ -142,7 +142,7 @@ func TestAsMultipleProfilesExtractsNames(t *testing.T) {
 			ResolveProfileFromHost,
 		},
 		ConfigFile: "profile/testdata/databrickscfg",
-		Host:       "https://foo/bar",
+		Host:       "https://foo.test/bar",
 	}
 
 	err := cfg.EnsureResolved()

--- a/libs/databrickscfg/ops_test.go
+++ b/libs/databrickscfg/ops_test.go
@@ -66,7 +66,7 @@ func TestMatchOrCreateSection_AccountID(t *testing.T) {
 
 func TestMatchOrCreateSection_NormalizeHost(t *testing.T) {
 	cfg := &config.Config{
-		Host: "https://query/?o=abracadabra",
+		Host: "https://query.test/?o=abracadabra",
 	}
 	file, err := loadOrCreateConfigFile(t.Context(), "profile/testdata/databrickscfg")
 	assert.NoError(t, err)
@@ -90,7 +90,7 @@ func TestMatchOrCreateSection_NoProfileOrHost(t *testing.T) {
 
 func TestMatchOrCreateSection_MultipleProfiles(t *testing.T) {
 	cfg := &config.Config{
-		Host: "https://foo",
+		Host: "https://foo.test",
 	}
 	file, err := loadOrCreateConfigFile(t.Context(), "profile/testdata/databrickscfg")
 	assert.NoError(t, err)

--- a/libs/databrickscfg/profile/testdata/databrickscfg
+++ b/libs/databrickscfg/profile/testdata/databrickscfg
@@ -1,26 +1,26 @@
 [DEFAULT]
-host = https://default
+host = https://default.test
 token = default
 
 [query]
-host = https://query/?o=1234
+host = https://query.test/?o=1234
 token = query
 
 [nohost]
 token = query
 
-# Duplicate entry for https://foo
+# Duplicate entry for https://foo.test
 [foo1]
-host = https://foo
+host = https://foo.test
 token = foo1
 
 [acc]
 host = https://accounts.cloud.databricks.com
 account_id = abc
 
-# Duplicate entry for https://foo
+# Duplicate entry for https://foo.test
 [foo2]
-host = https://foo
+host = https://foo.test
 token = foo2
 
 # SPOG profiles sharing the same host but with different workspace_ids

--- a/libs/databrickscfg/profile/testdata/sample-home/.databrickscfg
+++ b/libs/databrickscfg/profile/testdata/sample-home/.databrickscfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-host = https://default
+host = https://default.test
 token = default
 
 [acc]


### PR DESCRIPTION
## Changes

Rename bare-hostname test fixtures (no TLD) to use `.test`:

- `libs/databrickscfg/profile/testdata/databrickscfg` — `https://default`, `https://query/?o=1234`, `https://foo`
- `libs/databrickscfg/profile/testdata/sample-home/.databrickscfg` — `https://default`
- `libs/databrickscfg/loader_test.go` — `Host:` fields and the `multiple profiles matched` error-message assertion
- `libs/databrickscfg/ops_test.go` — only the two cases that match the renamed shared fixture profiles
- `cmd/labs/project/testdata/installed-in-home/.databrickscfg` — `https://abc`

`https://accounts.cloud.databricks.com` and `https://spog[-dup].databricks.com` in the same files are intentionally left as-is.

## Why

Follow-up to #5189. That sweep replaced real `.com` hosts; this catches the bare-hostname variants the `.com` filter missed. The SDK well-known endpoint resolver treats single-label hosts as real DNS lookups, so these fixtures stall ~3s each on the Windows CI runner.

From `test-output.json` of run 25496981743 (win-tf):

| Test                                                     | linux  | windows |
|----------------------------------------------------------|--------|---------|
| `TestLoaderSkipsExistingAuth`                            | 0.01s  | 3.04s   |
| `TestLoaderSkipsExplicitAuthType`                        | 0.01s  | 2.79s   |
| `TestLoaderMatchingHostWithQuery`                        | 0.03s  | 2.78s   |
| `TestLoaderMatchingHost`                                 | 0.00s  | 2.76s   |
| `TestLoaderSkipsNonExistingConfigFile`                   | 0.01s  | 2.75s   |
| `TestLoaderSkipsNoMatchingHost`                          | 0.01s  | 1.27s   |
| `cmd/labs/project: TestRunningCommand`                   | 0.10s  | 2.98s   |
| `cmd/labs/project: TestRenderingTable`                   | 0.03s  | 2.92s   |
| `cmd/labs/project: TestRunningBlueprintEchoProfileWrong` | 0.01s  | 2.76s   |

~25s per Windows job × 2 engines = ~50s expected to come back. Scope is limited to fixtures that actually trigger the resolver. Other `https://foo`-style strings in `ops_test.go` are in tempdir-only tests that never hit DNS and remain untouched to keep the diff focused.

## Tests

- `go test ./libs/databrickscfg/... ./cmd/labs/project/...` passes locally.
- `./task fmt`, `./task checks`, `./task lint` all clean.
- Watch the Windows-tf job duration on this PR — expect ~25–50s improvement.

_This PR was written by Claude Code._