### PR TITLE
Fix nil dereference in bundle run --no-wait when GetRun fails

### DIFF
--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -157,8 +157,11 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 		details, err := w.Jobs.GetRun(ctx, jobs.GetRunRequest{
 			RunId: waiter.RunId,
 		})
+		if err != nil {
+			return nil, err
+		}
 		cmdio.Log(ctx, progress.NewJobRunUrlEvent(details.RunPageUrl))
-		return nil, err
+		return nil, nil
 	}
 
 	run, err := waiter.OnProgress(monitor.onProgress).GetWithTimeout(jobRunTimeout)

--- a/bundle/run/job_test.go
+++ b/bundle/run/job_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -201,6 +202,42 @@ func TestJobRunnerRestart(t *testing.T) {
 		_, err := runner.Restart(ctx, &Options{})
 		require.NoError(t, err)
 	}
+}
+
+func TestJobRunnerRunNoWaitGetRunFails(t *testing.T) {
+	job := &resources.Job{
+		BaseResource: resources.BaseResource{ID: "123"},
+	}
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"test_job": job,
+				},
+			},
+		},
+	}
+
+	runner := jobRunner{key: "test", bundle: b, job: job}
+
+	m := mocks.NewMockWorkspaceClient(t)
+	b.SetWorkpaceClient(m.WorkspaceClient)
+
+	ctx := cmdio.MockDiscard(t.Context())
+
+	jobApi := m.GetMockJobsAPI()
+	jobApi.EXPECT().RunNow(mock.Anything, jobs.RunNow{
+		JobId: 123,
+	}).Return(&jobs.WaitGetRunJobTerminatedOrSkipped[jobs.RunNowResponse]{RunId: 456}, nil)
+
+	// The SDK returns (nil, err) on failure; Run must surface the error
+	// instead of dereferencing the nil run details.
+	jobApi.EXPECT().GetRun(mock.Anything, jobs.GetRunRequest{
+		RunId: 456,
+	}).Return(nil, errors.New("transient error"))
+
+	_, err := runner.Run(ctx, &Options{NoWait: true})
+	require.ErrorContains(t, err, "transient error")
 }
 
 func TestJobRunnerRestartForContinuousUnpausedJobs(t *testing.T) {

--- a/bundle/run/job_test.go
+++ b/bundle/run/job_test.go
@@ -230,8 +230,7 @@ func TestJobRunnerRunNoWaitGetRunFails(t *testing.T) {
 		JobId: 123,
 	}).Return(&jobs.WaitGetRunJobTerminatedOrSkipped[jobs.RunNowResponse]{RunId: 456}, nil)
 
-	// The SDK returns (nil, err) on failure; Run must surface the error
-	// instead of dereferencing the nil run details.
+	// Run must surface the error instead of dereferencing the nil run details.
 	jobApi.EXPECT().GetRun(mock.Anything, jobs.GetRunRequest{
 		RunId: 456,
 	}).Return(nil, errors.New("transient error"))


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. In `bundle run --no-wait`, the run page URL is read from the `GetRun` response before the error is checked. The SDK returns a nil response on failure, so a transient API error right after the run was successfully started crashes the CLI with a nil pointer dereference instead of reporting the error.

## Changes

Before, a failed `GetRun` call in the `--no-wait` path panicked; now it returns the error. The fix in `bundle/run/job.go` checks the error before dereferencing the response, and the success path is unchanged.

## Test plan

- [x] Added a unit test in `bundle/run/job_test.go` that mocks a successful `RunNow` followed by a failing `GetRun` and asserts the error is returned
- [x] Verified the new test panics with the nil pointer dereference on the code before the fix and passes after
- [x] `go test ./bundle/run/` passes
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass

This pull request and its description were written by Isaac.
