### PR TITLE
Remove Public Preview note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![build](https://github.com/databricks/cli/workflows/build/badge.svg?branch=main)](https://github.com/databricks/cli/actions?query=workflow%3Abuild+branch%3Amain)
 
-This project is in Public Preview.
-
 Documentation is available at https://docs.databricks.com/dev-tools/cli/databricks-cli.html.
 
 ## Installation


### PR DESCRIPTION
## Why

The CLI is GA, so the "This project is in Public Preview" line at the top of the README is no longer accurate.

## Changes

Before: README opens with a "This project is in Public Preview." line.
Now: That line is gone; the README jumps from the build badge straight to the documentation link.

## Test plan

- [x] `./task checks` passes