### PR TITLE
acceptance: unset all SDK-known AI-agent env vars before tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -202,15 +202,34 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	// pick up the host's agent. Setting these to "" via test.toml is not
 	// enough: the SDK (since v0.132.0) treats empty values as a truthy
 	// signal because os.LookupEnv reports them as present.
-	for _, v := range []string{
+	// Keep this list in sync with the SDK's useragent.listKnownAgents.
+	knownAgents := []string{
+		"AMP_CURRENT_THREAD_ID",
 		"ANTIGRAVITY_AGENT",
+		"AUGMENT_AGENT",
 		"CLAUDECODE",
 		"CLINE_ACTIVE",
 		"CODEX_CI",
+		"COPILOT_CLI",
 		"CURSOR_AGENT",
 		"GEMINI_CLI",
+		"GOOSE_TERMINAL",
+		"KIRO",
+		"OPENCLAW_SHELL",
 		"OPENCODE",
-	} {
+		"VSCODE_AGENT",
+		"WINDSURF_AGENT",
+	}
+
+	// AGENT and AI_AGENT are not in listKnownAgents; the SDK consults them as
+	// a generic fallback (useragent.agentEnvFallback) when none of the
+	// specific agents above is set.
+	genericAgents := []string{
+		"AGENT",
+		"AI_AGENT",
+	}
+
+	for _, v := range slices.Concat(knownAgents, genericAgents) {
 		os.Unsetenv(v) //nolint:usetesting // t.Setenv cannot unset
 	}
 


### PR DESCRIPTION
## Changes
- Sync `knownAgents` with SDK's `useragent.listKnownAgents`
- Add `AGENT` and `AI_AGENT` to env variable to drop during acceptance test

## Why
Local test failures when run from agents.

The SDK derives its user-agent from agent-detection env vars and, since v0.132.0, treats even empty values as present, so clearing them via test.toml does not help. The previous list covered only a subset, leaving acceptance output dependent on which agent launched the test runner. Expand it to mirror useragent.listKnownAgents and split the generic AGENT/AI_AGENT fallback vars into their own list.

## Tests
Local & CI

Previously, tests were failing with e.g.
```
--- FAIL: TestAccept (26.14s)
    --- FAIL: TestAccept/bundle/user_agent/simple
        --- FAIL: TestAccept/bundle/user_agent/simple/DATABRICKS_BUNDLE_ENGINE=direct (1.74s)
            acceptance_test.go:926: Diff:
                --- bundle/user_agent/simple/out.requests.validate.direct.json
                +++ .../out.requests.validate.direct.json
                @@ -1,7 +1,7 @@
                 {
                   "headers": {
                     "User-Agent": [
                -      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat"
                +      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat agent/claude-code_2-1-162_agent"
                     ]
                   },
                   "method": "GET",
```

---

Co-authored-by: Isaac
