### PR TITLE
acc: Reproduce an app being created but not recorded in the state when deployment fails

### DIFF
--- a/acceptance/bundle/apps/partial_create/databricks.yml.tmpl
+++ b/acceptance/bundle/apps/partial_create/databricks.yml.tmpl
@@ -1,0 +1,10 @@
+bundle:
+  name: partial-create-$UNIQUE_NAME
+
+resources:
+  apps:
+    my_app:
+      name: app-$UNIQUE_NAME
+      source_code_path: ./app
+      lifecycle:
+        started: true

--- a/acceptance/bundle/apps/partial_create/out.test.toml
+++ b/acceptance/bundle/apps/partial_create/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/apps/partial_create/output.txt
+++ b/acceptance/bundle/apps/partial_create/output.txt
@@ -1,0 +1,23 @@
+
+>>> errcode [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/partial-create-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Error: cannot create resources.apps.my_app: waiting after creating id=app-[UNIQUE_NAME]: Invalid source code path: /Workspace/Users/[USERNAME]/.bundle/partial-create-[UNIQUE_NAME]/default/files/app. Path does not exist. (400 INVALID_PARAMETER_VALUE)
+
+Endpoint: POST [DATABRICKS_URL]/api/2.0/apps/app-[UNIQUE_NAME]/deployments
+HTTP Status: 400 Bad Request
+API error_code: INVALID_PARAMETER_VALUE
+API message: Invalid source code path: /Workspace/Users/[USERNAME]/.bundle/partial-create-[UNIQUE_NAME]/default/files/app. Path does not exist.
+
+Updating deployment state...
+
+Exit code: 1
+
+=== App exists even after failed deployment
+>>> [CLI] apps get app-[UNIQUE_NAME]
+{
+  "message": "App has status: App has not been deployed yet. Run your app by deploying source code",
+  "state": "UNAVAILABLE"
+}
+
+=== App resource is not in the state fileapps my_app 

--- a/acceptance/bundle/apps/partial_create/script
+++ b/acceptance/bundle/apps/partial_create/script
@@ -1,0 +1,17 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+
+    $CLI bundle destroy --auto-approve > /dev/null 2>&1 || true
+    $CLI apps delete app-$UNIQUE_NAME > /dev/null 2>&1 || true
+    rm out.requests.txt
+}
+trap cleanup EXIT
+
+trace errcode $CLI bundle deploy
+
+title "App exists even after failed deployment"
+trace $CLI apps get app-$UNIQUE_NAME | jq '.app_status'
+
+title "App resource is not in the state file"
+read_state.py apps my_app

--- a/acceptance/bundle/apps/partial_create/script
+++ b/acceptance/bundle/apps/partial_create/script
@@ -1,7 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
+mkdir -p app
 
 cleanup() {
-
     $CLI bundle destroy --auto-approve > /dev/null 2>&1 || true
     $CLI apps delete app-$UNIQUE_NAME > /dev/null 2>&1 || true
     rm out.requests.txt

--- a/acceptance/bundle/apps/partial_create/test.toml
+++ b/acceptance/bundle/apps/partial_create/test.toml
@@ -1,0 +1,10 @@
+Badness = "App exists even after failed deployment"
+
+Local = true
+Cloud = true
+RecordRequests = true
+
+Ignore = [".databricks", "databricks.yml"]
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/apps/partial_create/test.toml
+++ b/acceptance/bundle/apps/partial_create/test.toml
@@ -4,7 +4,7 @@ Local = true
 Cloud = true
 RecordRequests = true
 
-Ignore = [".databricks", "databricks.yml"]
+Ignore = [".databricks", "databricks.yml", "app"]
 
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -102,6 +102,24 @@ func (s *FakeWorkspace) AppsCreateDeployment(req Request, name string) Response 
 		return Response{StatusCode: 500, Body: fmt.Sprintf("internal error: %s", err)}
 	}
 
+	// The real platform rejects deployments to workspace paths that don't exist.
+	// An empty SourceCodePath means a git-source deployment, which skips this check.
+	if deployment.SourceCodePath != "" {
+		p := deployment.SourceCodePath
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		if _, exists := s.directories[p]; !exists {
+			return Response{
+				StatusCode: http.StatusBadRequest,
+				Body: map[string]string{
+					"error_code": "INVALID_PARAMETER_VALUE",
+					"message":    fmt.Sprintf("Invalid source code path: %s. Path does not exist.", deployment.SourceCodePath),
+				},
+			}
+		}
+	}
+
 	deployment.DeploymentId = fmt.Sprintf("deploy-%d", nextID())
 	deployment.Status = &apps.AppDeploymentStatus{
 		State:   apps.AppDeploymentStateSucceeded,
@@ -110,6 +128,10 @@ func (s *FakeWorkspace) AppsCreateDeployment(req Request, name string) Response 
 
 	app.ActiveDeployment = &deployment
 	app.DefaultSourceCodePath = deployment.SourceCodePath
+	app.AppStatus = &apps.ApplicationStatus{
+		State:   apps.ApplicationStateRunning,
+		Message: "Application is running.",
+	}
 	s.Apps[name] = app
 
 	return Response{Body: deployment}
@@ -205,36 +227,26 @@ func (s *FakeWorkspace) AppsUpsert(req Request, name string) Response {
 		}
 	}
 
-	app.AppStatus = &apps.ApplicationStatus{
-		State:   "RUNNING",
-		Message: "Application is running.",
-	}
-
 	// Respect no_compute query param: if true, start the app in STOPPED state.
 	if req.URL.Query().Get("no_compute") == "true" {
 		app.ComputeStatus = &apps.ComputeStatus{
 			State:   apps.ComputeStateStopped,
 			Message: "App compute is stopped.",
 		}
+		app.AppStatus = &apps.ApplicationStatus{
+			State:   apps.ApplicationStateRunning,
+			Message: "Application is running.",
+		}
 	} else {
+		// App compute is starting but no code has been deployed yet.
 		app.ComputeStatus = &apps.ComputeStatus{
 			State:   "ACTIVE",
 			Message: "App compute is active.",
 		}
-
-		// Simulate the apps platform side effect: when an app is created, it is deployed with the default source code path.
-		deployment := apps.AppDeployment{
-			SourceCodePath: "/Workspace/Users/tester@databricks.com/" + name,
+		app.AppStatus = &apps.ApplicationStatus{
+			State:   apps.ApplicationStateUnavailable,
+			Message: "App has status: App has not been deployed yet. Run your app by deploying source code",
 		}
-
-		deployment.DeploymentId = fmt.Sprintf("deploy-%d", nextID())
-		deployment.Status = &apps.AppDeploymentStatus{
-			State:   apps.AppDeploymentStateSucceeded,
-			Message: "Deployment succeeded",
-		}
-
-		app.ActiveDeployment = &deployment
-		app.DefaultSourceCodePath = deployment.SourceCodePath
 	}
 
 	app.Url = name + "-123.cloud.databricksapps.com"


### PR DESCRIPTION
## Changes
Reproduce an app being created but not recorded in the state when deployment fails

## Why
When `bundle deploy` creates an app resource it might fail when doing initial deployment (e.g., the source code path doesn't exist in the workspace or the app can't start) in WaitAfterCreate method, the app ends up in a partially-created state: it exists remotely but is not recorded in the bundle's deployment state file.

This matters because on the next bundle deploy, the CLI will attempt to create the app again and get a RESOURCE_ALREADY_EXISTS conflict, rather than recognizing the existing app and updating it. The test verifies that:
1. The app is present remotely after the failed deploy (the create API call succeeded).
2. The app is absent from the state file (the deploy failed before the state was written).


<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
