### PR TITLE
Surface psql list errors instead of reporting an empty workspace

### DIFF
--- a/cmd/psql/psql.go
+++ b/cmd/psql/psql.go
@@ -181,7 +181,10 @@ For more information, see: https://docs.databricks.com/aws/en/oltp/
 		ctx := cmd.Context()
 		w := cmdctx.WorkspaceClient(ctx)
 
-		instances, projects := listAllDatabases(ctx, w)
+		instances, projects, err := listAllDatabases(ctx, w)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
 
 		var names []string
 		for _, inst := range instances {
@@ -237,8 +240,10 @@ func parseResourcePath(input string) (project, branch, endpoint string, err erro
 }
 
 // listAllDatabases fetches all database instances and projects in parallel.
-// Errors are silently ignored; callers should check for empty results.
-func listAllDatabases(ctx context.Context, w *databricks.WorkspaceClient) ([]database.DatabaseInstance, []postgres.Project) {
+// A single failing call is tolerated because a workspace may have only one of
+// the two products enabled; an error is returned only when both calls fail,
+// so that e.g. an auth failure is not reported as an empty workspace.
+func listAllDatabases(ctx context.Context, w *databricks.WorkspaceClient) ([]database.DatabaseInstance, []postgres.Project, error) {
 	type result[T any] struct {
 		value []T
 		err   error
@@ -260,6 +265,10 @@ func listAllDatabases(ctx context.Context, w *databricks.WorkspaceClient) ([]dat
 	instResult := <-instancesCh
 	projResult := <-projectsCh
 
+	if instResult.err != nil && projResult.err != nil {
+		return nil, nil, errors.Join(instResult.err, projResult.err)
+	}
+
 	var instances []database.DatabaseInstance
 	var projects []postgres.Project
 	if instResult.err == nil {
@@ -269,7 +278,7 @@ func listAllDatabases(ctx context.Context, w *databricks.WorkspaceClient) ([]dat
 		projects = projResult.value
 	}
 
-	return instances, projects
+	return instances, projects, nil
 }
 
 // showSelectionAndConnect shows a combined dropdown of Lakebase databases.
@@ -278,8 +287,11 @@ func showSelectionAndConnect(ctx context.Context, retryConfig libpsql.RetryConfi
 
 	sp := cmdio.NewSpinner(ctx)
 	sp.Update("Loading Lakebase databases...")
-	instances, projects := listAllDatabases(ctx, w)
+	instances, projects, err := listAllDatabases(ctx, w)
 	sp.Close()
+	if err != nil {
+		return fmt.Errorf("failed to list Lakebase databases: %w", err)
+	}
 
 	if len(instances) == 0 && len(projects) == 0 {
 		return errors.New("no Lakebase databases found in workspace")

--- a/cmd/psql/psql_test.go
+++ b/cmd/psql/psql_test.go
@@ -1,9 +1,14 @@
 package psql
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/database"
+	"github.com/databricks/databricks-sdk-go/service/postgres"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,6 +83,77 @@ func TestParseResourcePath(t *testing.T) {
 			assert.Equal(t, tc.project, project)
 			assert.Equal(t, tc.branch, branch)
 			assert.Equal(t, tc.endpoint, endpoint)
+		})
+	}
+}
+
+func TestListAllDatabases(t *testing.T) {
+	instErr := errors.New("instances list failed")
+	projErr := errors.New("projects list failed")
+	instances := []database.DatabaseInstance{{Name: "my-instance"}}
+	projects := []postgres.Project{{Name: "projects/my-project"}}
+
+	tests := []struct {
+		name          string
+		instErr       error
+		projErr       error
+		wantInstances []database.DatabaseInstance
+		wantProjects  []postgres.Project
+		wantErr       bool
+	}{
+		{
+			name:          "both succeed",
+			wantInstances: instances,
+			wantProjects:  projects,
+		},
+		{
+			name:         "instances call fails",
+			instErr:      instErr,
+			wantProjects: projects,
+		},
+		{
+			name:          "projects call fails",
+			projErr:       projErr,
+			wantInstances: instances,
+		},
+		{
+			name:    "both calls fail",
+			instErr: instErr,
+			projErr: projErr,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := mocks.NewMockWorkspaceClient(t)
+
+			var instReturn []database.DatabaseInstance
+			if tc.instErr == nil {
+				instReturn = instances
+			}
+			m.GetMockDatabaseAPI().EXPECT().
+				ListDatabaseInstancesAll(mock.Anything, database.ListDatabaseInstancesRequest{}).
+				Return(instReturn, tc.instErr)
+
+			var projReturn []postgres.Project
+			if tc.projErr == nil {
+				projReturn = projects
+			}
+			m.GetMockPostgresAPI().EXPECT().
+				ListProjectsAll(mock.Anything, postgres.ListProjectsRequest{}).
+				Return(projReturn, tc.projErr)
+
+			gotInstances, gotProjects, err := listAllDatabases(t.Context(), m.WorkspaceClient)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.instErr)
+				assert.ErrorIs(t, err, tc.projErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantInstances, gotInstances)
+			assert.Equal(t, tc.wantProjects, gotProjects)
 		})
 	}
 }


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. `databricks psql` lists both provisioned database instances and autoscaling projects to populate its interactive selector, but it discarded the errors from both list calls. When both calls fail (for example, an auth failure), the user gets "no Lakebase databases found in workspace" instead of the real error, which sends them debugging the wrong problem.

## Changes

Before, list-API failures were silently ignored and surfaced as an empty-workspace message; now, when both list calls fail, the underlying errors are returned to the user. `listAllDatabases` returns an error joined from both call errors when both fail. A single failing call is still tolerated, since a workspace may have only one of the two products enabled. The interactive selection path wraps and returns the error, and shell completion reports `ShellCompDirectiveError` instead of silently completing nothing.

## Test plan

- [x] Added a table-driven unit test for `listAllDatabases` covering both calls failing (error returned, `errors.Is` matches both), each single call failing (tolerated), and both succeeding
- [x] `go test ./cmd/psql/` passes
- [x] `go test ./acceptance -run 'TestAccept/cmd/psql'` passes
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass

This pull request and its description were written by Isaac.
