### PR TITLE
bundle: record auto-migration compatibility telemetry on deploy

### DIFF
--- a/acceptance/bundle/resource_deps/job_tasks/out.telemetry.direct.txt
+++ b/acceptance/bundle/resource_deps/job_tasks/out.telemetry.direct.txt
@@ -1,3 +1,4 @@
+dms_compat_auto true
 experimental.use_legacy_run_as false
 has_classic_interactive_compute false
 has_classic_job_compute false
@@ -8,3 +9,4 @@ presets_name_prefix_is_set false
 python_wheel_wrapper_is_set false
 run_as_set false
 skip_artifact_cleanup false
+state_path_is_shared false

--- a/acceptance/bundle/resource_deps/job_tasks/out.telemetry.terraform.txt
+++ b/acceptance/bundle/resource_deps/job_tasks/out.telemetry.terraform.txt
@@ -1,3 +1,4 @@
+dms_compat_auto true
 experimental.use_legacy_run_as false
 has_classic_interactive_compute false
 has_classic_job_compute false
@@ -8,3 +9,4 @@ presets_name_prefix_is_set false
 python_wheel_wrapper_is_set false
 run_as_set false
 skip_artifact_cleanup false
+state_path_is_shared false

--- a/acceptance/bundle/resource_deps/resources_var/output.txt
+++ b/acceptance/bundle/resource_deps/resources_var/output.txt
@@ -36,6 +36,7 @@
 "[dev [USERNAME]] pipeline for mycatalog.myschema.myname"
 
 >>> print_telemetry_bool_values
+dms_compat_auto true
 experimental.use_legacy_run_as false
 has_classic_interactive_compute false
 has_classic_job_compute false
@@ -46,3 +47,4 @@ presets_name_prefix_is_set true
 python_wheel_wrapper_is_set false
 run_as_set false
 skip_artifact_cleanup false
+state_path_is_shared false

--- a/acceptance/bundle/resource_deps/tf_path_only_error/out.telemetry.terraform.txt
+++ b/acceptance/bundle/resource_deps/tf_path_only_error/out.telemetry.terraform.txt
@@ -1,3 +1,4 @@
+dms_compat_auto true
 experimental.use_legacy_run_as false
 has_classic_interactive_compute false
 has_classic_job_compute false
@@ -9,3 +10,4 @@ presets_name_prefix_is_set false
 python_wheel_wrapper_is_set false
 run_as_set false
 skip_artifact_cleanup false
+state_path_is_shared false

--- a/acceptance/bundle/telemetry/deploy-app-lifecycle-started/output.txt
+++ b/acceptance/bundle/telemetry/deploy-app-lifecycle-started/output.txt
@@ -38,6 +38,14 @@ Deployment complete!
       "value": false
     },
     {
+      "key": "state_path_is_shared",
+      "value": false
+    },
+    {
+      "key": "dms_compat_auto",
+      "value": true
+    },
+    {
       "key": "has_serverless_compute",
       "value": false
     },

--- a/acceptance/bundle/telemetry/deploy-compute-type/output.txt
+++ b/acceptance/bundle/telemetry/deploy-compute-type/output.txt
@@ -42,6 +42,14 @@ Deployment complete!
     "value": false
   },
   {
+    "key": "state_path_is_shared",
+    "value": false
+  },
+  {
+    "key": "dms_compat_auto",
+    "value": true
+  },
+  {
     "key": "has_serverless_compute",
     "value": true
   },
@@ -82,6 +90,14 @@ Deployment complete!
   {
     "key": "skip_artifact_cleanup",
     "value": false
+  },
+  {
+    "key": "state_path_is_shared",
+    "value": false
+  },
+  {
+    "key": "dms_compat_auto",
+    "value": true
   },
   {
     "key": "has_serverless_compute",

--- a/acceptance/bundle/telemetry/deploy-experimental/output.txt
+++ b/acceptance/bundle/telemetry/deploy-experimental/output.txt
@@ -41,6 +41,14 @@ Deployment complete!
       "value": false
     },
     {
+      "key": "state_path_is_shared",
+      "value": false
+    },
+    {
+      "key": "dms_compat_auto",
+      "value": true
+    },
+    {
       "key": "has_serverless_compute",
       "value": false
     },

--- a/acceptance/bundle/telemetry/deploy-name-prefix/custom/output.txt
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/custom/output.txt
@@ -37,6 +37,14 @@ Deployment complete!
       "value": false
     },
     {
+      "key": "state_path_is_shared",
+      "value": false
+    },
+    {
+      "key": "dms_compat_auto",
+      "value": true
+    },
+    {
       "key": "has_serverless_compute",
       "value": false
     },

--- a/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/output.txt
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/output.txt
@@ -37,6 +37,14 @@ Deployment complete!
       "value": false
     },
     {
+      "key": "state_path_is_shared",
+      "value": false
+    },
+    {
+      "key": "dms_compat_auto",
+      "value": true
+    },
+    {
       "key": "has_serverless_compute",
       "value": false
     },

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/output.txt
@@ -41,6 +41,14 @@ Deployment complete!
       "value": false
     },
     {
+      "key": "state_path_is_shared",
+      "value": false
+    },
+    {
+      "key": "dms_compat_auto",
+      "value": true
+    },
+    {
       "key": "has_serverless_compute",
       "value": false
     },
@@ -82,6 +90,14 @@ Deployment complete!
     },
     {
       "key": "skip_artifact_cleanup",
+      "value": true
+    },
+    {
+      "key": "state_path_is_shared",
+      "value": false
+    },
+    {
+      "key": "dms_compat_auto",
       "value": true
     },
     {

--- a/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/databricks.yml
+++ b/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/databricks.yml
@@ -1,0 +1,41 @@
+bundle:
+  name: test-bundle
+
+# The deploying user is tester@databricks.com. A workspace folder under
+# /Workspace/Users/<owner> grants <owner> CAN_MANAGE, which the deploy observes as
+# inherited access in the SetPermissions response.
+targets:
+  # No permissions section: the migration mirrors the state folder's ACLs onto the
+  # deployment, so access is preserved wherever the state lives.
+  no_permissions:
+    default: true
+
+  # The deploying user (the home owner of the state folder) is declared.
+  user_declared:
+    permissions:
+      - user_name: ${workspace.current_user.userName}
+        level: CAN_MANAGE
+
+  # The deploying user (the home owner, with inherited CAN_MANAGE) is the only
+  # undeclared writer, so the migration could preserve them by granting the deployer.
+  user_not_declared:
+    permissions:
+      - group_name: team
+        level: CAN_MANAGE
+
+  # A shared state folder is writable by all workspace users; that access is declared
+  # via group_name: users CAN_MANAGE.
+  shared_users_can_manage:
+    permissions:
+      - group_name: users
+        level: CAN_MANAGE
+    workspace:
+      state_path: /Workspace/Shared/test-bundle-state
+
+  # A shared state folder without group_name: users CAN_MANAGE declared.
+  shared_not_declared:
+    permissions:
+      - user_name: ${workspace.current_user.userName}
+        level: CAN_MANAGE
+    workspace:
+      state_path: /Workspace/Shared/test-bundle-state

--- a/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/output.txt
+++ b/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/output.txt
@@ -1,0 +1,69 @@
+
+>>> [CLI] bundle deploy -t no_permissions
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/no_permissions/files...
+Deploying resources...
+Deployment complete!
+
+>>> print_telemetry_bool_values
+dms_compat_auto true
+state_path_is_shared false
+
+>>> [CLI] bundle deploy -t user_declared
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/user_declared/files...
+Deploying resources...
+Deployment complete!
+
+>>> print_telemetry_bool_values
+dms_compat_auto true
+state_path_is_shared false
+
+>>> [CLI] bundle deploy -t user_not_declared
+Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
+If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
+
+Consider using a adding a top-level permissions section such as the following:
+
+  permissions:
+    - user_name: [USERNAME]
+      level: CAN_MANAGE
+
+See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
+  in databricks.yml:23:7
+
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/user_not_declared/files...
+Deploying resources...
+Deployment complete!
+
+>>> print_telemetry_bool_values
+dms_compat_only_self_undeclared true
+state_path_is_shared false
+
+>>> [CLI] bundle deploy -t shared_users_can_manage
+Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
+If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
+
+Consider using a adding a top-level permissions section such as the following:
+
+  permissions:
+    - user_name: [USERNAME]
+      level: CAN_MANAGE
+
+See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
+  in databricks.yml:30:7
+
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/shared_users_can_manage/files...
+Deploying resources...
+Deployment complete!
+
+>>> print_telemetry_bool_values
+dms_compat_auto true
+state_path_is_shared true
+
+>>> [CLI] bundle deploy -t shared_not_declared
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/shared_not_declared/files...
+Deploying resources...
+Deployment complete!
+
+>>> print_telemetry_bool_values
+dms_compat_not true
+state_path_is_shared true

--- a/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/script
+++ b/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/script
@@ -1,0 +1,10 @@
+for target in \
+	no_permissions \
+	user_declared \
+	user_not_declared \
+	shared_users_can_manage \
+	shared_not_declared; do
+	trace $CLI bundle deploy -t "$target"
+	trace print_telemetry_bool_values | grep -E "state_path|dms_compat"
+	rm out.requests.txt
+done

--- a/acceptance/bundle/telemetry/deploy/out.telemetry.txt
+++ b/acceptance/bundle/telemetry/deploy/out.telemetry.txt
@@ -71,6 +71,14 @@
               "value": false
             },
             {
+              "key": "state_path_is_shared",
+              "value": false
+            },
+            {
+              "key": "dms_compat_auto",
+              "value": true
+            },
+            {
               "key": "has_serverless_compute",
               "value": false
             },

--- a/bundle/config/resources/permission.go
+++ b/bundle/config/resources/permission.go
@@ -32,6 +32,12 @@ func (p PermissionT[L]) String() string {
 	return "level: " + string(p.Level)
 }
 
+// CAN_EDIT is the workspace folder ACL level marking write access. It is not a valid
+// bundle permission level (those are CAN_MANAGE / CAN_VIEW / CAN_RUN, defined in the
+// permissions package), but permission checks rank against it via GetLevelScore, so it
+// is named here next to the level ordering it keys into.
+const CAN_EDIT = "CAN_EDIT"
+
 // PermissionOrder defines the hierarchy of permission levels.
 // Higher numbers mean more permissive access.
 // Based on https://docs.databricks.com/aws/en/security/auth/access-control

--- a/bundle/config/validate/folder_permissions.go
+++ b/bundle/config/validate/folder_permissions.go
@@ -23,7 +23,7 @@ func (f *folderPermissions) Apply(ctx context.Context, b *bundle.Bundle) diag.Di
 		return nil
 	}
 
-	bundlePaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config.Workspace)
+	bundlePaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config.Workspace).Paths
 
 	var diags diag.Diagnostics
 	g, ctx := errgroup.WithContext(ctx)

--- a/bundle/metrics/metrics.go
+++ b/bundle/metrics/metrics.go
@@ -10,4 +10,33 @@ const (
 	ClusterLifecycleStarted             = "cluster_lifecycle_started"
 	SqlWarehouseLifecycleStarted        = "sql_warehouse_lifecycle_started"
 	SelectUsed                          = "select_used"
+
+	// Whether workspace.state_path is under /Workspace/Shared.
+	StatePathIsShared = "state_path_is_shared"
+
+	// Whether this deploy is compatible with an automatic migration of the deployment
+	// state to a dedicated state storage service (DMS). Deploying a bundle requires
+	// write access (CAN_EDIT or higher) to the state folder; after migration that is
+	// governed by the permissions on the deployment object instead.
+	//
+	// When the bundle has no permissions section, the migration can mirror the state
+	// folder's ACLs onto the deployment (CAN_EDIT -> CAN_EDIT, CAN_MANAGE ->
+	// CAN_MANAGE), preserving everyone's access wherever the state lives. When a
+	// permissions section is set, the migration applies exactly those permissions, so
+	// anyone with write access to the state folder who is not declared with
+	// CAN_MANAGE would lose the ability to deploy.
+	//
+	// Exactly one of the three keys below is recorded per deploy:
+	//   - auto: no permissions section (folder ACLs are mirrored), or every principal
+	//           with write access to the state folder is declared.
+	//   - only_self_undeclared: a permissions section is set and the only principal
+	//           with undeclared write access is the deploying user. The migration
+	//           grants the deploying user CAN_MANAGE on the deployment object, so this
+	//           is auto-migratable if we choose to preserve that grant on future
+	//           deploys. Recorded separately to measure how common this case is.
+	//   - not:  a permissions section is set and the state folder has undeclared write
+	//           access from a principal other than the deploying user.
+	DMSCompatAuto               = "dms_compat_auto"
+	DMSCompatOnlySelfUndeclared = "dms_compat_only_self_undeclared"
+	DMSCompatNot                = "dms_compat_not"
 )

--- a/bundle/paths/paths.go
+++ b/bundle/paths/paths.go
@@ -7,7 +7,15 @@ import (
 	"github.com/databricks/cli/bundle/libraries"
 )
 
-func CollectUniqueWorkspacePathPrefixes(workspace config.Workspace) []string {
+// WorkspacePaths holds the unique workspace folders that bundle permissions are applied
+// to. A logical bundle path (artifact, file, state, resource) nested under another is
+// represented only by its enclosing folder, so permissions are applied once and the
+// nested paths inherit them.
+type WorkspacePaths struct {
+	Paths []string
+}
+
+func CollectUniqueWorkspacePathPrefixes(workspace config.Workspace) WorkspacePaths {
 	rootPath := workspace.RootPath
 	var paths []string
 	if !libraries.IsVolumesPath(rootPath) {
@@ -35,5 +43,20 @@ func CollectUniqueWorkspacePathPrefixes(workspace config.Workspace) []string {
 		paths = append(paths, p)
 	}
 
-	return paths
+	return WorkspacePaths{Paths: paths}
+}
+
+// Governing returns the path whose ACL governs the given path: the path itself when it
+// is one of the collected paths, or the enclosing path when it is nested under one (e.g.
+// the state path nested under the root path, which is deduplicated out of Paths).
+// Returns an empty string when no path governs it, e.g. a Volumes path that permissions
+// don't apply to. Paths are /Workspace-normalized by PrependWorkspacePrefix.
+func (w WorkspacePaths) Governing(path string) string {
+	for _, p := range w.Paths {
+		trimmed := strings.TrimSuffix(p, "/")
+		if path == trimmed || strings.HasPrefix(path, trimmed+"/") {
+			return p
+		}
+	}
+	return ""
 }

--- a/bundle/paths/paths_test.go
+++ b/bundle/paths/paths_test.go
@@ -1,0 +1,36 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkspacePathsGoverning(t *testing.T) {
+	// All logical paths nested under root_path collapse to a single prefix, and the
+	// state path is governed by (inherits the ACL of) that root prefix.
+	nested := CollectUniqueWorkspacePathPrefixes(config.Workspace{
+		RootPath:     "/Workspace/u/bundle",
+		ArtifactPath: "/Workspace/u/bundle/artifacts",
+		FilePath:     "/Workspace/u/bundle/files",
+		StatePath:    "/Workspace/u/bundle/state",
+		ResourcePath: "/Workspace/u/bundle/resources",
+	})
+	assert.Equal(t, []string{"/Workspace/u/bundle"}, nested.Paths)
+	assert.Equal(t, "/Workspace/u/bundle", nested.Governing("/Workspace/u/bundle/state"))
+
+	// A state path outside root_path is its own prefix and governs itself.
+	separate := CollectUniqueWorkspacePathPrefixes(config.Workspace{
+		RootPath:     "/Workspace/u/bundle",
+		ArtifactPath: "/Workspace/u/bundle/artifacts",
+		FilePath:     "/Workspace/u/bundle/files",
+		StatePath:    "/Workspace/Shared/state",
+		ResourcePath: "/Workspace/u/bundle/resources",
+	})
+	assert.Equal(t, []string{"/Workspace/u/bundle", "/Workspace/Shared/state"}, separate.Paths)
+	assert.Equal(t, "/Workspace/Shared/state", separate.Governing("/Workspace/Shared/state"))
+
+	// A path governed by no prefix (a sibling) returns an empty string.
+	assert.Empty(t, nested.Governing("/Workspace/u/bundle-2/state"))
+}

--- a/bundle/permissions/workspace_path_permissions.go
+++ b/bundle/permissions/workspace_path_permissions.go
@@ -66,6 +66,22 @@ func (p WorkspacePathPermissions) Compare(perms []resources.Permission) diag.Dia
 	return diags
 }
 
+// UndeclaredWriters returns the principals with write access to the workspace folder
+// (CAN_EDIT or higher — the access needed to deploy the bundle) that are not declared
+// in perms with at least that level. In practice CAN_MANAGE is the only declarable
+// level that grants write access, so such principals must be declared with CAN_MANAGE.
+// Read-only folder access does not need to be declared.
+func (p WorkspacePathPermissions) UndeclaredWriters(perms []resources.Permission) []resources.Permission {
+	var writers []resources.Permission
+	for _, wp := range p.Permissions {
+		if resources.GetLevelScore(string(wp.Level)) >= resources.GetLevelScore(resources.CAN_EDIT) {
+			writers = append(writers, wp)
+		}
+	}
+	_, missing := containsAll(writers, perms)
+	return missing
+}
+
 // samePrincipal checks if two permissions refer to the same user/group/service principal.
 func samePrincipal(a, b resources.Permission) bool {
 	return a.UserName == b.UserName &&

--- a/bundle/permissions/workspace_path_permissions_test.go
+++ b/bundle/permissions/workspace_path_permissions_test.go
@@ -217,3 +217,95 @@ func TestWorkspacePathPermissionsDeduplication(t *testing.T) {
 	require.Equal(t, iam.PermissionLevel(CAN_MANAGE), wp.Permissions[0].Level)
 	require.Equal(t, "foo@bar.test", wp.Permissions[0].UserName)
 }
+
+func TestWorkspacePathPermissionsUndeclaredWriters(t *testing.T) {
+	manage := func(p resources.Permission) resources.Permission {
+		p.Level = CAN_MANAGE
+		return p
+	}
+	user := resources.Permission{UserName: "foo@bar.test"}
+	group := resources.Permission{GroupName: "team"}
+	sp := resources.Permission{ServicePrincipalName: "00000000-0000-0000-0000-000000000001"}
+
+	testCases := []struct {
+		name     string
+		folder   []resources.Permission
+		declared []resources.Permission
+		expected []resources.Permission
+	}{
+		{
+			name:     "empty folder ACL",
+			expected: nil,
+		},
+		{
+			name:     "reader does not need to be declared",
+			folder:   []resources.Permission{{Level: CAN_VIEW, UserName: user.UserName}},
+			expected: nil,
+		},
+		{
+			name:     "runner does not need to be declared",
+			folder:   []resources.Permission{{Level: CAN_RUN, GroupName: group.GroupName}},
+			expected: nil,
+		},
+		{
+			name:     "manager declared",
+			folder:   []resources.Permission{manage(user)},
+			declared: []resources.Permission{manage(user)},
+			expected: nil,
+		},
+		{
+			name:     "manager not declared",
+			folder:   []resources.Permission{manage(user)},
+			expected: []resources.Permission{manage(user)},
+		},
+		{
+			name:     "manager declared with a lower level",
+			folder:   []resources.Permission{manage(user)},
+			declared: []resources.Permission{{Level: CAN_VIEW, UserName: user.UserName}},
+			expected: []resources.Permission{manage(user)},
+		},
+		{
+			name:     "editor must be declared with CAN_MANAGE",
+			folder:   []resources.Permission{{Level: resources.CAN_EDIT, GroupName: group.GroupName}},
+			declared: []resources.Permission{manage(group)},
+			expected: nil,
+		},
+		{
+			name:     "editor not declared",
+			folder:   []resources.Permission{{Level: resources.CAN_EDIT, GroupName: group.GroupName}},
+			declared: []resources.Permission{manage(user)},
+			expected: []resources.Permission{{Level: resources.CAN_EDIT, GroupName: group.GroupName}},
+		},
+		{
+			name:     "group writer requires the same group declared",
+			folder:   []resources.Permission{manage(group)},
+			declared: []resources.Permission{manage(user), manage(sp)},
+			expected: []resources.Permission{manage(group)},
+		},
+		{
+			name:     "service principal writer declared",
+			folder:   []resources.Permission{manage(sp)},
+			declared: []resources.Permission{manage(sp)},
+			expected: nil,
+		},
+		{
+			name:     "mixed: writers declared, reader not",
+			folder:   []resources.Permission{manage(user), manage(group), {Level: CAN_VIEW, ServicePrincipalName: sp.ServicePrincipalName}},
+			declared: []resources.Permission{manage(user), manage(group)},
+			expected: nil,
+		},
+		{
+			name:     "multiple undeclared writers are all returned",
+			folder:   []resources.Permission{manage(user), manage(group)},
+			declared: []resources.Permission{manage(sp)},
+			expected: []resources.Permission{manage(user), manage(group)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := WorkspacePathPermissions{Path: "path", Permissions: tc.folder}
+			require.Equal(t, tc.expected, p.UndeclaredWriters(tc.declared))
+		})
+	}
+}

--- a/bundle/permissions/workspace_root.go
+++ b/bundle/permissions/workspace_root.go
@@ -3,10 +3,13 @@ package permissions
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/bundle/libraries"
+	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/bundle/paths"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
@@ -25,21 +28,25 @@ func (*workspaceRootPermissions) Name() string {
 
 // Apply implements bundle.Mutator.
 func (*workspaceRootPermissions) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
-	err := giveAccessForWorkspaceRoot(ctx, b)
+	stateFolderPermissions, err := giveAccessForWorkspaceRoot(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
+	recordPermissionMetrics(b, stateFolderPermissions)
 	return nil
 }
 
-func giveAccessForWorkspaceRoot(ctx context.Context, b *bundle.Bundle) error {
+// giveAccessForWorkspaceRoot applies the bundle's top-level permissions to the
+// workspace folders and returns the resulting permissions of the folder that holds
+// the deployment state. It returns nil only when no permissions are declared, in
+// which case no folders are synced.
+func giveAccessForWorkspaceRoot(ctx context.Context, b *bundle.Bundle) (*WorkspacePathPermissions, error) {
 	var permissions []workspace.WorkspaceObjectAccessControlRequest
-
 	for _, p := range b.Config.Permissions {
 		level, err := GetWorkspaceObjectPermissionLevel(string(p.Level))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		permissions = append(permissions, workspace.WorkspaceObjectAccessControlRequest{
@@ -51,40 +58,68 @@ func giveAccessForWorkspaceRoot(ctx context.Context, b *bundle.Bundle) error {
 	}
 
 	if len(permissions) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	w := b.WorkspaceClient(ctx).Workspace
-	bundlePaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config.Workspace)
+	wsPaths := paths.CollectUniqueWorkspacePathPrefixes(b.Config.Workspace)
 
+	// Each goroutine writes the folder's resulting permissions into its own slot,
+	// so they are inspected after Wait rather than concurrently.
+	folderPermissions := make([]*WorkspacePathPermissions, len(wsPaths.Paths))
 	g, ctx := errgroup.WithContext(ctx)
-	for _, p := range bundlePaths {
+	for i, p := range wsPaths.Paths {
 		g.Go(func() error {
-			return setPermissions(ctx, w, p, permissions)
+			wp, err := setPermissions(ctx, w, p, permissions)
+			folderPermissions[i] = wp
+			return err
 		})
 	}
 
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Return the permissions of the folder governing the deployment state. When
+	// state_path is nested under root_path it is deduplicated out of the collected
+	// paths, so Governing resolves it to root_path, whose ACL it inherits.
+	stateFolder := wsPaths.Governing(b.Config.Workspace.StatePath)
+	i := slices.Index(wsPaths.Paths, stateFolder)
+	if i < 0 {
+		return nil, nil
+	}
+	return folderPermissions[i], nil
 }
 
-func setPermissions(ctx context.Context, w workspace.WorkspaceInterface, path string, permissions []workspace.WorkspaceObjectAccessControlRequest) error {
-	// If the folder is shared, then we don't need to set permissions since it's always set for all users and it's checked in mutators before.
+func setPermissions(ctx context.Context, w workspace.WorkspaceInterface, path string, permissions []workspace.WorkspaceObjectAccessControlRequest) (*WorkspacePathPermissions, error) {
+	// Shared folders are writable by all workspace users and the sync does not modify
+	// them. Return that ACL statically so callers need no special case for them.
 	if libraries.IsWorkspaceSharedPath(path) {
-		return nil
+		return &WorkspacePathPermissions{
+			Path:        path,
+			Permissions: []resources.Permission{{Level: CAN_MANAGE, GroupName: "users"}},
+		}, nil
 	}
 
 	obj, err := w.GetStatusByPath(ctx, path) //nolint:staticcheck // Deprecated in SDK v0.127.0. Migration to WorkspaceHierarchyService tracked separately.
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = w.SetPermissions(ctx, workspace.WorkspaceObjectPermissionsRequest{
+	// Reusing the SetPermissions response (the folder's resulting ACL) lets us compare
+	// it against the declaration without an extra API call. The Set replaces the direct
+	// ACL with the declared permissions, so any principal still showing higher access is
+	// inherited from a parent folder.
+	resp, err := w.SetPermissions(ctx, workspace.WorkspaceObjectPermissionsRequest{
 		WorkspaceObjectId:   strconv.FormatInt(obj.ObjectId, 10),
 		WorkspaceObjectType: "directories",
 		AccessControlList:   permissions,
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	return err
+	return ObjectAclToResourcePermissions(path, resp.AccessControlList), nil
 }
 
 func GetWorkspaceObjectPermissionLevel(bundlePermission string) (workspace.WorkspaceObjectPermissionLevel, error) {
@@ -98,4 +133,58 @@ func GetWorkspaceObjectPermissionLevel(bundlePermission string) (workspace.Works
 	default:
 		return "", fmt.Errorf("unsupported bundle permission level %s", bundlePermission)
 	}
+}
+
+// recordPermissionMetrics records telemetry describing how the deployment state
+// folder's permissions relate to the bundle's declared permissions. stateFolderPerms
+// is the folder's resulting ACL, or nil when no permissions are declared (no folders
+// are synced in that case).
+func recordPermissionMetrics(b *bundle.Bundle, stateFolderPerms *WorkspacePathPermissions) {
+	b.Metrics.SetBoolValue(metrics.StatePathIsShared, libraries.IsWorkspaceSharedPath(b.Config.Workspace.StatePath))
+	// Emit exactly one of the auto-migration verdict keys.
+	b.Metrics.SetBoolValue(autoMigrationVerdict(b, stateFolderPerms), true)
+}
+
+// autoMigrationVerdict returns the metric key describing whether this deploy is
+// compatible with an automatic migration of the deployment state to a dedicated
+// state storage service. See metrics.DMSCompatAuto.
+func autoMigrationVerdict(b *bundle.Bundle, stateFolderPerms *WorkspacePathPermissions) string {
+	// No permissions section: the migration mirrors the state folder's ACLs onto the
+	// deployment (CAN_EDIT -> CAN_EDIT, CAN_MANAGE -> CAN_MANAGE), preserving
+	// everyone's access wherever the state lives.
+	if len(b.Config.Permissions) == 0 {
+		return metrics.DMSCompatAuto
+	}
+
+	// A permissions section is set. The state folder is always one of the synced bundle
+	// folders (a /Volumes state_path is rejected earlier by ValidateVolumePath), so
+	// stateFolderPerms is non-nil here. Guard against nil regardless so a telemetry
+	// computation can never panic the deploy.
+	if stateFolderPerms == nil {
+		return metrics.DMSCompatNot
+	}
+
+	// The migration applies exactly the declared permissions to the deployment, so
+	// anyone with write access to the state folder who is not declared loses the
+	// ability to deploy.
+	undeclared := stateFolderPerms.UndeclaredWriters(b.Config.Permissions)
+	switch {
+	case len(undeclared) == 0:
+		return metrics.DMSCompatAuto
+	case len(undeclared) == 1 && isDeployingUser(b, undeclared[0]):
+		// The deploying user is the only undeclared writer. The migration grants the
+		// deploying user CAN_MANAGE on the deployment object, so this deploy is
+		// auto-migratable if we choose to preserve that grant on future deploys.
+		return metrics.DMSCompatOnlySelfUndeclared
+	default:
+		return metrics.DMSCompatNot
+	}
+}
+
+// isDeployingUser reports whether p is the user performing the deploy.
+func isDeployingUser(b *bundle.Bundle, p resources.Permission) bool {
+	if b.Config.Workspace.CurrentUser == nil {
+		return false
+	}
+	return p.UserName != "" && p.UserName == b.Config.Workspace.CurrentUser.UserName
 }

--- a/bundle/permissions/workspace_root_test.go
+++ b/bundle/permissions/workspace_root_test.go
@@ -70,7 +70,7 @@ func TestApplyWorkspaceRootPermissions(t *testing.T) {
 		},
 		WorkspaceObjectId:   "1234",
 		WorkspaceObjectType: "directories",
-	}).Return(nil, nil)
+	}).Return(&workspace.WorkspaceObjectPermissions{}, nil)
 
 	diags := bundle.ApplySeq(t.Context(), b, ValidateSharedRootPermissions(), ApplyWorkspaceRootPermissions())
 	require.Empty(t, diags)
@@ -143,7 +143,7 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 		},
 		WorkspaceObjectId:   "1",
 		WorkspaceObjectType: "directories",
-	}).Return(nil, nil)
+	}).Return(&workspace.WorkspaceObjectPermissions{}, nil)
 
 	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
 		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
@@ -153,7 +153,7 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 		},
 		WorkspaceObjectId:   "2",
 		WorkspaceObjectType: "directories",
-	}).Return(nil, nil)
+	}).Return(&workspace.WorkspaceObjectPermissions{}, nil)
 
 	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
 		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
@@ -163,7 +163,7 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 		},
 		WorkspaceObjectId:   "3",
 		WorkspaceObjectType: "directories",
-	}).Return(nil, nil)
+	}).Return(&workspace.WorkspaceObjectPermissions{}, nil)
 
 	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
 		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
@@ -173,7 +173,7 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 		},
 		WorkspaceObjectId:   "4",
 		WorkspaceObjectType: "directories",
-	}).Return(nil, nil)
+	}).Return(&workspace.WorkspaceObjectPermissions{}, nil)
 
 	workspaceApi.EXPECT().SetPermissions(mock.Anything, workspace.WorkspaceObjectPermissionsRequest{
 		AccessControlList: []workspace.WorkspaceObjectAccessControlRequest{
@@ -183,7 +183,7 @@ func TestApplyWorkspaceRootPermissionsForAllPaths(t *testing.T) {
 		},
 		WorkspaceObjectId:   "5",
 		WorkspaceObjectType: "directories",
-	}).Return(nil, nil)
+	}).Return(&workspace.WorkspaceObjectPermissions{}, nil)
 
 	diags := bundle.Apply(t.Context(), b, ApplyWorkspaceRootPermissions())
 	require.NoError(t, diags.Error())

--- a/libs/testserver/permissions.go
+++ b/libs/testserver/permissions.go
@@ -3,6 +3,9 @@ package testserver
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/databricks/databricks-sdk-go/service/iam"
 )
@@ -294,7 +297,44 @@ func (s *FakeWorkspace) SetPermissions(req Request) any {
 
 	s.Permissions[responseObjectID] = existingPermissions
 
-	return Response{
-		Body: existingPermissions,
+	// A directory under /Workspace/Users/<owner> grants the owner CAN_MANAGE
+	// (inherited), mirroring real workspaces where a user manages everything in their
+	// home folder. This holds regardless of what the request configured for them, so
+	// it overrides any lower level. SetPermissions replaces the direct ACL but this
+	// inherited access persists, so we add it to the response (not the stored value).
+	response := existingPermissions
+	if requestObjectType == "directories" {
+		if owner := s.directoryHomeOwner(objectId); owner != "" {
+			response.AccessControlList = slices.Clone(existingPermissions.AccessControlList)
+			upsertACL(&response, iam.AccessControlResponse{
+				UserName:       owner,
+				AllPermissions: []iam.Permission{{PermissionLevel: "CAN_MANAGE", Inherited: true}},
+			})
+		}
 	}
+
+	return Response{
+		Body: response,
+	}
+}
+
+// directoryHomeOwner returns the home-directory owner for the directory with the
+// given object id, i.e. <owner> when its path is under /Workspace/Users/<owner>.
+// Returns an empty string otherwise.
+func (s *FakeWorkspace) directoryHomeOwner(objectId string) string {
+	const usersPrefix = "/Workspace/Users/"
+	for path, info := range s.directories {
+		if strconv.FormatInt(info.ObjectId, 10) != objectId {
+			continue
+		}
+		if !strings.HasPrefix(path, usersPrefix) {
+			return ""
+		}
+		rest := path[len(usersPrefix):]
+		if before, _, ok := strings.Cut(rest, "/"); ok {
+			return before
+		}
+		return rest
+	}
+	return ""
 }


### PR DESCRIPTION
Telemetry only. Records whether each deploy is compatible with an **automatic migration of the deployment state to a dedicated state storage service**. Deploying a bundle requires write access (CAN_EDIT or higher) to the state folder; after migration that is governed by the deployment object's permissions instead.

When there's no permissions section the migration mirrors the state folder's ACLs onto the deployment, so access is preserved wherever the state lives. When a permissions section is set, the migration applies exactly those permissions, so undeclared writers on the state folder would lose the ability to deploy.

Exactly one verdict per deploy (`bool_values`), evaluated by reusing the existing `SetPermissions` response (no extra API call):
- `dms_compat_auto` — no permissions section, or all write access on the state folder is declared.
- `dms_compat_only_self_undeclared` — a permissions section is set and the only undeclared writer is the deploying user. The deployment object grants the deployer CAN_MANAGE initially, so this is migratable if we choose to preserve that grant on future deploys. Recorded separately to measure how common it is.
- `dms_compat_not` — undeclared write access from a principal other than the deploying user (`/Workspace/Shared` is treated as writable by all users, requiring `users: CAN_MANAGE`).

Plus `state_path_is_shared`.

Tested by an acceptance test over the case matrix (no permissions / declared / undeclared, home and shared state folders; the fake server models home-folder ownership as inherited CAN_MANAGE) and a table-driven unit test for `UndeclaredWriters`.