### PR TITLE
lakebox: skip 0o600 perm assertion on Windows in sshconfig_test

### DIFF
--- a/cmd/lakebox/sshconfig_test.go
+++ b/cmd/lakebox/sshconfig_test.go
@@ -3,6 +3,7 @@ package lakebox
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -45,7 +46,13 @@ func TestWriteManagedConfigCreatesWithRightPerms(t *testing.T) {
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "SSH config files must be 0600")
+
+	// Windows does not honor Unix permission bits; os.Stat reports 0o666
+	// regardless of what was passed to os.WriteFile (matches the carve-out
+	// in state_test.go).
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "SSH config files must be 0600")
+	}
 }
 
 func TestWriteManagedConfigIdempotentDoesNotRewriteFile(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestWriteManagedConfigCreatesWithRightPerms` (added in #5458) fails on Windows CI: `os.Stat` reports `0o666` regardless of what was passed to `os.WriteFile` because Windows doesn't honor Unix permission bits.

`state_test.go` already had this carve-out for the equivalent state-file test (lines 154-159). Mirroring the same `runtime.GOOS != "windows"` check here.

Unix tests still pin `0o600`; only the Windows path skips the assertion.

## Failure

From the demo-lakebox `task test (windows, direct)` run:

```
FAIL cmd/lakebox.TestWriteManagedConfigCreatesWithRightPerms (0.01s)
    sshconfig_test.go:48:
        Error:      Not equal:
                    expected: 0x180   (0o600)
                    actual  : 0x1b6   (0o666)
```

## Test plan

- [x] `go test ./cmd/lakebox/... -run TestWriteManagedConfigCreatesWithRightPerms` passes on Linux
- [x] `./task lint` clean
- [ ] Windows CI on this PR (the original symptom)

This pull request and its description were written by Isaac.