### PR TITLE
lakebox: replace `os.IsNotExist` with `errors.Is(err, fs.ErrNotExist)`

### DIFF
--- a/cmd/lakebox/sshconfig.go
+++ b/cmd/lakebox/sshconfig.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,7 +54,7 @@ func sshConfigAlreadyManaged(ctx context.Context) (bool, error) {
 	}
 	data, err := os.ReadFile(mainPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		return false, fmt.Errorf("reading %s: %w", mainPath, err)
@@ -140,7 +142,7 @@ func ensureMainIncludesManaged(mainPath, managedPath string) error {
 		if hasOurMarkedBlock(string(existing)) {
 			return nil
 		}
-	case os.IsNotExist(err):
+	case errors.Is(err, fs.ErrNotExist):
 		existing = nil
 	default:
 		return fmt.Errorf("reading %s: %w", mainPath, err)


### PR DESCRIPTION
## Summary

Two `os.IsNotExist(err)` callsites in `cmd/lakebox/sshconfig.go` slipped through before `./task lint` was re-run. The repo's golangci-lint config forbids `os.IsNotExist` (`forbidigo` rule) in favor of `errors.Is(err, fs.ErrNotExist)`.

The replacement is functionally identical — `fs.ErrNotExist` is the sentinel the standard library wraps for "file does not exist", and `errors.Is` unwraps through Go's error chain so wrapped variants are also handled correctly.

## Test plan

- [x] `./task lint` is now clean (was `2 issues: forbidigo`)
- [x] `go test ./cmd/lakebox/...` passes

This pull request and its description were written by Isaac.