### PR TITLE
Prepare NEXT_CHANGELOG.md for v1.1.1 patch release

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,6 +1,6 @@
 # NEXT CHANGELOG
 
-## Release v1.2.0
+## Release v1.1.1
 
 ### Notable Changes
 
@@ -11,3 +11,4 @@
 * Retry transient HTTP 504 Gateway Timeout errors in direct deployment engine ([#5349](https://github.com/databricks/cli/pull/5349)).
 
 ### Dependency updates
+* Bump `golang.org/x/crypto` from 0.51.0 to 0.52.0 ([#5344](https://github.com/databricks/cli/pull/5344)).


### PR DESCRIPTION
## Summary

Sets `NEXT_CHANGELOG.md` to v1.1.1 (patch) — keeps all existing entries and adds the `golang.org/x/crypto` bump from #5344 under Dependency updates.

**Merge order:** Merge #5344 first, then this PR, then trigger the tagging workflow.
