### PR TITLE
acceptance: guard git-repo-init against running inside an existing repo

### DIFF
--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -49,6 +49,10 @@ trace() {
 }
 
 git-repo-init() {
+    if git rev-parse --git-dir > /dev/null 2>&1; then
+        echo "git-repo-init: already inside a git repository" >&2
+        return 1
+    fi
     git init -qb main
     git config core.autocrlf false
     git config user.name "Tester"


### PR DESCRIPTION
## Why

"git config" writes to whatever repo CWD is in, so calling git-repo-init from inside an existing repo poisons that repo's config without any error signal. I had my cli repo config messed up by an agent.

Co-authored-by: Isaac