### PR TITLE
integration/git: use static subtest names in TestFetchRepositoryInfo*

### DIFF
--- a/integration/libs/git/git_fetch_test.go
+++ b/integration/libs/git/git_fetch_test.go
@@ -52,12 +52,15 @@ func TestFetchRepositoryInfoAPI_FromRepo(t *testing.T) {
 
 	ctx = dbr.MockRuntime(ctx, dbr.Environment{IsDbr: true, Version: "15.4"})
 
-	for _, inputPath := range []string{
-		path.Join(targetPath, "knowledge_base/dashboard_nyc_taxi"),
-		targetPath,
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"subdir", path.Join(targetPath, "knowledge_base/dashboard_nyc_taxi")},
+		{"root", targetPath},
 	} {
-		t.Run(inputPath, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, inputPath, wt.W)
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, tc.input, wt.W)
 			assert.NoError(t, err)
 			assertFullGitInfo(t, targetPath, info)
 		})
@@ -75,25 +78,29 @@ func TestFetchRepositoryInfoAPI_FromNonRepo(t *testing.T) {
 	ctx = dbr.MockRuntime(ctx, dbr.Environment{IsDbr: true, Version: "15.4"})
 
 	tests := []struct {
+		name  string
 		input string
 		msg   string
 	}{
 		{
+			name:  "subdir",
 			input: path.Join(rootPath, "a/b/c"),
 			msg:   "",
 		},
 		{
+			name:  "root",
 			input: rootPath,
 			msg:   "",
 		},
 		{
+			name:  "non-existent",
 			input: path.Join(rootPath, "/non-existent"),
 			msg:   "doesn't exist",
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.input+" <==> "+test.msg, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			info, err := git.FetchRepositoryInfo(ctx, test.input, wt.W)
 			if test.msg == "" {
 				assert.NoError(t, err)
@@ -111,12 +118,15 @@ func TestFetchRepositoryInfoDotGit_FromGitRepo(t *testing.T) {
 
 	repo := cloneRepoLocally(t, examplesRepoUrl)
 
-	for _, inputPath := range []string{
-		filepath.Join(repo, "knowledge_base/dashboard_nyc_taxi"),
-		repo,
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{"subdir", filepath.Join(repo, "knowledge_base/dashboard_nyc_taxi")},
+		{"root", repo},
 	} {
-		t.Run(inputPath, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, inputPath, wt.W)
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, tc.input, wt.W)
 			assert.NoError(t, err)
 			assertFullGitInfo(t, repo, info)
 		})
@@ -140,15 +150,18 @@ func TestFetchRepositoryInfoDotGit_FromNonGitRepo(t *testing.T) {
 	root := filepath.Join(tempDir, "repo")
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "a/b/c"), 0o700))
 
-	tests := []string{
-		filepath.Join(root, "a/b/c"),
-		root,
-		filepath.Join(root, "/non-existent"),
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"subdir", filepath.Join(root, "a/b/c")},
+		{"root", root},
+		{"non-existent", filepath.Join(root, "/non-existent")},
 	}
 
-	for _, input := range tests {
-		t.Run(input, func(t *testing.T) {
-			info, err := git.FetchRepositoryInfo(ctx, input, wt.W)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			info, err := git.FetchRepositoryInfo(ctx, test.input, wt.W)
 			assert.ErrorIs(t, err, os.ErrNotExist)
 			assertEmptyGitInfo(t, info)
 		})


### PR DESCRIPTION
The `TestFetchRepositoryInfo*` tests in `integration/libs/git` passed runtime values into `t.Run` — temporary workspace paths containing UUIDs and `t.TempDir()` paths — so each subtest got a different name on every run. In aggregated test output this shows up as thousands of distinct one-off test names instead of a single stable entry.

This replaces the dynamic names with static ones (`subdir`, `root`, `non-existent`) by giving each table case an explicit `name` field.

A sweep over every `t.Run` call in the repository found this to be the only place with this pattern.

This pull request and its description were written by Isaac.