### PR TITLE
Fix swapped tag/branch flag bindings in bundle init

### DIFF
--- a/cmd/bundle/init.go
+++ b/cmd/bundle/init.go
@@ -42,8 +42,8 @@ See https://docs.databricks.com/en/dev-tools/bundles/templates.html for more inf
 	cmd.Flags().StringVar(&configFile, "config-file", "", "JSON file containing key value pairs of input parameters required for template initialization.")
 	cmd.Flags().StringVar(&templateDir, "template-dir", "", "Directory path within a Git repository containing the template.")
 	cmd.Flags().StringVar(&outputDir, "output-dir", "", "Directory to write the initialized template to.")
-	cmd.Flags().StringVar(&branch, "tag", "", "Git tag to use for template initialization")
-	cmd.Flags().StringVar(&tag, "branch", "", "Git branch to use for template initialization")
+	cmd.Flags().StringVar(&tag, "tag", "", "Git tag to use for template initialization")
+	cmd.Flags().StringVar(&branch, "branch", "", "Git branch to use for template initialization")
 
 	cmd.PreRunE = root.MustWorkspaceClient
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. In `bundle init`, the `--tag` flag is bound to the `branch` variable and `--branch` to the `tag` variable. Behavior is unaffected today because the template resolver collapses both into a single git ref, but the crossed bindings are a landmine for any future code that treats tags and branches differently.

## Changes

Before, `--tag` wrote into the `branch` variable and `--branch` into the `tag` variable; now each flag is bound to its matching variable. Two-line swap of the pointer arguments in `cmd/bundle/init.go`. No user-visible behavior change.

## Test plan

- [x] `go build ./cmd/bundle/...`
- [x] `go test ./cmd/bundle/...`
- [x] `go test ./libs/template` (existing resolver tests cover the tag/branch handling downstream)
- [x] `./task fmt-q`, `./task lint-q`, `./task checks`

This pull request and its description were written by Isaac.
