### PR TITLE
acc: unset AI-agent env vars instead of setting them empty

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -198,6 +198,22 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	// Consistent behavior of locale-dependent tools, such as 'sort'
 	t.Setenv("LC_ALL", "C")
 
+	// Unset AI-agent detection env vars so the SDK's user-agent does not
+	// pick up the host's agent. Setting these to "" via test.toml is not
+	// enough: the SDK (since v0.132.0) treats empty values as a truthy
+	// signal because os.LookupEnv reports them as present.
+	for _, v := range []string{
+		"ANTIGRAVITY_AGENT",
+		"CLAUDECODE",
+		"CLINE_ACTIVE",
+		"CODEX_CI",
+		"CURSOR_AGENT",
+		"GEMINI_CLI",
+		"OPENCODE",
+	} {
+		os.Unsetenv(v) //nolint:usetesting // t.Setenv cannot unset
+	}
+
 	buildDir := getBuildDir(t, cwd, runtime.GOOS, runtime.GOARCH)
 
 	// Set up terraform for tests. Skip on DBR - tests with RunsOnDbr only use direct deployment.

--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -17,15 +17,6 @@ Env.PYTHONDONTWRITEBYTECODE = "1"
 Env.PYTHONUNBUFFERED = "1"
 Env.PYTHONUTF8 = "1"
 
-# Clear agent env vars to prevent them from affecting test output
-Env.ANTIGRAVITY_AGENT = ""
-Env.CLAUDECODE = ""
-Env.CLINE_ACTIVE = ""
-Env.CODEX_CI = ""
-Env.CURSOR_AGENT = ""
-Env.GEMINI_CLI = ""
-Env.OPENCODE = ""
-
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrixExclude.noplantf = ["DATABRICKS_BUNDLE_ENGINE=terraform", "READPLAN=1"]
 EnvRepl.DATABRICKS_BUNDLE_ENGINE = false


### PR DESCRIPTION
Move the agent env var scrub from `acceptance/test.toml` into `acceptance_test.go` and use `os.Unsetenv` so the keys are truly absent in child processes.

The old `Env.X = ""` approach left them present with an empty value; since SDK v0.132 the user-agent detector treats that as a match and stamps `agent/multiple` onto recorded requests.

This pull request and its description were written by Isaac.