### PR TITLE
Skip nil quality monitor entries in ApplyPresets

### DIFF
--- a/bundle/config/mutator/resourcemutator/apply_presets.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets.go
@@ -186,6 +186,9 @@ func (m *applyPresets) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnos
 	// Quality monitors presets: Schedule
 	if t.TriggerPauseStatus == config.Paused {
 		for _, q := range r.QualityMonitors {
+			if q == nil {
+				continue
+			}
 			// Remove all schedules from monitors, since they don't support pausing/unpausing.
 			// Quality monitors might support the "pause" property in the future, so at the
 			// CLI level we do respect that property if it is set to "unpaused."

--- a/bundle/config/mutator/resourcemutator/apply_presets_test.go
+++ b/bundle/config/mutator/resourcemutator/apply_presets_test.go
@@ -1,0 +1,40 @@
+package resourcemutator
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyPresetsSkipsNilQualityMonitors(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Presets: config.Presets{
+				TriggerPauseStatus: config.Paused,
+			},
+			Resources: config.Resources{
+				QualityMonitors: map[string]*resources.QualityMonitor{
+					// Python-generated configs can contain null resource entries that
+					// bypass AllResourcesHaveValues, so ApplyPresets must skip them.
+					"nil_monitor": nil,
+					"monitor": {
+						TableName: "monitor",
+						CreateMonitor: catalog.CreateMonitor{
+							OutputSchemaName: "catalog.schema",
+							Schedule:         &catalog.MonitorCronSchedule{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	diags := bundle.Apply(t.Context(), b, ApplyPresets())
+	require.NoError(t, diags.Error())
+	assert.Nil(t, b.Config.Resources.QualityMonitors["monitor"].Schedule)
+}


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. Every resource loop in `ApplyPresets` skips nil entries, except the quality monitors loop. Python-generated config can contain null resource entries that bypass `AllResourcesHaveValues`, so a `quality_monitors.foo: null` entry crashes the CLI with a nil pointer dereference when `trigger_pause_status` is paused (the development mode default).

## Changes

Before, a nil entry in `quality_monitors` panicked in `ApplyPresets`; now it is skipped like in every other resource loop. The fix adds the same `if q == nil { continue }` guard the sibling loops in `bundle/config/mutator/resourcemutator/apply_presets.go` already have.

## Test plan

- [x] Added `TestApplyPresetsSkipsNilQualityMonitors`, which panics without the fix and passes with it
- [x] `go test ./bundle/config/mutator/resourcemutator`
- [x] `./task fmt-q`, `./task lint-q`, `./task checks`

This pull request and its description were written by Isaac.
