### PR TITLE
Fix flaky bundle generate pipeline_and_deploy test: unique pipeline name

### DIFF
--- a/acceptance/bundle/generate/pipeline_and_deploy/script
+++ b/acceptance/bundle/generate/pipeline_and_deploy/script
@@ -4,7 +4,7 @@ trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test.py" --fi
 
 title "Create a pipeline that references the files"
 PIPELINE_ID=$($CLI pipelines create --json '{
-  "name": "test-pipeline-${UNIQUE_NAME}",
+  "name": "test-pipeline-'${UNIQUE_NAME}'",
   "libraries": [
     {
       "notebook": {


### PR DESCRIPTION
The `bundle/generate/pipeline_and_deploy` acceptance test set the pipeline name to `"test-pipeline-${UNIQUE_NAME}"` inside a single-quoted JSON block. Bash doesn't expand `${...}` within single quotes, so every run created a pipeline with the identical literal name `test-pipeline-${UNIQUE_NAME}`. On the cloud variant the Pipelines API rejects duplicate names, so the test failed intermittently with `The pipeline name 'test-pipeline-${UNIQUE_NAME}' is already used by another pipeline` whenever the `direct` and `terraform` variants ran against the same workspace or a prior run's pipeline lingered.

The fix breaks out of the single quotes so `$UNIQUE_NAME` is interpolated, matching the script's existing `'${CURRENT_USER_NAME}'` convention and giving each run a distinct pipeline name. Local output is unchanged: the name is never printed, and `UNIQUE_NAME` is normalized to `[UNIQUE_NAME]` by the replacer regardless.

I scanned the other `bundle/` acceptance scripts that embed variables in single-quoted JSON; this was the only one with the bug. The rest already use the break-out form.

This pull request and its description were written by Isaac.