### PR TITLE
Use root persistent flags in sync, bundle sync, and configure

### DIFF
--- a/acceptance/bundle/help/bundle-sync/output.txt
+++ b/acceptance/bundle/help/bundle-sync/output.txt
@@ -19,11 +19,11 @@ Flags:
       --full                perform full synchronization (default is incremental)
   -h, --help                help for sync
       --interval duration   file system polling interval (for --watch) (default 1s)
-      --output type         type of the output format
       --watch               watch local file system for changes
 
 Global Flags:
       --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
   -p, --profile string   ~/.databrickscfg profile
   -t, --target string    bundle target to use (if applicable)
       --var strings      set values for variables defined in bundle config. Example: --var="foo=bar"

--- a/acceptance/cmd/sync-without-args/output.txt
+++ b/acceptance/cmd/sync-without-args/output.txt
@@ -14,11 +14,11 @@ Flags:
       --include strings       patterns to include in sync (can be specified multiple times)
       --include-from string   file containing patterns to include to sync (one pattern per line)
       --interval duration     file system polling interval (for --watch) (default 1s)
-      --output type           type of output format (default text)
       --watch                 watch local file system for changes
 
 Global Flags:
       --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
   -p, --profile string   ~/.databrickscfg profile
   -t, --target string    bundle target to use (if applicable)
 

--- a/cmd/bundle/sync.go
+++ b/cmd/bundle/sync.go
@@ -20,7 +20,6 @@ type syncFlags struct {
 	interval time.Duration
 	full     bool
 	watch    bool
-	output   flags.Output
 	dryRun   bool
 }
 
@@ -30,9 +29,11 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, b *bundle.Bundle) 
 		return nil, fmt.Errorf("cannot get sync options: %w", err)
 	}
 
-	if f.output != "" {
+	// The root --output flag always has a value (defaults to text), so gate on
+	// it being explicitly set to keep bundle sync silent by default.
+	if cmd.Flag("output").Changed {
 		var outputFunc func(context.Context, <-chan sync.Event, io.Writer)
-		switch f.output {
+		switch root.OutputType(cmd) {
 		case flags.OutputText:
 			outputFunc = sync.TextOutput
 		case flags.OutputJSON:
@@ -72,7 +73,6 @@ Use 'databricks bundle deploy' for full resource deployment.`,
 	cmd.Flags().DurationVar(&f.interval, "interval", 1*time.Second, "file system polling interval (for --watch)")
 	cmd.Flags().BoolVar(&f.full, "full", false, "perform full synchronization (default is incremental)")
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
-	cmd.Flags().Var(&f.output, "output", "type of the output format")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "simulate sync execution without making actual changes")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/bundle/sync_test.go
+++ b/cmd/bundle/sync_test.go
@@ -1,0 +1,66 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/vfs"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSyncCommand returns the bundle sync command attached to a root
+// command so that the root persistent flags (--output, --profile) resolve
+// like in production.
+func newTestSyncCommand(t *testing.T) *cobra.Command {
+	syncCmd := newSyncCommand()
+	root.New(t.Context()).AddCommand(syncCmd)
+	return syncCmd
+}
+
+func TestBundleSyncShorthandFlags(t *testing.T) {
+	cmd := newTestSyncCommand(t)
+	require.NoError(t, cmd.ParseFlags([]string{"-o", "json", "-p", "myprofile"}))
+	assert.Equal(t, flags.OutputJSON, root.OutputType(cmd))
+	assert.Equal(t, "myprofile", cmd.Flag("profile").Value.String())
+}
+
+func TestBundleSyncOutputHandlerOnlyWhenOutputSet(t *testing.T) {
+	tempDir := t.TempDir()
+	b := &bundle.Bundle{
+		BundleRootPath: tempDir,
+		BundleRoot:     vfs.MustNew(tempDir),
+		SyncRootPath:   tempDir,
+		SyncRoot:       vfs.MustNew(tempDir),
+		Config: config.Root{
+			Bundle: config.Bundle{
+				Target: "default",
+			},
+			Workspace: config.Workspace{
+				FilePath: "/Users/jane@doe.com/path",
+			},
+		},
+	}
+
+	f := syncFlags{}
+
+	// Without --output, bundle sync stays silent: no output handler.
+	cmd := newTestSyncCommand(t)
+	cmd.SetContext(t.Context())
+	require.NoError(t, cmd.ParseFlags(nil))
+	opts, err := f.syncOptionsFromBundle(cmd, b)
+	require.NoError(t, err)
+	assert.Nil(t, opts.OutputHandler)
+
+	// With -o json, an output handler is installed.
+	cmd = newTestSyncCommand(t)
+	cmd.SetContext(t.Context())
+	require.NoError(t, cmd.ParseFlags([]string{"-o", "json"}))
+	opts, err = f.syncOptionsFromBundle(cmd, b)
+	require.NoError(t, err)
+	assert.NotNil(t, opts.OutputHandler)
+}

--- a/cmd/bundle/sync_test.go
+++ b/cmd/bundle/sync_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestSyncCommand returns the bundle sync command attached to a root
-// command so that the root persistent flags (--output, --profile) resolve
-// like in production.
+// newTestSyncCommand attaches the sync command to a root command so the root persistent flags resolve.
 func newTestSyncCommand(t *testing.T) *cobra.Command {
 	syncCmd := newSyncCommand()
 	root.New(t.Context()).AddCommand(syncCmd)
@@ -48,7 +46,6 @@ func TestBundleSyncOutputHandlerOnlyWhenOutputSet(t *testing.T) {
 
 	f := syncFlags{}
 
-	// Without --output, bundle sync stays silent: no output handler.
 	cmd := newTestSyncCommand(t)
 	cmd.SetContext(t.Context())
 	require.NoError(t, cmd.ParseFlags(nil))
@@ -56,7 +53,6 @@ func TestBundleSyncOutputHandlerOnlyWhenOutputSet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, opts.OutputHandler)
 
-	// With -o json, an output handler is installed.
 	cmd = newTestSyncCommand(t)
 	cmd.SetContext(t.Context())
 	require.NoError(t, cmd.ParseFlags([]string{"-o", "json"}))

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -119,12 +119,21 @@ The host must be specified with the --host flag or the DATABRICKS_HOST environme
 			return fmt.Errorf("unable to instantiate configuration from environment variables: %w", err)
 		}
 
-		// Populate configuration from flags (if set).
+		// Populate configuration from flags (if set). The profile flag is the
+		// root persistent flag, so the -p shorthand works here too.
 		if flags.Host != "" {
 			cfg.Host = normalizeHost(flags.Host)
 		}
-		if flags.Profile != "" {
-			cfg.Profile = flags.Profile
+		if profile := cmd.Flag("profile").Value.String(); profile != "" {
+			cfg.Profile = profile
+		}
+
+		// Same fallback as every other command: --profile flag, then
+		// DATABRICKS_CONFIG_PROFILE (loaded into cfg.Profile above), then
+		// DEFAULT. The name must be non-empty: SaveToProfile matches sections
+		// by host instead of by name when cfg.Profile is empty.
+		if cfg.Profile == "" {
+			cfg.Profile = "DEFAULT"
 		}
 
 		// Normalize and verify that the host is valid (if set).

--- a/cmd/configure/configure.go
+++ b/cmd/configure/configure.go
@@ -119,8 +119,8 @@ The host must be specified with the --host flag or the DATABRICKS_HOST environme
 			return fmt.Errorf("unable to instantiate configuration from environment variables: %w", err)
 		}
 
-		// Populate configuration from flags (if set). The profile flag is the
-		// root persistent flag, so the -p shorthand works here too.
+		// Populate configuration from flags (if set).
+		// The profile flag is the root persistent flag.
 		if flags.Host != "" {
 			cfg.Host = normalizeHost(flags.Host)
 		}
@@ -128,9 +128,7 @@ The host must be specified with the --host flag or the DATABRICKS_HOST environme
 			cfg.Profile = profile
 		}
 
-		// Same fallback as every other command: --profile flag, then
-		// DATABRICKS_CONFIG_PROFILE (loaded into cfg.Profile above), then
-		// DEFAULT. The name must be non-empty: SaveToProfile matches sections
+		// The profile name must be non-empty: SaveToProfile matches sections
 		// by host instead of by name when cfg.Profile is empty.
 		if cfg.Profile == "" {
 			cfg.Profile = "DEFAULT"

--- a/cmd/configure/configure_test.go
+++ b/cmd/configure/configure_test.go
@@ -27,6 +27,7 @@ func setup(t *testing.T) string {
 	}
 	t.Setenv(homeEnvVar, tempHomeDir)
 	t.Setenv("DATABRICKS_CONFIG_FILE", "")
+	t.Setenv("DATABRICKS_CONFIG_PROFILE", "")
 	t.Setenv("DATABRICKS_TOKEN", "")
 	return tempHomeDir
 }
@@ -178,6 +179,65 @@ func TestEnvVarsConfigureNoArgsNoInteractive(t *testing.T) {
 
 	assertKeyValueInSection(t, defaultSection, "host", "https://host")
 	assertKeyValueInSection(t, defaultSection, "token", "secret")
+}
+
+func TestEnvProfileConfigureNoInteractive(t *testing.T) {
+	ctx := t.Context()
+	tempHomeDir := setup(t)
+	cfgPath := filepath.Join(tempHomeDir, ".databrickscfg")
+	inp := getTempFileWithContent(t, tempHomeDir, "token\n")
+	defer inp.Close()
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+	os.Stdin = inp
+
+	t.Setenv("DATABRICKS_CONFIG_PROFILE", "FROM-ENV")
+
+	cmd := cmd.New(ctx)
+	cmd.SetArgs([]string{"configure", "--token", "--host", "https://host"})
+
+	err := root.Execute(ctx, cmd)
+	assert.NoError(t, err)
+
+	cfg, err := ini.Load(cfgPath)
+	assert.NoError(t, err)
+
+	section, err := cfg.GetSection("FROM-ENV")
+	assert.NoError(t, err)
+
+	assertKeyValueInSection(t, section, "host", "https://host")
+	assertKeyValueInSection(t, section, "token", "token")
+}
+
+func TestProfileShorthandOverridesEnvConfigureNoInteractive(t *testing.T) {
+	ctx := t.Context()
+	tempHomeDir := setup(t)
+	cfgPath := filepath.Join(tempHomeDir, ".databrickscfg")
+	inp := getTempFileWithContent(t, tempHomeDir, "token\n")
+	defer inp.Close()
+	oldStdin := os.Stdin
+	t.Cleanup(func() { os.Stdin = oldStdin })
+	os.Stdin = inp
+
+	t.Setenv("DATABRICKS_CONFIG_PROFILE", "FROM-ENV")
+
+	cmd := cmd.New(ctx)
+	cmd.SetArgs([]string{"configure", "--token", "--host", "https://host", "-p", "FROM-FLAG"})
+
+	err := root.Execute(ctx, cmd)
+	assert.NoError(t, err)
+
+	cfg, err := ini.Load(cfgPath)
+	assert.NoError(t, err)
+
+	section, err := cfg.GetSection("FROM-FLAG")
+	assert.NoError(t, err)
+
+	assertKeyValueInSection(t, section, "host", "https://host")
+	assertKeyValueInSection(t, section, "token", "token")
+
+	_, err = cfg.GetSection("FROM-ENV")
+	assert.Error(t, err)
 }
 
 func TestCustomProfileConfigureNoInteractive(t *testing.T) {

--- a/cmd/configure/flags.go
+++ b/cmd/configure/flags.go
@@ -5,8 +5,7 @@ import (
 )
 
 type configureFlags struct {
-	Host    string
-	Profile string
+	Host string
 
 	// Flag to request a prompt for cluster configuration.
 	ConfigureCluster bool
@@ -15,7 +14,6 @@ type configureFlags struct {
 // Register flags with command.
 func (f *configureFlags) Register(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.Host, "host", "", "Databricks workspace host.")
-	cmd.Flags().StringVar(&f.Profile, "profile", "DEFAULT", "Name for the connection profile to configure.")
 	cmd.Flags().BoolVar(&f.ConfigureCluster, "configure-cluster", false, "Prompts to configure cluster")
 
 	// Include token flag for compatibility with the legacy CLI.

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -29,7 +29,6 @@ type syncFlags struct {
 	interval    time.Duration
 	full        bool
 	watch       bool
-	output      flags.Output
 	exclude     []string
 	include     []string
 	dryRun      bool
@@ -37,14 +36,14 @@ type syncFlags struct {
 	includeFrom string
 }
 
-func readPatternsFile(filePath string) ([]string, error) {
+func readPatternsFile(flagName, filePath string) ([]string, error) {
 	if filePath == "" {
 		return nil, nil
 	}
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read exclude-from file: %w", err)
+		return nil, fmt.Errorf("failed to read %s file: %w", flagName, err)
 	}
 
 	var patterns []string
@@ -55,7 +54,7 @@ func readPatternsFile(filePath string) ([]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading exclude-from file: %w", err)
+		return nil, fmt.Errorf("error reading %s file: %w", flagName, err)
 	}
 
 	return patterns, nil
@@ -71,12 +70,12 @@ func (f *syncFlags) syncOptionsFromBundle(cmd *cobra.Command, args []string, b *
 		return nil, fmt.Errorf("cannot get sync options: %w", err)
 	}
 
-	excludePatterns, err := readPatternsFile(f.excludeFrom)
+	excludePatterns, err := readPatternsFile("exclude-from", f.excludeFrom)
 	if err != nil {
 		return nil, err
 	}
 
-	includePatterns, err := readPatternsFile(f.includeFrom)
+	includePatterns, err := readPatternsFile("include-from", f.includeFrom)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +97,7 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 	}
 
 	var outputFunc func(context.Context, <-chan sync.Event, io.Writer)
-	switch f.output {
+	switch root.OutputType(cmd) {
 	case flags.OutputText:
 		outputFunc = sync.TextOutput
 	case flags.OutputJSON:
@@ -119,12 +118,12 @@ func (f *syncFlags) syncOptionsFromArgs(cmd *cobra.Command, args []string) (*syn
 		log.Warnf(ctx, "Running in dry-run mode. No actual changes will be made.")
 	}
 
-	excludePatterns, err := readPatternsFile(f.excludeFrom)
+	excludePatterns, err := readPatternsFile("exclude-from", f.excludeFrom)
 	if err != nil {
 		return nil, err
 	}
 
-	includePatterns, err := readPatternsFile(f.includeFrom)
+	includePatterns, err := readPatternsFile("include-from", f.includeFrom)
 	if err != nil {
 		return nil, err
 	}
@@ -175,13 +174,10 @@ func New() *cobra.Command {
 		GroupID: "development",
 	}
 
-	f := syncFlags{
-		output: flags.OutputText,
-	}
+	var f syncFlags
 	cmd.Flags().DurationVar(&f.interval, "interval", 1*time.Second, "file system polling interval (for --watch)")
 	cmd.Flags().BoolVar(&f.full, "full", false, "perform full synchronization (default is incremental)")
 	cmd.Flags().BoolVar(&f.watch, "watch", false, "watch local file system for changes")
-	cmd.Flags().Var(&f.output, "output", "type of output format")
 	cmd.Flags().StringSliceVar(&f.exclude, "exclude", nil, "patterns to exclude from sync (can be specified multiple times)")
 	cmd.Flags().StringSliceVar(&f.include, "include", nil, "patterns to include in sync (can be specified multiple times)")
 	cmd.Flags().StringVar(&f.excludeFrom, "exclude-from", "", "file containing patterns to exclude from sync (one pattern per line)")

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -8,11 +8,23 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/libs/vfs"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newTestSyncCommand returns the sync command attached to a root command so
+// that the root persistent flags (--output, --profile) resolve like in
+// production.
+func newTestSyncCommand(t *testing.T) *cobra.Command {
+	syncCmd := New()
+	root.New(t.Context()).AddCommand(syncCmd)
+	return syncCmd
+}
 
 func TestSyncOptionsFromBundle(t *testing.T) {
 	tempDir := t.TempDir()
@@ -57,12 +69,27 @@ func TestSyncOptionsFromArgs(t *testing.T) {
 	remote := "/remote"
 
 	f := syncFlags{}
-	cmd := New()
+	cmd := newTestSyncCommand(t)
 	cmd.SetContext(cmdctx.SetWorkspaceClient(t.Context(), nil))
 	opts, err := f.syncOptionsFromArgs(cmd, []string{local, remote})
 	require.NoError(t, err)
 	assert.Equal(t, local, opts.LocalRoot.Native())
 	assert.Equal(t, remote, opts.RemotePath)
+}
+
+func TestSyncShorthandFlags(t *testing.T) {
+	cmd := newTestSyncCommand(t)
+	require.NoError(t, cmd.ParseFlags([]string{"-o", "json", "-p", "myprofile"}))
+	assert.Equal(t, flags.OutputJSON, root.OutputType(cmd))
+	assert.Equal(t, "myprofile", cmd.Flag("profile").Value.String())
+}
+
+func TestReadPatternsFileErrorNamesFlag(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.txt")
+	_, err := readPatternsFile("exclude-from", missing)
+	assert.ErrorContains(t, err, "failed to read exclude-from file")
+	_, err = readPatternsFile("include-from", missing)
+	assert.ErrorContains(t, err, "failed to read include-from file")
 }
 
 func TestExcludeFromFlag(t *testing.T) {
@@ -83,7 +110,7 @@ func TestExcludeFromFlag(t *testing.T) {
 
 	// Set up the flags
 	f := syncFlags{excludeFrom: excludeFromPath}
-	cmd := New()
+	cmd := newTestSyncCommand(t)
 	cmd.SetContext(cmdctx.SetWorkspaceClient(t.Context(), nil))
 
 	// Test with both exclude flag and exclude-from flag

--- a/cmd/sync/sync_test.go
+++ b/cmd/sync/sync_test.go
@@ -17,9 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestSyncCommand returns the sync command attached to a root command so
-// that the root persistent flags (--output, --profile) resolve like in
-// production.
+// newTestSyncCommand attaches the sync command to a root command so the root persistent flags resolve.
 func newTestSyncCommand(t *testing.T) *cobra.Command {
 	syncCmd := New()
 	root.New(t.Context()).AddCommand(syncCmd)


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. `databricks sync`, `databricks bundle sync`, and `databricks configure` registered their own local `--output` or `--profile` flags. A local flag with the same name hides the root persistent flag, so the inherited `-o` and `-p` shorthands failed with `unknown shorthand flag` on exactly these three commands. The local flag on `configure` also defaulted to `DEFAULT`, which silently overrode `DATABRICKS_CONFIG_PROFILE`, so profile resolution behaved differently here than in every other command. Separately, `readPatternsFile` hardcoded "exclude-from" in its error messages, so a bad `--include-from` file reported the wrong flag.

## Changes

Before, `sync -o json`, `bundle sync -o json`, and `configure -p NAME` errored on flag parsing; now all three commands use the root persistent flags and the shorthands work.

- `cmd/sync/sync.go`: dropped the local `--output` registration and read the output type via `root.OutputType`. The default stays `text`.
- `cmd/bundle/sync.go`: dropped the local `--output` registration. Since the root flag always has a value, the output handler is installed only when the flag is explicitly set, keeping `bundle sync` silent by default.
- `cmd/configure/flags.go` and `cmd/configure/configure.go`: dropped the local `--profile` flag (and its `DEFAULT` default). The profile now resolves like every other command: `--profile`/`-p` flag, then `DATABRICKS_CONFIG_PROFILE`, then `DEFAULT`. This is a small behavior change: with the env var set and no flag, `configure` now writes to the env var's profile instead of always writing to `DEFAULT`.
- `cmd/sync/sync.go`: `readPatternsFile` takes the flag name, so `--include-from` errors name the right flag.
- Regenerated the two help acceptance outputs: the shadowing local `--output` line disappears and the root `-o, --output` shows under global flags.

## Test plan

- [x] New unit tests parsing `-o`/`-p` through the sync, bundle sync, and configure commands
- [x] New configure tests: `DATABRICKS_CONFIG_PROFILE` fallback, and `-p` taking precedence over the env var
- [x] New test asserting `readPatternsFile` errors name the correct flag
- [x] New test asserting `bundle sync` installs an output handler only when `--output` is set
- [x] `go test ./cmd/sync/... ./cmd/configure/... ./cmd/bundle/` passes
- [x] Acceptance tests for `cmd/sync-without-args`, `bundle/help/bundle-sync` (regenerated with -update), `bundle/sync`, and `cmd/configure` pass
- [x] Manually verified against a built binary: `sync -o json`, `bundle sync -o json`, and `configure -p NAME` all parse
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass

This pull request and its description were written by Isaac.
