### PR TITLE
bundle/dms: record display_name on the deployment version

### DIFF
--- a/acceptance/bundle/dms/add-resources/output.txt
+++ b/acceptance/bundle/dms/add-resources/output.txt
@@ -56,6 +56,7 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "add-resources-test",
     "target_name": "default",
     "git_info": {}
   }
@@ -69,6 +70,7 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "add-resources-test",
     "target_name": "default",
     "git_info": {}
   }

--- a/acceptance/bundle/dms/deploy-error/output.txt
+++ b/acceptance/bundle/dms/deploy-error/output.txt
@@ -31,6 +31,7 @@ API message: Invalid job configuration.
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "metadata-service-error-test",
     "target_name": "default",
     "git_info": {}
   }

--- a/acceptance/bundle/dms/plan-and-summary/output.txt
+++ b/acceptance/bundle/dms/plan-and-summary/output.txt
@@ -42,6 +42,7 @@ Resources:
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "plan-summary-test",
     "target_name": "default",
     "git_info": {}
   }

--- a/acceptance/bundle/dms/release-lock-error/output.txt
+++ b/acceptance/bundle/dms/release-lock-error/output.txt
@@ -26,6 +26,7 @@ Warn: Failed to release deployment lock: simulated complete version failure
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "dms-release-lock-error",
     "target_name": "fail-complete",
     "git_info": {}
   }

--- a/acceptance/bundle/dms/sequential-deploys/output.txt
+++ b/acceptance/bundle/dms/sequential-deploys/output.txt
@@ -25,6 +25,7 @@ Deployment complete!
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "sequential-deploys-test",
     "target_name": "default",
     "git_info": {}
   }
@@ -93,6 +94,7 @@ Deployment complete!
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "sequential-deploys-test",
     "target_name": "default",
     "git_info": {}
   }
@@ -161,6 +163,7 @@ Deployment complete!
   "body": {
     "cli_version": "[DEV_VERSION]",
     "version_type": "VERSION_TYPE_DEPLOY",
+    "display_name": "sequential-deploys-test",
     "target_name": "default",
     "git_info": {}
   }

--- a/bundle/deploy/lock/deployment_metadata_service.go
+++ b/bundle/deploy/lock/deployment_metadata_service.go
@@ -153,6 +153,7 @@ func acquireLock(ctx context.Context, b *bundle.Bundle, svc *tmpdms.DeploymentMe
 		Parent:       "deployments/" + deploymentID,
 		VersionID:    versionID,
 		Version: &tmpdms.Version{
+			DisplayName: b.Config.Bundle.Name,
 			CliVersion:  build.GetInfo().Version,
 			VersionType: versionType,
 			TargetName:  b.Config.Bundle.Target,


### PR DESCRIPTION
## Changes
Set `display_name` on the DMS deployment version, using the bundle name — the same value already recorded on the deployment.

The `Version` proto has a `display_name` field, but the `CreateVersion` request never populated it, so every version came back with a null `display_name` even though the deployment had one. This stamps it for parity.

## Why
`display_name` is set on the deployment (from the bundle name) but was missing on each version, leaving version records without a human-readable label. Filling it in keeps deployment and version metadata consistent.

## Tests
Updated the `bundle/dms` acceptance outputs and confirmed they pass.

This pull request and its description were written by Isaac, an AI coding agent.
