### PR TITLE
bundle/dms: record deployment_mode on the deployment version

### DIFF
--- a/bundle/deploy/lock/deployment_metadata_service.go
+++ b/bundle/deploy/lock/deployment_metadata_service.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/deploy"
 	"github.com/databricks/cli/bundle/deployplan"
 	"github.com/databricks/cli/bundle/statemgmt"
@@ -153,10 +154,11 @@ func acquireLock(ctx context.Context, b *bundle.Bundle, svc *tmpdms.DeploymentMe
 		Parent:       "deployments/" + deploymentID,
 		VersionID:    versionID,
 		Version: &tmpdms.Version{
-			DisplayName: b.Config.Bundle.Name,
-			CliVersion:  build.GetInfo().Version,
-			VersionType: versionType,
-			TargetName:  b.Config.Bundle.Target,
+			DisplayName:    b.Config.Bundle.Name,
+			DeploymentMode: deploymentMode(b.Config.Bundle.Mode),
+			CliVersion:     build.GetInfo().Version,
+			VersionType:    versionType,
+			TargetName:     b.Config.Bundle.Target,
 			// Same git provenance the CLI records in metadata.json.
 			GitInfo: &tmpdms.GitInfo{
 				OriginURL: b.Config.Bundle.Git.OriginURL,
@@ -341,4 +343,17 @@ func startHeartbeat(ctx context.Context, svc *tmpdms.DeploymentMetadataAPI, depl
 func isAborted(err error) bool {
 	apiErr, ok := errors.AsType[*apierr.APIError](err)
 	return ok && apiErr.StatusCode == http.StatusConflict && apiErr.ErrorCode == "ABORTED"
+}
+
+// deploymentMode maps a bundle target mode to the DMS deployment mode enum.
+// Unset target modes produce an empty value, which is omitted from the request.
+func deploymentMode(mode config.Mode) tmpdms.DeploymentMode {
+	switch mode {
+	case config.Development:
+		return tmpdms.DeploymentModeDevelopment
+	case config.Production:
+		return tmpdms.DeploymentModeProduction
+	default:
+		return ""
+	}
 }

--- a/bundle/deploy/lock/deployment_metadata_service_test.go
+++ b/bundle/deploy/lock/deployment_metadata_service_test.go
@@ -3,6 +3,7 @@ package lock
 import (
 	"testing"
 
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/deployplan"
 	"github.com/databricks/cli/libs/tmpdms"
 	"github.com/stretchr/testify/assert"
@@ -51,4 +52,22 @@ func TestGoalToVersionType(t *testing.T) {
 
 	_, ok = goalToVersionType(GoalUnbind)
 	assert.False(t, ok)
+}
+
+func TestDeploymentMode(t *testing.T) {
+	tests := []struct {
+		mode     config.Mode
+		expected tmpdms.DeploymentMode
+	}{
+		{config.Development, tmpdms.DeploymentModeDevelopment},
+		{config.Production, tmpdms.DeploymentModeProduction},
+		{"", ""},
+		{"unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			assert.Equal(t, tt.expected, deploymentMode(tt.mode))
+		})
+	}
 }

--- a/libs/tmpdms/types.go
+++ b/libs/tmpdms/types.go
@@ -17,6 +17,7 @@ type (
 	OperationStatus        string
 	OperationActionType    string
 	DeploymentResourceType string
+	DeploymentMode         string
 )
 
 const (
@@ -45,6 +46,11 @@ const (
 	VersionTypeUnspecified VersionType = "VERSION_TYPE_UNSPECIFIED"
 	VersionTypeDeploy      VersionType = "VERSION_TYPE_DEPLOY"
 	VersionTypeDestroy     VersionType = "VERSION_TYPE_DESTROY"
+)
+
+const (
+	DeploymentModeDevelopment DeploymentMode = "DEPLOYMENT_MODE_DEVELOPMENT"
+	DeploymentModeProduction  DeploymentMode = "DEPLOYMENT_MODE_PRODUCTION"
 )
 
 const (
@@ -119,6 +125,7 @@ type Version struct {
 	VersionType      VersionType     `json:"version_type,omitempty"`
 	CompletionReason VersionComplete `json:"completion_reason,omitempty"`
 	CompletedBy      string          `json:"completed_by,omitempty"`
+	DeploymentMode   DeploymentMode  `json:"deployment_mode,omitempty"`
 	DisplayName      string          `json:"display_name,omitempty"`
 	TargetName       string          `json:"target_name,omitempty"`
 	GitInfo          *GitInfo        `json:"git_info,omitempty"`


### PR DESCRIPTION
## Changes
Record the bundle target deployment mode on each DMS version. Adds a `deployment_mode` field (and the `DEPLOYMENT_MODE_DEVELOPMENT` / `DEPLOYMENT_MODE_PRODUCTION` enum) to `tmpdms.Version`, and sets it in the `CreateVersion` request from `bundle.mode`.

Not set on the deployment: `Deployment.deployment_mode` is derived server-side from the most recent version's mode (output-only), so the CLI only sets it on the version. A target with no `mode` maps to an empty value, which is omitted (the server treats it as unspecified) — we don't fabricate a default.

## Why
The SDK's `bundle.Version` already carries `deployment_mode` ("captured at the time of this version"), but the CLI never populated it, so every version recorded a null mode. This stamps it so each version records whether it was a development or production deployment.

## Tests
Added a unit test for the mode mapping (development / production / unset). The `bundle/dms` acceptance outputs are unchanged because those targets don't set a mode. Verified live against a workspace: a `mode: development` target now records `deployment_mode: DEPLOYMENT_MODE_DEVELOPMENT` on the created version.

This pull request and its description were written by Isaac, an AI coding agent.
