### PR TITLE
Fix prepend_workspace_prefix to use visited value instead of closure root

### DIFF
--- a/bundle/config/mutator/prepend_workspace_prefix.go
+++ b/bundle/config/mutator/prepend_workspace_prefix.go
@@ -41,7 +41,7 @@ func (m *prependWorkspacePrefix) Apply(ctx context.Context, b *bundle.Bundle) di
 			v, err = dyn.MapByPattern(v, pattern, func(p dyn.Path, pv dyn.Value) (dyn.Value, error) {
 				path, ok := pv.AsString()
 				if !ok {
-					return dyn.InvalidValue, fmt.Errorf("expected string, got %s", v.Kind())
+					return dyn.InvalidValue, fmt.Errorf("expected string, got %s", pv.Kind())
 				}
 
 				// Skip prefixing if the path does not start with /, it might be variable reference or smth else.
@@ -55,7 +55,9 @@ func (m *prependWorkspacePrefix) Apply(ctx context.Context, b *bundle.Bundle) di
 					}
 				}
 
-				return dyn.NewValue("/Workspace"+path, v.Locations()), nil
+				// Use the visited value's locations, not the root's, so later
+				// diagnostics still point at the original line in the config.
+				return dyn.NewValue("/Workspace"+path, pv.Locations()), nil
 			})
 			if err != nil {
 				return dyn.InvalidValue, err

--- a/bundle/config/mutator/prepend_workspace_prefix.go
+++ b/bundle/config/mutator/prepend_workspace_prefix.go
@@ -55,8 +55,7 @@ func (m *prependWorkspacePrefix) Apply(ctx context.Context, b *bundle.Bundle) di
 					}
 				}
 
-				// Use the visited value's locations, not the root's, so later
-				// diagnostics still point at the original line in the config.
+				// Use pv's locations, not the root v's, so diagnostics point at the original config line.
 				return dyn.NewValue("/Workspace"+path, pv.Locations()), nil
 			})
 			if err != nil {

--- a/bundle/config/mutator/prepend_workspace_prefix_test.go
+++ b/bundle/config/mutator/prepend_workspace_prefix_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/internal/bundletest"
+	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +63,23 @@ func TestPrependWorkspacePrefix(t *testing.T) {
 		require.Equal(t, tc.expected, b.Config.Workspace.StatePath)
 		require.Equal(t, tc.expected, b.Config.Workspace.ResourcePath)
 	}
+}
+
+func TestPrependWorkspacePrefixPreservesLocations(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Workspace: config.Workspace{
+				RootPath: "/Users/test",
+			},
+		},
+	}
+	locations := []dyn.Location{{File: "databricks.yml", Line: 42, Column: 5}}
+	bundletest.SetLocation(b, "workspace.root_path", locations)
+
+	diags := bundle.Apply(t.Context(), b, PrependWorkspacePrefix())
+	require.Empty(t, diags)
+	require.Equal(t, "/Workspace/Users/test", b.Config.Workspace.RootPath)
+	require.Equal(t, locations, b.Config.GetLocations("workspace.root_path"))
 }
 
 func TestPrependWorkspaceForDefaultConfig(t *testing.T) {


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. The `MapByPattern` callback in `bundle/config/mutator/prepend_workspace_prefix.go` referenced the closure variable `v` (the root config value) instead of the visited value `pv`. Two consequences: the type-mismatch error always reported "got map" regardless of the actual kind, and every rewritten workspace path was assigned the root document's locations instead of its own. Any later diagnostic referring to one of these paths pointed at the wrong place in the config.

## Changes

Before, rewritten workspace paths lost their original source locations and the error message always claimed the value was a map; now both come from the value actually being visited. Two one-word fixes in the callback: the error uses `pv.Kind()` and the rewritten value uses `pv.Locations()`. Added a unit test that sets a location on `workspace.root_path` and asserts it survives the rewrite.

## Test plan

- [x] New unit test `TestPrependWorkspacePrefixPreservesLocations` (verified it fails on the previous code and passes with the fix)
- [x] `go test ./bundle/config/mutator/`
- [x] Acceptance test `TestAccept/bundle/variables/prepend-workspace-var`
- [x] `./task fmt-q`, `./task lint-q`, `./task checks`

This pull request and its description were written by Isaac.
