### PR TITLE
[lakebox] Default staging SSH gateway to ue1.s.dbrx.dev

### DIFF
--- a/cmd/lakebox/ssh.go
+++ b/cmd/lakebox/ssh.go
@@ -16,13 +16,14 @@ import (
 
 const (
 	defaultGatewayHost        = "uw2.dbrx.dev"
-	stagingDefaultGatewayHost = "uw2.s.dbrx.dev"
+	stagingDefaultGatewayHost = "ue1.s.dbrx.dev"
 	defaultGatewayPort        = "2222"
 )
 
 // resolveGatewayHost picks the SSH gateway hostname based on the workspace host.
 // Staging workspaces (*.staging.cloud.databricks.com etc.) route through
-// uw2.s.dbrx.dev; everything else uses prod uw2.dbrx.dev.
+// ue1.s.dbrx.dev; everything else uses uw2.dbrx.dev. Both are dev-tier
+// listeners (`.dbrx.dev`); there is no prod listener yet.
 func resolveGatewayHost(workspaceHost string) string {
 	if strings.Contains(workspaceHost, ".staging.") {
 		return stagingDefaultGatewayHost


### PR DESCRIPTION
us-east-1 is the staging region where the SSH gateway is reachable in practice; uw2.s.dbrx.dev does not have a routable lakebox listener. Users targeting a different staging region can still override with --gateway.

Co-authored-by: Isaac

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
