### PR TITLE
bundle/dms: set deployment display_name from bundle name on create

### DIFF
--- a/acceptance/bundle/dms/add-resources/output.txt
+++ b/acceptance/bundle/dms/add-resources/output.txt
@@ -20,6 +20,7 @@ Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged
     "deployment_id": "[UUID]"
   },
   "body": {
+    "display_name": "add-resources-test",
     "target_name": "default"
   }
 }

--- a/acceptance/bundle/dms/deploy-error/output.txt
+++ b/acceptance/bundle/dms/deploy-error/output.txt
@@ -18,6 +18,7 @@ API message: Invalid job configuration.
     "deployment_id": "[UUID]"
   },
   "body": {
+    "display_name": "metadata-service-error-test",
     "target_name": "default"
   }
 }

--- a/acceptance/bundle/dms/plan-and-summary/output.txt
+++ b/acceptance/bundle/dms/plan-and-summary/output.txt
@@ -27,6 +27,7 @@ Resources:
     "deployment_id": "[UUID]"
   },
   "body": {
+    "display_name": "plan-summary-test",
     "target_name": "default"
   }
 }

--- a/acceptance/bundle/dms/release-lock-error/output.txt
+++ b/acceptance/bundle/dms/release-lock-error/output.txt
@@ -13,6 +13,7 @@ Warn: Failed to release deployment lock: simulated complete version failure
     "deployment_id": "[UUID]"
   },
   "body": {
+    "display_name": "dms-release-lock-error",
     "target_name": "fail-complete"
   }
 }

--- a/acceptance/bundle/dms/sequential-deploys/output.txt
+++ b/acceptance/bundle/dms/sequential-deploys/output.txt
@@ -12,6 +12,7 @@ Deployment complete!
     "deployment_id": "[UUID]"
   },
   "body": {
+    "display_name": "sequential-deploys-test",
     "target_name": "default"
   }
 }

--- a/bundle/deploy/lock/deployment_metadata_service.go
+++ b/bundle/deploy/lock/deployment_metadata_service.go
@@ -118,7 +118,8 @@ func acquireLock(ctx context.Context, b *bundle.Bundle, svc *tmpdms.DeploymentMe
 		_, createErr := svc.CreateDeployment(ctx, tmpdms.CreateDeploymentRequest{
 			DeploymentID: deploymentID,
 			Deployment: &tmpdms.Deployment{
-				TargetName: b.Config.Bundle.Target,
+				DisplayName: b.Config.Bundle.Name,
+				TargetName:  b.Config.Bundle.Target,
 			},
 		})
 		if createErr != nil {

--- a/bundle/deploy/lock/deployment_metadata_service.go
+++ b/bundle/deploy/lock/deployment_metadata_service.go
@@ -269,7 +269,6 @@ func makeSyncReporter(svc *tmpdms.DeploymentMetadataAPI, deploymentID, versionID
 	}
 }
 
-
 // planActionToOperationAction maps a deploy plan action to a metadata service
 // operation action type. No-op actions like Skip return ("", nil) and should
 // be ignored.


### PR DESCRIPTION
## Why

DMS-backed bundle deployments (run with `DATABRICKS_BUNDLE_MANAGED_STATE=true DATABRICKS_BUNDLE_ENGINE=direct`) never set `display_name` when creating the deployment record, so the field is stored as `null`.

## What

Populate `DisplayName` from `bundle.Config.Bundle.Name` (i.e. the `bundle.name` from `databricks.yml`) when issuing `CreateDeployment`. This matches the human-readable label users already see in `databricks bundle validate`.

## Tests

Existing `acceptance/bundle/dms/*` tests record the `CreateDeployment` request body via `print_requests.py`; their `output.txt` files regenerate to assert the new `display_name` field.

This pull request and its description were written by Isaac.