### PR TITLE
cmdio: add Bold, Faint, Italic, Underline, Magenta helpers

### DIFF
--- a/libs/cmdio/color.go
+++ b/libs/cmdio/color.go
@@ -11,6 +11,7 @@ import (
 const (
 	ansiReset     = "\x1b[0m"
 	ansiBold      = "\x1b[1m"
+	ansiDim       = "\x1b[2m"
 	ansiFaint     = "\x1b[2m"
 	ansiItalic    = "\x1b[3m"
 	ansiUnderline = "\x1b[4m"
@@ -43,6 +44,12 @@ func render(ctx context.Context, code, msg string) string {
 	}
 	return code + msg + ansiReset
 }
+
+// Bold renders msg in bold.
+func Bold(ctx context.Context, msg string) string { return render(ctx, ansiBold, msg) }
+
+// Dim renders msg in dim (faint) intensity.
+func Dim(ctx context.Context, msg string) string { return render(ctx, ansiDim, msg) }
 
 // Red renders msg in red.
 func Red(ctx context.Context, msg string) string { return render(ctx, ansiRed, msg) }

--- a/libs/cmdio/color.go
+++ b/libs/cmdio/color.go
@@ -11,7 +11,6 @@ import (
 const (
 	ansiReset     = "\x1b[0m"
 	ansiBold      = "\x1b[1m"
-	ansiDim       = "\x1b[2m"
 	ansiFaint     = "\x1b[2m"
 	ansiItalic    = "\x1b[3m"
 	ansiUnderline = "\x1b[4m"
@@ -45,11 +44,17 @@ func render(ctx context.Context, code, msg string) string {
 	return code + msg + ansiReset
 }
 
-// Bold renders msg in bold.
+// Bold renders msg with increased intensity (bold).
 func Bold(ctx context.Context, msg string) string { return render(ctx, ansiBold, msg) }
 
-// Dim renders msg in dim (faint) intensity.
-func Dim(ctx context.Context, msg string) string { return render(ctx, ansiDim, msg) }
+// Faint renders msg with decreased intensity (faint, dim).
+func Faint(ctx context.Context, msg string) string { return render(ctx, ansiFaint, msg) }
+
+// Italic renders msg in italic.
+func Italic(ctx context.Context, msg string) string { return render(ctx, ansiItalic, msg) }
+
+// Underline renders msg underlined.
+func Underline(ctx context.Context, msg string) string { return render(ctx, ansiUnderline, msg) }
 
 // Red renders msg in red.
 func Red(ctx context.Context, msg string) string { return render(ctx, ansiRed, msg) }
@@ -62,6 +67,9 @@ func Yellow(ctx context.Context, msg string) string { return render(ctx, ansiYel
 
 // Blue renders msg in blue.
 func Blue(ctx context.Context, msg string) string { return render(ctx, ansiBlue, msg) }
+
+// Magenta renders msg in magenta.
+func Magenta(ctx context.Context, msg string) string { return render(ctx, ansiMagenta, msg) }
 
 // Cyan renders msg in cyan.
 func Cyan(ctx context.Context, msg string) string { return render(ctx, ansiCyan, msg) }
@@ -77,14 +85,16 @@ func HiBlue(ctx context.Context, msg string) string { return render(ctx, ansiHiB
 // helpers accept a format string + args.
 func RenderFuncMap(ctx context.Context) template.FuncMap {
 	return template.FuncMap{
-		"red":     templateColor(ctx, ansiRed),
-		"green":   templateColor(ctx, ansiGreen),
-		"blue":    templateColor(ctx, ansiBlue),
-		"yellow":  templateColor(ctx, ansiYellow),
-		"magenta": templateColor(ctx, ansiMagenta),
-		"cyan":    templateColor(ctx, ansiCyan),
-		"bold":    templateColor(ctx, ansiBold),
-		"italic":  templateColor(ctx, ansiItalic),
+		"red":       templateColor(ctx, ansiRed),
+		"green":     templateColor(ctx, ansiGreen),
+		"blue":      templateColor(ctx, ansiBlue),
+		"yellow":    templateColor(ctx, ansiYellow),
+		"magenta":   templateColor(ctx, ansiMagenta),
+		"cyan":      templateColor(ctx, ansiCyan),
+		"bold":      templateColor(ctx, ansiBold),
+		"faint":     templateColor(ctx, ansiFaint),
+		"italic":    templateColor(ctx, ansiItalic),
+		"underline": templateColor(ctx, ansiUnderline),
 	}
 }
 

--- a/libs/cmdio/color_test.go
+++ b/libs/cmdio/color_test.go
@@ -28,11 +28,14 @@ func TestColorHelpersEmitSGRWhenEnabled(t *testing.T) {
 		want string
 	}{
 		{"Bold", cmdio.Bold(ctx, "id"), "\x1b[1mid\x1b[0m"},
-		{"Dim", cmdio.Dim(ctx, "hint"), "\x1b[2mhint\x1b[0m"},
+		{"Faint", cmdio.Faint(ctx, "hint"), "\x1b[2mhint\x1b[0m"},
+		{"Italic", cmdio.Italic(ctx, "em"), "\x1b[3mem\x1b[0m"},
+		{"Underline", cmdio.Underline(ctx, "link"), "\x1b[4mlink\x1b[0m"},
 		{"Red", cmdio.Red(ctx, "hello"), "\x1b[31mhello\x1b[0m"},
 		{"Green", cmdio.Green(ctx, "ok"), "\x1b[32mok\x1b[0m"},
 		{"Yellow", cmdio.Yellow(ctx, "warn"), "\x1b[33mwarn\x1b[0m"},
 		{"Blue", cmdio.Blue(ctx, "info"), "\x1b[34minfo\x1b[0m"},
+		{"Magenta", cmdio.Magenta(ctx, "trace"), "\x1b[35mtrace\x1b[0m"},
 		{"Cyan", cmdio.Cyan(ctx, "debug"), "\x1b[36mdebug\x1b[0m"},
 		{"HiBlack", cmdio.HiBlack(ctx, "dim"), "\x1b[90mdim\x1b[0m"},
 		{"HiBlue", cmdio.HiBlue(ctx, "APP"), "\x1b[94mAPP\x1b[0m"},
@@ -66,7 +69,7 @@ func TestRenderFuncMap(t *testing.T) {
 	ctx := ttyContext(t)
 	fm := cmdio.RenderFuncMap(ctx)
 
-	for _, name := range []string{"red", "green", "blue", "yellow", "magenta", "cyan", "bold", "italic"} {
+	for _, name := range []string{"red", "green", "blue", "yellow", "magenta", "cyan", "bold", "faint", "italic", "underline"} {
 		_, ok := fm[name].(func(string, ...any) string)
 		assert.True(t, ok, "FuncMap missing %q or wrong signature", name)
 	}

--- a/libs/cmdio/color_test.go
+++ b/libs/cmdio/color_test.go
@@ -27,6 +27,8 @@ func TestColorHelpersEmitSGRWhenEnabled(t *testing.T) {
 		got  string
 		want string
 	}{
+		{"Bold", cmdio.Bold(ctx, "id"), "\x1b[1mid\x1b[0m"},
+		{"Dim", cmdio.Dim(ctx, "hint"), "\x1b[2mhint\x1b[0m"},
 		{"Red", cmdio.Red(ctx, "hello"), "\x1b[31mhello\x1b[0m"},
 		{"Green", cmdio.Green(ctx, "ok"), "\x1b[32mok\x1b[0m"},
 		{"Yellow", cmdio.Yellow(ctx, "warn"), "\x1b[33mwarn\x1b[0m"},


### PR DESCRIPTION
Expose Go-callable wrappers for SGR styles already present as constants in `libs/cmdio/color.go`: `Bold` (1), `Faint` (2), `Italic` (3), `Underline` (4), and `Magenta` (35).

Helpers are named after the SGR descriptor of their constant — so `ansiFaint` → `Faint`, matching the rest of the file. Doc comments use the SGR table phrasing so `Bold` and `Faint` read as paired intensities.

Also adds `faint` and `underline` bindings to `RenderFuncMap`.

Related to #5223.

This pull request and its description were written by Isaac.