### PR TITLE
Mark vector search index index_subtype as backend_default

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bundles
 * Set the default `data_security_mode` to `DATA_SECURITY_MODE_AUTO` in bundle templates ([#5452](https://github.com/databricks/cli/pull/5452)).
+* Mark vector search index index_subtype as backend_default to prevent drift after deployment ([#5454](https://github.com/databricks/cli/pull/5454)).
 
 ### Dependency updates
 

--- a/acceptance/bin/print_requests.py
+++ b/acceptance/bin/print_requests.py
@@ -56,6 +56,25 @@ R4 POST
 >>> # Test positive + negative filters (AND logic)
 >>> test(test_requests, ["//api", "^/jobs"], False, False)
 R4 POST
+
+>>> # --unique collapses consecutive duplicate requests (like uniq), e.g. repeated GET polls
+>>> dup_requests = [
+...     {"method": "POST", "path": "/api/2.0/idx", "body": {"n": 1}},
+...     {"method": "GET", "path": "/api/2.0/idx"},
+...     {"method": "GET", "path": "/api/2.0/idx"},
+... ]
+>>> [x["method"] for x in filter_requests(dup_requests, ["//idx"], True, False, unique=True)]
+['POST', 'GET']
+
+>>> # Only consecutive duplicates collapse; a repeat after another request is kept
+>>> seq = [
+...     {"method": "GET", "path": "/api/2.0/idx"},
+...     {"method": "DELETE", "path": "/api/2.0/idx"},
+...     {"method": "GET", "path": "/api/2.0/idx"},
+...     {"method": "GET", "path": "/api/2.0/idx"},
+... ]
+>>> [x["method"] for x in filter_requests(seq, ["//idx"], True, False, unique=True)]
+['GET', 'DELETE', 'GET']
 """
 
 import os
@@ -104,7 +123,7 @@ result = read_json_many(test)
 assert result == [{"method": "GET"}, {"method": "POST"}], result
 
 
-def filter_requests(requests, path_filters, include_get, should_sort):
+def filter_requests(requests, path_filters, include_get, should_sort, unique=False):
     """Filter requests based on method and path filters."""
     positive_filters = []
     negative_filters = []
@@ -145,6 +164,13 @@ def filter_requests(requests, path_filters, include_get, should_sort):
     if should_sort:
         filtered_requests.sort(key=str)
 
+    if unique:
+        deduped = []
+        for req in filtered_requests:
+            if not deduped or deduped[-1] != req:
+                deduped.append(req)
+        filtered_requests = deduped
+
     return filtered_requests
 
 
@@ -155,6 +181,11 @@ def main():
     parser.add_argument("--get", action="store_true", help="Include GET requests (excluded by default)")
     parser.add_argument("--keep", action="store_true", help="Keep out.requests.json file after processing")
     parser.add_argument("--sort", action="store_true", help="Sort requests before output")
+    parser.add_argument(
+        "--unique",
+        action="store_true",
+        help="Collapse consecutive duplicate requests (like uniq), e.g. repeated GET polls",
+    )
     parser.add_argument("--oneline", action="store_true", help="Print output with one request per line")
     parser.add_argument("--fname", default="out.requests.txt")
     args = parser.parse_args()
@@ -175,7 +206,7 @@ def main():
         return
 
     requests = read_json_many(data)
-    filtered_requests = filter_requests(requests, args.path_filters, args.get, args.sort)
+    filtered_requests = filter_requests(requests, args.path_filters, args.get, args.sort, args.unique)
     if args.verbose:
         print(
             f"Read {len(data)} chars, {len(requests)} requests, {len(filtered_requests)} after filtering",

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/output.txt
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/output.txt
@@ -6,7 +6,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> print_requests.py --get //vector-search/indexes
+>>> print_requests.py --get --unique //vector-search/indexes
 
 === Change embedding_dimension (should trigger recreation)
 >>> update_file.py databricks.yml embedding_dimension: 768 embedding_dimension: 384
@@ -27,7 +27,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> print_requests.py --get //vector-search/indexes
+>>> print_requests.py --get --unique //vector-search/indexes
 
 >>> [CLI] vector-search-indexes get-index main.default.vs_index_[UNIQUE_NAME]
 {

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/script
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/script
@@ -12,7 +12,9 @@ print_requests() {
     # without that, removing the wait would silently still pass against the
     # testserver (which finishes deletion synchronously) — the GET in the log
     # is the assertion that the wait actually fired.
-    trace print_requests.py --get '//vector-search/indexes' > out.requests.${name}.$DATABRICKS_BUNDLE_ENGINE.json
+    # --unique collapses the repeated identical poll GETs (one on the testserver,
+    # many on a real workspace that provisions asynchronously) to a stable count.
+    trace print_requests.py --get --unique '//vector-search/indexes' > out.requests.${name}.$DATABRICKS_BUNDLE_ENGINE.json
     rm -f out.requests.txt
 }
 

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/output.txt
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/output.txt
@@ -73,6 +73,7 @@ Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
         },
         "endpoint_name": "vs-endpoint-[UNIQUE_NAME]",
         "endpoint_uuid": "[UUID]",
+        "index_subtype": "HYBRID",
         "index_type": "DIRECT_ACCESS",
         "name": "main.default.vs_index_[UNIQUE_NAME]",
         "primary_key": "id",
@@ -86,6 +87,11 @@ Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
           "reason": "state-only field",
           "old": "[UUID]",
           "remote": "[UUID]"
+        },
+        "index_subtype": {
+          "action": "skip",
+          "reason": "backend_default",
+          "remote": "HYBRID"
         }
       }
     }

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -608,3 +608,6 @@ resources:
         reason: immutable
       - field: direct_access_index_spec
         reason: immutable
+    backend_defaults:
+      # The Vector Search API assigns index_subtype when the config omits it
+      - field: index_subtype

--- a/libs/testserver/vector_search_indexes.go
+++ b/libs/testserver/vector_search_indexes.go
@@ -64,11 +64,18 @@ func (s *FakeWorkspace) VectorSearchIndexCreate(req Request) Response {
 		}
 	}
 
+	// The backend assigns index_subtype when the request omits it (HYBRID by default)
+	indexSubtype := createReq.IndexSubtype
+	if indexSubtype == "" {
+		indexSubtype = vectorsearch.IndexSubtypeHybrid
+	}
+
 	index := fakeVectorSearchIndex{
 		VectorIndex: vectorsearch.VectorIndex{
 			Creator:               s.CurrentUser().UserName,
 			EndpointName:          createReq.EndpointName,
 			IndexType:             createReq.IndexType,
+			IndexSubtype:          indexSubtype,
 			Name:                  createReq.Name,
 			PrimaryKey:            createReq.PrimaryKey,
 			DeltaSyncIndexSpec:    remapDeltaSyncSpec(createReq.DeltaSyncIndexSpec),


### PR DESCRIPTION
## Changes
- Add `index_subtype` as `backend_default` for vector search indexes and teach testserver to return a default value
- Add `--unique` to `print_requests.py` so tests can choose to collapse subsequent GET requests (e.g. encountered during polling)

## Why
- Grants test was failing with recreate
  ```
  acceptance_test.go:939: Diff:
            --- bundle/resources/vector_search_indexes/grants/select/output.txt
            +++ /tmp/TestAcceptbundleresourcesvector_search_indexesgrantsselect1239696916/001/output.txt
            @@ -13,8 +13,11 @@
             Deployment complete!
             
             >>> [CLI] bundle plan
            -Plan: 0 to add, 0 to change, 0 to delete, 3 unchanged
            +recreate vector_search_indexes.my_index
            +update vector_search_indexes.my_index.grants
             
            +Plan: 1 to add, 1 to change, 1 to delete, 1 unchanged
            +
             >>> [CLI] grants get table main.default.vs_index_[UNIQUE_NAME]
             {
               "privilege_assignments": [
  ```
- `bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.requests.create.direct.json` had an extra GET 
  ```
  --- bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.requests.create.direct.json
            +++ /tmp/TestAcceptbundleresourcesvector_search_indexesrecreateembed3063347120/001/out.requests.create.direct.json
            @@ -21,3 +21,555 @@
               "method": "GET",
               "path": "/api/2.0/vector-search/indexes/main.default.vs_index_[UNIQUE_NAME]"
             }
            +{
            +  "method": "GET",
            +  "path": "/api/2.0/vector-search/indexes/main.default.vs_index_[UNIQUE_NAME]"
            +}
  ```

## Tests
Reverted the `resources.yml` change and reran `grants/select`:
```
>>> [CLI] bundle plan
-Plan: 0 to add, 0 to change, 0 to delete, 3 unchanged
+recreate vector_search_indexes.my_index
+update vector_search_indexes.my_index.grants
+
+Plan: 1 to add, 1 to change, 1 to delete, 1 unchanged
```
