### PR TITLE
testserver: default postgres project enable_pg_native_login to false

### DIFF
--- a/acceptance/bundle/resources/postgres_projects/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/basic/output.txt
@@ -38,7 +38,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Test Postgres Project",
-    "enable_pg_native_login": true,
+    "enable_pg_native_login": false,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
@@ -10,7 +10,7 @@
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Test Recreate",
-    "enable_pg_native_login": true,
+    "enable_pg_native_login": false,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -13,7 +13,7 @@
         "suspend_timeout_duration": "300s"
       },
       "display_name": "Original Name",
-      "enable_pg_native_login": true,
+      "enable_pg_native_login": false,
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -26,7 +26,7 @@
         "suspend_timeout_duration": "300s"
       },
       "display_name": "Updated Name",
-      "enable_pg_native_login": true,
+      "enable_pg_native_login": false,
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -26,7 +26,7 @@
         "suspend_timeout_duration": "300s"
       },
       "display_name": "Original Name",
-      "enable_pg_native_login": true,
+      "enable_pg_native_login": false,
       "history_retention_duration": "604800s",
       "owner": "[USERNAME]",
       "pg_version": 16,

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
@@ -36,7 +36,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Original Name",
-    "enable_pg_native_login": true,
+    "enable_pg_native_login": false,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
@@ -109,7 +109,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Updated Name",
-    "enable_pg_native_login": true,
+    "enable_pg_native_login": false,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,
@@ -149,7 +149,7 @@ Deployment complete!
       "suspend_timeout_duration": "300s"
     },
     "display_name": "Original Name",
-    "enable_pg_native_login": true,
+    "enable_pg_native_login": false,
     "history_retention_duration": "604800s",
     "owner": "[USERNAME]",
     "pg_version": 16,

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -109,11 +109,11 @@ func (s *FakeWorkspace) PostgresProjectCreate(req Request, projectID string) Res
 			DisplayName:                 project.Spec.DisplayName,
 			PgVersion:                   project.Spec.PgVersion,
 			HistoryRetentionDuration:    project.Spec.HistoryRetentionDuration,
-			EnablePgNativeLogin:         true,
+			EnablePgNativeLogin:         false,
 			Owner:                       TestUser.UserName,
 			BranchLogicalSizeLimitBytes: 8796093022208, // 8 TB (real API default)
 			SyntheticStorageSizeBytes:   0,
-			ForceSendFields:             []string{"SyntheticStorageSizeBytes"},
+			ForceSendFields:             []string{"EnablePgNativeLogin", "SyntheticStorageSizeBytes"},
 		}
 		if project.Spec.DefaultEndpointSettings != nil {
 			project.Status.DefaultEndpointSettings = &postgres.ProjectDefaultEndpointSettings{


### PR DESCRIPTION
The backend returns `enable_pg_native_login: false` by default on project creation, causing integration test divergence in `postgres_projects/*`.

Match the backend in testserver: set the default to `false` and add it to `ForceSendFields` so the field is emitted explicitly (the real API includes it in the response rather than omitting the zero value). Regenerated acceptance fixtures accordingly.

This pull request and its description were written by Isaac.