### PR TITLE
lakebox: shorten ssh "stopped sandbox" notice

### DIFF
--- a/cmd/lakebox/ssh.go
+++ b/cmd/lakebox/ssh.go
@@ -149,11 +149,11 @@ Examples:
 				}
 			}
 
-			// The gateway implicitly starts a Stopped sandbox on first
-			// connect, which can take minutes. Print an explicit notice
-			// so the user understands why the connect spinner is hanging.
+			// A stopped sandbox is implicitly started on connect, which
+			// can take minutes. Print an explicit notice so the user
+			// understands why the connect spinner is hanging.
 			if strings.EqualFold(sandboxStatus, "stopped") {
-				warn(ctx, "Lakebox "+cmdio.Bold(ctx, lakeboxID)+" is stopped; the gateway will start it on connect (this can take a few minutes)")
+				warn(ctx, "Starting "+cmdio.Bold(ctx, lakeboxID)+"… (may take a few minutes)")
 			}
 
 			// Resolution precedence: --gateway flag → fresh API response →


### PR DESCRIPTION
The notice introduced in #5350 was overlong and leaked "gateway", which is an internal abstraction users shouldn't need to know about. Render it as "Starting <id>… (may take a few minutes)" — action-led, no internals.

Co-authored-by: Isaac

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
