### PR TITLE
lakebox: explicitly start stopped sandbox before ssh

### DIFF
--- a/cmd/lakebox/ssh.go
+++ b/cmd/lakebox/ssh.go
@@ -1,6 +1,7 @@
 package lakebox
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -161,11 +162,21 @@ Examples:
 				}
 			}
 
-			// A stopped sandbox is implicitly started on connect, which
-			// can take minutes. Print an explicit notice so the user
-			// understands why the connect spinner is hanging.
-			if strings.EqualFold(sandboxStatus, "stopped") {
-				warn(ctx, "Starting "+cmdio.Bold(ctx, lakeboxID)+"… (may take a few minutes)")
+			// Explicitly start (and wait for) the sandbox if it isn't
+			// already Running. The gateway will auto-start a stopped
+			// sandbox on connect, but that path is opaque (ssh just
+			// hangs for minutes with no progress) and races the
+			// cold-start timeout. Driving the start ourselves gives
+			// the user a visible spinner with elapsed time and a
+			// deterministic timeout (see start.go).
+			if sandboxStatus != "" && !strings.EqualFold(sandboxStatus, "running") {
+				final, err := ensureRunning(ctx, api, lakeboxID, sandboxStatus)
+				if err != nil {
+					return err
+				}
+				if final.GatewayHost != "" {
+					sandboxGatewayHost = final.GatewayHost
+				}
 			}
 
 			// Resolution precedence: --gateway flag → fresh API response →
@@ -203,6 +214,37 @@ Examples:
 	cmd.Flags().StringVar(&gatewayPort, "port", defaultGatewayPort, "Lakebox gateway SSH port")
 
 	return cmd
+}
+
+// ensureRunning brings the named sandbox to Running before ssh hands
+// off. Owns its own spinner lifecycle — caller must not have one open.
+// Calls api.start when the sandbox is currently Stopped; falls through
+// to a poll for already-transitioning states (Creating, Starting).
+func ensureRunning(ctx context.Context, api *lakeboxAPI, id, currentStatus string) (*sandboxEntry, error) {
+	s := spin(ctx, "Starting "+cmdio.Bold(ctx, id)+"…")
+	defer s.Close()
+
+	var sb *sandboxEntry
+	if strings.EqualFold(currentStatus, "stopped") {
+		updated, err := api.start(ctx, id)
+		if err != nil {
+			s.fail("Failed to start " + id)
+			return nil, fmt.Errorf("failed to start lakebox %s: %w", id, err)
+		}
+		sb = updated
+	}
+
+	if sb == nil || !strings.EqualFold(sb.Status, "running") {
+		final, err := waitForRunning(ctx, api, s, id)
+		if err != nil {
+			s.fail("Failed to start " + id)
+			return nil, err
+		}
+		sb = final
+	}
+
+	s.ok("Started " + cmdio.Bold(ctx, id))
+	return sb, nil
 }
 
 // execSSHDirect replaces the CLI process with ssh (or simulates that on

--- a/cmd/lakebox/ui.go
+++ b/cmd/lakebox/ui.go
@@ -65,6 +65,8 @@ func status(ctx context.Context, s string) string {
 		return cmdio.Faint(ctx, "stopped")
 	case "creating":
 		return cmdio.Bold(ctx, cmdio.Cyan(ctx, "creating…"))
+	case "stopping":
+		return cmdio.Yellow(ctx, "stopping…")
 	default:
 		return cmdio.Faint(ctx, strings.ToLower(s))
 	}


### PR DESCRIPTION
## Summary

Replaces the bare `warn(ctx, "Starting <id>…")` notice in `lakebox ssh` with an explicit `api.start` + `waitForRunning` sequence before exec-ing ssh.

The SSH gateway already auto-starts a stopped sandbox on connect, but that path is opaque — ssh hangs for minutes with no progress — and races the cold-start timeout. Driving the start from the CLI gives the user a visible spinner with elapsed time and a deterministic timeout (the same one `databricks lakebox start` uses). The new `ensureRunning` helper also handles already-transitioning states (`Creating`, `Starting`) — it skips the `api.start` RPC and just polls. The fresh `sandboxEntry` returned by the helper also refreshes the cached `GatewayHost` if it changed during the start.

## User-visible change

Before:
```
! Starting happy-panda-1234… (may take a few minutes)
⠋ Connecting to happy-panda-1234…   ← hangs silently, can time out at the ssh layer
```

After:
```
⠋ Starting happy-panda-1234… (8s)
⠋ Starting happy-panda-1234… (10s)
…
✓ Started happy-panda-1234
⠋ Connecting to happy-panda-1234…   ← fast, sandbox already running
```

## Test plan

- [x] `go test ./cmd/lakebox/...` passes
- [x] `go build ./...` clean
- [ ] Live test against a stopped sandbox (deferred — 5–10 min wall clock per attempt)

This pull request and its description were written by Isaac.