### PR TITLE
Detect and log terminal/IDE host in telemetry

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -79,6 +79,7 @@ func New(ctx context.Context) *cobra.Command {
 		ctx = withCommandExecIdInUserAgent(ctx)
 		ctx = withUpstreamInUserAgent(ctx)
 		ctx = withInteractiveModeInUserAgent(ctx)
+		ctx = withHostInUserAgent(ctx)
 		ctx = InjectTestPidToUserAgent(ctx)
 		cmd.SetContext(ctx)
 		return nil
@@ -185,6 +186,7 @@ Stack Trace:
 		Command:         commandStr,
 		OperatingSystem: runtime.GOOS,
 		DbrVersion:      dbr.RuntimeVersion(ctx).String(),
+		Host:            string(cmdio.DetectHost(ctx)),
 		ExecutionTimeMs: time.Since(startTime).Milliseconds(),
 		ExitCode:        int64(exitCode),
 	})

--- a/cmd/root/user_agent_host.go
+++ b/cmd/root/user_agent_host.go
@@ -1,0 +1,24 @@
+// This file integrates terminal/IDE host detection with the user agent string.
+//
+// The detection logic is in libs/cmdio. This file retrieves the host from
+// the context and adds it to the user agent.
+//
+// Example user agent strings:
+//   - "cli/X.Y.Z ... host/vscode ..."
+//   - "cli/X.Y.Z ... host/cursor ..."
+//   - "cli/X.Y.Z ... host/unknown ..."
+package root
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/useragent"
+)
+
+// Key in the user agent.
+const hostKey = "host"
+
+func withHostInUserAgent(ctx context.Context) context.Context {
+	return useragent.InContext(ctx, hostKey, string(cmdio.DetectHost(ctx)))
+}

--- a/cmd/root/user_agent_host_test.go
+++ b/cmd/root/user_agent_host_test.go
@@ -1,0 +1,46 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/useragent"
+	"github.com/stretchr/testify/assert"
+)
+
+// hostEnvKeys mirrors the env vars read by cmdio.DetectHost. Tests clear them
+// so the developer's shell environment cannot bleed into assertions.
+var hostEnvKeys = []string{
+	"TERM_PROGRAM",
+	"TERMINAL_EMULATOR",
+	"CURSOR_TRACE_ID",
+	"__CFBundleIdentifier",
+	"GITHUB_COPILOT_AGENT_VERSION",
+	"COPILOT_AGENT_INTEGRATION_ID",
+}
+
+func clearHostEnv(t *testing.T) {
+	for _, k := range hostEnvKeys {
+		t.Setenv(k, "")
+	}
+}
+
+func TestHostInUserAgent_Unknown(t *testing.T) {
+	clearHostEnv(t)
+	ctx := withHostInUserAgent(t.Context())
+	assert.Contains(t, useragent.FromContext(ctx), "host/unknown")
+}
+
+func TestHostInUserAgent_VSCode(t *testing.T) {
+	clearHostEnv(t)
+	t.Setenv("TERM_PROGRAM", "vscode")
+	ctx := withHostInUserAgent(t.Context())
+	assert.Contains(t, useragent.FromContext(ctx), "host/vscode")
+}
+
+func TestHostInUserAgent_Cursor(t *testing.T) {
+	clearHostEnv(t)
+	t.Setenv("TERM_PROGRAM", "vscode")
+	t.Setenv("CURSOR_TRACE_ID", "abc")
+	ctx := withHostInUserAgent(t.Context())
+	assert.Contains(t, useragent.FromContext(ctx), "host/cursor")
+}

--- a/cmd/root/user_agent_host_test.go
+++ b/cmd/root/user_agent_host_test.go
@@ -12,8 +12,6 @@ import (
 var hostEnvKeys = []string{
 	"TERM_PROGRAM",
 	"TERMINAL_EMULATOR",
-	"CURSOR_TRACE_ID",
-	"__CFBundleIdentifier",
 	"GITHUB_COPILOT_AGENT_VERSION",
 	"COPILOT_AGENT_INTEGRATION_ID",
 }
@@ -37,10 +35,10 @@ func TestHostInUserAgent_VSCode(t *testing.T) {
 	assert.Contains(t, useragent.FromContext(ctx), "host/vscode")
 }
 
-func TestHostInUserAgent_Cursor(t *testing.T) {
+func TestHostInUserAgent_VSCodeCopilotSentinel(t *testing.T) {
 	clearHostEnv(t)
 	t.Setenv("TERM_PROGRAM", "vscode")
-	t.Setenv("CURSOR_TRACE_ID", "abc")
+	t.Setenv("GITHUB_COPILOT_AGENT_VERSION", "1.2.3")
 	ctx := withHostInUserAgent(t.Context())
-	assert.Contains(t, useragent.FromContext(ctx), "host/cursor")
+	assert.Contains(t, useragent.FromContext(ctx), "host/vscode-copilot")
 }

--- a/cmd/root/user_agent_host_test.go
+++ b/cmd/root/user_agent_host_test.go
@@ -12,8 +12,6 @@ import (
 var hostEnvKeys = []string{
 	"TERM_PROGRAM",
 	"TERMINAL_EMULATOR",
-	"GITHUB_COPILOT_AGENT_VERSION",
-	"COPILOT_AGENT_INTEGRATION_ID",
 }
 
 func clearHostEnv(t *testing.T) {
@@ -33,12 +31,4 @@ func TestHostInUserAgent_VSCode(t *testing.T) {
 	t.Setenv("TERM_PROGRAM", "vscode")
 	ctx := withHostInUserAgent(t.Context())
 	assert.Contains(t, useragent.FromContext(ctx), "host/vscode")
-}
-
-func TestHostInUserAgent_VSCodeCopilotSentinel(t *testing.T) {
-	clearHostEnv(t)
-	t.Setenv("TERM_PROGRAM", "vscode")
-	t.Setenv("GITHUB_COPILOT_AGENT_VERSION", "1.2.3")
-	ctx := withHostInUserAgent(t.Context())
-	assert.Contains(t, useragent.FromContext(ctx), "host/vscode-copilot")
 }

--- a/libs/cmdio/host.go
+++ b/libs/cmdio/host.go
@@ -11,55 +11,42 @@ import (
 type Host string
 
 const (
-	HostVSCode        Host = "vscode"
+	// HostVSCode covers TERM_PROGRAM=vscode, which is set by vanilla VSCode
+	// and every fork that inherits its terminal integration (Cursor, Windsurf,
+	// code-server, etc.). The forks don't expose a stable, trustworthy
+	// discriminator in env, so we deliberately don't try to split them apart.
+	HostVSCode Host = "vscode"
+
+	// HostVSCodeCopilot is a best-effort sentinel for invocations driven by
+	// VSCode's Copilot coding agent. The env vars Copilot sets are not
+	// publicly documented; the names checked here are educated guesses and
+	// may not fire in practice. Treat as a coarse signal to be refined once
+	// we observe real telemetry.
 	HostVSCodeCopilot Host = "vscode-copilot"
-	HostCursor        Host = "cursor"
-	HostWindsurf      Host = "windsurf"
+
 	HostJetBrains     Host = "jetbrains"
-	HostZed           Host = "zed"
-	HostWarp          Host = "warp"
-	HostITerm         Host = "iterm"
 	HostAppleTerminal Host = "apple-terminal"
-	HostGhostty       Host = "ghostty"
+	HostITerm         Host = "iterm"
+	HostWarp          Host = "warp"
 	HostWezTerm       Host = "wezterm"
-	HostHyper         Host = "hyper"
-	HostTabby         Host = "tabby"
+	HostGhostty       Host = "ghostty"
 	HostUnknown       Host = "unknown"
 )
 
-// Environment variables we inspect. Sources:
-//   - VSCode: https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
-//   - Cursor: VSCode fork; sets CURSOR_TRACE_ID in addition to VSCode vars
-//   - JetBrains: https://www.jetbrains.com/help/idea/terminal.html
-//   - Apple Terminal / iTerm / Warp / Ghostty / WezTerm / Hyper / Tabby: set TERM_PROGRAM directly
 const (
-	envTermProgram       = "TERM_PROGRAM"
-	envTerminalEmulator  = "TERMINAL_EMULATOR"
-	envCursorTraceID     = "CURSOR_TRACE_ID"
-	envCFBundleID        = "__CFBundleIdentifier"
-	envCopilotAgent      = "GITHUB_COPILOT_AGENT_VERSION"
-	envCopilotIntegrator = "COPILOT_AGENT_INTEGRATION_ID"
+	envTermProgram      = "TERM_PROGRAM"
+	envTerminalEmulator = "TERMINAL_EMULATOR"
 )
 
 // DetectHost returns the terminal or IDE host the CLI is being run from,
-// derived from environment variables only. Returns HostUnknown if no
-// signals match (the common case for raw shells without TERM_PROGRAM set).
+// derived from environment variables only.
+//
+// Only detections backed by direct observation or upstream documentation
+// are included. Anything we can't verify (Windsurf vs. Cursor split, Zed,
+// Hyper, Tabby, etc.) falls into HostUnknown until we see real evidence.
 func DetectHost(ctx context.Context) Host {
-	// Cursor and Windsurf are VSCode forks: they inherit TERM_PROGRAM=vscode,
-	// so check their discriminators before falling through to plain VSCode.
-	if env.Get(ctx, envCursorTraceID) != "" {
-		return HostCursor
-	}
-	if env.Get(ctx, envCFBundleID) == "com.exafunction.windsurf" {
-		return HostWindsurf
-	}
-
 	switch env.Get(ctx, envTermProgram) {
 	case "vscode":
-		// Best-effort sentinel for invocations driven by VSCode's Copilot
-		// coding agent. The exact env vars Copilot sets in agent-mode
-		// terminals are not stable yet; treat this as a coarse signal to
-		// be refined once we see real telemetry.
 		if isCopilotAgent(ctx) {
 			return HostVSCodeCopilot
 		}
@@ -70,18 +57,14 @@ func DetectHost(ctx context.Context) Host {
 		return HostITerm
 	case "WarpTerminal":
 		return HostWarp
-	case "ghostty":
-		return HostGhostty
 	case "WezTerm":
 		return HostWezTerm
-	case "Hyper":
-		return HostHyper
-	case "Tabby":
-		return HostTabby
-	case "zed":
-		return HostZed
+	case "ghostty":
+		return HostGhostty
 	}
 
+	// JediTerm is JetBrains' terminal library; sets TERMINAL_EMULATOR
+	// per https://github.com/JetBrains/jediterm/issues/253.
 	if env.Get(ctx, envTerminalEmulator) == "JetBrains-JediTerm" {
 		return HostJetBrains
 	}
@@ -90,5 +73,6 @@ func DetectHost(ctx context.Context) Host {
 }
 
 func isCopilotAgent(ctx context.Context) bool {
-	return env.Get(ctx, envCopilotAgent) != "" || env.Get(ctx, envCopilotIntegrator) != ""
+	return env.Get(ctx, "GITHUB_COPILOT_AGENT_VERSION") != "" ||
+		env.Get(ctx, "COPILOT_AGENT_INTEGRATION_ID") != ""
 }

--- a/libs/cmdio/host.go
+++ b/libs/cmdio/host.go
@@ -1,0 +1,94 @@
+package cmdio
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/env"
+)
+
+// Host describes the terminal or IDE the CLI is being invoked from.
+// Values are an enum, never raw env values, so they are safe to log.
+type Host string
+
+const (
+	HostVSCode        Host = "vscode"
+	HostVSCodeCopilot Host = "vscode-copilot"
+	HostCursor        Host = "cursor"
+	HostWindsurf      Host = "windsurf"
+	HostJetBrains     Host = "jetbrains"
+	HostZed           Host = "zed"
+	HostWarp          Host = "warp"
+	HostITerm         Host = "iterm"
+	HostAppleTerminal Host = "apple-terminal"
+	HostGhostty       Host = "ghostty"
+	HostWezTerm       Host = "wezterm"
+	HostHyper         Host = "hyper"
+	HostTabby         Host = "tabby"
+	HostUnknown       Host = "unknown"
+)
+
+// Environment variables we inspect. Sources:
+//   - VSCode: https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+//   - Cursor: VSCode fork; sets CURSOR_TRACE_ID in addition to VSCode vars
+//   - JetBrains: https://www.jetbrains.com/help/idea/terminal.html
+//   - Apple Terminal / iTerm / Warp / Ghostty / WezTerm / Hyper / Tabby: set TERM_PROGRAM directly
+const (
+	envTermProgram       = "TERM_PROGRAM"
+	envTerminalEmulator  = "TERMINAL_EMULATOR"
+	envCursorTraceID     = "CURSOR_TRACE_ID"
+	envCFBundleID        = "__CFBundleIdentifier"
+	envCopilotAgent      = "GITHUB_COPILOT_AGENT_VERSION"
+	envCopilotIntegrator = "COPILOT_AGENT_INTEGRATION_ID"
+)
+
+// DetectHost returns the terminal or IDE host the CLI is being run from,
+// derived from environment variables only. Returns HostUnknown if no
+// signals match (the common case for raw shells without TERM_PROGRAM set).
+func DetectHost(ctx context.Context) Host {
+	// Cursor and Windsurf are VSCode forks: they inherit TERM_PROGRAM=vscode,
+	// so check their discriminators before falling through to plain VSCode.
+	if env.Get(ctx, envCursorTraceID) != "" {
+		return HostCursor
+	}
+	if env.Get(ctx, envCFBundleID) == "com.exafunction.windsurf" {
+		return HostWindsurf
+	}
+
+	switch env.Get(ctx, envTermProgram) {
+	case "vscode":
+		// Best-effort sentinel for invocations driven by VSCode's Copilot
+		// coding agent. The exact env vars Copilot sets in agent-mode
+		// terminals are not stable yet; treat this as a coarse signal to
+		// be refined once we see real telemetry.
+		if isCopilotAgent(ctx) {
+			return HostVSCodeCopilot
+		}
+		return HostVSCode
+	case "Apple_Terminal":
+		return HostAppleTerminal
+	case "iTerm.app":
+		return HostITerm
+	case "WarpTerminal":
+		return HostWarp
+	case "ghostty":
+		return HostGhostty
+	case "WezTerm":
+		return HostWezTerm
+	case "Hyper":
+		return HostHyper
+	case "Tabby":
+		return HostTabby
+	case "zed":
+		return HostZed
+	}
+
+	if env.Get(ctx, envTerminalEmulator) == "JetBrains-JediTerm" {
+		return HostJetBrains
+	}
+
+	return HostUnknown
+}
+
+func isCopilotAgent(ctx context.Context) bool {
+	return env.Get(ctx, envCopilotAgent) != "" || env.Get(ctx, envCopilotIntegrator) != ""
+}

--- a/libs/cmdio/host.go
+++ b/libs/cmdio/host.go
@@ -17,13 +17,6 @@ const (
 	// discriminator in env, so we deliberately don't try to split them apart.
 	HostVSCode Host = "vscode"
 
-	// HostVSCodeCopilot is a best-effort sentinel for invocations driven by
-	// VSCode's Copilot coding agent. The env vars Copilot sets are not
-	// publicly documented; the names checked here are educated guesses and
-	// may not fire in practice. Treat as a coarse signal to be refined once
-	// we observe real telemetry.
-	HostVSCodeCopilot Host = "vscode-copilot"
-
 	HostJetBrains     Host = "jetbrains"
 	HostAppleTerminal Host = "apple-terminal"
 	HostITerm         Host = "iterm"
@@ -44,12 +37,14 @@ const (
 // Only detections backed by direct observation or upstream documentation
 // are included. Anything we can't verify (Windsurf vs. Cursor split, Zed,
 // Hyper, Tabby, etc.) falls into HostUnknown until we see real evidence.
+//
+// Whether a user has a particular extension or AI agent active (Copilot,
+// Claude Code, Cursor Agent, etc.) is intentionally not modelled here.
+// That's an independent dimension, so a downstream query can ask "vscode
+// users without Copilot" by joining the two signals.
 func DetectHost(ctx context.Context) Host {
 	switch env.Get(ctx, envTermProgram) {
 	case "vscode":
-		if isCopilotAgent(ctx) {
-			return HostVSCodeCopilot
-		}
 		return HostVSCode
 	case "Apple_Terminal":
 		return HostAppleTerminal
@@ -70,9 +65,4 @@ func DetectHost(ctx context.Context) Host {
 	}
 
 	return HostUnknown
-}
-
-func isCopilotAgent(ctx context.Context) bool {
-	return env.Get(ctx, "GITHUB_COPILOT_AGENT_VERSION") != "" ||
-		env.Get(ctx, "COPILOT_AGENT_INTEGRATION_ID") != ""
 }

--- a/libs/cmdio/host_test.go
+++ b/libs/cmdio/host_test.go
@@ -1,0 +1,128 @@
+package cmdio
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// envKeysToIsolate lists every environment variable read by DetectHost. Tests
+// clear all of them at the start so process env from the developer's shell
+// (e.g. TERM_PROGRAM=iTerm.app when running locally) cannot leak in.
+var envKeysToIsolate = []string{
+	envTermProgram,
+	envTerminalEmulator,
+	envCursorTraceID,
+	envCFBundleID,
+	envCopilotAgent,
+	envCopilotIntegrator,
+}
+
+func isolateHostEnv(t *testing.T, overrides map[string]string) {
+	for _, k := range envKeysToIsolate {
+		t.Setenv(k, "")
+	}
+	for k, v := range overrides {
+		t.Setenv(k, v)
+	}
+}
+
+func TestDetectHost(t *testing.T) {
+	tests := []struct {
+		name string
+		envs map[string]string
+		want Host
+	}{
+		{
+			name: "no env vars",
+			envs: nil,
+			want: HostUnknown,
+		},
+		{
+			name: "vscode",
+			envs: map[string]string{"TERM_PROGRAM": "vscode"},
+			want: HostVSCode,
+		},
+		{
+			name: "vscode with copilot agent",
+			envs: map[string]string{
+				"TERM_PROGRAM":                 "vscode",
+				"GITHUB_COPILOT_AGENT_VERSION": "1.2.3",
+			},
+			want: HostVSCodeCopilot,
+		},
+		{
+			name: "cursor wins over vscode TERM_PROGRAM",
+			envs: map[string]string{
+				"TERM_PROGRAM":    "vscode",
+				"CURSOR_TRACE_ID": "abc123",
+			},
+			want: HostCursor,
+		},
+		{
+			name: "windsurf wins over vscode TERM_PROGRAM",
+			envs: map[string]string{
+				"TERM_PROGRAM":         "vscode",
+				"__CFBundleIdentifier": "com.exafunction.windsurf",
+			},
+			want: HostWindsurf,
+		},
+		{
+			name: "jetbrains",
+			envs: map[string]string{"TERMINAL_EMULATOR": "JetBrains-JediTerm"},
+			want: HostJetBrains,
+		},
+		{
+			name: "apple terminal",
+			envs: map[string]string{"TERM_PROGRAM": "Apple_Terminal"},
+			want: HostAppleTerminal,
+		},
+		{
+			name: "iterm",
+			envs: map[string]string{"TERM_PROGRAM": "iTerm.app"},
+			want: HostITerm,
+		},
+		{
+			name: "warp",
+			envs: map[string]string{"TERM_PROGRAM": "WarpTerminal"},
+			want: HostWarp,
+		},
+		{
+			name: "ghostty",
+			envs: map[string]string{"TERM_PROGRAM": "ghostty"},
+			want: HostGhostty,
+		},
+		{
+			name: "wezterm",
+			envs: map[string]string{"TERM_PROGRAM": "WezTerm"},
+			want: HostWezTerm,
+		},
+		{
+			name: "zed",
+			envs: map[string]string{"TERM_PROGRAM": "zed"},
+			want: HostZed,
+		},
+		{
+			name: "hyper",
+			envs: map[string]string{"TERM_PROGRAM": "Hyper"},
+			want: HostHyper,
+		},
+		{
+			name: "tabby",
+			envs: map[string]string{"TERM_PROGRAM": "Tabby"},
+			want: HostTabby,
+		},
+		{
+			name: "unknown TERM_PROGRAM falls through to unknown",
+			envs: map[string]string{"TERM_PROGRAM": "somethingnew"},
+			want: HostUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateHostEnv(t, tt.envs)
+			assert.Equal(t, tt.want, DetectHost(t.Context()))
+		})
+	}
+}

--- a/libs/cmdio/host_test.go
+++ b/libs/cmdio/host_test.go
@@ -12,8 +12,6 @@ import (
 var envKeysToIsolate = []string{
 	envTermProgram,
 	envTerminalEmulator,
-	"GITHUB_COPILOT_AGENT_VERSION",
-	"COPILOT_AGENT_INTEGRATION_ID",
 }
 
 func isolateHostEnv(t *testing.T, overrides map[string]string) {
@@ -40,14 +38,6 @@ func TestDetectHost(t *testing.T) {
 			name: "vscode and forks all classify as vscode",
 			envs: map[string]string{"TERM_PROGRAM": "vscode"},
 			want: HostVSCode,
-		},
-		{
-			name: "vscode with copilot agent env",
-			envs: map[string]string{
-				"TERM_PROGRAM":                 "vscode",
-				"GITHUB_COPILOT_AGENT_VERSION": "1.2.3",
-			},
-			want: HostVSCodeCopilot,
 		},
 		{
 			name: "jetbrains",

--- a/libs/cmdio/host_test.go
+++ b/libs/cmdio/host_test.go
@@ -6,16 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// envKeysToIsolate lists every environment variable read by DetectHost. Tests
-// clear all of them at the start so process env from the developer's shell
-// (e.g. TERM_PROGRAM=iTerm.app when running locally) cannot leak in.
+// envKeysToIsolate lists every environment variable read by DetectHost.
+// Tests clear all of them at the start so process env from the developer's
+// shell (e.g. TERM_PROGRAM=iTerm.app on a macOS dev machine) cannot leak in.
 var envKeysToIsolate = []string{
 	envTermProgram,
 	envTerminalEmulator,
-	envCursorTraceID,
-	envCFBundleID,
-	envCopilotAgent,
-	envCopilotIntegrator,
+	"GITHUB_COPILOT_AGENT_VERSION",
+	"COPILOT_AGENT_INTEGRATION_ID",
 }
 
 func isolateHostEnv(t *testing.T, overrides map[string]string) {
@@ -39,33 +37,17 @@ func TestDetectHost(t *testing.T) {
 			want: HostUnknown,
 		},
 		{
-			name: "vscode",
+			name: "vscode and forks all classify as vscode",
 			envs: map[string]string{"TERM_PROGRAM": "vscode"},
 			want: HostVSCode,
 		},
 		{
-			name: "vscode with copilot agent",
+			name: "vscode with copilot agent env",
 			envs: map[string]string{
 				"TERM_PROGRAM":                 "vscode",
 				"GITHUB_COPILOT_AGENT_VERSION": "1.2.3",
 			},
 			want: HostVSCodeCopilot,
-		},
-		{
-			name: "cursor wins over vscode TERM_PROGRAM",
-			envs: map[string]string{
-				"TERM_PROGRAM":    "vscode",
-				"CURSOR_TRACE_ID": "abc123",
-			},
-			want: HostCursor,
-		},
-		{
-			name: "windsurf wins over vscode TERM_PROGRAM",
-			envs: map[string]string{
-				"TERM_PROGRAM":         "vscode",
-				"__CFBundleIdentifier": "com.exafunction.windsurf",
-			},
-			want: HostWindsurf,
 		},
 		{
 			name: "jetbrains",
@@ -88,29 +70,14 @@ func TestDetectHost(t *testing.T) {
 			want: HostWarp,
 		},
 		{
-			name: "ghostty",
-			envs: map[string]string{"TERM_PROGRAM": "ghostty"},
-			want: HostGhostty,
-		},
-		{
 			name: "wezterm",
 			envs: map[string]string{"TERM_PROGRAM": "WezTerm"},
 			want: HostWezTerm,
 		},
 		{
-			name: "zed",
-			envs: map[string]string{"TERM_PROGRAM": "zed"},
-			want: HostZed,
-		},
-		{
-			name: "hyper",
-			envs: map[string]string{"TERM_PROGRAM": "Hyper"},
-			want: HostHyper,
-		},
-		{
-			name: "tabby",
-			envs: map[string]string{"TERM_PROGRAM": "Tabby"},
-			want: HostTabby,
+			name: "ghostty",
+			envs: map[string]string{"TERM_PROGRAM": "ghostty"},
+			want: HostGhostty,
 		},
 		{
 			name: "unknown TERM_PROGRAM falls through to unknown",

--- a/libs/telemetry/protos/databricks_cli_log.go
+++ b/libs/telemetry/protos/databricks_cli_log.go
@@ -23,6 +23,11 @@ type ExecutionContext struct {
 	// If true, the CLI is being run from a Databricks notebook / cluster web terminal.
 	FromWebTerminal bool `json:"from_web_terminal,omitempty"`
 
+	// Terminal or IDE the CLI is being run from, detected from environment
+	// variables (TERM_PROGRAM, TERMINAL_EMULATOR, etc.). Enum value, never a
+	// raw env value. See libs/cmdio/host.go for the full enum.
+	Host string `json:"host,omitempty"`
+
 	// Time taken for the CLI command to execute.
 	// We want to serialize the zero value as well so the omitempty tag is not set.
 	ExecutionTimeMs int64 `json:"execution_time_ms"`


### PR DESCRIPTION
## Why

Today we have no way to tell whether the CLI is being run from a raw terminal or from inside an IDE (VSCode, Cursor, IntelliJ, etc.). We want that signal so we can answer questions like:

- How many of our users are on VSCode but not using the Copilot extension? (a real population we want to size)
- What's the upper bound on how many users *could* be on VSCode Copilot? Since we at least know who's on VSCode, that gives us the ceiling.
- Where should we prioritize IDE-specific UX work?

## Changes

Adds env-var-based host detection in `libs/cmdio/host.go`. Surfaces the result two ways:
- User agent: `host/vscode`, `host/jetbrains`, `host/iterm`, `host/unknown`, etc.
- New `Host` field on the telemetry `ExecutionContext`.

Scope is deliberately narrow. Only detections backed by direct observation or upstream docs are shipped:
- `vscode`: covers vanilla VSCode and any fork (Cursor, Windsurf, code-server). Forks don't expose a stable, trustworthy discriminator in env, so we don't try to split them.
- `jetbrains`, `apple-terminal`, `iterm`, `warp`, `wezterm`, `ghostty`
- `unknown` for everything else (raw shells, terminals we don't recognize yet)

### What's deliberately NOT in this PR

Detecting whether a user has the Copilot extension active, or whether Claude Code / Cursor Agent is driving the CLI, is a separate dimension. We want it to be independent of host so the analyses above stay clean: "VSCode users WITHOUT Copilot" should be a join across two dimensions, not a single enum value. Conflating them (e.g. emitting `vscode-copilot` as a single host value) would make that query awkward. Agent/extension detection will land as its own field once we've verified the actual env signals.

Privacy: enum-only values, no raw env values, no paths, no versions.

## Test plan

- [x] Unit tests for \`DetectHost\` covering every shipped host
- [x] Unit tests for the user-agent hook
- [x] \`./task checks\` clean
- [x] \`./task fmt-q lint-q\` clean