### PR TITLE
lakebox: color "stopping" status yellow

### DIFF
--- a/cmd/lakebox/ui.go
+++ b/cmd/lakebox/ui.go
@@ -65,6 +65,8 @@ func status(ctx context.Context, s string) string {
 		return cmdio.Faint(ctx, "stopped")
 	case "creating":
 		return cmdio.Bold(ctx, cmdio.Cyan(ctx, "creating…"))
+	case "stopping":
+		return cmdio.Yellow(ctx, "stopping…")
 	default:
 		return cmdio.Faint(ctx, strings.ToLower(s))
 	}


### PR DESCRIPTION
## Summary

Adds a yellow color treatment for the transient `Stopping` lifecycle state in `lakebox list` and `lakebox status` output, mirroring the existing `creating…` treatment so transient states are visually distinct from terminal ones (`Running` cyan / `Stopped` faint).

## Test plan

- [x] `go test ./cmd/lakebox/...` passes
- [x] `go build ./cmd/lakebox/...` clean
- [ ] Eye-check in a TTY against a sandbox mid-stop

This pull request and its description were written by Isaac.