### PR TITLE
Remove EnvVaryOutput config field, hardcode DATABRICKS_BUNDLE_ENGINE

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1581,17 +1581,14 @@ func loadUserReplacements(t *testing.T, repls *testdiff.ReplacementsContext, tmp
 
 type pathFilter struct {
 	// contains substrings from the variants other than current.
-	// E.g. if EnvVaryOutput is DATABRICKS_BUNDLE_ENGINE and current test running DATABRICKS_BUNDLE_ENGINE="terraform" then
-	// notSelected contains ".direct." meaning if filename contains that (e.g. out.deploy.direct.txt) then we ignore it here.
+	// E.g. current test running DATABRICKS_BUNDLE_ENGINE="terraform" means
+	// notSelected contains ".direct." so files like out.deploy.direct.txt are ignored.
 	notSelected []string
 }
 
-// preparePathFilter builds filter based on EnvVaryOutput and current variant env.
+// preparePathFilter builds filter based on DATABRICKS_BUNDLE_ENGINE and current variant env.
 func preparePathFilter(config internal.TestConfig, customEnv []string) pathFilter {
-	if config.EnvVaryOutput == nil {
-		return pathFilter{}
-	}
-	key := *config.EnvVaryOutput
+	const key = "DATABRICKS_BUNDLE_ENGINE"
 	vals := config.EnvMatrix[key]
 	if len(vals) <= 1 {
 		return pathFilter{}

--- a/acceptance/bundle/test.toml
+++ b/acceptance/bundle/test.toml
@@ -1,6 +1,3 @@
-# This allows recording per-deployment output files, e.g. $CLI bundle deploy > out.$DATABRICKS_BUNDLE_ENGINE.txt
-EnvVaryOutput = "DATABRICKS_BUNDLE_ENGINE"
-
 # The lowest Python version we support. Alternative to "uv run --python 3.10"
 Env.UV_PYTHON = "3.10"
 

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -117,11 +117,6 @@ type TestConfig struct {
 	// List of keys for which to do string replacement value -> [KEY]. If not set, defaults to true.
 	EnvRepl map[string]bool
 
-	// Name of EnvMatrix key that determines variant-specific output file names.
-	// If set and present in EnvMatrix, update mode will run all variants for this key,
-	// and comparison will only consider files containing the current variant value.
-	EnvVaryOutput *string
-
 	// Maximum amount of time the test is allowed to run, will be killed after that.
 	Timeout time.Duration
 

--- a/acceptance/selftest/envoutput/test.toml
+++ b/acceptance/selftest/envoutput/test.toml
@@ -1,4 +1,2 @@
-EnvVaryOutput = "DATABRICKS_BUNDLE_ENGINE"
-
 [EnvMatrix]
 DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/subset_ancestor_engine/child/test.toml
+++ b/acceptance/selftest/subset_ancestor_engine/child/test.toml
@@ -1,1 +1,0 @@
-EnvVaryOutput = "DATABRICKS_BUNDLE_ENGINE"


### PR DESCRIPTION
## Summary

- `EnvVaryOutput` in `TestConfig` was always set to `"DATABRICKS_BUNDLE_ENGINE"` in every `test.toml` that used it — there were no other values
- Remove the field and hardcode the key directly in `preparePathFilter`
- Drop the three `EnvVaryOutput = "DATABRICKS_BUNDLE_ENGINE"` lines from `test.toml` files

## Test plan

- [ ] Existing acceptance tests cover this path (`selftest/envoutput`, `selftest/subset_ancestor_engine`)

This pull request was AI-assisted by Isaac.