### PR TITLE
lakebox: prompt before delete; --auto-approve to skip

### DIFF
--- a/cmd/lakebox/delete.go
+++ b/cmd/lakebox/delete.go
@@ -12,15 +12,20 @@ import (
 )
 
 func newDeleteCommand() *cobra.Command {
+	var autoApprove bool
+
 	cmd := &cobra.Command{
 		Use:   "delete <lakebox-id>",
 		Short: "Delete a Lakebox environment",
 		Long: `Delete a Lakebox environment.
 
-Permanently terminates and removes the specified lakebox.
+Permanently terminates and removes the specified lakebox. Prompts for
+confirmation interactively; pass --auto-approve to skip the prompt
+(required in non-interactive contexts).
 
-Example:
-  databricks lakebox delete happy-panda-1234`,
+Examples:
+  databricks lakebox delete happy-panda-1234
+  databricks lakebox delete happy-panda-1234 --auto-approve`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: root.MustWorkspaceClient,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,11 +42,35 @@ Example:
 			// instead of returning a confident "✓ Removed" on a sandbox
 			// the server never had — the DELETE endpoint treats 404 as
 			// idempotent success on the wire.
-			if _, err := api.get(ctx, lakeboxID); err != nil {
+			entry, err := api.get(ctx, lakeboxID)
+			if err != nil {
 				if errors.Is(err, apierr.ErrNotFound) {
 					return fmt.Errorf("no lakebox named %q — `databricks lakebox list` shows available IDs", lakeboxID)
 				}
 				return fmt.Errorf("failed to look up lakebox %s: %w", lakeboxID, err)
+			}
+
+			if !autoApprove {
+				// Non-interactive contexts can't prompt; fail fast with
+				// a pointer to the bypass flag instead of hanging on a
+				// read from a closed/redirected stdin.
+				if !cmdio.IsPromptSupported(ctx) {
+					return errors.New("`databricks lakebox delete` permanently destroys the sandbox; pass --auto-approve to confirm in non-interactive contexts")
+				}
+				question := "Delete lakebox " + cmdio.Bold(ctx, entry.SandboxID)
+				if entry.Name != "" && entry.Name != entry.SandboxID {
+					question += " (name: " + entry.Name + ", status: " + entry.Status + ")"
+				} else {
+					question += " (status: " + entry.Status + ")"
+				}
+				question += "?"
+				confirmed, err := cmdio.AskYesOrNo(ctx, question)
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					return errors.New("aborted")
+				}
 			}
 
 			s := spin(ctx, "Removing "+lakeboxID+"…")
@@ -65,6 +94,8 @@ Example:
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip the interactive confirmation prompt")
 
 	return cmd
 }


### PR DESCRIPTION
`databricks lakebox delete <id>` was immediate-execute, which made it easy to nuke the wrong sandbox in scripts and surprised users in the recent bug bash. Adopt the same shape `cmd/bundle/destroy` uses:

  - Default: prompt with the sandbox ID, name (if set), and current status, so the user sees exactly what's about to be destroyed.
  - --auto-approve: skip the prompt. Required in non-interactive contexts; without it, the CLI fails fast pointing at the flag rather than hanging on a closed/redirected stdin.

`delete` is the only destructive lakebox verb; stop/start/config are reversible and unchanged.

Co-authored-by: Isaac

## Changes
<!-- Brief summary of your changes that is easy to understand -->

## Why
<!-- Why are these changes needed? Provide the context that the reviewer might be missing.
For example, were there any decisions behind the change that are not reflected in the code itself? -->

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
