### PR TITLE
bundle: add experimental.use_deployment_metadata_service flag

### DIFF
--- a/bundle/config/experimental.go
+++ b/bundle/config/experimental.go
@@ -42,6 +42,11 @@ type Experimental struct {
 	// Eventually this can be made the default once we have native CRUD in DABs
 	// at which point we can deprecate or remove this field all together.
 	SkipNamePrefixForSchema bool `json:"skip_name_prefix_for_schema,omitempty"`
+
+	// UseDeploymentMetadataService opts the bundle into the deployment metadata
+	// service (DMS), which records deployment history and tracks what changed
+	// across deployments.
+	UseDeploymentMetadataService bool `json:"use_deployment_metadata_service,omitempty"`
 }
 
 type Python struct {

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -85,6 +85,9 @@ github.com/databricks/cli/bundle/config.Experimental:
     "description": |-
       Skip adding the prefix that is either set in `presets.name_prefix` or computed when `mode: development`
       is set, to the names of UC schemas defined in the bundle.
+  "use_deployment_metadata_service":
+    "description": |-
+      Whether to use the deployment metadata service (DMS), which records deployment history and tracks what changed across deployments.
   "use_legacy_run_as":
     "description": |-
       Whether to use the legacy run_as behavior.

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -2451,6 +2451,10 @@
                       "description": "Skip adding the prefix that is either set in `presets.name_prefix` or computed when `mode: development`\nis set, to the names of UC schemas defined in the bundle.",
                       "$ref": "#/$defs/bool"
                     },
+                    "use_deployment_metadata_service": {
+                      "description": "Whether to use the deployment metadata service (DMS), which records deployment history and tracks what changed across deployments.",
+                      "$ref": "#/$defs/bool"
+                    },
                     "use_legacy_run_as": {
                       "description": "Whether to use the legacy run_as behavior.",
                       "$ref": "#/$defs/bool"


### PR DESCRIPTION
Adds an experimental opt-in for the deployment metadata service (DMS), which records deployment history and tracks what changed across deployments.

```yaml
# databricks.yml
experimental:
  use_deployment_metadata_service: true
```

Foundation flag with no consumers yet — lock impl, state read, and operation reporting follow separately.