### PR TITLE
acc: fix volumes/recreate output after JSON formatter change

### DIFF
--- a/acceptance/bundle/resources/volumes/recreate/output.txt
+++ b/acceptance/bundle/resources/volumes/recreate/output.txt
@@ -28,7 +28,7 @@ Deployment complete!
 {
   "privilege_assignments": [
     {
-      "principal":"account users",
+      "principal": "account users",
       "privileges": [
         "WRITE_VOLUME"
       ]


### PR DESCRIPTION
Since #5170 the CLI's JSON output uses the standard `: ` separator (via `json.MarshalIndent`) rather than the compact `":"` form produced by the previous `nwidger/jsoncolor` dependency. The acceptance output for `bundle/resources/volumes/recreate` still captured the compact form for one `grants get` line and has been failing on UCWS nightlies since #5170 merged. #5227 picked up the same staleness in `TestClustersGet`; this picks up the missed acceptance output.

This pull request and its description were written by Isaac.