### PR TITLE
Introduce a CLI-owned Store interface for token storage

### DIFF
--- a/cmd/auth/in_memory_test.go
+++ b/cmd/auth/in_memory_test.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
+	"github.com/databricks/cli/libs/auth/storage"
 	"golang.org/x/oauth2"
 )
 
@@ -9,31 +9,32 @@ type inMemoryTokenCache struct {
 	Tokens map[string]*oauth2.Token
 }
 
-// Lookup implements TokenCache.
-// Returns a copy to match real (file-backed) cache behavior, where each
-// Lookup deserializes a fresh struct. Without the copy, callers that
+// Lookup returns a copy to match real (file-backed) cache behavior, where
+// each lookup deserializes a fresh struct. Without the copy, callers that
 // mutate the returned token (e.g. clearing RefreshToken) would corrupt
 // entries shared across test cases.
-func (i *inMemoryTokenCache) Lookup(key string) (*oauth2.Token, error) {
+func (i *inMemoryTokenCache) Lookup(key string) (storage.Entry, error) {
 	token, ok := i.Tokens[key]
 	if !ok {
-		return nil, cache.ErrNotFound
+		return storage.Entry{}, storage.ErrNotFound
 	}
 	cp := *token
-	return &cp, nil
+	return storage.Entry{Token: &cp}, nil
 }
 
-// Store implements TokenCache.
-// Stores a copy to prevent callers from mutating cached entries after Store
-// returns (mirrors file-backed cache semantics).
-func (i *inMemoryTokenCache) Store(key string, t *oauth2.Token) error {
-	if t == nil {
-		delete(i.Tokens, key)
-	} else {
-		cp := *t
-		i.Tokens[key] = &cp
-	}
+// Put stores a copy to prevent callers from mutating cached entries after
+// put returns (mirrors file-backed cache semantics).
+func (i *inMemoryTokenCache) Put(key string, e storage.Entry) error {
+	cp := *e.Token
+	i.Tokens[key] = &cp
 	return nil
 }
 
-var _ cache.TokenCache = (*inMemoryTokenCache)(nil)
+// Delete deletes the entry under key. Deleting a missing entry is not
+// an error.
+func (i *inMemoryTokenCache) Delete(key string) error {
+	delete(i.Tokens, key)
+	return nil
+}
+
+var _ storage.Store = (*inMemoryTokenCache)(nil)

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -22,7 +22,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/config"
 	"github.com/databricks/databricks-sdk-go/config/experimental/auth/authconv"
 	"github.com/databricks/databricks-sdk-go/credentials/u2m"
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
 )
@@ -300,7 +299,7 @@ a new profile is created.
 		persistentAuthOpts := []u2m.PersistentAuthOption{
 			u2m.WithOAuthArgument(oauthArgument),
 			u2m.WithBrowser(getBrowserFunc(cmd)),
-			u2m.WithTokenCache(storage.WrapForOAuthArgument(tokenCache, mode, oauthArgument)),
+			u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, tokenCache, mode, oauthArgument)),
 		}
 		if len(scopesList) > 0 {
 			persistentAuthOpts = append(persistentAuthOpts, u2m.WithScopes(scopesList))
@@ -629,7 +628,7 @@ type discoveryLoginInputs struct {
 	scopes          string
 	existingProfile *profile.Profile
 	browserFunc     func(string) error
-	tokenCache      cache.TokenCache
+	tokenCache      storage.Store
 	mode            storage.StorageMode
 }
 
@@ -651,7 +650,7 @@ func discoveryLogin(ctx context.Context, in discoveryLoginInputs) error {
 		u2m.WithOAuthArgument(arg),
 		u2m.WithBrowser(in.browserFunc),
 		u2m.WithDiscoveryLogin(),
-		u2m.WithTokenCache(storage.WrapForOAuthArgument(in.tokenCache, in.mode, arg)),
+		u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, in.tokenCache, in.mode, arg)),
 	}
 	if len(scopesList) > 0 {
 		opts = append(opts, u2m.WithScopes(scopesList))

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	"github.com/databricks/cli/libs/auth"
+	"github.com/databricks/cli/libs/auth/storage"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/databrickscfg/profile"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go/credentials/u2m"
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +29,7 @@ import (
 
 // newTestTokenCache returns an in-memory token cache for tests so that
 // discoveryLogin and other login helpers don't touch ~/.databricks/token-cache.json.
-func newTestTokenCache() cache.TokenCache {
+func newTestTokenCache() storage.Store {
 	return &inMemoryTokenCache{Tokens: map[string]*oauth2.Token{}}
 }
 

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -28,7 +28,6 @@ import (
 	"github.com/databricks/cli/libs/databrickscfg/profile"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go/config"
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/spf13/cobra"
 )
 
@@ -158,7 +157,7 @@ type logoutArgs struct {
 	autoApprove    bool
 	deleteProfile  bool
 	profiler       profile.Profiler
-	tokenCache     cache.TokenCache
+	tokenCache     storage.Store
 	configFilePath string
 }
 
@@ -270,8 +269,8 @@ func getMatchingProfile(ctx context.Context, profileName string, profiler profil
 //     remaining profile references the same key. For account and unified
 //     profiles, the cache key includes the OIDC path
 //     (host/oidc/accounts/<account_id>).
-func clearTokenCache(ctx context.Context, p profile.Profile, profiler profile.Profiler, tokenCache cache.TokenCache) error {
-	if err := tokenCache.Store(p.Name, nil); err != nil {
+func clearTokenCache(ctx context.Context, p profile.Profile, profiler profile.Profiler, tokenCache storage.Store) error {
+	if err := tokenCache.Delete(p.Name); err != nil {
 		return fmt.Errorf("failed to delete profile-keyed token for profile %q: %w", p.Name, err)
 	}
 
@@ -291,7 +290,7 @@ func clearTokenCache(ctx context.Context, p profile.Profile, profiler profile.Pr
 	}
 
 	if len(otherProfiles) == 0 {
-		if err := tokenCache.Store(hostCacheKey, nil); err != nil {
+		if err := tokenCache.Delete(hostCacheKey); err != nil {
 			return fmt.Errorf("failed to delete host-keyed token for %q: %w", hostCacheKey, err)
 		}
 	}

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -118,9 +118,9 @@ type loadTokenArgs struct {
 	// profiler is the profiler to use for reading the host and account ID from the .databrickscfg file.
 	profiler profile.Profiler
 
-	// tokenCache is the underlying TokenCache used for OAuth tokens. The caller is
+	// tokenCache is the underlying CLI cache used for OAuth tokens. The caller is
 	// responsible for construction so that tests can substitute an in-memory cache.
-	tokenCache cache.TokenCache
+	tokenCache storage.Store
 
 	// mode is the resolved storage mode. When set to StorageModePlaintext,
 	// login paths mirror freshly minted tokens under the legacy host-based
@@ -264,7 +264,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	allArgs := append([]u2m.PersistentAuthOption{u2m.WithTokenCache(args.tokenCache)}, args.persistentAuthOpts...)
+	allArgs := append([]u2m.PersistentAuthOption{u2m.WithTokenCache(storage.OAuthTokenCache(ctx, args.tokenCache, args.mode))}, args.persistentAuthOpts...)
 	allArgs = append(allArgs, u2m.WithOAuthArgument(oauthArgument))
 	persistentAuth, err := u2m.NewPersistentAuth(ctx, allArgs...)
 	if err != nil {
@@ -318,7 +318,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 //
 // Returns the resolved profile name and profile (if any). The host and related
 // fields on authArgs are updated in place when resolved via environment variables.
-func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs *auth.AuthArguments, tokenCache cache.TokenCache, mode storage.StorageMode) (string, *profile.Profile, error) {
+func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs *auth.AuthArguments, tokenCache storage.Store, mode storage.StorageMode) (string, *profile.Profile, error) {
 	// Step 1: Try DATABRICKS_HOST env var (highest priority).
 	if envHost := env.Get(ctx, "DATABRICKS_HOST"); envHost != "" {
 		authArgs.Host = envHost
@@ -394,7 +394,7 @@ func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs
 // runInlineLogin runs a minimal interactive login flow: prompts for a profile
 // name and host, performs the OAuth challenge, saves the profile to
 // .databrickscfg, and returns the new profile name and profile.
-func runInlineLogin(ctx context.Context, profiler profile.Profiler, tokenCache cache.TokenCache, mode storage.StorageMode) (string, *profile.Profile, error) {
+func runInlineLogin(ctx context.Context, profiler profile.Profiler, tokenCache storage.Store, mode storage.StorageMode) (string, *profile.Profile, error) {
 	profileName, err := promptForProfile(ctx, "DEFAULT")
 	if err != nil {
 		return "", nil, err
@@ -428,7 +428,7 @@ func runInlineLogin(ctx context.Context, profiler profile.Profiler, tokenCache c
 	persistentAuthOpts := []u2m.PersistentAuthOption{
 		u2m.WithOAuthArgument(oauthArgument),
 		u2m.WithBrowser(func(url string) error { return browser.Open(ctx, url) }),
-		u2m.WithTokenCache(storage.WrapForOAuthArgument(tokenCache, mode, oauthArgument)),
+		u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, tokenCache, mode, oauthArgument)),
 	}
 	if len(scopesList) > 0 {
 		persistentAuthOpts = append(persistentAuthOpts, u2m.WithScopes(scopesList))

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/databricks/cli/libs/databrickscfg/profile"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go/credentials/u2m"
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/databricks/databricks-sdk-go/httpclient/fixtures"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
@@ -29,14 +28,15 @@ import (
 // of dropping it for the SDK-compat constant string.
 type upgradeHintTokenCache struct{}
 
-func (upgradeHintTokenCache) Store(string, *oauth2.Token) error { return nil }
-func (upgradeHintTokenCache) Lookup(string) (*oauth2.Token, error) {
-	return nil, storage.NewNotFoundHint(
+func (upgradeHintTokenCache) Put(string, storage.Entry) error { return nil }
+func (upgradeHintTokenCache) Delete(string) error             { return nil }
+func (upgradeHintTokenCache) Lookup(string) (storage.Entry, error) {
+	return storage.Entry{}, storage.NewNotFoundHint(
 		"stored credentials from older CLI versions are no longer used; run `databricks auth login` to sign in again, or set DATABRICKS_AUTH_STORAGE=plaintext to keep using the file cache",
 	)
 }
 
-var _ cache.TokenCache = upgradeHintTokenCache{}
+var _ storage.Store = upgradeHintTokenCache{}
 
 type failOnCallTransport struct{}
 
@@ -242,7 +242,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
@@ -263,7 +263,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
@@ -281,7 +281,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureInvalidResponse}}),
 				},
@@ -299,7 +299,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureOtherError}}),
 				},
@@ -317,7 +317,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -334,7 +334,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -351,7 +351,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -368,7 +368,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -385,7 +385,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -402,7 +402,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -419,7 +419,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -447,7 +447,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    upgradeHintTokenCache{},
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(upgradeHintTokenCache{}),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(upgradeHintTokenCache{})),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -480,7 +480,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -498,7 +498,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -517,7 +517,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -537,7 +537,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -555,7 +555,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -574,7 +574,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -591,7 +591,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -691,7 +691,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -712,7 +712,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -733,7 +733,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -755,7 +755,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -791,7 +791,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:     profiler,
 				tokenCache:   tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -808,7 +808,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: failOnCallTransport{}}),
 				},
@@ -828,7 +828,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -846,7 +846,7 @@ func TestToken_loadToken(t *testing.T) {
 				profiler:      profiler,
 				tokenCache:    tokenCache,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(tokenCache),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},

--- a/libs/auth/credentials.go
+++ b/libs/auth/credentials.go
@@ -103,13 +103,13 @@ func (c CLICredentials) Configure(ctx context.Context, cfg *config.Config) (cred
 	// across two backends: login writes to the keyring, but every workspace
 	// client built through this strategy would read an empty file cache and
 	// fail with "cache: token not found".
-	tokenCache, _, err := storage.ResolveCache(ctx, "")
+	tokenCache, mode, err := storage.ResolveCache(ctx, "")
 	if err != nil {
 		return nil, err
 	}
 	ts, err := c.persistentAuth(ctx,
 		u2m.WithOAuthArgument(oauthArg),
-		u2m.WithTokenCache(tokenCache),
+		u2m.WithTokenCache(storage.OAuthTokenCache(ctx, tokenCache, mode)),
 	)
 	if err != nil {
 		return nil, err

--- a/libs/auth/storage/cache.go
+++ b/libs/auth/storage/cache.go
@@ -16,8 +16,8 @@ import (
 // so unit tests can inject stubs without hitting the real OS keyring or
 // filesystem. Production code uses defaultCacheFactories().
 type cacheFactories struct {
-	newFile          func(context.Context) (cache.TokenCache, error)
-	newKeyring       func() cache.TokenCache
+	newFile          func(context.Context) (Store, error)
+	newKeyring       func() Store
 	probeKeyring     func() error
 	probeKeyringRead func() error
 }
@@ -25,7 +25,7 @@ type cacheFactories struct {
 // defaultCacheFactories returns the production factory set.
 func defaultCacheFactories() cacheFactories {
 	return cacheFactories{
-		newFile:          func(ctx context.Context) (cache.TokenCache, error) { return NewFileTokenCache(ctx) },
+		newFile:          func(ctx context.Context) (Store, error) { return NewFileTokenCache(ctx) },
 		newKeyring:       NewKeyringCache,
 		probeKeyring:     ProbeKeyring,
 		probeKeyringRead: ProbeKeyringRead,
@@ -49,12 +49,8 @@ func defaultCacheFactories() cacheFactories {
 // Every CLI code path that calls u2m.NewPersistentAuth must route the result
 // through u2m.WithTokenCache, otherwise the SDK defaults to the file cache
 // and splits the user's tokens across two backends.
-func ResolveCache(ctx context.Context, override StorageMode) (cache.TokenCache, StorageMode, error) {
-	inner, mode, err := resolveCacheForReadWith(ctx, override, defaultCacheFactories())
-	if err != nil {
-		return nil, "", err
-	}
-	return withNotFoundHint(ctx, inner, mode), mode, nil
+func ResolveCache(ctx context.Context, override StorageMode) (Store, StorageMode, error) {
+	return resolveCacheForReadWith(ctx, override, defaultCacheFactories())
 }
 
 // ResolveCacheForLogin resolves the cache like ResolveCache with extra rules
@@ -75,27 +71,34 @@ func ResolveCache(ctx context.Context, override StorageMode) (cache.TokenCache, 
 // Login-specific. Read paths (auth token, bundle commands) keep the original
 // keyring error so they don't silently mint plaintext copies of tokens that
 // were stored in the keyring on another machine.
-func ResolveCacheForLogin(ctx context.Context, override StorageMode) (cache.TokenCache, StorageMode, error) {
-	inner, mode, err := resolveCacheForLoginWith(ctx, override, defaultCacheFactories())
-	if err != nil {
-		return nil, "", err
-	}
-	return withNotFoundHint(ctx, inner, mode), mode, nil
+func ResolveCacheForLogin(ctx context.Context, override StorageMode) (Store, StorageMode, error) {
+	return resolveCacheForLoginWith(ctx, override, defaultCacheFactories())
 }
 
-// WrapForOAuthArgument wraps tokenCache so SDK-side writes (Challenge, refresh)
-// dual-write to the legacy host-based cache key when mode is plaintext. Other
-// modes return tokenCache unchanged: secure mode never writes a host-key entry,
-// and the wrapper has nothing to do for non-file backends.
+// OAuthTokenCache adapts a CLI Store to the SDK's u2m_cache.TokenCache for the
+// U2M PersistentAuth flow, applying the not-found hint so a cache miss carries
+// actionable "run databricks auth login" guidance. Use on read and credential
+// paths. M2M/OIDC callers use the CLI Store directly and must not route through
+// here: the login hint is the wrong remedy for those auth types.
+func OAuthTokenCache(ctx context.Context, c Store, mode StorageMode) cache.TokenCache {
+	return withNotFoundHint(ctx, ToU2MTokenCache(c), mode)
+}
+
+// WrapForOAuthArgument is OAuthTokenCache plus, in plaintext mode, a dual-write
+// of every Challenge/refresh write to the legacy host-based cache key. Use on
+// the login and refresh write paths. Other modes return the plain adapter:
+// secure mode never writes a host-key entry, and the dual-write has nothing to
+// do for non-file backends.
 //
 // Pass the OAuthArgument that the same NewPersistentAuth call will use. For
 // discovery arguments the discovered host is read at Store time, so it is
 // safe to wrap before Challenge populates it.
-func WrapForOAuthArgument(tokenCache cache.TokenCache, mode StorageMode, arg u2m.OAuthArgument) cache.TokenCache {
+func WrapForOAuthArgument(ctx context.Context, c Store, mode StorageMode, arg u2m.OAuthArgument) cache.TokenCache {
+	tc := OAuthTokenCache(ctx, c, mode)
 	if mode != StorageModePlaintext {
-		return tokenCache
+		return tc
 	}
-	return NewDualWritingTokenCache(tokenCache, arg)
+	return NewDualWritingTokenCache(tc, arg)
 }
 
 // resolveCacheWith is the pure form of ResolveCache without the read-path
@@ -103,7 +106,7 @@ func WrapForOAuthArgument(tokenCache cache.TokenCache, mode StorageMode, arg u2m
 // Used directly by ResolveCacheForLogin (which has its own fallback rules)
 // and indirectly by ResolveCache (which adds the read-path fallback in
 // resolveCacheForReadWith).
-func resolveCacheWith(ctx context.Context, override StorageMode, f cacheFactories) (cache.TokenCache, StorageMode, error) {
+func resolveCacheWith(ctx context.Context, override StorageMode, f cacheFactories) (Store, StorageMode, error) {
 	mode, err := ResolveStorageMode(ctx, override)
 	if err != nil {
 		return nil, "", err
@@ -126,7 +129,7 @@ func resolveCacheWith(ctx context.Context, override StorageMode, f cacheFactorie
 // read-path fallback: when mode is secure-from-default and the keyring
 // probes as definitively unavailable, return the file cache instead.
 // Timeouts keep the keyring (could be transient).
-func resolveCacheForReadWith(ctx context.Context, override StorageMode, f cacheFactories) (cache.TokenCache, StorageMode, error) {
+func resolveCacheForReadWith(ctx context.Context, override StorageMode, f cacheFactories) (Store, StorageMode, error) {
 	mode, source, err := ResolveStorageModeWithSource(ctx, override)
 	if err != nil {
 		return nil, "", err
@@ -146,7 +149,7 @@ func resolveCacheForReadWith(ctx context.Context, override StorageMode, f cacheF
 // Explicit secure is honored: callers who asked for secure get the keyring
 // cache even if the probe fails, so the actual Lookup error surfaces the
 // unreachability instead of silently using a different backend.
-func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f cacheFactories) (cache.TokenCache, StorageMode, error) {
+func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f cacheFactories) (Store, StorageMode, error) {
 	switch mode {
 	case StorageModePlaintext:
 		c, err := f.newFile(ctx)
@@ -178,7 +181,7 @@ func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f c
 
 // resolveCacheForLoginWith is the pure form of ResolveCacheForLogin. It takes
 // the factory set as a parameter so tests can inject stubs.
-func resolveCacheForLoginWith(ctx context.Context, override StorageMode, f cacheFactories) (cache.TokenCache, StorageMode, error) {
+func resolveCacheForLoginWith(ctx context.Context, override StorageMode, f cacheFactories) (Store, StorageMode, error) {
 	mode, source, err := ResolveStorageModeWithSource(ctx, override)
 	if err != nil {
 		return nil, "", err
@@ -190,7 +193,7 @@ func resolveCacheForLoginWith(ctx context.Context, override StorageMode, f cache
 // resolved mode and whether the user explicitly asked for it. Split out so
 // tests can drive the (mode, explicit) input space directly without depending
 // on whatever the resolver's default mode happens to be at any point in time.
-func applyLoginFallback(ctx context.Context, mode StorageMode, explicit bool, f cacheFactories) (cache.TokenCache, StorageMode, error) {
+func applyLoginFallback(ctx context.Context, mode StorageMode, explicit bool, f cacheFactories) (Store, StorageMode, error) {
 	switch mode {
 	case StorageModePlaintext:
 		c, err := f.newFile(ctx)

--- a/libs/auth/storage/cache_test.go
+++ b/libs/auth/storage/cache_test.go
@@ -12,24 +12,41 @@ import (
 	"github.com/databricks/cli/libs/databrickscfg"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/databricks-sdk-go/credentials/u2m"
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
-// stubCache is a test double for cache.TokenCache that records the source
-// it was constructed from. It lets the tests confirm which factory ran.
+// stubCache is a test double for Store that records the source it was
+// constructed from. It lets the tests confirm which factory ran.
 type stubCache struct{ source string }
 
-func (stubCache) Store(string, *oauth2.Token) error    { return nil }
-func (stubCache) Lookup(string) (*oauth2.Token, error) { return nil, cache.ErrNotFound }
+func (stubCache) Put(string, Entry) error      { return nil }
+func (stubCache) Lookup(string) (Entry, error) { return Entry{}, ErrNotFound }
+func (stubCache) Delete(string) error          { return nil }
+
+// memStore is a functional in-memory Store for exercising the OAuth wrappers.
+type memStore struct{ entries map[string]Entry }
+
+func newMemStore() *memStore { return &memStore{entries: map[string]Entry{}} }
+
+func (m *memStore) Put(key string, e Entry) error { m.entries[key] = e; return nil }
+
+func (m *memStore) Lookup(key string) (Entry, error) {
+	e, ok := m.entries[key]
+	if !ok {
+		return Entry{}, ErrNotFound
+	}
+	return e, nil
+}
+
+func (m *memStore) Delete(key string) error { delete(m.entries, key); return nil }
 
 func fakeFactories(t *testing.T) cacheFactories {
 	t.Helper()
 	return cacheFactories{
-		newFile:          func(context.Context) (cache.TokenCache, error) { return stubCache{source: "file"}, nil },
-		newKeyring:       func() cache.TokenCache { return stubCache{source: "keyring"} },
+		newFile:          func(context.Context) (Store, error) { return stubCache{source: "file"}, nil },
+		newKeyring:       func() Store { return stubCache{source: "keyring"} },
 		probeKeyring:     func() error { return nil },
 		probeKeyringRead: func() error { return nil },
 	}
@@ -112,8 +129,8 @@ func TestResolveCache_FileFactoryErrorPropagates(t *testing.T) {
 	ctx := t.Context()
 	boom := errors.New("disk full")
 	factories := cacheFactories{
-		newFile:          func(context.Context) (cache.TokenCache, error) { return nil, boom },
-		newKeyring:       func() cache.TokenCache { return stubCache{source: "keyring"} },
+		newFile:          func(context.Context) (Store, error) { return nil, boom },
+		newKeyring:       func() Store { return stubCache{source: "keyring"} },
 		probeKeyring:     func() error { return nil },
 		probeKeyringRead: func() error { return nil },
 	}
@@ -500,8 +517,8 @@ func TestWrapForOAuthArgument(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			inner := newMemoryCache()
-			got := WrapForOAuthArgument(inner, tc.mode, arg)
+			inner := newMemStore()
+			got := WrapForOAuthArgument(t.Context(), inner, tc.mode, arg)
 
 			_, wrapped := got.(*DualWritingTokenCache)
 			assert.Equal(t, tc.wantWrap, wrapped, "wrapper presence")
@@ -511,13 +528,13 @@ func TestWrapForOAuthArgument(t *testing.T) {
 
 			primary, err := inner.Lookup(profileKey)
 			require.NoError(t, err, "primary key must always be written")
-			assert.Equal(t, tok, primary)
+			assert.Equal(t, tok, primary.Token)
 
 			_, err = inner.Lookup(host)
 			if tc.wantHostKey {
 				require.NoError(t, err, "host-key mirror expected in plaintext mode")
 			} else {
-				assert.ErrorIs(t, err, cache.ErrNotFound, "no host-key mirror expected outside plaintext mode")
+				assert.ErrorIs(t, err, ErrNotFound, "no host-key mirror expected outside plaintext mode")
 			}
 		})
 	}

--- a/libs/auth/storage/file_cache.go
+++ b/libs/auth/storage/file_cache.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/databricks/cli/libs/env"
-	u2m_cache "github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"golang.org/x/oauth2"
 )
 
@@ -44,10 +43,17 @@ const (
 	tokenCacheVersion = 1
 )
 
+// fileEntry is the per-key on-disk shape. The embedded *oauth2.Token promotes
+// the token fields to the top level of the entry object so the layout matches
+// the historical bare-token format, leaving room for additive sibling fields.
+type fileEntry struct {
+	*oauth2.Token
+}
+
 // tokenCacheFile is the format of the token cache file.
 type tokenCacheFile struct {
-	Version int                      `json:"version"`
-	Tokens  map[string]*oauth2.Token `json:"tokens"`
+	Version int                   `json:"version"`
+	Tokens  map[string]*fileEntry `json:"tokens"`
 }
 
 type FileTokenCacheOption func(*fileTokenCache)
@@ -73,7 +79,7 @@ type fileTokenCache struct {
 // 0600 and the directory is created with owner permissions 0700. If the cache
 // file is corrupt or if its version does not match tokenCacheVersion, an error
 // is returned.
-func NewFileTokenCache(ctx context.Context, opts ...FileTokenCacheOption) (u2m_cache.TokenCache, error) {
+func NewFileTokenCache(ctx context.Context, opts ...FileTokenCacheOption) (Store, error) {
 	c := &fileTokenCache{}
 	for _, opt := range opts {
 		opt(c)
@@ -88,8 +94,8 @@ func NewFileTokenCache(ctx context.Context, opts ...FileTokenCacheOption) (u2m_c
 	return c, nil
 }
 
-// Store implements the TokenCache interface.
-func (c *fileTokenCache) Store(key string, t *oauth2.Token) error {
+// Put implements the Store interface.
+func (c *fileTokenCache) Put(key string, e Entry) error {
 	c.locker.Lock()
 	defer c.locker.Unlock()
 	f, err := c.load()
@@ -97,13 +103,41 @@ func (c *fileTokenCache) Store(key string, t *oauth2.Token) error {
 		return fmt.Errorf("load: %w", err)
 	}
 	if f.Tokens == nil {
-		f.Tokens = map[string]*oauth2.Token{}
+		f.Tokens = map[string]*fileEntry{}
 	}
-	if t == nil {
-		delete(f.Tokens, key)
-	} else {
-		f.Tokens[key] = t
+	f.Tokens[key] = &fileEntry{Token: e.Token}
+	return c.write(f)
+}
+
+// Lookup implements the Store interface.
+func (c *fileTokenCache) Lookup(key string) (Entry, error) {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+	f, err := c.load()
+	if err != nil {
+		return Entry{}, fmt.Errorf("load: %w", err)
 	}
+	fe, ok := f.Tokens[key]
+	if !ok {
+		return Entry{}, ErrNotFound
+	}
+	return Entry{Token: fe.Token}, nil
+}
+
+// Delete implements the Store interface. Removing a missing key is a no-op.
+func (c *fileTokenCache) Delete(key string) error {
+	c.locker.Lock()
+	defer c.locker.Unlock()
+	f, err := c.load()
+	if err != nil {
+		return fmt.Errorf("load: %w", err)
+	}
+	delete(f.Tokens, key)
+	return c.write(f)
+}
+
+// write marshals f and atomically replaces the cache file.
+func (c *fileTokenCache) write(f *tokenCacheFile) error {
 	raw, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
@@ -112,21 +146,6 @@ func (c *fileTokenCache) Store(key string, t *oauth2.Token) error {
 		return fmt.Errorf("error storing token in local cache: %w", err)
 	}
 	return nil
-}
-
-// Lookup implements the TokenCache interface.
-func (c *fileTokenCache) Lookup(key string) (*oauth2.Token, error) {
-	c.locker.Lock()
-	defer c.locker.Unlock()
-	f, err := c.load()
-	if err != nil {
-		return nil, fmt.Errorf("load: %w", err)
-	}
-	t, ok := f.Tokens[key]
-	if !ok {
-		return nil, u2m_cache.ErrNotFound
-	}
-	return t, nil
 }
 
 // init initializes the token cache file. It creates the file and directory if
@@ -153,7 +172,7 @@ func (c *fileTokenCache) init(ctx context.Context) error {
 		// Create an empty cache file.
 		f := &tokenCacheFile{
 			Version: tokenCacheVersion,
-			Tokens:  map[string]*oauth2.Token{},
+			Tokens:  map[string]*fileEntry{},
 		}
 		raw, err := json.MarshalIndent(f, "", "  ")
 		if err != nil {

--- a/libs/auth/storage/file_cache_test.go
+++ b/libs/auth/storage/file_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	u2m_cache "github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
@@ -19,29 +18,29 @@ func setup(t *testing.T) string {
 func TestStoreAndLookup(t *testing.T) {
 	c, err := NewFileTokenCache(t.Context(), WithFileLocation(setup(t)))
 	require.NoError(t, err)
-	err = c.Store("x", &oauth2.Token{
+	err = c.Put("x", Entry{Token: &oauth2.Token{
 		AccessToken: "abc",
-	})
+	}})
 	require.NoError(t, err)
 
-	err = c.Store("y", &oauth2.Token{
+	err = c.Put("y", Entry{Token: &oauth2.Token{
 		AccessToken: "bcd",
-	})
+	}})
 	require.NoError(t, err)
 
-	tok, err := c.Lookup("x")
+	got, err := c.Lookup("x")
 	require.NoError(t, err)
-	assert.Equal(t, "abc", tok.AccessToken)
+	assert.Equal(t, "abc", got.Token.AccessToken)
 
 	_, err = c.Lookup("z")
-	assert.Equal(t, u2m_cache.ErrNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestNoCacheFileReturnsErrNotConfigured(t *testing.T) {
 	l, err := NewFileTokenCache(t.Context(), WithFileLocation(setup(t)))
 	require.NoError(t, err)
 	_, err = l.Lookup("x")
-	assert.Equal(t, u2m_cache.ErrNotFound, err)
+	assert.Equal(t, ErrNotFound, err)
 }
 
 func TestLoadCorruptFile(t *testing.T) {

--- a/libs/auth/storage/keyring.go
+++ b/libs/auth/storage/keyring.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/google/uuid"
 	"github.com/zalando/go-keyring"
 	"golang.org/x/oauth2"
@@ -80,7 +79,7 @@ type keyringCache struct {
 
 // NewKeyringCache returns a cache.TokenCache backed by the OS-native secure
 // store (via zalando/go-keyring) with a 3-second per-operation timeout.
-func NewKeyringCache() cache.TokenCache {
+func NewKeyringCache() Store {
 	return &keyringCache{
 		backend:        zalandoBackend{},
 		timeout:        defaultKeyringTimeout,
@@ -107,10 +106,10 @@ func probeWithBackend(backend keyringBackend, timeout time.Duration) error {
 	}
 	account := keyringProbeAccountPrefix + uuid.NewString()
 	tok := &oauth2.Token{AccessToken: "probe"}
-	if err := c.Store(account, tok); err != nil {
+	if err := c.Put(account, Entry{Token: tok}); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
-	if err := c.Store(account, nil); err != nil {
+	if err := c.Delete(account); err != nil {
 		return fmt.Errorf("delete: %w", err)
 	}
 	return nil
@@ -145,19 +144,9 @@ func probeReadWithBackend(backend keyringBackend, timeout time.Duration) error {
 	return err
 }
 
-// Store stores t under key. Nil t deletes the entry; deleting a missing
-// entry is not an error.
-func (k *keyringCache) Store(key string, t *oauth2.Token) error {
-	if t == nil {
-		return k.withTimeout("delete", func() error {
-			err := k.backend.Delete(k.keyringSvcName, key)
-			if errors.Is(err, keyring.ErrNotFound) {
-				return nil
-			}
-			return err
-		})
-	}
-	raw, err := json.Marshal(keyringEntry{Token: t})
+// Put implements the Store interface.
+func (k *keyringCache) Put(key string, e Entry) error {
+	raw, err := json.Marshal(keyringEntry(e))
 	if err != nil {
 		return fmt.Errorf("marshal token: %w", err)
 	}
@@ -166,8 +155,19 @@ func (k *keyringCache) Store(key string, t *oauth2.Token) error {
 	})
 }
 
-// Lookup returns the token under key or cache.ErrNotFound.
-func (k *keyringCache) Lookup(key string) (*oauth2.Token, error) {
+// Delete implements the Store interface. Removing a missing entry is a no-op.
+func (k *keyringCache) Delete(key string) error {
+	return k.withTimeout("delete", func() error {
+		err := k.backend.Delete(k.keyringSvcName, key)
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil
+		}
+		return err
+	})
+}
+
+// Lookup implements the Store interface, returning ErrNotFound on a miss.
+func (k *keyringCache) Lookup(key string) (Entry, error) {
 	var raw string
 	err := k.withTimeout("get", func() error {
 		got, gerr := k.backend.Get(k.keyringSvcName, key)
@@ -178,17 +178,17 @@ func (k *keyringCache) Lookup(key string) (*oauth2.Token, error) {
 		return nil
 	})
 	if errors.Is(err, keyring.ErrNotFound) {
-		return nil, cache.ErrNotFound
+		return Entry{}, ErrNotFound
 	}
 	if err != nil {
-		return nil, wrapKeyringUnreachable(err)
+		return Entry{}, wrapKeyringUnreachable(err)
 	}
 
 	var entry keyringEntry
 	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
-		return nil, fmt.Errorf("unmarshal token: %w", err)
+		return Entry{}, fmt.Errorf("unmarshal token: %w", err)
 	}
-	return entry.Token, nil
+	return Entry(entry), nil
 }
 
 // wrapKeyringUnreachable wraps a non-ErrNotFound keyring error with
@@ -209,8 +209,8 @@ func wrapKeyringUnreachable(err error) error {
 	return fmt.Errorf("OS keyring unreachable: %w (set DATABRICKS_AUTH_STORAGE=plaintext or run `databricks auth login` to use file-based token storage)", err)
 }
 
-// Compile-time confirmation that keyringCache satisfies the SDK interface.
-var _ cache.TokenCache = (*keyringCache)(nil)
+// Compile-time confirmation that keyringCache satisfies the CLI interface.
+var _ Store = (*keyringCache)(nil)
 
 // TimeoutError is returned when a keyring operation exceeds the configured
 // timeout. Callers can use errors.As to detect and present a clear message.

--- a/libs/auth/storage/keyring_test.go
+++ b/libs/auth/storage/keyring_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando/go-keyring"
@@ -83,7 +82,7 @@ func TestKeyringCache_Store_WritesJSON(t *testing.T) {
 
 	tok := &oauth2.Token{AccessToken: "abc", TokenType: "Bearer"}
 
-	require.NoError(t, c.Store("my-profile", tok))
+	require.NoError(t, c.Put("my-profile", Entry{Token: tok}))
 
 	stored, ok := backend.items[itemKey("databricks-cli", "my-profile")]
 	require.True(t, ok, "token should be stored under service=databricks-cli, account=my-profile")
@@ -101,7 +100,7 @@ func TestKeyringCache_Store_PropagatesBackendError(t *testing.T) {
 	backend.setErr = boom
 	c := newTestCache(backend)
 
-	err := c.Store("my-profile", &oauth2.Token{AccessToken: "x"})
+	err := c.Put("my-profile", Entry{Token: &oauth2.Token{AccessToken: "x"}})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
 }
@@ -111,12 +110,12 @@ func TestKeyringCache_Lookup_ReturnsStoredToken(t *testing.T) {
 	c := newTestCache(backend)
 
 	want := &oauth2.Token{AccessToken: "abc", TokenType: "Bearer"}
-	require.NoError(t, c.Store("my-profile", want))
+	require.NoError(t, c.Put("my-profile", Entry{Token: want}))
 
 	got, err := c.Lookup("my-profile")
 	require.NoError(t, err)
-	assert.Equal(t, "abc", got.AccessToken)
-	assert.Equal(t, "Bearer", got.TokenType)
+	assert.Equal(t, "abc", got.Token.AccessToken)
+	assert.Equal(t, "Bearer", got.Token.TokenType)
 }
 
 func TestKeyringCache_Lookup_MissingReturnsCacheErrNotFound(t *testing.T) {
@@ -125,7 +124,7 @@ func TestKeyringCache_Lookup_MissingReturnsCacheErrNotFound(t *testing.T) {
 
 	_, err := c.Lookup("nope")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, cache.ErrNotFound)
+	assert.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestKeyringCache_Lookup_PropagatesOtherErrors(t *testing.T) {
@@ -154,7 +153,7 @@ func TestKeyringCache_Lookup_NotFoundIsNotWrapped(t *testing.T) {
 
 	_, err := c.Lookup("nope")
 	require.Error(t, err)
-	assert.ErrorIs(t, err, cache.ErrNotFound)
+	assert.ErrorIs(t, err, ErrNotFound)
 	assert.NotContains(t, err.Error(), "OS keyring unreachable")
 }
 
@@ -172,8 +171,8 @@ func TestKeyringCache_StoreNil_DeletesEntry(t *testing.T) {
 	backend := newFakeBackend()
 	c := newTestCache(backend)
 
-	require.NoError(t, c.Store("my-profile", &oauth2.Token{AccessToken: "abc"}))
-	require.NoError(t, c.Store("my-profile", nil))
+	require.NoError(t, c.Put("my-profile", Entry{Token: &oauth2.Token{AccessToken: "abc"}}))
+	require.NoError(t, c.Delete("my-profile"))
 
 	_, ok := backend.items[itemKey("databricks-cli", "my-profile")]
 	assert.False(t, ok, "entry should be gone after delete")
@@ -184,7 +183,7 @@ func TestKeyringCache_StoreNil_MissingIsIdempotent(t *testing.T) {
 	backend.deleteErr = keyring.ErrNotFound
 	c := newTestCache(backend)
 
-	err := c.Store("never-stored", nil)
+	err := c.Delete("never-stored")
 	require.NoError(t, err, "deleting a missing entry must not error")
 }
 
@@ -194,7 +193,7 @@ func TestKeyringCache_StoreNil_PropagatesOtherDeleteErrors(t *testing.T) {
 	backend.deleteErr = boom
 	c := newTestCache(backend)
 
-	err := c.Store("my-profile", nil)
+	err := c.Delete("my-profile")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
 }
@@ -205,7 +204,7 @@ func TestKeyringCache_Store_TimesOut(t *testing.T) {
 	c := newTestCache(backend) // 100ms timeout from newTestCache
 
 	start := time.Now()
-	err := c.Store("my-profile", &oauth2.Token{AccessToken: "x"})
+	err := c.Put("my-profile", Entry{Token: &oauth2.Token{AccessToken: "x"}})
 	require.Error(t, err)
 
 	var timeoutErr *TimeoutError
@@ -230,7 +229,7 @@ func TestKeyringCache_StoreNil_TimesOut(t *testing.T) {
 	backend.deleteBlock = true
 	c := newTestCache(backend)
 
-	err := c.Store("my-profile", nil)
+	err := c.Delete("my-profile")
 	require.Error(t, err)
 
 	var timeoutErr *TimeoutError

--- a/libs/auth/storage/mode.go
+++ b/libs/auth/storage/mode.go
@@ -1,10 +1,3 @@
-// Package storage selects and constructs the CLI's U2M token storage backend.
-//
-// Two modes are supported. Secure writes to the OS-native keyring under the
-// profile cache key only; it is the resolver default. Plaintext writes to
-// ~/.databricks/token-cache.json with host-key dual-write for older Go SDK
-// versions (v0.61-v0.103); it is the opt-in fallback for environments where
-// the OS keyring is not available.
 package storage
 
 import (

--- a/libs/auth/storage/not_found_hint_test.go
+++ b/libs/auth/storage/not_found_hint_test.go
@@ -38,9 +38,9 @@ func (c boomCache) Lookup(string) (*oauth2.Token, error) { return nil, c.err }
 func writeLegacyCache(t *testing.T, path string, hasEntries bool) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
-	tokens := map[string]*oauth2.Token{}
+	tokens := map[string]*fileEntry{}
 	if hasEntries {
-		tokens["my-profile"] = &oauth2.Token{AccessToken: "abc"}
+		tokens["my-profile"] = &fileEntry{Token: &oauth2.Token{AccessToken: "abc"}}
 	}
 	body, err := json.Marshal(tokenCacheFile{Version: tokenCacheVersion, Tokens: tokens})
 	require.NoError(t, err)

--- a/libs/auth/storage/sdku2m.go
+++ b/libs/auth/storage/sdku2m.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"errors"
+
+	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
+	"golang.org/x/oauth2"
+)
+
+// ToU2MTokenCache adapts a CLI Store to the SDK's u2m_cache.TokenCache so it
+// can be passed to u2m.WithTokenCache for the U2M PersistentAuth flow, the one
+// place the SDK requires that interface. The SDK's Store(key, nil) "delete"
+// convention maps to Store.Delete.
+func ToU2MTokenCache(s Store) cache.TokenCache {
+	return &sdkTokenCache{store: s}
+}
+
+// sdkTokenCache is the ToU2MTokenCache adapter.
+type sdkTokenCache struct {
+	store Store
+}
+
+// Store implements u2m_cache.TokenCache. A nil token is the SDK's delete
+// signal; everything else is a plain put with no metadata.
+func (sdktc *sdkTokenCache) Store(key string, t *oauth2.Token) error {
+	if t == nil {
+		return sdktc.store.Delete(key)
+	}
+	return sdktc.store.Put(key, Entry{Token: t})
+}
+
+// Lookup implements cache.TokenCache, translating the CLI miss sentinel to
+// the SDK's so the SDK's errors.Is(err, cache.ErrNotFound) branches fire.
+func (sdktc *sdkTokenCache) Lookup(key string) (*oauth2.Token, error) {
+	e, err := sdktc.store.Lookup(key)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, cache.ErrNotFound
+		}
+		return nil, err
+	}
+	return e.Token, nil
+}
+
+var _ cache.TokenCache = (*sdkTokenCache)(nil)

--- a/libs/auth/storage/storage.go
+++ b/libs/auth/storage/storage.go
@@ -1,0 +1,48 @@
+// Package storage selects and constructs the CLI's U2M token storage backend.
+//
+// Two modes are supported. Secure writes to the OS-native keyring under the
+// profile cache key only; it is the resolver default. Plaintext writes to
+// ~/.databricks/token-cache.json with host-key dual-write for older Go SDK
+// versions (v0.61-v0.103); it is the opt-in fallback for environments where
+// the OS keyring is not available.
+package storage
+
+import (
+	"errors"
+
+	"golang.org/x/oauth2"
+)
+
+// ErrNotFound is returned by Store.Lookup when no entry exists for the key, or
+// when a stored entry cannot be decoded by this CLI version (an unknown format
+// is treated as a miss so the caller re-mints rather than failing). It is the
+// CLI-owned counterpart to the SDK's u2m_cache.ErrNotFound; the adapter in
+// ToU2MTokenCache translates between the two.
+var ErrNotFound = errors.New("token not found")
+
+// Entry is the value held in the CLI token store. It wraps the credential so
+// the schema can grow additive metadata (e.g. a config fingerprint, scopes)
+// without changing the Store interface. Backends persist it verbatim and never
+// interpret its contents.
+type Entry struct {
+	// Token is the cached OAuth token. Always set for stored entries.
+	Token *oauth2.Token
+}
+
+// Store is the CLI's token-storage abstraction: a key/value store with no
+// policy of its own. Implementations are the plaintext file cache and the OS
+// keyring cache. The interface is owned by the CLI rather than the SDK so the
+// entry schema can evolve (metadata, per-entry resilience) without being
+// constrained by the SDK's U2M-internal u2m_cache.TokenCache, which only
+// carries a bare *oauth2.Token.
+type Store interface {
+	// Put writes e under key, replacing any existing entry.
+	Put(key string, e Entry) error
+
+	// Lookup returns the entry stored under key, or ErrNotFound.
+	Lookup(key string) (Entry, error)
+
+	// Delete removes the entry under key. Deleting a missing entry is not an
+	// error.
+	Delete(key string) error
+}


### PR DESCRIPTION
## What is this about?

The CLI's token storage is currently shaped by the SDK's TokenCache interface. That interface is internal to the SDK's user-to-machine (U2M) login flow and only carries a bare OAuth token keyed by a string, so there is no room to store anything alongside a token, and the CLI's storage is coupled to an SDK type that exists specifically for U2M login.

This PR introduces a CLI-owned `Store` interface (`Put`, `Lookup`, `Delete`) over an explicit `Entry` envelope that wraps the token. A small adapter, `ToU2MTokenCache`, presents a `Store` to the SDK at the one place that still requires the SDK interface: passing a cache to `u2m.PersistentAuth`. The file and keyring backends now implement `Store`, and the OAuth helpers adapt it for the U2M paths.

This is a structural change with no behavior change. The `Entry` only holds the token; the point is that it can now grow additional fields without changing the interface or depending on the SDK. The first such field will be a config checksum used to invalidate a cached token when its profile changed, which arrives with a later change that adds caching for machine-to-machine (M2M) and OIDC tokens.

**Naming note for reviewers:** the new interface is named Store to distinguish the CLI's durable storage from the SDK's transient Cache. The concrete types and helpers in this package are intentionally left in the old vocabulary (fileTokenCache, keyringCache, and so on) in this PR to keep the diff focused on the structural change. A follow-up PR will take care of renaming.

## Testing

Existing auth unit and acceptance tests pass; there are no output or behavior changes.
