### PR TITLE
Reject and ignore deployment_id/version_id on jobs and pipelines

### DIFF
--- a/acceptance/bundle/validate/reserved_deployment_fields/databricks.yml
+++ b/acceptance/bundle/validate/reserved_deployment_fields/databricks.yml
@@ -1,0 +1,18 @@
+bundle:
+  name: test-bundle
+
+resources:
+  jobs:
+    my_job:
+      name: my_job
+      deployment:
+        kind: BUNDLE
+        deployment_id: "dep-123"
+        version_id: "ver-456"
+  pipelines:
+    my_pipeline:
+      name: my_pipeline
+      deployment:
+        kind: BUNDLE
+        deployment_id: "dep-789"
+        version_id: "ver-012"

--- a/acceptance/bundle/validate/reserved_deployment_fields/out.test.toml
+++ b/acceptance/bundle/validate/reserved_deployment_fields/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/reserved_deployment_fields/output.txt
+++ b/acceptance/bundle/validate/reserved_deployment_fields/output.txt
@@ -1,0 +1,27 @@
+
+>>> [CLI] bundle validate
+Error: deployment_id must not be set in bundle configuration; it is managed by Declarative Automation Bundles
+  at resources.jobs.my_job.deployment.deployment_id
+  in databricks.yml:10:24
+
+Error: version_id must not be set in bundle configuration; it is managed by Declarative Automation Bundles
+  at resources.jobs.my_job.deployment.version_id
+  in databricks.yml:11:21
+
+Error: deployment_id must not be set in bundle configuration; it is managed by Declarative Automation Bundles
+  at resources.pipelines.my_pipeline.deployment.deployment_id
+  in databricks.yml:17:24
+
+Error: version_id must not be set in bundle configuration; it is managed by Declarative Automation Bundles
+  at resources.pipelines.my_pipeline.deployment.version_id
+  in databricks.yml:18:21
+
+Name: test-bundle
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Found 4 errors
+
+Exit code: 1

--- a/acceptance/bundle/validate/reserved_deployment_fields/script
+++ b/acceptance/bundle/validate/reserved_deployment_fields/script
@@ -1,0 +1,1 @@
+trace $CLI bundle validate

--- a/bundle/config/validate/validate_deployment_fields.go
+++ b/bundle/config/validate/validate_deployment_fields.go
@@ -1,0 +1,61 @@
+package validate
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+)
+
+func ValidateDeploymentFields() bundle.ReadOnlyMutator {
+	return &validateDeploymentFields{}
+}
+
+type validateDeploymentFields struct{ bundle.RO }
+
+func (v *validateDeploymentFields) Name() string {
+	return "validate:validate_deployment_fields"
+}
+
+func (v *validateDeploymentFields) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	// deployment_id and version_id identify the bundle deployment and its version
+	// in the Deployment Metadata Service. The CLI sets them on every deploy, so a
+	// value provided by hand would be overwritten; reject it up front.
+	reject := func(resourcePath, field, value string) {
+		if value == "" {
+			return
+		}
+		path := resourcePath + ".deployment." + field
+		diags = append(diags, diag.Diagnostic{
+			Severity:  diag.Error,
+			Summary:   field + " must not be set in bundle configuration; it is managed by Declarative Automation Bundles",
+			Paths:     []dyn.Path{dyn.MustPathFromString(path)},
+			Locations: b.Config.GetLocations(path),
+		})
+	}
+
+	for name, job := range b.Config.Resources.Jobs {
+		if d := job.Deployment; d != nil {
+			reject("resources.jobs."+name, "deployment_id", d.DeploymentId)
+			reject("resources.jobs."+name, "version_id", d.VersionId)
+		}
+	}
+	for name, pipeline := range b.Config.Resources.Pipelines {
+		if d := pipeline.Deployment; d != nil {
+			reject("resources.pipelines."+name, "deployment_id", d.DeploymentId)
+			reject("resources.pipelines."+name, "version_id", d.VersionId)
+		}
+	}
+
+	// Map iteration order is randomized; sort by path for stable output.
+	slices.SortFunc(diags, func(x, y diag.Diagnostic) int {
+		return cmp.Compare(x.Paths[0].String(), y.Paths[0].String())
+	})
+
+	return diags
+}

--- a/bundle/config/validate/validate_deployment_fields_test.go
+++ b/bundle/config/validate/validate_deployment_fields_test.go
@@ -1,0 +1,80 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const reservedFieldMsg = " must not be set in bundle configuration; it is managed by Declarative Automation Bundles"
+
+func jobBundle(d *jobs.JobDeployment) *bundle.Bundle {
+	return &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job": {JobSettings: jobs.JobSettings{Name: "my_job", Deployment: d}},
+				},
+			},
+		},
+	}
+}
+
+func pipelineBundle(d *pipelines.PipelineDeployment) *bundle.Bundle {
+	return &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Pipelines: map[string]*resources.Pipeline{
+					"my_pipeline": {CreatePipeline: pipelines.CreatePipeline{Name: "my_pipeline", Deployment: d}},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateDeploymentFieldsRejectsReservedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		b    *bundle.Bundle
+		want string
+	}{
+		{"job deployment_id", jobBundle(&jobs.JobDeployment{DeploymentId: "x"}), "deployment_id" + reservedFieldMsg},
+		{"job version_id", jobBundle(&jobs.JobDeployment{VersionId: "x"}), "version_id" + reservedFieldMsg},
+		{"pipeline deployment_id", pipelineBundle(&pipelines.PipelineDeployment{DeploymentId: "x"}), "deployment_id" + reservedFieldMsg},
+		{"pipeline version_id", pipelineBundle(&pipelines.PipelineDeployment{VersionId: "x"}), "version_id" + reservedFieldMsg},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := ValidateDeploymentFields().Apply(t.Context(), tt.b)
+			require.Len(t, diags, 1)
+			assert.Equal(t, diag.Error, diags[0].Severity)
+			assert.Equal(t, tt.want, diags[0].Summary)
+		})
+	}
+}
+
+func TestValidateDeploymentFieldsReportsAllOffenders(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"my_job": {JobSettings: jobs.JobSettings{Deployment: &jobs.JobDeployment{DeploymentId: "a"}}},
+				},
+				Pipelines: map[string]*resources.Pipeline{
+					"my_pipeline": {CreatePipeline: pipelines.CreatePipeline{Deployment: &pipelines.PipelineDeployment{VersionId: "b"}}},
+				},
+			},
+		},
+	}
+
+	diags := ValidateDeploymentFields().Apply(t.Context(), b)
+	require.Len(t, diags, 2)
+}

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -16,7 +16,20 @@
 resources:
 
   jobs:
+    # version_id is set to the current DMS deployment version on every deploy, so
+    # it changes constantly. Ignoring it as a local and remote change keeps that
+    # churn from driving an update or showing as drift on its own; when the job is
+    # updated for any other reason, DoUpdate sends the full config via Reset, so
+    # the current version_id is still recorded. deployment_id is intentionally
+    # left out: it is stable across versions, so a change to it is worth showing.
+    ignore_local_changes:
+      - field: deployment.version_id
+        reason: managed by the deployment metadata service
+
     ignore_remote_changes:
+      - field: deployment.version_id
+        reason: managed by the deployment metadata service
+
       # Same as clusters.{aws,azure,gcp}_attributes — see clusters/resource_cluster.go#L361-L363
       # s.SchemaPath("aws_attributes").SetSuppressDiff()
       # s.SchemaPath("azure_attributes").SetSuppressDiff()
@@ -118,7 +131,11 @@ resources:
       - field: ingestion_definition.ingest_from_uc_foreign_catalog
         reason: immutable
 
+    # See jobs above: version_id is set on every deploy, so it is ignored as a
+    # local/remote change. deployment_id is left out so a change to it still shows.
     ignore_remote_changes:
+      - field: deployment.version_id
+        reason: managed by the deployment metadata service
       # "id" is handled in a special way before any fields changed
       # However, it is also part of RemotePipeline via CreatePipeline.
       # Thus it shows up as a remote change since we don't set on the object.
@@ -128,6 +145,8 @@ resources:
         reason: input_only
 
     ignore_local_changes:
+      - field: deployment.version_id
+        reason: managed by the deployment metadata service
       # "id" is output-only, providing it in config would be a mistake
       - field: id
         reason: "!drop"

--- a/bundle/internal/schema/main.go
+++ b/bundle/internal/schema/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/databricks/cli/libs/dyn/dynvar"
 	"github.com/databricks/cli/libs/jsonschema"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
 )
 
 // interpolationPattern builds a JSON Schema regex for ${prefix.path...} references.
@@ -132,6 +133,25 @@ func removePipelineFields(typ reflect.Type, s jsonschema.Schema) jsonschema.Sche
 	return s
 }
 
+// removeDeploymentFields strips deployment_id and version_id from the job and
+// pipeline deployment blocks. The CLI sets these to track the bundle
+// deployment in the Deployment Metadata Service; they are not user-configurable,
+// so they must not appear in the JSON schema or the generated annotation files.
+// The parent "deployment" block is already removed from the Job and Pipeline
+// schemas (see removeJobsFields / removePipelineFields); this removes the fields
+// from the JobDeployment / PipelineDeployment type definitions themselves.
+func removeDeploymentFields(typ reflect.Type, s jsonschema.Schema) jsonschema.Schema {
+	switch typ {
+	case reflect.TypeFor[jobs.JobDeployment](), reflect.TypeFor[pipelines.PipelineDeployment]():
+		delete(s.Properties, "deployment_id")
+		delete(s.Properties, "version_id")
+	default:
+		// Do nothing
+	}
+
+	return s
+}
+
 // While volume_type is required in the volume create API, DABs automatically sets
 // it's value to "MANAGED" if it's not provided. Thus, we make it optional
 // in the bundle schema.
@@ -238,6 +258,7 @@ func generateSchema(workdir, outputFile string, docsMode bool) {
 	transforms := []func(reflect.Type, jsonschema.Schema) jsonschema.Schema{
 		removeJobsFields,
 		removePipelineFields,
+		removeDeploymentFields,
 		makeVolumeTypeOptional,
 		a.addAnnotations,
 		removeOutputOnlyFields,

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -161,6 +161,10 @@ func Initialize(ctx context.Context, b *bundle.Bundle) {
 		// Validate that no genie space etags are set. They are purely internal state and should not be set by the user.
 		validate.ValidateGenieSpaceEtags(),
 
+		// Validate that deployment_id / version_id are not set on jobs or pipelines.
+		// They are set by the CLI to track the bundle deployment and must not be set by the user.
+		validate.ValidateDeploymentFields(),
+
 		// Reads (dynamic): * (strings) (searches for ${resources.*} references)
 		// Warns (TF engine) or errors (direct engine) when a cross-resource reference
 		// points to a Terraform-only field with no DABs equivalent.

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -6598,12 +6598,6 @@
                 {
                   "type": "object",
                   "properties": {
-                    "deployment_id": {
-                      "description": "[Private Preview] ID of the deployment that manages this job. Only set when `kind` is\n`BUNDLE`. Used to look up deployment metadata from the Deployment\nMetadata service.",
-                      "$ref": "#/$defs/string",
-                      "x-databricks-preview": "PRIVATE",
-                      "doNotSuggest": true
-                    },
                     "kind": {
                       "description": "The kind of deployment that manages the job.\n\n* `BUNDLE`: The job is managed by Databricks Asset Bundle.\n* `SYSTEM_MANAGED`: The job is managed by Databricks and is read-only.",
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobDeploymentKind"
@@ -6611,12 +6605,6 @@
                     "metadata_file_path": {
                       "description": "Path of the file that contains deployment metadata.",
                       "$ref": "#/$defs/string"
-                    },
-                    "version_id": {
-                      "description": "[Private Preview] ID of the version of the deployment that produced this job. Only set\nwhen `kind` is `BUNDLE`. Identifies a specific snapshot of the deployment\nin the Deployment Metadata service.",
-                      "$ref": "#/$defs/string",
-                      "x-databricks-preview": "PRIVATE",
-                      "doNotSuggest": true
                     }
                   },
                   "additionalProperties": false,
@@ -9812,12 +9800,6 @@
                 {
                   "type": "object",
                   "properties": {
-                    "deployment_id": {
-                      "description": "[Private Preview] ID of the deployment that manages this pipeline. Only set when `kind` is\n`BUNDLE`. Used to look up deployment metadata from the Deployment\nMetadata service.",
-                      "$ref": "#/$defs/string",
-                      "x-databricks-preview": "PRIVATE",
-                      "doNotSuggest": true
-                    },
                     "kind": {
                       "description": "The deployment method that manages the pipeline.",
                       "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.DeploymentKind"
@@ -9825,12 +9807,6 @@
                     "metadata_file_path": {
                       "description": "The path to the file containing metadata about the deployment.",
                       "$ref": "#/$defs/string"
-                    },
-                    "version_id": {
-                      "description": "[Private Preview] ID of the version of the deployment that produced this pipeline. Only\nset when `kind` is `BUNDLE`. Identifies a specific snapshot of the\ndeployment in the Deployment Metadata service.",
-                      "$ref": "#/$defs/string",
-                      "x-databricks-preview": "PRIVATE",
-                      "doNotSuggest": true
                     }
                   },
                   "additionalProperties": false,

--- a/bundle/schema/jsonschema_for_docs.json
+++ b/bundle/schema/jsonschema_for_docs.json
@@ -5758,13 +5758,6 @@
             "jobs.JobDeployment": {
               "type": "object",
               "properties": {
-                "deployment_id": {
-                  "description": "[Private Preview] ID of the deployment that manages this job. Only set when `kind` is\n`BUNDLE`. Used to look up deployment metadata from the Deployment\nMetadata service.",
-                  "$ref": "#/$defs/string",
-                  "x-databricks-preview": "PRIVATE",
-                  "doNotSuggest": true,
-                  "x-since-version": "v1.2.0"
-                },
                 "kind": {
                   "description": "The kind of deployment that manages the job.\n\n* `BUNDLE`: The job is managed by Databricks Asset Bundle.\n* `SYSTEM_MANAGED`: The job is managed by Databricks and is read-only.",
                   "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobDeploymentKind",
@@ -5774,13 +5767,6 @@
                   "description": "Path of the file that contains deployment metadata.",
                   "$ref": "#/$defs/string",
                   "x-since-version": "v0.229.0"
-                },
-                "version_id": {
-                  "description": "[Private Preview] ID of the version of the deployment that produced this job. Only set\nwhen `kind` is `BUNDLE`. Identifies a specific snapshot of the deployment\nin the Deployment Metadata service.",
-                  "$ref": "#/$defs/string",
-                  "x-databricks-preview": "PRIVATE",
-                  "doNotSuggest": true,
-                  "x-since-version": "v1.2.0"
                 }
               },
               "additionalProperties": false,
@@ -8473,13 +8459,6 @@
             "pipelines.PipelineDeployment": {
               "type": "object",
               "properties": {
-                "deployment_id": {
-                  "description": "[Private Preview] ID of the deployment that manages this pipeline. Only set when `kind` is\n`BUNDLE`. Used to look up deployment metadata from the Deployment\nMetadata service.",
-                  "$ref": "#/$defs/string",
-                  "x-databricks-preview": "PRIVATE",
-                  "doNotSuggest": true,
-                  "x-since-version": "v1.2.0"
-                },
                 "kind": {
                   "description": "The deployment method that manages the pipeline.",
                   "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.DeploymentKind",
@@ -8489,13 +8468,6 @@
                   "description": "The path to the file containing metadata about the deployment.",
                   "$ref": "#/$defs/string",
                   "x-since-version": "v0.229.0"
-                },
-                "version_id": {
-                  "description": "[Private Preview] ID of the version of the deployment that produced this pipeline. Only\nset when `kind` is `BUNDLE`. Identifies a specific snapshot of the\ndeployment in the Deployment Metadata service.",
-                  "$ref": "#/$defs/string",
-                  "x-databricks-preview": "PRIVATE",
-                  "doNotSuggest": true,
-                  "x-since-version": "v1.2.0"
                 }
               },
               "additionalProperties": false,


### PR DESCRIPTION
## Why

`deployment_id` and `version_id` on a job/pipeline `deployment` block are set by the CLI to identify the bundle deployment and its version in the Deployment Metadata Service. They are not user-configurable.

Benefits:
1. Users can't accidentally set these fields.
2. `version_id` changes on every deploy; ignoring it as a local/remote change keeps that churn from driving spurious updates or showing as drift.