### PR TITLE
auth: add DATABRICKS_DISCOVERY_HOST env var to override login.databricks.com

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,7 +8,6 @@
 
 * Added `databricks aitools` command group for installing Databricks skills into your coding agents (Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Antigravity). Skills are fetched from [github.com/databricks/databricks-agent-skills](https://github.com/databricks/databricks-agent-skills) and either symlinked into each agent's skills directory or copied into the current project. Use `databricks aitools install` to set up, `update` to pull newer versions, `list` to see what's available, and `uninstall` to remove them.
 * `[__settings__].default_profile` is now consulted as a fallback by `databricks api`, `databricks auth token`, and bundle commands when neither `--profile` nor `DATABRICKS_CONFIG_PROFILE` is set. `databricks auth token` continues to give precedence to `DATABRICKS_HOST` over `default_profile`. For bundle commands, `default_profile` only applies when the bundle does not pin its own `workspace.host`.
-* Added `DATABRICKS_DISCOVERY_HOST` environment variable to override the default `https://login.databricks.com` host used by the `databricks auth login` discovery flow. Intended for testing and development against non-production login instances; unset for normal use.
 
 ### Bundles
 * Make sure warnings asking for approval are understood by agents ([#5239](https://github.com/databricks/cli/pull/5239))

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Added `databricks aitools` command group for installing Databricks skills into your coding agents (Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Antigravity). Skills are fetched from [github.com/databricks/databricks-agent-skills](https://github.com/databricks/databricks-agent-skills) and either symlinked into each agent's skills directory or copied into the current project. Use `databricks aitools install` to set up, `update` to pull newer versions, `list` to see what's available, and `uninstall` to remove them.
 * `[__settings__].default_profile` is now consulted as a fallback by `databricks api`, `databricks auth token`, and bundle commands when neither `--profile` nor `DATABRICKS_CONFIG_PROFILE` is set. `databricks auth token` continues to give precedence to `DATABRICKS_HOST` over `default_profile`. For bundle commands, `default_profile` only applies when the bundle does not pin its own `workspace.host`.
+* Added `DATABRICKS_DISCOVERY_HOST` environment variable to override the default `https://login.databricks.com` host used by the `databricks auth login` discovery flow. Intended for testing and development against non-production login instances; unset for normal use.
 
 ### Bundles
 * Make sure warnings asking for approval are understood by agents ([#5239](https://github.com/databricks/cli/pull/5239))

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -46,6 +46,11 @@ const (
 	defaultTimeout          = 1 * time.Hour
 	authTypeDatabricksCLI   = "databricks-cli"
 	discoveryFallbackTip    = "\n\nTip: you can specify a workspace directly with: databricks auth login --host <url>"
+	// discoveryHostEnvVar overrides the default https://login.databricks.com
+	// host used by the discovery login flow. Intended for testing and
+	// development against non-production environments. See WithDiscoveryHost
+	// in github.com/databricks/databricks-sdk-go/credentials/u2m.
+	discoveryHostEnvVar = "DATABRICKS_DISCOVERY_HOST"
 )
 
 // discoveryErr wraps an error (or creates a new one) and appends the
@@ -618,6 +623,10 @@ func discoveryLogin(ctx context.Context, in discoveryLoginInputs) error {
 	if len(scopesList) > 0 {
 		opts = append(opts, u2m.WithScopes(scopesList))
 	}
+	discoveryHost := env.Get(ctx, discoveryHostEnvVar)
+	if discoveryHost != "" {
+		opts = append(opts, u2m.WithDiscoveryHost(discoveryHost))
+	}
 
 	// Apply timeout before creating PersistentAuth so Challenge() respects it.
 	ctx, cancel := context.WithTimeout(ctx, in.timeout)
@@ -629,7 +638,11 @@ func discoveryLogin(ctx context.Context, in discoveryLoginInputs) error {
 	}
 	defer persistentAuth.Close()
 
-	cmdio.LogString(ctx, "Opening login.databricks.com in your browser...")
+	displayHost := "login.databricks.com"
+	if discoveryHost != "" {
+		displayHost = discoveryHost
+	}
+	cmdio.LogString(ctx, fmt.Sprintf("Opening %s in your browser...", displayHost))
 	if err := persistentAuth.Challenge(); err != nil {
 		return discoveryErr("login via login.databricks.com failed", err)
 	}

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -1082,6 +1082,40 @@ auth_type = databricks-cli
 	assert.Equal(t, "222222", savedProfile.WorkspaceID, "workspace_id should be updated to fresh introspection value")
 }
 
+func TestDiscoveryLogin_OverridesHostFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".databrickscfg")
+	err := os.WriteFile(configPath, []byte(""), 0o600)
+	require.NoError(t, err)
+	t.Setenv("DATABRICKS_CONFIG_FILE", configPath)
+
+	oauthArg, err := u2m.NewBasicDiscoveryOAuthArgument("DISCOVERY")
+	require.NoError(t, err)
+	oauthArg.SetDiscoveredHost("https://workspace.example.com")
+
+	dc := &fakeDiscoveryClient{
+		oauthArg: oauthArg,
+		persistentAuth: &fakeDiscoveryPersistentAuth{
+			token: &oauth2.Token{AccessToken: "test-token"},
+		},
+		introspectionErr: errors.New("introspection failed"),
+	}
+
+	ctx, stderr := cmdio.NewTestContextWithStderr(t.Context())
+	ctx = env.Set(ctx, "DATABRICKS_DISCOVERY_HOST", "https://login.staging.test")
+	err = discoveryLogin(ctx, discoveryLoginInputs{
+		dc:          dc,
+		profileName: "DISCOVERY",
+		timeout:     time.Second,
+		browserFunc: func(string) error { return nil },
+		tokenCache:  newTestTokenCache(),
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "Opening https://login.staging.test in your browser...")
+	assert.NotContains(t, stderr.String(), "Opening login.databricks.com in your browser...")
+}
+
 func TestLoginRejectsPositionalArgWithHostFlag(t *testing.T) {
 	ctx := cmdio.MockDiscard(t.Context())
 	authArgs := &auth.AuthArguments{Host: "https://example.com"}


### PR DESCRIPTION
## Why

The discovery login flow (`databricks auth login` without `--host`) opens `https://login.databricks.com`. That host is hardcoded in the CLI, so there is no way to point the flow at a non-production login instance during testing or development.

The SDK already exposes `u2m.WithDiscoveryHost` (added in databricks-sdk-go #1640, on the CLI's pinned v0.132.0). This PR wires it up.

## Changes

**Before:** No way to override the discovery host. `databricks auth login` always opens `https://login.databricks.com`.

**Now:** If `DATABRICKS_DISCOVERY_HOST` is set, the CLI passes it through to `u2m.WithDiscoveryHost(...)`. When unset, behavior is identical to before. The "Opening ... in your browser..." log line reflects the override host so it's clear which host is being opened.

Intended for testing and development against non-production login instances; unset for normal use.

## Test plan

- [x] New unit test `TestDiscoveryLogin_OverridesHostFromEnv` confirms the env var is read and the log message reflects the override host
- [x] `go test ./cmd/auth/...` passes
- [x] `./task checks` passes
- [x] `./task lint-q` passes