### PR TITLE
acc: Fixed lifecycle started tests for clusters on non AWS clouds

### DIFF
--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/databricks.yml.tmpl
@@ -8,7 +8,7 @@ resources:
   clusters:
     mycluster:
       cluster_name: $UNIQUE_NAME
-      spark_version: $DEFAULT_SPARK_VERSION
+      spark_version: 15.4.x-scala2.12
       node_type_id: $NODE_TYPE_ID
       num_workers: 1
       lifecycle:

--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/databricks.yml.tmpl
@@ -8,8 +8,8 @@ resources:
   clusters:
     mycluster:
       cluster_name: $UNIQUE_NAME
-      spark_version: "15.4.x-scala2.12"
-      node_type_id: "i3.xlarge"
+      spark_version: $DEFAULT_SPARK_VERSION
+      node_type_id: $NODE_TYPE_ID
       num_workers: 1
       lifecycle:
         started: true

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/databricks.yml.tmpl
@@ -8,7 +8,7 @@ resources:
   clusters:
     mycluster:
       cluster_name: $UNIQUE_NAME
-      spark_version: $DEFAULT_SPARK_VERSION
+      spark_version: 15.4.x-scala2.12
       node_type_id: $NODE_TYPE_ID
       num_workers: 1
       lifecycle:

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/databricks.yml.tmpl
@@ -8,8 +8,8 @@ resources:
   clusters:
     mycluster:
       cluster_name: $UNIQUE_NAME
-      spark_version: "15.4.x-scala2.12"
-      node_type_id: "i3.xlarge"
+      spark_version: $DEFAULT_SPARK_VERSION
+      node_type_id: $NODE_TYPE_ID
       num_workers: 1
       lifecycle:
         started: false

--- a/acceptance/bundle/resources/clusters/lifecycle-started/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/databricks.yml.tmpl
@@ -8,7 +8,7 @@ resources:
   clusters:
     mycluster:
       cluster_name: $UNIQUE_NAME
-      spark_version: $DEFAULT_SPARK_VERSION
+      spark_version: 15.4.x-scala2.12
       node_type_id: $NODE_TYPE_ID
       num_workers: 1
       lifecycle:

--- a/acceptance/bundle/resources/clusters/lifecycle-started/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/databricks.yml.tmpl
@@ -8,8 +8,8 @@ resources:
   clusters:
     mycluster:
       cluster_name: $UNIQUE_NAME
-      spark_version: "15.4.x-scala2.12"
-      node_type_id: "i3.xlarge"
+      spark_version: $DEFAULT_SPARK_VERSION
+      node_type_id: $NODE_TYPE_ID
       num_workers: 1
       lifecycle:
         started: true


### PR DESCRIPTION
## Changes
Fixed lifecycle started tests for clusters on non AWS clouds

## Why
Node type is different for all the cluster, so we need to use the env variable instead

## Tests
Test passes

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
