### PR TITLE
Bump NEXT_CHANGELOG to v1.0.0 and add SECURITY.md support policy

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,8 +1,10 @@
 # NEXT CHANGELOG
 
-## Release v0.300.0
+## Release v1.0.0
 
 ### Notable Changes
+
+* The Databricks CLI is now generally available. v1.0.0 is the first major release. From this version on, the CLI follows semantic versioning: breaking changes will only ship in a new major version. The 0.299.x line continues to receive security-critical patches through June 2027; see SECURITY.md for the support policy.
 
 ### CLI
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,13 @@
+## Supported Versions
+
+| Version | Supported                                         |
+| ------- | ------------------------------------------------- |
+| 1.x     | Full support                                      |
+| 0.299.x | Security-critical patches only, through June 2027 |
+| < 0.299 | Not supported                                     |
+
+New features and non-critical fixes land on the 1.x line only. The 0.299.x line receives security-critical patches for one year after the v1.0.0 release to give users on the 0.x line time to migrate.
+
 ## Reporting a Vulnerability
 
 We appreciate any security concerns brought to our attention and encourage you to notify us of any potential vulnerabilities discovered in our systems or products.


### PR DESCRIPTION
## Why

The next CLI release is v1.0.0, the first generally available major release (the previous shipped release was v0.299.2; `v0.300.0` was only a placeholder in `NEXT_CHANGELOG.md`, never released). The release notes need to reflect the v1.0 milestone, and `SECURITY.md` needs to document how long the 0.x line will continue to receive patches so users have a clear migration window.

## Changes

**Before:** `NEXT_CHANGELOG.md` headed the next release as `v0.300.0` (placeholder) with no GA messaging. `SECURITY.md` only had a one-line vulnerability reporting paragraph; no statement of which versions are supported.

**Now:**
- `NEXT_CHANGELOG.md` heads the next release as `v1.0.0` (jumping from the v0.299.2 released line) and opens Notable Changes with a one-line GA statement: first major release, semver from here on, 0.299.x continues to get security-critical patches through June 2027 with a pointer to SECURITY.md.
- `SECURITY.md` gets a Supported Versions table at the top: 1.x (full support), 0.299.x (security-critical patches only, through June 2027), < 0.299 (not supported), plus a short paragraph explaining the policy.

Conflicts likely with #5272 (also touches `NEXT_CHANGELOG.md` Notable Changes). Whichever lands first, the other rebases.

## Test plan

- [x] `./task checks` clean (tidy, whitespace, links, deadcode).
- [x] Manual review of rendered Markdown for both files.
- [ ] Confirm June 2027 date and "security-critical patches only" wording match the announced support policy.

This pull request and its description were written by Claude.