### PR TITLE
Default to `DATA_SECURITY_MODE_AUTO` in bundle templates

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### CLI
 
 ### Bundles
-* New projects created from the `default` and `dbt-sql` templates default their job cluster `data_security_mode` to `DATA_SECURITY_MODE_AUTO` ([#5452](https://github.com/databricks/cli/pull/5452)).
+* Set the default `data_security_mode` to `DATA_SECURITY_MODE_AUTO` in bundle templates ([#5452](https://github.com/databricks/cli/pull/5452)).
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 ### Bundles
+* New projects created from the `default` and `dbt-sql` templates default their job cluster `data_security_mode` to `DATA_SECURITY_MODE_AUTO` ([#5452](https://github.com/databricks/cli/pull/5452)).
 
 ### Dependency updates
 

--- a/acceptance/bundle/migrate/default-python/out.plan_after_deploy.json
+++ b/acceptance/bundle/migrate/default-python/out.plan_after_deploy.json
@@ -28,7 +28,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }
@@ -128,7 +128,7 @@
                 "max_workers": 4,
                 "min_workers": 1
               },
-              "data_security_mode": "SINGLE_USER",
+              "data_security_mode": "DATA_SECURITY_MODE_AUTO",
               "node_type_id": "[NODE_TYPE_ID]",
               "spark_version": "16.4.x-scala2.12"
             }

--- a/acceptance/bundle/migrate/default-python/out.plan_after_migration.json
+++ b/acceptance/bundle/migrate/default-python/out.plan_after_migration.json
@@ -28,7 +28,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }
@@ -128,7 +128,7 @@
                 "max_workers": 4,
                 "min_workers": 1
               },
-              "data_security_mode": "SINGLE_USER",
+              "data_security_mode": "DATA_SECURITY_MODE_AUTO",
               "node_type_id": "[NODE_TYPE_ID]",
               "spark_version": "16.4.x-scala2.12"
             }

--- a/acceptance/bundle/migrate/default-python/out.state_after_migration.json
+++ b/acceptance/bundle/migrate/default-python/out.state_after_migration.json
@@ -21,7 +21,7 @@
         "max_workers": 4,
         "min_workers": 1
        },
-       "data_security_mode": "SINGLE_USER",
+       "data_security_mode": "DATA_SECURITY_MODE_AUTO",
        "node_type_id": "[NODE_TYPE_ID]",
        "spark_version": "16.4.x-scala2.12"
       }

--- a/acceptance/bundle/migrate/default-python/out.state_original.json
+++ b/acceptance/bundle/migrate/default-python/out.state_original.json
@@ -65,7 +65,7 @@
                     "cluster_mount_info": [],
                     "cluster_name": "",
                     "custom_tags": null,
-                    "data_security_mode": "SINGLE_USER",
+                    "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                     "docker_image": [],
                     "driver_instance_pool_id": "",
                     "driver_node_type_flexibility": [],

--- a/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
+++ b/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
@@ -62,7 +62,7 @@
 +          new_cluster:
 +            spark_version: 16.4.x-scala2.12
 +            node_type_id: [NODE_TYPE_ID]
-+            data_security_mode: SINGLE_USER
++            data_security_mode: DATA_SECURITY_MODE_AUTO
 +            autoscale:
 +              min_workers: 1
 +              max_workers: 4

--- a/acceptance/bundle/templates/default-python/classic/out.plan_after_deploy_dev.direct.json
+++ b/acceptance/bundle/templates/default-python/classic/out.plan_after_deploy_dev.direct.json
@@ -28,7 +28,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }
@@ -128,7 +128,7 @@
                 "max_workers": 4,
                 "min_workers": 1
               },
-              "data_security_mode": "SINGLE_USER",
+              "data_security_mode": "DATA_SECURITY_MODE_AUTO",
               "node_type_id": "[NODE_TYPE_ID]",
               "spark_version": "16.4.x-scala2.12"
             }

--- a/acceptance/bundle/templates/default-python/classic/out.plan_after_deploy_prod.direct.json
+++ b/acceptance/bundle/templates/default-python/classic/out.plan_after_deploy_prod.direct.json
@@ -30,7 +30,7 @@
                 "max_workers": 4,
                 "min_workers": 1
               },
-              "data_security_mode": "SINGLE_USER",
+              "data_security_mode": "DATA_SECURITY_MODE_AUTO",
               "node_type_id": "[NODE_TYPE_ID]",
               "spark_version": "16.4.x-scala2.12"
             }

--- a/acceptance/bundle/templates/default-python/classic/out.plan_dev.direct.json
+++ b/acceptance/bundle/templates/default-python/classic/out.plan_dev.direct.json
@@ -26,7 +26,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }

--- a/acceptance/bundle/templates/default-python/classic/out.plan_prod.direct.json
+++ b/acceptance/bundle/templates/default-python/classic/out.plan_prod.direct.json
@@ -26,7 +26,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.dev.direct.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.dev.direct.txt
@@ -104,7 +104,7 @@
             "max_workers": 4,
             "min_workers": 1
           },
-          "data_security_mode": "SINGLE_USER",
+          "data_security_mode": "DATA_SECURITY_MODE_AUTO",
           "node_type_id": "[NODE_TYPE_ID]",
           "spark_version": "16.4.x-scala2.12"
         }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.dev.terraform.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.dev.terraform.txt
@@ -104,7 +104,7 @@
             "max_workers": 4,
             "min_workers": 1
           },
-          "data_security_mode": "SINGLE_USER",
+          "data_security_mode": "DATA_SECURITY_MODE_AUTO",
           "node_type_id": "[NODE_TYPE_ID]",
           "spark_version": "16.4.x-scala2.12"
         }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.prod.direct.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.prod.direct.txt
@@ -107,7 +107,7 @@
             "max_workers": 4,
             "min_workers": 1
           },
-          "data_security_mode": "SINGLE_USER",
+          "data_security_mode": "DATA_SECURITY_MODE_AUTO",
           "node_type_id": "[NODE_TYPE_ID]",
           "spark_version": "16.4.x-scala2.12"
         }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.prod.terraform.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.prod.terraform.txt
@@ -107,7 +107,7 @@
             "max_workers": 4,
             "min_workers": 1
           },
-          "data_security_mode": "SINGLE_USER",
+          "data_security_mode": "DATA_SECURITY_MODE_AUTO",
           "node_type_id": "[NODE_TYPE_ID]",
           "spark_version": "16.4.x-scala2.12"
         }

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/resources/sample_job.job.yml
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/resources/sample_job.job.yml
@@ -59,7 +59,7 @@ resources:
           new_cluster:
             spark_version: 16.4.x-scala2.12
             node_type_id: [NODE_TYPE_ID]
-            data_security_mode: SINGLE_USER
+            data_security_mode: DATA_SECURITY_MODE_AUTO
             autoscale:
               min_workers: 1
               max_workers: 4

--- a/acceptance/bundle/templates/default-python/integration_classic/out.plan_dev.direct.json
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.plan_dev.direct.json
@@ -26,7 +26,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }

--- a/acceptance/bundle/templates/default-python/integration_classic/out.plan_prod.direct.json
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.plan_prod.direct.json
@@ -26,7 +26,7 @@
                   "max_workers": 4,
                   "min_workers": 1
                 },
-                "data_security_mode": "SINGLE_USER",
+                "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                 "node_type_id": "[NODE_TYPE_ID]",
                 "spark_version": "16.4.x-scala2.12"
               }

--- a/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
+++ b/acceptance/bundle/templates/default-python/integration_classic/out.validate.dev.json
@@ -58,7 +58,7 @@
                 "max_workers": 4,
                 "min_workers": 1
               },
-              "data_security_mode": "SINGLE_USER",
+              "data_security_mode": "DATA_SECURITY_MODE_AUTO",
               "node_type_id": "[NODE_TYPE_ID]",
               "spark_version": "16.4.x-scala2.12"
             }

--- a/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/resources/sample_job.py
+++ b/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/resources/sample_job.py
@@ -82,7 +82,7 @@ sample_job = Job.from_dict(
                 "new_cluster": {
                     "spark_version": "16.4.x-scala2.12",
                     "node_type_id": "[NODE_TYPE_ID]",
-                    "data_security_mode": "SINGLE_USER",
+                    "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                     "autoscale": {
                         "min_workers": 1,
                         "max_workers": 4,

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -46,7 +46,7 @@ resources:
           new_cluster:
             spark_version: {{template "latest_lts_dbr_version"}}
             node_type_id: {{smallest_node_type}}
-            data_security_mode: SINGLE_USER
+            data_security_mode: DATA_SECURITY_MODE_AUTO
             num_workers: 0
             spark_conf:
               spark.master: "local[*, 4]"

--- a/libs/template/templates/default/template/{{.project_name}}/resources/sample_job.job.yml.tmpl
+++ b/libs/template/templates/default/template/{{.project_name}}/resources/sample_job.job.yml.tmpl
@@ -109,7 +109,7 @@ resources:
           new_cluster:
             spark_version: {{template "latest_lts_dbr_version"}}
             node_type_id: {{smallest_node_type}}
-            data_security_mode: SINGLE_USER
+            data_security_mode: DATA_SECURITY_MODE_AUTO
             autoscale:
               min_workers: 1
               max_workers: 4

--- a/libs/template/templates/default/template/{{.project_name}}/resources/sample_job.py.tmpl
+++ b/libs/template/templates/default/template/{{.project_name}}/resources/sample_job.py.tmpl
@@ -135,7 +135,7 @@ sample_job = Job.from_dict(
                 "new_cluster": {
                     "spark_version": "{{template "latest_lts_dbr_version"}}",
                     "node_type_id": "{{smallest_node_type}}",
-                    "data_security_mode": "SINGLE_USER",
+                    "data_security_mode": "DATA_SECURITY_MODE_AUTO",
                     "autoscale": {
                         "min_workers": 1,
                         "max_workers": 4,


### PR DESCRIPTION
## Changes

The default `data_security_mode` for job clusters created by the bundle templates is now `DATA_SECURITY_MODE_AUTO`. With Auto, the access mode is selected automatically: Standard by default, and Dedicated when the cluster configuration requires it (for example ML Runtime, GPUs, R, Databricks Container Services, or global init scripts). See [Access modes](https://docs.databricks.com/aws/en/compute/configure#access-modes).

## Why

Auto selects an access mode that works across the broadest set of configurations without the user having to pick one. The job definition stores and returns `auto` verbatim; the access mode is resolved per run when the job cluster launches, and that resolved value is never written back to the job — so bundles see no drift.

## Tests

- Acceptance tests updated and passing for both deploy engines.
- Deployed against a production workspace on both engines and confirmed the value round-trips as `DATA_SECURITY_MODE_AUTO` with no drift, and that Auto resolves to a concrete access mode at cluster launch.
- Manually verified the dbt-sql template's classic (non-serverless) job cluster by deploying and running the job: Auto round-trips and resolves correctly and the run completes.

This pull request and its description were written by Isaac.
