### PR TITLE
Fix pydabs acceptance test regex to match v1.x bundle versions

### DIFF
--- a/acceptance/bundle/templates/pydabs/test.toml
+++ b/acceptance/bundle/templates/pydabs/test.toml
@@ -5,5 +5,5 @@ Local = true
 Cloud = false
 
 [[Repls]]
-Old = '"databricks-bundles==0.\d+.\d+"'
+Old = '"databricks-bundles==\d+\.\d+\.\d+"'
 New = '"databricks-bundles==x.y.z"'


### PR DESCRIPTION
The `acceptance/bundle/templates/pydabs/test.toml` replacement regex only matched `databricks-bundles==0.x.y`, so after the v1.0.0 release the wheel version `1.0.0` slipped through unredacted and the recorded output (`databricks-bundles==x.y.z`) no longer matched.

Broaden the regex to `\d+\.\d+\.\d+` (and escape the dots) so any future version is normalized.