### PR TITLE
Fix labs panic on empty release list and make update check best-effort

### DIFF
--- a/cmd/labs/project/command_test.go
+++ b/cmd/labs/project/command_test.go
@@ -74,8 +74,6 @@ func TestRenderingTable(t *testing.T) {
 }
 
 func TestRunningCommandWhenUpdateCheckFails(t *testing.T) {
-	// Emulates an exhausted unauthenticated GitHub API quota: the update
-	// check only prints an upgrade hint and must not block the command.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))

--- a/cmd/labs/project/command_test.go
+++ b/cmd/labs/project/command_test.go
@@ -2,15 +2,20 @@ package project_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/databricks/cli/cmd/labs/github"
 	"github.com/databricks/cli/internal/testcli"
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/python"
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type echoOut struct {
@@ -66,4 +71,29 @@ func TestRenderingTable(t *testing.T) {
 	First  Second
 	Third  Fourth
 	`)
+}
+
+func TestRunningCommandWhenUpdateCheckFails(t *testing.T) {
+	// Emulates an exhausted unauthenticated GitHub API quota: the update
+	// check only prints an upgrade hint and must not block the command.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	home := copyTestdata(t, "testdata/installed-in-home")
+	// Drop the cached releases so the update check has to hit the API.
+	err := os.Remove(filepath.Join(home, ".databricks", "labs", "blueprint", "cache", "databrickslabs-blueprint-releases.json"))
+	require.NoError(t, err)
+
+	ctx := github.WithApiOverride(t.Context(), server.URL)
+	ctx = env.WithUserHomeDir(ctx, home)
+	py, _ := python.DetectExecutable(ctx)
+	py, _ = filepath.Abs(py)
+	ctx = env.Set(ctx, "PYTHON_BIN", py)
+
+	r := testcli.NewRunner(t, ctx, "labs", "blueprint", "echo")
+	var out echoOut
+	r.RunAndParseJSON(&out)
+	assert.Equal(t, "echo", out.Command)
 }

--- a/cmd/labs/project/project.go
+++ b/cmd/labs/project/project.go
@@ -308,8 +308,7 @@ func (p *Project) checkUpdates(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	// Repositories without releases cache an empty list and the offline
-	// fallback returns no versions, so there is nothing to advise on.
+	// Repositories without releases (and the offline fallback) yield no versions; nothing to advise on.
 	if len(versions) == 0 {
 		return nil
 	}

--- a/cmd/labs/project/project.go
+++ b/cmd/labs/project/project.go
@@ -308,6 +308,11 @@ func (p *Project) checkUpdates(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	// Repositories without releases cache an empty list and the offline
+	// fallback returns no versions, so there is nothing to advise on.
+	if len(versions) == 0 {
+		return nil
+	}
 	installed, err := p.InstalledVersion(ctx)
 	if err != nil {
 		return err

--- a/cmd/labs/project/project_test.go
+++ b/cmd/labs/project/project_test.go
@@ -31,8 +31,7 @@ func TestCheckUpdatesWithEmptyReleaseList(t *testing.T) {
 	prj := &Project{Name: "blueprint", rootDir: rootDir}
 	require.NoError(t, prj.EnsureFoldersExist())
 
-	// A repository without releases caches an empty list; the far-future
-	// refresh timestamp keeps the cache valid so no network call is made.
+	// The far-future refreshed_at keeps the cache valid so no network call is made.
 	cache := []byte(`{"refreshed_at": "2033-01-01T00:00:00Z", "data": []}`)
 	require.NoError(t, os.WriteFile(filepath.Join(prj.CacheDir(), "databrickslabs-blueprint-releases.json"), cache, ownerRW))
 	version := []byte(`{"version": "v0.3.15", "date": "2023-10-24T15:04:05+01:00"}`)

--- a/cmd/labs/project/project_test.go
+++ b/cmd/labs/project/project_test.go
@@ -2,10 +2,14 @@ package project
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/databricks/cli/libs/env"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func assertEqualPaths(t *testing.T, expected, actual string) {
@@ -18,4 +22,23 @@ func TestLoad(t *testing.T) {
 	prj, err := Load(ctx, "testdata/installed-in-home/.databricks/labs/blueprint/lib/labs.yml")
 	assert.NoError(t, err)
 	assertEqualPaths(t, "testdata/installed-in-home/.databricks/labs/blueprint/lib", prj.folder)
+}
+
+func TestCheckUpdatesWithEmptyReleaseList(t *testing.T) {
+	ctx := env.WithUserHomeDir(t.Context(), t.TempDir())
+	rootDir, err := PathInLabs(ctx, "blueprint")
+	require.NoError(t, err)
+	prj := &Project{Name: "blueprint", rootDir: rootDir}
+	require.NoError(t, prj.EnsureFoldersExist())
+
+	// A repository without releases caches an empty list; the far-future
+	// refresh timestamp keeps the cache valid so no network call is made.
+	cache := []byte(`{"refreshed_at": "2033-01-01T00:00:00Z", "data": []}`)
+	require.NoError(t, os.WriteFile(filepath.Join(prj.CacheDir(), "databrickslabs-blueprint-releases.json"), cache, ownerRW))
+	version := []byte(`{"version": "v0.3.15", "date": "2023-10-24T15:04:05+01:00"}`)
+	require.NoError(t, os.WriteFile(filepath.Join(prj.StateDir(), "version.json"), version, ownerRW))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	assert.NoError(t, prj.checkUpdates(cmd))
 }

--- a/cmd/labs/project/proxy.go
+++ b/cmd/labs/project/proxy.go
@@ -38,8 +38,7 @@ func (cp *proxy) register(parent *cobra.Command) {
 }
 
 func (cp *proxy) runE(cmd *cobra.Command, _ []string) error {
-	// The update check only prints an upgrade hint, so a failure (e.g. the
-	// unauthenticated GitHub API rate limit) must not block the command.
+	// The update check only prints an upgrade hint, so a failure must not block the command.
 	if err := cp.checkUpdates(cmd); err != nil {
 		log.Debugf(cmd.Context(), "Failed to check for newer release of %s: %s", cp.Project.Name, err)
 	}

--- a/cmd/labs/project/proxy.go
+++ b/cmd/labs/project/proxy.go
@@ -38,9 +38,10 @@ func (cp *proxy) register(parent *cobra.Command) {
 }
 
 func (cp *proxy) runE(cmd *cobra.Command, _ []string) error {
-	err := cp.checkUpdates(cmd)
-	if err != nil {
-		return err
+	// The update check only prints an upgrade hint, so a failure (e.g. the
+	// unauthenticated GitHub API rate limit) must not block the command.
+	if err := cp.checkUpdates(cmd); err != nil {
+		log.Debugf(cmd.Context(), "Failed to check for newer release of %s: %s", cp.Project.Name, err)
 	}
 	args, err := cp.commandInput(cmd)
 	if err != nil {


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. Two related problems in the `databricks labs` update check that runs before every command of an installed project:

1. The CLI panics with an index-out-of-range error when the release list is empty. This happens for repositories with zero GitHub releases, and also offline: the cache falls back to an empty list when the network is unreachable.
2. The check is fail-closed. It exists only to print an upgrade hint, yet any error aborts the command. The unauthenticated GitHub API allows only 60 requests per hour per IP, so a 403 from rate limiting blocks every `databricks labs <project> ...` invocation until the quota resets.

## Changes

Before, an empty release list crashed the CLI and any update-check failure aborted the command; now the upgrade hint is skipped and the command runs normally in both cases.

- `cmd/labs/project/project.go`: `checkUpdates` returns early when the loaded release list is empty instead of indexing into it.
- `cmd/labs/project/proxy.go`: a failing update check is logged at debug level and the command proceeds, instead of returning the error.

## Test plan

- [x] New unit test `TestCheckUpdatesWithEmptyReleaseList`: panics with "index out of range [0] with length 0" before the fix, passes after.
- [x] New test `TestRunningCommandWhenUpdateCheckFails`: runs `labs blueprint echo` with the GitHub API returning HTTP 500; fails with "github request failed: 500 Internal Server Error" before the fix, passes after.
- [x] `go test ./cmd/labs/...` passes.
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass.

This pull request and its description were written by Isaac.
