### PR TITLE
Drop unused `Default` field from `cmdio.PromptOptions`

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -36,8 +36,6 @@ func promptForProfile(ctx context.Context, defaultValue string) (string, error) 
 		Label: "Databricks profile name [" + defaultValue + "]",
 	})
 	if result == "" {
-		// Manually return the default value. We could use the prompt.Default
-		// field, but be inconsistent with other prompts in the CLI.
 		return defaultValue, err
 	}
 	return result, err

--- a/cmd/selftest/tui/prompt.go
+++ b/cmd/selftest/tui/prompt.go
@@ -11,9 +11,8 @@ import (
 
 func newPromptCmd() *cobra.Command {
 	var (
-		defaultVal string
-		mask       bool
-		validate   bool
+		mask     bool
+		validate bool
 	)
 	cmd := &cobra.Command{
 		Use:   "prompt",
@@ -21,8 +20,7 @@ func newPromptCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			opts := cmdio.PromptOptions{
-				Label:   "Enter a value",
-				Default: defaultVal,
+				Label: "Enter a value",
 			}
 			if mask {
 				opts.Mask = '*'
@@ -47,7 +45,6 @@ func newPromptCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&defaultVal, "default", "", "pre-fill the input with this value")
 	cmd.Flags().BoolVar(&mask, "mask", false, "echo input as '*'")
 	cmd.Flags().BoolVar(&validate, "validate", false, "require '://' in input")
 	return cmd

--- a/libs/cmdio/prompt.go
+++ b/libs/cmdio/prompt.go
@@ -11,9 +11,6 @@ type PromptOptions struct {
 	// Label is shown before the input field. Required.
 	Label string
 
-	// Default is the value pre-filled in the input field.
-	Default string
-
 	// Mask, when non-zero, replaces typed characters with the given rune
 	// (use '*' for password-style input).
 	Mask rune
@@ -31,7 +28,6 @@ func RunPrompt(ctx context.Context, opts PromptOptions) (string, error) {
 	c := fromContext(ctx)
 	p := promptui.Prompt{
 		Label:       opts.Label,
-		Default:     opts.Default,
 		Mask:        opts.Mask,
 		HideEntered: opts.HideEntered,
 		Validate:    opts.Validate,


### PR DESCRIPTION
## Summary
- Remove the `Default` field from `cmdio.PromptOptions`. No production caller sets it; `databricks auth login` renders the default in the label and substitutes it manually on empty input (see PR #3252). Follow-up to #5177, which removed the now-orphaned `AllowEdit` companion field.
- Drop the corresponding `--default` flag from `databricks selftest tui prompt`, which only existed to exercise the field.

This pull request and its description were written by Isaac.