### PR TITLE
Fix deadlock in cmdio tea program queueing

### DIFF
--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -156,8 +156,16 @@ func (c *cmdIO) acquireTeaProgram(p *tea.Program) {
 	defer c.teaMu.Unlock()
 
 	// Wait for existing program to finish
-	if c.teaDone != nil {
-		<-c.teaDone
+	//
+	// The channel receive must happen with teaMu released: releaseTeaProgram
+	// locks teaMu to close teaDone, so waiting while holding the lock would
+	// deadlock both goroutines. Re-check in a loop because another acquirer
+	// may register a new program before this one reacquires the lock.
+	for c.teaDone != nil {
+		done := c.teaDone
+		c.teaMu.Unlock()
+		<-done
+		c.teaMu.Lock()
 	}
 
 	// Register new program

--- a/libs/cmdio/io.go
+++ b/libs/cmdio/io.go
@@ -156,11 +156,9 @@ func (c *cmdIO) acquireTeaProgram(p *tea.Program) {
 	defer c.teaMu.Unlock()
 
 	// Wait for existing program to finish
-	//
-	// The channel receive must happen with teaMu released: releaseTeaProgram
-	// locks teaMu to close teaDone, so waiting while holding the lock would
-	// deadlock both goroutines. Re-check in a loop because another acquirer
-	// may register a new program before this one reacquires the lock.
+	// Receive with teaMu released: releaseTeaProgram locks teaMu to close
+	// teaDone, so waiting while holding it would deadlock. Loop because another
+	// acquirer may register a new program before the lock is reacquired.
 	for c.teaDone != nil {
 		done := c.teaDone
 		c.teaMu.Unlock()

--- a/libs/cmdio/io_test.go
+++ b/libs/cmdio/io_test.go
@@ -1,0 +1,39 @@
+package cmdio
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAcquireTeaProgramWaitsForRelease(t *testing.T) {
+	c := &cmdIO{}
+	// acquireTeaProgram only stores the pointer, so nil is enough to exercise
+	// the queueing without running a real tea.Program.
+	c.acquireTeaProgram(nil)
+
+	acquired := make(chan struct{})
+	go func() {
+		c.acquireTeaProgram(nil)
+		close(acquired)
+	}()
+
+	// The second acquire must queue behind the active program.
+	select {
+	case <-acquired:
+		t.Fatal("second acquireTeaProgram returned while the first program was still active")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Release on a separate goroutine: the original implementation deadlocked
+	// here because the waiter held teaMu while blocked on teaDone, which
+	// releaseTeaProgram needs to close it.
+	go c.releaseTeaProgram()
+
+	select {
+	case <-acquired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second acquireTeaProgram did not return after the first program was released")
+	}
+
+	c.releaseTeaProgram()
+}

--- a/libs/cmdio/io_test.go
+++ b/libs/cmdio/io_test.go
@@ -7,8 +7,7 @@ import (
 
 func TestAcquireTeaProgramWaitsForRelease(t *testing.T) {
 	c := &cmdIO{}
-	// acquireTeaProgram only stores the pointer, so nil is enough to exercise
-	// the queueing without running a real tea.Program.
+	// acquireTeaProgram only stores the pointer, so a nil program suffices.
 	c.acquireTeaProgram(nil)
 
 	acquired := make(chan struct{})
@@ -17,16 +16,14 @@ func TestAcquireTeaProgramWaitsForRelease(t *testing.T) {
 		close(acquired)
 	}()
 
-	// The second acquire must queue behind the active program.
 	select {
 	case <-acquired:
 		t.Fatal("second acquireTeaProgram returned while the first program was still active")
 	case <-time.After(50 * time.Millisecond):
 	}
 
-	// Release on a separate goroutine: the original implementation deadlocked
-	// here because the waiter held teaMu while blocked on teaDone, which
-	// releaseTeaProgram needs to close it.
+	// Release on a goroutine so a regressed deadlock fails the timeout below
+	// instead of hanging the test.
 	go c.releaseTeaProgram()
 
 	select {


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. `acquireTeaProgram` in `libs/cmdio` is documented to queue a new `tea.Program` behind an active one, but it waits on the `teaDone` channel while holding `teaMu`. `releaseTeaProgram` needs that same mutex to close the channel, so the moment two programs overlap, both goroutines deadlock and the CLI hangs. It is latent today because callers happen to serialize, but any future concurrent spinner or prompt would trip it.

## Changes

Before, starting a second `tea.Program` while one was active deadlocked; now the second one waits for the active program to finish and then runs. `acquireTeaProgram` copies `teaDone` under the lock, releases the lock while waiting on the channel, and re-checks in a loop before registering, since another acquirer may take the slot first. `releaseTeaProgram` and `Wait` are unchanged.

## Test plan

- [x] Added `TestAcquireTeaProgramWaitsForRelease` in `libs/cmdio/io_test.go`: starts a second acquire while a program is active, asserts it queues, then asserts it completes after release, with a timeout guarding against deadlock
- [x] Verified the new test fails against the previous implementation (times out at the release step)
- [x] `go test -race ./libs/cmdio/...` passes
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass

This pull request and its description were written by Isaac.
