### PR TITLE
Rename CLI token storage types to the Store vocabulary

### DIFF
--- a/cmd/auth/in_memory_test.go
+++ b/cmd/auth/in_memory_test.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type inMemoryTokenCache struct {
+type inMemoryStore struct {
 	Tokens map[string]*oauth2.Token
 }
 
@@ -13,7 +13,7 @@ type inMemoryTokenCache struct {
 // each lookup deserializes a fresh struct. Without the copy, callers that
 // mutate the returned token (e.g. clearing RefreshToken) would corrupt
 // entries shared across test cases.
-func (i *inMemoryTokenCache) Lookup(key string) (storage.Entry, error) {
+func (i *inMemoryStore) Lookup(key string) (storage.Entry, error) {
 	token, ok := i.Tokens[key]
 	if !ok {
 		return storage.Entry{}, storage.ErrNotFound
@@ -24,7 +24,7 @@ func (i *inMemoryTokenCache) Lookup(key string) (storage.Entry, error) {
 
 // Put stores a copy to prevent callers from mutating cached entries after
 // put returns (mirrors file-backed cache semantics).
-func (i *inMemoryTokenCache) Put(key string, e storage.Entry) error {
+func (i *inMemoryStore) Put(key string, e storage.Entry) error {
 	cp := *e.Token
 	i.Tokens[key] = &cp
 	return nil
@@ -32,9 +32,9 @@ func (i *inMemoryTokenCache) Put(key string, e storage.Entry) error {
 
 // Delete deletes the entry under key. Deleting a missing entry is not
 // an error.
-func (i *inMemoryTokenCache) Delete(key string) error {
+func (i *inMemoryStore) Delete(key string) error {
 	delete(i.Tokens, key)
 	return nil
 }
 
-var _ storage.Store = (*inMemoryTokenCache)(nil)
+var _ storage.Store = (*inMemoryStore)(nil)

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -178,7 +178,7 @@ a new profile is created.
 		// triggers the OS unlock prompt, which the user can answer during
 		// OAuth. Run after input validation so trivially-invalid commands
 		// fail without probing.
-		tokenCache, mode, err := storage.ResolveCacheForLogin(ctx, "")
+		tokenStore, mode, err := storage.ResolveStoreForLogin(ctx, "")
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,7 @@ a new profile is created.
 				scopes:          scopes,
 				existingProfile: existingProfile,
 				browserFunc:     getBrowserFunc(cmd),
-				tokenCache:      tokenCache,
+				tokenStore:      tokenStore,
 				mode:            mode,
 			})
 		}
@@ -299,7 +299,7 @@ a new profile is created.
 		persistentAuthOpts := []u2m.PersistentAuthOption{
 			u2m.WithOAuthArgument(oauthArgument),
 			u2m.WithBrowser(getBrowserFunc(cmd)),
-			u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, tokenCache, mode, oauthArgument)),
+			u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, tokenStore, mode, oauthArgument)),
 		}
 		if len(scopesList) > 0 {
 			persistentAuthOpts = append(persistentAuthOpts, u2m.WithScopes(scopesList))
@@ -628,7 +628,7 @@ type discoveryLoginInputs struct {
 	scopes          string
 	existingProfile *profile.Profile
 	browserFunc     func(string) error
-	tokenCache      storage.Store
+	tokenStore      storage.Store
 	mode            storage.StorageMode
 }
 
@@ -650,7 +650,7 @@ func discoveryLogin(ctx context.Context, in discoveryLoginInputs) error {
 		u2m.WithOAuthArgument(arg),
 		u2m.WithBrowser(in.browserFunc),
 		u2m.WithDiscoveryLogin(),
-		u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, in.tokenCache, in.mode, arg)),
+		u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, in.tokenStore, in.mode, arg)),
 	}
 	if len(scopesList) > 0 {
 		opts = append(opts, u2m.WithScopes(scopesList))

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -27,10 +27,10 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// newTestTokenCache returns an in-memory token cache for tests so that
+// newTestStore returns an in-memory token cache for tests so that
 // discoveryLogin and other login helpers don't touch ~/.databricks/token-cache.json.
-func newTestTokenCache() storage.Store {
-	return &inMemoryTokenCache{Tokens: map[string]*oauth2.Token{}}
+func newTestStore() storage.Store {
+	return &inMemoryStore{Tokens: map[string]*oauth2.Token{}}
 }
 
 // logBuffer is a thread-safe bytes.Buffer for capturing log output in tests.
@@ -765,7 +765,7 @@ func TestDiscoveryLogin_IntrospectionFailureStillSavesProfile(t *testing.T) {
 		timeout:     time.Second,
 		scopes:      "all-apis, ,sql,",
 		browserFunc: func(string) error { return nil },
-		tokenCache:  newTestTokenCache(),
+		tokenStore:  newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -820,7 +820,7 @@ func TestDiscoveryLogin_AccountIDMismatchWarning(t *testing.T) {
 		timeout:         time.Second,
 		existingProfile: existingProfile,
 		browserFunc:     func(string) error { return nil },
-		tokenCache:      newTestTokenCache(),
+		tokenStore:      newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -875,7 +875,7 @@ func TestDiscoveryLogin_NoWarningWhenAccountIDsMatch(t *testing.T) {
 		timeout:         time.Second,
 		existingProfile: existingProfile,
 		browserFunc:     func(string) error { return nil },
-		tokenCache:      newTestTokenCache(),
+		tokenStore:      newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -901,7 +901,7 @@ func TestDiscoveryLogin_EmptyDiscoveredHostReturnsError(t *testing.T) {
 		profileName: "DISCOVERY",
 		timeout:     time.Second,
 		browserFunc: func(string) error { return nil },
-		tokenCache:  newTestTokenCache(),
+		tokenStore:  newTestStore(),
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no workspace host was discovered")
@@ -940,7 +940,7 @@ func TestDiscoveryLogin_ReloginPreservesExistingProfileScopes(t *testing.T) {
 		timeout:         time.Second,
 		existingProfile: existingProfile,
 		browserFunc:     func(string) error { return nil },
-		tokenCache:      newTestTokenCache(),
+		tokenStore:      newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -985,7 +985,7 @@ func TestDiscoveryLogin_ExplicitScopesOverrideExistingProfile(t *testing.T) {
 		scopes:          "all-apis",
 		existingProfile: existingProfile,
 		browserFunc:     func(string) error { return nil },
-		tokenCache:      newTestTokenCache(),
+		tokenStore:      newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -1031,7 +1031,7 @@ func TestDiscoveryLogin_SPOGHostPopulatesAccountIDFromDiscovery(t *testing.T) {
 		profileName: "DISCOVERY",
 		timeout:     time.Second,
 		browserFunc: func(string) error { return nil },
-		tokenCache:  newTestTokenCache(),
+		tokenStore:  newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -1072,7 +1072,7 @@ func TestDiscoveryLogin_IntrospectionFallsBackWhenDiscoveryFails(t *testing.T) {
 		profileName: "DISCOVERY",
 		timeout:     time.Second,
 		browserFunc: func(string) error { return nil },
-		tokenCache:  newTestTokenCache(),
+		tokenStore:  newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -1127,7 +1127,7 @@ auth_type = databricks-cli
 		timeout:         time.Second,
 		existingProfile: existingProfile,
 		browserFunc:     func(string) error { return nil },
-		tokenCache:      newTestTokenCache(),
+		tokenStore:      newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -1188,7 +1188,7 @@ auth_type = databricks-cli
 		timeout:         time.Second,
 		existingProfile: existingProfile,
 		browserFunc:     func(string) error { return nil },
-		tokenCache:      newTestTokenCache(),
+		tokenStore:      newTestStore(),
 	})
 	require.NoError(t, err)
 
@@ -1226,7 +1226,7 @@ func TestDiscoveryLogin_OverridesHostFromEnv(t *testing.T) {
 		profileName: "DISCOVERY",
 		timeout:     time.Second,
 		browserFunc: func(string) error { return nil },
-		tokenCache:  newTestTokenCache(),
+		tokenStore:  newTestStore(),
 	})
 	require.NoError(t, err)
 

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -134,7 +134,7 @@ to specify it explicitly.
 			profileName = selected
 		}
 
-		tokenCache, _, err := storage.ResolveCache(ctx, "")
+		tokenStore, _, err := storage.ResolveStore(ctx, "")
 		if err != nil {
 			return fmt.Errorf("failed to open token cache: %w", err)
 		}
@@ -144,7 +144,7 @@ to specify it explicitly.
 			autoApprove:    autoApprove,
 			deleteProfile:  deleteProfile,
 			profiler:       profiler,
-			tokenCache:     tokenCache,
+			tokenStore:     tokenStore,
 			configFilePath: env.Get(ctx, "DATABRICKS_CONFIG_FILE"),
 		})
 	}
@@ -157,7 +157,7 @@ type logoutArgs struct {
 	autoApprove    bool
 	deleteProfile  bool
 	profiler       profile.Profiler
-	tokenCache     storage.Store
+	tokenStore     storage.Store
 	configFilePath string
 }
 
@@ -206,7 +206,7 @@ func runLogout(ctx context.Context, args logoutArgs) error {
 	// Otherwise, we could be deleting profiles that were created by other means (e.g. manually).
 	isCreatedByLogin := matchedProfile.AuthType == "databricks-cli"
 	if isCreatedByLogin {
-		err = clearTokenCache(ctx, *matchedProfile, args.profiler, args.tokenCache)
+		err = clearTokenStore(ctx, *matchedProfile, args.profiler, args.tokenStore)
 		if err != nil {
 			return fmt.Errorf("failed to clear token cache: %w", err)
 		}
@@ -262,15 +262,15 @@ func getMatchingProfile(ctx context.Context, profileName string, profiler profil
 	return &profiles[0], nil
 }
 
-// clearTokenCache removes cached OAuth tokens for the given profile from the
+// clearTokenStore removes cached OAuth tokens for the given profile from the
 // token cache. It removes:
 //  1. The entry keyed by the profile name.
 //  2. The entry keyed by the host-based cache key, but only if no other
 //     remaining profile references the same key. For account and unified
 //     profiles, the cache key includes the OIDC path
 //     (host/oidc/accounts/<account_id>).
-func clearTokenCache(ctx context.Context, p profile.Profile, profiler profile.Profiler, tokenCache storage.Store) error {
-	if err := tokenCache.Delete(p.Name); err != nil {
+func clearTokenStore(ctx context.Context, p profile.Profile, profiler profile.Profiler, tokenStore storage.Store) error {
+	if err := tokenStore.Delete(p.Name); err != nil {
 		return fmt.Errorf("failed to delete profile-keyed token for profile %q: %w", p.Name, err)
 	}
 
@@ -290,7 +290,7 @@ func clearTokenCache(ctx context.Context, p profile.Profile, profiler profile.Pr
 	}
 
 	if len(otherProfiles) == 0 {
-		if err := tokenCache.Delete(hostCacheKey); err != nil {
+		if err := tokenStore.Delete(hostCacheKey); err != nil {
 			return fmt.Errorf("failed to delete host-keyed token for %q: %w", hostCacheKey, err)
 		}
 	}

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -164,7 +164,7 @@ func TestLogout(t *testing.T) {
 			configPath := writeTempConfig(t, logoutTestConfig)
 			t.Setenv("DATABRICKS_CONFIG_FILE", configPath)
 
-			tokenCache := &inMemoryTokenCache{
+			tokenStore := &inMemoryStore{
 				Tokens: copyTokens(logoutTestTokensCacheConfig),
 			}
 
@@ -173,7 +173,7 @@ func TestLogout(t *testing.T) {
 				autoApprove:    tc.autoApprove,
 				deleteProfile:  tc.deleteProfile,
 				profiler:       profile.DefaultProfiler,
-				tokenCache:     tokenCache,
+				tokenStore:     tokenStore,
 				configFilePath: configPath,
 			})
 
@@ -194,14 +194,14 @@ func TestLogout(t *testing.T) {
 			// Verify token cache state.
 			if tc.isNonU2M {
 				// Non-U2M profiles should not touch the token cache at all.
-				assert.NotNil(t, tokenCache.Tokens[tc.profileName], "expected token %q to be preserved for non-U2M profile", tc.profileName)
-				assert.NotNil(t, tokenCache.Tokens[tc.hostBasedKey], "expected token %q to be preserved for non-U2M profile", tc.hostBasedKey)
+				assert.NotNil(t, tokenStore.Tokens[tc.profileName], "expected token %q to be preserved for non-U2M profile", tc.profileName)
+				assert.NotNil(t, tokenStore.Tokens[tc.hostBasedKey], "expected token %q to be preserved for non-U2M profile", tc.hostBasedKey)
 			} else {
-				assert.Nil(t, tokenCache.Tokens[tc.profileName], "expected token %q to be removed", tc.profileName)
+				assert.Nil(t, tokenStore.Tokens[tc.profileName], "expected token %q to be removed", tc.profileName)
 				if tc.isSharedKey {
-					assert.NotNil(t, tokenCache.Tokens[tc.hostBasedKey], "expected token %q to be preserved", tc.hostBasedKey)
+					assert.NotNil(t, tokenStore.Tokens[tc.hostBasedKey], "expected token %q to be preserved", tc.hostBasedKey)
 				} else {
-					assert.Nil(t, tokenCache.Tokens[tc.hostBasedKey], "expected token %q to be removed", tc.hostBasedKey)
+					assert.Nil(t, tokenStore.Tokens[tc.hostBasedKey], "expected token %q to be removed", tc.hostBasedKey)
 				}
 			}
 		})
@@ -213,7 +213,7 @@ func TestLogoutNoTokens(t *testing.T) {
 	configPath := writeTempConfig(t, logoutTestConfig)
 	t.Setenv("DATABRICKS_CONFIG_FILE", configPath)
 
-	tokenCache := &inMemoryTokenCache{
+	tokenStore := &inMemoryStore{
 		Tokens: map[string]*oauth2.Token{},
 	}
 
@@ -221,7 +221,7 @@ func TestLogoutNoTokens(t *testing.T) {
 		profileName:    "my-workspace",
 		autoApprove:    true,
 		profiler:       profile.DefaultProfiler,
-		tokenCache:     tokenCache,
+		tokenStore:     tokenStore,
 		configFilePath: configPath,
 	})
 	require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestLogoutNoTokensWithDelete(t *testing.T) {
 	configPath := writeTempConfig(t, logoutTestConfig)
 	t.Setenv("DATABRICKS_CONFIG_FILE", configPath)
 
-	tokenCache := &inMemoryTokenCache{
+	tokenStore := &inMemoryStore{
 		Tokens: map[string]*oauth2.Token{},
 	}
 
@@ -246,7 +246,7 @@ func TestLogoutNoTokensWithDelete(t *testing.T) {
 		autoApprove:    true,
 		deleteProfile:  true,
 		profiler:       profile.DefaultProfiler,
-		tokenCache:     tokenCache,
+		tokenStore:     tokenStore,
 		configFilePath: configPath,
 	})
 	require.NoError(t, err)
@@ -302,7 +302,7 @@ default_profile = my-workspace
 			configPath := writeTempConfig(t, configWithDefault)
 			t.Setenv("DATABRICKS_CONFIG_FILE", configPath)
 
-			tokenCache := &inMemoryTokenCache{
+			tokenStore := &inMemoryStore{
 				Tokens: copyTokens(logoutTestTokensCacheConfig),
 			}
 
@@ -311,7 +311,7 @@ default_profile = my-workspace
 				autoApprove:    true,
 				deleteProfile:  true,
 				profiler:       profile.DefaultProfiler,
-				tokenCache:     tokenCache,
+				tokenStore:     tokenStore,
 				configFilePath: configPath,
 			})
 			require.NoError(t, err)
@@ -360,7 +360,7 @@ auth_type = databricks-cli
 	t.Setenv("DATABRICKS_CONFIG_FILE", configPath)
 
 	hostKey := spogServer.URL + "/oidc/accounts/spog-acct"
-	tokenCache := &inMemoryTokenCache{
+	tokenStore := &inMemoryStore{
 		Tokens: map[string]*oauth2.Token{
 			"spog-profile": {AccessToken: "spog-profile-token"},
 			hostKey:        {AccessToken: "spog-host-token"},
@@ -371,13 +371,13 @@ auth_type = databricks-cli
 		profileName:    "spog-profile",
 		autoApprove:    true,
 		profiler:       profile.DefaultProfiler,
-		tokenCache:     tokenCache,
+		tokenStore:     tokenStore,
 		configFilePath: configPath,
 	})
 	require.NoError(t, err)
 
-	assert.Nil(t, tokenCache.Tokens["spog-profile"])
-	assert.Nil(t, tokenCache.Tokens[hostKey])
+	assert.Nil(t, tokenStore.Tokens["spog-profile"])
+	assert.Nil(t, tokenStore.Tokens[hostKey])
 }
 
 func TestHostCacheKeyAndMatchFn(t *testing.T) {

--- a/cmd/auth/token.go
+++ b/cmd/auth/token.go
@@ -56,7 +56,7 @@ and secret is not supported.`,
 		ctx := cmd.Context()
 		profileName := cmd.Flag("profile").Value.String()
 
-		tokenCache, mode, err := storage.ResolveCache(ctx, "")
+		tokenStore, mode, err := storage.ResolveStore(ctx, "")
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ and secret is not supported.`,
 			tokenTimeout:       tokenTimeout,
 			forceRefresh:       forceRefresh,
 			profiler:           profile.DefaultProfiler,
-			tokenCache:         tokenCache,
+			tokenStore:         tokenStore,
 			mode:               mode,
 			persistentAuthOpts: nil,
 		})
@@ -118,9 +118,9 @@ type loadTokenArgs struct {
 	// profiler is the profiler to use for reading the host and account ID from the .databrickscfg file.
 	profiler profile.Profiler
 
-	// tokenCache is the underlying CLI cache used for OAuth tokens. The caller is
+	// tokenStore is the underlying CLI cache used for OAuth tokens. The caller is
 	// responsible for construction so that tests can substitute an in-memory cache.
-	tokenCache storage.Store
+	tokenStore storage.Store
 
 	// mode is the resolved storage mode. When set to StorageModePlaintext,
 	// login paths mirror freshly minted tokens under the legacy host-based
@@ -176,7 +176,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 	// resolve the target through environment variables or interactive profile selection.
 	if args.profileName == "" && args.authArguments.Host == "" && len(args.args) == 0 {
 		var resolvedProfile string
-		resolvedProfile, existingProfile, err = resolveNoArgsToken(ctx, args.profiler, args.authArguments, args.tokenCache, args.mode)
+		resolvedProfile, existingProfile, err = resolveNoArgsToken(ctx, args.profiler, args.authArguments, args.tokenStore, args.mode)
 		if err != nil {
 			return nil, err
 		}
@@ -264,7 +264,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	allArgs := append([]u2m.PersistentAuthOption{u2m.WithTokenCache(storage.OAuthTokenCache(ctx, args.tokenCache, args.mode))}, args.persistentAuthOpts...)
+	allArgs := append([]u2m.PersistentAuthOption{u2m.WithTokenCache(storage.OAuthTokenCache(ctx, args.tokenStore, args.mode))}, args.persistentAuthOpts...)
 	allArgs = append(allArgs, u2m.WithOAuthArgument(oauthArgument))
 	persistentAuth, err := u2m.NewPersistentAuth(ctx, allArgs...)
 	if err != nil {
@@ -318,7 +318,7 @@ func loadToken(ctx context.Context, args loadTokenArgs) (*oauth2.Token, error) {
 //
 // Returns the resolved profile name and profile (if any). The host and related
 // fields on authArgs are updated in place when resolved via environment variables.
-func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs *auth.AuthArguments, tokenCache storage.Store, mode storage.StorageMode) (string, *profile.Profile, error) {
+func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs *auth.AuthArguments, tokenStore storage.Store, mode storage.StorageMode) (string, *profile.Profile, error) {
 	// Step 1: Try DATABRICKS_HOST env var (highest priority).
 	if envHost := env.Get(ctx, "DATABRICKS_HOST"); envHost != "" {
 		authArgs.Host = envHost
@@ -381,7 +381,7 @@ func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs
 		// Fall through — setHostAndAccountId will prompt for the host.
 		return "", nil, nil
 	case profilePickerCreateNew:
-		return runInlineLogin(ctx, profiler, tokenCache, mode)
+		return runInlineLogin(ctx, profiler, tokenStore, mode)
 	default:
 		p, err := loadProfileByName(ctx, selectedName, profiler)
 		if err != nil {
@@ -394,7 +394,7 @@ func resolveNoArgsToken(ctx context.Context, profiler profile.Profiler, authArgs
 // runInlineLogin runs a minimal interactive login flow: prompts for a profile
 // name and host, performs the OAuth challenge, saves the profile to
 // .databrickscfg, and returns the new profile name and profile.
-func runInlineLogin(ctx context.Context, profiler profile.Profiler, tokenCache storage.Store, mode storage.StorageMode) (string, *profile.Profile, error) {
+func runInlineLogin(ctx context.Context, profiler profile.Profiler, tokenStore storage.Store, mode storage.StorageMode) (string, *profile.Profile, error) {
 	profileName, err := promptForProfile(ctx, "DEFAULT")
 	if err != nil {
 		return "", nil, err
@@ -428,7 +428,7 @@ func runInlineLogin(ctx context.Context, profiler profile.Profiler, tokenCache s
 	persistentAuthOpts := []u2m.PersistentAuthOption{
 		u2m.WithOAuthArgument(oauthArgument),
 		u2m.WithBrowser(func(url string) error { return browser.Open(ctx, url) }),
-		u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, tokenCache, mode, oauthArgument)),
+		u2m.WithTokenCache(storage.WrapForOAuthArgument(ctx, tokenStore, mode, oauthArgument)),
 	}
 	if len(scopesList) > 0 {
 		persistentAuthOpts = append(persistentAuthOpts, u2m.WithScopes(scopesList))

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -20,23 +20,23 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// upgradeHintTokenCache returns a notFoundHint-wrapped ErrNotFound on
+// upgradeHintStore returns a notFoundHint-wrapped ErrNotFound on
 // Lookup, mirroring what storage.notFoundHintCache produces in
 // production when ~/.databricks/token-cache.json has entries and the
 // resolver picked secure mode by default. Used by TestToken_loadToken
 // to verify that auth token surfaces the upgrade-specific hint instead
 // of dropping it for the SDK-compat constant string.
-type upgradeHintTokenCache struct{}
+type upgradeHintStore struct{}
 
-func (upgradeHintTokenCache) Put(string, storage.Entry) error { return nil }
-func (upgradeHintTokenCache) Delete(string) error             { return nil }
-func (upgradeHintTokenCache) Lookup(string) (storage.Entry, error) {
+func (upgradeHintStore) Put(string, storage.Entry) error { return nil }
+func (upgradeHintStore) Delete(string) error             { return nil }
+func (upgradeHintStore) Lookup(string) (storage.Entry, error) {
 	return storage.Entry{}, storage.NewNotFoundHint(
 		"stored credentials from older CLI versions are no longer used; run `databricks auth login` to sign in again, or set DATABRICKS_AUTH_STORAGE=plaintext to keep using the file cache",
 	)
 }
 
-var _ storage.Store = upgradeHintTokenCache{}
+var _ storage.Store = upgradeHintStore{}
 
 type failOnCallTransport struct{}
 
@@ -169,7 +169,7 @@ func TestToken_loadToken(t *testing.T) {
 			},
 		},
 	}
-	tokenCache := &inMemoryTokenCache{
+	tokenStore := &inMemoryStore{
 		Tokens: map[string]*oauth2.Token{
 			"https://accounts.cloud.databricks.com/oidc/accounts/expired": {
 				RefreshToken: "expired",
@@ -240,9 +240,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
@@ -261,9 +261,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},
@@ -279,9 +279,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureInvalidResponse}}),
 				},
@@ -297,9 +297,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureOtherError}}),
 				},
@@ -315,9 +315,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -332,9 +332,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -349,9 +349,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -366,9 +366,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{"workspace-a"},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -383,9 +383,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{"workspace-a.cloud.databricks.com"},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -400,9 +400,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{"default.dev"},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -417,9 +417,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{"nonexistent.cloud.databricks.com"},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -445,9 +445,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{"nonexistent.cloud.databricks.com"},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    upgradeHintTokenCache{},
+				tokenStore:    upgradeHintStore{},
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(upgradeHintTokenCache{})),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(upgradeHintStore{})),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -478,9 +478,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -496,9 +496,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -515,9 +515,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -535,9 +535,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -553,9 +553,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -572,9 +572,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -589,9 +589,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{"workspace-a"},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
@@ -605,7 +605,7 @@ func TestToken_loadToken(t *testing.T) {
 				args:               []string{},
 				tokenTimeout:       1 * time.Hour,
 				profiler:           profiler,
-				tokenCache:         tokenCache,
+				tokenStore:         tokenStore,
 				persistentAuthOpts: nil,
 			},
 			wantErr: "no profile specified. Use --profile <name> to specify which profile to use",
@@ -618,7 +618,7 @@ func TestToken_loadToken(t *testing.T) {
 				args:               []string{},
 				tokenTimeout:       1 * time.Hour,
 				profiler:           profile.InMemoryProfiler{},
-				tokenCache:         tokenCache,
+				tokenStore:         tokenStore,
 				persistentAuthOpts: nil,
 			},
 			wantErr: "no profiles configured. Run 'databricks auth login' to create a profile",
@@ -631,7 +631,7 @@ func TestToken_loadToken(t *testing.T) {
 				args:               []string{},
 				tokenTimeout:       1 * time.Hour,
 				profiler:           errProfiler{err: profile.ErrNoConfiguration},
-				tokenCache:         tokenCache,
+				tokenStore:         tokenStore,
 				persistentAuthOpts: nil,
 			},
 			wantErr: "no profiles configured. Run 'databricks auth login' to create a profile",
@@ -689,9 +689,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -710,9 +710,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -731,9 +731,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -753,9 +753,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -789,9 +789,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:         []string{},
 				tokenTimeout: 1 * time.Hour,
 				profiler:     profiler,
-				tokenCache:   tokenCache,
+				tokenStore:   tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -806,9 +806,9 @@ func TestToken_loadToken(t *testing.T) {
 				args:          []string{},
 				tokenTimeout:  1 * time.Hour,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: failOnCallTransport{}}),
 				},
@@ -826,9 +826,9 @@ func TestToken_loadToken(t *testing.T) {
 				tokenTimeout:  1 * time.Hour,
 				forceRefresh:  true,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshSuccessTokenResponse}}),
 				},
@@ -844,9 +844,9 @@ func TestToken_loadToken(t *testing.T) {
 				tokenTimeout:  1 * time.Hour,
 				forceRefresh:  true,
 				profiler:      profiler,
-				tokenCache:    tokenCache,
+				tokenStore:    tokenStore,
 				persistentAuthOpts: []u2m.PersistentAuthOption{
-					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenCache)),
+					u2m.WithTokenCache(storage.ToU2MTokenCache(tokenStore)),
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 					u2m.WithHttpClient(&http.Client{Transport: fixtures.SliceTransport{refreshFailureTokenResponse}}),
 				},

--- a/libs/auth/credentials.go
+++ b/libs/auth/credentials.go
@@ -103,13 +103,13 @@ func (c CLICredentials) Configure(ctx context.Context, cfg *config.Config) (cred
 	// across two backends: login writes to the keyring, but every workspace
 	// client built through this strategy would read an empty file cache and
 	// fail with "cache: token not found".
-	tokenCache, mode, err := storage.ResolveCache(ctx, "")
+	tokenStore, mode, err := storage.ResolveStore(ctx, "")
 	if err != nil {
 		return nil, err
 	}
 	ts, err := c.persistentAuth(ctx,
 		u2m.WithOAuthArgument(oauthArg),
-		u2m.WithTokenCache(storage.OAuthTokenCache(ctx, tokenCache, mode)),
+		u2m.WithTokenCache(storage.OAuthTokenCache(ctx, tokenStore, mode)),
 	)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func (c CLICredentials) Configure(ctx context.Context, cfg *config.Config) (cred
 // overrides the default implementation of the persistent auth client if
 // an alternative implementation is provided for testing. The caller is
 // responsible for supplying the token cache via u2m.WithTokenCache; Configure
-// does this via storage.ResolveCache so login, refresh, and all workspace
+// does this via storage.ResolveStore so login, refresh, and all workspace
 // clients share the same backend.
 func (c CLICredentials) persistentAuth(ctx context.Context, opts ...u2m.PersistentAuthOption) (auth.TokenSource, error) {
 	if c.persistentAuthFn != nil {

--- a/libs/auth/credentials_test.go
+++ b/libs/auth/credentials_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // hermeticAuthStorage isolates the test from the caller's real env vars and
-// .databrickscfg so storage.ResolveCache sees a clean default.
+// .databrickscfg so storage.ResolveStore sees a clean default.
 func hermeticAuthStorage(t *testing.T) {
 	t.Helper()
 	t.Setenv(storage.EnvVar, "")
@@ -235,7 +235,7 @@ func TestCLICredentialsConfigure_ThreadsResolvedTokenCache(t *testing.T) {
 // TestCLICredentialsConfigure_PropagatesStorageResolutionError confirms
 // Configure surfaces invalid DATABRICKS_AUTH_STORAGE values instead of
 // silently falling back to the file cache. If Configure ever stops calling
-// storage.ResolveCache, this test will catch it.
+// storage.ResolveStore, this test will catch it.
 func TestCLICredentialsConfigure_PropagatesStorageResolutionError(t *testing.T) {
 	hermeticAuthStorage(t)
 	t.Setenv(storage.EnvVar, "bogus")

--- a/libs/auth/storage/cache.go
+++ b/libs/auth/storage/cache.go
@@ -12,27 +12,27 @@ import (
 	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
 )
 
-// cacheFactories bundles the constructors ResolveCache depends on. Extracted
+// storeFactories bundles the constructors ResolveStore depends on. Extracted
 // so unit tests can inject stubs without hitting the real OS keyring or
-// filesystem. Production code uses defaultCacheFactories().
-type cacheFactories struct {
+// filesystem. Production code uses defaultStoreFactories().
+type storeFactories struct {
 	newFile          func(context.Context) (Store, error)
 	newKeyring       func() Store
 	probeKeyring     func() error
 	probeKeyringRead func() error
 }
 
-// defaultCacheFactories returns the production factory set.
-func defaultCacheFactories() cacheFactories {
-	return cacheFactories{
-		newFile:          func(ctx context.Context) (Store, error) { return NewFileTokenCache(ctx) },
-		newKeyring:       NewKeyringCache,
+// defaultStoreFactories returns the production factory set.
+func defaultStoreFactories() storeFactories {
+	return storeFactories{
+		newFile:          func(ctx context.Context) (Store, error) { return NewFileStore(ctx) },
+		newKeyring:       NewKeyringStore,
 		probeKeyring:     ProbeKeyring,
 		probeKeyringRead: ProbeKeyringRead,
 	}
 }
 
-// ResolveCache resolves the storage mode for this invocation and returns
+// ResolveStore resolves the storage mode for this invocation and returns
 // the corresponding token cache plus the resolved mode (so callers can log
 // or surface it).
 //
@@ -49,11 +49,11 @@ func defaultCacheFactories() cacheFactories {
 // Every CLI code path that calls u2m.NewPersistentAuth must route the result
 // through u2m.WithTokenCache, otherwise the SDK defaults to the file cache
 // and splits the user's tokens across two backends.
-func ResolveCache(ctx context.Context, override StorageMode) (Store, StorageMode, error) {
-	return resolveCacheForReadWith(ctx, override, defaultCacheFactories())
+func ResolveStore(ctx context.Context, override StorageMode) (Store, StorageMode, error) {
+	return resolveStoreForReadWith(ctx, override, defaultStoreFactories())
 }
 
-// ResolveCacheForLogin resolves the cache like ResolveCache with extra rules
+// ResolveStoreForLogin resolves the cache like ResolveStore with extra rules
 // for the auth login path:
 //
 //  1. When the resolved mode is secure and the user did not explicitly ask
@@ -71,8 +71,8 @@ func ResolveCache(ctx context.Context, override StorageMode) (Store, StorageMode
 // Login-specific. Read paths (auth token, bundle commands) keep the original
 // keyring error so they don't silently mint plaintext copies of tokens that
 // were stored in the keyring on another machine.
-func ResolveCacheForLogin(ctx context.Context, override StorageMode) (Store, StorageMode, error) {
-	return resolveCacheForLoginWith(ctx, override, defaultCacheFactories())
+func ResolveStoreForLogin(ctx context.Context, override StorageMode) (Store, StorageMode, error) {
+	return resolveStoreForLoginWith(ctx, override, defaultStoreFactories())
 }
 
 // OAuthTokenCache adapts a CLI Store to the SDK's u2m_cache.TokenCache for the
@@ -101,12 +101,12 @@ func WrapForOAuthArgument(ctx context.Context, c Store, mode StorageMode, arg u2
 	return NewDualWritingTokenCache(tc, arg)
 }
 
-// resolveCacheWith is the pure form of ResolveCache without the read-path
+// resolveStoreWith is the pure form of ResolveStore without the read-path
 // fallback. Takes the factory set as a parameter so tests can inject stubs.
-// Used directly by ResolveCacheForLogin (which has its own fallback rules)
-// and indirectly by ResolveCache (which adds the read-path fallback in
-// resolveCacheForReadWith).
-func resolveCacheWith(ctx context.Context, override StorageMode, f cacheFactories) (Store, StorageMode, error) {
+// Used directly by ResolveStoreForLogin (which has its own fallback rules)
+// and indirectly by ResolveStore (which adds the read-path fallback in
+// resolveStoreForReadWith).
+func resolveStoreWith(ctx context.Context, override StorageMode, f storeFactories) (Store, StorageMode, error) {
 	mode, err := ResolveStorageMode(ctx, override)
 	if err != nil {
 		return nil, "", err
@@ -125,11 +125,11 @@ func resolveCacheWith(ctx context.Context, override StorageMode, f cacheFactorie
 	}
 }
 
-// resolveCacheForReadWith is the pure form of ResolveCache. It applies the
+// resolveStoreForReadWith is the pure form of ResolveStore. It applies the
 // read-path fallback: when mode is secure-from-default and the keyring
 // probes as definitively unavailable, return the file cache instead.
 // Timeouts keep the keyring (could be transient).
-func resolveCacheForReadWith(ctx context.Context, override StorageMode, f cacheFactories) (Store, StorageMode, error) {
+func resolveStoreForReadWith(ctx context.Context, override StorageMode, f storeFactories) (Store, StorageMode, error) {
 	mode, source, err := ResolveStorageModeWithSource(ctx, override)
 	if err != nil {
 		return nil, "", err
@@ -149,7 +149,7 @@ func resolveCacheForReadWith(ctx context.Context, override StorageMode, f cacheF
 // Explicit secure is honored: callers who asked for secure get the keyring
 // cache even if the probe fails, so the actual Lookup error surfaces the
 // unreachability instead of silently using a different backend.
-func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f cacheFactories) (Store, StorageMode, error) {
+func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f storeFactories) (Store, StorageMode, error) {
 	switch mode {
 	case StorageModePlaintext:
 		c, err := f.newFile(ctx)
@@ -167,11 +167,11 @@ func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f c
 				return f.newKeyring(), mode, nil
 			}
 			log.Debugf(ctx, "secure storage unavailable on read path (%v), using file cache", probeErr)
-			fileCache, fileErr := f.newFile(ctx)
+			store, fileErr := f.newFile(ctx)
 			if fileErr != nil {
 				return nil, "", fmt.Errorf("open file token cache: %w", fileErr)
 			}
-			return fileCache, StorageModePlaintext, nil
+			return store, StorageModePlaintext, nil
 		}
 		return f.newKeyring(), mode, nil
 	default:
@@ -179,9 +179,9 @@ func applyReadFallback(ctx context.Context, mode StorageMode, explicit bool, f c
 	}
 }
 
-// resolveCacheForLoginWith is the pure form of ResolveCacheForLogin. It takes
+// resolveStoreForLoginWith is the pure form of ResolveStoreForLogin. It takes
 // the factory set as a parameter so tests can inject stubs.
-func resolveCacheForLoginWith(ctx context.Context, override StorageMode, f cacheFactories) (Store, StorageMode, error) {
+func resolveStoreForLoginWith(ctx context.Context, override StorageMode, f storeFactories) (Store, StorageMode, error) {
 	mode, source, err := ResolveStorageModeWithSource(ctx, override)
 	if err != nil {
 		return nil, "", err
@@ -193,7 +193,7 @@ func resolveCacheForLoginWith(ctx context.Context, override StorageMode, f cache
 // resolved mode and whether the user explicitly asked for it. Split out so
 // tests can drive the (mode, explicit) input space directly without depending
 // on whatever the resolver's default mode happens to be at any point in time.
-func applyLoginFallback(ctx context.Context, mode StorageMode, explicit bool, f cacheFactories) (Store, StorageMode, error) {
+func applyLoginFallback(ctx context.Context, mode StorageMode, explicit bool, f storeFactories) (Store, StorageMode, error) {
 	switch mode {
 	case StorageModePlaintext:
 		c, err := f.newFile(ctx)
@@ -215,12 +215,12 @@ func applyLoginFallback(ctx context.Context, mode StorageMode, explicit bool, f 
 				return nil, "", fmt.Errorf("secure storage was requested but the OS keyring is not reachable: %w", probeErr)
 			}
 			log.Debugf(ctx, "secure storage unavailable (%v), falling back to plaintext", probeErr)
-			fileCache, fileErr := f.newFile(ctx)
+			fileStore, fileErr := f.newFile(ctx)
 			if fileErr != nil {
 				return nil, "", fmt.Errorf("open file token cache: %w", fileErr)
 			}
 			persistPlaintextFallback(ctx)
-			return fileCache, StorageModePlaintext, nil
+			return fileStore, StorageModePlaintext, nil
 		}
 		return f.newKeyring(), mode, nil
 	default:
@@ -250,7 +250,7 @@ func persistPlaintextFallback(ctx context.Context) {
 //
 // No-op when mode is not secure or when the user already chose a mode
 // explicitly via override, env var, or config. override must be the same
-// value the caller passed to ResolveCacheForLogin so the source check sees
+// value the caller passed to ResolveStoreForLogin so the source check sees
 // the caller's intent rather than re-resolving without it.
 //
 // Persistence failures are logged at warn: they do not block login, but

--- a/libs/auth/storage/cache_test.go
+++ b/libs/auth/storage/cache_test.go
@@ -17,13 +17,13 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// stubCache is a test double for Store that records the source it was
+// stubStore is a test double for Store that records the source it was
 // constructed from. It lets the tests confirm which factory ran.
-type stubCache struct{ source string }
+type stubStore struct{ source string }
 
-func (stubCache) Put(string, Entry) error      { return nil }
-func (stubCache) Lookup(string) (Entry, error) { return Entry{}, ErrNotFound }
-func (stubCache) Delete(string) error          { return nil }
+func (stubStore) Put(string, Entry) error      { return nil }
+func (stubStore) Lookup(string) (Entry, error) { return Entry{}, ErrNotFound }
+func (stubStore) Delete(string) error          { return nil }
 
 // memStore is a functional in-memory Store for exercising the OAuth wrappers.
 type memStore struct{ entries map[string]Entry }
@@ -42,11 +42,11 @@ func (m *memStore) Lookup(key string) (Entry, error) {
 
 func (m *memStore) Delete(key string) error { delete(m.entries, key); return nil }
 
-func fakeFactories(t *testing.T) cacheFactories {
+func fakeFactories(t *testing.T) storeFactories {
 	t.Helper()
-	return cacheFactories{
-		newFile:          func(context.Context) (Store, error) { return stubCache{source: "file"}, nil },
-		newKeyring:       func() Store { return stubCache{source: "keyring"} },
+	return storeFactories{
+		newFile:          func(context.Context) (Store, error) { return stubStore{source: "file"}, nil },
+		newKeyring:       func() Store { return stubStore{source: "keyring"} },
 		probeKeyring:     func() error { return nil },
 		probeKeyringRead: func() error { return nil },
 	}
@@ -60,82 +60,82 @@ func hermetic(t *testing.T) {
 	t.Setenv("DATABRICKS_CONFIG_FILE", filepath.Join(t.TempDir(), "databrickscfg"))
 }
 
-func TestResolveCache_DefaultsToSecureKeyring(t *testing.T) {
+func TestResolveStore_DefaultsToSecureKeyring(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 
-	got, mode, err := resolveCacheWith(ctx, "", fakeFactories(t))
+	got, mode, err := resolveStoreWith(ctx, "", fakeFactories(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModeSecure, mode)
-	assert.Equal(t, "keyring", got.(stubCache).source)
+	assert.Equal(t, "keyring", got.(stubStore).source)
 }
 
-func TestResolveCache_OverrideSecureUsesKeyring(t *testing.T) {
+func TestResolveStore_OverrideSecureUsesKeyring(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 
-	got, mode, err := resolveCacheWith(ctx, StorageModeSecure, fakeFactories(t))
+	got, mode, err := resolveStoreWith(ctx, StorageModeSecure, fakeFactories(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModeSecure, mode)
-	assert.Equal(t, "keyring", got.(stubCache).source)
+	assert.Equal(t, "keyring", got.(stubStore).source)
 }
 
-func TestResolveCache_EnvVarSelectsSecure(t *testing.T) {
+func TestResolveStore_EnvVarSelectsSecure(t *testing.T) {
 	hermetic(t)
 	ctx := env.Set(t.Context(), EnvVar, "secure")
 
-	got, mode, err := resolveCacheWith(ctx, "", fakeFactories(t))
+	got, mode, err := resolveStoreWith(ctx, "", fakeFactories(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModeSecure, mode)
-	assert.Equal(t, "keyring", got.(stubCache).source)
+	assert.Equal(t, "keyring", got.(stubStore).source)
 }
 
-func TestResolveCache_PlaintextOverrideUsesFile(t *testing.T) {
+func TestResolveStore_PlaintextOverrideUsesFile(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 
-	got, mode, err := resolveCacheWith(ctx, StorageModePlaintext, fakeFactories(t))
+	got, mode, err := resolveStoreWith(ctx, StorageModePlaintext, fakeFactories(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModePlaintext, mode)
-	assert.Equal(t, "file", got.(stubCache).source)
+	assert.Equal(t, "file", got.(stubStore).source)
 }
 
-func TestResolveCache_InvalidOverrideReturnsError(t *testing.T) {
+func TestResolveStore_InvalidOverrideReturnsError(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 
-	_, _, err := resolveCacheWith(ctx, StorageMode("bogus"), fakeFactories(t))
+	_, _, err := resolveStoreWith(ctx, StorageMode("bogus"), fakeFactories(t))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `unsupported storage mode "bogus"`)
 }
 
-func TestResolveCache_InvalidEnvReturnsError(t *testing.T) {
+func TestResolveStore_InvalidEnvReturnsError(t *testing.T) {
 	hermetic(t)
 	ctx := env.Set(t.Context(), EnvVar, "bogus")
 
-	_, _, err := resolveCacheWith(ctx, "", fakeFactories(t))
+	_, _, err := resolveStoreWith(ctx, "", fakeFactories(t))
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "DATABRICKS_AUTH_STORAGE")
 }
 
-func TestResolveCache_FileFactoryErrorPropagates(t *testing.T) {
+func TestResolveStore_FileFactoryErrorPropagates(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 	boom := errors.New("disk full")
-	factories := cacheFactories{
+	factories := storeFactories{
 		newFile:          func(context.Context) (Store, error) { return nil, boom },
-		newKeyring:       func() Store { return stubCache{source: "keyring"} },
+		newKeyring:       func() Store { return stubStore{source: "keyring"} },
 		probeKeyring:     func() error { return nil },
 		probeKeyringRead: func() error { return nil },
 	}
 
-	_, _, err := resolveCacheWith(ctx, StorageModePlaintext, factories)
+	_, _, err := resolveStoreWith(ctx, StorageModePlaintext, factories)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
@@ -160,7 +160,7 @@ func TestApplyReadFallback_PlaintextSkipsProbe(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModePlaintext, mode)
-	assert.Equal(t, "file", got.(stubCache).source)
+	assert.Equal(t, "file", got.(stubStore).source)
 	assert.False(t, probed, "probe must not run when mode is already plaintext")
 }
 
@@ -178,7 +178,7 @@ func TestApplyReadFallback_ExplicitSecureSkipsProbe(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModeSecure, mode)
-	assert.Equal(t, "keyring", got.(stubCache).source)
+	assert.Equal(t, "keyring", got.(stubStore).source)
 	assert.False(t, probed, "probe must not run when user is explicit about secure mode")
 }
 
@@ -190,7 +190,7 @@ func TestApplyReadFallback_DefaultSecure_ProbeOK_UsesKeyring(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModeSecure, mode)
-	assert.Equal(t, "keyring", got.(stubCache).source)
+	assert.Equal(t, "keyring", got.(stubStore).source)
 }
 
 func TestApplyReadFallback_DefaultSecure_ProbeFail_FallsBack(t *testing.T) {
@@ -205,7 +205,7 @@ func TestApplyReadFallback_DefaultSecure_ProbeFail_FallsBack(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModePlaintext, mode)
-	assert.Equal(t, "file", got.(stubCache).source)
+	assert.Equal(t, "file", got.(stubStore).source)
 
 	// Read-path fallback must NOT pin: pinning is reserved for login,
 	// where the write-probe gives stronger evidence of unavailability.
@@ -239,7 +239,7 @@ func TestApplyReadFallback_DefaultSecure_ProbeTimeout_StaysOnKeyring(t *testing.
 
 			require.NoError(t, err)
 			assert.Equal(t, StorageModeSecure, mode)
-			assert.Equal(t, "keyring", got.(stubCache).source)
+			assert.Equal(t, "keyring", got.(stubStore).source)
 
 			persisted, gerr := databrickscfg.GetConfiguredAuthStorage(ctx, configPath)
 			require.NoError(t, gerr)
@@ -248,7 +248,7 @@ func TestApplyReadFallback_DefaultSecure_ProbeTimeout_StaysOnKeyring(t *testing.
 	}
 }
 
-func TestResolveCacheForLogin_PlaintextSkipsProbe(t *testing.T) {
+func TestResolveStoreForLogin_PlaintextSkipsProbe(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 	probed := false
@@ -258,26 +258,26 @@ func TestResolveCacheForLogin_PlaintextSkipsProbe(t *testing.T) {
 		return nil
 	}
 
-	got, mode, err := resolveCacheForLoginWith(ctx, StorageModePlaintext, f)
+	got, mode, err := resolveStoreForLoginWith(ctx, StorageModePlaintext, f)
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModePlaintext, mode)
-	assert.Equal(t, "file", got.(stubCache).source)
+	assert.Equal(t, "file", got.(stubStore).source)
 	assert.False(t, probed, "probe must not run when mode is already plaintext")
 }
 
-func TestResolveCacheForLogin_SecureProbeOK(t *testing.T) {
+func TestResolveStoreForLogin_SecureProbeOK(t *testing.T) {
 	hermetic(t)
 	ctx := env.Set(t.Context(), EnvVar, "secure")
 
-	got, mode, err := resolveCacheForLoginWith(ctx, "", fakeFactories(t))
+	got, mode, err := resolveStoreForLoginWith(ctx, "", fakeFactories(t))
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModeSecure, mode)
-	assert.Equal(t, "keyring", got.(stubCache).source)
+	assert.Equal(t, "keyring", got.(stubStore).source)
 }
 
-func TestResolveCacheForLogin_ExplicitEnvSecure_ProbeFail_Errors(t *testing.T) {
+func TestResolveStoreForLogin_ExplicitEnvSecure_ProbeFail_Errors(t *testing.T) {
 	hermetic(t)
 	ctx := env.Set(t.Context(), EnvVar, "secure")
 	configPath := env.Get(ctx, "DATABRICKS_CONFIG_FILE")
@@ -285,7 +285,7 @@ func TestResolveCacheForLogin_ExplicitEnvSecure_ProbeFail_Errors(t *testing.T) {
 	f := fakeFactories(t)
 	f.probeKeyring = func() error { return errors.New("no keyring") }
 
-	_, _, err := resolveCacheForLoginWith(ctx, "", f)
+	_, _, err := resolveStoreForLoginWith(ctx, "", f)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "secure storage was requested")
 
@@ -294,7 +294,7 @@ func TestResolveCacheForLogin_ExplicitEnvSecure_ProbeFail_Errors(t *testing.T) {
 	assert.Empty(t, persisted, "env-set secure must not be persisted as plaintext")
 }
 
-func TestResolveCacheForLogin_ExplicitConfigSecure_ProbeFail_Errors(t *testing.T) {
+func TestResolveStoreForLogin_ExplicitConfigSecure_ProbeFail_Errors(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 	configPath := env.Get(ctx, "DATABRICKS_CONFIG_FILE")
@@ -303,7 +303,7 @@ func TestResolveCacheForLogin_ExplicitConfigSecure_ProbeFail_Errors(t *testing.T
 	f := fakeFactories(t)
 	f.probeKeyring = func() error { return errors.New("no keyring") }
 
-	_, _, err := resolveCacheForLoginWith(ctx, "", f)
+	_, _, err := resolveStoreForLoginWith(ctx, "", f)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "secure storage was requested")
 
@@ -312,14 +312,14 @@ func TestResolveCacheForLogin_ExplicitConfigSecure_ProbeFail_Errors(t *testing.T
 	assert.Equal(t, "secure", persisted, "config-set secure must not be silently rewritten")
 }
 
-func TestResolveCacheForLogin_ExplicitOverrideSecure_ProbeFail_Errors(t *testing.T) {
+func TestResolveStoreForLogin_ExplicitOverrideSecure_ProbeFail_Errors(t *testing.T) {
 	hermetic(t)
 	ctx := t.Context()
 
 	f := fakeFactories(t)
 	f.probeKeyring = func() error { return errors.New("no keyring") }
 
-	_, _, err := resolveCacheForLoginWith(ctx, StorageModeSecure, f)
+	_, _, err := resolveStoreForLoginWith(ctx, StorageModeSecure, f)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "secure storage was requested")
 }
@@ -336,7 +336,7 @@ func TestApplyLoginFallback_DefaultSecure_ProbeFail_FallsBackAndPersists(t *test
 
 	require.NoError(t, err)
 	assert.Equal(t, StorageModePlaintext, mode)
-	assert.Equal(t, "file", got.(stubCache).source)
+	assert.Equal(t, "file", got.(stubStore).source)
 
 	persisted, err := databrickscfg.GetConfiguredAuthStorage(ctx, configPath)
 	require.NoError(t, err)
@@ -390,7 +390,7 @@ func TestApplyLoginFallback_ProbeTimeout_StaysOnKeyring(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, StorageModeSecure, mode)
-			assert.Equal(t, "keyring", got.(stubCache).source)
+			assert.Equal(t, "keyring", got.(stubStore).source)
 
 			persisted, gerr := databrickscfg.GetConfiguredAuthStorage(ctx, configPath)
 			require.NoError(t, gerr)

--- a/libs/auth/storage/filestore.go
+++ b/libs/auth/storage/filestore.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
-	// tokenCacheFile is the path of the default token cache, relative to the
-	// user's home directory.
-	tokenCacheFilePath = ".databricks/token-cache.json"
+	// tokenStoreFilePath is the path of the default token store, relative to
+	// the user's home directory. The on-disk filename stays "token-cache.json"
+	// for backward compatibility with tokens written by older CLI versions,
+	// even though the Go identifiers now use the "store" vocabulary.
+	tokenStoreFilePath = ".databricks/token-cache.json"
 
 	// ownerExecReadWrite is the permission for the .databricks directory.
 	ownerExecReadWrite = 0o700
@@ -25,7 +27,7 @@ const (
 	// ownerReadWrite is the permission for the token-cache.json file.
 	ownerReadWrite = 0o600
 
-	// tokenCacheVersion is the version of the token cache file format.
+	// tokenStoreVersion is the version of the token store file format.
 	//
 	// Version 1 format:
 	//
@@ -40,7 +42,7 @@ const (
 	//     }
 	//   }
 	// }
-	tokenCacheVersion = 1
+	tokenStoreVersion = 1
 )
 
 // fileEntry is the per-key on-disk shape. The embedded *oauth2.Token promotes
@@ -50,44 +52,43 @@ type fileEntry struct {
 	*oauth2.Token
 }
 
-// tokenCacheFile is the format of the token cache file.
-type tokenCacheFile struct {
+// tokenStoreFile is the format of the token store file.
+type tokenStoreFile struct {
 	Version int                   `json:"version"`
 	Tokens  map[string]*fileEntry `json:"tokens"`
 }
 
-type FileTokenCacheOption func(*fileTokenCache)
+type FileStoreOption func(*fileStore)
 
-func WithFileLocation(fileLocation string) FileTokenCacheOption {
-	return func(c *fileTokenCache) {
+func WithFileLocation(fileLocation string) FileStoreOption {
+	return func(c *fileStore) {
 		c.fileLocation = fileLocation
 	}
 }
 
-// fileTokenCache caches tokens in "~/.databricks/token-cache.json". fileTokenCache
-// implements the TokenCache interface.
-type fileTokenCache struct {
+// fileStore stores tokens in "~/.databricks/token-cache.json". fileStore
+// implements the Store interface.
+type fileStore struct {
 	fileLocation string
 
-	// locker protects the token cache file from concurrent reads and writes.
+	// locker protects the token store file from concurrent reads and writes.
 	locker sync.Mutex
 }
 
-// NewFileTokenCache creates a new FileTokenCache. By default, the cache is
-// stored in "~/.databricks/token-cache.json". The cache file is created if it
-// does not already exist. The cache file is created with owner permissions
-// 0600 and the directory is created with owner permissions 0700. If the cache
-// file is corrupt or if its version does not match tokenCacheVersion, an error
-// is returned.
-func NewFileTokenCache(ctx context.Context, opts ...FileTokenCacheOption) (Store, error) {
-	c := &fileTokenCache{}
+// NewFileStore creates a new file-backed Store. By default, tokens are stored
+// in "~/.databricks/token-cache.json". The store file is created if it does
+// not already exist, with owner permissions 0600 and the directory with owner
+// permissions 0700. If the store file is corrupt or if its version does not
+// match tokenStoreVersion, an error is returned.
+func NewFileStore(ctx context.Context, opts ...FileStoreOption) (Store, error) {
+	c := &fileStore{}
 	for _, opt := range opts {
 		opt(c)
 	}
 	if err := c.init(ctx); err != nil {
 		return nil, err
 	}
-	// Fail fast if the cache is not working.
+	// Fail fast if the store is not working.
 	if _, err := c.load(); err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}
@@ -95,7 +96,7 @@ func NewFileTokenCache(ctx context.Context, opts ...FileTokenCacheOption) (Store
 }
 
 // Put implements the Store interface.
-func (c *fileTokenCache) Put(key string, e Entry) error {
+func (c *fileStore) Put(key string, e Entry) error {
 	c.locker.Lock()
 	defer c.locker.Unlock()
 	f, err := c.load()
@@ -110,7 +111,7 @@ func (c *fileTokenCache) Put(key string, e Entry) error {
 }
 
 // Lookup implements the Store interface.
-func (c *fileTokenCache) Lookup(key string) (Entry, error) {
+func (c *fileStore) Lookup(key string) (Entry, error) {
 	c.locker.Lock()
 	defer c.locker.Unlock()
 	f, err := c.load()
@@ -125,7 +126,7 @@ func (c *fileTokenCache) Lookup(key string) (Entry, error) {
 }
 
 // Delete implements the Store interface. Removing a missing key is a no-op.
-func (c *fileTokenCache) Delete(key string) error {
+func (c *fileStore) Delete(key string) error {
 	c.locker.Lock()
 	defer c.locker.Unlock()
 	f, err := c.load()
@@ -136,8 +137,8 @@ func (c *fileTokenCache) Delete(key string) error {
 	return c.write(f)
 }
 
-// write marshals f and atomically replaces the cache file.
-func (c *fileTokenCache) write(f *tokenCacheFile) error {
+// write marshals f and atomically replaces the store file.
+func (c *fileStore) write(f *tokenStoreFile) error {
 	raw, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)
@@ -148,18 +149,18 @@ func (c *fileTokenCache) write(f *tokenCacheFile) error {
 	return nil
 }
 
-// init initializes the token cache file. It creates the file and directory if
+// init initializes the token store file. It creates the file and directory if
 // they do not already exist.
-func (c *fileTokenCache) init(ctx context.Context) error {
+func (c *fileStore) init(ctx context.Context) error {
 	// set the default file location
 	if c.fileLocation == "" {
 		home, err := env.UserHomeDir(ctx)
 		if err != nil {
 			return fmt.Errorf("failed loading home directory: %w", err)
 		}
-		c.fileLocation = filepath.Join(home, tokenCacheFilePath)
+		c.fileLocation = filepath.Join(home, tokenStoreFilePath)
 	}
-	// Create the cache file if it does not exist.
+	// Create the store file if it does not exist.
 	if _, err := os.Stat(c.fileLocation); err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("stat file: %w", err)
@@ -169,9 +170,9 @@ func (c *fileTokenCache) init(ctx context.Context) error {
 			return fmt.Errorf("mkdir: %w", err)
 		}
 
-		// Create an empty cache file.
-		f := &tokenCacheFile{
-			Version: tokenCacheVersion,
+		// Create an empty store file.
+		f := &tokenStoreFile{
+			Version: tokenStoreVersion,
 			Tokens:  map[string]*fileEntry{},
 		}
 		raw, err := json.MarshalIndent(f, "", "  ")
@@ -179,28 +180,28 @@ func (c *fileTokenCache) init(ctx context.Context) error {
 			return fmt.Errorf("marshal: %w", err)
 		}
 		if err := c.atomicWriteFile(raw); err != nil {
-			return fmt.Errorf("error creating token cache file: %w", err)
+			return fmt.Errorf("error creating token store file: %w", err)
 		}
 	}
 	return nil
 }
 
-// load loads the token cache file from disk. If the file is corrupt or if its
-// version does not match tokenCacheVersion, it returns an error.
-func (c *fileTokenCache) load() (*tokenCacheFile, error) {
+// load loads the token store file from disk. If the file is corrupt or if its
+// version does not match tokenStoreVersion, it returns an error.
+func (c *fileStore) load() (*tokenStoreFile, error) {
 	raw, err := os.ReadFile(c.fileLocation)
 	if err != nil {
 		return nil, fmt.Errorf("read: %w", err)
 	}
-	f := &tokenCacheFile{}
+	f := &tokenStoreFile{}
 	if err := json.Unmarshal(raw, &f); err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
-	if f.Version != tokenCacheVersion {
+	if f.Version != tokenStoreVersion {
 		// in the later iterations we could do state upgraders,
-		// so that we transform token cache from v1 to v2 without
+		// so that we transform token store from v1 to v2 without
 		// losing the tokens and asking the user to re-authenticate.
-		return nil, fmt.Errorf("needs version %d, got version %d", tokenCacheVersion, f.Version)
+		return nil, fmt.Errorf("needs version %d, got version %d", tokenStoreVersion, f.Version)
 	}
 	return f, nil
 }
@@ -208,7 +209,7 @@ func (c *fileTokenCache) load() (*tokenCacheFile, error) {
 // atomicWriteFile writes data to the file atomically by first writing to a
 // temporary file in the same directory and then renaming it to the target.
 // This prevents corruption from interrupted writes.
-func (c *fileTokenCache) atomicWriteFile(data []byte) error {
+func (c *fileStore) atomicWriteFile(data []byte) error {
 	tmp, err := c.writeTmpFile(data)
 	if err != nil {
 		return err
@@ -217,7 +218,7 @@ func (c *fileTokenCache) atomicWriteFile(data []byte) error {
 	return os.Rename(tmp, c.fileLocation)
 }
 
-func (c *fileTokenCache) writeTmpFile(data []byte) (string, error) {
+func (c *fileStore) writeTmpFile(data []byte) (string, error) {
 	tmp, err := os.CreateTemp(filepath.Dir(c.fileLocation), ".token-cache-*.tmp")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)

--- a/libs/auth/storage/filestore_test.go
+++ b/libs/auth/storage/filestore_test.go
@@ -16,7 +16,7 @@ func setup(t *testing.T) string {
 }
 
 func TestStoreAndLookup(t *testing.T) {
-	c, err := NewFileTokenCache(t.Context(), WithFileLocation(setup(t)))
+	c, err := NewFileStore(t.Context(), WithFileLocation(setup(t)))
 	require.NoError(t, err)
 	err = c.Put("x", Entry{Token: &oauth2.Token{
 		AccessToken: "abc",
@@ -36,8 +36,8 @@ func TestStoreAndLookup(t *testing.T) {
 	assert.Equal(t, ErrNotFound, err)
 }
 
-func TestNoCacheFileReturnsErrNotConfigured(t *testing.T) {
-	l, err := NewFileTokenCache(t.Context(), WithFileLocation(setup(t)))
+func TestNoStoreFileReturnsErrNotConfigured(t *testing.T) {
+	l, err := NewFileStore(t.Context(), WithFileLocation(setup(t)))
 	require.NoError(t, err)
 	_, err = l.Lookup("x")
 	assert.Equal(t, ErrNotFound, err)
@@ -50,7 +50,7 @@ func TestLoadCorruptFile(t *testing.T) {
 	err = os.WriteFile(f, []byte("abc"), ownerExecReadWrite)
 	require.NoError(t, err)
 
-	_, err = NewFileTokenCache(t.Context(), WithFileLocation(f))
+	_, err = NewFileStore(t.Context(), WithFileLocation(f))
 	assert.EqualError(t, err, "load: parse: invalid character 'a' looking for beginning of value")
 }
 
@@ -61,6 +61,6 @@ func TestLoadWrongVersion(t *testing.T) {
 	err = os.WriteFile(f, []byte(`{"version": 823, "things": []}`), ownerExecReadWrite)
 	require.NoError(t, err)
 
-	_, err = NewFileTokenCache(t.Context(), WithFileLocation(f))
+	_, err = NewFileStore(t.Context(), WithFileLocation(f))
 	assert.EqualError(t, err, "load: needs version 1, got version 823")
 }

--- a/libs/auth/storage/keyring.go
+++ b/libs/auth/storage/keyring.go
@@ -20,7 +20,7 @@ const keyringServiceName = "databricks-cli"
 // keyringProbeAccountPrefix is prefixed onto a per-call random suffix to form
 // the account name ProbeKeyring writes and deletes. A fixed name like
 // "__probe__" could collide with a user profile of the same name (which is
-// what keyringCache uses as the account field), so the probe would clobber
+// what keyringStore uses as the account field), so the probe would clobber
 // and delete that user's stored token. Per-call randomness also means
 // concurrent probes don't step on each other.
 const keyringProbeAccountPrefix = "__probe_"
@@ -65,22 +65,22 @@ func (zalandoBackend) Delete(service, account string) error {
 	return keyring.Delete(service, account)
 }
 
-// keyringCache stores OAuth tokens in the OS-native secure store.
-// It implements the SDK's cache.TokenCache interface.
+// keyringStore stores OAuth tokens in the OS-native secure store.
+// It implements the Store interface.
 //
 // The type is unexported so that the only way to construct a working instance
-// is NewKeyringCache. A bare &keyringCache{} has a nil backend, which would
+// is NewKeyringStore. A bare &keyringStore{} has a nil backend, which would
 // panic on first use.
-type keyringCache struct {
+type keyringStore struct {
 	backend        keyringBackend
 	timeout        time.Duration
 	keyringSvcName string
 }
 
-// NewKeyringCache returns a cache.TokenCache backed by the OS-native secure
-// store (via zalando/go-keyring) with a 3-second per-operation timeout.
-func NewKeyringCache() Store {
-	return &keyringCache{
+// NewKeyringStore returns a Store backed by the OS-native secure store (via
+// zalando/go-keyring) with a 3-second per-operation timeout.
+func NewKeyringStore() Store {
+	return &keyringStore{
 		backend:        zalandoBackend{},
 		timeout:        defaultKeyringTimeout,
 		keyringSvcName: keyringServiceName,
@@ -99,7 +99,7 @@ func ProbeKeyring() error {
 }
 
 func probeWithBackend(backend keyringBackend, timeout time.Duration) error {
-	c := &keyringCache{
+	c := &keyringStore{
 		backend:        backend,
 		timeout:        timeout,
 		keyringSvcName: keyringServiceName,
@@ -128,7 +128,7 @@ func ProbeKeyringRead() error {
 }
 
 func probeReadWithBackend(backend keyringBackend, timeout time.Duration) error {
-	c := &keyringCache{
+	c := &keyringStore{
 		backend:        backend,
 		timeout:        timeout,
 		keyringSvcName: keyringServiceName,
@@ -145,7 +145,7 @@ func probeReadWithBackend(backend keyringBackend, timeout time.Duration) error {
 }
 
 // Put implements the Store interface.
-func (k *keyringCache) Put(key string, e Entry) error {
+func (k *keyringStore) Put(key string, e Entry) error {
 	raw, err := json.Marshal(keyringEntry(e))
 	if err != nil {
 		return fmt.Errorf("marshal token: %w", err)
@@ -156,7 +156,7 @@ func (k *keyringCache) Put(key string, e Entry) error {
 }
 
 // Delete implements the Store interface. Removing a missing entry is a no-op.
-func (k *keyringCache) Delete(key string) error {
+func (k *keyringStore) Delete(key string) error {
 	return k.withTimeout("delete", func() error {
 		err := k.backend.Delete(k.keyringSvcName, key)
 		if errors.Is(err, keyring.ErrNotFound) {
@@ -167,7 +167,7 @@ func (k *keyringCache) Delete(key string) error {
 }
 
 // Lookup implements the Store interface, returning ErrNotFound on a miss.
-func (k *keyringCache) Lookup(key string) (Entry, error) {
+func (k *keyringStore) Lookup(key string) (Entry, error) {
 	var raw string
 	err := k.withTimeout("get", func() error {
 		got, gerr := k.backend.Get(k.keyringSvcName, key)
@@ -209,8 +209,8 @@ func wrapKeyringUnreachable(err error) error {
 	return fmt.Errorf("OS keyring unreachable: %w (set DATABRICKS_AUTH_STORAGE=plaintext or run `databricks auth login` to use file-based token storage)", err)
 }
 
-// Compile-time confirmation that keyringCache satisfies the CLI interface.
-var _ Store = (*keyringCache)(nil)
+// Compile-time confirmation that keyringStore satisfies the CLI interface.
+var _ Store = (*keyringStore)(nil)
 
 // TimeoutError is returned when a keyring operation exceeds the configured
 // timeout. Callers can use errors.As to detect and present a clear message.
@@ -227,7 +227,7 @@ func (e *TimeoutError) Error() string {
 // goroutine is not cancelled; it will complete (or outlive the process)
 // in the background. This mirrors the pattern used by GitHub CLI; see
 // https://github.com/cli/cli/blob/trunk/internal/keyring/keyring.go.
-func (k *keyringCache) withTimeout(op string, fn func() error) error {
+func (k *keyringStore) withTimeout(op string, fn func() error) error {
 	ch := make(chan error, 1)
 	go func() {
 		ch <- fn()

--- a/libs/auth/storage/keyring_test.go
+++ b/libs/auth/storage/keyring_test.go
@@ -68,17 +68,17 @@ func (f *fakeBackend) Delete(service, account string) error {
 	return nil
 }
 
-func newTestCache(backend keyringBackend) *keyringCache {
-	return &keyringCache{
+func newTestStore(backend keyringBackend) *keyringStore {
+	return &keyringStore{
 		backend:        backend,
 		timeout:        100 * time.Millisecond,
 		keyringSvcName: "databricks-cli",
 	}
 }
 
-func TestKeyringCache_Store_WritesJSON(t *testing.T) {
+func TestKeyringStore_Store_WritesJSON(t *testing.T) {
 	backend := newFakeBackend()
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	tok := &oauth2.Token{AccessToken: "abc", TokenType: "Bearer"}
 
@@ -94,20 +94,20 @@ func TestKeyringCache_Store_WritesJSON(t *testing.T) {
 	assert.Equal(t, "Bearer", got.Token.TokenType)
 }
 
-func TestKeyringCache_Store_PropagatesBackendError(t *testing.T) {
+func TestKeyringStore_Store_PropagatesBackendError(t *testing.T) {
 	boom := errors.New("backend boom")
 	backend := newFakeBackend()
 	backend.setErr = boom
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	err := c.Put("my-profile", Entry{Token: &oauth2.Token{AccessToken: "x"}})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
 }
 
-func TestKeyringCache_Lookup_ReturnsStoredToken(t *testing.T) {
+func TestKeyringStore_Lookup_ReturnsStoredToken(t *testing.T) {
 	backend := newFakeBackend()
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	want := &oauth2.Token{AccessToken: "abc", TokenType: "Bearer"}
 	require.NoError(t, c.Put("my-profile", Entry{Token: want}))
@@ -118,20 +118,20 @@ func TestKeyringCache_Lookup_ReturnsStoredToken(t *testing.T) {
 	assert.Equal(t, "Bearer", got.Token.TokenType)
 }
 
-func TestKeyringCache_Lookup_MissingReturnsCacheErrNotFound(t *testing.T) {
+func TestKeyringStore_Lookup_MissingReturnsCacheErrNotFound(t *testing.T) {
 	backend := newFakeBackend()
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	_, err := c.Lookup("nope")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
-func TestKeyringCache_Lookup_PropagatesOtherErrors(t *testing.T) {
+func TestKeyringStore_Lookup_PropagatesOtherErrors(t *testing.T) {
 	boom := errors.New("backend boom")
 	backend := newFakeBackend()
 	backend.getErr = boom
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	_, err := c.Lookup("my-profile")
 	require.Error(t, err)
@@ -147,9 +147,9 @@ func TestKeyringCache_Lookup_PropagatesOtherErrors(t *testing.T) {
 // ErrNotFound has to pass through unwrapped because callers branch on it
 // (cache.ErrNotFound is the "no token, please log in" signal). Wrapping it
 // with the unreachability hint would mislead the user.
-func TestKeyringCache_Lookup_NotFoundIsNotWrapped(t *testing.T) {
+func TestKeyringStore_Lookup_NotFoundIsNotWrapped(t *testing.T) {
 	backend := newFakeBackend()
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	_, err := c.Lookup("nope")
 	require.Error(t, err)
@@ -157,19 +157,19 @@ func TestKeyringCache_Lookup_NotFoundIsNotWrapped(t *testing.T) {
 	assert.NotContains(t, err.Error(), "OS keyring unreachable")
 }
 
-func TestKeyringCache_Lookup_CorruptedJSONReturnsError(t *testing.T) {
+func TestKeyringStore_Lookup_CorruptedJSONReturnsError(t *testing.T) {
 	backend := newFakeBackend()
 	backend.items[itemKey("databricks-cli", "my-profile")] = "{not json"
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	_, err := c.Lookup("my-profile")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal token")
 }
 
-func TestKeyringCache_StoreNil_DeletesEntry(t *testing.T) {
+func TestKeyringStore_StoreNil_DeletesEntry(t *testing.T) {
 	backend := newFakeBackend()
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	require.NoError(t, c.Put("my-profile", Entry{Token: &oauth2.Token{AccessToken: "abc"}}))
 	require.NoError(t, c.Delete("my-profile"))
@@ -178,30 +178,30 @@ func TestKeyringCache_StoreNil_DeletesEntry(t *testing.T) {
 	assert.False(t, ok, "entry should be gone after delete")
 }
 
-func TestKeyringCache_StoreNil_MissingIsIdempotent(t *testing.T) {
+func TestKeyringStore_StoreNil_MissingIsIdempotent(t *testing.T) {
 	backend := newFakeBackend()
 	backend.deleteErr = keyring.ErrNotFound
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	err := c.Delete("never-stored")
 	require.NoError(t, err, "deleting a missing entry must not error")
 }
 
-func TestKeyringCache_StoreNil_PropagatesOtherDeleteErrors(t *testing.T) {
+func TestKeyringStore_StoreNil_PropagatesOtherDeleteErrors(t *testing.T) {
 	boom := errors.New("backend boom")
 	backend := newFakeBackend()
 	backend.deleteErr = boom
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	err := c.Delete("my-profile")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
 }
 
-func TestKeyringCache_Store_TimesOut(t *testing.T) {
+func TestKeyringStore_Store_TimesOut(t *testing.T) {
 	backend := newFakeBackend()
 	backend.setBlock = true
-	c := newTestCache(backend) // 100ms timeout from newTestCache
+	c := newTestStore(backend) // 100ms timeout from newTestStore
 
 	start := time.Now()
 	err := c.Put("my-profile", Entry{Token: &oauth2.Token{AccessToken: "x"}})
@@ -212,10 +212,10 @@ func TestKeyringCache_Store_TimesOut(t *testing.T) {
 	assert.Less(t, time.Since(start), 2*time.Second, "should time out quickly")
 }
 
-func TestKeyringCache_Lookup_TimesOut(t *testing.T) {
+func TestKeyringStore_Lookup_TimesOut(t *testing.T) {
 	backend := newFakeBackend()
 	backend.getBlock = true
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	_, err := c.Lookup("my-profile")
 	require.Error(t, err)
@@ -224,10 +224,10 @@ func TestKeyringCache_Lookup_TimesOut(t *testing.T) {
 	assert.ErrorAs(t, err, &timeoutErr, "expected TimeoutError, got %T: %v", err, err)
 }
 
-func TestKeyringCache_StoreNil_TimesOut(t *testing.T) {
+func TestKeyringStore_StoreNil_TimesOut(t *testing.T) {
 	backend := newFakeBackend()
 	backend.deleteBlock = true
-	c := newTestCache(backend)
+	c := newTestStore(backend)
 
 	err := c.Delete("my-profile")
 	require.Error(t, err)

--- a/libs/auth/storage/not_found_hint.go
+++ b/libs/auth/storage/not_found_hint.go
@@ -25,7 +25,7 @@ import (
 type notFoundHintCache struct {
 	inner           cache.TokenCache
 	mode            StorageMode
-	legacyCachePath string
+	legacyStorePath string
 }
 
 func (c *notFoundHintCache) Store(key string, t *oauth2.Token) error {
@@ -37,7 +37,7 @@ func (c *notFoundHintCache) Lookup(key string) (*oauth2.Token, error) {
 	if err == nil || !errors.Is(err, cache.ErrNotFound) {
 		return tok, err
 	}
-	if c.mode == StorageModeSecure && legacyCacheHasTokens(c.legacyCachePath) {
+	if c.mode == StorageModeSecure && legacyStoreHasTokens(c.legacyStorePath) {
 		return nil, &notFoundHint{msg: "stored credentials from older CLI versions are no longer used; run `databricks auth login` to sign in again, or set DATABRICKS_AUTH_STORAGE=plaintext to keep using the file cache"}
 	}
 	return nil, &notFoundHint{msg: "no cached credentials; run `databricks auth login` to sign in"}
@@ -89,21 +89,21 @@ func NewNotFoundHint(msg string) error {
 // is available) so Lookup can do its check without needing a context.
 //
 // Resolution failures for the home directory are not fatal: an empty
-// legacyCachePath simply disables the upgrade-specific message, which
+// legacyStorePath simply disables the upgrade-specific message, which
 // falls back to the generic "run auth login" hint.
 func withNotFoundHint(ctx context.Context, inner cache.TokenCache, mode StorageMode) cache.TokenCache {
-	var legacyCachePath string
+	var legacyStorePath string
 	if home, err := env.UserHomeDir(ctx); err == nil {
-		legacyCachePath = filepath.Join(home, tokenCacheFilePath)
+		legacyStorePath = filepath.Join(home, tokenStoreFilePath)
 	}
-	return &notFoundHintCache{inner: inner, mode: mode, legacyCachePath: legacyCachePath}
+	return &notFoundHintCache{inner: inner, mode: mode, legacyStorePath: legacyStorePath}
 }
 
-// legacyCacheHasTokens reports whether the file at path is a valid token
+// legacyStoreHasTokens reports whether the file at path is a valid token
 // cache with at least one entry. Best-effort and read-only: any I/O or
 // parse error returns false so we never claim "you have legacy tokens"
 // when we cannot actually tell.
-func legacyCacheHasTokens(path string) bool {
+func legacyStoreHasTokens(path string) bool {
 	if path == "" {
 		return false
 	}
@@ -111,7 +111,7 @@ func legacyCacheHasTokens(path string) bool {
 	if err != nil {
 		return false
 	}
-	var f tokenCacheFile
+	var f tokenStoreFile
 	if err := json.Unmarshal(raw, &f); err != nil {
 		return false
 	}

--- a/libs/auth/storage/not_found_hint_test.go
+++ b/libs/auth/storage/not_found_hint_test.go
@@ -35,24 +35,24 @@ type boomCache struct{ err error }
 func (c boomCache) Store(string, *oauth2.Token) error    { return nil }
 func (c boomCache) Lookup(string) (*oauth2.Token, error) { return nil, c.err }
 
-func writeLegacyCache(t *testing.T, path string, hasEntries bool) {
+func writeLegacyStore(t *testing.T, path string, hasEntries bool) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
 	tokens := map[string]*fileEntry{}
 	if hasEntries {
 		tokens["my-profile"] = &fileEntry{Token: &oauth2.Token{AccessToken: "abc"}}
 	}
-	body, err := json.Marshal(tokenCacheFile{Version: tokenCacheVersion, Tokens: tokens})
+	body, err := json.Marshal(tokenStoreFile{Version: tokenStoreVersion, Tokens: tokens})
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, body, 0o600))
 }
 
 func TestNotFoundHintCache_SecureWithLegacyEntries_UsesUpgradeMessage(t *testing.T) {
 	tmp := t.TempDir()
-	legacyPath := filepath.Join(tmp, tokenCacheFilePath)
-	writeLegacyCache(t, legacyPath, true)
+	legacyPath := filepath.Join(tmp, tokenStoreFilePath)
+	writeLegacyStore(t, legacyPath, true)
 
-	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyCachePath: legacyPath}
+	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyStorePath: legacyPath}
 	_, err := c.Lookup("anything")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -63,10 +63,10 @@ func TestNotFoundHintCache_SecureWithLegacyEntries_UsesUpgradeMessage(t *testing
 
 func TestNotFoundHintCache_SecureWithEmptyLegacyFile_UsesGenericMessage(t *testing.T) {
 	tmp := t.TempDir()
-	legacyPath := filepath.Join(tmp, tokenCacheFilePath)
-	writeLegacyCache(t, legacyPath, false)
+	legacyPath := filepath.Join(tmp, tokenStoreFilePath)
+	writeLegacyStore(t, legacyPath, false)
 
-	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyCachePath: legacyPath}
+	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyStorePath: legacyPath}
 	_, err := c.Lookup("anything")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -75,7 +75,7 @@ func TestNotFoundHintCache_SecureWithEmptyLegacyFile_UsesGenericMessage(t *testi
 }
 
 func TestNotFoundHintCache_SecureNoLegacyFile_UsesGenericMessage(t *testing.T) {
-	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyCachePath: filepath.Join(t.TempDir(), "missing.json")}
+	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyStorePath: filepath.Join(t.TempDir(), "missing.json")}
 	_, err := c.Lookup("anything")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -84,12 +84,12 @@ func TestNotFoundHintCache_SecureNoLegacyFile_UsesGenericMessage(t *testing.T) {
 
 func TestNotFoundHintCache_Plaintext_AlwaysGenericMessage(t *testing.T) {
 	tmp := t.TempDir()
-	legacyPath := filepath.Join(tmp, tokenCacheFilePath)
-	writeLegacyCache(t, legacyPath, true)
+	legacyPath := filepath.Join(tmp, tokenStoreFilePath)
+	writeLegacyStore(t, legacyPath, true)
 
 	// Even with a populated legacy file present, plaintext mode reads from
 	// that same file, so the upgrade copy would be misleading.
-	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModePlaintext, legacyCachePath: legacyPath}
+	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModePlaintext, legacyStorePath: legacyPath}
 	_, err := c.Lookup("anything")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, cache.ErrNotFound)
@@ -99,7 +99,7 @@ func TestNotFoundHintCache_Plaintext_AlwaysGenericMessage(t *testing.T) {
 
 func TestNotFoundHintCache_NonErrNotFound_PassesThrough(t *testing.T) {
 	boom := errors.New("backend blew up")
-	c := &notFoundHintCache{inner: boomCache{err: boom}, mode: StorageModeSecure, legacyCachePath: ""}
+	c := &notFoundHintCache{inner: boomCache{err: boom}, mode: StorageModeSecure, legacyStorePath: ""}
 	_, err := c.Lookup("anything")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, boom)
@@ -108,14 +108,14 @@ func TestNotFoundHintCache_NonErrNotFound_PassesThrough(t *testing.T) {
 
 func TestNotFoundHintCache_SuccessfulLookupUnchanged(t *testing.T) {
 	tok := &oauth2.Token{AccessToken: "abc"}
-	c := &notFoundHintCache{inner: foundCache{tok: tok}, mode: StorageModeSecure, legacyCachePath: ""}
+	c := &notFoundHintCache{inner: foundCache{tok: tok}, mode: StorageModeSecure, legacyStorePath: ""}
 	got, err := c.Lookup("anything")
 	require.NoError(t, err)
 	assert.Equal(t, tok, got)
 }
 
 func TestNotFoundHintCache_StoreIsDelegated(t *testing.T) {
-	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyCachePath: ""}
+	c := &notFoundHintCache{inner: missingCache{}, mode: StorageModeSecure, legacyStorePath: ""}
 	require.NoError(t, c.Store("k", &oauth2.Token{AccessToken: "abc"}))
 }
 
@@ -149,32 +149,32 @@ func TestHintForNotFound(t *testing.T) {
 	})
 }
 
-func TestLegacyCacheHasTokens(t *testing.T) {
+func TestLegacyStoreHasTokens(t *testing.T) {
 	tmp := t.TempDir()
 
 	t.Run("empty path returns false", func(t *testing.T) {
-		assert.False(t, legacyCacheHasTokens(""))
+		assert.False(t, legacyStoreHasTokens(""))
 	})
 
 	t.Run("missing file returns false", func(t *testing.T) {
-		assert.False(t, legacyCacheHasTokens(filepath.Join(tmp, "missing.json")))
+		assert.False(t, legacyStoreHasTokens(filepath.Join(tmp, "missing.json")))
 	})
 
 	t.Run("garbage file returns false", func(t *testing.T) {
 		p := filepath.Join(tmp, "garbage.json")
 		require.NoError(t, os.WriteFile(p, []byte("not json"), 0o600))
-		assert.False(t, legacyCacheHasTokens(p))
+		assert.False(t, legacyStoreHasTokens(p))
 	})
 
 	t.Run("empty token map returns false", func(t *testing.T) {
 		p := filepath.Join(tmp, "empty.json")
-		writeLegacyCache(t, p, false)
-		assert.False(t, legacyCacheHasTokens(p))
+		writeLegacyStore(t, p, false)
+		assert.False(t, legacyStoreHasTokens(p))
 	})
 
 	t.Run("populated token map returns true", func(t *testing.T) {
 		p := filepath.Join(tmp, "populated.json")
-		writeLegacyCache(t, p, true)
-		assert.True(t, legacyCacheHasTokens(p))
+		writeLegacyStore(t, p, true)
+		assert.True(t, legacyStoreHasTokens(p))
 	})
 }


### PR DESCRIPTION
## What is this about?

Follow-up to #5383, which introduced the CLI-owned `Store` interface but deliberately left the concrete types and helpers in the old `Cache` vocabulary to keep that PR focused on the structural change. This PR does the rename that #5383 promised, so the package reads consistently.

## Testing

Pure rename, no behavior change. Existing auth unit and acceptance tests pass.
