### PR TITLE
Fix bundle generate producing wrong output for pipelines with no root_path

### DIFF
--- a/acceptance/bundle/generate/pipeline_with_glob/databricks.yml
+++ b/acceptance/bundle/generate/pipeline_with_glob/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: generate-pipeline

--- a/acceptance/bundle/generate/pipeline_with_glob/out.pipeline.yml
+++ b/acceptance/bundle/generate/pipeline_with_glob/out.pipeline.yml
@@ -1,0 +1,7 @@
+resources:
+  pipelines:
+    out:
+      name: generate-pipeline
+      libraries:
+        - glob:
+            include: /Workspace/Users/[USERNAME]/src/*.py

--- a/acceptance/bundle/generate/pipeline_with_glob/out.test.toml
+++ b/acceptance/bundle/generate/pipeline_with_glob/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/pipeline_with_glob/output.txt
+++ b/acceptance/bundle/generate/pipeline_with_glob/output.txt
@@ -1,0 +1,1 @@
+Pipeline configuration successfully saved to out.pipeline.yml

--- a/acceptance/bundle/generate/pipeline_with_glob/script
+++ b/acceptance/bundle/generate/pipeline_with_glob/script
@@ -1,0 +1,1 @@
+$CLI bundle generate pipeline --existing-pipeline-id 1234 --config-dir . --key out --force --source-dir .

--- a/acceptance/bundle/generate/pipeline_with_glob/test.toml
+++ b/acceptance/bundle/generate/pipeline_with_glob/test.toml
@@ -1,0 +1,17 @@
+[[Server]]
+Pattern = "GET /api/2.0/pipelines/1234"
+Response.Body = '''
+{
+    "pipeline_id": 1234,
+    "spec": {
+        "name": "generate-pipeline",
+        "libraries": [
+            {
+                "glob": {
+                    "include": "/Workspace/Users/tester@databricks.com/src/*.py"
+                }
+            }
+        ]
+    }
+}
+'''

--- a/bundle/generate/pipeline.go
+++ b/bundle/generate/pipeline.go
@@ -15,7 +15,7 @@ func ConvertPipelineToValue(pipeline *pipelines.PipelineSpec, rootPath, remoteRo
 		pipeline.RootPath = rootPath
 	}
 
-	if pipeline.Libraries != nil {
+	if pipeline.Libraries != nil && remoteRootPath != "" {
 		for i := range pipeline.Libraries {
 			lib := &pipeline.Libraries[i]
 			if lib.Glob != nil {


### PR DESCRIPTION
## Changes
Fix bundle generate producing wrong output for pipelines with no root_path

## Why
The pipeline libraries' paths were incorrectly split by each character because root_path was empty leading to the wrong paths generated
 
## Tests
Added an acceptance test

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
