### PR TITLE
auth: stop writing workspace_id = none on --skip-workspace

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -318,20 +318,17 @@ a new profile is created.
 			authArguments.WorkspaceID == "" &&
 			!skipWorkspace
 
-		if skipWorkspace && authArguments.WorkspaceID == "" {
-			authArguments.WorkspaceID = auth.WorkspaceIDNone
-		}
-
 		if shouldPromptWorkspace {
 			wsID, wsErr := promptForWorkspaceSelection(ctx, authArguments, persistentAuth)
 			if wsErr != nil {
 				log.Warnf(ctx, "Workspace selection failed: %v", wsErr)
-			} else if wsID == "" {
-				// User selected "Skip" from the prompt.
-				authArguments.WorkspaceID = auth.WorkspaceIDNone
-			} else {
+			} else if wsID != "" {
 				authArguments.WorkspaceID = wsID
 			}
+			// If wsID is empty, the user picked "Skip" — leave WorkspaceID empty.
+			// SaveToProfile omits the workspace_id key entirely for account-level
+			// profiles; MatchAccountProfiles treats absent workspace_id the same
+			// as the legacy "none" sentinel.
 		}
 
 		var clusterID, serverlessComputeID string

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -311,14 +311,7 @@ a new profile is created.
 		// 2. Configuring cluster and serverless;
 		// 3. Saving the profile.
 
-		// If discovery gave us an account_id but we still have no workspace_id,
-		// prompt the user to select a workspace. This applies to any host where
-		// .well-known/databricks-config returned an account_id.
-		shouldPromptWorkspace := authArguments.AccountID != "" &&
-			authArguments.WorkspaceID == "" &&
-			!skipWorkspace
-
-		if shouldPromptWorkspace {
+		if shouldPromptWorkspace(authArguments, existingProfile, skipWorkspace) {
 			wsID, wsErr := promptForWorkspaceSelection(ctx, authArguments, persistentAuth)
 			if wsErr != nil {
 				log.Warnf(ctx, "Workspace selection failed: %v", wsErr)
@@ -395,6 +388,23 @@ a new profile is created.
 	}
 
 	return cmd
+}
+
+// shouldPromptWorkspace reports whether the login flow should ask the user to
+// pick a workspace. We prompt when we have an account_id but no workspace_id
+// and the user did not pass --skip-workspace, with one exception: re-login
+// into an existing profile that's already account-only (account_id set,
+// workspace_id absent or the legacy "none" sentinel) honors the user's prior
+// "skip" choice instead of re-prompting on every login.
+func shouldPromptWorkspace(authArguments *auth.AuthArguments, existingProfile *profile.Profile, skipWorkspace bool) bool {
+	if authArguments.AccountID == "" || authArguments.WorkspaceID != "" || skipWorkspace {
+		return false
+	}
+	if existingProfile != nil && existingProfile.AccountID != "" &&
+		(existingProfile.WorkspaceID == "" || existingProfile.WorkspaceID == auth.WorkspaceIDNone) {
+		return false
+	}
+	return true
 }
 
 // Sets the host in the persistentAuth object based on the provided arguments and flags.

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -393,14 +393,17 @@ a new profile is created.
 // shouldPromptWorkspace reports whether the login flow should ask the user to
 // pick a workspace. We prompt when we have an account_id but no workspace_id
 // and the user did not pass --skip-workspace, with one exception: re-login
-// into an existing profile that's already account-only (account_id set,
-// workspace_id absent or the legacy "none" sentinel) honors the user's prior
-// "skip" choice instead of re-prompting on every login.
+// into an existing profile that's already account-only for the SAME account
+// (account_id matches and workspace_id is absent or the legacy "none"
+// sentinel) honors the user's prior "skip" choice instead of re-prompting on
+// every login. We require the account_id to match so reusing a profile name
+// against a different account still gets the workspace prompt.
 func shouldPromptWorkspace(authArguments *auth.AuthArguments, existingProfile *profile.Profile, skipWorkspace bool) bool {
 	if authArguments.AccountID == "" || authArguments.WorkspaceID != "" || skipWorkspace {
 		return false
 	}
-	if existingProfile != nil && existingProfile.AccountID != "" &&
+	if existingProfile != nil &&
+		existingProfile.AccountID == authArguments.AccountID &&
 		(existingProfile.WorkspaceID == "" || existingProfile.WorkspaceID == auth.WorkspaceIDNone) {
 		return false
 	}

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -585,6 +585,12 @@ func TestShouldPromptWorkspace(t *testing.T) {
 			want:            true,
 		},
 		{
+			name:            "account-only profile for a different account still prompts",
+			authArguments:   auth.AuthArguments{AccountID: "different-account"},
+			existingProfile: legacyAccountProfile,
+			want:            true,
+		},
+		{
 			name:          "skipWorkspace suppresses the prompt",
 			authArguments: auth.AuthArguments{AccountID: "acc"},
 			skipWorkspace: true,

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -546,6 +546,69 @@ func TestSetHostAndAccountId_WorkspaceIDNoneSentinelInherited(t *testing.T) {
 	assert.Equal(t, auth.WorkspaceIDNone, args.WorkspaceID)
 }
 
+func TestShouldPromptWorkspace(t *testing.T) {
+	t.Setenv("DATABRICKS_CONFIG_FILE", "./testdata/.databrickscfg")
+	ctx, _ := cmdio.SetupTest(t.Context(), cmdio.TestOptions{})
+
+	legacyAccountProfile := loadTestProfile(t, ctx, "spog-skip-workspace")
+	newAccountProfile := loadTestProfile(t, ctx, "spog-skip-workspace-new")
+	workspaceProfile := loadTestProfile(t, ctx, "unified-workspace")
+
+	tests := []struct {
+		name            string
+		authArguments   auth.AuthArguments
+		existingProfile *profile.Profile
+		skipWorkspace   bool
+		want            bool
+	}{
+		{
+			name:          "no profile, account_id set, no workspace_id",
+			authArguments: auth.AuthArguments{AccountID: "acc"},
+			want:          true,
+		},
+		{
+			name:            "re-login into legacy account-only profile (workspace_id = none)",
+			authArguments:   auth.AuthArguments{AccountID: "spog-account"},
+			existingProfile: legacyAccountProfile,
+			want:            false,
+		},
+		{
+			name:            "re-login into new account-only profile (no workspace_id key)",
+			authArguments:   auth.AuthArguments{AccountID: "spog-account"},
+			existingProfile: newAccountProfile,
+			want:            false,
+		},
+		{
+			name:            "re-login into workspace profile prompts when workspace_id missing from args",
+			authArguments:   auth.AuthArguments{AccountID: "test-unified-account"},
+			existingProfile: workspaceProfile,
+			want:            true,
+		},
+		{
+			name:          "skipWorkspace suppresses the prompt",
+			authArguments: auth.AuthArguments{AccountID: "acc"},
+			skipWorkspace: true,
+			want:          false,
+		},
+		{
+			name:          "no account_id means no prompt",
+			authArguments: auth.AuthArguments{},
+			want:          false,
+		},
+		{
+			name:          "workspace_id already known means no prompt",
+			authArguments: auth.AuthArguments{AccountID: "acc", WorkspaceID: "12345"},
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPromptWorkspace(&tt.authArguments, tt.existingProfile, tt.skipWorkspace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSetHostAndAccountId_URLParamsOverrideProfile(t *testing.T) {
 	t.Setenv("DATABRICKS_CONFIG_FILE", "./testdata/.databrickscfg")
 	ctx, _ := cmdio.SetupTest(t.Context(), cmdio.TestOptions{})

--- a/cmd/auth/testdata/.databrickscfg
+++ b/cmd/auth/testdata/.databrickscfg
@@ -31,3 +31,7 @@ experimental_is_unified_host = true
 host = https://spog.example.com
 account_id = spog-account
 workspace_id = none
+
+[spog-skip-workspace-new]
+host = https://spog.example.com
+account_id = spog-account


### PR DESCRIPTION
## Why

`databricks auth login --skip-workspace` writes a literal `workspace_id = none` into `.databrickscfg` when no workspace can be discovered. That string is a CLI-internal sentinel.

## Changes

- Before: `--skip-workspace` (and "Skip" picked in the interactive workspace prompt) set the in-memory `WorkspaceIDNone` sentinel, which was then saved to disk as `workspace_id = none`.
- Now: both paths leave `WorkspaceID` empty. `SaveToProfile` already omits empty fields, so account-only profiles land with no `workspace_id` key at all. `MatchAccountProfiles` already treats absent and `none` identically, so legacy profiles that still have `workspace_id = none` keep working.

`auth.WorkspaceIDNone` stays defined for backwards-compatible parsing.

Re-login regression fix: without the sentinel, an account-only profile loads back with `WorkspaceID == ""`, which has the same shape as a fresh login that still needs a workspace pick. Without further changes, `databricks auth login --profile foo` (no `--skip-workspace`) would prompt again on every run. Extract `shouldPromptWorkspace` and treat "existing profile is already account-only" as honoring the user's prior skip choice. Covers both the new (absent `workspace_id`) and legacy (`workspace_id = none`) shapes.

## Test plan

- [x] `go test ./cmd/auth/...` (existing tests, including `TestSetHostAndAccountId_WorkspaceIDNoneSentinelInherited`)
- [x] New `TestShouldPromptWorkspace` table-driven test exercises re-login into legacy and new-shape account-only profiles, a workspace profile, `--skip-workspace`, and the no-account-id / known-workspace-id short-circuits.
- [x] `go test ./acceptance -run TestAccept/cmd/auth/profiles/spog-account` (legacy `workspace_id = none` profile still parses as account)
- [x] `./task checks`
- [x] `./task lint-q`