### PR TITLE
bundle/direct: record INITIAL_REGISTER when adopting existing resources

### DIFF
--- a/acceptance/bundle/deploy/record-deployment-history/bind/databricks.yml
+++ b/acceptance/bundle/deploy/record-deployment-history/bind/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: test-rdh-bind
+
+experimental:
+  record_deployment_history: true
+
+resources:
+  jobs:
+    foo:
+      name: foo-job

--- a/acceptance/bundle/deploy/record-deployment-history/bind/out.test.toml
+++ b/acceptance/bundle/deploy/record-deployment-history/bind/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/record-deployment-history/bind/output.txt
+++ b/acceptance/bundle/deploy/record-deployment-history/bind/output.txt
@@ -1,0 +1,36 @@
+
+=== bind: records OPERATION_ACTION_TYPE_INITIAL_REGISTER for an existing resource
+>>> [CLI] jobs create --json {"name": "foo-job"}
+
+>>> [CLI] bundle deployment bind foo [NUMID] --auto-approve
+Updating deployment state...
+Successfully bound job with an id '[NUMID]'
+Run 'bundle deploy' to deploy changes to your workspace
+
+>>> print_requests.py //api/2.0/bundle
+{
+  "method": "POST",
+  "path": "/api/2.0/bundle/deployments/abcd/versions/0/operations",
+  "q": {
+    "resource_key": "resources.jobs.foo"
+  },
+  "body": {
+    "action_type": "OPERATION_ACTION_TYPE_INITIAL_REGISTER",
+    "resource_id": "[NUMID]",
+    "resource_key": "resources.jobs.foo",
+    "state": {
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-rdh-bind/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "max_concurrent_runs": 1,
+      "name": "foo-job",
+      "queue": {
+        "enabled": true
+      }
+    },
+    "status": "OPERATION_STATUS_SUCCEEDED"
+  }
+}

--- a/acceptance/bundle/deploy/record-deployment-history/bind/script
+++ b/acceptance/bundle/deploy/record-deployment-history/bind/script
@@ -1,0 +1,4 @@
+title "bind: records OPERATION_ACTION_TYPE_INITIAL_REGISTER for an existing resource"
+job_id=$(trace $CLI jobs create --json '{"name": "foo-job"}' | jq -r '.job_id')
+trace $CLI bundle deployment bind foo "$job_id" --auto-approve
+trace print_requests.py //api/2.0/bundle

--- a/acceptance/bundle/deploy/record-deployment-history/bind/test.toml
+++ b/acceptance/bundle/deploy/record-deployment-history/bind/test.toml
@@ -1,0 +1,2 @@
+# bind writes the direct deployment state under .databricks; ignore it.
+Ignore = [".databricks"]

--- a/acceptance/bundle/deploy/record-deployment-history/migrate/databricks.yml
+++ b/acceptance/bundle/deploy/record-deployment-history/migrate/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: test-rdh-migrate
+
+experimental:
+  record_deployment_history: true
+
+resources:
+  jobs:
+    foo:
+      name: foo-job

--- a/acceptance/bundle/deploy/record-deployment-history/migrate/out.test.toml
+++ b/acceptance/bundle/deploy/record-deployment-history/migrate/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deploy/record-deployment-history/migrate/output.txt
+++ b/acceptance/bundle/deploy/record-deployment-history/migrate/output.txt
@@ -1,0 +1,46 @@
+
+=== deploy with terraform (no DMS recording on the terraform engine)
+>>> DATABRICKS_BUNDLE_ENGINE=terraform [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-rdh-migrate/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== migrate: records OPERATION_ACTION_TYPE_INITIAL_REGISTER for the existing job
+>>> [CLI] bundle deployment migrate --noplancheck
+Success! Migrated 1 resources to direct engine state file: [TEST_TMP_DIR]/.databricks/bundle/default/resources.json
+
+Validate the migration by running "databricks bundle plan", there should be no actions planned.
+
+The state file is not synchronized to the workspace yet. To do that and finalize the migration, run "bundle deploy".
+
+To undo the migration, remove [TEST_TMP_DIR]/.databricks/bundle/default/resources.json and rename [TEST_TMP_DIR]/.databricks/bundle/default/terraform/terraform.tfstate.backup to [TEST_TMP_DIR]/.databricks/bundle/default/terraform/terraform.tfstate
+
+
+>>> print_requests.py //api/2.0/bundle
+{
+  "method": "POST",
+  "path": "/api/2.0/bundle/deployments/abcd/versions/0/operations",
+  "q": {
+    "resource_key": "resources.jobs.foo"
+  },
+  "body": {
+    "action_type": "OPERATION_ACTION_TYPE_INITIAL_REGISTER",
+    "resource_id": "[NUMID]",
+    "resource_key": "resources.jobs.foo",
+    "state": {
+      "deployment": {
+        "kind": "BUNDLE",
+        "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/test-rdh-migrate/default/state/metadata.json"
+      },
+      "edit_mode": "UI_LOCKED",
+      "format": "MULTI_TASK",
+      "max_concurrent_runs": 1,
+      "name": "foo-job",
+      "queue": {
+        "enabled": true
+      }
+    },
+    "status": "OPERATION_STATUS_SUCCEEDED"
+  }
+}

--- a/acceptance/bundle/deploy/record-deployment-history/migrate/script
+++ b/acceptance/bundle/deploy/record-deployment-history/migrate/script
@@ -1,0 +1,10 @@
+# Deploy with terraform first, then migrate to the direct engine. Migration adopts
+# the already-deployed job, so DMS records an INITIAL_REGISTER rather than a create.
+export DATABRICKS_BUNDLE_ENGINE=
+
+title "deploy with terraform (no DMS recording on the terraform engine)"
+trace DATABRICKS_BUNDLE_ENGINE=terraform $CLI bundle deploy
+
+title "migrate: records OPERATION_ACTION_TYPE_INITIAL_REGISTER for the existing job"
+trace $CLI bundle deployment migrate --noplancheck
+trace print_requests.py //api/2.0/bundle

--- a/acceptance/bundle/deploy/record-deployment-history/migrate/test.toml
+++ b/acceptance/bundle/deploy/record-deployment-history/migrate/test.toml
@@ -1,0 +1,2 @@
+# migrate renames terraform.tfstate to a .backup and writes resources.json.
+Ignore = [".databricks"]

--- a/bundle/direct/bind.go
+++ b/bundle/direct/bind.go
@@ -46,6 +46,9 @@ type BindResult struct {
 	TempStatePath string
 	// StatePath is the path to the final state file
 	StatePath string
+	// State is the resolved config persisted for the bound resource. It is
+	// reported to DMS as the registered state once the bind is committed.
+	State any
 }
 
 // Bind adds an existing workspace resource to a temporary state and calculates
@@ -124,9 +127,11 @@ func (b *DeploymentBundle) Bind(ctx context.Context, client *databricks.Workspac
 	}
 
 	// Populate the state with the resolved config
+	var boundState any
 	entry := plan.Plan[resourceKey]
 	sv, ok := b.StateCache.Load(resourceKey)
 	if ok && sv != nil {
+		boundState = sv.Value
 		var dependsOn []deployplan.DependsOnEntry
 		if entry != nil {
 			dependsOn = entry.DependsOn
@@ -185,6 +190,7 @@ func (b *DeploymentBundle) Bind(ctx context.Context, client *databricks.Workspac
 		Plan:          plan,
 		TempStatePath: tmpStatePath,
 		StatePath:     statePath,
+		State:         boundState,
 	}
 
 	entry = plan.Plan[resourceKey]

--- a/bundle/direct/bundle_apply.go
+++ b/bundle/direct/bundle_apply.go
@@ -136,13 +136,19 @@ func (b *DeploymentBundle) Apply(ctx context.Context, client *databricks.Workspa
 				return false
 			}
 
-			// Record the operation with DMS. Migration only mirrors existing
-			// state into the local store; there is no operation to report.
-			if !migrateMode {
-				if err := b.recordOperation(ctx, resourceKey, action, b.StateDB.GetResourceID(resourceKey), sv.Value); err != nil {
-					logdiag.LogError(ctx, fmt.Errorf("%s: %w", errorPrefix, err))
-					return false
-				}
+			// Record the operation with DMS. Migration adopts a resource that
+			// already exists in the workspace, so the first thing DMS learns
+			// about it is its registration (INITIAL_REGISTER) rather than the
+			// planned action.
+			var recErr error
+			if migrateMode {
+				recErr = b.RecordInitialRegister(ctx, resourceKey, b.StateDB.GetResourceID(resourceKey), sv.Value)
+			} else {
+				recErr = b.recordOperation(ctx, resourceKey, action, b.StateDB.GetResourceID(resourceKey), sv.Value)
+			}
+			if recErr != nil {
+				logdiag.LogError(ctx, fmt.Errorf("%s: %w", errorPrefix, recErr))
+				return false
 			}
 		}
 
@@ -213,6 +219,18 @@ func (b *DeploymentBundle) recordOperation(ctx context.Context, resourceKey stri
 		return nil
 	}
 	return b.OpRec.record(ctx, resourceKey, action, resourceID, state)
+}
+
+// RecordInitialRegister reports the one-time registration of an existing
+// resource with DMS. The migrate and bind workflows adopt a resource that
+// already exists in the workspace; this records that DMS has started tracking
+// it. It is a no-op unless the bundle is opted into managed state (OpRec is
+// set). It is exported because bind is driven from the phases package.
+func (b *DeploymentBundle) RecordInitialRegister(ctx context.Context, resourceKey, resourceID string, state any) error {
+	if b.OpRec == nil {
+		return nil
+	}
+	return b.OpRec.recordInitialRegister(ctx, resourceKey, resourceID, state)
 }
 
 func jsonDump(obj any) string {

--- a/bundle/direct/oprecorder.go
+++ b/bundle/direct/oprecorder.go
@@ -14,6 +14,9 @@ import (
 // local config after the operation and must be nil for delete operations.
 type opRecorder interface {
 	record(ctx context.Context, resourceKey string, action deployplan.ActionType, resourceID string, state any) error
+	// recordInitialRegister records the one-time registration of an existing
+	// resource that was already managed by DABs but not yet tracked by DMS.
+	recordInitialRegister(ctx context.Context, resourceKey, resourceID string, state any) error
 }
 
 // operationRecorder records operations via the DMS CreateOperation API.
@@ -39,7 +42,18 @@ func (r *operationRecorder) record(ctx context.Context, resourceKey string, acti
 	if err != nil {
 		return err
 	}
+	return r.recordAction(ctx, resourceKey, actionType, resourceID, state)
+}
 
+// recordInitialRegister records an INITIAL_REGISTER operation. The migrate and
+// bind workflows adopt an existing resource into the direct engine without a
+// deploy-time create/update, so the first operation DMS sees for that resource
+// is its registration rather than a mutation.
+func (r *operationRecorder) recordInitialRegister(ctx context.Context, resourceKey, resourceID string, state any) error {
+	return r.recordAction(ctx, resourceKey, sdkbundle.OperationActionTypeOperationActionTypeInitialRegister, resourceID, state)
+}
+
+func (r *operationRecorder) recordAction(ctx context.Context, resourceKey string, actionType sdkbundle.OperationActionType, resourceID string, state any) error {
 	op := sdkbundle.Operation{
 		ActionType:  actionType,
 		ResourceId:  resourceID,
@@ -59,7 +73,7 @@ func (r *operationRecorder) record(ctx context.Context, resourceKey string, acti
 		op.State = &msg
 	}
 
-	_, err = r.client.CreateOperation(ctx, sdkbundle.CreateOperationRequest{
+	_, err := r.client.CreateOperation(ctx, sdkbundle.CreateOperationRequest{
 		Parent:      r.parent,
 		ResourceKey: resourceKey,
 		Operation:   op,

--- a/bundle/direct/oprecorder_test.go
+++ b/bundle/direct/oprecorder_test.go
@@ -70,6 +70,20 @@ func TestOperationRecorderOmitsStateForDelete(t *testing.T) {
 	assert.Equal(t, sdkbundle.OperationActionTypeOperationActionTypeDelete, client.requests[0].Operation.ActionType)
 }
 
+func TestOperationRecorderRecordsInitialRegister(t *testing.T) {
+	client := &fakeBundleClient{}
+	rec := NewOperationRecorder(client, "dep", 1)
+
+	err := rec.recordInitialRegister(t.Context(), "resources.jobs.foo", "job-1", map[string]any{"name": "foo"})
+	require.NoError(t, err)
+
+	require.Len(t, client.requests, 1)
+	op := client.requests[0].Operation
+	assert.Equal(t, sdkbundle.OperationActionTypeOperationActionTypeInitialRegister, op.ActionType)
+	assert.Equal(t, "job-1", op.ResourceId)
+	require.NotNil(t, op.State)
+}
+
 func TestOperationRecorderPropagatesAPIError(t *testing.T) {
 	wantErr := errors.New("boom")
 	client := &fakeBundleClient{err: wantErr}

--- a/bundle/phases/bind.go
+++ b/bundle/phases/bind.go
@@ -13,6 +13,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/lock"
 	"github.com/databricks/cli/bundle/deploy/terraform"
 	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/cli/bundle/direct"
 	"github.com/databricks/cli/bundle/statemgmt"
 	"github.com/databricks/cli/libs/agent"
 	"github.com/databricks/cli/libs/cmdio"
@@ -41,6 +42,13 @@ func Bind(ctx context.Context, b *bundle.Bundle, opts *terraform.BindOptions, en
 		}
 		resourceKey := fmt.Sprintf("resources.%s.%s", groupName, opts.ResourceKey)
 		_, statePath := b.StateFilenameDirect(ctx)
+
+		if b.Config.Experimental != nil && b.Config.Experimental.RecordDeploymentHistory {
+			// TODO(DMS): source the deployment ID and version from the DMS
+			// CreateVersion response once the deployment-version flow is wired in.
+			// "abcd"/0 are placeholders until then.
+			b.DeploymentBundle.OpRec = direct.NewOperationRecorder(b.WorkspaceClient(ctx).Bundle, "abcd", 0)
+		}
 
 		result, err := b.DeploymentBundle.Bind(ctx, b.WorkspaceClient(ctx), &b.Config, statePath, resourceKey, opts.ResourceId)
 		if err != nil {
@@ -88,6 +96,14 @@ func Bind(ctx context.Context, b *bundle.Bundle, opts *terraform.BindOptions, en
 
 		// Finalize: rename temp state to final location
 		err = result.Finalize()
+		if err != nil {
+			logdiag.LogError(ctx, err)
+			return
+		}
+
+		// Bind adopts an existing workspace resource, so DMS first learns about
+		// it through its registration rather than a deploy-time action.
+		err = b.DeploymentBundle.RecordInitialRegister(ctx, resourceKey, opts.ResourceId, result.State)
 		if err != nil {
 			logdiag.LogError(ctx, err)
 			return

--- a/cmd/bundle/deployment/migrate.go
+++ b/cmd/bundle/deployment/migrate.go
@@ -280,6 +280,13 @@ To start using direct engine, set "engine: direct" under bundle in your databric
 			return fmt.Errorf("upgrading state for apply: %w", err)
 		}
 
+		if b.Config.Experimental != nil && b.Config.Experimental.RecordDeploymentHistory {
+			// TODO(DMS): source the deployment ID and version from the DMS
+			// CreateVersion response once the deployment-version flow is wired in.
+			// "abcd"/0 are placeholders until then.
+			deploymentBundle.OpRec = direct.NewOperationRecorder(b.WorkspaceClient(ctx).Bundle, "abcd", 0)
+		}
+
 		deploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan, direct.MigrateMode(true))
 		if _, err := deploymentBundle.StateDB.Finalize(ctx); err != nil {
 			logdiag.LogError(ctx, err)


### PR DESCRIPTION
## Why

Stacks on #5387. That PR records a deploy-time action (create/update/delete/…) per resource with DMS. But the migrate and bind workflows *adopt* a resource that already exists in the workspace — DMS has never seen it. The first operation DMS should record for such a resource is its **registration**, not a create/update.

The proto already has the enum for exactly this case:

```proto
// One-time registration of a resource that was already managed by DABs
// but not yet tracked by the metadata service.
OPERATION_ACTION_TYPE_INITIAL_REGISTER = 9;
```

## What

Record `OPERATION_ACTION_TYPE_INITIAL_REGISTER` from the two existing-resource entry points, both gated on `experimental.record_deployment_history` (same as deploy):

- **migrate-mode `Apply`** (`bundle deployment migrate`, terraform→direct) — previously recorded nothing.
- **direct-engine `bind`** (`bundle deployment bind`) — previously recorded nothing.

`oprecorder` gains `recordInitialRegister`; the `CreateOperation` call is factored into a shared `recordAction` so the normal-deploy path is unchanged.

## Tests

- Unit: `recordInitialRegister` emits the right action type and state.
- Acceptance under `record-deployment-history/`: `bind/` and `migrate/` assert a single `INITIAL_REGISTER` operation is posted for the adopted job.

This pull request and its description were written by Isaac.