### PR TITLE
Bug fixes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -151,6 +151,10 @@ mattn/go-isatty - https://github.com/mattn/go-isatty
 Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 License - https://github.com/mattn/go-isatty/blob/master/LICENSE
 
+mattn/go-runewidth - https://github.com/mattn/go-runewidth
+Copyright (c) 2016 Yasuhiro Matsumoto
+License - https://github.com/mattn/go-runewidth/blob/master/LICENSE
+
 sabhiram/go-gitignore - https://github.com/sabhiram/go-gitignore
 Copyright (c) 2015 Shaba Abhiram
 License - https://github.com/sabhiram/go-gitignore/blob/master/LICENSE

--- a/cmd/lakebox/config.go
+++ b/cmd/lakebox/config.go
@@ -38,7 +38,7 @@ Three knobs are independent — pass any combination:
                               the sandbox after this much idle time. Pass
                               0 (or 0s) to clear and revert to the manager's
                               global default (10m). Valid range when set:
-                              60s to 24h.
+                              1m to 24h.
 
   --no-autostop[=true|false]  When true, the sandbox is exempt from
                               idle-driven auto-stop entirely. The
@@ -157,9 +157,15 @@ func checkIdleSecs(secs int64) (int64, error) {
 		return 0, nil // clear / revert to global default
 	}
 	if secs < minIdleTimeoutSecs || secs > maxIdleTimeoutSecs {
+		// Format both the bounds and the offending value as Go-style
+		// durations to match the input form the user typed and the
+		// flag's --help text (Anwell flagged the prior `86400s` /
+		// `90000s` echoes as confusing — same unit as input now).
 		return 0, fmt.Errorf(
-			"idle-timeout must be 0 (clear) or between %ds and %ds, got %ds",
-			minIdleTimeoutSecs, maxIdleTimeoutSecs, secs,
+			"idle-timeout must be 0 (clear) or between %s and %s, got %s",
+			formatDurationSecs(minIdleTimeoutSecs),
+			formatDurationSecs(maxIdleTimeoutSecs),
+			formatDurationSecs(secs),
 		)
 	}
 	return secs, nil

--- a/cmd/lakebox/list.go
+++ b/cmd/lakebox/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 )
 
@@ -101,21 +102,27 @@ Example:
 			// rendered only when at least one entry sets a display name
 			// different from the ID — there's no point in a column of
 			// pet-names that duplicate the ID column.
+			// All column widths are measured in *terminal cells*, not
+			// bytes or runes — emoji and CJK glyphs render as 2 cells
+			// despite being 1 rune / multi-byte, and using len() here
+			// (which counts bytes) misaligns the row whenever a `--name`
+			// includes wide characters. runewidth.StringWidth gives the
+			// East-Asian-Width-corrected cell count.
 			idCol := 10
 			autostopCol := 8
 			nameCol := 4
 			showName := false
 			for _, e := range entries {
-				if l := len(e.SandboxID); l > idCol {
+				if l := runewidth.StringWidth(e.SandboxID); l > idCol {
 					idCol = l
 				}
-				if l := len(e.autoStopLabel()); l > autostopCol {
+				if l := runewidth.StringWidth(e.autoStopLabel()); l > autostopCol {
 					autostopCol = l
 				}
 				if e.Name != "" && e.Name != e.SandboxID {
 					showName = true
 				}
-				if l := len(e.Name); l > nameCol {
+				if l := runewidth.StringWidth(e.Name); l > nameCol {
 					nameCol = l
 				}
 			}
@@ -152,11 +159,11 @@ Example:
 				}
 				// Pad each cell manually so visible-width alignment is
 				// preserved after the helpers wrap them with ANSI escapes.
-				idPad := max(idCol-len(id), 0)
+				idPad := max(idCol-runewidth.StringWidth(id), 0)
 				st := status(ctx, e.Status)
-				stPad := max(statusCol-len(e.Status), 0)
+				stPad := max(statusCol-runewidth.StringWidth(e.Status), 0)
 				as := e.autoStopLabel()
-				asPad := max(autostopCol-len(as), 0)
+				asPad := max(autostopCol-runewidth.StringWidth(as), 0)
 				idStr := cmdio.Bold(ctx, id)
 				if strings.EqualFold(e.Status, "running") {
 					idStr = cmdio.Bold(ctx, cmdio.Cyan(ctx, id))
@@ -166,7 +173,7 @@ Example:
 					if nm == "" || nm == id {
 						nm = "-"
 					}
-					nmPad := max(nameCol-len(nm), 0)
+					nmPad := max(nameCol-runewidth.StringWidth(nm), 0)
 					nmStr := nm
 					if nm == "-" {
 						nmStr = cmdio.Faint(ctx, "-")

--- a/cmd/lakebox/sshkey.go
+++ b/cmd/lakebox/sshkey.go
@@ -10,6 +10,7 @@ import (
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 )
 
@@ -115,9 +116,11 @@ Examples:
 			out := cmd.OutOrStdout()
 			blank(out)
 
+			// Measure in terminal cells (runewidth) so wide / emoji
+			// glyphs in `--name` don't misalign the row.
 			nameCol := 4
 			for _, k := range keys {
-				if l := len(k.Name); l > nameCol {
+				if l := runewidth.StringWidth(k.Name); l > nameCol {
 					nameCol = l
 				}
 			}
@@ -136,10 +139,10 @@ Examples:
 			for _, k := range keys {
 				// Pad NAME manually from the raw width because cmdio.Faint
 				// wraps the cell in ANSI escapes that throw off `%-*s`.
-				displayName, visibleNameLen := k.Name, len(k.Name)
+				displayName, visibleNameLen := k.Name, runewidth.StringWidth(k.Name)
 				if displayName == "" {
 					displayName = cmdio.Faint(ctx, "(unset)")
-					visibleNameLen = len("(unset)")
+					visibleNameLen = runewidth.StringWidth("(unset)")
 				}
 				namePad := max(nameCol-visibleNameLen, 0)
 				gutter := "    "

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // BSD-3-Clause
 	github.com/jackc/pgx/v5 v5.9.2 // MIT
 	github.com/mattn/go-isatty v0.0.22 // MIT
+	github.com/mattn/go-runewidth v0.0.23 // MIT
 	github.com/palantir/pkg/yamlpatch v1.5.0 // BSD-3-Clause
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // BSD-2-Clause
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22 // BSD-3-Clause
@@ -80,7 +81,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect


### PR DESCRIPTION
 ## Summary

  Two CLI fixes from Anwell's bug-bash form submissions (the third was
  the `-o json` issue, already fixed in #5372 and verified live; the
  fourth — `stop` printing `✓ Stopped` on already-stopped — skipped
  intentionally).

  ### `273d68a3e` — measure NAME column widths in terminal cells

  `lakebox list` and `ssh-key list` padded NAME columns using `len()`
  (bytes). Emoji and CJK glyphs are 1 rune / multi-byte / **2 cells**, so
  rows with `🚀 rocket box` or `测试盒子` in NAME shifted STATUS /
  AUTOSTOP / DEFAULT out of alignment. Switched padding math to
  `runewidth.StringWidth` (East-Asian-Width-correct). Promoted
  `mattn/go-runewidth` from indirect to direct require + NOTICE entry.

  ### `d6e585163` — `--idle-timeout` errors echo in Go-duration units

  `--idle-timeout 25h` was rejected with `between 60s and 86400s, got
  90000s` — every number in a different unit than what the user typed,
  even though `--help` already documented bounds as `60s to 24h`.
  Routed through the existing `formatDurationSecs` helper so error reads
  `between 1m and 24h, got 25h`. Also tweaked `--help` lower bound `60s`
  → `1m` so both strings agree.

  ## Test plan
  - [x] `lakebox list` with emoji `--name` aligns cleanly
  - [x] `lakebox list` with CJK `--name` aligns cleanly
  - [x] `--idle-timeout 25h` error: `between 1m and 24h, got 25h`
  - [x] `--idle-timeout 30s` error: `between 1m and 24h, got 30s`
  - [x] `--idle-timeout 90m` (valid) — no error
  - [x] license_test (NOTICE allowlist) passes
  - [x] all existing unit tests pass