### PR TITLE
lakebox: `register` writes `~/.ssh/config` alias; ed25519 keys; verify key registered before ssh

### DIFF
--- a/cmd/lakebox/register.go
+++ b/cmd/lakebox/register.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const lakeboxKeyName = "lakebox_rsa"
+const lakeboxKeyName = "lakebox_ed25519"
 
 func newRegisterCommand() *cobra.Command {
 	var name string
@@ -26,10 +26,13 @@ func newRegisterCommand() *cobra.Command {
 		Long: `Generate a dedicated SSH key for lakebox and register it with the service.
 
 This command:
-1. Generates an RSA SSH key at ~/.ssh/lakebox_rsa (if it doesn't exist)
+1. Generates an Ed25519 SSH key at ~/.ssh/lakebox_ed25519 (if it doesn't exist)
 2. Registers the public key with the lakebox service, labeled with --name
    (defaults to this machine's hostname so 'ssh-key list' is meaningful
    across multiple machines)
+3. Optionally adds a 'Host lakebox-gw' alias to ~/.ssh/config (prompted
+   the first time) so editor Remote-SSH ("Open in VS Code / Cursor"
+   from the workspace UI) and plain 'ssh <id>@lakebox-gw' both work
 
 After registration, 'databricks lakebox ssh' will use this key automatically.
 Run this once per machine.
@@ -81,6 +84,23 @@ Examples:
 			}
 			s.ok("SSH key registered")
 
+			// Write the shared `lakebox-gw` SSH-config alias so editor
+			// Remote-SSH ("Open in VS Code/Cursor") deep links and
+			// `ssh <id>@lakebox-gw` from a plain shell both work
+			// without the user having to paste any config block. The
+			// alias name and shape are aligned with the workspace UI's
+			// "First time setup?" disclosure, so CLI users and
+			// pasted-snippet users converge on the same config.
+			//
+			// First register on this machine prompts for consent (the
+			// Include line we add to ~/.ssh/config is a permanent
+			// change to a user-managed file). Re-runs are silent — if
+			// the Include is already there, the user has opted in and
+			// we just refresh the managed file's contents.
+			if err := maybeWriteSSHConfig(ctx, keyPath, w.Config.Host); err != nil {
+				warn(ctx, fmt.Sprintf("registered key, but failed to update ~/.ssh/config: %v", err))
+			}
+
 			blank(stderr)
 			fmt.Fprintf(stderr, "  Run %s to connect.\n\n", cmdio.Bold(ctx, "databricks lakebox ssh"))
 			return nil
@@ -130,7 +150,7 @@ func ensureLakeboxKey(ctx context.Context) (string, bool, error) {
 		return "", false, fmt.Errorf("failed to create %s: %w", sshDir, err)
 	}
 
-	genCmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", "4096", "-f", keyPath, "-N", "", "-q", "-C", "lakebox")
+	genCmd := exec.Command("ssh-keygen", "-t", "ed25519", "-f", keyPath, "-N", "", "-q", "-C", "lakebox")
 	genCmd.Stdin = os.Stdin
 	genCmd.Stdout = os.Stderr
 	genCmd.Stderr = os.Stderr

--- a/cmd/lakebox/ssh.go
+++ b/cmd/lakebox/ssh.go
@@ -119,6 +119,22 @@ Examples:
 				return err
 			}
 
+			// Verify the local key is still registered before opening
+			// the SSH socket. The gateway's publickey-callback already
+			// checks the key (see lakebox/src/ssh/handler.rs's
+			// verify_ssh_key), but SSH_MSG_USERAUTH_FAILURE has no
+			// free-form reason field and SSH_MSG_USERAUTH_BANNER is
+			// swallowed by many client wrappers — so the gateway can't
+			// communicate "key not registered" through the SSH channel.
+			// The HTTP API is the only out-of-band wire that can
+			// surface a structured "run register" pointer to the user.
+			// listKeys errors fall through with a warning so a
+			// transient API hiccup doesn't block a connection the
+			// gateway could still route.
+			if err := verifyKeyRegistered(ctx, api, keyPath); err != nil {
+				return err
+			}
+
 			if lakeboxID == "" {
 				def := getDefault(ctx, profile)
 				if def == "" {
@@ -214,6 +230,37 @@ Examples:
 	cmd.Flags().StringVar(&gatewayPort, "port", defaultGatewayPort, "Lakebox gateway SSH port")
 
 	return cmd
+}
+
+// verifyKeyRegistered confirms the local lakebox public key is still
+// registered with the workspace before we open the SSH socket. The
+// gateway itself already does this check during userauth, but the
+// SSH protocol's reply surface (USERAUTH_FAILURE has no free-form
+// reason; USERAUTH_BANNER is widely swallowed) flattens "unknown
+// key", "key registered but not authorized for this sandbox", and
+// "ESM is down" into the same "Permission denied (publickey)". This
+// out-of-band HTTP check surfaces the specific case in language the
+// user can act on. listKeys errors fall through with a warning so a
+// transient API hiccup doesn't block a connection the gateway could
+// still route.
+func verifyKeyRegistered(ctx context.Context, api *lakeboxAPI, keyPath string) error {
+	pub, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		return fmt.Errorf("reading public key %s.pub: %w", keyPath, err)
+	}
+	want := keyHash(string(pub))
+
+	keys, err := api.listKeys(ctx)
+	if err != nil {
+		warn(ctx, fmt.Sprintf("could not verify SSH key registration: %v", err))
+		return nil
+	}
+	for _, k := range keys {
+		if k.KeyHash == want {
+			return nil
+		}
+	}
+	return fmt.Errorf("your lakebox SSH key (%s) is not registered with this workspace — run `databricks lakebox register` to re-register it", want)
 }
 
 // ensureRunning brings the named sandbox to Running before ssh hands

--- a/cmd/lakebox/sshconfig.go
+++ b/cmd/lakebox/sshconfig.go
@@ -1,0 +1,241 @@
+package lakebox
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/env"
+)
+
+const (
+	// sshConfigAlias is the SSH-config Host that all lakebox sandboxes
+	// route through. Shared with the workspace UI's "First time setup?"
+	// disclosure, so IDE Remote-SSH deep links resolve identically
+	// whether the user set up via the CLI or pasted the UI snippet.
+	sshConfigAlias = "lakebox-gw"
+
+	// sshIncludeFileName is the lakebox-managed file referenced by the
+	// user's ~/.ssh/config. The file is fully owned: we rewrite it on
+	// every `lakebox register`, so manual edits to it will not survive.
+	sshIncludeFileName = "databricks-lakebox"
+
+	// sshConfigBeginMarker / sshConfigEndMarker bracket the single line we
+	// add to the user's ~/.ssh/config (the Include directive). Markers make
+	// the line greppable and removable without re-parsing the file.
+	sshConfigBeginMarker = "# >>> databricks lakebox >>>"
+	sshConfigEndMarker   = "# <<< databricks lakebox <<<"
+)
+
+// sshConfigPaths returns (managedFile, mainConfig) under the user's
+// ~/.ssh directory. Side-effect free; safe to call before deciding
+// whether to actually write anything.
+func sshConfigPaths(ctx context.Context) (string, string, error) {
+	home, err := env.UserHomeDir(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	return filepath.Join(sshDir, sshIncludeFileName), filepath.Join(sshDir, "config"), nil
+}
+
+// sshConfigAlreadyManaged reports whether ~/.ssh/config already
+// contains the lakebox-managed Include block. Used by `register` to
+// decide whether to prompt the user for consent (first time) or
+// silently refresh the managed file (already opted in).
+func sshConfigAlreadyManaged(ctx context.Context) (bool, error) {
+	_, mainPath, err := sshConfigPaths(ctx)
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(mainPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading %s: %w", mainPath, err)
+	}
+	return hasOurMarkedBlock(string(data)), nil
+}
+
+// writeSSHConfig writes the lakebox-managed SSH config block to a
+// managed file and, if not already present, adds an Include directive
+// to the user's ~/.ssh/config pointing at that file.
+//
+// Returns (managedFilePath, mainConfigPath, error).
+func writeSSHConfig(ctx context.Context, keyPath, gatewayHost, gatewayPort string) (string, string, error) {
+	home, err := env.UserHomeDir(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		return "", "", fmt.Errorf("creating %s: %w", sshDir, err)
+	}
+
+	managedPath := filepath.Join(sshDir, sshIncludeFileName)
+	mainPath := filepath.Join(sshDir, "config")
+
+	block := buildSSHConfigBlock(keyPath, gatewayHost, gatewayPort)
+	if err := writeManagedConfig(managedPath, block); err != nil {
+		return managedPath, mainPath, err
+	}
+	if err := ensureMainIncludesManaged(mainPath, managedPath); err != nil {
+		return managedPath, mainPath, err
+	}
+	return managedPath, mainPath, nil
+}
+
+// buildSSHConfigBlock renders the Host stanza we write to the
+// lakebox-managed include file. The -o flags here mirror buildSSHArgs
+// in ssh.go so connections that resolve through this alias (IDE
+// Remote-SSH, raw `ssh <id>@lakebox-gw`) behave identically to
+// `databricks lakebox ssh`.
+//
+// No User directive is set, so the per-sandbox identifier travels in
+// the destination (`ssh <sandbox-id>@lakebox-gw`); a single alias
+// serves every sandbox on this profile's workspace.
+func buildSSHConfigBlock(keyPath, gatewayHost, gatewayPort string) string {
+	return fmt.Sprintf(`# Managed by `+"`databricks lakebox register`"+`.
+# Manual edits will be overwritten on the next run.
+Host %s
+    HostName %s
+    Port %s
+    IdentityFile %s
+    IdentitiesOnly yes
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    LogLevel ERROR
+`, sshConfigAlias, gatewayHost, gatewayPort, keyPath)
+}
+
+// writeManagedConfig writes content to path with 0600 perms, atomically
+// via tmp + rename so a crash mid-write can't leave a half-written
+// file. Skips the write entirely when the existing content already
+// matches, so repeated `lakebox register` runs don't churn the file's
+// mtime.
+func writeManagedConfig(path, content string) error {
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, []byte(content)) {
+		return nil
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming %s to %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+// ensureMainIncludesManaged makes sure ~/.ssh/config begins with an
+// `Include <managedPath>` directive bracketed by our begin/end markers.
+// If our block is already present, the file is left alone; if absent,
+// we prepend the block so it takes precedence over any later Host
+// blocks the user has defined (SSH applies the first match per option).
+func ensureMainIncludesManaged(mainPath, managedPath string) error {
+	managedBlock := fmt.Sprintf("%s\nInclude %s\n%s\n", sshConfigBeginMarker, managedPath, sshConfigEndMarker)
+
+	existing, err := os.ReadFile(mainPath)
+	switch {
+	case err == nil:
+		if hasOurMarkedBlock(string(existing)) {
+			return nil
+		}
+	case os.IsNotExist(err):
+		existing = nil
+	default:
+		return fmt.Errorf("reading %s: %w", mainPath, err)
+	}
+
+	// Prepend our block. SSH processes the file top-down and uses the
+	// first value seen for each option; placing our Include first lets
+	// `lakebox-gw` always resolve to the managed values even if the
+	// user has a wildcard `Host *` block later.
+	var buf bytes.Buffer
+	buf.WriteString(managedBlock)
+	if len(existing) > 0 {
+		// Ensure visual separation between our block and the user's
+		// content. If the existing file already starts with a blank
+		// line, don't add another.
+		if !strings.HasPrefix(string(existing), "\n") {
+			buf.WriteString("\n")
+		}
+		buf.Write(existing)
+	}
+
+	tmp := mainPath + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, mainPath); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming %s to %s: %w", tmp, mainPath, err)
+	}
+	return nil
+}
+
+// hasOurMarkedBlock reports whether the given config text already has
+// a lakebox-managed Include block (delimited by our markers).
+func hasOurMarkedBlock(text string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == sshConfigBeginMarker {
+			return true
+		}
+	}
+	return false
+}
+
+// maybeWriteSSHConfig writes the lakebox-managed SSH config, prompting
+// for consent the first time on this machine. Re-runs are silent: the
+// Include line in ~/.ssh/config signals prior opt-in, and we just
+// refresh the managed file's contents (e.g. if the gateway host has
+// changed).
+//
+// In non-interactive contexts (no TTY, no `--yes`-style flag here),
+// we skip the write rather than fail — `lakebox ssh` still works via
+// argv-explicit flags, only IDE Remote-SSH from the workspace UI
+// needs the config alias.
+func maybeWriteSSHConfig(ctx context.Context, keyPath, workspaceHost string) error {
+	already, err := sshConfigAlreadyManaged(ctx)
+	if err != nil {
+		return err
+	}
+	if !already {
+		_, mainPath, err := sshConfigPaths(ctx)
+		if err != nil {
+			return err
+		}
+		if !cmdio.IsPromptSupported(ctx) {
+			cmdio.LogString(ctx, "  "+cmdio.Faint(ctx, "skipped SSH config update (non-interactive); re-run `databricks lakebox register` from a terminal to add the `"+sshConfigAlias+"` alias"))
+			return nil
+		}
+		question := fmt.Sprintf(
+			"Add a `Host %s` alias to %s? This lets editor Remote-SSH (VS Code / Cursor) and `ssh <id>@%s` connect without further setup.",
+			sshConfigAlias, mainPath, sshConfigAlias,
+		)
+		confirmed, err := cmdio.AskYesOrNo(ctx, question)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			cmdio.LogString(ctx, "  "+cmdio.Faint(ctx, "skipped SSH config update; re-run `databricks lakebox register` to revisit"))
+			return nil
+		}
+	}
+
+	gateway := resolveGatewayHost(workspaceHost)
+	managedPath, _, err := writeSSHConfig(ctx, keyPath, gateway, defaultGatewayPort)
+	if err != nil {
+		return err
+	}
+	ok(ctx, "Updated SSH config (managed: "+cmdio.Faint(ctx, managedPath)+")")
+	return nil
+}

--- a/cmd/lakebox/sshconfig_test.go
+++ b/cmd/lakebox/sshconfig_test.go
@@ -1,0 +1,150 @@
+package lakebox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSSHConfigBlockShape(t *testing.T) {
+	block := buildSSHConfigBlock("/home/u/.ssh/lakebox_ed25519", "uw2.dbrx.dev", "2222")
+
+	// Header marker so users know not to hand-edit, and the alias name
+	// that the UI's "First time setup?" disclosure documents.
+	assert.Contains(t, block, "# Managed by")
+	assert.Contains(t, block, "Host "+sshConfigAlias+"\n")
+	assert.Contains(t, block, "HostName uw2.dbrx.dev")
+	assert.Contains(t, block, "Port 2222")
+	assert.Contains(t, block, "IdentityFile /home/u/.ssh/lakebox_ed25519")
+
+	// Mirrors buildSSHArgs in ssh.go so connections through this alias
+	// behave identically to `databricks lakebox ssh`. If those change,
+	// this list should change too.
+	for _, expect := range []string{
+		"IdentitiesOnly yes",
+		"StrictHostKeyChecking no",
+		"UserKnownHostsFile /dev/null",
+		"LogLevel ERROR",
+	} {
+		assert.Contains(t, block, expect, "missing required SSH option %q", expect)
+	}
+
+	// No User directive — the sandbox id travels in the destination
+	// (`ssh <id>@lakebox-gw`), so one alias serves every sandbox.
+	assert.NotContains(t, block, "\n    User ", "User directive must not be set")
+}
+
+func TestWriteManagedConfigCreatesWithRightPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, sshIncludeFileName)
+	require.NoError(t, writeManagedConfig(path, "Host foo\n    HostName bar\n"))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "SSH config files must be 0600")
+}
+
+func TestWriteManagedConfigIdempotentDoesNotRewriteFile(t *testing.T) {
+	// A no-op re-write must not bump the file's mtime — otherwise
+	// `lakebox register` looks like it's churning files on every call.
+	dir := t.TempDir()
+	path := filepath.Join(dir, sshIncludeFileName)
+	content := "Host foo\n    HostName bar\n"
+	require.NoError(t, writeManagedConfig(path, content))
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, writeManagedConfig(path, content))
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, before.ModTime(), after.ModTime(), "matching content must short-circuit before rename")
+}
+
+func TestWriteManagedConfigReplacesDifferentContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, sshIncludeFileName)
+	require.NoError(t, writeManagedConfig(path, "v1\n"))
+	require.NoError(t, writeManagedConfig(path, "v2\n"))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "v2\n", string(data))
+}
+
+func TestEnsureMainIncludesManagedCreatesFileFromScratch(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "config")
+	managedPath := filepath.Join(dir, sshIncludeFileName)
+
+	require.NoError(t, ensureMainIncludesManaged(mainPath, managedPath))
+
+	data, err := os.ReadFile(mainPath)
+	require.NoError(t, err)
+	text := string(data)
+	assert.Contains(t, text, sshConfigBeginMarker)
+	assert.Contains(t, text, "Include "+managedPath)
+	assert.Contains(t, text, sshConfigEndMarker)
+}
+
+func TestEnsureMainIncludesManagedIsIdempotent(t *testing.T) {
+	// Second call must be a no-op — the existing block is detected by
+	// marker presence and we leave the file alone.
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "config")
+	managedPath := filepath.Join(dir, sshIncludeFileName)
+	require.NoError(t, ensureMainIncludesManaged(mainPath, managedPath))
+	first, err := os.ReadFile(mainPath)
+	require.NoError(t, err)
+
+	require.NoError(t, ensureMainIncludesManaged(mainPath, managedPath))
+	second, err := os.ReadFile(mainPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(first), string(second))
+}
+
+func TestEnsureMainIncludesManagedPreservesUserConfigBelow(t *testing.T) {
+	// Existing user config must survive verbatim, and our block must
+	// land *above* it so SSH's first-match-wins behaviour picks our
+	// values for the alias.
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "config")
+	managedPath := filepath.Join(dir, sshIncludeFileName)
+	userContent := "Host myserver\n    HostName example.test\n    User alice\n"
+	require.NoError(t, os.WriteFile(mainPath, []byte(userContent), 0o600))
+
+	require.NoError(t, ensureMainIncludesManaged(mainPath, managedPath))
+	data, err := os.ReadFile(mainPath)
+	require.NoError(t, err)
+	text := string(data)
+	assert.Contains(t, text, userContent, "user's existing config must be preserved")
+
+	beginIdx := strings.Index(text, sshConfigBeginMarker)
+	userIdx := strings.Index(text, "Host myserver")
+	require.GreaterOrEqual(t, beginIdx, 0)
+	require.GreaterOrEqual(t, userIdx, 0)
+	assert.Less(t, beginIdx, userIdx, "managed block must precede the user's existing config")
+}
+
+func TestHasOurMarkedBlock(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"only user content", "Host foo\n    HostName bar\n", false},
+		{"with our marker", sshConfigBeginMarker + "\nInclude /tmp/x\n" + sshConfigEndMarker + "\n", true},
+		{"marker with surrounding whitespace", "   " + sshConfigBeginMarker + "   \n", true},
+		// A user could conceivably write a comment containing the
+		// literal marker text — accepted; it's their own footgun.
+		{"marker mid-line (rejected)", "## " + sshConfigBeginMarker + " inline\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasOurMarkedBlock(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three changes on the `lakebox register` → `lakebox ssh` path that together make *"register once, then everything just works"* actually true.

### 1. `register` writes a `Host lakebox-gw` alias to `~/.ssh/config`

Gated by a one-time Y/n prompt:

```
? Add a `Host lakebox-gw` alias to /home/me/.ssh/config? This lets editor
  Remote-SSH (VS Code / Cursor) and `ssh <id>@lakebox-gw` connect without
  further setup. [Y/n]
```

Re-runs are silent — the prior `Include` line signals opt-in, so we just refresh the managed file's contents. The alias name and shape match [the workspace UI's "First time setup?" disclosure](https://github.com/databricks-eng/universe/pull/2042253), so editor Remote-SSH deep links resolve identically whether the user set up via the CLI or pasted the UI snippet.

Layout: managed block lives in `~/.ssh/databricks-lakebox`; only one marker-bracketed `Include` line lands in the user's main config, trivially greppable and removable. The `-o` flags in the alias mirror `buildSSHArgs` in ssh.go so connections through the alias behave identically to `databricks lakebox ssh`.

In non-interactive contexts (no TTY), we skip the write rather than fail — `lakebox ssh` still works via argv-explicit flags; only IDE Remote-SSH from the workspace UI needs the alias.

### 2. Generated keys switched to ed25519

`~/.ssh/lakebox_ed25519` instead of `lakebox_rsa`. The lakebox gateway is a modern Go SSH server — no compatibility reason to prefer RSA. ed25519 also matches what the UI work recommends and what the "First time setup?" snippet defaults to. No backward-compat path because the CLI isn't shipped yet.

### 3. `lakebox ssh` pre-flights an `api.listKeys` check

The gateway already does the check (see `verify_ssh_key` in `lakebox/src/ssh/handler.rs`), but the SSH protocol's reply surface is too narrow to carry the reason back to the user: `SSH_MSG_USERAUTH_FAILURE` has no free-form reason field, and `SSH_MSG_USERAUTH_BANNER` is widely swallowed by client wrappers. So *every* publickey-stage rejection — "unknown key", "key registered but you don't own this sandbox", "ESM is down" — looks like the same flat `Permission denied (publickey)` to the user.

The HTTP API is the only out-of-band wire that can surface a structured pointer. The CLI lists registered hashes (auth'd via OAuth/PAT, separate from the SSH key), computes the local key's hash, and if not present prints "run `databricks lakebox register`" before ever opening the SSH socket. `listKeys` errors fall through with a warning so a transient API hiccup doesn't block a connection the gateway could still route.

## Test plan

- [x] `go test ./cmd/lakebox/...` passes (new tests for block shape, idempotency, 0600 perms, marker detection, user-config preservation, managed-block-precedes-user-content ordering)
- [x] `go build ./...` clean
- [x] `gofmt -l cmd/lakebox/` clean
- [x] `databricks lakebox register --help` shows the new behaviour
- [ ] Live: register on a fresh machine; verify ~/.ssh/config has the Include line and ~/.ssh/databricks-lakebox has the `lakebox-gw` block
- [ ] Live: `ssh <sandbox-id>@lakebox-gw` connects without any extra flags
- [ ] Live: "Open in VS Code" from the workspace UI connects (via Remote-SSH resolving the alias)
- [ ] Live: delete the registered key from the UI; verify `lakebox ssh` errors with the actionable message immediately (not after the SSH handshake timeout)

This pull request and its description were written by Isaac.