### PR TITLE
acceptance: make generate/*_and_deploy bundle names unique

### DIFF
--- a/acceptance/bundle/generate/pipeline_and_deploy/databricks.yml
+++ b/acceptance/bundle/generate/pipeline_and_deploy/databricks.yml
@@ -1,2 +1,0 @@
-bundle:
-  name: pipeline_and_deploy

--- a/acceptance/bundle/generate/pipeline_and_deploy/databricks.yml.tmpl
+++ b/acceptance/bundle/generate/pipeline_and_deploy/databricks.yml.tmpl
@@ -1,0 +1,2 @@
+bundle:
+  name: pipeline_and_deploy-$UNIQUE_NAME

--- a/acceptance/bundle/generate/pipeline_and_deploy/output.txt
+++ b/acceptance/bundle/generate/pipeline_and_deploy/output.txt
@@ -13,13 +13,13 @@ Pipeline configuration successfully saved to resources/out.pipeline.yml
 === Verify generated yaml has expected fields
 === Deploy the generated bundle
 >>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/pipeline_and_deploy/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/pipeline_and_deploy-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Deployment complete!
 
 === Destroy the deployed bundle
 >>> [CLI] bundle destroy --auto-approve
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/pipeline_and_deploy/default
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/pipeline_and_deploy-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/generate/pipeline_and_deploy/script
+++ b/acceptance/bundle/generate/pipeline_and_deploy/script
@@ -1,3 +1,5 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+
 title "Upload files to workspace"
 trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/notebook.py" --file notebook.py --format AUTO --overwrite
 trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test.py" --file test.py --format AUTO --overwrite

--- a/acceptance/bundle/generate/python_job_and_deploy/databricks.yml
+++ b/acceptance/bundle/generate/python_job_and_deploy/databricks.yml
@@ -1,2 +1,0 @@
-bundle:
-  name: python_job_and_deploy

--- a/acceptance/bundle/generate/python_job_and_deploy/databricks.yml.tmpl
+++ b/acceptance/bundle/generate/python_job_and_deploy/databricks.yml.tmpl
@@ -1,0 +1,2 @@
+bundle:
+  name: python_job_and_deploy-$UNIQUE_NAME

--- a/acceptance/bundle/generate/python_job_and_deploy/output.txt
+++ b/acceptance/bundle/generate/python_job_and_deploy/output.txt
@@ -12,13 +12,13 @@ Job configuration successfully saved to resources/out.job.yml
 === Verify generated yaml has expected fields
 === Deploy the generated bundle
 >>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/python_job_and_deploy/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/python_job_and_deploy-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Deployment complete!
 
 === Destroy the deployed bundle
 >>> [CLI] bundle destroy --auto-approve
-All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/python_job_and_deploy/default
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/python_job_and_deploy-[UNIQUE_NAME]/default
 
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/generate/python_job_and_deploy/script
+++ b/acceptance/bundle/generate/python_job_and_deploy/script
@@ -1,3 +1,5 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+
 title "Upload notebook to a workspace path"
 trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test_notebook.py" --file test_notebook.py --format AUTO --overwrite
 


### PR DESCRIPTION
## Changes
Append `-$UNIQUE_NAME` to the bundle name in `generate/pipeline_and_deploy` and `python_job_and_deploy` (via `databricks.yml.tmpl` + `envsubst`).

## Why
The static bundle name made all parallel cloud variants deploy to the same path, causing deploy-lock contention where all but one variant failed.

## Tests
Regenerated outputs; both tests pass across all engine variants.