### PR TITLE
auth: fix stale host prompt renders by shortening the prompt label

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 * `databricks auth describe` now reports where U2M (`databricks-cli`) tokens are stored: `plaintext` (`~/.databricks/token-cache.json`) or `secure` (OS keyring), and the source of the choice (env var, config setting, or default).
 * Marked the default profile in the interactive pickers shown by `databricks auth switch`, `databricks auth logout`, `databricks auth token`, and `databricks auth login`, and moved it to the top of the list. `databricks auth login` and `databricks auth logout` now offer the same selectors as `databricks auth token` and `databricks auth switch` respectively.
 * The interactive auth profile pickers now start in search mode so typing immediately filters the list, and the action entries (`+ Create a new profile`, `→ Enter a host URL manually`) are visually distinct from real profiles and stay visible regardless of the search query.
+* Shortened the host prompt label shown after `→ Enter a host URL manually` in `databricks auth login` so the prompt no longer leaves stale lines on screen when typing or pasting a host URL.
 
 ### Bundles
 * Stop applying `presets.name_prefix` (and the dev-mode `[dev <user>]` rename) to `vector_search_endpoints` ([#5209](https://github.com/databricks/cli/pull/5209)).

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -45,8 +45,13 @@ func promptForHost(ctx context.Context) (string, error) {
 		return "", errors.New("the command is being run in a non-interactive environment, please specify a host using --host")
 	}
 
+	// The hint is printed separately so the prompt label stays short.
+	// promptui's screenbuf does not account for terminal line wrapping, and a
+	// long "label + value" line that wraps causes each keystroke to leave a
+	// stale render on screen instead of overwriting the previous one.
+	cmdio.LogString(ctx, "Example: https://<databricks-instance>.cloud.databricks.com")
 	return cmdio.RunPrompt(ctx, cmdio.PromptOptions{
-		Label: "Databricks host (e.g. https://<databricks-instance>.cloud.databricks.com)",
+		Label: "Databricks host",
 	})
 }
 


### PR DESCRIPTION
## Why

In `databricks auth login`, after selecting `→ Enter a host URL manually`, typing or pasting a workspace URL would leave the prompt visibly stuck on screen — the same `✔ Databricks host …` line stacked up many times before the next prompt appeared. Functionally everything still worked, but the picker output looked broken.

## Changes

**Before:** The prompt label was

```
Databricks host (e.g. https://<databricks-instance>.cloud.databricks.com):
```

which is ~75 characters before the user even types anything. Once the value pushed the line past the terminal width, promptui's `screenbuf` (which only tracks logical lines, not wrapped physical lines) failed to clear the previous render on each keystroke, and stale copies stacked up.

**Now:** The example is printed once on its own line above the prompt and the prompt label is just `Databricks host`. With a realistic workspace URL the whole line stays well under 80 characters and never wraps in normal terminals.

```
Example: https://<databricks-instance>.cloud.databricks.com
✔ Databricks host: https://dogfood.staging.databricks.com/?o=60519214█
```

## Test plan

- [x] Reproduced the bug locally with a 100-col terminal and a typical workspace URL.
- [x] Verified the fix with the same URL: prompt renders on a single line, no stale duplicates.
- [x] `./task fmt-q`, `./task lint-q`, `./task checks` clean.
- [x] `go test ./cmd/auth/...` passes.