### PR TITLE
acceptance: exit cleanly from -update when only regenerating outputs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -799,8 +799,7 @@ tasks:
     generates:
       - acceptance/bundle/refschema/out.fields.txt
     cmds:
-      - cmd: go test ./acceptance -run TestAccept/bundle/refschema -update &> /dev/null
-        ignore_error: true # -update returns non-zero exit code on changes
+      - go test ./acceptance -run TestAccept/bundle/refschema -update
 
   generate-schema:
     desc: Generate bundle JSON schema

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -899,38 +899,43 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		valueNew = repls.Replace(valueNew)
 	}
 
-	// In update mode, (re)generating the reference files is the goal, so applying
-	// a change is success, not failure. Write or remove the reference file to match
-	// what the test produced, then return without marking the test failed. Genuine
-	// problems still fail the run: read errors (reported by tryReading above) and
-	// write errors (via require/testutil below).
-	if testdiff.OverwriteMode {
-		switch {
-		case okRef && !okNew:
-			// The test no longer produces this output; drop the stale reference.
-			t.Logf("Removing output file: %s", relPath)
-			require.NoError(t, os.Remove(pathRef))
-		case !okRef && okNew:
-			t.Logf("Writing output file: %s", relPath)
-			testutil.WriteFile(t, pathRef, valueNew)
-		case valueRef != valueNew:
-			t.Logf("Overwriting existing output file: %s", relPath)
-			testutil.WriteFile(t, pathRef, valueNew)
-		}
-		return
-	}
+	// In update mode, regenerating the reference files is the goal: each branch below
+	// writes or removes the reference and returns without failing the test. Genuine
+	// problems still fail — read errors (via tryReading above), write errors (via
+	// require/testutil), and the both-missing case above.
 
 	// The test did not produce an expected output file.
 	if okRef && !okNew {
+		if testdiff.OverwriteMode {
+			// The test no longer produces this output; drop the stale reference.
+			t.Logf("Removing output file: %s", relPath)
+			require.NoError(t, os.Remove(pathRef))
+			return
+		}
 		t.Errorf("Missing output file: %s", relPath)
 		return
 	}
 
 	// The test produced an unexpected output file.
 	if !okRef && okNew {
+		if testdiff.OverwriteMode {
+			t.Logf("Writing output file: %s", relPath)
+			testutil.WriteFile(t, pathRef, valueNew)
+			return
+		}
 		t.Errorf("Unexpected output file: %s\npathRef: %s\npathNew: %s", relPath, pathRef, pathNew)
 		if shouldShowDiff(pathNew, valueNew) {
 			testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
+		}
+		return
+	}
+
+	// In update mode, overwrite on any difference rather than calling
+	// AssertEqualTexts, which would mark the test failed.
+	if testdiff.OverwriteMode {
+		if valueRef != valueNew {
+			t.Logf("Overwriting existing output file: %s", relPath)
+			testutil.WriteFile(t, pathRef, valueNew)
 		}
 		return
 	}

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -899,13 +899,30 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		valueNew = repls.Replace(valueNew)
 	}
 
+	// In update mode, (re)generating the reference files is the goal, so applying
+	// a change is success, not failure. Write or remove the reference file to match
+	// what the test produced, then return without marking the test failed. Genuine
+	// problems still fail the run: read errors (reported by tryReading above) and
+	// write errors (via require/testutil below).
+	if testdiff.OverwriteMode {
+		switch {
+		case okRef && !okNew:
+			// The test no longer produces this output; drop the stale reference.
+			t.Logf("Removing output file: %s", relPath)
+			require.NoError(t, os.Remove(pathRef))
+		case !okRef && okNew:
+			t.Logf("Writing output file: %s", relPath)
+			testutil.WriteFile(t, pathRef, valueNew)
+		case valueRef != valueNew:
+			t.Logf("Overwriting existing output file: %s", relPath)
+			testutil.WriteFile(t, pathRef, valueNew)
+		}
+		return
+	}
+
 	// The test did not produce an expected output file.
 	if okRef && !okNew {
 		t.Errorf("Missing output file: %s", relPath)
-		if testdiff.OverwriteMode {
-			t.Logf("Removing output file: %s", relPath)
-			require.NoError(t, os.Remove(pathRef))
-		}
 		return
 	}
 
@@ -915,19 +932,11 @@ func doComparison(t *testing.T, repls testdiff.ReplacementsContext, dirRef, dirN
 		if shouldShowDiff(pathNew, valueNew) {
 			testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
 		}
-		if testdiff.OverwriteMode {
-			t.Logf("Writing output file: %s", relPath)
-			testutil.WriteFile(t, pathRef, valueNew)
-		}
 		return
 	}
 
 	// Compare the reference and new values.
 	equal := testdiff.AssertEqualTexts(t, pathRef, pathNew, valueRef, valueNew)
-	if !equal && testdiff.OverwriteMode {
-		t.Logf("Overwriting existing output file: %s", relPath)
-		testutil.WriteFile(t, pathRef, valueNew)
-	}
 
 	if VerboseTest && !equal && printedRepls != nil && !*printedRepls {
 		*printedRepls = true


### PR DESCRIPTION
## Changes
- Don't error during OverwriteMode (`-update` flag on tests) if there were changes
- Update Taskfile which previously ignored errors

## Why
- Updates should only error if actual errors occurred, since new files/removed old ones are expected

## Tests
```
┌───────────────────────────────────┬──────┬────────────────────────────────┐
│             Scenario              │ Exit │             Result             │
├───────────────────────────────────┼──────┼────────────────────────────────┤
│ -update, no change                │ 0    │ ✓ (unchanged)                  │
├───────────────────────────────────┼──────┼────────────────────────────────┤
│ -update, with change              │ 0    │ file updated correctly (was 1) │
├───────────────────────────────────┼──────┼────────────────────────────────┤
│ no -update, clean                 │ 0    │ ✓                              │
├───────────────────────────────────┼──────┼────────────────────────────────┤
│ no -update, drift                 │ 1    │ drift still detected ✓         │
├───────────────────────────────────┼──────┼────────────────────────────────┤
│ ./task --force generate-refschema │ 0    │ clean, output visible          │
├───────────────────────────────────┼──────┼────────────────────────────────┤
│ task ... && git diff --exit-code  │ 0    │ CI pattern works               │
└───────────────────────────────────┴──────┴────────────────────────────────┘
```

---

Co-authored-by: Isaac
