### PR TITLE
ci: catch new untracked files after running tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -152,10 +152,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-      - name: Check out.test.toml files are up to date
+      - name: Check no files changed or appeared after running tests
         run: |
+          # Register untracked files with intent-to-add so `git diff` reports them
+          # too; a plain `git diff` ignores new files, which is how a missing
+          # out.test.toml previously slipped through. Ignored test artifacts are
+          # unaffected because intent-to-add respects .gitignore.
+          git add --intent-to-add .
           if ! git diff --exit-code; then
-            echo "ERROR: detected changed files in the repository; Most likely you have out.test.toml files that are out of date. Run 'go test ./acceptance -run \"^TestAccept$\" -only-out-test-toml' to update."
+            echo "ERROR: detected changed or new files in the repository; Most likely you have out.test.toml files that are out of date. Run 'go test ./acceptance -run \"^TestAccept$\" -only-out-test-toml' to update."
             exit 1
           fi
 

--- a/acceptance/bundle/paths/designer_notebook/out.test.toml
+++ b/acceptance/bundle/paths/designer_notebook/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]


### PR DESCRIPTION
The `designer_notebook` acceptance test (added in #5370) was missing its generated `out.test.toml`. The file is written as a side effect of test discovery and explicitly excluded from output comparison, so a missing copy never fails a test — and the post-test `git diff --exit-code` guard didn't catch it either, because plain `git diff` ignores untracked files. The result: the file silently regenerated as an untracked change in every worktree that ran the acceptance suite.

This adds the missing `out.test.toml` and fixes the CI guard to register untracked files with `git add --intent-to-add .` before diffing, so any new file appearing after a test run now fails the build. Gitignored test artifacts are unaffected, since intent-to-add respects `.gitignore`.

This pull request and its description were written by Isaac.