### PR TITLE
auth: suggest ACCOUNT-<id> as default profile name for --skip-workspace

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -221,6 +221,23 @@ a new profile is created.
 			}
 		}
 
+		// If --skip-workspace is set and we already know the host, eagerly run
+		// URL-param extraction and host discovery so getProfileName can suggest
+		// ACCOUNT-<account-id> as the default name. Without this, AccountID is
+		// only populated by setHostAndAccountId further down, which runs after
+		// the profile-name prompt.
+		if skipWorkspace && profileName == "" && authArguments.Host != "" && authArguments.AccountID == "" {
+			params := auth.ExtractHostQueryParams(authArguments.Host)
+			authArguments.Host = params.Host
+			if authArguments.AccountID == "" {
+				authArguments.AccountID = params.AccountID
+			}
+			if authArguments.WorkspaceID == "" {
+				authArguments.WorkspaceID = params.WorkspaceID
+			}
+			runHostDiscovery(ctx, authArguments)
+		}
+
 		// If the user has not specified a profile name, prompt for one.
 		if profileName == "" {
 			var err error

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -564,6 +564,55 @@ func TestSetHostAndAccountId_URLParamsOverrideProfile(t *testing.T) {
 	assert.Equal(t, "99999", args.WorkspaceID)
 }
 
+func TestGetProfileName(t *testing.T) {
+	tests := []struct {
+		name string
+		args *auth.AuthArguments
+		want string
+	}{
+		{
+			name: "account id set",
+			args: &auth.AuthArguments{Host: "https://db-deco-test.databricks.com", AccountID: "abc-123"},
+			want: "ACCOUNT-abc-123",
+		},
+		{
+			name: "no account id falls back to host",
+			args: &auth.AuthArguments{Host: "https://db-deco-test.databricks.com"},
+			want: "db-deco-test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getProfileName(tt.args))
+		})
+	}
+}
+
+// TestSkipWorkspaceProfileNameUsesDiscoveredAccountID verifies that the
+// pre-naming discovery block populates AccountID from .well-known so the
+// profile-name prompt suggests ACCOUNT-<account-id> instead of the host-based
+// default.
+func TestSkipWorkspaceProfileNameUsesDiscoveredAccountID(t *testing.T) {
+	server := newDiscoveryServer(t, map[string]any{
+		"account_id":    "abc-123",
+		"oidc_endpoint": "https://spog.example.com/oidc/accounts/abc-123",
+	})
+
+	ctx := t.Context()
+	args := &auth.AuthArguments{Host: server.URL}
+
+	// Mirrors the pre-naming block in newLoginCommand's RunE for --skip-workspace.
+	params := auth.ExtractHostQueryParams(args.Host)
+	args.Host = params.Host
+	if args.AccountID == "" {
+		args.AccountID = params.AccountID
+	}
+	runHostDiscovery(ctx, args)
+
+	assert.Equal(t, "abc-123", args.AccountID)
+	assert.Equal(t, "ACCOUNT-abc-123", getProfileName(args))
+}
+
 func TestValidateDiscoveryFlagCompatibility(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Why

When you run \`databricks auth login --host X --skip-workspace\`, the profile-name prompt suggests the host's first DNS label (e.g. \`db-deco-test\`) even though the resulting profile is account-only. 

## Changes

\`getProfileName\` already returns \`ACCOUNT-<account-id>\` when \`AccountID\` is populated, but \`setHostAndAccountId\` (which fills \`AccountID\` from \`.well-known/databricks-config\`) only runs *after* the profile-name prompt. So at prompt time, \`AccountID\` was always empty for the no-\`--profile\` flow.

- Before: \`auth login --host https://db-deco-test... --skip-workspace\` → prompt suggests \`db-deco-test\`.
- Now: same command → URL-param extraction + host discovery run eagerly before the prompt, so the suggestion is \`ACCOUNT-<account-id>\`.

Other login paths are unchanged. The discovery call is redundant with the one in \`setHostAndAccountId\` later in the flow; \`runHostDiscovery\` is idempotent for the auth-arguments fields it touches, so the cost is at most one extra \`.well-known\` round-trip (≤5s timeout) and only on the \`--skip-workspace\` path.

## Test plan

- [x] New unit tests: \`TestGetProfileName\`, \`TestSkipWorkspaceProfileNameUsesDiscoveredAccountID\` (uses a mock \`.well-known\` server)
- [x] \`go test ./cmd/auth/...\` (full package)
- [x] \`./task checks\`
- [x] \`./task lint-q\`