### PR TITLE
testserver: populate new postgres short-ID fields

### DIFF
--- a/acceptance/bundle/resources/postgres_branches/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/basic/output.txt
@@ -35,6 +35,7 @@ Deployment complete!
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
+    "branch_id": "main",
     "current_state": "READY",
     "default": false,
     "is_protected": false,

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.get_branch.txt
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.get_branch.txt
@@ -2,6 +2,7 @@
   "name": "[MAIN_ID_2]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
+    "branch_id": "new-branch-[UNIQUE_NAME]",
     "current_state": "READY",
     "default": false,
     "is_protected": false,

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
@@ -11,6 +11,7 @@
     "name": "[DEV_BRANCH_ID]",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
     "status": {
+      "branch_id": "dev-branch",
       "current_state": "READY",
       "default": false,
       "is_protected": false,

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
@@ -19,6 +19,7 @@
     "name": "[DEV_BRANCH_ID]",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
     "status": {
+      "branch_id": "dev-branch",
       "current_state": "READY",
       "default": false,
       "is_protected": true,

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
@@ -19,6 +19,7 @@
     "name": "[DEV_BRANCH_ID]",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
     "status": {
+      "branch_id": "dev-branch",
       "current_state": "READY",
       "default": false,
       "is_protected": false,

--- a/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
@@ -30,6 +30,7 @@ Deployment complete!
   "name": "[DEV_BRANCH_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
+    "branch_id": "dev-branch",
     "current_state": "READY",
     "default": false,
     "is_protected": false,
@@ -104,6 +105,7 @@ Deployment complete!
   "name": "[DEV_BRANCH_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
+    "branch_id": "dev-branch",
     "current_state": "READY",
     "default": false,
     "is_protected": true,
@@ -138,6 +140,7 @@ Deployment complete!
   "name": "[DEV_BRANCH_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
+    "branch_id": "dev-branch",
     "current_state": "READY",
     "default": false,
     "is_protected": false,

--- a/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
@@ -43,6 +43,7 @@ Deployment complete!
     "autoscaling_limit_min_cu": 0.5,
     "current_state": "ACTIVE",
     "disabled": false,
+    "endpoint_id": "custom",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
     "group": {
       "enable_readable_secondaries": true,

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
@@ -15,6 +15,7 @@
       "autoscaling_limit_min_cu": 0.5,
       "current_state": "ACTIVE",
       "disabled": false,
+      "endpoint_id": "my-endpoint",
       "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
       "group": {
         "enable_readable_secondaries": true,

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
@@ -25,6 +25,7 @@
       "autoscaling_limit_min_cu": 0.5,
       "current_state": "ACTIVE",
       "disabled": false,
+      "endpoint_id": "my-endpoint",
       "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
       "group": {
         "enable_readable_secondaries": true,

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
@@ -25,6 +25,7 @@
       "autoscaling_limit_min_cu": 0.5,
       "current_state": "ACTIVE",
       "disabled": false,
+      "endpoint_id": "my-endpoint",
       "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
       "group": {
         "enable_readable_secondaries": true,

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
@@ -35,6 +35,7 @@ Deployment complete!
     "autoscaling_limit_min_cu": 0.5,
     "current_state": "ACTIVE",
     "disabled": false,
+    "endpoint_id": "my-endpoint",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
     "group": {
       "enable_readable_secondaries": true,
@@ -122,6 +123,7 @@ Deployment complete!
     "autoscaling_limit_min_cu": 0.5,
     "current_state": "ACTIVE",
     "disabled": false,
+    "endpoint_id": "my-endpoint",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
     "group": {
       "enable_readable_secondaries": true,
@@ -165,6 +167,7 @@ Deployment complete!
     "autoscaling_limit_min_cu": 0.5,
     "current_state": "ACTIVE",
     "disabled": false,
+    "endpoint_id": "my-endpoint",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
     "group": {
       "enable_readable_secondaries": true,

--- a/acceptance/bundle/resources/postgres_projects/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/basic/output.txt
@@ -42,6 +42,7 @@ Deployment complete!
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
+    "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "synthetic_storage_size_bytes": 0
   },
   "uid": "[UUID]"

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
@@ -14,6 +14,7 @@
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
+    "project_id": "test-pg-new-[UNIQUE_NAME]",
     "synthetic_storage_size_bytes": 0
   },
   "uid": "[UUID]",

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -16,6 +16,7 @@
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,
+      "project_id": "test-pg-proj-[UNIQUE_NAME]",
       "synthetic_storage_size_bytes": 0
     },
     "uid": "[UUID]",

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -29,6 +29,7 @@
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,
+      "project_id": "test-pg-proj-[UNIQUE_NAME]",
       "synthetic_storage_size_bytes": 0
     },
     "uid": "[UUID]",

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -29,6 +29,7 @@
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,
+      "project_id": "test-pg-proj-[UNIQUE_NAME]",
       "synthetic_storage_size_bytes": 0
     },
     "uid": "[UUID]",

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
@@ -40,6 +40,7 @@ Deployment complete!
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
+    "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "synthetic_storage_size_bytes": 0
   },
   "uid": "[UUID]"
@@ -112,6 +113,7 @@ Deployment complete!
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
+    "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "synthetic_storage_size_bytes": 0
   },
   "uid": "[UUID]"
@@ -151,6 +153,7 @@ Deployment complete!
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
+    "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "synthetic_storage_size_bytes": 0
   },
   "uid": "[UUID]"

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -74,6 +74,7 @@ func (s *FakeWorkspace) PostgresProjectCreate(req Request, projectID string) Res
 	// Copy spec fields to status (API returns status as materialized view)
 	if project.Spec != nil {
 		project.Status = &postgres.ProjectStatus{
+			ProjectId:                   projectID,
 			DefaultBranch:               name + "/branches/production",
 			DisplayName:                 project.Spec.DisplayName,
 			PgVersion:                   project.Spec.PgVersion,
@@ -248,6 +249,7 @@ func (s *FakeWorkspace) PostgresBranchCreate(req Request, parent, branchID strin
 
 	// Initialize status with all required fields
 	branch.Status = &postgres.BranchStatus{
+		BranchId:         branchID,
 		CurrentState:     postgres.BranchStatusStateReady,
 		StateChangeTime:  now,
 		Default:          false,
@@ -425,6 +427,7 @@ func (s *FakeWorkspace) PostgresEndpointCreate(req Request, parent, endpointID s
 
 	// Initialize status with all required fields
 	endpoint.Status = &postgres.EndpointStatus{
+		EndpointId:             endpointID,
 		CurrentState:           postgres.EndpointStatusStateActive,
 		Disabled:               false,
 		Settings:               &postgres.EndpointSettings{},
@@ -642,6 +645,7 @@ func (s *FakeWorkspace) createDefaultBranchLocked(projectName string) {
 		CreateTime: now,
 		UpdateTime: now,
 		Status: &postgres.BranchStatus{
+			BranchId:         "production",
 			CurrentState:     postgres.BranchStatusStateReady,
 			StateChangeTime:  now,
 			Default:          true,


### PR DESCRIPTION
SDK v0.132.0 added `project_id`, `branch_id`, and `endpoint_id` to the postgres `*Status` types — short identifiers parallel to the existing full resource names. The cloud API was already returning these; older SDK versions silently dropped them, so acceptance fixtures didn't record them. With the bumped SDK, the new fields surface in test output and diverge from what the testserver returns.

Populate the IDs on resource creation so testserver responses match the cloud, and regenerate the affected postgres acceptance fixtures.

Verified locally and against aws-prod-ucws — postgres acceptance tests pass in both engines.