### PR TITLE
auth: honor --host on `auth describe` and prefer default profile when host is ambiguous

### DIFF
--- a/cmd/auth/describe.go
+++ b/cmd/auth/describe.go
@@ -10,6 +10,7 @@ import (
 	"github.com/databricks/cli/libs/auth/storage"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/databrickscfg/profile"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/log"
@@ -65,6 +66,9 @@ func newDescribeCommand() *cobra.Command {
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
+		if err := resolveProfileFromHostFlag(cmd, profile.DefaultProfiler); err != nil {
+			return err
+		}
 		var status *authStatus
 		var err error
 		status, err = getAuthStatus(cmd, args, showSensitive, func(cmd *cobra.Command, args []string) (*config.Config, bool, error) {
@@ -83,6 +87,33 @@ func newDescribeCommand() *cobra.Command {
 	}
 
 	return cmd
+}
+
+// resolveProfileFromHostFlag translates an explicit --host into a --profile
+// for `auth describe`. Without this, the downstream profile resolver ignores
+// --host and either falls back to [__settings__].default_profile (silently
+// describing a different host than the one the user named) or errors with the
+// SDK's default-credentials message even though a host-matching profile
+// exists. DATABRICKS_CONFIG_PROFILE is left alone — it's an explicit signal
+// the user already made.
+func resolveProfileFromHostFlag(cmd *cobra.Command, profiler profile.Profiler) error {
+	hostFlag := cmd.Flag("host")
+	profileFlag := cmd.Flag("profile")
+	if hostFlag == nil || profileFlag == nil {
+		return nil
+	}
+	if !hostFlag.Changed || profileFlag.Changed {
+		return nil
+	}
+	ctx := cmd.Context()
+	if env.Get(ctx, "DATABRICKS_CONFIG_PROFILE") != "" {
+		return nil
+	}
+	profileName, err := resolveHostToProfile(ctx, hostFlag.Value.String(), profiler)
+	if err != nil {
+		return err
+	}
+	return profileFlag.Value.Set(profileName)
 }
 
 type tryAuth func(cmd *cobra.Command, args []string) (*config.Config, bool, error)

--- a/cmd/auth/describe_test.go
+++ b/cmd/auth/describe_test.go
@@ -2,11 +2,13 @@ package auth
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/libs/auth/storage"
 	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/databrickscfg/profile"
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/iam"
@@ -15,6 +17,67 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func newHostProfileCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().String("host", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.SetContext(t.Context())
+	return cmd
+}
+
+func TestResolveProfileFromHostFlag(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), ".databrickscfg")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(""), 0o600))
+	t.Setenv("DATABRICKS_CONFIG_FILE", cfgPath)
+
+	profiler := profile.InMemoryProfiler{
+		Profiles: profile.Profiles{
+			{Name: "dev", Host: "https://dev.cloud.databricks.com", AuthType: "databricks-cli"},
+		},
+	}
+
+	t.Run("no flags set is a no-op", func(t *testing.T) {
+		cmd := newHostProfileCmd(t)
+		require.NoError(t, resolveProfileFromHostFlag(cmd, profiler))
+		assert.Empty(t, cmd.Flag("profile").Value.String())
+	})
+
+	t.Run("--profile already set wins; --host is ignored", func(t *testing.T) {
+		cmd := newHostProfileCmd(t)
+		require.NoError(t, cmd.Flags().Set("host", "https://dev.cloud.databricks.com"))
+		require.NoError(t, cmd.Flags().Set("profile", "explicit"))
+		require.NoError(t, resolveProfileFromHostFlag(cmd, profiler))
+		assert.Equal(t, "explicit", cmd.Flag("profile").Value.String())
+	})
+
+	t.Run("--host with a single match wires --profile", func(t *testing.T) {
+		cmd := newHostProfileCmd(t)
+		require.NoError(t, cmd.Flags().Set("host", "https://dev.cloud.databricks.com"))
+		require.NoError(t, resolveProfileFromHostFlag(cmd, profiler))
+		assert.Equal(t, "dev", cmd.Flag("profile").Value.String())
+	})
+
+	t.Run("--host with no match surfaces a clear error", func(t *testing.T) {
+		cmd := newHostProfileCmd(t)
+		require.NoError(t, cmd.Flags().Set("host", "https://nope.cloud.databricks.com"))
+		err := resolveProfileFromHostFlag(cmd, profiler)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no profile found matching host")
+		assert.Empty(t, cmd.Flag("profile").Value.String())
+	})
+
+	t.Run("DATABRICKS_CONFIG_PROFILE is left alone", func(t *testing.T) {
+		t.Setenv("DATABRICKS_CONFIG_PROFILE", "from-env")
+		cmd := newHostProfileCmd(t)
+		require.NoError(t, cmd.Flags().Set("host", "https://dev.cloud.databricks.com"))
+		require.NoError(t, resolveProfileFromHostFlag(cmd, profiler))
+		// We don't overwrite --profile when the user signalled an explicit
+		// choice via the env var.
+		assert.Empty(t, cmd.Flag("profile").Value.String())
+	})
+}
 
 func TestGetWorkspaceAuthStatus(t *testing.T) {
 	ctx := t.Context()

--- a/cmd/auth/resolve.go
+++ b/cmd/auth/resolve.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/databricks/cli/libs/databrickscfg/profile"
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/config"
 )
 
@@ -72,6 +75,17 @@ func resolveHostToProfile(ctx context.Context, host string, profiler profile.Pro
 		names := strings.Join(allProfiles.Names(), ", ")
 		return "", fmt.Errorf("no profile found matching host %q. Available profiles: %s", host, names)
 	default:
+		// Prefer the configured default profile when it's one of the host
+		// matches, so commands that pass --host don't trip the picker for
+		// users who already picked a default.
+		if defaultProfile, _ := databrickscfg.GetDefaultProfile(ctx, env.Get(ctx, "DATABRICKS_CONFIG_FILE")); defaultProfile != "" {
+			for _, p := range hostProfiles {
+				if p.Name == defaultProfile {
+					log.Debugf(ctx, "multiple profiles match host %q; using default profile %q", host, defaultProfile)
+					return p.Name, nil
+				}
+			}
+		}
 		if cmdio.IsPromptSupported(ctx) {
 			selected, err := profile.SelectProfile(ctx, profile.SelectConfig{
 				Label:             fmt.Sprintf("Multiple profiles found for %q. Select one to use", host),

--- a/cmd/auth/resolve_test.go
+++ b/cmd/auth/resolve_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/libs/cmdio"
@@ -125,6 +127,36 @@ func TestResolveHostToProfileMatchesMultipleProfiles(t *testing.T) {
 	assert.ErrorContains(t, err, "multiple profiles found matching host")
 	assert.ErrorContains(t, err, "dev1")
 	assert.ErrorContains(t, err, "dev2")
+}
+
+func TestResolveHostToProfilePrefersConfiguredDefault(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), ".databrickscfg")
+	err := os.WriteFile(cfgPath, []byte(`
+[__settings__]
+default_profile = dev2
+
+[dev1]
+host = https://shared.cloud.databricks.com
+auth_type = databricks-cli
+
+[dev2]
+host = https://shared.cloud.databricks.com
+auth_type = databricks-cli
+`), 0o600)
+	require.NoError(t, err)
+	t.Setenv("DATABRICKS_CONFIG_FILE", cfgPath)
+
+	ctx := cmdio.MockDiscard(t.Context())
+	profiler := profile.InMemoryProfiler{
+		Profiles: profile.Profiles{
+			{Name: "dev1", Host: "https://shared.cloud.databricks.com", AuthType: "databricks-cli"},
+			{Name: "dev2", Host: "https://shared.cloud.databricks.com", AuthType: "databricks-cli"},
+		},
+	}
+
+	resolved, err := resolveHostToProfile(ctx, "https://shared.cloud.databricks.com", profiler)
+	require.NoError(t, err)
+	assert.Equal(t, "dev2", resolved)
 }
 
 func TestResolveHostToProfileMatchesNothing(t *testing.T) {

--- a/cmd/auth/resolve_test.go
+++ b/cmd/auth/resolve_test.go
@@ -115,6 +115,12 @@ func TestResolveHostToProfileMatchesOneProfile(t *testing.T) {
 }
 
 func TestResolveHostToProfileMatchesMultipleProfiles(t *testing.T) {
+	// Point at an isolated config file with no default_profile so the new
+	// prefer-default branch doesn't pick up the caller's real .databrickscfg.
+	cfgPath := filepath.Join(t.TempDir(), ".databrickscfg")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(""), 0o600))
+	t.Setenv("DATABRICKS_CONFIG_FILE", cfgPath)
+
 	ctx := cmdio.MockDiscard(t.Context())
 	profiler := profile.InMemoryProfiler{
 		Profiles: profile.Profiles{


### PR DESCRIPTION
## Why

\`databricks auth describe --host X\` silently ignored the flag. The value was bound to the parent \`auth\` command's \`authArguments.Host\` but never read by the describe flow, so the SDK fell back to \`[__settings__].default_profile\` (silently describing a different host than the one named) or the \"default auth: cannot configure default credentials\" error even when a host-matching profile existed. The display still labelled the value \`(from --host flag)\`, making the mismatch hard to spot. Reported in a bug bash.

Reproduced against \`db-deco-test.databricks.com\` (which has two matching profiles in my .databrickscfg):
\`\`\`
$ databricks auth describe --host https://db-deco-test.databricks.com
Host: https://dogfood.staging.databricks.com   ← actually dogfood, not db-deco-test
✓ host: https://dogfood.staging.databricks.com (from --host flag)   ← misleading label
✓ profile: dogfood
\`\`\`

## Changes

- \`describe.go\`: when \`--host\` is set without \`--profile\`, resolve the host to a profile name via the existing \`resolveHostToProfile\` and set \`--profile\` so the downstream \`MustAnyClient\` uses it. \`DATABRICKS_CONFIG_PROFILE\` is left alone — it's an explicit user signal.
- \`resolve.go\`: when multiple profiles match a host, prefer \`[__settings__].default_profile\` if it's one of the matches before falling back to the picker or ambiguity error. The same helper is used by \`auth logout\`, which gets the same UX improvement (no prompt when the user's default already disambiguates).

After the fix, against the same host:
\`\`\`
$ databricks auth describe --host https://db-deco-test.databricks.com
Error: multiple profiles found matching host \"https://db-deco-test.databricks.com\":
  spog-deco-aws, db-deco-test-chrisst. Please specify the profile name directly
\`\`\`
And with \`default_profile = spog-deco-aws\` in \`[__settings__]\`, the same command auto-selects \`spog-deco-aws\` without prompting.

## Test plan

- [x] Reproduced against \`db-deco-test.databricks.com\`: confirmed the original bug (default profile silently used, misleading source label).
- [x] After the fix: single-host-match case picks the matching profile, multi-match case prefers the configured default, no-match case gives a clean error.
- [x] No-flag case still uses \`default_profile\` as before — no regression.
- [x] New unit test: \`TestResolveHostToProfilePrefersConfiguredDefault\`.
- [x] \`go test ./cmd/auth/...\`, \`./task checks\`, \`./task lint-q\`.