### PR TITLE
acc: Fixed failing TestAccept/bundle/generate/python_job_and_deploy

### DIFF
--- a/acceptance/bundle/generate/python_job_and_deploy/script
+++ b/acceptance/bundle/generate/python_job_and_deploy/script
@@ -11,6 +11,11 @@ JOB_ID=$($CLI jobs create --json '{
       "task_key": "test_task",
       "notebook_task": {
         "notebook_path": "/Workspace/Users/'${CURRENT_USER_NAME}'/test_notebook"
+      },
+      "new_cluster": {
+        "spark_version": "'${DEFAULT_SPARK_VERSION}'",
+        "node_type_id": "'${NODE_TYPE_ID}'",
+        "num_workers": 1
       }
     }
   ]


### PR DESCRIPTION
## Changes
Fixed failing TestAccept/bundle/generate/python_job_and_deploy

## Why
Nightlies were failing with 

```
--- bundle/generate/python_job_and_deploy/output.txt
          +++ /tmp/TestAcceptbundlegeneratepython_job_and_deployDATABRICKS_BUND3845738023/001/output.txt
          @@ -2,28 +2,6 @@
           === Upload notebook to a workspace path
           >>> [CLI] workspace import /Workspace/Users/[USERNAME]/test_notebook.py --file test_notebook.py --format AUTO --overwrite
           
          -=== Create a job that references the notebookCreated job
          +=== Create a job that references the notebookError: One of job_cluster_key, new_cluster, or existing_cluster_id must be specified. Serverless compute for workflows is not enabled in the workspace.
           
```

## Tests
Test succeeds on Cloud

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
