### PR TITLE
lakebox: factor API namespace into `lakeboxAPIRoot` constant

### DIFF
--- a/cmd/lakebox/api.go
+++ b/cmd/lakebox/api.go
@@ -23,10 +23,15 @@ func sandboxPath(id string) string {
 	return lakeboxAPIPath + "/" + url.PathEscape(id)
 }
 
+// lakeboxAPIRoot is the service namespace under which the sandbox and
+// ssh-key sub-collections live. Centralised so a server-side rename
+// (e.g. "lakebox" → "sandbox") is a one-line change.
+const lakeboxAPIRoot = "/api/2.0/lakebox"
+
 // Sub-collections under the lakebox service namespace.
 const (
-	lakeboxAPIPath     = "/api/2.0/lakebox/sandboxes"
-	lakeboxKeysAPIPath = "/api/2.0/lakebox/ssh-keys"
+	lakeboxAPIPath     = lakeboxAPIRoot + "/sandboxes"
+	lakeboxKeysAPIPath = lakeboxAPIRoot + "/ssh-keys"
 )
 
 // orgIDHeader scopes the credential to a workspace on multi-workspace


### PR DESCRIPTION
## Summary

Both `lakeboxAPIPath` and `lakeboxKeysAPIPath` share the `/api/2.0/lakebox` prefix. Pulling it into its own constant turns a future server-side service rename (e.g. `lakebox` → `sandbox`) into a one-line change.

Before:
```go
const (
    lakeboxAPIPath     = "/api/2.0/lakebox/sandboxes"
    lakeboxKeysAPIPath = "/api/2.0/lakebox/ssh-keys"
)
```

After:
```go
const lakeboxAPIRoot = "/api/2.0/lakebox"

const (
    lakeboxAPIPath     = lakeboxAPIRoot + "/sandboxes"
    lakeboxKeysAPIPath = lakeboxAPIRoot + "/ssh-keys"
)
```

No behavior change.

## Test plan

- [x] `go test ./cmd/lakebox/...` passes
- [x] `./task lint` clean

This pull request and its description were written by Isaac.