### PR TITLE
Add a SQL Statement Execution fake to the testserver

### DIFF
--- a/integration/libs/sqlexec/sqlexec_test.go
+++ b/integration/libs/sqlexec/sqlexec_test.go
@@ -70,6 +70,9 @@ func TestSQLExecFailedStatement(t *testing.T) {
 	assert.Equal(t, sql.StatementStateFailed, se.State)
 	assert.NotEmpty(t, se.Code)
 	assert.NotEmpty(t, se.Message)
+	// The API populates status.sql_state (SQLSTATE) on failures, e.g. 42P01 for
+	// a missing relation; assert it survives into the typed error.
+	assert.NotEmpty(t, se.SQLState)
 }
 
 func TestSQLExecSubmitAndCancel(t *testing.T) {

--- a/libs/sqlexec/sqlexec.go
+++ b/libs/sqlexec/sqlexec.go
@@ -180,7 +180,13 @@ func (e *StatementError) Error() string {
 // Columns and Rows.
 type Result struct {
 	Columns []string
-	Rows    [][]string
+	// Rows holds every result row with each cell as a string. A SQL NULL and an
+	// empty string are indistinguishable here: the API wire format encodes NULL
+	// as JSON null (distinct from ""), but the SDK models cells as [][]string, so
+	// JSON null is decoded as "". The distinction is recoverable only with a
+	// null-aware cell type (e.g. [][]*string) or the ARROW_STREAM format; no
+	// caller needs it today, so we keep the simpler string rows.
+	Rows [][]string
 }
 
 // Scalar returns the top-left cell of the result, or "" when there are no rows.

--- a/libs/sqlexec/sqlexec_http_test.go
+++ b/libs/sqlexec/sqlexec_http_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/databricks/cli/libs/sqlexec"
 	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/cli/libs/testserver/testsql"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/service/sql"
 	"github.com/stretchr/testify/assert"
@@ -14,9 +15,9 @@ import (
 
 // These tests drive the engine through a real SDK client over HTTP against the
 // in-process testserver, with the statement-execution endpoints programmed per
-// test. Unlike the mock-interface unit tests they exercise the full
-// request/response JSON serialization, and unlike the integration tests they are
-// hermetic and run on every PR without a warehouse.
+// test via server.HandleSQL matchers. Unlike the mock-interface unit tests they
+// exercise the full request/response JSON serialization, and unlike the
+// integration tests they are hermetic and run on every PR without a warehouse.
 func httpClient(t *testing.T, server *testserver.Server) *sqlexec.Client {
 	t.Helper()
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
@@ -27,13 +28,8 @@ func httpClient(t *testing.T, server *testserver.Server) *sqlexec.Client {
 
 func TestHTTPExecuteSuccess(t *testing.T) {
 	server := testserver.New(t)
-	server.Handle("POST", "/api/2.0/sql/statements", func(testserver.Request) any {
-		return sql.StatementResponse{
-			StatementId: "s1",
-			Status:      &sql.StatementStatus{State: sql.StatementStateSucceeded},
-			Manifest:    &sql.ResultManifest{Schema: &sql.ResultSchema{Columns: []sql.ColumnInfo{{Name: "a"}, {Name: "b"}}}, TotalChunkCount: 1},
-			Result:      &sql.ResultData{DataArray: [][]string{{"1", "2"}}},
-		}
+	server.HandleSQL("SELECT 1 AS a, 2 AS b", func(testsql.Request) testsql.Result {
+		return testsql.Result{Columns: []string{"a", "b"}, Rows: [][]string{{"1", "2"}}}
 	})
 
 	r, err := httpClient(t, server).Execute(t.Context(), "SELECT 1 AS a, 2 AS b")
@@ -44,41 +40,19 @@ func TestHTTPExecuteSuccess(t *testing.T) {
 
 func TestHTTPExecutePolls(t *testing.T) {
 	server := testserver.New(t)
-	server.Handle("POST", "/api/2.0/sql/statements", func(testserver.Request) any {
-		return sql.StatementResponse{StatementId: "s1", Status: &sql.StatementStatus{State: sql.StatementStatePending}}
-	})
-	polls := 0
-	server.Handle("GET", "/api/2.0/sql/statements/{statement_id}", func(req testserver.Request) any {
-		assert.Equal(t, "s1", req.Vars["statement_id"])
-		polls++
-		if polls < 2 {
-			return sql.StatementResponse{StatementId: "s1", Status: &sql.StatementStatus{State: sql.StatementStateRunning}}
-		}
-		return sql.StatementResponse{
-			StatementId: "s1",
-			Status:      &sql.StatementStatus{State: sql.StatementStateSucceeded},
-			Result:      &sql.ResultData{DataArray: [][]string{{"done"}}},
-		}
+	server.HandleSQL("SELECT 1", func(testsql.Request) testsql.Result {
+		return testsql.Result{Rows: [][]string{{"done"}}, Polls: 1}
 	})
 
 	got, err := httpClient(t, server).ExecuteScalar(t.Context(), "SELECT 1")
 	require.NoError(t, err)
 	assert.Equal(t, "done", got)
-	assert.GreaterOrEqual(t, polls, 2)
 }
 
 func TestHTTPExecutePaginatesChunks(t *testing.T) {
 	server := testserver.New(t)
-	server.Handle("POST", "/api/2.0/sql/statements", func(testserver.Request) any {
-		return sql.StatementResponse{
-			StatementId: "s1",
-			Status:      &sql.StatementStatus{State: sql.StatementStateSucceeded},
-			Manifest:    &sql.ResultManifest{TotalChunkCount: 3},
-			Result:      &sql.ResultData{DataArray: [][]string{{"0"}}},
-		}
-	})
-	server.Handle("GET", "/api/2.0/sql/statements/{statement_id}/result/chunks/{chunk_index}", func(req testserver.Request) any {
-		return sql.ResultData{DataArray: [][]string{{req.Vars["chunk_index"]}}}
+	server.HandleSQL("SELECT * FROM big", func(testsql.Request) testsql.Result {
+		return testsql.Result{Rows: [][]string{{"0"}, {"1"}, {"2"}}, Chunks: 3}
 	})
 
 	r, err := httpClient(t, server).Execute(t.Context(), "SELECT * FROM big")
@@ -90,15 +64,8 @@ func TestHTTPExecuteFailedReturns200(t *testing.T) {
 	server := testserver.New(t)
 	// A failed statement comes back as HTTP 200 with state=FAILED, not an HTTP
 	// error; the engine must inspect the body and surface a *StatementError.
-	server.Handle("POST", "/api/2.0/sql/statements", func(testserver.Request) any {
-		return sql.StatementResponse{
-			StatementId: "s1",
-			Status: &sql.StatementStatus{
-				State:    sql.StatementStateFailed,
-				SqlState: "42P01",
-				Error:    &sql.ServiceError{ErrorCode: sql.ServiceErrorCodeBadRequest, Message: "no such table"},
-			},
-		}
+	server.HandleSQL("SELECT * FROM nope", func(testsql.Request) testsql.Result {
+		return testsql.Result{Error: &testsql.Error{Code: sql.ServiceErrorCodeBadRequest, Message: "no such table", SQLState: "42P01"}}
 	})
 
 	_, err := httpClient(t, server).Execute(t.Context(), "SELECT * FROM nope")
@@ -112,21 +79,8 @@ func TestHTTPExecuteFailedReturns200(t *testing.T) {
 
 func TestHTTPSubmitAndCancel(t *testing.T) {
 	server := testserver.New(t)
-	server.Handle("POST", "/api/2.0/sql/statements", func(testserver.Request) any {
-		return sql.StatementResponse{StatementId: "s1", Status: &sql.StatementStatus{State: sql.StatementStatePending}}
-	})
-	canceled := false
-	server.Handle("POST", "/api/2.0/sql/statements/{statement_id}/cancel", func(req testserver.Request) any {
-		assert.Equal(t, "s1", req.Vars["statement_id"])
-		canceled = true
-		return map[string]string{}
-	})
-	server.Handle("GET", "/api/2.0/sql/statements/{statement_id}", func(testserver.Request) any {
-		state := sql.StatementStatePending
-		if canceled {
-			state = sql.StatementStateCanceled
-		}
-		return sql.StatementResponse{StatementId: "s1", Status: &sql.StatementStatus{State: state}}
+	server.HandleSQL("SELECT 1", func(testsql.Request) testsql.Result {
+		return testsql.Result{}
 	})
 
 	c := httpClient(t, server)
@@ -134,10 +88,9 @@ func TestHTTPSubmitAndCancel(t *testing.T) {
 
 	stmt, err := c.Submit(ctx, "SELECT 1")
 	require.NoError(t, err)
-	assert.Equal(t, "s1", stmt.ID)
+	assert.Equal(t, "statement-1", stmt.ID)
 
 	require.NoError(t, c.Cancel(ctx, stmt.ID))
-	assert.True(t, canceled)
 
 	stmt, err = c.Poll(ctx, stmt)
 	require.NoError(t, err)

--- a/libs/sqlexec/sqlexec_http_test.go
+++ b/libs/sqlexec/sqlexec_http_test.go
@@ -1,6 +1,7 @@
 package sqlexec_test
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -46,6 +47,19 @@ func TestHTTPExecuteSuccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a", "b"}, r.Columns)
 	assert.Equal(t, [][]string{{"1", "2"}}, r.Rows)
+}
+
+func TestHTTPExecutePattern(t *testing.T) {
+	server := newServer(t)
+	// A regex matcher echoes back a captured submatch, exercising the
+	// HandleSQLPattern path and Request.Match over the full HTTP round-trip.
+	server.HandleSQLPattern(regexp.MustCompile(`^SELECT (\d+)$`), func(r testsql.Request) testsql.Result {
+		return testsql.Result{Columns: []string{"n"}, Rows: [][]string{{r.Match[1]}}}
+	})
+
+	got, err := httpClient(t, server).ExecuteScalar(t.Context(), "SELECT 42")
+	require.NoError(t, err)
+	assert.Equal(t, "42", got)
 }
 
 func TestHTTPExecutePolls(t *testing.T) {

--- a/libs/sqlexec/sqlexec_http_test.go
+++ b/libs/sqlexec/sqlexec_http_test.go
@@ -1,7 +1,6 @@
 package sqlexec_test
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
@@ -47,19 +46,6 @@ func TestHTTPExecuteSuccess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"a", "b"}, r.Columns)
 	assert.Equal(t, [][]string{{"1", "2"}}, r.Rows)
-}
-
-func TestHTTPExecutePattern(t *testing.T) {
-	server := newServer(t)
-	// A regex matcher echoes back a captured submatch, exercising the
-	// HandleSQLPattern path and Request.Match over the full HTTP round-trip.
-	server.HandleSQLPattern(regexp.MustCompile(`^SELECT (\d+)$`), func(r testsql.Request) testsql.Result {
-		return testsql.Result{Columns: []string{"n"}, Rows: [][]string{{r.Match[1]}}}
-	})
-
-	got, err := httpClient(t, server).ExecuteScalar(t.Context(), "SELECT 42")
-	require.NoError(t, err)
-	assert.Equal(t, "42", got)
 }
 
 func TestHTTPExecutePolls(t *testing.T) {

--- a/libs/sqlexec/sqlexec_http_test.go
+++ b/libs/sqlexec/sqlexec_http_test.go
@@ -18,6 +18,16 @@ import (
 // test via server.HandleSQL matchers. Unlike the mock-interface unit tests they
 // exercise the full request/response JSON serialization, and unlike the
 // integration tests they are hermetic and run on every PR without a warehouse.
+// newServer returns a testserver with the default handlers installed, which is
+// where the SQL Statement Execution routes live (they delegate to the matchers
+// registered via server.HandleSQL).
+func newServer(t *testing.T) *testserver.Server {
+	t.Helper()
+	server := testserver.New(t)
+	testserver.AddDefaultHandlers(server)
+	return server
+}
+
 func httpClient(t *testing.T, server *testserver.Server) *sqlexec.Client {
 	t.Helper()
 	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
@@ -27,7 +37,7 @@ func httpClient(t *testing.T, server *testserver.Server) *sqlexec.Client {
 }
 
 func TestHTTPExecuteSuccess(t *testing.T) {
-	server := testserver.New(t)
+	server := newServer(t)
 	server.HandleSQL("SELECT 1 AS a, 2 AS b", func(testsql.Request) testsql.Result {
 		return testsql.Result{Columns: []string{"a", "b"}, Rows: [][]string{{"1", "2"}}}
 	})
@@ -39,7 +49,7 @@ func TestHTTPExecuteSuccess(t *testing.T) {
 }
 
 func TestHTTPExecutePolls(t *testing.T) {
-	server := testserver.New(t)
+	server := newServer(t)
 	server.HandleSQL("SELECT 1", func(testsql.Request) testsql.Result {
 		return testsql.Result{Rows: [][]string{{"done"}}, Polls: 1}
 	})
@@ -50,7 +60,7 @@ func TestHTTPExecutePolls(t *testing.T) {
 }
 
 func TestHTTPExecutePaginatesChunks(t *testing.T) {
-	server := testserver.New(t)
+	server := newServer(t)
 	server.HandleSQL("SELECT * FROM big", func(testsql.Request) testsql.Result {
 		return testsql.Result{Rows: [][]string{{"0"}, {"1"}, {"2"}}, Chunks: 3}
 	})
@@ -61,7 +71,7 @@ func TestHTTPExecutePaginatesChunks(t *testing.T) {
 }
 
 func TestHTTPExecuteFailedReturns200(t *testing.T) {
-	server := testserver.New(t)
+	server := newServer(t)
 	// A failed statement comes back as HTTP 200 with state=FAILED, not an HTTP
 	// error; the engine must inspect the body and surface a *StatementError.
 	server.HandleSQL("SELECT * FROM nope", func(testsql.Request) testsql.Result {
@@ -78,7 +88,7 @@ func TestHTTPExecuteFailedReturns200(t *testing.T) {
 }
 
 func TestHTTPSubmitAndCancel(t *testing.T) {
-	server := testserver.New(t)
+	server := newServer(t)
 	server.HandleSQL("SELECT 1", func(testsql.Request) testsql.Result {
 		return testsql.Result{}
 	})

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -567,6 +567,17 @@ func AddDefaultHandlers(server *Server) {
 		return MapDelete(req.Workspace, req.Workspace.SqlWarehouses, req.Vars["warehouse_id"])
 	})
 
+	// SQL Statement Execution lifecycle. Tests program these by registering
+	// matchers via Server.HandleSQL / HandleSQLPattern (see statements.go).
+	// They live here, not in New, so they act as overridable defaults: a test
+	// that needs raw control over a SQL endpoint (malformed body, transport
+	// error, custom status) can register its own handler for the same pattern
+	// before calling AddDefaultHandlers, or stub it via test.toml in acceptance.
+	server.Handle("POST", "/api/2.0/sql/statements", server.sqlExecuteStatement)
+	server.Handle("GET", "/api/2.0/sql/statements/{statement_id}", server.sqlGetStatement)
+	server.Handle("GET", "/api/2.0/sql/statements/{statement_id}/result/chunks/{chunk_index}", server.sqlGetStatementResultChunk)
+	server.Handle("POST", "/api/2.0/sql/statements/{statement_id}/cancel", server.sqlCancelStatement)
+
 	server.Handle("GET", "/api/2.0/preview/sql/data_sources", func(req Request) any {
 		return req.Workspace.SqlDataSourcesList(req)
 	})

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/databricks/cli/internal/testutil"
+	"github.com/databricks/cli/libs/testserver/testsql"
 )
 
 const testPidKey = "test-pid"
@@ -48,6 +49,8 @@ type Server struct {
 
 	kills  *killRules
 	faults *FaultRules
+
+	sqlHandler *testsql.Handler
 
 	RequestCallback  func(request *Request)
 	ResponseCallback func(request *Request, response *EncodedResponse)
@@ -228,6 +231,7 @@ func New(t testutil.TestingT) *Server {
 		fakeOidc:       &FakeOidc{url: server.URL},
 		kills:          kills,
 		faults:         faults,
+		sqlHandler:     testsql.New(),
 	}
 	router.Dispatch = s.serve
 
@@ -292,6 +296,14 @@ Response.Body = '<response body here>'
 			"workspace_id":  "900800700600",
 		}
 	})
+
+	// Register the SQL Statement Execution lifecycle endpoints. Tests program
+	// these by registering matchers via Server.HandleSQL / HandleSQLPattern;
+	// see statements.go.
+	s.Handle("POST", "/api/2.0/sql/statements", s.sqlExecuteStatement)
+	s.Handle("GET", "/api/2.0/sql/statements/{statement_id}", s.sqlGetStatement)
+	s.Handle("GET", "/api/2.0/sql/statements/{statement_id}/result/chunks/{chunk_index}", s.sqlGetStatementResultChunk)
+	s.Handle("POST", "/api/2.0/sql/statements/{statement_id}/cancel", s.sqlCancelStatement)
 
 	return s
 }

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -297,14 +297,6 @@ Response.Body = '<response body here>'
 		}
 	})
 
-	// Register the SQL Statement Execution lifecycle endpoints. Tests program
-	// these by registering matchers via Server.HandleSQL / HandleSQLPattern;
-	// see statements.go.
-	s.Handle("POST", "/api/2.0/sql/statements", s.sqlExecuteStatement)
-	s.Handle("GET", "/api/2.0/sql/statements/{statement_id}", s.sqlGetStatement)
-	s.Handle("GET", "/api/2.0/sql/statements/{statement_id}/result/chunks/{chunk_index}", s.sqlGetStatementResultChunk)
-	s.Handle("POST", "/api/2.0/sql/statements/{statement_id}/cancel", s.sqlCancelStatement)
-
 	return s
 }
 

--- a/libs/testserver/statements.go
+++ b/libs/testserver/statements.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 
 	"github.com/databricks/cli/libs/testserver/testsql"
@@ -11,11 +12,15 @@ import (
 )
 
 // HandleSQL registers a matcher that runs fn when a submitted statement equals
-// statement exactly (after trimming). For regex matching with submatches, the
-// underlying engine exposes HandlePattern; a Server-level wrapper will be added
-// alongside its first consumer.
+// statement exactly (after trimming).
 func (s *Server) HandleSQL(statement string, fn func(testsql.Request) testsql.Result) {
 	s.sqlHandler.Handle(statement, fn)
+}
+
+// HandleSQLPattern registers a matcher that runs fn when re matches a submitted
+// statement, passing the submatches through as Request.Match.
+func (s *Server) HandleSQLPattern(re *regexp.Regexp, fn func(testsql.Request) testsql.Result) {
+	s.sqlHandler.HandlePattern(re, fn)
 }
 
 // sqlExecuteStatement handles POST /api/2.0/sql/statements. A statement that

--- a/libs/testserver/statements.go
+++ b/libs/testserver/statements.go
@@ -1,0 +1,64 @@
+package testserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/databricks/cli/libs/testserver/testsql"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+)
+
+// HandleSQL registers a matcher that runs fn when a submitted statement equals
+// statement exactly (after trimming).
+func (s *Server) HandleSQL(statement string, fn func(testsql.Request) testsql.Result) {
+	s.sqlHandler.Handle(statement, fn)
+}
+
+// HandleSQLPattern registers a matcher that runs fn when re matches a submitted
+// statement.
+func (s *Server) HandleSQLPattern(re *regexp.Regexp, fn func(testsql.Request) testsql.Result) {
+	s.sqlHandler.HandlePattern(re, fn)
+}
+
+// sqlExecuteStatement handles POST /api/2.0/sql/statements. A statement that
+// terminates as FAILED comes back as HTTP 200 with state=FAILED; the engine
+// builds that response and this HTTP layer is just transport.
+func (s *Server) sqlExecuteStatement(req Request) any {
+	var r sql.ExecuteStatementRequest
+	if err := json.Unmarshal(req.Body, &r); err != nil {
+		return Response{StatusCode: http.StatusBadRequest, Body: fmt.Sprintf("invalid execute statement request: %s", err)}
+	}
+	return s.sqlHandler.Submit(r.Statement, r.WaitTimeout, r.Parameters)
+}
+
+// sqlGetStatement handles GET /api/2.0/sql/statements/{statement_id}.
+func (s *Server) sqlGetStatement(req Request) any {
+	resp := s.sqlHandler.Get(req.Vars["statement_id"])
+	if resp == nil {
+		return Response{StatusCode: http.StatusNotFound}
+	}
+	return resp
+}
+
+// sqlGetStatementResultChunk handles GET
+// /api/2.0/sql/statements/{statement_id}/result/chunks/{chunk_index}.
+func (s *Server) sqlGetStatementResultChunk(req Request) any {
+	idx, err := strconv.Atoi(req.Vars["chunk_index"])
+	if err != nil {
+		return Response{StatusCode: http.StatusBadRequest, Body: fmt.Sprintf("invalid chunk index: %s", err)}
+	}
+	data := s.sqlHandler.Chunk(req.Vars["statement_id"], idx)
+	if data == nil {
+		return Response{StatusCode: http.StatusNotFound}
+	}
+	return data
+}
+
+// sqlCancelStatement handles POST /api/2.0/sql/statements/{statement_id}/cancel.
+func (s *Server) sqlCancelStatement(req Request) any {
+	s.sqlHandler.Cancel(req.Vars["statement_id"])
+	return map[string]any{}
+}

--- a/libs/testserver/statements.go
+++ b/libs/testserver/statements.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 
 	"github.com/databricks/cli/libs/testserver/testsql"
@@ -12,15 +11,11 @@ import (
 )
 
 // HandleSQL registers a matcher that runs fn when a submitted statement equals
-// statement exactly (after trimming).
+// statement exactly (after trimming). For regex matching with submatches, the
+// underlying engine exposes HandlePattern; a Server-level wrapper will be added
+// alongside its first consumer.
 func (s *Server) HandleSQL(statement string, fn func(testsql.Request) testsql.Result) {
 	s.sqlHandler.Handle(statement, fn)
-}
-
-// HandleSQLPattern registers a matcher that runs fn when re matches a submitted
-// statement.
-func (s *Server) HandleSQLPattern(re *regexp.Regexp, fn func(testsql.Request) testsql.Result) {
-	s.sqlHandler.HandlePattern(re, fn)
 }
 
 // sqlExecuteStatement handles POST /api/2.0/sql/statements. A statement that

--- a/libs/testserver/statements_test.go
+++ b/libs/testserver/statements_test.go
@@ -1,0 +1,51 @@
+package testserver
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/databricks/cli/libs/testserver/testsql"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// submitSQL runs a statement through the POST handler and returns the response.
+func submitSQL(t *testing.T, server *Server, statement string) *sql.StatementResponse {
+	t.Helper()
+	body, err := json.Marshal(sql.ExecuteStatementRequest{Statement: statement, WaitTimeout: "10s"})
+	require.NoError(t, err)
+	resp, ok := server.sqlExecuteStatement(Request{Body: body}).(*sql.StatementResponse)
+	require.True(t, ok)
+	return resp
+}
+
+func TestHandleSQL(t *testing.T) {
+	server := New(t)
+	server.HandleSQL("SELECT 1 AS a", func(r testsql.Request) testsql.Result {
+		assert.Equal(t, []string{"SELECT 1 AS a"}, r.Match)
+		return testsql.Result{Columns: []string{"a"}, Rows: [][]string{{"1"}}}
+	})
+
+	resp := submitSQL(t, server, "SELECT 1 AS a")
+	require.NotNil(t, resp.Status)
+	assert.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
+	require.NotNil(t, resp.Result)
+	assert.Equal(t, [][]string{{"1"}}, resp.Result.DataArray)
+}
+
+func TestHandleSQLPattern(t *testing.T) {
+	server := New(t)
+	// A regex matcher echoes back a captured submatch, exercising both the
+	// HandleSQLPattern registration and Request.Match.
+	server.HandleSQLPattern(regexp.MustCompile(`^SELECT (\d+)$`), func(r testsql.Request) testsql.Result {
+		return testsql.Result{Columns: []string{"n"}, Rows: [][]string{{r.Match[1]}}}
+	})
+
+	resp := submitSQL(t, server, "SELECT 42")
+	require.NotNil(t, resp.Status)
+	assert.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
+	require.NotNil(t, resp.Result)
+	assert.Equal(t, [][]string{{"42"}}, resp.Result.DataArray)
+}

--- a/libs/testserver/testsql/testsql.go
+++ b/libs/testserver/testsql/testsql.go
@@ -77,8 +77,9 @@ type matcher struct {
 type statement struct {
 	id      string
 	columns []string
-	// chunks always has length >= 1; chunk 0 carries the inline data returned
-	// with the terminal response and may be empty.
+	// chunks holds the result split into fetchable chunks. A statement with rows
+	// has at least one chunk (chunk 0 carries the inline data returned with the
+	// terminal response); a statement with no rows has zero chunks.
 	chunks         [][][]string
 	err            *Error
 	remainingPolls int
@@ -252,19 +253,28 @@ func (s *statement) terminalResponse() *sql.StatementResponse {
 		}
 		manifest.Schema = &sql.ResultSchema{Columns: cols}
 	}
+	// A no-row statement reports an empty result (matching the real API, which
+	// returns "result": {} with no data_array); otherwise chunk 0 is inlined.
+	result := &sql.ResultData{}
+	if len(s.chunks) > 0 {
+		result.DataArray = s.chunks[0]
+	}
 	return &sql.StatementResponse{
 		StatementId: s.id,
 		Status:      &sql.StatementStatus{State: sql.StatementStateSucceeded},
 		Manifest:    manifest,
-		Result:      &sql.ResultData{DataArray: s.chunks[0]},
+		Result:      result,
 	}
 }
 
 // splitChunks divides rows into max(1, chunks) chunks as evenly as possible by
-// ceil division. The returned slice always has at least one element so chunk 0
-// always exists (possibly empty); a no-rows DDL result therefore yields
-// TotalChunkCount=1 and an empty inline chunk.
+// ceil division. A statement with no rows yields zero chunks (TotalChunkCount=0
+// and an empty result), matching the real API's response to a 0-row SELECT or a
+// no-result-set DDL statement.
 func splitChunks(rows [][]string, chunks int) [][][]string {
+	if len(rows) == 0 {
+		return nil
+	}
 	n := max(1, chunks)
 	out := make([][][]string, n)
 	size := (len(rows) + n - 1) / n

--- a/libs/testserver/testsql/testsql.go
+++ b/libs/testserver/testsql/testsql.go
@@ -1,0 +1,277 @@
+// Package testsql is a fake of the Databricks SQL Statement Execution API for
+// the testserver. It is NOT a SQL engine: tests register matchers that map a
+// submitted statement to a declarative Result (columns, rows, an optional
+// error, a poll count, and a chunk count). On submit the handler routes the
+// statement to the first matching matcher, runs that matcher exactly once to
+// capture a plan, stores the plan under a deterministic statement ID, and then
+// replays it across the statement lifecycle (poll -> chunk pagination ->
+// cancel).
+//
+// Because the matcher runs only once per Submit, a matcher may close over
+// mutable state (e.g. a map) and have its side effects persist across
+// statements, which lets tests model stateful resources (create then read
+// back) without a real backend.
+package testsql
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/databricks/databricks-sdk-go/service/sql"
+)
+
+// asyncWaitTimeout is the WaitTimeout value that callers send to submit a
+// statement asynchronously. The real API returns immediately with state
+// PENDING in this case so the caller can wire up cancellation before the
+// statement finishes, so the fake mirrors that and never returns a terminal
+// state for "0s" regardless of the matcher's poll count.
+const asyncWaitTimeout = "0s"
+
+// Request is what a matcher sees for one submitted statement.
+type Request struct {
+	// Statement is the trimmed statement text.
+	Statement string
+	// Match holds regex submatches for a HandlePattern matcher; for an exact
+	// Handle matcher it is []string{Statement}.
+	Match []string
+	// Parameters are the bound :name parameters from the submit request.
+	Parameters []sql.StatementParameterListItem
+}
+
+// Result is the declarative plan a matcher returns. The zero value is a
+// terminal SUCCEEDED statement with no columns and no rows in a single inline
+// chunk.
+type Result struct {
+	Columns []string
+	Rows    [][]string
+	// Error, when non-nil, makes the statement terminate as FAILED (which the
+	// real API reports over HTTP 200, not an HTTP error).
+	Error *Error
+	// Polls is the number of non-terminal GET responses returned before the
+	// statement reaches a terminal state.
+	Polls int
+	// Chunks splits Rows across this many chunk fetches. 0 or 1 means a single
+	// inline chunk.
+	Chunks int
+}
+
+// Error describes a terminal FAILED statement.
+type Error struct {
+	Code     sql.ServiceErrorCode
+	Message  string
+	SQLState string
+}
+
+// matcher pairs a predicate against a statement with the plan-producing fn.
+type matcher struct {
+	// match returns the submatches to pass to fn, or nil when the statement
+	// does not match this matcher.
+	match func(stmt string) []string
+	fn    func(Request) Result
+}
+
+// statement is the captured plan for one submitted statement, replayed across
+// its lifecycle.
+type statement struct {
+	id      string
+	columns []string
+	// chunks always has length >= 1; chunk 0 carries the inline data returned
+	// with the terminal response and may be empty.
+	chunks         [][][]string
+	err            *Error
+	remainingPolls int
+	canceled       bool
+}
+
+// Handler routes submitted statements to matchers and replays their captured
+// plans across the statement lifecycle.
+type Handler struct {
+	mu         sync.Mutex
+	matchers   []matcher
+	statements map[string]*statement
+	nextID     int
+}
+
+// New returns a Handler with no matchers registered.
+func New() *Handler {
+	return &Handler{statements: map[string]*statement{}}
+}
+
+// Handle registers a matcher that runs fn when a submitted statement equals
+// statement exactly (after trimming). The first registered matching matcher
+// wins. The matcher's Request.Match is []string{statement}.
+func (h *Handler) Handle(statement string, fn func(Request) Result) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.matchers = append(h.matchers, matcher{
+		match: func(stmt string) []string {
+			if stmt == statement {
+				return []string{stmt}
+			}
+			return nil
+		},
+		fn: fn,
+	})
+}
+
+// HandlePattern registers a matcher that runs fn when re matches a submitted
+// statement. The first registered matching matcher wins. The matcher's
+// Request.Match is re.FindStringSubmatch(stmt).
+func (h *Handler) HandlePattern(re *regexp.Regexp, fn func(Request) Result) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.matchers = append(h.matchers, matcher{
+		match: func(stmt string) []string {
+			return re.FindStringSubmatch(stmt)
+		},
+		fn: fn,
+	})
+}
+
+// Submit matches the statement, runs the matcher once to capture its plan,
+// stores it under a new deterministic ID ("statement-1", "statement-2", ...),
+// and returns the first lifecycle response. A "0s" wait timeout always yields
+// PENDING; otherwise the response is terminal when the plan has no remaining
+// polls and PENDING otherwise.
+func (h *Handler) Submit(statement, waitTimeout string, params []sql.StatementParameterListItem) *sql.StatementResponse {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	stmt := h.plan(strings.TrimSpace(statement), params)
+	h.nextID++
+	stmt.id = fmt.Sprintf("statement-%d", h.nextID)
+	h.statements[stmt.id] = stmt
+
+	if waitTimeout == asyncWaitTimeout || stmt.remainingPolls > 0 {
+		return &sql.StatementResponse{
+			StatementId: stmt.id,
+			Status:      &sql.StatementStatus{State: sql.StatementStatePending},
+		}
+	}
+	return stmt.terminalResponse()
+}
+
+// Get returns the current state of the statement. A canceled statement reports
+// CANCELED (this takes precedence over remaining polls). Otherwise a statement
+// with remaining polls decrements its counter and reports RUNNING; a statement
+// with no remaining polls reports its terminal state with manifest and chunk 0.
+// An unknown id returns nil.
+func (h *Handler) Get(statementID string) *sql.StatementResponse {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	stmt := h.statements[statementID]
+	if stmt == nil {
+		return nil
+	}
+	if stmt.canceled {
+		return &sql.StatementResponse{
+			StatementId: stmt.id,
+			Status:      &sql.StatementStatus{State: sql.StatementStateCanceled},
+		}
+	}
+	if stmt.remainingPolls > 0 {
+		stmt.remainingPolls--
+		return &sql.StatementResponse{
+			StatementId: stmt.id,
+			Status:      &sql.StatementStatus{State: sql.StatementStateRunning},
+		}
+	}
+	return stmt.terminalResponse()
+}
+
+// Chunk returns the rows of chunk chunkIndex for the statement. An unknown id
+// or out-of-range index returns nil.
+func (h *Handler) Chunk(statementID string, chunkIndex int) *sql.ResultData {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	stmt := h.statements[statementID]
+	if stmt == nil || chunkIndex < 0 || chunkIndex >= len(stmt.chunks) {
+		return nil
+	}
+	return &sql.ResultData{DataArray: stmt.chunks[chunkIndex]}
+}
+
+// Cancel marks the statement canceled. An unknown id is a no-op.
+func (h *Handler) Cancel(statementID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if stmt := h.statements[statementID]; stmt != nil {
+		stmt.canceled = true
+	}
+}
+
+// plan runs the first matching matcher once and turns its Result into a stored
+// statement. With no matching matcher the statement terminates as FAILED with
+// an "unsupported statement" error, mirroring how the real backend rejects a
+// statement it cannot run.
+func (h *Handler) plan(stmt string, params []sql.StatementParameterListItem) *statement {
+	res := Result{Error: &Error{
+		Code:    sql.ServiceErrorCodeBadRequest,
+		Message: "unsupported statement: " + stmt,
+	}}
+	for _, m := range h.matchers {
+		groups := m.match(stmt)
+		if groups == nil {
+			continue
+		}
+		res = m.fn(Request{Statement: stmt, Match: groups, Parameters: params})
+		break
+	}
+	return &statement{
+		columns:        res.Columns,
+		chunks:         splitChunks(res.Rows, res.Chunks),
+		err:            res.Error,
+		remainingPolls: res.Polls,
+	}
+}
+
+// terminalResponse builds the terminal response for a statement: FAILED when it
+// carries an error, otherwise SUCCEEDED with the manifest and inline chunk 0.
+func (s *statement) terminalResponse() *sql.StatementResponse {
+	if s.err != nil {
+		return &sql.StatementResponse{
+			StatementId: s.id,
+			Status: &sql.StatementStatus{
+				State:    sql.StatementStateFailed,
+				SqlState: s.err.SQLState,
+				Error:    &sql.ServiceError{ErrorCode: s.err.Code, Message: s.err.Message},
+			},
+		}
+	}
+
+	manifest := &sql.ResultManifest{TotalChunkCount: len(s.chunks)}
+	if len(s.columns) > 0 {
+		cols := make([]sql.ColumnInfo, len(s.columns))
+		for i, name := range s.columns {
+			cols[i] = sql.ColumnInfo{Name: name}
+		}
+		manifest.Schema = &sql.ResultSchema{Columns: cols}
+	}
+	return &sql.StatementResponse{
+		StatementId: s.id,
+		Status:      &sql.StatementStatus{State: sql.StatementStateSucceeded},
+		Manifest:    manifest,
+		Result:      &sql.ResultData{DataArray: s.chunks[0]},
+	}
+}
+
+// splitChunks divides rows into max(1, chunks) chunks as evenly as possible by
+// ceil division. The returned slice always has at least one element so chunk 0
+// always exists (possibly empty); a no-rows DDL result therefore yields
+// TotalChunkCount=1 and an empty inline chunk.
+func splitChunks(rows [][]string, chunks int) [][][]string {
+	n := max(1, chunks)
+	out := make([][][]string, n)
+	size := (len(rows) + n - 1) / n
+	for i := range n {
+		start := min(i*size, len(rows))
+		end := min(start+size, len(rows))
+		out[i] = rows[start:end]
+	}
+	return out
+}

--- a/libs/testserver/testsql/testsql_test.go
+++ b/libs/testserver/testsql/testsql_test.go
@@ -1,0 +1,237 @@
+package testsql_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/databricks/cli/libs/testserver/testsql"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExactDispatch(t *testing.T) {
+	e := testsql.New()
+	var seen testsql.Request
+	e.Handle("SELECT 1", func(r testsql.Request) testsql.Result {
+		seen = r
+		return testsql.Result{Columns: []string{"a"}, Rows: [][]string{{"1"}}}
+	})
+
+	// Statement is trimmed before matching.
+	resp := e.Submit("  SELECT 1  ", "10s", nil)
+	require.NotNil(t, resp.Status)
+	assert.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
+	assert.Equal(t, "SELECT 1", seen.Statement)
+	assert.Equal(t, []string{"SELECT 1"}, seen.Match)
+	assert.Equal(t, []string{"a"}, columnNames(resp))
+	assert.Equal(t, [][]string{{"1"}}, resp.Result.DataArray)
+}
+
+func TestPatternDispatchSubmatches(t *testing.T) {
+	e := testsql.New()
+	re := regexp.MustCompile(`^CREATE TABLE (\w+)$`)
+	var seen testsql.Request
+	e.HandlePattern(re, func(r testsql.Request) testsql.Result {
+		seen = r
+		return testsql.Result{}
+	})
+
+	resp := e.Submit("CREATE TABLE foo", "10s", nil)
+	assert.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
+	assert.Equal(t, []string{"CREATE TABLE foo", "foo"}, seen.Match)
+}
+
+func TestFirstMatchWins(t *testing.T) {
+	e := testsql.New()
+	e.HandlePattern(regexp.MustCompile(`SELECT`), func(testsql.Request) testsql.Result {
+		return testsql.Result{Columns: []string{"first"}}
+	})
+	e.Handle("SELECT 1", func(testsql.Request) testsql.Result {
+		return testsql.Result{Columns: []string{"second"}}
+	})
+
+	resp := e.Submit("SELECT 1", "10s", nil)
+	assert.Equal(t, []string{"first"}, columnNames(resp))
+}
+
+func TestUnsupportedStatement(t *testing.T) {
+	e := testsql.New()
+	resp := e.Submit("SELECT 1", "10s", nil)
+	require.NotNil(t, resp.Status)
+	assert.Equal(t, sql.StatementStateFailed, resp.Status.State)
+	require.NotNil(t, resp.Status.Error)
+	assert.Equal(t, sql.ServiceErrorCodeBadRequest, resp.Status.Error.ErrorCode)
+	assert.Contains(t, resp.Status.Error.Message, "unsupported statement")
+	assert.Contains(t, resp.Status.Error.Message, "SELECT 1")
+}
+
+func TestWaitTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		waitTimeout string
+		want        sql.StatementState
+	}{
+		{"async stays pending even without polls", "0s", sql.StatementStatePending},
+		{"sync with no polls terminates", "10s", sql.StatementStateSucceeded},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := testsql.New()
+			e.Handle("SELECT 1", func(testsql.Request) testsql.Result {
+				return testsql.Result{Rows: [][]string{{"x"}}}
+			})
+			resp := e.Submit("SELECT 1", tc.waitTimeout, nil)
+			assert.Equal(t, tc.want, resp.Status.State)
+		})
+	}
+}
+
+func TestPollCountdown(t *testing.T) {
+	e := testsql.New()
+	e.Handle("SELECT 1", func(testsql.Request) testsql.Result {
+		return testsql.Result{Rows: [][]string{{"done"}}, Polls: 2}
+	})
+
+	resp := e.Submit("SELECT 1", "10s", nil)
+	require.Equal(t, sql.StatementStatePending, resp.Status.State)
+
+	got := e.Get(resp.StatementId)
+	assert.Equal(t, sql.StatementStateRunning, got.Status.State)
+	got = e.Get(resp.StatementId)
+	assert.Equal(t, sql.StatementStateRunning, got.Status.State)
+
+	got = e.Get(resp.StatementId)
+	require.Equal(t, sql.StatementStateSucceeded, got.Status.State)
+	assert.Equal(t, [][]string{{"done"}}, got.Result.DataArray)
+}
+
+func TestChunkSplitting(t *testing.T) {
+	e := testsql.New()
+	rows := [][]string{{"0"}, {"1"}, {"2"}}
+	e.Handle("SELECT * FROM big", func(testsql.Request) testsql.Result {
+		return testsql.Result{Rows: rows, Chunks: 3}
+	})
+
+	resp := e.Submit("SELECT * FROM big", "10s", nil)
+	require.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
+	require.NotNil(t, resp.Manifest)
+	assert.Equal(t, 3, resp.Manifest.TotalChunkCount)
+
+	var all [][]string
+	all = append(all, resp.Result.DataArray...)
+	for i := 1; i < resp.Manifest.TotalChunkCount; i++ {
+		chunk := e.Chunk(resp.StatementId, i)
+		require.NotNil(t, chunk)
+		all = append(all, chunk.DataArray...)
+	}
+	assert.Equal(t, rows, all)
+	assert.Equal(t, [][]string{{"0"}}, resp.Result.DataArray)
+	assert.Equal(t, [][]string{{"1"}}, e.Chunk(resp.StatementId, 1).DataArray)
+	assert.Equal(t, [][]string{{"2"}}, e.Chunk(resp.StatementId, 2).DataArray)
+}
+
+func TestNoRowsSingleChunk(t *testing.T) {
+	e := testsql.New()
+	e.Handle("CREATE TABLE foo", func(testsql.Request) testsql.Result {
+		return testsql.Result{}
+	})
+
+	resp := e.Submit("CREATE TABLE foo", "10s", nil)
+	require.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
+	require.NotNil(t, resp.Manifest)
+	assert.Equal(t, 1, resp.Manifest.TotalChunkCount)
+	assert.Nil(t, resp.Manifest.Schema)
+	assert.Empty(t, resp.Result.DataArray)
+}
+
+func TestErrorResult(t *testing.T) {
+	e := testsql.New()
+	e.Handle("SELECT 1", func(testsql.Request) testsql.Result {
+		return testsql.Result{Error: &testsql.Error{
+			Code:     sql.ServiceErrorCodeBadRequest,
+			Message:  "no such table",
+			SQLState: "42P01",
+		}}
+	})
+
+	resp := e.Submit("SELECT 1", "10s", nil)
+	require.Equal(t, sql.StatementStateFailed, resp.Status.State)
+	assert.Equal(t, "42P01", resp.Status.SqlState)
+	require.NotNil(t, resp.Status.Error)
+	assert.Equal(t, sql.ServiceErrorCodeBadRequest, resp.Status.Error.ErrorCode)
+	assert.Equal(t, "no such table", resp.Status.Error.Message)
+	assert.Nil(t, resp.Manifest)
+	assert.Nil(t, resp.Result)
+}
+
+func TestCancelPrecedence(t *testing.T) {
+	e := testsql.New()
+	e.Handle("SELECT 1", func(testsql.Request) testsql.Result {
+		return testsql.Result{Polls: 5}
+	})
+
+	resp := e.Submit("SELECT 1", "0s", nil)
+	require.Equal(t, sql.StatementStatePending, resp.Status.State)
+
+	e.Cancel(resp.StatementId)
+
+	// Cancel takes precedence over the remaining polls.
+	got := e.Get(resp.StatementId)
+	assert.Equal(t, sql.StatementStateCanceled, got.Status.State)
+	assert.Nil(t, got.Manifest)
+	assert.Nil(t, got.Result)
+}
+
+func TestUnknownStatement(t *testing.T) {
+	e := testsql.New()
+	assert.Nil(t, e.Get("statement-99"))
+	assert.Nil(t, e.Chunk("statement-99", 0))
+	e.Cancel("statement-99") // no-op, must not panic
+}
+
+func TestDeterministicIDs(t *testing.T) {
+	e := testsql.New()
+	e.Handle("SELECT 1", func(testsql.Request) testsql.Result { return testsql.Result{} })
+	assert.Equal(t, "statement-1", e.Submit("SELECT 1", "10s", nil).StatementId)
+	assert.Equal(t, "statement-2", e.Submit("SELECT 1", "10s", nil).StatementId)
+}
+
+// TestStatefulMatcher proves the matcher runs exactly once per Submit and that
+// side effects persist across statements: a create matcher stores a body keyed
+// by a regex submatch, and a separate select matcher reads it back.
+func TestStatefulMatcher(t *testing.T) {
+	e := testsql.New()
+	store := map[string]string{}
+	calls := 0
+
+	e.HandlePattern(regexp.MustCompile(`^CREATE (\w+) AS (.+)$`), func(r testsql.Request) testsql.Result {
+		calls++
+		store[r.Match[1]] = r.Match[2]
+		return testsql.Result{}
+	})
+	e.HandlePattern(regexp.MustCompile(`^READ (\w+)$`), func(r testsql.Request) testsql.Result {
+		return testsql.Result{Columns: []string{"def"}, Rows: [][]string{{store[r.Match[1]]}}}
+	})
+
+	create := e.Submit("CREATE v AS body", "10s", nil)
+	require.Equal(t, sql.StatementStateSucceeded, create.Status.State)
+	assert.Equal(t, 1, calls, "matcher must run exactly once per Submit")
+
+	read := e.Submit("READ v", "10s", nil)
+	require.Equal(t, sql.StatementStateSucceeded, read.Status.State)
+	assert.Equal(t, [][]string{{"body"}}, read.Result.DataArray)
+	assert.Equal(t, 1, calls, "create matcher must not run again")
+}
+
+// columnNames mirrors how libs/sqlexec reads column names off the manifest.
+func columnNames(resp *sql.StatementResponse) []string {
+	if resp.Manifest == nil || resp.Manifest.Schema == nil {
+		return nil
+	}
+	out := make([]string, len(resp.Manifest.Schema.Columns))
+	for i, c := range resp.Manifest.Schema.Columns {
+		out[i] = c.Name
+	}
+	return out
+}

--- a/libs/testserver/testsql/testsql_test.go
+++ b/libs/testserver/testsql/testsql_test.go
@@ -131,17 +131,20 @@ func TestChunkSplitting(t *testing.T) {
 	assert.Equal(t, [][]string{{"2"}}, e.Chunk(resp.StatementId, 2).DataArray)
 }
 
-func TestNoRowsSingleChunk(t *testing.T) {
+func TestNoRowsZeroChunks(t *testing.T) {
 	e := testsql.New()
 	e.Handle("CREATE TABLE foo", func(testsql.Request) testsql.Result {
 		return testsql.Result{}
 	})
 
+	// A no-row statement reports zero chunks and an empty result, matching the
+	// real API (a 0-row SELECT or a no-result-set DDL returns total_chunk_count=0).
 	resp := e.Submit("CREATE TABLE foo", "10s", nil)
 	require.Equal(t, sql.StatementStateSucceeded, resp.Status.State)
 	require.NotNil(t, resp.Manifest)
-	assert.Equal(t, 1, resp.Manifest.TotalChunkCount)
+	assert.Equal(t, 0, resp.Manifest.TotalChunkCount)
 	assert.Nil(t, resp.Manifest.Schema)
+	require.NotNil(t, resp.Result)
 	assert.Empty(t, resp.Result.DataArray)
 }
 


### PR DESCRIPTION
## Summary

Adds `libs/testserver/testsql`, a pluggable fake of the SQL Statement Execution API, so tests can drive `/api/2.0/sql/statements` natively instead of hand-building `StatementResponse` stubs.

Tests register matchers via `Server.HandleSQL` (exact) / `Server.HandleSQLPattern` (regex), each mapping a statement to a declarative result — columns, rows, an optional error, a poll count, and a chunk count. The testserver models the full lifecycle over the real HTTP endpoints: submit (honoring `wait_timeout`), poll, chunk pagination, and cancel. A matcher runs once per submission, so a matcher that closes over a map can model stateful resources (create then read back).

The lifecycle routes are registered in `AddDefaultHandlers` as overridable defaults: a raw `Server.Handle` for the same pattern registered before `AddDefaultHandlers` wins, as do `test.toml` stubs in acceptance — preserving an escape hatch for responses the fake doesn't model (malformed bodies, transport errors, custom status codes).

The `libs/sqlexec` HTTP tests are migrated onto the fake, replacing per-test `StatementResponse` construction with one-line matchers.

## Cross-check against the real API

Behaviors were verified against a live SQL warehouse, which drove three refinements:

- A no-row statement (0-row `SELECT` or no-result-set DDL) reports `total_chunk_count: 0` with an empty result; the fake now matches (previously it always emitted one empty chunk).
- `status.sql_state` is populated on failures (e.g. `42P01`); added an assertion to the failed-statement integration test so the typed `StatementError.SQLState` contract is covered.
- Documented on `Result.Rows` that SQL `NULL` and empty string are indistinguishable there: the wire format encodes `NULL` as JSON `null`, but the SDK models cells as `[][]string`, so `null` decodes to `""`. Recovering the distinction would need a null-aware cell type or the `ARROW_STREAM` format; no caller needs it today.

## Test plan

- `sqlexec` integration suite passes live (`TestSQLExec*`, incl. the new `SQLState` assertion).

This pull request and its description were written by Isaac.
