### PR TITLE
Skip workspace selection in auth login on account console hosts

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### CLI
 * Added the `databricks quickstart` command, a short introduction to the CLI that prints a human-friendly guide interactively and an agent-oriented version when run non-interactively ([#5464](https://github.com/databricks/cli/pull/5464)).
+* `databricks auth login` no longer prompts for workspace selection when logging in to an account console host (`https://accounts.*`). Pass `--workspace-id` explicitly to store a workspace ID on such a profile ([#5504](https://github.com/databricks/cli/pull/5504)).
 
 ### Bundles
 * Set the default `data_security_mode` to `DATA_SECURITY_MODE_AUTO` in bundle templates ([#5452](https://github.com/databricks/cli/pull/5452)).

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -410,14 +410,21 @@ a new profile is created.
 
 // shouldPromptWorkspace reports whether the login flow should ask the user to
 // pick a workspace. We prompt when we have an account_id but no workspace_id
-// and the user did not pass --skip-workspace, with one exception: re-login
-// into an existing profile that's already account-only for the SAME account
-// (account_id matches and workspace_id is absent or the legacy "none"
-// sentinel) honors the user's prior "skip" choice instead of re-prompting on
-// every login. We require the account_id to match so reusing a profile name
-// against a different account still gets the workspace prompt.
+// and the user did not pass --skip-workspace, with two exceptions:
+//   - Classic account console hosts (accounts.*) serve only account-level
+//     APIs, so a selected workspace_id would be unusable against that host
+//     and only misleads later commands.
+//   - Re-login into an existing profile that's already account-only for the
+//     SAME account (account_id matches and workspace_id is absent or the
+//     legacy "none" sentinel) honors the user's prior "skip" choice instead
+//     of re-prompting on every login. We require the account_id to match so
+//     reusing a profile name against a different account still gets the
+//     workspace prompt.
 func shouldPromptWorkspace(authArguments *auth.AuthArguments, existingProfile *profile.Profile, skipWorkspace bool) bool {
 	if authArguments.AccountID == "" || authArguments.WorkspaceID != "" || skipWorkspace {
+		return false
+	}
+	if auth.IsClassicAccountHost((&config.Config{Host: authArguments.Host}).CanonicalHostName()) {
 		return false
 	}
 	if existingProfile != nil &&

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -567,6 +567,31 @@ func TestShouldPromptWorkspace(t *testing.T) {
 			want:          true,
 		},
 		{
+			name:          "classic account console host never prompts",
+			authArguments: auth.AuthArguments{Host: "https://accounts.test", AccountID: "acc"},
+			want:          false,
+		},
+		{
+			name:          "classic account console host without scheme never prompts",
+			authArguments: auth.AuthArguments{Host: "accounts.test", AccountID: "acc"},
+			want:          false,
+		},
+		{
+			name:          "accounts-dod host never prompts",
+			authArguments: auth.AuthArguments{Host: "https://accounts-dod.test", AccountID: "acc"},
+			want:          false,
+		},
+		{
+			name:          "workspace host with account_id prompts",
+			authArguments: auth.AuthArguments{Host: "https://myworkspace.test", AccountID: "acc"},
+			want:          true,
+		},
+		{
+			name:          "classic account console host with workspace_id set never prompts",
+			authArguments: auth.AuthArguments{Host: "https://accounts.test", AccountID: "acc", WorkspaceID: "12345"},
+			want:          false,
+		},
+		{
 			name:            "re-login into legacy account-only profile (workspace_id = none)",
 			authArguments:   auth.AuthArguments{AccountID: "spog-account"},
 			existingProfile: legacyAccountProfile,


### PR DESCRIPTION
## Why

Logging in to an account console host (for example `https://accounts.cloud.databricks.com`) with an account ID prompted "Select a workspace", and silently auto-selected one when the account had exactly one workspace. These hosts only serve account-level APIs, so the stored `workspace_id` refers to a workspace the profile can never talk to, and later commands fail in confusing ways.

Relates to #5479.

## Changes

Before, `databricks auth login --host https://accounts.cloud.databricks.com --account-id <id>` prompted for (or auto-selected) a workspace and wrote `workspace_id` into the profile. Now it skips workspace selection entirely on classic account console hosts and writes no `workspace_id` key.

`shouldPromptWorkspace` returns false when the host is a classic account console host, using `auth.IsClassicAccountHost` on the canonical host name (the same check `needsAccountIDPrompt` and `ToOAuthArgument` already use). Passing `--workspace-id` explicitly (or `?w=` / `?o=` host query params) still works and is still written to the profile. SPOG and unified hosts keep prompting exactly as before.

## Test plan

- [x] Extended the `shouldPromptWorkspace` unit tests: classic accounts host, accounts-dod host, host without scheme, accounts host with an explicit workspace ID, and a workspace host that still prompts.
- [x] `go test ./cmd/auth/... ./libs/auth/...` passes.
- [x] Existing auth acceptance tests pass unchanged (`go test ./acceptance -run TestAccept/cmd/auth`). No acceptance test was added: the harness cannot complete an OAuth challenge against an `accounts.*` host, and the workspace selection step only runs after a successful challenge.
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass.

This pull request and its description were written by Isaac.
