### PR TITLE
Fix generate-direct race that ran apitypes generation twice

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -888,7 +888,12 @@ tasks:
 
   generate-direct:
     desc: Generate direct engine config (apitypes + resources)
-    deps: ['generate-direct-apitypes', 'generate-direct-resources']
+    # Depend only on generate-direct-resources; it already pulls in
+    # generate-direct-apitypes transitively. Listing both as parallel deps
+    # races: resources reads apitypes.generated.yml while the apitypes step's
+    # `>` redirect is truncating it, silently dropping every resource whose
+    # type comes from that file. Keep this chain linear.
+    deps: ['generate-direct-resources']
 
   generate-direct-apitypes:
     desc: Generate direct engine API types YAML


### PR DESCRIPTION
## What
- Remove dependency on `generate-direct-apitypes` from `generate-direct` target, keep only `generate-direct-resources`

## Why
- `generate-direct-resources` already depends on `generate-direct-apitypes` which means apitypes is invoked twice concurrently

## Testing

`./task generate-direct --dry --force`

**Before**

```
[generate-openapi-json]    wget ... && mv ...
[generate-direct-apitypes] python3 generate_apitypes.py ... > apitypes.generated.yml
[generate-openapi-json]    wget ... && mv ...
[generate-direct-apitypes] python3 generate_apitypes.py ... > apitypes.generated.yml
[generate-direct-resources] uv run ... > resources.generated.yml
```

**After**:

```
[generate-openapi-json]    wget ... && mv ...
[generate-direct-apitypes] python3 generate_apitypes.py ... > apitypes.generated.yml
[generate-direct-resources] uv run ... > resources.generated.yml
```

This pull request was written by Isaac.
