### PR TITLE
Rename reflect.Ptr to reflect.Pointer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -99,6 +99,8 @@ linters:
           msg: Use errors.Is(err, fs.ErrPermission) instead.
         - pattern: 'sync\.Once\b($|[^FV])'
           msg: Use sync.OnceFunc, sync.OnceValue, or sync.OnceValues instead.
+        - pattern: '\breflect\.Ptr\b'
+          msg: Use reflect.Pointer; reflect.Ptr is a legacy alias kept for backwards compat.
       analyze-types: true
     copyloopvar:
       check-alias: true

--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -59,7 +59,7 @@ func TestCustomMarshallerIsImplemented(t *testing.T) {
 		kt := field.Type.Key()
 		assert.Equal(t, reflect.String, kt.Kind(), "Resource %s is not a map with string keys", field.Name)
 		vt := field.Type.Elem()
-		assert.Equal(t, reflect.Ptr, vt.Kind(), "Resource %s is not a map with pointer values", field.Name)
+		assert.Equal(t, reflect.Pointer, vt.Kind(), "Resource %s is not a map with pointer values", field.Name)
 
 		// Marshalling a resourceStruct will panic if resourceStruct does not have a custom marshaller
 		// This is because resourceStruct embeds a Go SDK struct that implements

--- a/bundle/config/resources_types.go
+++ b/bundle/config/resources_types.go
@@ -26,7 +26,7 @@ var ResourcesTypes = func() map[string]reflect.Type {
 			continue
 		}
 		elemType := field.Type.Elem()
-		if elemType.Kind() == reflect.Ptr {
+		if elemType.Kind() == reflect.Pointer {
 			elemType = elemType.Elem()
 		}
 

--- a/bundle/deploy/terraform/tfdyn/convert_job_test.go
+++ b/bundle/deploy/terraform/tfdyn/convert_job_test.go
@@ -304,7 +304,7 @@ func TestSupportedTypeTasksComplete(t *testing.T) {
 
 		// Get the type of the task field (e.g., *NotebookTask)
 		taskFieldType := field.Type
-		if taskFieldType.Kind() == reflect.Ptr {
+		if taskFieldType.Kind() == reflect.Pointer {
 			taskFieldType = taskFieldType.Elem()
 		}
 
@@ -339,7 +339,7 @@ func TestSupportedTypeTasksComplete(t *testing.T) {
 // findSourceFieldsShallow searches for Source fields in a struct type, going only one level deep.
 // Returns a list of paths to Source fields (e.g., "" for direct Source, "file" for sql_task.file).
 func findSourceFieldsShallow(t reflect.Type) []string {
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 
@@ -358,7 +358,7 @@ func findSourceFieldsShallow(t reflect.Type) []string {
 
 		// Only search one level deep in nested structs
 		fieldType := field.Type
-		if fieldType.Kind() == reflect.Ptr {
+		if fieldType.Kind() == reflect.Pointer {
 			fieldType = fieldType.Elem()
 		}
 

--- a/bundle/direct/bundle_plan.go
+++ b/bundle/direct/bundle_plan.go
@@ -522,7 +522,7 @@ func isEmpty(rv reflect.Value) bool {
 }
 
 func isEmptyStruct(rv reflect.Value) bool {
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return false
 		}

--- a/bundle/direct/dresources/adapter.go
+++ b/bundle/direct/dresources/adapter.go
@@ -414,7 +414,7 @@ func normalizeNilPointer(v any) any {
 		return nil
 	}
 	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+	if rv.Kind() == reflect.Pointer && rv.IsNil() {
 		return nil
 	}
 	return v
@@ -550,7 +550,7 @@ func validatePointerToStruct(t reflect.Type, context string) error {
 	if t == nil {
 		return fmt.Errorf("%s not set", context)
 	}
-	if t.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Pointer {
 		return fmt.Errorf("%s must be a pointer, got %s", context, t.Kind())
 	}
 	if t.Elem().Kind() != reflect.Struct {

--- a/bundle/internal/schema/parser.go
+++ b/bundle/internal/schema/parser.go
@@ -65,7 +65,7 @@ func (p *openapiParser) findRef(typ reflect.Type) (jsonschema.Schema, bool) {
 
 			// Deference current type if it's a pointer.
 			ctyp := field.Type
-			for ctyp.Kind() == reflect.Ptr {
+			for ctyp.Kind() == reflect.Pointer {
 				ctyp = ctyp.Elem()
 			}
 

--- a/bundle/mutator.go
+++ b/bundle/mutator.go
@@ -32,7 +32,7 @@ func safeMutatorName(m Mutator) string {
 	t := reflect.TypeOf(m)
 
 	// Handle pointer types by getting the element type
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/libs/calladapt/calladapt.go
+++ b/libs/calladapt/calladapt.go
@@ -46,7 +46,7 @@ func (c *BoundCaller) call(args ...any) ([]reflect.Value, error) {
 		it := c.InTypes[i]
 		if a == nil {
 			// Allow untyped nil for pointer types, converting to typed nil
-			if it.Kind() == reflect.Ptr {
+			if it.Kind() == reflect.Pointer {
 				in[i+1] = reflect.Zero(it)
 				continue
 			}

--- a/libs/flags/json_flag.go
+++ b/libs/flags/json_flag.go
@@ -59,7 +59,7 @@ func (j *JsonFlag) Unmarshal(v any) diag.Diagnostics {
 
 	if !nv.IsValid() {
 		kind := reflect.TypeOf(v).Kind()
-		if kind == reflect.Ptr {
+		if kind == reflect.Pointer {
 			kind = reflect.TypeOf(v).Elem().Kind()
 		}
 
@@ -88,7 +88,7 @@ func (j *JsonFlag) Unmarshal(v any) diag.Diagnostics {
 	}
 
 	kind := reflect.ValueOf(v).Kind()
-	if kind == reflect.Ptr {
+	if kind == reflect.Pointer {
 		kind = reflect.ValueOf(v).Elem().Kind()
 	}
 

--- a/libs/jsonschema/from_type.go
+++ b/libs/jsonschema/from_type.go
@@ -121,7 +121,7 @@ func TypePath(typ reflect.Type) string {
 // JSON schema will refer to this path. See TestTypePath for examples outputs.
 func typePath(typ reflect.Type) string {
 	// Pointers have a typ.Name() of "". Dereference them to get the underlying type.
-	for typ.Kind() == reflect.Ptr {
+	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 
@@ -159,7 +159,7 @@ func typePath(typ reflect.Type) string {
 // the corresponding $ref in the JSON schema.
 func (c *constructor) walk(typ reflect.Type) (string, error) {
 	// Dereference pointers if necessary.
-	for typ.Kind() == reflect.Ptr {
+	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 

--- a/libs/structs/structaccess/convert.go
+++ b/libs/structs/structaccess/convert.go
@@ -10,7 +10,7 @@ func ConvertToString(value any) (string, error) {
 
 	// Handle pointers by dereferencing them first
 	rv := reflect.ValueOf(value)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return "", nil
 		}

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -368,7 +368,7 @@ func isNil(i any) bool {
 	}
 	v := reflect.ValueOf(i)
 	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.Interface, reflect.Slice:
 		return v.IsNil()
 	default:
 		return false


### PR DESCRIPTION
Stacked on top of #5302.

`reflect.Ptr` is a legacy alias for `reflect.Pointer`. Renames the 13 call sites and adds a forbidigo rule to keep it that way.

This pull request and its description were written by Isaac.