### PR TITLE
ci: stop saving Go build cache outside of main

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -15,17 +15,55 @@ runs:
     - name: Setup JFrog
       uses: ./.github/actions/setup-jfrog
 
-    - name: Create cache identifier
-      run: echo "${{ inputs.cache-key }}" > cache.txt
-      shell: bash
-
-    - name: Setup Go
+    - id: setup-go
+      name: Setup Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
-        cache-dependency-path: |
-          go.sum
-          cache.txt
+        # Disable setup-go's built-in cache; the steps below manage the
+        # cache so that only push-to-main runs save it. PR / merge_group /
+        # schedule saves are scoped to refs no other run can read, and
+        # they evict main's caches from the 10 GB GHA cache quota via LRU.
+        #
+        # See: https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching
+        cache: false
+
+    - name: Resolve Go cache paths
+      id: go-paths
+      shell: bash
+      run: |
+        echo "build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+        echo "mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+    # On runs against main (push + the scheduled wipe-and-repopulate
+    # cron added in #2092): restore now, save at job end via the
+    # unified action's post-step (which fires at the calling job's
+    # end, even when invoked from a composite).
+    - name: Restore and save Go cache (main)
+      if: github.ref == 'refs/heads/main'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ steps.go-paths.outputs.mod }}
+          ${{ steps.go-paths.outputs.build }}
+        key: setup-go-${{ inputs.cache-key }}-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          setup-go-${{ inputs.cache-key }}-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-
+
+    # On every other ref (PR / merge_group): restore only. Prefix
+    # fallback via restore-keys means runs whose go.sum differs from
+    # main still restore main's most recent cache and rebuild only
+    # the delta.
+    - name: Restore Go cache (non-main)
+      if: github.ref != 'refs/heads/main'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ steps.go-paths.outputs.mod }}
+          ${{ steps.go-paths.outputs.build }}
+        key: setup-go-${{ inputs.cache-key }}-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          setup-go-${{ inputs.cache-key }}-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-
 
     - name: Setup Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 0,12 * * *' # Runs at 00:00 and 12:00 UTC daily
+    - cron: '0 0 * * *' # Runs at 00:00 UTC daily
 
 env:
   GOTESTSUM_FORMAT: github-actions
@@ -137,21 +137,10 @@ jobs:
         with:
           cache-key: test-${{ matrix.deployment }}
 
-      - name: Run tests without coverage
-        # We run tests without coverage on PR, merge_group, and schedule because we don't make use of coverage information
-        # and would like to run the tests as fast as possible. We run it on schedule as well, because that is what
-        # populates the cache and cache may include test results.
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'schedule' }}
+      - name: Run tests
         env:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}
         run: go tool -modfile=tools/task/go.mod task test
-
-      - name: Run tests with coverage
-        # Only run 'task cover' on push to main to make sure it does not get broken.
-        if: ${{ github.event_name == 'push' }}
-        env:
-          ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}
-        run: go tool -modfile=tools/task/go.mod task cover
 
       - name: Upload gotestsum JSON output
         # Always upload so we can inspect timing even if tests fail.


### PR DESCRIPTION
## Why

`push.yml` saves many setup-go caches per run, but PR / merge_group / schedule saves are scoped to refs no other run can read. They still count against the 10 GB per-repo quota and evict main's caches via LRU, so most PRs miss the cache entirely.

See the [GitHub Actions dependency-caching docs](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) for the scope and eviction rules.

## What

### `setup-build-environment` composite

The composite now manages the Go cache explicitly instead of relying on `setup-go`'s built-in caching. `setup-go` runs with `cache: false`. On `refs/heads/main` (push + the scheduled wipe-and-repopulate cron from #2092) the unified `actions/cache@v5.0.5` restores immediately and its post-step saves at the calling job's end — composite-action post-steps fire at the job's end, not the composite's, so this works inside the composite. On every other ref, `actions/cache/restore@v5.0.5` restores only. `restore-keys` provides prefix fallback so PR runs with a changed `go.sum` still restore main's most recent cache and rebuild only the delta. The `cache.txt` workaround is gone — `inputs.cache-key` goes directly into the cache key string.

### Drop `task cover` from CI

`task cover` was a smoke check on main pushes. Cover-instrumented test binaries land in a different `GOCACHE` slot than the non-cover binaries PRs need, so a `go.sum` bump landing on a main push would leave the cache holding cover artifacts until the next 00:00 UTC wipe-and-repopulate fixed it (up to 24h of PRs missing the test-binary slot). Running `task test` on every event eliminates that hole; coverage stays in `Taskfile.yml` for local use and can come back to CI when there's a real consumer.

### Scheduled cache wipe: twice daily → once daily

The cron from #2092 wiped the cache at 00:00 and 12:00 UTC. The noon wipe was harmless when every PR repopulated; now that only main runs repopulate, it creates an unnecessary cold-cache window during the workday. Trimmed to 00:00 UTC.

## Potential follow-ups

- `check.yml` lint cache
- Three standalone `setup-go` invocations in `push.yml` (`testmask`, `validate-generated-is-up-to-date`, `validate-python-codegen`)
- `~/.cache/golangci-lint` analyzer cache

This pull request and its description were written by Isaac.