### PR TITLE
bundle/deploy/lock: write deployment_version.json on every CreateVersion

### DIFF
--- a/bundle/deploy/lock/export_test.go
+++ b/bundle/deploy/lock/export_test.go
@@ -1,0 +1,12 @@
+package lock
+
+import (
+	"context"
+
+	"github.com/databricks/cli/libs/filer"
+)
+
+// IncrementDeploymentVersion is exported for testing.
+var IncrementDeploymentVersion = func(ctx context.Context, f filer.Filer) (int64, error) {
+	return incrementDeploymentVersion(ctx, f)
+}

--- a/bundle/deploy/lock/lock.go
+++ b/bundle/deploy/lock/lock.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/permissions"
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/filer"
 )
 
 // Goal describes the purpose of a deployment operation.
@@ -60,6 +61,7 @@ func NewDeploymentManager(ctx context.Context, b *bundle.Bundle) DeploymentManag
 		reportPermissionError: func(ctx context.Context, path string) diag.Diagnostics {
 			return permissions.ReportPossiblePermissionDenied(ctx, b, path)
 		},
+		newStateFiler: filer.NewWorkspaceFilesClient,
 	}
 	if enabled {
 		l.client = b.WorkspaceClient(ctx)

--- a/bundle/deploy/lock/workspace_filesystem.go
+++ b/bundle/deploy/lock/workspace_filesystem.go
@@ -1,15 +1,24 @@
 package lock
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io/fs"
 
 	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/filer"
 	"github.com/databricks/cli/libs/locker"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go"
 )
+
+const versionFileName = "deployment_version.json"
+
+type versionRecord struct {
+	Version int64 `json:"version"`
+}
 
 // workspaceFilesystemLock implements DeploymentManager using a lock file in the
 // bundle's workspace state path. Holds only the primitives it needs from the
@@ -25,6 +34,10 @@ type workspaceFilesystemLock struct {
 	// when the workspace API returns ErrPermission/ErrNotExist from Lock.
 	// Lifted to a callback so this struct does not pin a *bundle.Bundle.
 	reportPermissionError func(ctx context.Context, path string) diag.Diagnostics
+
+	// newStateFiler creates the filer used to read/write deployment state files.
+	// Overridable in tests.
+	newStateFiler func(client *databricks.WorkspaceClient, path string) (filer.Filer, error)
 
 	locker *locker.Locker
 	goal   Goal
@@ -60,7 +73,19 @@ func (l *workspaceFilesystemLock) CreateVersion(ctx context.Context, goal Goal) 
 		return 0, err
 	}
 
-	return 0, nil
+	f, err := l.newStateFiler(l.client, l.statePath)
+	if err != nil {
+		_ = lk.Unlock(ctx)
+		return 0, err
+	}
+
+	version, err := incrementDeploymentVersion(ctx, f)
+	if err != nil {
+		_ = lk.Unlock(ctx)
+		return 0, err
+	}
+
+	return version, nil
 }
 
 func (l *workspaceFilesystemLock) CompleteVersion(ctx context.Context, _ int64, _ DeploymentStatus) error {
@@ -84,4 +109,34 @@ func (l *workspaceFilesystemLock) CompleteVersion(ctx context.Context, _ int64, 
 		return l.locker.Unlock(ctx, locker.AllowLockFileNotExist)
 	}
 	return l.locker.Unlock(ctx)
+}
+
+// incrementDeploymentVersion reads the current version from versionFileName,
+// increments it, writes the new value back, and returns the new version.
+// The first call (no file yet) creates version 1.
+func incrementDeploymentVersion(ctx context.Context, f filer.Filer) (int64, error) {
+	var current versionRecord
+
+	r, err := f.Read(ctx, versionFileName)
+	if err == nil {
+		defer r.Close()
+		if err := json.NewDecoder(r).Decode(&current); err != nil {
+			return 0, err
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return 0, err
+	}
+
+	next := current.Version + 1
+	data, err := json.Marshal(versionRecord{Version: next})
+	if err != nil {
+		return 0, err
+	}
+
+	err = f.Write(ctx, versionFileName, bytes.NewReader(data), filer.OverwriteIfExists, filer.CreateParentDirectories)
+	if err != nil {
+		return 0, err
+	}
+
+	return next, nil
 }

--- a/bundle/deploy/lock/workspace_filesystem_test.go
+++ b/bundle/deploy/lock/workspace_filesystem_test.go
@@ -1,0 +1,81 @@
+package lock_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"sync"
+	"testing"
+
+	"github.com/databricks/cli/bundle/deploy/lock"
+	"github.com/databricks/cli/libs/filer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// memFiler is a simple in-memory filer for testing.
+type memFiler struct {
+	mu    sync.Mutex
+	files map[string][]byte
+}
+
+func newMemFiler() *memFiler {
+	return &memFiler{files: make(map[string][]byte)}
+}
+
+func (m *memFiler) Read(_ context.Context, path string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, ok := m.files[path]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (m *memFiler) Write(_ context.Context, path string, r io.Reader, _ ...filer.WriteMode) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	m.files[path] = data
+	return nil
+}
+
+func (m *memFiler) Delete(_ context.Context, _ string, _ ...filer.DeleteMode) error {
+	return nil
+}
+
+func (m *memFiler) ReadDir(_ context.Context, _ string) ([]fs.DirEntry, error) {
+	return nil, nil
+}
+
+func (m *memFiler) Mkdir(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *memFiler) Stat(_ context.Context, _ string) (fs.FileInfo, error) {
+	return nil, fs.ErrNotExist
+}
+
+func TestIncrementDeploymentVersion_FirstDeploy(t *testing.T) {
+	ctx := t.Context()
+	f := newMemFiler()
+	version, err := lock.IncrementDeploymentVersion(ctx, f)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), version)
+}
+
+func TestIncrementDeploymentVersion_IncrementsOnEachCall(t *testing.T) {
+	ctx := t.Context()
+	f := newMemFiler()
+
+	for i := range int64(5) {
+		version, err := lock.IncrementDeploymentVersion(ctx, f)
+		require.NoError(t, err)
+		assert.Equal(t, i+1, version)
+	}
+}


### PR DESCRIPTION
## Summary

Stacks on #5314.

Replaces the placeholder `version=0` with a real monotonic counter stored at `{state_path}/deployment_version.json` alongside the lock file.

**What changed:**
- After acquiring the lock, `CreateVersion` reads `deployment_version.json`, increments the counter, writes it back under the same lock, and returns the new version number (first deployment = 1).
- `newStateFiler` callback on `workspaceFilesystemLock` defaults to `filer.NewWorkspaceFilesClient`; overridable in tests.
- Unit tests use an in-memory filer via `export_test.go` — no workspace API needed.

**File format** (`state_path/deployment_version.json`):
```json
{"version": 3}
```

## Test plan
- [x] `go test ./bundle/deploy/lock/... ./bundle/phases/...` green
- [x] `./task lint-q` clean
- [ ] CI