### PR TITLE
integration: fix TestClustersGet assertion after JSON formatter change

### DIFF
--- a/integration/cmd/clusters/clusters_test.go
+++ b/integration/cmd/clusters/clusters_test.go
@@ -32,7 +32,7 @@ func TestClustersGet(t *testing.T) {
 	clusterId := findValidClusterID(t)
 	stdout, stderr := testcli.RequireSuccessfulRun(t, ctx, "clusters", "get", clusterId)
 	outStr := stdout.String()
-	assert.Contains(t, outStr, fmt.Sprintf(`"cluster_id":"%s"`, clusterId))
+	assert.Contains(t, outStr, fmt.Sprintf(`"cluster_id": "%s"`, clusterId))
 	assert.Equal(t, "", stderr.String())
 }
 


### PR DESCRIPTION
Since #5170 the CLI's JSON output uses the standard `: ` separator (via `json.MarshalIndent`) rather than the compact `":"` form produced by the previous `nwidger/jsoncolor` dependency. `TestClustersGet`'s substring assertion still expected the compact form and has been failing in every nightly environment; updating it to match the new output.

This pull request and its description were written by Isaac.