### PR TITLE
Fix spurious git-info warning on DBR acceptance tests

### DIFF
--- a/bundle/config/mutator/load_git_details.go
+++ b/bundle/config/mutator/load_git_details.go
@@ -2,8 +2,6 @@ package mutator
 
 import (
 	"context"
-	"errors"
-	"os"
 	"path/filepath"
 
 	"github.com/databricks/cli/bundle"
@@ -26,9 +24,7 @@ func (m *loadGitDetails) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 	var diags diag.Diagnostics
 	info, err := git.FetchRepositoryInfo(ctx, b.BundleRoot.Native(), b.WorkspaceClient(ctx))
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			diags = append(diags, diag.WarningFromErr(err)...)
-		}
+		diags = append(diags, diag.WarningFromErr(err)...)
 	}
 
 	if info.WorktreeRoot == "" {

--- a/integration/libs/git/git_fetch_test.go
+++ b/integration/libs/git/git_fetch_test.go
@@ -77,37 +77,21 @@ func TestFetchRepositoryInfoAPI_FromNonRepo(t *testing.T) {
 
 	ctx = dbr.MockRuntime(ctx, dbr.Environment{IsDbr: true, Version: "15.4"})
 
+	// A path outside a Repo has no git info; a non-existent path is treated the
+	// same way (no repository there), so all cases return empty info with no error.
 	tests := []struct {
 		name  string
 		input string
-		msg   string
 	}{
-		{
-			name:  "subdir",
-			input: path.Join(rootPath, "a/b/c"),
-			msg:   "",
-		},
-		{
-			name:  "root",
-			input: rootPath,
-			msg:   "",
-		},
-		{
-			name:  "non-existent",
-			input: path.Join(rootPath, "/non-existent"),
-			msg:   "doesn't exist",
-		},
+		{"subdir", path.Join(rootPath, "a/b/c")},
+		{"root", rootPath},
+		{"non-existent", path.Join(rootPath, "/non-existent")},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			info, err := git.FetchRepositoryInfo(ctx, test.input, wt.W)
-			if test.msg == "" {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, test.msg)
-			}
+			assert.NoError(t, err)
 			assertEmptyGitInfo(t, info)
 		})
 	}
@@ -162,7 +146,7 @@ func TestFetchRepositoryInfoDotGit_FromNonGitRepo(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			info, err := git.FetchRepositoryInfo(ctx, test.input, wt.W)
-			assert.ErrorIs(t, err, os.ErrNotExist)
+			assert.NoError(t, err)
 			assertEmptyGitInfo(t, info)
 		})
 	}

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"net/http"
 	"path"
 	"strings"
@@ -11,6 +13,7 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/vfs"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/client"
 )
 
@@ -36,18 +39,29 @@ type response struct {
 }
 
 // Fetch repository information either by quering .git or by fetching it from API (for dabs-in-workspace case).
-//   - In case we could not find git repository, all string fields of RepositoryInfo will be "" and err will be nil.
+//   - In case we could not find git repository (including when the path does not exist), all string fields of RepositoryInfo will be "" and err will be nil.
 //   - If there were any errors when trying to determine git root (e.g. API call returned an error or there were permission issues
 //     reading the file system), all strings fields of RepositoryInfo will be "" and err will be non-nil.
 //   - If we could determine git worktree root but there were errors when reading metadata (origin, branch, commit), those errors
 //     will be logged as warnings, RepositoryInfo is guaranteed to have non-empty WorktreeRoot and other fields on best effort basis.
 //   - In successful case, all fields are set to proper git repository metadata.
 func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
+	var info RepositoryInfo
+	var err error
 	if strings.HasPrefix(path, "/Workspace/") && dbr.RunsOnRuntime(ctx) {
-		return fetchRepositoryInfoAPI(ctx, path, w)
+		info, err = fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
-		return fetchRepositoryInfoDotGit(ctx, path)
+		info, err = fetchRepositoryInfoDotGit(ctx, path)
 	}
+
+	// A path that does not exist just means there is no repository there, which
+	// is not an error. Both backends report this as fs.ErrNotExist (the API
+	// backend translates a workspace 404 to it), so it is normalized to a nil
+	// error in a single place rather than special-cased by every caller.
+	if errors.Is(err, fs.ErrNotExist) {
+		return info, nil
+	}
+	return info, err
 }
 
 func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
@@ -74,6 +88,14 @@ func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.Work
 		&response,
 	)
 	if err != nil {
+		// The workspace API returns 404 when the path is not a workspace object
+		// (for example, an ephemeral directory that is not part of a Repo).
+		// Normalize it to fs.ErrNotExist, the same signal fetchRepositoryInfoDotGit
+		// produces for a missing local path, so FetchRepositoryInfo can treat
+		// "no path" as "no repository" uniformly.
+		if apierr.IsMissing(err) {
+			return result, fs.ErrNotExist
+		}
 		return result, err
 	}
 


### PR DESCRIPTION
## Problem

Acceptance tests on DBR were failing because we would emit a warning that the repo does not exist. That did not happen normally (the warnings were silenced) causing test failures. This PR fixes that.
