### PR TITLE
apps init: support databricks.yml.tmpl in pre-rendered templates

### DIFF
--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -48,6 +48,11 @@ const (
 
 	// bundleConfigFile is the standard bundle configuration filename.
 	bundleConfigFile = "databricks.yml"
+
+	// agenticModeEnvVar controls the agentic app creation flow where resources
+	// are not provided upfront. When set to "true", --set requirement and
+	// resource validation are skipped.
+	agenticModeEnvVar = "DATABRICKS_APPS_AGENTIC_MODE"
 )
 
 // normalizeVersion converts a version string to the template tag format "template-vX.X.X".
@@ -649,13 +654,14 @@ func commitInPlace() (string, error) {
 	return appName, nil
 }
 
-// isPreRenderedTemplate returns true when the template directory contains an
-// already-materialised project (e.g. one of the app-templates/appkit-* repos)
-// rather than a raw Go-template tree.
-//
-// Detection: there is no {{.project_name}} subdirectory AND the databricks.yml
-// file (if present) contains no Go template syntax ("{{").
-func isPreRenderedTemplate(templateDir string) bool {
+// shouldSkipPluginSelection returns true when the template has a plugin
+// manifest but no {{.project_name}} subdirectory — meaning plugins are
+// pre-baked in the code files (e.g. app-templates/appkit-* repos) and
+// the user should not be prompted to select plugins.
+func shouldSkipPluginSelection(templateDir string) bool {
+	if !manifest.HasManifest(templateDir) {
+		return false
+	}
 	entries, err := os.ReadDir(templateDir)
 	if err != nil {
 		return false
@@ -665,12 +671,7 @@ func isPreRenderedTemplate(templateDir string) bool {
 			return false
 		}
 	}
-	data, err := os.ReadFile(filepath.Join(templateDir, bundleConfigFile))
-	if err != nil {
-		// No databricks.yml — can't tell, assume normal template.
-		return false
-	}
-	return !strings.Contains(string(data), "{{")
+	return true
 }
 
 // replaceProjectName updates the project name in key files after copying a
@@ -1131,12 +1132,16 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		}
 	}
 
-	// Detect whether this is a pre-rendered template (already-materialised
-	// project with no Go template placeholders in databricks.yml).
-	preRendered := isPreRenderedTemplate(templateDir)
-	if preRendered {
-		log.Debugf(ctx, "Detected pre-rendered template at %s", templateDir)
+	// Check whether plugin selection should be skipped (pre-baked plugins
+	// in a pre-rendered template with a manifest but no {{.project_name}} dir).
+	skipPluginSelection := shouldSkipPluginSelection(templateDir)
+	if skipPluginSelection {
+		log.Debugf(ctx, "Skipping plugin selection for pre-rendered template at %s", templateDir)
 	}
+
+	// Agentic mode: resources are not provided upfront, skip --set
+	// requirement and validation.
+	agenticMode := env.Get(ctx, agenticModeEnvVar) == "true"
 
 	// Start npm install in the background so it runs while the user answers prompts.
 	// This is a Node.js-only optimisation — non-Node templates skip this.
@@ -1171,8 +1176,8 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	// Skip deploy/run prompts if in flags mode or if deploy/run flags were explicitly set
 	skipDeployRunPrompt := flagsMode || opts.deployChanged || opts.runChanged
 
-	if preRendered {
-		// Pre-rendered templates already have their plugins configured.
+	if skipPluginSelection {
+		// Pre-rendered templates already have their plugins configured in code.
 		// Skip plugin/resource prompting entirely — just use mandatory plugins.
 		if isInteractive && !skipDeployRunPrompt {
 			var err error
@@ -1236,19 +1241,12 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		maps.Copy(resourceValues, setVals)
 	}
 
-	// Pre-rendered templates have no Go template placeholders, so --set
-	// values cannot be injected into the output files.
-	if preRendered && len(setVals) > 0 {
-		log.Warnf(ctx, "--set values are ignored for pre-rendered templates (resources are already configured in %s)", bundleConfigFile)
-	}
-
 	// Always include mandatory plugins regardless of user selection or flags.
 	selectedPlugins = appendUnique(selectedPlugins, m.GetMandatoryPluginNames()...)
 
 	// Warn when --features adds plugins that the pre-rendered template
-	// cannot inject (its databricks.yml, server.ts, and app.yaml are
-	// already finalised).
-	if preRendered && opts.pluginsChanged {
+	// cannot inject (its server.ts and app.yaml are already finalised).
+	if skipPluginSelection && opts.pluginsChanged {
 		mandatoryNames := m.GetMandatoryPluginNames()
 		mandatory := make(map[string]bool, len(mandatoryNames))
 		for _, n := range mandatoryNames {
@@ -1264,9 +1262,8 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	}
 
 	// In flags/non-interactive mode, resolve derived values and validate resources.
-	// Skip validation for pre-rendered templates — their resources are already
-	// configured in databricks.yml.
-	if !preRendered && (flagsMode || !isInteractive) {
+	// Agentic mode skips validation — resources are filled in later.
+	if !agenticMode && (flagsMode || !isInteractive) {
 		resources := m.CollectResources(selectedPlugins)
 
 		// Resolve derived values for resources that support it.
@@ -1411,9 +1408,9 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	}
 	projectCreated = true // From here on, cleanup on failure
 
-	// For pre-rendered templates, update the project name in key files since
-	// Go template substitution had no placeholders to fill.
-	if preRendered {
+	// For pre-rendered templates, update package.json name (not a .tmpl file)
+	// and serve as a safety net for the agentic flow.
+	if skipPluginSelection {
 		if err := replaceProjectName(destDir, opts.name); err != nil {
 			log.Warnf(ctx, "Could not update project name in output files: %v", err)
 		}

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -688,7 +688,9 @@ func replaceProjectName(destDir, newName string) error {
 			if err == nil {
 				// Preserve trailing newline convention.
 				out = append(out, '\n')
-				_ = os.WriteFile(pkgPath, out, 0o644)
+				if err := os.WriteFile(pkgPath, out, 0o644); err != nil {
+					return fmt.Errorf("write package.json: %w", err)
+				}
 			}
 		}
 	}
@@ -714,7 +716,9 @@ func replaceProjectName(destDir, newName string) error {
 	if err := enc.Encode(&doc); err != nil {
 		return fmt.Errorf("encode %s: %w", bundleConfigFile, err)
 	}
-	enc.Close()
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("encode %s: %w", bundleConfigFile, err)
+	}
 
 	return os.WriteFile(ymlPath, buf.Bytes(), 0o644)
 }
@@ -1232,12 +1236,18 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		maps.Copy(resourceValues, setVals)
 	}
 
+	// Pre-rendered templates have no Go template placeholders, so --set
+	// values cannot be injected into the output files.
+	if preRendered && len(setVals) > 0 {
+		log.Warnf(ctx, "--set values are ignored for pre-rendered templates (resources are already configured in %s)", bundleConfigFile)
+	}
+
 	// Always include mandatory plugins regardless of user selection or flags.
 	selectedPlugins = appendUnique(selectedPlugins, m.GetMandatoryPluginNames()...)
 
 	// Warn when --features adds plugins that the pre-rendered template
-	// cannot inject (they'll appear in .env but not in databricks.yml,
-	// server.ts, or app.yaml).
+	// cannot inject (its databricks.yml, server.ts, and app.yaml are
+	// already finalised).
 	if preRendered && opts.pluginsChanged {
 		mandatoryNames := m.GetMandatoryPluginNames()
 		mandatory := make(map[string]bool, len(mandatoryNames))

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -654,12 +654,17 @@ func commitInPlace() (string, error) {
 	return appName, nil
 }
 
-// shouldSkipPluginSelection returns true when the template has a plugin
-// manifest but no {{.project_name}} subdirectory — meaning plugins are
-// pre-baked in the code files (e.g. app-templates/appkit-* repos) and
-// the user should not be prompted to select plugins.
+// shouldSkipPluginSelection returns true when the template is a pre-rendered
+// appkit template: it has a plugin manifest, no {{.project_name}} subdirectory,
+// and a plain databricks.yml file. The full appkit template only has
+// databricks.yml.tmpl (no plain databricks.yml), so it is not matched here.
 func shouldSkipPluginSelection(templateDir string) bool {
 	if !manifest.HasManifest(templateDir) {
+		return false
+	}
+	// Pre-rendered templates ship a plain databricks.yml as a static reference.
+	// The full appkit template only has databricks.yml.tmpl.
+	if _, err := os.Stat(filepath.Join(templateDir, bundleConfigFile)); err != nil {
 		return false
 	}
 	entries, err := os.ReadDir(templateDir)

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -31,6 +31,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	ignore "github.com/sabhiram/go-gitignore"
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 )
 
 const (
@@ -40,6 +41,13 @@ const (
 	appkitDefaultBranch  = "main"
 	appkitTemplateTagPfx = "template-v"
 	defaultProfile       = "DEFAULT"
+
+	// projectNamePlaceholder is the Go template variable used in template
+	// directory names to stand in for the user-provided project name.
+	projectNamePlaceholder = "{{.project_name}}"
+
+	// bundleConfigFile is the standard bundle configuration filename.
+	bundleConfigFile = "databricks.yml"
 )
 
 // normalizeVersion converts a version string to the template tag format "template-vX.X.X".
@@ -653,11 +661,11 @@ func isPreRenderedTemplate(templateDir string) bool {
 		return false
 	}
 	for _, e := range entries {
-		if e.IsDir() && strings.Contains(e.Name(), "{{.project_name}}") {
+		if e.IsDir() && strings.Contains(e.Name(), projectNamePlaceholder) {
 			return false
 		}
 	}
-	data, err := os.ReadFile(filepath.Join(templateDir, "databricks.yml"))
+	data, err := os.ReadFile(filepath.Join(templateDir, bundleConfigFile))
 	if err != nil {
 		// No databricks.yml — can't tell, assume normal template.
 		return false
@@ -666,8 +674,8 @@ func isPreRenderedTemplate(templateDir string) bool {
 }
 
 // replaceProjectName updates the project name in key files after copying a
-// pre-rendered template.  It reads the original bundle name from
-// databricks.yml and replaces it with newName in databricks.yml and
+// pre-rendered template.  It sets bundle.name and the first
+// resources.apps.*.name in databricks.yml, and the name field in
 // package.json.
 func replaceProjectName(destDir, newName string) error {
 	// Update package.json name field via JSON round-trip.
@@ -685,34 +693,87 @@ func replaceProjectName(destDir, newName string) error {
 		}
 	}
 
-	// Update databricks.yml: bundle name and app name.
-	ymlPath := filepath.Join(destDir, "databricks.yml")
+	// Update databricks.yml using yaml.Node to preserve comments and formatting.
+	ymlPath := filepath.Join(destDir, bundleConfigFile)
 	data, err := os.ReadFile(ymlPath)
 	if err != nil {
-		return nil
+		return err
 	}
-	content := string(data)
 
-	// Read the original bundle name so we can do a targeted replace of the
-	// app resource name that usually matches it.
-	origName := ""
-	for _, line := range strings.Split(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "name:") && origName == "" {
-			origName = strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
-			origName = strings.Trim(origName, "\"'")
-			break
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parse %s: %w", bundleConfigFile, err)
+	}
+
+	setYAMLValue(&doc, []string{"bundle", "name"}, newName)
+	setFirstAppName(&doc, newName)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return fmt.Errorf("encode %s: %w", bundleConfigFile, err)
+	}
+	enc.Close()
+
+	return os.WriteFile(ymlPath, buf.Bytes(), 0o644)
+}
+
+// setYAMLValue walks a yaml.Node tree following the given key path and
+// replaces the leaf scalar value. It handles both document and mapping nodes.
+func setYAMLValue(node *yaml.Node, keys []string, value string) {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		setYAMLValue(node.Content[0], keys, value)
+		return
+	}
+	if node.Kind != yaml.MappingNode || len(keys) == 0 {
+		return
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == keys[0] {
+			if len(keys) == 1 {
+				node.Content[i+1].Value = value
+				// Clear any explicit style so the encoder picks the
+				// simplest representation for the new value.
+				node.Content[i+1].Style = 0
+				return
+			}
+			setYAMLValue(node.Content[i+1], keys[1:], value)
+			return
 		}
 	}
+}
 
-	// Replace the bundle name line (first occurrence of "name:" under "bundle:").
-	if origName != "" {
-		content = strings.Replace(content, "name: "+origName, "name: "+newName, 1)
-		// Replace the quoted app name in the resources section.
-		content = strings.Replace(content, "name: \""+origName+"\"", "name: \""+newName+"\"", 1)
+// setFirstAppName sets the name field of the first app entry under
+// resources.apps in a yaml.Node tree.
+func setFirstAppName(node *yaml.Node, name string) {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		setFirstAppName(node.Content[0], name)
+		return
 	}
+	if node.Kind != yaml.MappingNode {
+		return
+	}
+	// Find resources → apps → first entry → name.
+	appsNode := yamlMapLookup(yamlMapLookup(node, "resources"), "apps")
+	if appsNode == nil || appsNode.Kind != yaml.MappingNode || len(appsNode.Content) < 2 {
+		return
+	}
+	// First app entry is at Content[1] (Content[0] is the key).
+	setYAMLValue(appsNode.Content[1], []string{"name"}, name)
+}
 
-	return os.WriteFile(ymlPath, []byte(content), 0o644)
+// yamlMapLookup returns the value node for a key in a mapping node, or nil.
+func yamlMapLookup(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
 }
 
 // findProjectSrcDir locates the actual source directory inside a template.
@@ -723,7 +784,7 @@ func findProjectSrcDir(templateDir string) string {
 		return templateDir
 	}
 	for _, e := range entries {
-		if e.IsDir() && strings.Contains(e.Name(), "{{.project_name}}") {
+		if e.IsDir() && strings.Contains(e.Name(), projectNamePlaceholder) {
 			return filepath.Join(templateDir, e.Name())
 		}
 	}
@@ -1185,9 +1246,9 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		}
 		for _, p := range opts.plugins {
 			if !mandatory[p] {
-				log.Warnf(ctx, "Feature %q is not supported by this pre-rendered template and will be ignored."+
-					" Only .env will include its configuration."+
-					" To use all features dynamically, use the default AppKit template instead.", p)
+				log.Warnf(ctx, "Adding feature %q to a pre-rendered template is not currently supported.\n"+
+					"To add it manually, register the plugin in server/server.ts and run `npx @databricks/appkit plugin sync --write`.\n"+
+					"To use all features dynamically, run `databricks apps init` without --template.", p)
 			}
 		}
 	}
@@ -1565,7 +1626,7 @@ func copyTemplate(ctx context.Context, src, dest string, vars templateVars) (int
 		return 0, err
 	}
 	for _, e := range entries {
-		if e.IsDir() && strings.Contains(e.Name(), "{{.project_name}}") {
+		if e.IsDir() && strings.Contains(e.Name(), projectNamePlaceholder) {
 			srcProjectDir = filepath.Join(src, e.Name())
 			break
 		}

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -658,7 +658,7 @@ func commitInPlace() (string, error) {
 // appkit template: it has a plugin manifest, no {{.project_name}} subdirectory,
 // and a plain databricks.yml file. The full appkit template only has
 // databricks.yml.tmpl (no plain databricks.yml), so it is not matched here.
-func shouldSkipPluginSelection(templateDir string) bool {
+func shouldSkipPluginSelection(ctx context.Context, templateDir string) bool {
 	if !manifest.HasManifest(templateDir) {
 		return false
 	}
@@ -669,6 +669,7 @@ func shouldSkipPluginSelection(templateDir string) bool {
 	}
 	entries, err := os.ReadDir(templateDir)
 	if err != nil {
+		log.Debugf(ctx, "Could not read template directory %s: %v", templateDir, err)
 		return false
 	}
 	for _, e := range entries {
@@ -686,26 +687,32 @@ func shouldSkipPluginSelection(templateDir string) bool {
 func replaceProjectName(destDir, newName string) error {
 	// Update package.json name field via JSON round-trip.
 	pkgPath := filepath.Join(destDir, "package.json")
-	if data, err := os.ReadFile(pkgPath); err == nil {
+	data, err := os.ReadFile(pkgPath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read package.json: %w", err)
+	}
+	if err == nil {
 		var pkg map[string]any
-		if err := json.Unmarshal(data, &pkg); err == nil {
-			pkg["name"] = newName
-			out, err := json.MarshalIndent(pkg, "", "  ")
-			if err == nil {
-				// Preserve trailing newline convention.
-				out = append(out, '\n')
-				if err := os.WriteFile(pkgPath, out, 0o644); err != nil {
-					return fmt.Errorf("write package.json: %w", err)
-				}
-			}
+		if err := json.Unmarshal(data, &pkg); err != nil {
+			return fmt.Errorf("parse package.json: %w", err)
+		}
+		pkg["name"] = newName
+		out, err := json.MarshalIndent(pkg, "", "  ")
+		if err != nil {
+			return fmt.Errorf("encode package.json: %w", err)
+		}
+		// Preserve trailing newline convention.
+		out = append(out, '\n')
+		if err := safeWriteFile(pkgPath, out); err != nil {
+			return err
 		}
 	}
 
 	// Update databricks.yml using yaml.Node to preserve comments and formatting.
 	ymlPath := filepath.Join(destDir, bundleConfigFile)
-	data, err := os.ReadFile(ymlPath)
+	data, err = os.ReadFile(ymlPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("read %s: %w", bundleConfigFile, err)
 	}
 
 	var doc yaml.Node
@@ -713,8 +720,12 @@ func replaceProjectName(destDir, newName string) error {
 		return fmt.Errorf("parse %s: %w", bundleConfigFile, err)
 	}
 
-	setYAMLValue(&doc, []string{"bundle", "name"}, newName)
-	setFirstAppName(&doc, newName)
+	if err := setYAMLValue(&doc, []string{"bundle", "name"}, newName); err != nil {
+		return fmt.Errorf("set bundle.name in %s: %w", bundleConfigFile, err)
+	}
+	if err := setFirstAppName(&doc, newName); err != nil {
+		return fmt.Errorf("set app name in %s: %w", bundleConfigFile, err)
+	}
 
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
@@ -726,51 +737,69 @@ func replaceProjectName(destDir, newName string) error {
 		return fmt.Errorf("encode %s: %w", bundleConfigFile, err)
 	}
 
-	return os.WriteFile(ymlPath, buf.Bytes(), 0o644)
+	return safeWriteFile(ymlPath, buf.Bytes())
+}
+
+// safeWriteFile writes data to a file while preserving the original file mode
+// and refusing to follow symlinks.
+func safeWriteFile(path string, data []byte) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", filepath.Base(path), err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write through symlink: %s", filepath.Base(path))
+	}
+	return os.WriteFile(path, data, info.Mode().Perm())
 }
 
 // setYAMLValue walks a yaml.Node tree following the given key path and
-// replaces the leaf scalar value. It handles both document and mapping nodes.
-func setYAMLValue(node *yaml.Node, keys []string, value string) {
+// replaces the leaf scalar value. Returns an error if the key path is not
+// found or the target node is not a scalar.
+func setYAMLValue(node *yaml.Node, keys []string, value string) error {
 	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
-		setYAMLValue(node.Content[0], keys, value)
-		return
+		return setYAMLValue(node.Content[0], keys, value)
 	}
 	if node.Kind != yaml.MappingNode || len(keys) == 0 {
-		return
+		return fmt.Errorf("key path %v not found", keys)
 	}
 	for i := 0; i < len(node.Content)-1; i += 2 {
 		if node.Content[i].Value == keys[0] {
 			if len(keys) == 1 {
-				node.Content[i+1].Value = value
+				leaf := node.Content[i+1]
+				if leaf.Kind != yaml.ScalarNode {
+					return fmt.Errorf("expected scalar at %q, got kind %d", keys[0], leaf.Kind)
+				}
+				leaf.Value = value
 				// Clear any explicit style so the encoder picks the
 				// simplest representation for the new value.
-				node.Content[i+1].Style = 0
-				return
+				leaf.Style = 0
+				return nil
 			}
-			setYAMLValue(node.Content[i+1], keys[1:], value)
-			return
+			return setYAMLValue(node.Content[i+1], keys[1:], value)
 		}
 	}
+	return fmt.Errorf("key %q not found", keys[0])
 }
 
 // setFirstAppName sets the name field of the first app entry under
-// resources.apps in a yaml.Node tree.
-func setFirstAppName(node *yaml.Node, name string) {
+// resources.apps in a yaml.Node tree. Returns nil if resources.apps
+// is not present (not all templates have it).
+func setFirstAppName(node *yaml.Node, name string) error {
 	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
-		setFirstAppName(node.Content[0], name)
-		return
+		return setFirstAppName(node.Content[0], name)
 	}
 	if node.Kind != yaml.MappingNode {
-		return
+		return nil
 	}
 	// Find resources → apps → first entry → name.
 	appsNode := yamlMapLookup(yamlMapLookup(node, "resources"), "apps")
 	if appsNode == nil || appsNode.Kind != yaml.MappingNode || len(appsNode.Content) < 2 {
-		return
+		// No resources.apps section — not an error, some templates lack it.
+		return nil
 	}
 	// First app entry is at Content[1] (Content[0] is the key).
-	setYAMLValue(appsNode.Content[1], []string{"name"}, name)
+	return setYAMLValue(appsNode.Content[1], []string{"name"}, name)
 }
 
 // yamlMapLookup returns the value node for a key in a mapping node, or nil.
@@ -1139,7 +1168,7 @@ func runCreate(ctx context.Context, opts createOptions) error {
 
 	// Check whether plugin selection should be skipped (pre-baked plugins
 	// in a pre-rendered template with a manifest but no {{.project_name}} dir).
-	skipPluginSelection := shouldSkipPluginSelection(templateDir)
+	skipPluginSelection := shouldSkipPluginSelection(ctx, templateDir)
 	if skipPluginSelection {
 		log.Debugf(ctx, "Skipping plugin selection for pre-rendered template at %s", templateDir)
 	}
@@ -1147,6 +1176,9 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	// Agentic mode: resources are not provided upfront, skip --set
 	// requirement and validation.
 	agenticMode := env.Get(ctx, agenticModeEnvVar) == "true"
+	if agenticMode {
+		cmdio.LogString(ctx, "Note: agentic mode active — resource validation skipped.")
+	}
 
 	// Start npm install in the background so it runs while the user answers prompts.
 	// This is a Node.js-only optimisation — non-Node templates skip this.
@@ -1417,7 +1449,7 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	// and serve as a safety net for the agentic flow.
 	if skipPluginSelection {
 		if err := replaceProjectName(destDir, opts.name); err != nil {
-			log.Warnf(ctx, "Could not update project name in output files: %v", err)
+			return fmt.Errorf("update project name: %w", err)
 		}
 	}
 
@@ -1720,7 +1752,9 @@ func copyTemplate(ctx context.Context, src, dest string, vars templateVars) (int
 			return err
 		}
 
-		// Handle .tmpl extension - strip it
+		// Handle .tmpl extension — strip it. When a template ships both
+		// foo and foo.tmpl, filepath.Walk's lexical order processes foo first
+		// and foo.tmpl second, so the rendered .tmpl overwrites the static file.
 		relPath = strings.TrimSuffix(relPath, ".tmpl")
 
 		// Apply file renames (e.g., _gitignore -> .gitignore)

--- a/cmd/apps/init.go
+++ b/cmd/apps/init.go
@@ -641,6 +641,80 @@ func commitInPlace() (string, error) {
 	return appName, nil
 }
 
+// isPreRenderedTemplate returns true when the template directory contains an
+// already-materialised project (e.g. one of the app-templates/appkit-* repos)
+// rather than a raw Go-template tree.
+//
+// Detection: there is no {{.project_name}} subdirectory AND the databricks.yml
+// file (if present) contains no Go template syntax ("{{").
+func isPreRenderedTemplate(templateDir string) bool {
+	entries, err := os.ReadDir(templateDir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.Contains(e.Name(), "{{.project_name}}") {
+			return false
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(templateDir, "databricks.yml"))
+	if err != nil {
+		// No databricks.yml — can't tell, assume normal template.
+		return false
+	}
+	return !strings.Contains(string(data), "{{")
+}
+
+// replaceProjectName updates the project name in key files after copying a
+// pre-rendered template.  It reads the original bundle name from
+// databricks.yml and replaces it with newName in databricks.yml and
+// package.json.
+func replaceProjectName(destDir, newName string) error {
+	// Update package.json name field via JSON round-trip.
+	pkgPath := filepath.Join(destDir, "package.json")
+	if data, err := os.ReadFile(pkgPath); err == nil {
+		var pkg map[string]any
+		if err := json.Unmarshal(data, &pkg); err == nil {
+			pkg["name"] = newName
+			out, err := json.MarshalIndent(pkg, "", "  ")
+			if err == nil {
+				// Preserve trailing newline convention.
+				out = append(out, '\n')
+				_ = os.WriteFile(pkgPath, out, 0o644)
+			}
+		}
+	}
+
+	// Update databricks.yml: bundle name and app name.
+	ymlPath := filepath.Join(destDir, "databricks.yml")
+	data, err := os.ReadFile(ymlPath)
+	if err != nil {
+		return nil
+	}
+	content := string(data)
+
+	// Read the original bundle name so we can do a targeted replace of the
+	// app resource name that usually matches it.
+	origName := ""
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "name:") && origName == "" {
+			origName = strings.TrimSpace(strings.TrimPrefix(trimmed, "name:"))
+			origName = strings.Trim(origName, "\"'")
+			break
+		}
+	}
+
+	// Replace the bundle name line (first occurrence of "name:" under "bundle:").
+	if origName != "" {
+		content = strings.Replace(content, "name: "+origName, "name: "+newName, 1)
+		// Replace the quoted app name in the resources section.
+		content = strings.Replace(content, "name: \""+origName+"\"", "name: \""+newName+"\"", 1)
+	}
+
+	return os.WriteFile(ymlPath, []byte(content), 0o644)
+}
+
 // findProjectSrcDir locates the actual source directory inside a template.
 // Templates may nest their content inside a {{.project_name}} directory.
 func findProjectSrcDir(templateDir string) string {
@@ -992,6 +1066,13 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		}
 	}
 
+	// Detect whether this is a pre-rendered template (already-materialised
+	// project with no Go template placeholders in databricks.yml).
+	preRendered := isPreRenderedTemplate(templateDir)
+	if preRendered {
+		log.Debugf(ctx, "Detected pre-rendered template at %s", templateDir)
+	}
+
 	// Start npm install in the background so it runs while the user answers prompts.
 	// This is a Node.js-only optimisation — non-Node templates skip this.
 	// Honour --skip-install by not kicking off the background install at all.
@@ -1025,7 +1106,17 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	// Skip deploy/run prompts if in flags mode or if deploy/run flags were explicitly set
 	skipDeployRunPrompt := flagsMode || opts.deployChanged || opts.runChanged
 
-	if isInteractive && !opts.pluginsChanged && !flagsMode {
+	if preRendered {
+		// Pre-rendered templates already have their plugins configured.
+		// Skip plugin/resource prompting entirely — just use mandatory plugins.
+		if isInteractive && !skipDeployRunPrompt {
+			var err error
+			shouldDeploy, runMode, err = prompt.PromptForDeployAndRun(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	} else if isInteractive && !opts.pluginsChanged && !flagsMode {
 		// Interactive mode without --plugins flag: prompt for plugins, dependencies, description
 		config, err := promptForPluginsAndDeps(ctx, m, selectedPlugins, skipDeployRunPrompt, opts.autoApprove)
 		if err != nil {
@@ -1083,8 +1174,28 @@ func runCreate(ctx context.Context, opts createOptions) error {
 	// Always include mandatory plugins regardless of user selection or flags.
 	selectedPlugins = appendUnique(selectedPlugins, m.GetMandatoryPluginNames()...)
 
+	// Warn when --features adds plugins that the pre-rendered template
+	// cannot inject (they'll appear in .env but not in databricks.yml,
+	// server.ts, or app.yaml).
+	if preRendered && opts.pluginsChanged {
+		mandatoryNames := m.GetMandatoryPluginNames()
+		mandatory := make(map[string]bool, len(mandatoryNames))
+		for _, n := range mandatoryNames {
+			mandatory[n] = true
+		}
+		for _, p := range opts.plugins {
+			if !mandatory[p] {
+				log.Warnf(ctx, "Feature %q is not supported by this pre-rendered template and will be ignored."+
+					" Only .env will include its configuration."+
+					" To use all features dynamically, use the default AppKit template instead.", p)
+			}
+		}
+	}
+
 	// In flags/non-interactive mode, resolve derived values and validate resources.
-	if flagsMode || !isInteractive {
+	// Skip validation for pre-rendered templates — their resources are already
+	// configured in databricks.yml.
+	if !preRendered && (flagsMode || !isInteractive) {
 		resources := m.CollectResources(selectedPlugins)
 
 		// Resolve derived values for resources that support it.
@@ -1228,6 +1339,14 @@ func runCreate(ctx context.Context, opts createOptions) error {
 		return runErr
 	}
 	projectCreated = true // From here on, cleanup on failure
+
+	// For pre-rendered templates, update the project name in key files since
+	// Go template substitution had no placeholders to fill.
+	if preRendered {
+		if err := replaceProjectName(destDir, opts.name); err != nil {
+			log.Warnf(ctx, "Could not update project name in output files: %v", err)
+		}
+	}
 
 	// Get absolute path
 	absOutputDir, err := filepath.Abs(destDir)

--- a/cmd/apps/init_test.go
+++ b/cmd/apps/init_test.go
@@ -1246,7 +1246,7 @@ func TestShouldSkipPluginSelection(t *testing.T) {
 			} else {
 				tt.setup(dir)
 			}
-			assert.Equal(t, tt.expected, shouldSkipPluginSelection(dir))
+			assert.Equal(t, tt.expected, shouldSkipPluginSelection(t.Context(), dir))
 		})
 	}
 }
@@ -1276,10 +1276,10 @@ func TestReplaceProjectName(t *testing.T) {
 			wantBundleName: "new-app",
 		},
 		{
-			name:        "no bundle.name, only app name",
-			yml:         "resources:\n  apps:\n    myapp:\n      name: \"myapp\"\n",
-			newName:     "new-app",
-			wantAppName: "new-app",
+			name:    "no bundle.name, only app name",
+			yml:     "resources:\n  apps:\n    myapp:\n      name: \"myapp\"\n",
+			newName: "new-app",
+			wantErr: true,
 		},
 		{
 			name:           "package.json round-trip",
@@ -1353,12 +1353,39 @@ func TestReplaceProjectNameNoDatabricksYml(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestReplaceProjectNameMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("{{invalid yaml"), 0o644))
+	err := replaceProjectName(dir, "new-app")
+	assert.ErrorContains(t, err, "parse")
+}
+
+func TestReplaceProjectNameMalformedPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: old\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{invalid json}"), 0o644))
+	err := replaceProjectName(dir, "new-app")
+	assert.ErrorContains(t, err, "parse package.json")
+}
+
+func TestReplaceProjectNameSymlinkRefused(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a real file and a symlink to it named databricks.yml.
+	realFile := filepath.Join(dir, "real.yml")
+	require.NoError(t, os.WriteFile(realFile, []byte("bundle:\n  name: old\n"), 0o644))
+	require.NoError(t, os.Symlink(realFile, filepath.Join(dir, bundleConfigFile)))
+
+	err := replaceProjectName(dir, "new-app")
+	assert.ErrorContains(t, err, "symlink")
+}
+
 func TestSetYAMLValue(t *testing.T) {
 	input := "top:\n  nested:\n    leaf: old\n"
 	var doc yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
 
-	setYAMLValue(&doc, []string{"top", "nested", "leaf"}, "new")
+	require.NoError(t, setYAMLValue(&doc, []string{"top", "nested", "leaf"}, "new"))
 
 	val := yamlMapLookup(yamlMapLookup(yamlMapLookup(doc.Content[0], "top"), "nested"), "leaf")
 	require.NotNil(t, val)
@@ -1370,12 +1397,21 @@ func TestSetYAMLValueMissingKey(t *testing.T) {
 	var doc yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
 
-	// Should not panic or modify the tree.
-	setYAMLValue(&doc, []string{"top", "nonexistent", "leaf"}, "new")
+	err := setYAMLValue(&doc, []string{"top", "nonexistent", "leaf"}, "new")
+	assert.Error(t, err)
 
 	val := yamlMapLookup(yamlMapLookup(yamlMapLookup(doc.Content[0], "top"), "nested"), "leaf")
 	require.NotNil(t, val)
 	assert.Equal(t, "old", val.Value)
+}
+
+func TestSetYAMLValueNonScalarLeaf(t *testing.T) {
+	input := "bundle:\n  name:\n    nested: value\n"
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
+
+	err := setYAMLValue(&doc, []string{"bundle", "name"}, "new-name")
+	assert.ErrorContains(t, err, "expected scalar")
 }
 
 func TestYamlMapLookup(t *testing.T) {
@@ -1395,7 +1431,7 @@ func TestSetFirstAppName(t *testing.T) {
 	var doc yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
 
-	setFirstAppName(&doc, "new-name")
+	require.NoError(t, setFirstAppName(&doc, "new-name"))
 
 	appsNode := yamlMapLookup(yamlMapLookup(doc.Content[0], "resources"), "apps")
 	require.NotNil(t, appsNode)
@@ -1414,8 +1450,8 @@ func TestSetFirstAppNameNoResources(t *testing.T) {
 	var doc yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
 
-	// Should not panic when resources.apps is absent.
-	setFirstAppName(&doc, "new-name")
+	// No error when resources.apps is absent.
+	require.NoError(t, setFirstAppName(&doc, "new-name"))
 
 	bundleName := yamlMapLookup(yamlMapLookup(doc.Content[0], "bundle"), "name")
 	require.NotNil(t, bundleName)

--- a/cmd/apps/init_test.go
+++ b/cmd/apps/init_test.go
@@ -1200,16 +1200,26 @@ func TestShouldSkipPluginSelection(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "manifest present, no project_name dir",
+			name: "pre-rendered: manifest + databricks.yml + no project_name dir",
 			setup: func(dir string) {
 				require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.ManifestFileName), []byte(`{"plugins":{}}`), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: myapp\n"), 0o644))
 			},
 			expected: true,
+		},
+		{
+			name: "full appkit template: manifest + no databricks.yml",
+			setup: func(dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.ManifestFileName), []byte(`{"plugins":{}}`), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "databricks.yml.tmpl"), []byte("bundle:\n  name: {{.projectName}}\n"), 0o644))
+			},
+			expected: false,
 		},
 		{
 			name: "manifest present, project_name dir present",
 			setup: func(dir string) {
 				require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.ManifestFileName), []byte(`{"plugins":{}}`), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: myapp\n"), 0o644))
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "{{.project_name}}"), 0o755))
 			},
 			expected: false,

--- a/cmd/apps/init_test.go
+++ b/cmd/apps/init_test.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"io/fs"
@@ -18,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestIsTextFile(t *testing.T) {
@@ -1189,4 +1191,232 @@ func TestPrependInstall(t *testing.T) {
 			assert.Equal(t, tt.want, prependInstall(tt.install, tt.nextSteps))
 		})
 	}
+}
+
+func TestIsPreRenderedTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(dir string)
+		expected bool
+	}{
+		{
+			name: "normal template with project_name dir",
+			setup: func(dir string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "{{.project_name}}"), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: myapp\n"), 0o644))
+			},
+			expected: false,
+		},
+		{
+			name: "pre-rendered template",
+			setup: func(dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: myapp\n"), 0o644))
+			},
+			expected: true,
+		},
+		{
+			name: "no databricks.yml",
+			setup: func(dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello"), 0o644))
+			},
+			expected: false,
+		},
+		{
+			name: "databricks.yml with Go template syntax",
+			setup: func(dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: {{.project_name}}\n"), 0o644))
+			},
+			expected: false,
+		},
+		{
+			name: "unreadable directory",
+			setup: func(_ string) {
+				// dir is replaced with a nonexistent path below.
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.name == "unreadable directory" {
+				dir = filepath.Join(dir, "nonexistent")
+			} else {
+				tt.setup(dir)
+			}
+			assert.Equal(t, tt.expected, isPreRenderedTemplate(dir))
+		})
+	}
+}
+
+func TestReplaceProjectName(t *testing.T) {
+	tests := []struct {
+		name           string
+		yml            string
+		pkgJSON        string // empty means no package.json
+		newName        string
+		wantBundleName string
+		wantAppName    string
+		wantPkgName    string
+		wantErr        bool
+	}{
+		{
+			name:           "bundle and app name replaced",
+			yml:            "bundle:\n  name: old-app\nresources:\n  apps:\n    old-app:\n      name: \"old-app\"\n",
+			newName:        "new-app",
+			wantBundleName: "new-app",
+			wantAppName:    "new-app",
+		},
+		{
+			name:           "bundle name only, no resources",
+			yml:            "bundle:\n  name: old-app\n",
+			newName:        "new-app",
+			wantBundleName: "new-app",
+		},
+		{
+			name:        "no bundle.name, only app name",
+			yml:         "resources:\n  apps:\n    myapp:\n      name: \"myapp\"\n",
+			newName:     "new-app",
+			wantAppName: "new-app",
+		},
+		{
+			name:           "package.json round-trip",
+			yml:            "bundle:\n  name: old-app\n",
+			pkgJSON:        `{"name":"old-app","version":"1.0.0"}`,
+			newName:        "new-app",
+			wantBundleName: "new-app",
+			wantPkgName:    "new-app",
+		},
+		{
+			name:           "no package.json",
+			yml:            "bundle:\n  name: old-app\n",
+			newName:        "new-app",
+			wantBundleName: "new-app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte(tt.yml), 0o644))
+
+			if tt.pkgJSON != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(tt.pkgJSON), 0o644))
+			}
+
+			err := replaceProjectName(dir, tt.newName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Verify databricks.yml via yaml.Node to avoid format sensitivity.
+			ymlData, err := os.ReadFile(filepath.Join(dir, bundleConfigFile))
+			require.NoError(t, err)
+
+			var doc yaml.Node
+			require.NoError(t, yaml.Unmarshal(ymlData, &doc))
+
+			if tt.wantBundleName != "" {
+				bundleName := yamlMapLookup(yamlMapLookup(doc.Content[0], "bundle"), "name")
+				require.NotNil(t, bundleName, "bundle.name not found in output")
+				assert.Equal(t, tt.wantBundleName, bundleName.Value)
+			}
+
+			if tt.wantAppName != "" {
+				appsNode := yamlMapLookup(yamlMapLookup(doc.Content[0], "resources"), "apps")
+				require.NotNil(t, appsNode)
+				require.True(t, appsNode.Kind == yaml.MappingNode && len(appsNode.Content) >= 2)
+				appName := yamlMapLookup(appsNode.Content[1], "name")
+				require.NotNil(t, appName, "resources.apps.*.name not found in output")
+				assert.Equal(t, tt.wantAppName, appName.Value)
+			}
+
+			if tt.wantPkgName != "" {
+				pkgData, err := os.ReadFile(filepath.Join(dir, "package.json"))
+				require.NoError(t, err)
+				var pkg map[string]any
+				require.NoError(t, json.Unmarshal(pkgData, &pkg))
+				assert.Equal(t, tt.wantPkgName, pkg["name"])
+			}
+		})
+	}
+}
+
+func TestReplaceProjectNameNoDatabricksYml(t *testing.T) {
+	dir := t.TempDir()
+	err := replaceProjectName(dir, "new-app")
+	require.Error(t, err)
+}
+
+func TestSetYAMLValue(t *testing.T) {
+	input := "top:\n  nested:\n    leaf: old\n"
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
+
+	setYAMLValue(&doc, []string{"top", "nested", "leaf"}, "new")
+
+	val := yamlMapLookup(yamlMapLookup(yamlMapLookup(doc.Content[0], "top"), "nested"), "leaf")
+	require.NotNil(t, val)
+	assert.Equal(t, "new", val.Value)
+}
+
+func TestSetYAMLValueMissingKey(t *testing.T) {
+	input := "top:\n  nested:\n    leaf: old\n"
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
+
+	// Should not panic or modify the tree.
+	setYAMLValue(&doc, []string{"top", "nonexistent", "leaf"}, "new")
+
+	val := yamlMapLookup(yamlMapLookup(yamlMapLookup(doc.Content[0], "top"), "nested"), "leaf")
+	require.NotNil(t, val)
+	assert.Equal(t, "old", val.Value)
+}
+
+func TestYamlMapLookup(t *testing.T) {
+	input := "a: 1\nb: 2\n"
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
+
+	root := doc.Content[0]
+	assert.NotNil(t, yamlMapLookup(root, "a"))
+	assert.Equal(t, "1", yamlMapLookup(root, "a").Value)
+	assert.Nil(t, yamlMapLookup(root, "missing"))
+	assert.Nil(t, yamlMapLookup(nil, "a"))
+}
+
+func TestSetFirstAppName(t *testing.T) {
+	input := "resources:\n  apps:\n    myapp:\n      name: \"old-name\"\n      description: keep\n"
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
+
+	setFirstAppName(&doc, "new-name")
+
+	appsNode := yamlMapLookup(yamlMapLookup(doc.Content[0], "resources"), "apps")
+	require.NotNil(t, appsNode)
+	appName := yamlMapLookup(appsNode.Content[1], "name")
+	require.NotNil(t, appName)
+	assert.Equal(t, "new-name", appName.Value)
+
+	// Verify description is untouched.
+	desc := yamlMapLookup(appsNode.Content[1], "description")
+	require.NotNil(t, desc)
+	assert.Equal(t, "keep", desc.Value)
+}
+
+func TestSetFirstAppNameNoResources(t *testing.T) {
+	input := "bundle:\n  name: myapp\n"
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(input), &doc))
+
+	// Should not panic when resources.apps is absent.
+	setFirstAppName(&doc, "new-name")
+
+	bundleName := yamlMapLookup(yamlMapLookup(doc.Content[0], "bundle"), "name")
+	require.NotNil(t, bundleName)
+	assert.Equal(t, "myapp", bundleName.Value)
 }

--- a/cmd/apps/init_test.go
+++ b/cmd/apps/init_test.go
@@ -1193,46 +1193,37 @@ func TestPrependInstall(t *testing.T) {
 	}
 }
 
-func TestIsPreRenderedTemplate(t *testing.T) {
+func TestShouldSkipPluginSelection(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    func(dir string)
 		expected bool
 	}{
 		{
-			name: "normal template with project_name dir",
+			name: "manifest present, no project_name dir",
 			setup: func(dir string) {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "{{.project_name}}"), 0o755))
-				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: myapp\n"), 0o644))
-			},
-			expected: false,
-		},
-		{
-			name: "pre-rendered template",
-			setup: func(dir string) {
-				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: myapp\n"), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.ManifestFileName), []byte(`{"plugins":{}}`), 0o644))
 			},
 			expected: true,
 		},
 		{
-			name: "no databricks.yml",
+			name: "manifest present, project_name dir present",
+			setup: func(dir string) {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.ManifestFileName), []byte(`{"plugins":{}}`), 0o644))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "{{.project_name}}"), 0o755))
+			},
+			expected: false,
+		},
+		{
+			name: "no manifest",
 			setup: func(dir string) {
 				require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello"), 0o644))
 			},
 			expected: false,
 		},
 		{
-			name: "databricks.yml with Go template syntax",
-			setup: func(dir string) {
-				require.NoError(t, os.WriteFile(filepath.Join(dir, bundleConfigFile), []byte("bundle:\n  name: {{.project_name}}\n"), 0o644))
-			},
-			expected: false,
-		},
-		{
-			name: "unreadable directory",
-			setup: func(_ string) {
-				// dir is replaced with a nonexistent path below.
-			},
+			name:     "unreadable directory",
+			setup:    func(_ string) {},
 			expected: false,
 		},
 	}
@@ -1245,7 +1236,7 @@ func TestIsPreRenderedTemplate(t *testing.T) {
 			} else {
 				tt.setup(dir)
 			}
-			assert.Equal(t, tt.expected, isPreRenderedTemplate(dir))
+			assert.Equal(t, tt.expected, shouldSkipPluginSelection(dir))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`apps init --template <path>` now works correctly with pre-rendered templates (like `app-templates/appkit-*`). Previously it required `--set` flags for resources that were already configured, didn't update project names, and silently produced broken projects when `--features` was used.

## Key changes

### Manifest-based detection (`shouldSkipPluginSelection`)
Replaces the old `isPreRenderedTemplate()` heuristic (which checked for absence of `{{` in databricks.yml) with a structural check: manifest (`appkit.plugins.json`) exists AND no `{{.project_name}}` subdirectory.

### Pre-rendered templates with `databricks.yml.tmpl`
Pre-rendered appkit templates now ship **both** `databricks.yml` (static reference) and `databricks.yml.tmpl` (full appkit template). When the CLI runs `copyTemplate()`:
- `filepath.Walk` processes files in lexical order
- `databricks.yml` is copied first
- `databricks.yml.tmpl` renders and overwrites it (`.tmpl` suffix stripped)

This means `--set` values properly flow through the generator pipeline into `{{.bundle.resources}}`, `{{.bundle.variables}}`, `{{.bundle.targetVariables}}`, etc.

### `DATABRICKS_APPS_AGENTIC_MODE` env var
When `true`, skips `--set` requirement and resource validation for the agentic app creation flow where resources are not provided upfront.

## Behavior comparison

| Scenario | Before | After |
|----------|--------|-------|
| `--template appkit-analytics --name my-app --set analytics.sql-warehouse.id=abc` | ❌ `--set values are ignored` warning | ✅ `--set` renders into databricks.yml via template |
| `--template appkit-analytics --name my-app` (no `--set`) | ✅ Succeeds (resources ignored) | ✅ Error: `missing required resource "SQL Warehouse"` — validation now runs |
| `--features genie` on pre-rendered template | ✅ Warning shown | ✅ Warning shown (unchanged) |
| `DATABRICKS_APPS_AGENTIC_MODE=true --name my-app` | N/A | ✅ Succeeds without `--set` |
| Non-appkit template (e.g. `streamlit-hello-world-app`) | ✅ Works | ✅ No regression |

## Test results

| # | Test | Result |
|---|------|--------|
| 1 | `appkit-analytics` with `--set` | ✅ databricks.yml has rendered name, resources, host |
| 2 | `appkit-analytics` + `--features genie` | ✅ Warning shown, validation catches missing resource |
| 3 | `appkit-analytics` without `--set` | ✅ Error: missing required resource |
| 4 | `DATABRICKS_APPS_AGENTIC_MODE=true` | ✅ Succeeds without `--set` |
| 5 | `streamlit-hello-world-app` (no manifest) | ✅ No regression |

This pull request and its description were written by Isaac.