### PR TITLE
Make acceptance sethome export an absolute HOME (cross-platform)

### DIFF
--- a/acceptance/auth/bundle_default_profile/output.txt
+++ b/acceptance/auth/bundle_default_profile/output.txt
@@ -23,6 +23,10 @@ Exit code: 1
 === Bundle with workspace.host: default_profile is NOT applied
 
 >>> errcode [CLI] bundle validate -o json
+Error: failed during request visitor: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method. Config: host=[DATABRICKS_URL], workspace_id=[NUMID], databricks_cli_path=[CLI]. Env: DATABRICKS_CLI_PATH
+
+
+Exit code: 1
 {
   "host": "[DATABRICKS_URL]",
   "profile": null
@@ -31,7 +35,7 @@ Exit code: 1
 === Bundle with workspace.profile: pinned profile wins over default_profile
 
 >>> errcode [CLI] bundle validate -o json
-Error: Get "https://other.test/api/2.0/preview/scim/v2/Me": (redacted)
+Error: failed during request visitor: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method. Config: profile=other, databricks_cli_path=[CLI]. Env: DATABRICKS_CLI_PATH
 
 
 Exit code: 1

--- a/acceptance/auth/bundle_default_profile/output.txt
+++ b/acceptance/auth/bundle_default_profile/output.txt
@@ -23,10 +23,6 @@ Exit code: 1
 === Bundle with workspace.host: default_profile is NOT applied
 
 >>> errcode [CLI] bundle validate -o json
-Error: failed during request visitor: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method. Config: host=[DATABRICKS_URL], workspace_id=[NUMID], databricks_cli_path=[CLI]. Env: DATABRICKS_CLI_PATH
-
-
-Exit code: 1
 {
   "host": "[DATABRICKS_URL]",
   "profile": null
@@ -35,7 +31,7 @@ Exit code: 1
 === Bundle with workspace.profile: pinned profile wins over default_profile
 
 >>> errcode [CLI] bundle validate -o json
-Error: failed during request visitor: default auth: cannot configure default credentials, please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication to configure credentials for your preferred authentication method. Config: profile=other, databricks_cli_path=[CLI]. Env: DATABRICKS_CLI_PATH
+Error: Get "https://other.test/api/2.0/preview/scim/v2/Me": (redacted)
 
 
 Exit code: 1

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/output.txt
@@ -2,11 +2,11 @@
 >>> [CLI] auth describe --profile u2m-profile
 Warn: [hostmetadata] failed to fetch host metadata for https://u2m-profile.databricks.test, will skip for 1m0s
 Unable to authenticate: error getting token: cache: token not found
-Token storage: plaintext, ~/.databricks/token-cache.json (from auth_storage in [__settings__] section of home/.databrickscfg)
+Token storage: plaintext, ~/.databricks/token-cache.json (from auth_storage in [__settings__] section of [TEST_TMP_DIR]/home/.databrickscfg)
 -----
 Current configuration:
-  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
+  ✓ host: https://u2m-profile.databricks.test (from [TEST_TMP_DIR]/home/.databrickscfg config file)
   ✓ profile: u2m-profile (from --profile flag)
   ✓ databricks_cli_path: [CLI]
-  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
+  ✓ auth_type: databricks-cli (from [TEST_TMP_DIR]/home/.databrickscfg config file)
   ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/output.txt
@@ -2,11 +2,11 @@
 >>> [CLI] auth describe --profile u2m-profile
 Warn: [hostmetadata] failed to fetch host metadata for https://u2m-profile.databricks.test, will skip for 1m0s
 Unable to authenticate: error getting token: cache: token not found
-Token storage: plaintext, ~/.databricks/token-cache.json (from auth_storage in [__settings__] section of [TEST_TMP_DIR]/home/.databrickscfg)
+Token storage: plaintext, ~/.databricks/token-cache.json (from auth_storage in [__settings__] section of home/.databrickscfg)
 -----
 Current configuration:
-  ✓ host: https://u2m-profile.databricks.test (from [TEST_TMP_DIR]/home/.databrickscfg config file)
+  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
   ✓ profile: u2m-profile (from --profile flag)
   ✓ databricks_cli_path: [CLI]
-  ✓ auth_type: databricks-cli (from [TEST_TMP_DIR]/home/.databrickscfg config file)
+  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
   ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-default/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-default/output.txt
@@ -5,8 +5,8 @@ Unable to authenticate: error getting token: cache: token not found
 Token storage: plaintext, ~/.databricks/token-cache.json (from default)
 -----
 Current configuration:
-  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
+  ✓ host: https://u2m-profile.databricks.test (from [TEST_TMP_DIR]/home/.databrickscfg config file)
   ✓ profile: u2m-profile (from --profile flag)
   ✓ databricks_cli_path: [CLI]
-  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
+  ✓ auth_type: databricks-cli (from [TEST_TMP_DIR]/home/.databrickscfg config file)
   ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-default/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-default/output.txt
@@ -5,8 +5,8 @@ Unable to authenticate: error getting token: cache: token not found
 Token storage: plaintext, ~/.databricks/token-cache.json (from default)
 -----
 Current configuration:
-  ✓ host: https://u2m-profile.databricks.test (from [TEST_TMP_DIR]/home/.databrickscfg config file)
+  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
   ✓ profile: u2m-profile (from --profile flag)
   ✓ databricks_cli_path: [CLI]
-  ✓ auth_type: databricks-cli (from [TEST_TMP_DIR]/home/.databrickscfg config file)
+  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
   ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/output.txt
@@ -5,8 +5,8 @@ Unable to authenticate: error getting token: cache: token not found
 Token storage: plaintext, ~/.databricks/token-cache.json (from DATABRICKS_AUTH_STORAGE environment variable)
 -----
 Current configuration:
-  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
+  ✓ host: https://u2m-profile.databricks.test (from [TEST_TMP_DIR]/home/.databrickscfg config file)
   ✓ profile: u2m-profile (from --profile flag)
   ✓ databricks_cli_path: [CLI]
-  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
+  ✓ auth_type: databricks-cli (from [TEST_TMP_DIR]/home/.databrickscfg config file)
   ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/output.txt
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/output.txt
@@ -5,8 +5,8 @@ Unable to authenticate: error getting token: cache: token not found
 Token storage: plaintext, ~/.databricks/token-cache.json (from DATABRICKS_AUTH_STORAGE environment variable)
 -----
 Current configuration:
-  ✓ host: https://u2m-profile.databricks.test (from [TEST_TMP_DIR]/home/.databrickscfg config file)
+  ✓ host: https://u2m-profile.databricks.test (from ./home/.databrickscfg config file)
   ✓ profile: u2m-profile (from --profile flag)
   ✓ databricks_cli_path: [CLI]
-  ✓ auth_type: databricks-cli (from [TEST_TMP_DIR]/home/.databrickscfg config file)
+  ✓ auth_type: databricks-cli (from ./home/.databrickscfg config file)
   ✓ rate_limit: [NUMID] (from DATABRICKS_RATE_LIMIT environment variable)

--- a/acceptance/cmd/completion/output.txt
+++ b/acceptance/cmd/completion/output.txt
@@ -1,34 +1,34 @@
 
 >>> [CLI] completion install --shell zsh --auto-approve
 Databricks CLI completions installed for zsh.
-Restart your shell or run 'source [HOME]/.zshrc' to activate.
+Restart your shell or run 'source home/.zshrc' to activate.
 
 Warning: zsh completions require the completion system to be initialized.
-Add the following to your [HOME]/.zshrc:
+Add the following to your home/.zshrc:
   autoload -U compinit && compinit
 
 >>> [CLI] completion status --shell zsh
 Shell:   zsh
-File:    [HOME]/.zshrc
+File:    home/.zshrc
 Status:  installed
 
 Warning: zsh completions require the completion system to be initialized.
-Add the following to your [HOME]/.zshrc:
+Add the following to your home/.zshrc:
   autoload -U compinit && compinit
 
 >>> [CLI] completion install --shell zsh --auto-approve
-Databricks CLI completions are already installed for zsh in [HOME]/.zshrc.
+Databricks CLI completions are already installed for zsh in home/.zshrc.
 
 Warning: zsh completions require the completion system to be initialized.
-Add the following to your [HOME]/.zshrc:
+Add the following to your home/.zshrc:
   autoload -U compinit && compinit
 
 >>> [CLI] completion uninstall --shell zsh --auto-approve
-Databricks CLI completions removed for zsh from [HOME]/.zshrc.
+Databricks CLI completions removed for zsh from home/.zshrc.
 
 >>> [CLI] completion status --shell zsh
 Shell:   zsh
-File:    [HOME]/.zshrc
+File:    home/.zshrc
 Status:  not installed
 # bash completion V2 for databricks                           -*- shell-script -*-
 #compdef databricks

--- a/acceptance/cmd/completion/output.txt
+++ b/acceptance/cmd/completion/output.txt
@@ -1,34 +1,34 @@
 
 >>> [CLI] completion install --shell zsh --auto-approve
 Databricks CLI completions installed for zsh.
-Restart your shell or run 'source home/.zshrc' to activate.
+Restart your shell or run 'source [HOME]/.zshrc' to activate.
 
 Warning: zsh completions require the completion system to be initialized.
-Add the following to your home/.zshrc:
+Add the following to your [HOME]/.zshrc:
   autoload -U compinit && compinit
 
 >>> [CLI] completion status --shell zsh
 Shell:   zsh
-File:    home/.zshrc
+File:    [HOME]/.zshrc
 Status:  installed
 
 Warning: zsh completions require the completion system to be initialized.
-Add the following to your home/.zshrc:
+Add the following to your [HOME]/.zshrc:
   autoload -U compinit && compinit
 
 >>> [CLI] completion install --shell zsh --auto-approve
-Databricks CLI completions are already installed for zsh in home/.zshrc.
+Databricks CLI completions are already installed for zsh in [HOME]/.zshrc.
 
 Warning: zsh completions require the completion system to be initialized.
-Add the following to your home/.zshrc:
+Add the following to your [HOME]/.zshrc:
   autoload -U compinit && compinit
 
 >>> [CLI] completion uninstall --shell zsh --auto-approve
-Databricks CLI completions removed for zsh from home/.zshrc.
+Databricks CLI completions removed for zsh from [HOME]/.zshrc.
 
 >>> [CLI] completion status --shell zsh
 Shell:   zsh
-File:    home/.zshrc
+File:    [HOME]/.zshrc
 Status:  not installed
 # bash completion V2 for databricks                           -*- shell-script -*-
 #compdef databricks

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -101,24 +101,11 @@ sethome() {
     local home="$1"
     mkdir -p "$home"
 
-    # Resolve to an absolute path so HOME (and USERPROFILE) keep pointing at
-    # the same directory after the test cd's elsewhere. The SDK expands
-    # `~/.databrickscfg` against $HOME at lookup time; with a relative path
-    # the cfg silently disappears once the cwd changes, and helpers like
-    # databrickscfg.GetConfiguredDefaultProfile return "" instead of
-    # erroring.
-
     # For macOS and Linux, use HOME.
-    export HOME="$(cd "$home" && pwd)"
+    export HOME="$home"
 
-    # For Windows, use USERPROFILE. On Git Bash (MSYS), plain `pwd` returns
-    # Unix-style /c/... paths that the native Windows Go binary can't open;
-    # `pwd -W` returns the mixed C:/... form instead.
-    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
-        export USERPROFILE="$(cd "$home" && pwd -W)"
-    else
-        export USERPROFILE="$(cd "$home" && pwd)"
-    fi
+    # For Windows, use USERPROFILE.
+    export USERPROFILE="$home"
 }
 
 as-test-sp() {

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -101,6 +101,25 @@ sethome() {
     local home="$1"
     mkdir -p "$home"
 
+    # Resolve to an absolute path so HOME (and USERPROFILE) keep pointing at
+    # the same directory after the test cd's elsewhere. The SDK expands
+    # `~/.databrickscfg` against $HOME at lookup time; with a relative path
+    # the cfg silently disappears once the cwd changes, and helpers like
+    # databrickscfg.GetConfiguredDefaultProfile return "" instead of
+    # erroring.
+    #
+    # On Git Bash (MSYS), plain `pwd` returns Unix-style /c/... paths that
+    # the native Windows Go binary can't open; `pwd -W` returns the mixed
+    # C:/... form instead. Use the same form for both HOME and USERPROFILE
+    # so tests that compare a `$HOME`-based placeholder against the CLI's
+    # `os.UserHomeDir()` output (which reads USERPROFILE on Windows) find
+    # a match.
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+        home="$(cd "$home" && pwd -W)"
+    else
+        home="$(cd "$home" && pwd)"
+    fi
+
     # For macOS and Linux, use HOME.
     export HOME="$home"
 

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -101,6 +101,14 @@ sethome() {
     local home="$1"
     mkdir -p "$home"
 
+    # Resolve to an absolute path so HOME (and USERPROFILE) keep pointing at
+    # the same directory after the test cd's elsewhere. The SDK expands
+    # `~/.databrickscfg` against $HOME at lookup time; with a relative path
+    # the cfg silently disappears once the cwd changes, and helpers like
+    # databrickscfg.GetConfiguredDefaultProfile return "" instead of
+    # erroring. `cd && pwd` is portable across macOS/Linux/Windows-MSYS.
+    home="$(cd "$home" && pwd)"
+
     # For macOS and Linux, use HOME.
     export HOME="$home"
 

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -106,14 +106,19 @@ sethome() {
     # `~/.databrickscfg` against $HOME at lookup time; with a relative path
     # the cfg silently disappears once the cwd changes, and helpers like
     # databrickscfg.GetConfiguredDefaultProfile return "" instead of
-    # erroring. `cd && pwd` is portable across macOS/Linux/Windows-MSYS.
-    home="$(cd "$home" && pwd)"
+    # erroring.
 
     # For macOS and Linux, use HOME.
-    export HOME="$home"
+    export HOME="$(cd "$home" && pwd)"
 
-    # For Windows, use USERPROFILE.
-    export USERPROFILE="$home"
+    # For Windows, use USERPROFILE. On Git Bash (MSYS), plain `pwd` returns
+    # Unix-style /c/... paths that the native Windows Go binary can't open;
+    # `pwd -W` returns the mixed C:/... form instead.
+    if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+        export USERPROFILE="$(cd "$home" && pwd -W)"
+    else
+        export USERPROFILE="$(cd "$home" && pwd)"
+    fi
 }
 
 as-test-sp() {


### PR DESCRIPTION
Follow-up to #5214 

sethome exported HOME (and USERPROFILE) as the relative path the caller passed in (typically "./home"). The SDK expands `~/.databrickscfg` against $HOME at lookup time, so the moment a test cd's into a child directory the cfg "disappears": helpers like
databrickscfg.GetConfiguredDefaultProfile silently return "" because the relative path no longer points at a real file. That made it easy to write tests that look like they exercise default_profile resolution but actually only succeed because the cfg lookup short-circuits.

Resolve $1 to an absolute path with `cd && pwd` before exporting. On Git Bash (MSYS) plain `pwd` returns Unix-style /c/... paths that the native Windows Go binary can't open, so use `pwd -W` to get the mixed C:/... form. Use the same form for both HOME and USERPROFILE so tests like cmd/completion (which registers `$HOME` as the `[HOME]` replacement) match the CLI's USERPROFILE-derived output on Windows.

Regenerate the four affected outputs.

Co-authored-by: Isaac
