### PR TITLE
bundle: rename use_deployment_metadata_service to experimental.record_deployment_history

### DIFF
--- a/bundle/config/experimental.go
+++ b/bundle/config/experimental.go
@@ -43,10 +43,10 @@ type Experimental struct {
 	// at which point we can deprecate or remove this field all together.
 	SkipNamePrefixForSchema bool `json:"skip_name_prefix_for_schema,omitempty"`
 
-	// UseDeploymentMetadataService opts the bundle into the deployment metadata
+	// RecordDeploymentHistory opts the bundle into the deployment metadata
 	// service (DMS), which records deployment history and tracks what changed
 	// across deployments.
-	UseDeploymentMetadataService bool `json:"use_deployment_metadata_service,omitempty"`
+	RecordDeploymentHistory bool `json:"record_deployment_history,omitempty"`
 }
 
 type Python struct {

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -75,6 +75,9 @@ github.com/databricks/cli/bundle/config.Experimental:
   "python_wheel_wrapper":
     "description": |-
       Whether to use a Python wheel wrapper.
+  "record_deployment_history":
+    "description": |-
+      Whether to record deployment history using the deployment metadata service (DMS), which tracks what changed across deployments.
   "scripts":
     "description": |-
       The commands to run.
@@ -85,9 +88,6 @@ github.com/databricks/cli/bundle/config.Experimental:
     "description": |-
       Skip adding the prefix that is either set in `presets.name_prefix` or computed when `mode: development`
       is set, to the names of UC schemas defined in the bundle.
-  "use_deployment_metadata_service":
-    "description": |-
-      Whether to use the deployment metadata service (DMS), which records deployment history and tracks what changed across deployments.
   "use_legacy_run_as":
     "description": |-
       Whether to use the legacy run_as behavior.

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -2439,6 +2439,10 @@
                       "description": "Whether to use a Python wheel wrapper.",
                       "$ref": "#/$defs/bool"
                     },
+                    "record_deployment_history": {
+                      "description": "Whether to record deployment history using the deployment metadata service (DMS), which tracks what changed across deployments.",
+                      "$ref": "#/$defs/bool"
+                    },
                     "scripts": {
                       "description": "The commands to run.",
                       "$ref": "#/$defs/map/github.com/databricks/cli/bundle/config.Command"
@@ -2449,10 +2453,6 @@
                     },
                     "skip_name_prefix_for_schema": {
                       "description": "Skip adding the prefix that is either set in `presets.name_prefix` or computed when `mode: development`\nis set, to the names of UC schemas defined in the bundle.",
-                      "$ref": "#/$defs/bool"
-                    },
-                    "use_deployment_metadata_service": {
-                      "description": "Whether to use the deployment metadata service (DMS), which records deployment history and tracks what changed across deployments.",
                       "$ref": "#/$defs/bool"
                     },
                     "use_legacy_run_as": {


### PR DESCRIPTION
Renames the `experimental.use_deployment_metadata_service` config field to `experimental.record_deployment_history`.

Changes:
- `bundle/config/experimental.go`: Go field `UseDeploymentMetadataService` → `RecordDeploymentHistory`, JSON tag updated
- `bundle/internal/schema/annotations.yml`: key and description updated
- `bundle/schema/jsonschema.json`: regenerated