### PR TITLE
lakebox: add start command, tab completion, fail-fast on unknown sandbox

### DIFF
--- a/cmd/lakebox/api.go
+++ b/cmd/lakebox/api.go
@@ -305,6 +305,18 @@ func (a *lakeboxAPI) stop(ctx context.Context, id string) (*sandboxEntry, error)
 	return &resp, nil
 }
 
+// start calls POST /api/2.0/lakebox/sandboxes/{id}/start and returns the
+// refreshed sandbox. Mirror of `stop`; same body shape per `body: "*"`.
+func (a *lakeboxAPI) start(ctx context.Context, id string) (*sandboxEntry, error) {
+	body := map[string]string{"sandbox_id": id}
+	var resp sandboxEntry
+	err := a.c.Do(ctx, http.MethodPost, lakeboxAPIPath+"/"+id+"/start", a.headers(), nil, body, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // registerKey calls POST /api/2.0/lakebox/ssh-keys. An empty `name` is
 // omitted from the wire payload so the server records "unset" rather than
 // an explicit empty string.

--- a/cmd/lakebox/completion.go
+++ b/cmd/lakebox/completion.go
@@ -1,0 +1,63 @@
+package lakebox
+
+import (
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/spf13/cobra"
+)
+
+// completeSandboxIDs is a Cobra ValidArgsFunction returning the caller's
+// sandbox IDs for tab completion. Cobra runs this in a separate process
+// from the main command, so we need to bootstrap the workspace client
+// ourselves (PreRunE is skipped during completion).
+//
+// Best-effort: any failure (no auth, no network, lakebox not deployed)
+// returns no suggestions instead of an error so the shell stays usable
+// and the user can still type the ID by hand.
+func completeSandboxIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	if err := root.MustWorkspaceClient(cmd, args); err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ctx := cmd.Context()
+	api, err := newLakeboxAPI(cmdctx.WorkspaceClient(ctx))
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	entries, err := api.list(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.SandboxID)
+	}
+	return ids, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeSSHKeyHashes is the equivalent for `ssh-key delete <hash>`,
+// returning the hashes of registered keys. Same best-effort semantics.
+func completeSSHKeyHashes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	if err := root.MustWorkspaceClient(cmd, args); err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ctx := cmd.Context()
+	api, err := newLakeboxAPI(cmdctx.WorkspaceClient(ctx))
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	keys, err := api.listKeys(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	hashes := make([]string, 0, len(keys))
+	for _, k := range keys {
+		hashes = append(hashes, k.KeyHash)
+	}
+	return hashes, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/lakebox/config.go
+++ b/cmd/lakebox/config.go
@@ -56,8 +56,9 @@ Examples:
   databricks lakebox config happy-panda-1234 --no-autostop                  # never auto-stop
   databricks lakebox config happy-panda-1234 --no-autostop=false            # back to timeout path
   databricks lakebox config happy-panda-1234 --idle-timeout 30m --no-autostop=false`,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: root.MustWorkspaceClient,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           root.MustWorkspaceClient,
+		ValidArgsFunction: completeSandboxIDs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := cmdctx.WorkspaceClient(ctx)

--- a/cmd/lakebox/default.go
+++ b/cmd/lakebox/default.go
@@ -18,8 +18,9 @@ The default is stored locally in ~/.databricks/lakebox.json per profile.
 
 Example:
   databricks lakebox set-default happy-panda-1234`,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: root.MustWorkspaceClient,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           root.MustWorkspaceClient,
+		ValidArgsFunction: completeSandboxIDs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := cmdctx.WorkspaceClient(ctx)

--- a/cmd/lakebox/delete.go
+++ b/cmd/lakebox/delete.go
@@ -19,8 +19,9 @@ Permanently terminates and removes the specified lakebox.
 
 Example:
   databricks lakebox delete happy-panda-1234`,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: root.MustWorkspaceClient,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           root.MustWorkspaceClient,
+		ValidArgsFunction: completeSandboxIDs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := cmdctx.WorkspaceClient(ctx)

--- a/cmd/lakebox/lakebox.go
+++ b/cmd/lakebox/lakebox.go
@@ -39,6 +39,7 @@ Common workflows:
 	cmd.AddCommand(newCreateCommand())
 	cmd.AddCommand(newDeleteCommand())
 	cmd.AddCommand(newStopCommand())
+	cmd.AddCommand(newStartCommand())
 	cmd.AddCommand(newStatusCommand())
 	cmd.AddCommand(newConfigCommand())
 

--- a/cmd/lakebox/ssh.go
+++ b/cmd/lakebox/ssh.go
@@ -11,6 +11,7 @@ import (
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/execv"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/spf13/cobra"
 )
 
@@ -52,6 +53,10 @@ Examples:
   databricks lakebox ssh -- -L 8080:localhost:8080        # port forwarding on default lakebox`,
 		Args:    cobra.ArbitraryArgs,
 		PreRunE: root.MustWorkspaceClient,
+		// Tab-complete the optional first positional only. Cobra strips
+		// anything after `--` before reaching us, so `len(args) > 0`
+		// suffices to detect "user is past the first positional."
+		ValidArgsFunction: completeSandboxIDs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := cmdctx.WorkspaceClient(ctx)
@@ -131,13 +136,22 @@ Examples:
 						warn(ctx, fmt.Sprintf("Could not save default: %v", err))
 					}
 				}
-			} else if getGatewayHost(ctx, profile) == "" {
-				// Explicit-id ssh on a profile we have no cached gateway for:
-				// one-time `get` to learn it. Subsequent invocations hit the
-				// cache and skip the round-trip. Failure here is non-fatal —
-				// we fall through to the workspace-host heuristic.
-				if sb, err := api.get(ctx, lakeboxID); err == nil {
+			} else {
+				// Validate the explicit ID against the server. Two reasons:
+				//   1. Surface `lakebox ssh fake-id` as a clear 404 instead of
+				//      letting the user wade through `Permission denied` from
+				//      ssh when the gateway can't route an unknown sandbox.
+				//   2. Capture `gateway_host` to drive the resolution below.
+				// Non-NotFound errors fall through so transient API hiccups
+				// don't block a connection the gateway can still route.
+				sb, err := api.get(ctx, lakeboxID)
+				switch {
+				case err == nil:
 					sandboxGatewayHost = sb.GatewayHost
+				case errors.Is(err, apierr.ErrNotFound):
+					return fmt.Errorf("no lakebox named %q — `databricks lakebox list` shows available IDs", lakeboxID)
+				default:
+					warn(ctx, fmt.Sprintf("could not validate lakebox %s: %v", lakeboxID, err))
 				}
 			}
 

--- a/cmd/lakebox/sshkey.go
+++ b/cmd/lakebox/sshkey.go
@@ -35,8 +35,9 @@ private key will fail until the key is re-registered.
 
 Example:
   databricks lakebox ssh-key delete a1b2c3d4e5f6...`,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: root.MustWorkspaceClient,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           root.MustWorkspaceClient,
+		ValidArgsFunction: completeSSHKeyHashes,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := cmdctx.WorkspaceClient(ctx)

--- a/cmd/lakebox/start.go
+++ b/cmd/lakebox/start.go
@@ -9,20 +9,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newStopCommand() *cobra.Command {
+func newStartCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "stop <lakebox-id>",
-		Short: "Stop a running Lakebox environment",
-		Long: `Stop a running Lakebox environment.
+		Use:   "start <lakebox-id>",
+		Short: "Start a stopped Lakebox environment",
+		Long: `Start a stopped Lakebox environment.
 
-Terminates the backing microVM but preserves the sandbox record and its
-persistent storage. To restart, run 'databricks lakebox ssh' — the
-gateway auto-starts a stopped sandbox on connection.
+Boots the backing microVM and brings the sandbox to Running.
+'databricks lakebox ssh' already auto-starts a stopped sandbox on
+connection, so this command is mostly useful for pre-warming an
+environment without immediately connecting.
 
-Stopping an already-stopped sandbox is a no-op.
+Starting an already-running sandbox is a no-op.
 
 Example:
-  databricks lakebox stop happy-panda-1234`,
+  databricks lakebox start happy-panda-1234`,
 		Args:              cobra.ExactArgs(1),
 		PreRunE:           root.MustWorkspaceClient,
 		ValidArgsFunction: completeSandboxIDs,
@@ -35,13 +36,13 @@ Example:
 			}
 
 			lakeboxID := args[0]
-			s := spin(ctx, "Stopping "+lakeboxID+"…")
+			s := spin(ctx, "Starting "+lakeboxID+"…")
 			defer s.Close()
 
-			updated, err := api.stop(ctx, lakeboxID)
+			updated, err := api.start(ctx, lakeboxID)
 			if err != nil {
-				s.fail("Failed to stop " + lakeboxID)
-				return fmt.Errorf("failed to stop lakebox %s: %w", lakeboxID, err)
+				s.fail("Failed to start " + lakeboxID)
+				return fmt.Errorf("failed to start lakebox %s: %w", lakeboxID, err)
 			}
 
 			profile := w.Config.Profile
@@ -50,7 +51,7 @@ Example:
 			}
 			_ = setGatewayHost(ctx, profile, updated.GatewayHost)
 
-			s.ok("Stopped " + cmdio.Bold(ctx, updated.SandboxID))
+			s.ok("Started " + cmdio.Bold(ctx, updated.SandboxID))
 			return nil
 		},
 	}

--- a/cmd/lakebox/status.go
+++ b/cmd/lakebox/status.go
@@ -21,8 +21,9 @@ func newStatusCommand() *cobra.Command {
 Example:
   lakebox status happy-panda-1234
   lakebox status happy-panda-1234 --json`,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: root.MustWorkspaceClient,
+		Args:              cobra.ExactArgs(1),
+		PreRunE:           root.MustWorkspaceClient,
+		ValidArgsFunction: completeSandboxIDs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := cmdctx.WorkspaceClient(ctx)


### PR DESCRIPTION
Three small additions that close gaps surfaced testing the gateway-host PR end-to-end.

1. `databricks lakebox start <id>` — wraps the existing StartSandbox RPC. Symmetric to `stop`. Useful for pre-warming a sandbox before connecting (the gateway also auto-starts on ssh, so this is mostly for scripting).

2. Tab completion for sandbox IDs on every command that takes one (ssh / status / stop / start / delete / config / set-default) and key hashes on `ssh-key delete`. Best-effort: completion silently produces no suggestions when the API call fails so the shell stays usable. Standard Cobra ValidArgsFunction pattern, surfaced via `databricks completion bash|zsh|fish` like every other Cobra CLI.

3. `databricks lakebox ssh <unknown-id>` now fails with `no lakebox named "..." — `databricks lakebox list` shows available IDs` instead of falling through to ssh and surfacing `Permission denied (publickey)` from the gateway. Implemented by making the existing pre-ssh `api.get` (added in #5292 for gateway discovery) treat `apierr.ErrNotFound` as fatal. Non-NotFound errors still fall through so transient API hiccups don't block a connection the gateway can still route.

Co-authored-by: Isaac

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
