### PR TITLE
Configure JFrog GOPROXY in the vulnerable-dependency bumper

### DIFF
--- a/.github/workflows/bump-vuln-deps.yml
+++ b/.github/workflows/bump-vuln-deps.yml
@@ -10,6 +10,9 @@ permissions:
   contents: write
   pull-requests: write
 
+  # Required by setup-jfrog (GOPROXY exchange).
+  id-token: write
+
 jobs:
   bump-vuln-deps:
     runs-on:
@@ -19,6 +22,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup JFrog
+        uses: ./.github/actions/setup-jfrog
 
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
The `bump-vuln-deps` workflow added in #5437 runs on the protected runner group, which can't reach `proxy.golang.org`, so building vulnbump failed. Add the `Setup JFrog` step (and the `id-token: write` it needs) to route module downloads through Artifactory, like the other Go workflows.