### PR TITLE
Bump Go to 1.26.3

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,3 +8,6 @@
 
 ### Bundles
 * The error reported when a direct-only resource (catalogs, external locations, vector search endpoints) is used with the terraform engine now also suggests setting `bundle.engine: direct` in `databricks.yml`, in addition to the `DATABRICKS_BUNDLE_ENGINE` environment variable ([#5295](https://github.com/databricks/cli/pull/5295)).
+
+### Dependency updates
+* Bump Go toolchain to 1.26.3 ([#5302](https://github.com/databricks/cli/pull/5302)).

--- a/bundle/config/resources/dashboard_test.go
+++ b/bundle/config/resources/dashboard_test.go
@@ -29,8 +29,8 @@ func TestDashboardConfigIsSupersetOfSDKDashboard(t *testing.T) {
 
 	// Create a map of SDK fields by name and their JSON tags
 	sdkFields := make(map[string]string)
-	for i := range sdkType.NumField() {
-		field := sdkType.Field(i)
+	for field := range sdkType.Fields() {
+		field := field
 		jsonTag := field.Tag.Get("json")
 		jsonName := getJSONTagName(jsonTag)
 		if jsonName != "" {
@@ -40,8 +40,8 @@ func TestDashboardConfigIsSupersetOfSDKDashboard(t *testing.T) {
 
 	// Create a map of config fields by name and their JSON tags
 	configFields := make(map[string]string)
-	for i := range configType.NumField() {
-		field := configType.Field(i)
+	for field := range configType.Fields() {
+		field := field
 		jsonTag := field.Tag.Get("json")
 		jsonName := getJSONTagName(jsonTag)
 		if jsonName != "" {

--- a/bundle/config/resources/dashboard_test.go
+++ b/bundle/config/resources/dashboard_test.go
@@ -30,7 +30,6 @@ func TestDashboardConfigIsSupersetOfSDKDashboard(t *testing.T) {
 	// Create a map of SDK fields by name and their JSON tags
 	sdkFields := make(map[string]string)
 	for field := range sdkType.Fields() {
-		field := field
 		jsonTag := field.Tag.Get("json")
 		jsonName := getJSONTagName(jsonTag)
 		if jsonName != "" {
@@ -41,7 +40,6 @@ func TestDashboardConfigIsSupersetOfSDKDashboard(t *testing.T) {
 	// Create a map of config fields by name and their JSON tags
 	configFields := make(map[string]string)
 	for field := range configType.Fields() {
-		field := field
 		jsonTag := field.Tag.Get("json")
 		jsonName := getJSONTagName(jsonTag)
 		if jsonName != "" {

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -54,8 +54,6 @@ func TestCustomMarshallerIsImplemented(t *testing.T) {
 	rt := reflect.TypeFor[Resources]()
 
 	for field := range rt.Fields() {
-		field := field
-
 		// Fields in Resources are expected be of the form map[string]*resourceStruct
 		assert.Equal(t, reflect.Map, field.Type.Kind(), "Resource %s is not a map", field.Name)
 		kt := field.Type.Key()
@@ -96,7 +94,6 @@ func TestResourcesAllResourcesCompleteness(t *testing.T) {
 	}
 
 	for field := range rt.Fields() {
-		field := field
 		jsonTag := field.Tag.Get("json")
 
 		if idx := strings.Index(jsonTag, ","); idx != -1 {
@@ -113,7 +110,6 @@ func TestSupportedResources(t *testing.T) {
 
 	typ := reflect.TypeFor[Resources]()
 	for field := range typ.Fields() {
-		field := field
 		jsonTags := strings.Split(field.Tag.Get("json"), ",")
 		pluralName := jsonTags[0]
 		assert.Equal(t, actual[pluralName].PluralName, pluralName)

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -53,8 +53,8 @@ import (
 func TestCustomMarshallerIsImplemented(t *testing.T) {
 	rt := reflect.TypeFor[Resources]()
 
-	for i := range rt.NumField() {
-		field := rt.Field(i)
+	for field := range rt.Fields() {
+		field := field
 
 		// Fields in Resources are expected be of the form map[string]*resourceStruct
 		assert.Equal(t, reflect.Map, field.Type.Kind(), "Resource %s is not a map", field.Name)
@@ -95,8 +95,8 @@ func TestResourcesAllResourcesCompleteness(t *testing.T) {
 		types = append(types, group.Description.PluralName)
 	}
 
-	for i := range rt.NumField() {
-		field := rt.Field(i)
+	for field := range rt.Fields() {
+		field := field
 		jsonTag := field.Tag.Get("json")
 
 		if idx := strings.Index(jsonTag, ","); idx != -1 {
@@ -112,8 +112,8 @@ func TestSupportedResources(t *testing.T) {
 	actual := SupportedResources()
 
 	typ := reflect.TypeFor[Resources]()
-	for i := range typ.NumField() {
-		field := typ.Field(i)
+	for field := range typ.Fields() {
+		field := field
 		jsonTags := strings.Split(field.Tag.Get("json"), ",")
 		pluralName := jsonTags[0]
 		assert.Equal(t, actual[pluralName].PluralName, pluralName)

--- a/bundle/deploy/terraform/tfdyn/convert_job_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_job_test.go
@@ -296,8 +296,8 @@ func TestSupportedTypeTasksComplete(t *testing.T) {
 	taskType := reflect.TypeFor[jobs.Task]()
 	var tasksWithSource []string
 
-	for i := range taskType.NumField() {
-		field := taskType.Field(i)
+	for field := range taskType.Fields() {
+		field := field
 
 		// Skip non-task fields (like DependsOn, Libraries, etc.)
 		if !strings.HasSuffix(field.Name, "Task") {
@@ -351,8 +351,8 @@ func findSourceFieldsShallow(t reflect.Type) []string {
 
 	var paths []string
 
-	for i := range t.NumField() {
-		field := t.Field(i)
+	for field := range t.Fields() {
+		field := field
 
 		// Check if this field is named "Source"
 		if field.Name == "Source" {

--- a/bundle/deploy/terraform/tfdyn/convert_job_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_job_test.go
@@ -297,8 +297,6 @@ func TestSupportedTypeTasksComplete(t *testing.T) {
 	var tasksWithSource []string
 
 	for field := range taskType.Fields() {
-		field := field
-
 		// Skip non-task fields (like DependsOn, Libraries, etc.)
 		if !strings.HasSuffix(field.Name, "Task") {
 			continue
@@ -352,8 +350,6 @@ func findSourceFieldsShallow(t reflect.Type) []string {
 	var paths []string
 
 	for field := range t.Fields() {
-		field := field
-
 		// Check if this field is named "Source"
 		if field.Name == "Source" {
 			paths = append(paths, "")

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -149,8 +149,8 @@ func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 
 	fields := reflect.TypeFor[apps.App]()
 	var allFields []string
-	for i := range fields.NumField() {
-		field := fields.Field(i)
+	for field := range fields.Fields() {
+		field := field
 		jsonTag := field.Tag.Get("json")
 		if jsonTag == "" || jsonTag == "-" {
 			continue

--- a/bundle/direct/dresources/app_test.go
+++ b/bundle/direct/dresources/app_test.go
@@ -150,7 +150,6 @@ func TestAppDoUpdate_UpdateMaskHasAllFields(t *testing.T) {
 	fields := reflect.TypeFor[apps.App]()
 	var allFields []string
 	for field := range fields.Fields() {
-		field := field
 		jsonTag := field.Tag.Get("json")
 		if jsonTag == "" || jsonTag == "-" {
 			continue

--- a/bundle/direct/dresources/util_test.go
+++ b/bundle/direct/dresources/util_test.go
@@ -13,14 +13,12 @@ func assertFieldsCovered(t *testing.T, sdkType, remoteType reflect.Type, skip ma
 	t.Helper()
 	remoteFields := map[string]bool{}
 	for f := range remoteType.Fields() {
-		f := f
 		if !f.Anonymous {
 			remoteFields[f.Name] = true
 		}
 	}
 
 	for field := range sdkType.Fields() {
-		field := field
 		if skip[field.Name] {
 			assert.NotContains(t, remoteFields, field.Name, "field %s is in skip list but present in %s; remove it from skip", field.Name, remoteType.Name())
 			continue

--- a/bundle/direct/dresources/util_test.go
+++ b/bundle/direct/dresources/util_test.go
@@ -12,15 +12,15 @@ import (
 func assertFieldsCovered(t *testing.T, sdkType, remoteType reflect.Type, skip map[string]bool) {
 	t.Helper()
 	remoteFields := map[string]bool{}
-	for i := range remoteType.NumField() {
-		f := remoteType.Field(i)
+	for f := range remoteType.Fields() {
+		f := f
 		if !f.Anonymous {
 			remoteFields[f.Name] = true
 		}
 	}
 
-	for i := range sdkType.NumField() {
-		field := sdkType.Field(i)
+	for field := range sdkType.Fields() {
+		field := field
 		if skip[field.Name] {
 			assert.NotContains(t, remoteFields, field.Name, "field %s is in skip list but present in %s; remove it from skip", field.Name, remoteType.Name())
 			continue

--- a/bundle/docsgen/nodes_test.go
+++ b/bundle/docsgen/nodes_test.go
@@ -25,7 +25,7 @@ func TestBuildNodes_ChildExpansion(t *testing.T) {
 						Items: &jsonschema.Schema{
 							Type: "object",
 							Properties: map[string]*jsonschema.Schema{
-								"listSub": {Reference: strPtr("#/$defs/github.com/listSub")},
+								"listSub": {Reference: new("#/$defs/github.com/listSub")},
 							},
 						},
 					},
@@ -61,9 +61,9 @@ func TestBuildNodes_ChildExpansion(t *testing.T) {
 					"myMap": {
 						Type: "object",
 						AdditionalProperties: &jsonschema.Schema{
-							Reference: strPtr("#/$defs/github.com/myMap"),
+							Reference: new("#/$defs/github.com/myMap"),
 							Properties: map[string]*jsonschema.Schema{
-								"mapSub": {Type: "object", Reference: strPtr("#/$defs/github.com/mapSub")},
+								"mapSub": {Type: "object", Reference: new("#/$defs/github.com/mapSub")},
 							},
 						},
 					},
@@ -73,7 +73,7 @@ func TestBuildNodes_ChildExpansion(t *testing.T) {
 				"github.com/myMap": {
 					Type: "object",
 					Properties: map[string]*jsonschema.Schema{
-						"mapSub": {Type: "boolean", Reference: strPtr("#/$defs/github.com/mapSub")},
+						"mapSub": {Type: "boolean", Reference: new("#/$defs/github.com/mapSub")},
 					},
 				},
 				"github.com/mapSub": {
@@ -171,6 +171,7 @@ func TestDoNotSuggestFields(t *testing.T) {
 	assert.Equal(t, "nestedNotDoNotSuggestField", nodes[0].Attributes[0].Title)
 }
 
+//go:fix inline
 func strPtr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/bundle/docsgen/nodes_test.go
+++ b/bundle/docsgen/nodes_test.go
@@ -170,8 +170,3 @@ func TestDoNotSuggestFields(t *testing.T) {
 	assert.Len(t, nodes[0].Attributes, 1)
 	assert.Equal(t, "nestedNotDoNotSuggestField", nodes[0].Attributes[0].Title)
 }
-
-//go:fix inline
-func strPtr(s string) *string {
-	return new(s)
-}

--- a/bundle/internal/schema/parser.go
+++ b/bundle/internal/schema/parser.go
@@ -58,13 +58,13 @@ func (p *openapiParser) findRef(typ reflect.Type) (jsonschema.Schema, bool) {
 
 	// Check for embedded Databricks Go SDK types.
 	if typ.Kind() == reflect.Struct {
-		for i := range typ.NumField() {
-			if !typ.Field(i).Anonymous {
+		for field := range typ.Fields() {
+			if !field.Anonymous {
 				continue
 			}
 
 			// Deference current type if it's a pointer.
-			ctyp := typ.Field(i).Type
+			ctyp := field.Type
 			for ctyp.Kind() == reflect.Ptr {
 				ctyp = ctyp.Elem()
 			}

--- a/bundle/internal/tf/codegen/go.mod
+++ b/bundle/internal/tf/codegen/go.mod
@@ -1,8 +1,8 @@
 module github.com/databricks/cli/bundle/internal/tf/codegen
 
-go 1.25.8
+go 1.26.0
 
-toolchain go1.25.10
+toolchain go1.26.3
 
 require (
 	github.com/hashicorp/go-version v1.9.0

--- a/cmd/pipelines/history_test.go
+++ b/cmd/pipelines/history_test.go
@@ -24,25 +24,25 @@ func TestUpdatesBefore(t *testing.T) {
 	}{
 		{
 			name:          "before 700",
-			timestamp:     int64Ptr(700),
+			timestamp:     new(int64(700)),
 			expectedCount: 3,
 			expectedFirst: 600,
 		},
 		{
 			name:          "before 1000",
-			timestamp:     int64Ptr(1000),
+			timestamp:     new(int64(1000)),
 			expectedCount: 5,
 			expectedFirst: 1000,
 		},
 		{
 			name:          "before 200",
-			timestamp:     int64Ptr(200),
+			timestamp:     new(int64(200)),
 			expectedCount: 1,
 			expectedFirst: 200,
 		},
 		{
 			name:          "before 100",
-			timestamp:     int64Ptr(100),
+			timestamp:     new(int64(100)),
 			expectedCount: 0,
 			expectedFirst: 0,
 		},
@@ -79,25 +79,25 @@ func TestUpdatesAfter(t *testing.T) {
 	}{
 		{
 			name:          "after 500",
-			timestamp:     int64Ptr(500),
+			timestamp:     new(int64(500)),
 			expectedCount: 3,
 			expectedFirst: 1000,
 		},
 		{
 			name:          "after 200",
-			timestamp:     int64Ptr(200),
+			timestamp:     new(int64(200)),
 			expectedCount: 5,
 			expectedFirst: 1000,
 		},
 		{
 			name:          "after 1000",
-			timestamp:     int64Ptr(1000),
+			timestamp:     new(int64(1000)),
 			expectedCount: 1,
 			expectedFirst: 1000,
 		},
 		{
 			name:          "after 1200",
-			timestamp:     int64Ptr(1200),
+			timestamp:     new(int64(1200)),
 			expectedCount: 0,
 			expectedFirst: 0,
 		},
@@ -181,7 +181,7 @@ func TestFilterUpdates(t *testing.T) {
 			name:          "start time nil, end time set",
 			updates:       updates,
 			startTime:     nil,
-			endTime:       int64Ptr(700),
+			endTime:       new(int64(700)),
 			expectedCount: 3,
 			expectedFirst: 600,
 			expectedLast:  200,
@@ -189,7 +189,7 @@ func TestFilterUpdates(t *testing.T) {
 		{
 			name:          "start time set, end time nil",
 			updates:       updates,
-			startTime:     int64Ptr(500),
+			startTime:     new(int64(500)),
 			endTime:       nil,
 			expectedCount: 3,
 			expectedFirst: 1000,
@@ -198,8 +198,8 @@ func TestFilterUpdates(t *testing.T) {
 		{
 			name:          "both times set within range",
 			updates:       updates,
-			startTime:     int64Ptr(300),
-			endTime:       int64Ptr(900),
+			startTime:     new(int64(300)),
+			endTime:       new(int64(900)),
 			expectedCount: 3,
 			expectedFirst: 800,
 			expectedLast:  400,
@@ -207,8 +207,8 @@ func TestFilterUpdates(t *testing.T) {
 		{
 			name:          "both times set, no overlap",
 			updates:       updates,
-			startTime:     int64Ptr(1200),
-			endTime:       int64Ptr(1500),
+			startTime:     new(int64(1200)),
+			endTime:       new(int64(1500)),
 			expectedCount: 0,
 			expectedFirst: 0,
 			expectedLast:  0,
@@ -216,7 +216,7 @@ func TestFilterUpdates(t *testing.T) {
 		{
 			name:          "start time after all updates",
 			updates:       updates,
-			startTime:     int64Ptr(1200),
+			startTime:     new(int64(1200)),
 			endTime:       nil,
 			expectedCount: 0,
 			expectedFirst: 0,
@@ -226,7 +226,7 @@ func TestFilterUpdates(t *testing.T) {
 			name:          "end time before all updates",
 			updates:       updates,
 			startTime:     nil,
-			endTime:       int64Ptr(100),
+			endTime:       new(int64(100)),
 			expectedCount: 0,
 			expectedFirst: 0,
 			expectedLast:  0,
@@ -234,8 +234,8 @@ func TestFilterUpdates(t *testing.T) {
 		{
 			name:          "start time after end time but within range",
 			updates:       updates,
-			startTime:     int64Ptr(700),
-			endTime:       int64Ptr(500),
+			startTime:     new(int64(700)),
+			endTime:       new(int64(500)),
 			expectedCount: 0,
 			expectedFirst: 0,
 			expectedLast:  0,
@@ -243,8 +243,8 @@ func TestFilterUpdates(t *testing.T) {
 		{
 			name:          "start and end time match exact values in list",
 			updates:       updates,
-			startTime:     int64Ptr(400),
-			endTime:       int64Ptr(800),
+			startTime:     new(int64(400)),
+			endTime:       new(int64(800)),
 			expectedCount: 3,
 			expectedFirst: 800,
 			expectedLast:  400,
@@ -289,8 +289,3 @@ func TestFilterUpdates(t *testing.T) {
 		})
 	}
 }
-
-// Helper function to create int64 pointers
-//
-//go:fix inline
-func int64Ptr(v int64) *int64 { return new(v) }

--- a/cmd/pipelines/history_test.go
+++ b/cmd/pipelines/history_test.go
@@ -291,4 +291,6 @@ func TestFilterUpdates(t *testing.T) {
 }
 
 // Helper function to create int64 pointers
-func int64Ptr(v int64) *int64 { return &v }
+//
+//go:fix inline
+func int64Ptr(v int64) *int64 { return new(v) }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/databricks/cli
 
-go 1.25.8
+go 1.26.0
 
-toolchain go1.25.10
+toolchain go1.26.3
 
 require (
 	dario.cat/mergo v1.0.2 // BSD-3-Clause

--- a/libs/apps/runlocal/spec_test.go
+++ b/libs/apps/runlocal/spec_test.go
@@ -28,11 +28,11 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 					EnvVars: []AppEnvVar{
 						{
 							Name:  "VAR1",
-							Value: stringPtr("value1"),
+							Value: new("value1"),
 						},
 						{
 							Name:  "VAR2",
-							Value: stringPtr("value2"),
+							Value: new("value2"),
 						},
 					},
 				}
@@ -53,11 +53,11 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 					EnvVars: []AppEnvVar{
 						{
 							Name:      "VAR1",
-							ValueFrom: stringPtr("VAR1"),
+							ValueFrom: new("VAR1"),
 						},
 						{
 							Name:      "VAR2",
-							ValueFrom: stringPtr("VAR2"),
+							ValueFrom: new("VAR2"),
 						},
 					},
 				}
@@ -77,11 +77,11 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 					EnvVars: []AppEnvVar{
 						{
 							Name:  "VAR1",
-							Value: stringPtr("value1"),
+							Value: new("value1"),
 						},
 						{
 							Name:      "VAR2",
-							ValueFrom: stringPtr("VAR2"),
+							ValueFrom: new("VAR2"),
 						},
 					},
 				}
@@ -101,7 +101,7 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 					EnvVars: []AppEnvVar{
 						{
 							Name:      "VAR1",
-							ValueFrom: stringPtr("VAR1"),
+							ValueFrom: new("VAR1"),
 						},
 					},
 				}
@@ -121,7 +121,7 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 					EnvVars: []AppEnvVar{
 						{
 							Name:      "VAR1",
-							ValueFrom: stringPtr("MISSING_VAR"),
+							ValueFrom: new("MISSING_VAR"),
 						},
 					},
 				}
@@ -151,6 +151,8 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 }
 
 // Helper function to create a string pointer
+//
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/libs/apps/runlocal/spec_test.go
+++ b/libs/apps/runlocal/spec_test.go
@@ -149,10 +149,3 @@ func TestAppSpecLoadEnvVars(t *testing.T) {
 		})
 	}
 }
-
-// Helper function to create a string pointer
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}

--- a/libs/calladapt/validate.go
+++ b/libs/calladapt/validate.go
@@ -11,13 +11,13 @@ func EnsureNoExtraMethods(receiver any, ifaceTypes ...reflect.Type) error {
 
 	allowed := make(map[string]struct{})
 	for _, ifaceType := range ifaceTypes {
-		for i := range ifaceType.NumMethod() {
-			allowed[ifaceType.Method(i).Name] = struct{}{}
+		for method := range ifaceType.Methods() {
+			allowed[method.Name] = struct{}{}
 		}
 	}
 
-	for i := range rt.NumMethod() {
-		m := rt.Method(i)
+	for m := range rt.Methods() {
+		m := m
 		if _, ok := allowed[m.Name]; !ok {
 			return fmt.Errorf("unexpected method %s on %v; only methods from %v are allowed", m.Name, rt, ifaceTypes)
 		}

--- a/libs/calladapt/validate.go
+++ b/libs/calladapt/validate.go
@@ -17,7 +17,6 @@ func EnsureNoExtraMethods(receiver any, ifaceTypes ...reflect.Type) error {
 	}
 
 	for m := range rt.Methods() {
-		m := m
 		if _, ok := allowed[m.Name]; !ok {
 			return fmt.Errorf("unexpected method %s on %v; only methods from %v are allowed", m.Name, rt, ifaceTypes)
 		}

--- a/libs/cmdio/pager_test.go
+++ b/libs/cmdio/pager_test.go
@@ -57,9 +57,9 @@ func printedText(t *testing.T, msg tea.Msg) string {
 	t.Helper()
 	rv := reflect.ValueOf(msg)
 	require.Equal(t, reflect.Struct, rv.Kind(), "expected a struct msg, got %T", msg)
-	for i := range rv.NumField() {
-		if rv.Field(i).Kind() == reflect.String {
-			return rv.Field(i).String()
+	for _, field := range rv.Fields() {
+		if field.Kind() == reflect.String {
+			return field.String()
 		}
 	}
 	t.Fatalf("no string field in %T", msg)

--- a/libs/jsonschema/from_type.go
+++ b/libs/jsonschema/from_type.go
@@ -224,8 +224,8 @@ func getStructFields(typ reflect.Type) []reflect.StructField {
 	var fields []reflect.StructField
 	bfsQueue := list.New()
 
-	for i := range typ.NumField() {
-		bfsQueue.PushBack(typ.Field(i))
+	for field := range typ.Fields() {
+		bfsQueue.PushBack(field)
 	}
 	for bfsQueue.Len() > 0 {
 		front := bfsQueue.Front()
@@ -246,8 +246,8 @@ func getStructFields(typ reflect.Type) []reflect.StructField {
 			fieldType = fieldType.Elem()
 		}
 
-		for i := range fieldType.NumField() {
-			bfsQueue.PushBack(fieldType.Field(i))
+		for field := range fieldType.Fields() {
+			bfsQueue.PushBack(field)
 		}
 	}
 	return fields

--- a/libs/structs/structaccess/convert_test.go
+++ b/libs/structs/structaccess/convert_test.go
@@ -61,22 +61,22 @@ func TestConvertToString(t *testing.T) {
 		// Pointers
 		{
 			name:     "string pointer",
-			value:    stringPtr("test"),
+			value:    new("test"),
 			expected: "test",
 		},
 		{
 			name:     "int pointer",
-			value:    intPtr(123),
+			value:    new(123),
 			expected: "123",
 		},
 		{
 			name:     "float64 pointer",
-			value:    float64Ptr(2.5),
+			value:    new(2.5),
 			expected: "2.5",
 		},
 		{
 			name:     "bool pointer",
-			value:    boolPtr(true),
+			value:    new(true),
 			expected: "true",
 		},
 		{
@@ -147,18 +147,22 @@ func TestConvertToString(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }
 
+//go:fix inline
 func intPtr(i int) *int {
-	return &i
+	return new(i)
 }
 
+//go:fix inline
 func float64Ptr(f float64) *float64 {
-	return &f
+	return new(f)
 }
 
+//go:fix inline
 func boolPtr(b bool) *bool {
-	return &b
+	return new(b)
 }

--- a/libs/structs/structaccess/convert_test.go
+++ b/libs/structs/structaccess/convert_test.go
@@ -146,23 +146,3 @@ func TestConvertToString(t *testing.T) {
 		})
 	}
 }
-
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}
-
-//go:fix inline
-func intPtr(i int) *int {
-	return new(i)
-}
-
-//go:fix inline
-func float64Ptr(f float64) *float64 {
-	return new(f)
-}
-
-//go:fix inline
-func boolPtr(b bool) *bool {
-	return new(b)
-}

--- a/libs/structs/structaccess/typecheck.go
+++ b/libs/structs/structaccess/typecheck.go
@@ -142,8 +142,8 @@ func FindStructFieldByKeyType(t reflect.Type, key string) (reflect.StructField, 
 	}
 
 	// First pass: direct fields
-	for i := range t.NumField() {
-		sf := t.Field(i)
+	for sf := range t.Fields() {
+		sf := sf
 		if sf.PkgPath != "" { // unexported
 			continue
 		}
@@ -162,8 +162,8 @@ func FindStructFieldByKeyType(t reflect.Type, key string) (reflect.StructField, 
 	}
 
 	// Second pass: search embedded anonymous structs recursively (flattening semantics)
-	for i := range t.NumField() {
-		sf := t.Field(i)
+	for sf := range t.Fields() {
+		sf := sf
 		if !sf.Anonymous {
 			continue
 		}

--- a/libs/structs/structaccess/typecheck.go
+++ b/libs/structs/structaccess/typecheck.go
@@ -143,7 +143,6 @@ func FindStructFieldByKeyType(t reflect.Type, key string) (reflect.StructField, 
 
 	// First pass: direct fields
 	for sf := range t.Fields() {
-		sf := sf
 		if sf.PkgPath != "" { // unexported
 			continue
 		}
@@ -163,7 +162,6 @@ func FindStructFieldByKeyType(t reflect.Type, key string) (reflect.StructField, 
 
 	// Second pass: search embedded anonymous structs recursively (flattening semantics)
 	for sf := range t.Fields() {
-		sf := sf
 		if !sf.Anonymous {
 			continue
 		}

--- a/libs/structs/structwalk/walktype.go
+++ b/libs/structs/structwalk/walktype.go
@@ -105,7 +105,6 @@ func walkTypeValue(path *structpath.PatternNode, typ reflect.Type, field *reflec
 
 func walkTypeStruct(path *structpath.PatternNode, st reflect.Type, visit VisitTypeFunc, visitedCount map[reflect.Type]int) {
 	for sf := range st.Fields() {
-		sf := sf
 		if sf.PkgPath != "" {
 			continue // unexported
 		}

--- a/libs/structs/structwalk/walktype.go
+++ b/libs/structs/structwalk/walktype.go
@@ -104,8 +104,8 @@ func walkTypeValue(path *structpath.PatternNode, typ reflect.Type, field *reflec
 }
 
 func walkTypeStruct(path *structpath.PatternNode, st reflect.Type, visit VisitTypeFunc, visitedCount map[reflect.Type]int) {
-	for i := range st.NumField() {
-		sf := st.Field(i)
+	for sf := range st.Fields() {
+		sf := sf
 		if sf.PkgPath != "" {
 			continue // unexported
 		}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,8 @@
 module github.com/databricks/cli/tools
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.10
+toolchain go1.26.3
 
 require github.com/stretchr/testify v1.11.1
 

--- a/tools/task/go.mod
+++ b/tools/task/go.mod
@@ -1,8 +1,8 @@
 module github.com/databricks/cli/tools/task
 
-go 1.25.8
+go 1.26.0
 
-toolchain go1.25.10
+toolchain go1.26.3
 
 require (
 	cel.dev/expr v0.25.1 // indirect


### PR DESCRIPTION
Bumps `go` to `1.26.0` and `toolchain` to `go1.26.3` across all four modules (root, `tools/`, `tools/task/`, `bundle/internal/tf/codegen/`), and folds in the `golangci-lint --fix` output that the new minor version requires.

Bumping the `go` directive to 1.26 unlocks two `modernize` analyzers (already enabled in `.golangci.yaml`) that were silent on 1.25:

- `stditerators` — prefer `reflect.Type.Fields()`/`Methods()` and `reflect.Value.Fields()`/`Methods()` over the `NumField()`/`Field(i)` loop pattern.
- `newexpr` — replace local `*T` helpers like `func intPtr(v int) *int { return &v }` (and their callers) with Go 1.26's `new(expr)`.

These fixes are in the same PR so CI doesn't fail the moment the bump lands. A manual fixup commit removes the redundant `field := field` shadows and the now-dead `*Ptr` helpers the auto-fix left behind (including rewriting 20 `int64Ptr(N)` callers to `new(int64(N))`).

Release notes: https://go.dev/doc/go1.26

## Test plan

- `go build ./...` and `go vet ./...` clean on all four modules
- `go tool -modfile=tools/go.mod golangci-lint run ./...` — 0 issues
- Unit tests pass on all packages touched by the `--fix` and cleanup

This pull request and its description were written by Isaac.