### PR TITLE
acc: regenerate stale out.test.toml for job_nested_notebooks

### DIFF
--- a/acceptance/bundle/generate/job_nested_notebooks/out.test.toml
+++ b/acceptance/bundle/generate/job_nested_notebooks/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-
-[EnvMatrix]
-  DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]


### PR DESCRIPTION
## Summary
- PR #4596 (just merged on main) committed `out.test.toml` for `acceptance/bundle/generate/job_nested_notebooks` in the pre-#5146 multi-line `[EnvMatrix]` form.
- Regenerated via `go test ./acceptance -run '^TestAccept$' -only-out-test-toml`.

## Test plan
- [x] `go test ./acceptance -run '^TestAccept$' -only-out-test-toml` produces only this one-file diff
- [x] `git diff` after regeneration matches the diff CI was reporting

This pull request and its description were written by Isaac.