### PR TITLE
lint: cap -j=4 and use --allow-parallel-runners

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -84,22 +84,23 @@ tasks:
 
   # `golangci-lint run` typechecks, so it stops at go.mod boundaries. We have
   # one task per Go module; `lint-go` composes them to cover the whole repo.
-  # Children run in parallel — each uses its own TMPDIR (set inline on the
-  # golangci-lint command below) to avoid the shared /tmp lock that serializes
-  # concurrent golangci-lint invocations. This matters in two scenarios:
-  #   1. siblings of `lint-go` running in parallel on subprojects here, and
-  #   2. `lint-go` invocations in sibling worktrees running at the same time.
-  # The TMPDIR must live under the repo but NOT equal {{.ROOT_DIR}} itself
-  # (the Go toolchain refuses a go.mod inside os.TempDir, which would break
-  # golangci-lint's typechecker).
+  #
+  # Flags on every invocation:
+  #   --allow-parallel-runners — by default golangci-lint takes a system-wide
+  #     lock and refuses to start if another copy is already running. This
+  #     flag opts out so parallel runs (e.g. `lint-go`'s three sub-lints, or
+  #     two worktrees linting at once) don't block each other.
+  #   -j=4 — cap analyzer concurrency; higher values use more CPU without
+  #     reducing wall time on this codebase.
+  #
+  # Cross-worktree concurrency relies on content-addressable cache keys added
+  # in golangci-lint v2.12.0; keep the binary at v2.12.0+ in tools/go.mod.
   lint-go:
     desc: Lint Go files across all modules (root, tools, codegen)
     deps: ['lint-go-root', 'lint-go-tools', 'lint-go-codegen']
 
   lint-go-root:
     desc: Lint Go files in the root module
-    vars:
-      TMPDIR: '{{.ROOT_DIR}}/.tmp/golangci-lint-root'
     sources: &ROOT_LINT_SOURCES
       - "**/*.go"
       - exclude: tools/**
@@ -109,48 +110,36 @@ tasks:
       - go.sum
       - "{{.EMBED_SOURCES}}"
     cmds:
-      - cmd: mkdir -p "{{.TMPDIR}}"
-        silent: true
-      - TMPDIR="{{.TMPDIR}}" {{.GO_TOOL}} golangci-lint run ./...
+      - "{{.GO_TOOL}} golangci-lint run --allow-parallel-runners -j=4 ./..."
 
   lint-go-tools:
     desc: Lint Go files in tools/ module
     dir: tools
-    vars:
-      TMPDIR: '{{.ROOT_DIR}}/.tmp/golangci-lint-tools'
     sources:
       - "**/*.go"
       - '{{.ROOT_DIR}}/.golangci.yaml'
       - go.mod
       - go.sum
     cmds:
-      - cmd: mkdir -p "{{.TMPDIR}}"
-        silent: true
       # gocritic is disabled because root's ruleguard rules path is cwd-relative
       # and cannot be resolved from this nested module.
-      - TMPDIR="{{.TMPDIR}}" {{.GO_TOOL}} golangci-lint run --disable gocritic ./...
+      - "{{.GO_TOOL}} golangci-lint run --allow-parallel-runners -j=4 --disable gocritic ./..."
 
   lint-go-codegen:
     desc: Lint Go files in bundle/internal/tf/codegen module
     dir: bundle/internal/tf/codegen
-    vars:
-      TMPDIR: '{{.ROOT_DIR}}/.tmp/golangci-lint-codegen'
     sources:
       - "**/*.go"
       - '{{.ROOT_DIR}}/.golangci.yaml'
       - go.mod
       - go.sum
     cmds:
-      - cmd: mkdir -p "{{.TMPDIR}}"
-        silent: true
       # gocritic is disabled because root's ruleguard rules path is cwd-relative
       # and cannot be resolved from this nested module.
-      - TMPDIR="{{.TMPDIR}}" {{.GO_TOOL}} golangci-lint run --disable gocritic ./...
+      - "{{.GO_TOOL}} golangci-lint run --allow-parallel-runners -j=4 --disable gocritic ./..."
 
   lint-q-go-root:
     desc: Lint changed Go files in root module (diff vs main, with --fix). Does not check tools/ or bundle/internal/tf/codegen — use `lint` for full coverage.
-    vars:
-      TMPDIR: '{{.ROOT_DIR}}/.tmp/golangci-lint-root'
     sources:
       - "**/*.go"
       - exclude: tools/**
@@ -162,9 +151,7 @@ tasks:
       - "{{.EMBED_SOURCES}}"
       - "**/testdata/**"
     cmds:
-      - cmd: mkdir -p "{{.TMPDIR}}"
-        silent: true
-      - TMPDIR="{{.TMPDIR}}" ./tools/lintdiff.py {{.GO_TOOL}} golangci-lint run --fix
+      - "./tools/lintdiff.py {{.GO_TOOL}} golangci-lint run --allow-parallel-runners -j=4 --fix"
 
   # --- Formatting ---
 


### PR DESCRIPTION
Two changes to the four `golangci-lint run` invocations in `Taskfile.yml`:

- Add `-j=4` to cap analyzer concurrency.
- Add `--allow-parallel-runners` and drop the per-task `TMPDIR` workaround introduced in #5050.

`./task lint`, fresh caches, same `tools/go.mod`:

| | Cold wall | Cold CPU (user+sys) | Warm wall |
|---|---|---|---|
| origin/main | 185s | 2282s | 4.1s |
| this PR | 76s | 327s | 4.0s |

2.4× faster cold wall, 7× less CPU. Warm runs are cache-bound and unchanged.

## `-j=4`

golangci-lint scales poorly past 4–6 workers (upstream [#5149](https://github.com/golangci/golangci-lint/issues/5149)). With three sub-lints running in parallel under `lint-go`, the default `-j=GOMAXPROCS` puts ~48 nominal workers on 16 cores — most of the 2282s on origin/main is kernel scheduling contention. Capping at 4 lets the three modules cooperate.

## `--allow-parallel-runners`

By default golangci-lint takes a system-wide lock and refuses to start if another copy is already running. The per-task `TMPDIR` override existed to give each invocation its own copy of that lock file so it didn't collide; `--allow-parallel-runners` tells golangci-lint not to take the lock in the first place. Same outcome, no `TMPDIR` plumbing.

Parallel runs happen when `lint-go` fans out to the three module sub-lints, and when multiple worktrees lint at once.

Safe to skip the lock because golangci-lint v2.12.0 added content-addressable cache keys ([PR #6445](https://github.com/golangci/golangci-lint/pull/6445)). Before that, two worktrees produced separate cache entries (keyed by absolute path) — no sharing, but also no contention. Now the entries are shared by content, so concurrent runs read and write the same files; the cache uses OS-level file locks with atomic write semantics to keep that safe. `origin/main` already pins v2.12.2.

## Trade-off

Two `task lint` runs in the *same* worktree no longer fail-fast with `"parallel golangci-lint is running"` — they race instead, harmlessly but wastefully (duplicate analysis work). Minor.

## Test plan

- [x] `task lint` clean
- [x] `task lint-q` clean
- [x] Parallel `task lint` across two worktrees both succeed
- [ ] CI lint job passes

This pull request and its description were written by Isaac.