### PR TITLE
direct: Fix updating the apps after the Go SDK upgrade

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -1,12 +1,13 @@
 # NEXT CHANGELOG
 
-## Release v1.3.0
+## Release v1.2.1
 
 ### Notable Changes
 
 ### CLI
 
 ### Bundles
+* direct: Fix updating the apps after the Go SDK upgrade ([#5444](https://github.com/databricks/cli/pull/5444))
 
 ### Dependency updates
 

--- a/acceptance/bundle/resources/apps/lifecycle-started/output.txt
+++ b/acceptance/bundle/resources/apps/lifecycle-started/output.txt
@@ -90,7 +90,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_2",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
   }
 }
 
@@ -117,7 +117,7 @@ Deployment complete!
       "description": "MY_APP_DESCRIPTION_3",
       "name": "[UNIQUE_NAME]"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
   }
 }
 {

--- a/acceptance/bundle/resources/apps/update/out.requests.direct.json
+++ b/acceptance/bundle/resources/apps/update/out.requests.direct.json
@@ -15,7 +15,7 @@
       "description": "MY_APP_DESCRIPTION",
       "name": "myappname"
     },
-    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,compute_min_instances,compute_max_instances,git_repository,telemetry_export_destinations"
+    "update_mask": "description,budget_policy_id,usage_policy_id,resources,user_api_scopes,compute_size,git_repository,telemetry_export_destinations"
   },
   "method": "POST",
   "path": "/api/2.0/apps/myappname/update"

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -164,8 +164,8 @@ var UpdateMaskFields = []string{
 	"resources",
 	"user_api_scopes",
 	"compute_size",
-	"compute_min_instances",
-	"compute_max_instances",
+	// "compute_min_instances", // TODO: add back when update APIs correctly support it
+	// "compute_max_instances", // TODO: add back when update APIs correctly support it
 	"git_repository",
 	"telemetry_export_destinations",
 }

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -376,6 +376,10 @@ resources:
     ignore_remote_changes:
       - field: space # This field is not yet supported by Update APIs but exposed in the API spec. TODO: fix when update APIs supports it.
         reason: managed
+      - field: compute_min_instances # This field does not work correctly in update_mask but exposed in the API spec. TODO: add back when update APIs correctly support it
+        reason: managed
+      - field: compute_max_instances # This field does not work correctly in update_mask but exposed in the API spec. TODO: add back when update APIs correctly support it
+        reason: managed
 
   secret_scopes:
     backend_defaults:


### PR DESCRIPTION
## Changes
Fix updating the apps after the Go SDK upgrade

## Why
Go SDK upgrade introduced 2 new fields to apps update_mask, which do not work correctly and cause apps updates to fail

## Tests
Acceptance test pass

```
    --- SKIP: TestAccept/bundle/resources/apps/update (0.00s)
    --- SKIP: TestAccept/bundle/undefined_resources (0.00s)
    --- PASS: TestAccept/bundle/resources/apps/lifecycle-started-terraform-error (0.00s)
        --- PASS: TestAccept/bundle/resources/apps/lifecycle-started-terraform-error/DATABRICKS_BUNDLE_ENGINE=terraform (6.22s)
    --- PASS: TestAccept/bundle/resources/apps/lifecycle-started-omitted (0.00s)
        --- PASS: TestAccept/bundle/resources/apps/lifecycle-started-omitted/DATABRICKS_BUNDLE_ENGINE=direct (180.07s)
    --- PASS: TestAccept/bundle/resources/apps/lifecycle-started-toggle (0.00s)
        --- PASS: TestAccept/bundle/resources/apps/lifecycle-started-toggle/DATABRICKS_BUNDLE_ENGINE=direct (180.84s)
    --- PASS: TestAccept/bundle/resources/apps/inline_config (0.00s)
        --- PASS: TestAccept/bundle/resources/apps/inline_config/DATABRICKS_BUNDLE_ENGINE=direct (181.98s)
    --- PASS: TestAccept/bundle/resources/apps/lifecycle-started (0.00s)
        --- PASS: TestAccept/bundle/resources/apps/lifecycle-started/DATABRICKS_BUNDLE_ENGINE=direct (424.84s)
PASS
ok      github.com/databricks/cli/acceptance    442.607s
```

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
