### PR TITLE
experimental/ssh: drop [EXPERIMENTAL] tag and clean up help copy

### DIFF
--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -12,11 +12,20 @@ import (
 func newConnectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "Connect to Databricks compute via SSH",
+		Short: "Connect to Databricks serverless or dedicated compute via SSH",
 		Long: `Connect to Databricks compute via SSH.
 
 This command establishes an SSH connection to Databricks compute, setting up
 the SSH server and handling the connection proxy.
+
+Connect to serverless (no cluster ID needed):
+  databricks ssh connect
+  databricks ssh connect --accelerator=GPU_1xA10            # serverless GPU
+  databricks ssh connect --environment-version=4            # custom serverless environment
+  databricks ssh connect --ide=cursor                       # launch Cursor remote window on connect
+
+Connect to a dedicated cluster:
+  databricks ssh connect --cluster=<cluster-id>
 
 ` + disclaimer,
 	}
@@ -43,12 +52,9 @@ the SSH server and handling the connection proxy.
 	cmd.Flags().IntVar(&maxClients, "max-clients", defaultMaxClients, "Maximum number of SSH clients")
 	cmd.Flags().BoolVar(&autoStartCluster, "auto-start-cluster", true, "Automatically start the cluster if it is not running")
 
-	cmd.Flags().StringVar(&connectionName, "name", "", "Connection name (for serverless compute)")
-	cmd.Flags().MarkHidden("name")
-	cmd.Flags().StringVar(&accelerator, "accelerator", "", "GPU accelerator type (GPU_1xA10 or GPU_8xH100)")
-	cmd.Flags().MarkHidden("accelerator")
-	cmd.Flags().StringVar(&ide, "ide", "", "Open remote IDE window (vscode or cursor)")
-	cmd.Flags().MarkHidden("ide")
+	cmd.Flags().StringVar(&connectionName, "name", "", "Connection name to reuse across sessions (serverless only)")
+	cmd.Flags().StringVar(&accelerator, "accelerator", "", "Serverless GPU accelerator type (GPU_1xA10 or GPU_8xH100)")
+	cmd.Flags().StringVar(&ide, "ide", "", "Open a remote IDE window on connect (vscode or cursor)")
 
 	cmd.Flags().BoolVar(&proxyMode, "proxy", false, "ProxyCommand mode")
 	cmd.Flags().MarkHidden("proxy")
@@ -69,8 +75,7 @@ the SSH server and handling the connection proxy.
 	cmd.Flags().BoolVar(&skipSettingsCheck, "skip-settings-check", false, "Skip checking and updating IDE settings")
 	cmd.Flags().MarkHidden("skip-settings-check")
 
-	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for serverless compute")
-	cmd.Flags().MarkHidden("environment-version")
+	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Serverless environment version to use for the session")
 
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -71,6 +71,7 @@ Connect to a dedicated cluster:
 	cmd.Flags().MarkHidden("skip-settings-check")
 
 	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for AI Runtime")
+	cmd.Flags().MarkHidden("environment-version")
 
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -49,7 +49,7 @@ Connect to a dedicated cluster:
 
 	cmd.Flags().StringVar(&connectionName, "name", "", "Connection name to reuse across sessions (serverless only)")
 	cmd.Flags().StringVar(&accelerator, "accelerator", "", "Serverless GPU accelerator type (GPU_1xA10 or GPU_8xH100)")
-	cmd.Flags().StringVar(&ide, "ide", "", "Open a remote IDE window on connect (vscode or cursor)")
+	cmd.Flags().StringVar(&ide, "ide", "", "Open remote IDE window (vscode or cursor)")
 
 	cmd.Flags().BoolVar(&proxyMode, "proxy", false, "ProxyCommand mode")
 	cmd.Flags().MarkHidden("proxy")

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -12,17 +12,12 @@ import (
 func newConnectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "Connect to Databricks serverless or dedicated compute via SSH",
-		Long: `Connect to Databricks compute via SSH.
+		Short: "Connect to Databricks compute via SSH",
+		Long: `Connect to your Databricks compute and workspace with ssh.
 
-This command establishes an SSH connection to Databricks compute, setting up
-the SSH server and handling the connection proxy.
-
-Connect to serverless (no cluster ID needed):
+Connect to serverless:
   databricks ssh connect
-  databricks ssh connect --accelerator=GPU_1xA10            # serverless GPU
-  databricks ssh connect --environment-version=4            # custom serverless environment
-  databricks ssh connect --ide=cursor                       # launch Cursor remote window on connect
+  databricks ssh connect --accelerator=<GPU_type>	# AI Runtime
 
 Connect to a dedicated cluster:
   databricks ssh connect --cluster=<cluster-id>
@@ -47,7 +42,7 @@ Connect to a dedicated cluster:
 	var environmentVersion int
 	var autoApprove bool
 
-	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks cluster ID (for dedicated clusters)")
+	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks dedicated cluster ID")
 	cmd.Flags().DurationVar(&shutdownDelay, "shutdown-delay", defaultShutdownDelay, "Delay before shutting down the server after the last client disconnects")
 	cmd.Flags().IntVar(&maxClients, "max-clients", defaultMaxClients, "Maximum number of SSH clients")
 	cmd.Flags().BoolVar(&autoStartCluster, "auto-start-cluster", true, "Automatically start the cluster if it is not running")
@@ -75,7 +70,7 @@ Connect to a dedicated cluster:
 	cmd.Flags().BoolVar(&skipSettingsCheck, "skip-settings-check", false, "Skip checking and updating IDE settings")
 	cmd.Flags().MarkHidden("skip-settings-check")
 
-	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Serverless environment version to use for the session")
+	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for AI Runtime")
 
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -12,8 +12,8 @@ import (
 func newConnectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "Connect to Databricks compute via SSH",
-		Long: `Connect to your Databricks compute and workspace with ssh.
+		Short: "Connect to your Databricks compute and workspace via SSH",
+		Long: `Connect to your Databricks compute and workspace via SSH.
 
 Connect to serverless:
   databricks ssh connect

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -12,14 +12,12 @@ import (
 func newConnectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH",
-		Long: `[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH.
-
-This is an experimental feature and is subject to change.
+		Short: "Connect to your Databricks compute and workspace via SSH",
+		Long: `Connect to your Databricks compute and workspace via SSH.
 
 Connect to serverless:
   databricks ssh connect
-  databricks ssh connect --accelerator=<GPU_type>	# AI Runtime
+  databricks ssh connect --accelerator=<GPU_type>   # AI Runtime
 
 Connect to a dedicated cluster:
   databricks ssh connect --cluster=<cluster-id>`,

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -12,17 +12,17 @@ import (
 func newConnectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connect",
-		Short: "Connect to your Databricks compute and workspace via SSH",
-		Long: `Connect to your Databricks compute and workspace via SSH.
+		Short: "[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH",
+		Long: `[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH.
+
+This is an experimental feature and is subject to change.
 
 Connect to serverless:
   databricks ssh connect
   databricks ssh connect --accelerator=<GPU_type>	# AI Runtime
 
 Connect to a dedicated cluster:
-  databricks ssh connect --cluster=<cluster-id>
-
-` + disclaimer,
+  databricks ssh connect --cluster=<cluster-id>`,
 	}
 
 	var clusterID string

--- a/experimental/ssh/cmd/server.go
+++ b/experimental/ssh/cmd/server.go
@@ -12,10 +12,8 @@ import (
 func newServerCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
-		Short: "[EXPERIMENTAL] Run SSH tunnel server",
-		Long: `[EXPERIMENTAL] Run SSH tunnel server.
-
-This is an experimental feature and is subject to change.
+		Short: "Run SSH tunnel server",
+		Long: `Run SSH tunnel server.
 
 This command starts an SSH tunnel server that accepts WebSocket connections
 and proxies them to local SSH daemon processes.`,

--- a/experimental/ssh/cmd/server.go
+++ b/experimental/ssh/cmd/server.go
@@ -12,13 +12,13 @@ import (
 func newServerCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "server",
-		Short: "Run SSH tunnel server",
-		Long: `Run SSH tunnel server.
+		Short: "[EXPERIMENTAL] Run SSH tunnel server",
+		Long: `[EXPERIMENTAL] Run SSH tunnel server.
+
+This is an experimental feature and is subject to change.
 
 This command starts an SSH tunnel server that accepts WebSocket connections
-and proxies them to local SSH daemon processes.
-
-` + disclaimer,
+and proxies them to local SSH daemon processes.`,
 		// This is an internal command spawned by the SSH client running the "ssh-server-bootstrap.py" job
 		Hidden: true,
 	}

--- a/experimental/ssh/cmd/setup.go
+++ b/experimental/ssh/cmd/setup.go
@@ -12,11 +12,14 @@ import (
 func newSetupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Setup SSH configuration for Databricks compute",
-		Long: `Setup SSH configuration for Databricks compute.
+		Short: "Setup SSH configuration for a Databricks dedicated cluster",
+		Long: `Setup SSH configuration for a Databricks dedicated cluster.
 
-This command configures SSH to connect to Databricks compute by adding
-an SSH host configuration to your SSH config file.
+This command configures SSH to connect to a Databricks dedicated cluster by
+adding an SSH host configuration to your SSH config file. After running setup,
+you can connect with ` + "`ssh <name>`" + ` directly.
+
+For serverless connections, use ` + "`databricks ssh connect`" + ` (no setup step needed).
 
 ` + disclaimer,
 	}

--- a/experimental/ssh/cmd/setup.go
+++ b/experimental/ssh/cmd/setup.go
@@ -12,14 +12,14 @@ import (
 func newSetupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Setup SSH configuration for dedicated (single-user) clusters",
-		Long: `Setup SSH configuration for dedicated (single-user) clusters.
+		Short: "[EXPERIMENTAL] Setup SSH configuration for dedicated (single-user) clusters",
+		Long: `[EXPERIMENTAL] Setup SSH configuration for dedicated (single-user) clusters.
+
+This is an experimental feature and is subject to change.
 
 After running setup, you can connect with ` + "`ssh <name>`" + `.
 
-For serverless connections, use ` + "`databricks ssh connect`" + ` (no setup step needed).
-
-` + disclaimer,
+For serverless connections, use ` + "`databricks ssh connect`" + ` (no setup step needed).`,
 	}
 
 	var hostName string

--- a/experimental/ssh/cmd/setup.go
+++ b/experimental/ssh/cmd/setup.go
@@ -12,12 +12,10 @@ import (
 func newSetupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "Setup SSH configuration for a Databricks dedicated cluster",
-		Long: `Setup SSH configuration for a Databricks dedicated cluster.
+		Short: "Setup SSH configuration for dedicated (single-user) clusters",
+		Long: `Setup SSH configuration for dedicated (single-user) clusters.
 
-This command configures SSH to connect to a Databricks dedicated cluster by
-adding an SSH host configuration to your SSH config file. After running setup,
-you can connect with ` + "`ssh <name>`" + ` directly.
+After running setup, you can connect with ` + "`ssh <name>`" + `.
 
 For serverless connections, use ` + "`databricks ssh connect`" + ` (no setup step needed).
 

--- a/experimental/ssh/cmd/setup.go
+++ b/experimental/ssh/cmd/setup.go
@@ -12,10 +12,8 @@ import (
 func newSetupCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
-		Short: "[EXPERIMENTAL] Setup SSH configuration for dedicated (single-user) clusters",
-		Long: `[EXPERIMENTAL] Setup SSH configuration for dedicated (single-user) clusters.
-
-This is an experimental feature and is subject to change.
+		Short: "Setup SSH configuration for dedicated (single-user) clusters",
+		Long: `Setup SSH configuration for dedicated (single-user) clusters.
 
 After running setup, you can connect with ` + "`ssh <name>`" + `.
 

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -20,9 +20,12 @@ func New() *cobra.Command {
 SSH commands let you setup and establish ssh connections to Databricks compute.
 
 Common workflows:
-  databricks ssh connect --cluster=<cluster-id> --profile=<profile-name>  # connect to a cluster without any setup
-  databricks ssh setup --name=my-compute --cluster=<cluster-id>           # update local ssh config
-  ssh my-compute                                                          # connect to the compute using ssh client
+  databricks ssh connect                                          # connect to serverless compute
+  databricks ssh connect --cluster=<cluster-id>                   # connect to a dedicated cluster
+  databricks ssh setup --name=my-compute --cluster=<cluster-id>   # update local ssh config for a dedicated cluster
+  ssh my-compute                                                  # connect using the ssh client (after setup)
+
+Use ` + "`databricks ssh connect --help`" + ` to see flags for serverless GPUs and serverless environment versions.
 
 ` + disclaimer,
 	}

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -13,9 +13,9 @@ const disclaimer = `WARNING! This is an experimental feature:
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ssh",
-		Short:  "Connect to Databricks compute with ssh",
+		Short:  "Connect to your Databricks compute and workspace via SSH",
 		Hidden: true,
-		Long: `Connect to your Databricks compute and workspace with ssh.
+		Long: `Connect to your Databricks compute and workspace via SSH.
 
 Common workflows:
   databricks ssh connect --ide=cursor                       		# connect to serverless through Cursor

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -4,27 +4,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const disclaimer = `WARNING! This is an experimental feature:
-- The product is in preview and not intended to be used in production;
-- The product may change or may never be released;
-- While we will not charge separately for this product right now, we may charge for it in the future. You will still incur charges for DBUs;
-- There's no formal support or SLAs for the preview - so please reach out to your account or other contact with any questions or feedback;`
-
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ssh",
-		Short:  "Connect to your Databricks compute and workspace via SSH",
+		Short:  "[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH",
 		Hidden: true,
-		Long: `Connect to your Databricks compute and workspace via SSH.
+		Long: `[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH.
+
+This is an experimental feature and is subject to change.
 
 Common workflows:
   databricks ssh connect --ide=cursor                       		# connect to serverless through Cursor
   databricks ssh setup --name=<connection> --cluster=<cluster-id>   # update ~/.ssh/config so you can reconnect to a dedicated cluster
   ssh <connection>                                                  # connect to dedicated cluster after setup
 
-Use ` + "`databricks ssh connect --help`" + ` to see all available flags.
-
-` + disclaimer,
+Use ` + "`databricks ssh connect --help`" + ` to see all available flags.`,
 	}
 
 	cmd.AddCommand(newSetupCommand())

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -15,17 +15,14 @@ func New() *cobra.Command {
 		Use:    "ssh",
 		Short:  "Connect to Databricks compute with ssh",
 		Hidden: true,
-		Long: `Connect to Databricks compute with ssh.
-
-SSH commands let you setup and establish ssh connections to Databricks compute.
+		Long: `Connect to your Databricks compute and workspace with ssh.
 
 Common workflows:
-  databricks ssh connect                                          # connect to serverless compute
-  databricks ssh connect --cluster=<cluster-id>                   # connect to a dedicated cluster
-  databricks ssh setup --name=my-compute --cluster=<cluster-id>   # update local ssh config for a dedicated cluster
-  ssh my-compute                                                  # connect using the ssh client (after setup)
+  databricks ssh connect --ide=cursor                       		# connect to serverless through Cursor
+  databricks ssh setup --name=<connection> --cluster=<cluster-id>   # update ~/.ssh/config so you can reconnect to a dedicated cluster
+  ssh <connection>                                                  # connect to dedicated cluster after setup
 
-Use ` + "`databricks ssh connect --help`" + ` to see flags for serverless GPUs and serverless environment versions.
+Use ` + "`databricks ssh connect --help`" + ` to see all available flags.
 
 ` + disclaimer,
 	}

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -12,9 +12,9 @@ func New() *cobra.Command {
 		Long: `Connect to your Databricks compute and workspace via SSH.
 
 Common workflows:
-  databricks ssh connect --ide=cursor                       # connect to serverless through Cursor
-  databricks ssh setup --name=<name> --cluster=<cluster-id> # update ~/.ssh/config so you can reconnect to a dedicated cluster
-  ssh <name>                                                # connect to dedicated cluster after setup
+  databricks ssh connect --ide=cursor                         # connect to serverless through Cursor
+  databricks ssh setup --name=<name> --cluster=<cluster-id>   # update ~/.ssh/config so you can reconnect to a dedicated cluster
+  ssh <name>                                                  # connect to dedicated cluster after setup
 
 Use ` + "`databricks ssh connect --help`" + ` to see all available flags.`,
 	}

--- a/experimental/ssh/cmd/ssh.go
+++ b/experimental/ssh/cmd/ssh.go
@@ -7,16 +7,14 @@ import (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "ssh",
-		Short:  "[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH",
+		Short:  "Connect to your Databricks compute and workspace via SSH",
 		Hidden: true,
-		Long: `[EXPERIMENTAL] Connect to your Databricks compute and workspace via SSH.
-
-This is an experimental feature and is subject to change.
+		Long: `Connect to your Databricks compute and workspace via SSH.
 
 Common workflows:
-  databricks ssh connect --ide=cursor                       		# connect to serverless through Cursor
-  databricks ssh setup --name=<connection> --cluster=<cluster-id>   # update ~/.ssh/config so you can reconnect to a dedicated cluster
-  ssh <connection>                                                  # connect to dedicated cluster after setup
+  databricks ssh connect --ide=cursor                       # connect to serverless through Cursor
+  databricks ssh setup --name=<name> --cluster=<cluster-id> # update ~/.ssh/config so you can reconnect to a dedicated cluster
+  ssh <name>                                                # connect to dedicated cluster after setup
 
 Use ` + "`databricks ssh connect --help`" + ` to see all available flags.`,
 	}


### PR DESCRIPTION
## Summary
- Replace verbose disclaimer with lightweight tag, then drop [EXPERIMENTAL] entirely
- Hide env-version flag, fix alignment in help text
- Replace tabs with spaces, update `<connection>` to `<name>` in examples

Supersedes #5325 and #5326 (fork PRs that couldn't run CI).

## Test plan
- [ ] Verify `databricks ssh --help`, `databricks ssh connect --help`, `databricks ssh setup --help` output
- [ ] CI passes (including `test-exp-ssh`)