### PR TITLE
lakebox: switch state_test empty-string assertions to assert.Empty

### DIFF
--- a/cmd/lakebox/state_test.go
+++ b/cmd/lakebox/state_test.go
@@ -31,7 +31,7 @@ func TestStateLoadMissingFileReturnsEmpty(t *testing.T) {
 
 func TestStateGetDefaultMissingProfileReturnsEmpty(t *testing.T) {
 	ctx, _ := stateCtx(t)
-	assert.Equal(t, "", getDefault(ctx, "any-profile"))
+	assert.Empty(t, getDefault(ctx, "any-profile"))
 }
 
 func TestStateSetGetDefaultRoundTrip(t *testing.T) {
@@ -39,7 +39,7 @@ func TestStateSetGetDefaultRoundTrip(t *testing.T) {
 
 	require.NoError(t, setDefault(ctx, "profile-a", "lakebox-a"))
 	assert.Equal(t, "lakebox-a", getDefault(ctx, "profile-a"))
-	assert.Equal(t, "", getDefault(ctx, "profile-b"))
+	assert.Empty(t, getDefault(ctx, "profile-b"))
 }
 
 func TestStateMultipleProfilesIndependent(t *testing.T) {
@@ -67,7 +67,7 @@ func TestStateClearDefault(t *testing.T) {
 	require.NoError(t, setDefault(ctx, "profile-b", "lakebox-b"))
 
 	require.NoError(t, clearDefault(ctx, "profile-a"))
-	assert.Equal(t, "", getDefault(ctx, "profile-a"))
+	assert.Empty(t, getDefault(ctx, "profile-a"))
 	assert.Equal(t, "lakebox-b", getDefault(ctx, "profile-b"))
 }
 
@@ -98,7 +98,7 @@ func TestStateSetDefaultMissingNoFileBeforeWrite(t *testing.T) {
 	ctx, path := stateCtx(t)
 
 	// Loading state on a fresh tempdir must not create the file.
-	assert.Equal(t, "", getDefault(ctx, "profile-a"))
+	assert.Empty(t, getDefault(ctx, "profile-a"))
 	_, err := os.Stat(path)
 	assert.ErrorIs(t, err, fs.ErrNotExist, "getDefault must not create the state file")
 }


### PR DESCRIPTION
CI's testifylint run on demo-lakebox (post-PR #5350) flagged four `assert.Equal(t, "", x)` calls as `empty: use assert.Empty (testifylint)`. Locally `golangci-lint v2.11.4` doesn't repro the warning, so this is just an upstream linter rule that surfaced on a fresh CI cache; the test bodies are unchanged.

Co-authored-by: Isaac

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
