### PR TITLE
Suggest bundle.engine config alternative in direct-only resource error

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,3 +7,4 @@
 ### CLI
 
 ### Bundles
+* The error reported when a direct-only resource (catalogs, external locations, vector search endpoints) is used with the terraform engine now also suggests setting `bundle.engine: direct` in `databricks.yml`, in addition to the `DATABRICKS_BUNDLE_ENGINE` environment variable.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,4 +7,4 @@
 ### CLI
 
 ### Bundles
-* The error reported when a direct-only resource (catalogs, external locations, vector search endpoints) is used with the terraform engine now also suggests setting `bundle.engine: direct` in `databricks.yml`, in addition to the `DATABRICKS_BUNDLE_ENGINE` environment variable.
+* The error reported when a direct-only resource (catalogs, external locations, vector search endpoints) is used with the terraform engine now also suggests setting `bundle.engine: direct` in `databricks.yml`, in addition to the `DATABRICKS_BUNDLE_ENGINE` environment variable ([#5295](https://github.com/databricks/cli/pull/5295)).

--- a/acceptance/bundle/validate/catalog_requires_direct_mode/output.txt
+++ b/acceptance/bundle/validate/catalog_requires_direct_mode/output.txt
@@ -1,7 +1,7 @@
 Error: Catalog resources are only supported with direct deployment mode
   in databricks.yml:6:5
 
-Catalog resources require direct deployment mode. Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use catalog resources.
+Catalog resources require direct deployment mode. Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' or set 'bundle.engine: direct' in your databricks.yml to use catalog resources.
 Learn more at https://docs.databricks.com/dev-tools/bundles/direct
 
 

--- a/bundle/config/mutator/validate_direct_only_resources.go
+++ b/bundle/config/mutator/validate_direct_only_resources.go
@@ -51,7 +51,7 @@ func (m *validateDirectOnlyResources) Apply(ctx context.Context, b *bundle.Bundl
 			Severity: diag.Error,
 			Summary:  group.Description.SingularTitle + " resources are only supported with direct deployment mode",
 			Detail: fmt.Sprintf("%s resources require direct deployment mode. "+
-				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use %s resources.\n"+
+				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' or set 'bundle.engine: direct' in your databricks.yml to use %s resources.\n"+
 				"Learn more at https://docs.databricks.com/dev-tools/bundles/direct",
 				group.Description.SingularTitle, group.Description.SingularName),
 			Locations: b.Config.GetLocations("resources." + group.Description.PluralName),

--- a/bundle/config/mutator/validate_direct_only_resources_test.go
+++ b/bundle/config/mutator/validate_direct_only_resources_test.go
@@ -61,7 +61,7 @@ func TestValidateDirectOnlyResourcesTerraformEngineDirectOnlyEmitsError(t *testi
 			},
 			expectedSummary: "Catalog resources are only supported with direct deployment mode",
 			expectedDetail: "Catalog resources require direct deployment mode. " +
-				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use catalog resources.\n" +
+				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' or set 'bundle.engine: direct' in your databricks.yml to use catalog resources.\n" +
 				"Learn more at https://docs.databricks.com/dev-tools/bundles/direct",
 		},
 		{
@@ -77,7 +77,7 @@ func TestValidateDirectOnlyResourcesTerraformEngineDirectOnlyEmitsError(t *testi
 			},
 			expectedSummary: "External Location resources are only supported with direct deployment mode",
 			expectedDetail: "External Location resources require direct deployment mode. " +
-				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use external_location resources.\n" +
+				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' or set 'bundle.engine: direct' in your databricks.yml to use external_location resources.\n" +
 				"Learn more at https://docs.databricks.com/dev-tools/bundles/direct",
 		},
 		{
@@ -93,7 +93,7 @@ func TestValidateDirectOnlyResourcesTerraformEngineDirectOnlyEmitsError(t *testi
 			},
 			expectedSummary: "Vector Search Endpoint resources are only supported with direct deployment mode",
 			expectedDetail: "Vector Search Endpoint resources require direct deployment mode. " +
-				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' to use vector_search_endpoint resources.\n" +
+				"Please set the DATABRICKS_BUNDLE_ENGINE environment variable to 'direct' or set 'bundle.engine: direct' in your databricks.yml to use vector_search_endpoint resources.\n" +
 				"Learn more at https://docs.databricks.com/dev-tools/bundles/direct",
 		},
 	}


### PR DESCRIPTION
## Changes
Update the error emitted by `ValidateDirectOnlyResources` (raised when a direct-only resource type — catalogs, external locations, vector search endpoints — is declared while running with the terraform engine) to mention both ways of switching to the direct engine:

> Please set the `DATABRICKS_BUNDLE_ENGINE` environment variable to 'direct' **or set `bundle.engine: direct` in your databricks.yml** to use ... resources.

## Why
The previous wording only pointed users at the env var. `bundle.engine` is the equivalent (and usually more durable) configuration knob, so mentioning it makes the error actionable for users who prefer to declare engine choice in `databricks.yml` instead of plumbing an env var through their workflow.

## Tests
- `go test ./bundle/config/mutator/ -run TestValidateDirectOnlyResources` — unit tests updated to assert the new message.
- `go test ./acceptance -run TestAccept/bundle/validate/catalog_requires_direct_mode` — acceptance snapshot updated.
- `./task fmt`, `./task checks`, `./task lint` — clean.

_This PR was written by Claude Code._