### PR TITLE
acc: Use unique pipeline name in TestAccept/bundle/generate/pipeline_and_deploy

### DIFF
--- a/acceptance/bundle/generate/pipeline_and_deploy/script
+++ b/acceptance/bundle/generate/pipeline_and_deploy/script
@@ -4,7 +4,7 @@ trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test.py" --fi
 
 title "Create a pipeline that references the files"
 PIPELINE_ID=$($CLI pipelines create --json '{
-  "name": "test-pipeline",
+  "name": "test-pipeline-${UNIQUE_NAME}",
   "libraries": [
     {
       "notebook": {


### PR DESCRIPTION
## Changes
Use unique pipeline name in TestAccept/bundle/generate/pipeline_and_deploy

## Why
Fixes the error
```
  acceptance_test.go:926: Diff:
          --- bundle/generate/pipeline_and_deploy/output.txt
          +++ /tmp/TestAcceptbundlegeneratepipeline_and_deployDATABRICKS_BUNDLE4019091230/001/output.txt
          @@ -4,29 +4,6 @@
           
           >>> [CLI] workspace import /Workspace/Users/[USERNAME]/test.py --file test.py --format AUTO --overwrite
           
          -=== Create a pipeline that references the filesCreated pipeline
          +=== Create a pipeline that references the filesError: The pipeline name 'test-pipeline' is already used by another pipeline. This check can be skipped by setting `allow_duplicate_names = true` in the request.
```

## Tests
Tests pass

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
