### PR TITLE
Fix response body leak in labs GitHub client

### DIFF
--- a/cmd/labs/github/github.go
+++ b/cmd/labs/github/github.go
@@ -64,6 +64,7 @@ func getPagedBytes(ctx context.Context, method, url string, body io.Reader) (*pa
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	if res.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
 	}
@@ -71,7 +72,6 @@ func getPagedBytes(ctx context.Context, method, url string, body io.Reader) (*pa
 		return nil, fmt.Errorf("github request failed: %s", res.Status)
 	}
 	nextLink := parseNextLink(res.Header.Get("link"))
-	defer res.Body.Close()
 	bodyBytes, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err

--- a/cmd/labs/github/github_test.go
+++ b/cmd/labs/github/github_test.go
@@ -1,10 +1,64 @@
 package github
 
 import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type closeRecordingBody struct {
+	io.Reader
+	closed *bool
+}
+
+func (b *closeRecordingBody) Close() error {
+	*b.closed = true
+	return nil
+}
+
+type stubTransport struct {
+	status int
+	closed bool
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.status,
+		Status:     fmt.Sprintf("%d %s", s.status, http.StatusText(s.status)),
+		Header:     http.Header{},
+		Body:       &closeRecordingBody{Reader: strings.NewReader("{}"), closed: &s.closed},
+		Request:    req,
+	}, nil
+}
+
+func TestGetPagedBytesClosesBodyOnHTTPError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"not found", http.StatusNotFound},
+		{"server error", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// getPagedBytes hardcodes http.DefaultClient, so swapping its
+			// transport is the only seam to observe body closure.
+			stub := &stubTransport{status: tt.status}
+			prev := http.DefaultClient.Transport
+			http.DefaultClient.Transport = stub
+			t.Cleanup(func() { http.DefaultClient.Transport = prev })
+
+			_, err := getPagedBytes(t.Context(), "GET", "https://api.github.test/x", nil)
+			assert.Error(t, err)
+			assert.True(t, stub.closed)
+		})
+	}
+}
 
 func TestParseNextLink(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. In `cmd/labs/github/github.go`, `getPagedBytes` registers `defer res.Body.Close()` only after the early returns for 404 and other 4xx/5xx responses. On those paths the response body is never closed, which leaks the connection. The labs update check polls the GitHub API unauthenticated, where 403 rate-limit responses are common, so these error paths are hit in practice.

## Changes

Before, the response body was only closed on successful responses; now it is closed on every path. The fix moves the `defer res.Body.Close()` to immediately after the `http.DefaultClient.Do` error check, before the status-code checks.

Also adds a unit test that stubs the HTTP transport and asserts the body is closed when the request returns 404 or 500. The test fails on the previous code.

## Test plan

- [x] New unit test `TestGetPagedBytesClosesBodyOnHTTPError` passes, and was verified to fail against the unfixed code
- [x] `go test ./cmd/labs/...` passes
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` pass

This pull request and its description were written by Isaac.
