### PR TITLE
lakebox: fixes from Mitch's bug bash on demo-lakebox

### DIFF
--- a/cmd/lakebox/create.go
+++ b/cmd/lakebox/create.go
@@ -1,6 +1,7 @@
 package lakebox
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/databricks/cli/cmd/root"
@@ -11,6 +12,7 @@ import (
 
 func newCreateCommand() *cobra.Command {
 	var name string
+	var outputJSON bool
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -22,7 +24,8 @@ Blocks until the lakebox is running and prints the lakebox ID.
 
 Examples:
   databricks lakebox create
-  databricks lakebox create --name my-project`,
+  databricks lakebox create --name my-project
+  databricks lakebox create --json`,
 		PreRunE: root.MustWorkspaceClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -32,16 +35,25 @@ Examples:
 				return err
 			}
 
-			s := spin(ctx, "Provisioning your lakebox…")
-			defer s.Close()
-
-			result, err := api.create(ctx, name)
-			if err != nil {
-				s.fail("Failed to create lakebox")
-				return fmt.Errorf("failed to create lakebox: %w", err)
+			// In JSON mode, suppress the spinner+ok lines so the only thing
+			// on stdout/stderr that a scripted caller has to parse is the
+			// JSON body itself.
+			var result *createResponse
+			if outputJSON {
+				result, err = api.create(ctx, name)
+				if err != nil {
+					return fmt.Errorf("failed to create lakebox: %w", err)
+				}
+			} else {
+				s := spin(ctx, "Provisioning your lakebox…")
+				defer s.Close()
+				result, err = api.create(ctx, name)
+				if err != nil {
+					s.fail("Failed to create lakebox")
+					return fmt.Errorf("failed to create lakebox: %w", err)
+				}
+				s.ok("Lakebox " + cmdio.Bold(ctx, result.SandboxID) + " is " + status(ctx, result.Status))
 			}
-
-			s.ok("Lakebox " + cmdio.Bold(ctx, result.SandboxID) + " is " + status(ctx, result.Status))
 
 			profile := w.Config.Profile
 			if profile == "" {
@@ -59,9 +71,15 @@ Examples:
 			if shouldSetDefault {
 				if err := setDefault(ctx, profile, result.SandboxID); err != nil {
 					warn(ctx, fmt.Sprintf("Could not save default: %v", err))
-				} else {
+				} else if !outputJSON {
 					field(ctx, cmd.ErrOrStderr(), "default", result.SandboxID)
 				}
+			}
+
+			if outputJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(result)
 			}
 
 			blank(cmd.ErrOrStderr())
@@ -71,6 +89,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "Display label for the lakebox (max 256 bytes)")
+	cmd.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
 
 	return cmd
 }

--- a/cmd/lakebox/default.go
+++ b/cmd/lakebox/default.go
@@ -1,23 +1,29 @@
 package lakebox
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/spf13/cobra"
 )
 
 func newSetDefaultCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set-default <lakebox-id>",
-		Short: "Set the default Lakebox for SSH",
+		Use:     "default <lakebox-id>",
+		Aliases: []string{"set-default"},
+		Short:   "Set the default Lakebox for SSH",
 		Long: `Set the default Lakebox that 'databricks lakebox ssh' connects to.
 
 The default is stored locally in ~/.databricks/lakebox.json per profile.
+The ID is validated against the server before being written, so a typo
+or a sandbox that lives on a different workspace fails fast instead of
+silently corrupting local state.
 
 Example:
-  databricks lakebox set-default happy-panda-1234`,
+  databricks lakebox default happy-panda-1234`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: root.MustWorkspaceClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -29,6 +35,17 @@ Example:
 			}
 
 			lakeboxID := args[0]
+			api, err := newLakeboxAPI(w)
+			if err != nil {
+				return err
+			}
+			if _, err := api.get(ctx, lakeboxID); err != nil {
+				if errors.Is(err, apierr.ErrNotFound) {
+					return fmt.Errorf("no lakebox named %q — `databricks lakebox list` shows available IDs", lakeboxID)
+				}
+				return fmt.Errorf("failed to validate lakebox %s: %w", lakeboxID, err)
+			}
+
 			if err := setDefault(ctx, profile, lakeboxID); err != nil {
 				return fmt.Errorf("failed to set default: %w", err)
 			}

--- a/cmd/lakebox/delete.go
+++ b/cmd/lakebox/delete.go
@@ -1,11 +1,13 @@
 package lakebox
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +32,18 @@ Example:
 			}
 
 			lakeboxID := args[0]
+
+			// Validate existence first so `delete <typo>` fails clearly
+			// instead of returning a confident "✓ Removed" on a sandbox
+			// the server never had — the DELETE endpoint treats 404 as
+			// idempotent success on the wire.
+			if _, err := api.get(ctx, lakeboxID); err != nil {
+				if errors.Is(err, apierr.ErrNotFound) {
+					return fmt.Errorf("no lakebox named %q — `databricks lakebox list` shows available IDs", lakeboxID)
+				}
+				return fmt.Errorf("failed to look up lakebox %s: %w", lakeboxID, err)
+			}
+
 			s := spin(ctx, "Removing "+lakeboxID+"…")
 			defer s.Close()
 

--- a/cmd/lakebox/lakebox.go
+++ b/cmd/lakebox/lakebox.go
@@ -19,6 +19,7 @@ tooling (Python, Node.js, Rust, Databricks CLI) and persistent storage.
 Getting started:
   databricks auth login --host https://...   # authenticate to a Databricks workspace
   databricks lakebox register                # generate and register an SSH key
+  databricks lakebox create                  # provision a lakebox (becomes your default)
   databricks lakebox ssh                     # SSH to your default lakebox
 
 Common workflows:

--- a/cmd/lakebox/list.go
+++ b/cmd/lakebox/list.go
@@ -88,25 +88,52 @@ Example:
 			out := cmd.OutOrStdout()
 
 			// Compute column widths. AUTOSTOP holds short tokens like
-			// `default`, `never`, `15m`, `1h30m` — 8 chars covers them.
-			col := 10
+			// `never`, `15m`, `1h30m` — 8 chars covers them. NAME is
+			// rendered only when at least one entry sets a display name
+			// different from the ID — there's no point in a column of
+			// pet-names that duplicate the ID column.
+			idCol := 10
 			autostopCol := 8
+			nameCol := 4
+			showName := false
 			for _, e := range entries {
-				if l := len(e.SandboxID); l > col {
-					col = l
+				if l := len(e.SandboxID); l > idCol {
+					idCol = l
 				}
 				if l := len(e.autoStopLabel()); l > autostopCol {
 					autostopCol = l
 				}
+				if e.Name != "" && e.Name != e.SandboxID {
+					showName = true
+				}
+				if l := len(e.Name); l > nameCol {
+					nameCol = l
+				}
 			}
-			col += 2
+			idCol += 2
 			autostopCol += 2
+			if showName {
+				nameCol += 2
+			}
+			const statusCol = 10
+			const defaultCol = 7
 
 			blank(out)
-			header := fmt.Sprintf("%-*s  %-10s  %-*s  %s",
-				col, "ID", "STATUS", autostopCol, "AUTOSTOP", "DEFAULT")
+			var header string
+			if showName {
+				header = fmt.Sprintf("%-*s  %-*s  %-*s  %-*s  %s",
+					idCol, "ID", nameCol, "NAME", statusCol, "STATUS", autostopCol, "AUTOSTOP", "DEFAULT")
+			} else {
+				header = fmt.Sprintf("%-*s  %-*s  %-*s  %s",
+					idCol, "ID", statusCol, "STATUS", autostopCol, "AUTOSTOP", "DEFAULT")
+			}
 			fmt.Fprintf(out, "  %s\n", cmdio.Dim(ctx, header))
-			fmt.Fprintf(out, "  %s\n", cmdio.Dim(ctx, strings.Repeat("─", col+10+autostopCol+12)))
+
+			ruleLen := idCol + statusCol + autostopCol + defaultCol + 6
+			if showName {
+				ruleLen += nameCol + 2
+			}
+			fmt.Fprintf(out, "  %s\n", cmdio.Dim(ctx, strings.Repeat("─", ruleLen)))
 
 			for _, e := range entries {
 				id := e.SandboxID
@@ -114,22 +141,40 @@ Example:
 				if id == defaultID {
 					def = cmdio.Cyan(ctx, "*")
 				}
-				// Pad ID manually so visible-width alignment is preserved
-				// after the helpers wrap each cell with ANSI escapes.
-				idPad := max(col-len(id), 0)
+				// Pad each cell manually so visible-width alignment is
+				// preserved after the helpers wrap them with ANSI escapes.
+				idPad := max(idCol-len(id), 0)
 				st := status(ctx, e.Status)
-				stPad := max(10-len(e.Status), 0)
+				stPad := max(statusCol-len(e.Status), 0)
 				as := e.autoStopLabel()
 				asPad := max(autostopCol-len(as), 0)
 				idStr := cmdio.Bold(ctx, id)
 				if strings.EqualFold(e.Status, "running") {
 					idStr = cmdio.Bold(ctx, cmdio.Cyan(ctx, id))
 				}
-				fmt.Fprintf(out, "  %s%s  %s%s  %s%s  %s\n",
-					idStr, strings.Repeat(" ", idPad),
-					st, strings.Repeat(" ", stPad),
-					cmdio.Dim(ctx, as), strings.Repeat(" ", asPad),
-					def)
+				if showName {
+					nm := e.Name
+					if nm == "" || nm == id {
+						nm = "-"
+					}
+					nmPad := max(nameCol-len(nm), 0)
+					nmStr := nm
+					if nm == "-" {
+						nmStr = cmdio.Dim(ctx, "-")
+					}
+					fmt.Fprintf(out, "  %s%s  %s%s  %s%s  %s%s  %s\n",
+						idStr, strings.Repeat(" ", idPad),
+						nmStr, strings.Repeat(" ", nmPad),
+						st, strings.Repeat(" ", stPad),
+						cmdio.Dim(ctx, as), strings.Repeat(" ", asPad),
+						def)
+				} else {
+					fmt.Fprintf(out, "  %s%s  %s%s  %s%s  %s\n",
+						idStr, strings.Repeat(" ", idPad),
+						st, strings.Repeat(" ", stPad),
+						cmdio.Dim(ctx, as), strings.Repeat(" ", asPad),
+						def)
+				}
 			}
 			blank(out)
 			return nil

--- a/cmd/lakebox/ssh.go
+++ b/cmd/lakebox/ssh.go
@@ -95,42 +95,39 @@ Examples:
 			// with a warm cache).
 			var sandboxGatewayHost string
 
+			// sandboxStatus is the server-side state observed in this
+			// invocation, used to print an explicit "starting from stopped"
+			// notice before the connect spinner. Empty when we never hit
+			// the API.
+			var sandboxStatus string
+
 			api, err := newLakeboxAPI(w)
 			if err != nil {
 				return err
 			}
 
 			if lakeboxID == "" {
-				// If we have a saved default, confirm it still exists on the
-				// server. The lakebox may have been auto-stopped, deleted from
-				// another machine, or reaped by an admin since we wrote the
-				// state file. Clear the stale entry and fall through to
-				// provisioning a fresh one.
-				if def := getDefault(ctx, profile); def != "" {
-					if sb, err := api.get(ctx, def); err == nil {
-						lakeboxID = def
-						sandboxGatewayHost = sb.GatewayHost
-					} else {
-						warn(ctx, fmt.Sprintf("Saved default %s is gone; provisioning a new lakebox", def))
-						_ = clearDefault(ctx, profile)
-					}
+				def := getDefault(ctx, profile)
+				if def == "" {
+					return errors.New("no default lakebox configured — run `databricks lakebox create` to provision one, or `databricks lakebox default <id>` to point at an existing sandbox")
 				}
-
-				if lakeboxID == "" {
-					s := spin(ctx, "Provisioning your lakebox…")
-					defer s.Close()
-					result, err := api.create(ctx, "")
-					if err != nil {
-						s.fail("Failed to create lakebox")
-						return fmt.Errorf("failed to create lakebox: %w", err)
-					}
-					lakeboxID = result.SandboxID
-					sandboxGatewayHost = result.GatewayHost
-					s.ok("Lakebox " + cmdio.Bold(ctx, lakeboxID) + " ready")
-
-					if err := setDefault(ctx, profile, lakeboxID); err != nil {
-						warn(ctx, fmt.Sprintf("Could not save default: %v", err))
-					}
+				// Confirm the saved default still exists. A stale entry is
+				// almost always user-correctable (deleted from another
+				// machine, reaped by an admin); fail fast with an actionable
+				// message rather than silently provisioning a fresh sandbox
+				// and surprising the user with a bill.
+				sb, err := api.get(ctx, def)
+				switch {
+				case err == nil:
+					lakeboxID = def
+					sandboxGatewayHost = sb.GatewayHost
+					sandboxStatus = sb.Status
+				case errors.Is(err, apierr.ErrNotFound):
+					_ = clearDefault(ctx, profile)
+					return fmt.Errorf("saved default %q no longer exists (cleared) — run `databricks lakebox create` to provision a new one, or `databricks lakebox default <id>` to point at an existing sandbox", def)
+				default:
+					warn(ctx, fmt.Sprintf("could not validate default %s: %v", def, err))
+					lakeboxID = def
 				}
 			} else {
 				// Validate the explicit ID against the server. Two reasons:
@@ -144,11 +141,19 @@ Examples:
 				switch {
 				case err == nil:
 					sandboxGatewayHost = sb.GatewayHost
+					sandboxStatus = sb.Status
 				case errors.Is(err, apierr.ErrNotFound):
 					return fmt.Errorf("no lakebox named %q — `databricks lakebox list` shows available IDs", lakeboxID)
 				default:
 					warn(ctx, fmt.Sprintf("could not validate lakebox %s: %v", lakeboxID, err))
 				}
+			}
+
+			// The gateway implicitly starts a Stopped sandbox on first
+			// connect, which can take minutes. Print an explicit notice
+			// so the user understands why the connect spinner is hanging.
+			if strings.EqualFold(sandboxStatus, "stopped") {
+				warn(ctx, "Lakebox "+cmdio.Bold(ctx, lakeboxID)+" is stopped; the gateway will start it on connect (this can take a few minutes)")
 			}
 
 			// Resolution precedence: --gateway flag → fresh API response →

--- a/cmd/lakebox/sshkey.go
+++ b/cmd/lakebox/sshkey.go
@@ -131,6 +131,7 @@ Examples:
 			fmt.Fprintf(out, "    %s\n", cmdio.Dim(ctx, header))
 			fmt.Fprintf(out, "    %s\n", cmdio.Dim(ctx, strings.Repeat("─", nameCol+hashCol+timeCol+timeCol+6)))
 
+			localFound := false
 			for _, k := range keys {
 				// Pad NAME manually from the raw width because cmdio.Dim
 				// wraps the cell in ANSI escapes that throw off `%-*s`.
@@ -143,6 +144,7 @@ Examples:
 				gutter := "    "
 				if localHash != "" && k.KeyHash == localHash {
 					gutter = "  " + cmdio.Cyan(ctx, "*") + " "
+					localFound = true
 				}
 				fmt.Fprintf(out, "%s%s%s  %-*s  %-*s  %s\n",
 					gutter,
@@ -150,6 +152,18 @@ Examples:
 					hashCol, k.KeyHash,
 					timeCol, formatTimeShort(k.CreateTime),
 					formatTimeShort(k.LastUseTime))
+			}
+			// Without a legend the `*` (or its absence) is opaque. Print the
+			// meaning either way so users can tell "no `*` on any row" apart
+			// from "this terminal doesn't print the marker".
+			blank(out)
+			switch {
+			case localFound:
+				fmt.Fprintf(out, "  %s\n", cmdio.Dim(ctx, cmdio.Cyan(ctx, "*")+" key matches the one on this machine"))
+			case localHash != "":
+				fmt.Fprintf(out, "  %s\n", cmdio.Dim(ctx, "(no registered key matches this machine's local key — run `databricks lakebox register` to register it)"))
+			default:
+				fmt.Fprintf(out, "  %s\n", cmdio.Dim(ctx, "(no local lakebox key on this machine — run `databricks lakebox register` to create and register one)"))
 			}
 			blank(out)
 			return nil


### PR DESCRIPTION
Bundles the CLI-only findings from the 2026-05-27 demo-lakebox bug bash so each follow-up doesn't churn the same surface in series. The two big behavior changes are the `ssh` and `default` ones — the rest are output hygiene.

- `lakebox ssh` no longer silently provisions a new sandbox when the saved default is gone (F19). The saved default is validated against the server up-front; a 404 clears local state and returns an error pointing at `create` or `default <id>`. No default + no explicit ID is now an error rather than a costly surprise.
- `lakebox ssh` prints an explicit notice when the target sandbox is Stopped (F20). The gateway auto-starts on connect — which can take minutes — so we now tell the user that's what's happening instead of letting the spinner hang silently.
- `lakebox set-default` is renamed to `lakebox default` (set-default kept as alias, F1) and now validates the ID against the server before writing `~/.databricks/lakebox.json` (F17). Eliminates the prior path where a typo corrupted local state and combined with the old `ssh` auto-provision to bill the user.
- `lakebox delete` now pre-checks existence (F16). The DELETE wire endpoint returns success on a 404, so the CLI was confidently printing "✓ Removed" for sandboxes that never existed.
- `lakebox create --json` works (F7). Previously rejected as "unknown flag" even though list/status/ssh-key-list accepted it. In JSON mode the spinner and decorative ok/default lines are suppressed so callers see only the JSON body.
- `lakebox list` shows a NAME column when any entry has a display name distinct from its ID (F8). The underline rule also spans the full header width now (F5).
- `lakebox ssh-key list` prints a legend explaining the `*` marker (F23). When no `*` appears we tell the user whether it's because this machine has no local lakebox key, or because the local key isn't registered server-side.
- Top-level lakebox help now lists `lakebox create` in the getting-started flow, reflecting that `ssh` no longer auto-provisions.

Server-side findings from the same bug bash (delete on Creating, cold-start time, "ESM" error leak, etc.) are out of scope here and tracked under CJ-75149.

Co-authored-by: Isaac

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
