### PR TITLE
acceptance: prefix unique test resource names with "cli-"

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -633,7 +633,14 @@ func runTest(t *testing.T,
 	}
 
 	id := uuid.New()
-	uniqueName := strings.ToLower(strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "="))
+	// Prefix the unique name so that cloud resources created by acceptance tests
+	// (SQL warehouses, clusters, schemas, ...) are attributable to the CLI acceptance
+	// suite and can be found and cleaned up in shared test workspaces. The replacement
+	// below keys on the full value, so output normalization to [UNIQUE_NAME] is unaffected.
+	// The prefix has no separator on purpose: the name feeds both bundle/project names
+	// (which allow only [a-zA-Z0-9_]) and app hostnames (which disallow underscores), so a
+	// separator-less alphanumeric prefix is the only form valid in every context.
+	uniqueName := "cli" + strings.ToLower(strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "="))
 	repls.Set(uniqueName, "[UNIQUE_NAME]")
 
 	var tmpDir string


### PR DESCRIPTION
## Changes
Prefix the per-run `uniqueName` used by the acceptance test harness with `cli`.

This name is exported to tests as `$UNIQUE_NAME` and used to name resources. When acceptance tests run against a real workspace (cloud mode), some of those resources are real Databricks objects (SQL warehouses, clusters, schemas, ...). Previously the name was a bare lowercased base32 string, e.g. `ricmuzymnfab5hj5z2r43mck2u`.

## Why
Shared test workspaces accumulate resources created by many different test suites and tools. A bare base32 name makes CLI-created resources which are hard to attribute. A stable `cli` prefix makes these resources greppable and attributable, matching the convention other suites already use for their own resources.

The change is intentionally at the single point where `uniqueName` is generated, so every resource named via `$UNIQUE_NAME` benefits, not just one fixture.

## Tests
No behavior change for test output. Existing tests pass.

This pull request and its description were written by Isaac.
