### PR TITLE
Fix flag names in `bundle generate dashboard` error message

### DIFF
--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -79,7 +79,7 @@ func (d *dashboard) resolveID(ctx context.Context, b *bundle.Bundle) string {
 		return d.resolveFromID(ctx, b)
 	}
 
-	logdiag.LogError(ctx, errors.New("expected one of --dashboard-path, --dashboard-id"))
+	logdiag.LogError(ctx, errors.New("expected one of --existing-path, --existing-id"))
 	return ""
 }
 


### PR DESCRIPTION
## Changes
Fix the flag names in the `bundle generate dashboard` fallback error. `resolveID` referenced `--dashboard-path` / `--dashboard-id`, which are not flags of this command; the real flags are `--existing-path` / `--existing-id`.

## Why
The message printed flag names that don't exist, which would mislead anyone who hit it.

## Tests
Existing `cmd/bundle/generate` unit tests and `bundle/generate/dashboard*` acceptance tests pass. No test asserted the old string.

_This PR was written by Claude Code._