### PR TITLE
Remove import-time side effects from bundle/config and databrickscfg

### DIFF
--- a/bundle/config/workspace.go
+++ b/bundle/config/workspace.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/databricks/cli/bundle/env"
@@ -208,14 +206,4 @@ func (w *Workspace) Client(ctx context.Context) (*databricks.WorkspaceClient, er
 	}
 
 	return databricks.NewWorkspaceClient((*databricks.Config)(cfg))
-}
-
-func init() {
-	arg0 := os.Args[0]
-
-	// Configure DATABRICKS_CLI_PATH only if our caller intends to use this specific version of this binary.
-	// Otherwise, if it is equal to its basename, processes can find it in $PATH.
-	if arg0 != filepath.Base(arg0) {
-		os.Setenv("DATABRICKS_CLI_PATH", arg0)
-	}
 }

--- a/libs/databrickscfg/ops.go
+++ b/libs/databrickscfg/ops.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
@@ -357,7 +358,16 @@ func AuthCredentialKeys() []string {
 	return keys
 }
 
+// We document databrickscfg files with a [DEFAULT] header and wish to keep it that way.
+// This, however, does mean we emit a [DEFAULT] section even if it's empty.
+// ini.DefaultHeader is process-global, so it is enabled on first write instead of
+// at import time to keep this package free of import side effects.
+var enableDefaultHeader = sync.OnceFunc(func() {
+	ini.DefaultHeader = true
+})
+
 func writeConfigFile(ctx context.Context, configFile *config.File) error {
+	enableDefaultHeader()
 	section := configFile.Section(ini.DefaultSection)
 	if len(section.Keys()) == 0 && section.Comment == "" {
 		section.Comment = defaultComment
@@ -498,10 +508,4 @@ func ValidateConfigAndProfileHost(cfg *config.Config, profile string) error {
 	}
 
 	return nil
-}
-
-func init() {
-	// We document databrickscfg files with a [DEFAULT] header and wish to keep it that way.
-	// This, however, does mean we emit a [DEFAULT] section even if it's empty.
-	ini.DefaultHeader = true
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/databricks/cli/cmd"
 	"github.com/databricks/cli/cmd/root"
@@ -13,6 +14,16 @@ import (
 )
 
 func main() {
+	// Configure DATABRICKS_CLI_PATH only if our caller intends to use this specific version of this binary.
+	// Otherwise, if it is equal to its basename, processes can find it in $PATH.
+	// This runs in main rather than in a package init so that importing CLI
+	// packages (e.g. from test binaries or generators) does not mutate the
+	// process environment.
+	arg0 := os.Args[0]
+	if arg0 != filepath.Base(arg0) {
+		os.Setenv("DATABRICKS_CLI_PATH", arg0)
+	}
+
 	ctx := context.Background()
 	err := root.Execute(ctx, cmd.New(ctx))
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/databricks/cli/cmd"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/module"
 )
 
@@ -24,6 +26,21 @@ func TestCommandsDontUseUnderscoreInName(t *testing.T) {
 		assert.NotContains(t, cmd.Name(), "_")
 		queue = append(queue[1:], cmd.Commands()...)
 	}
+}
+
+func TestImportDoesNotSetCliPathEnv(t *testing.T) {
+	// Exporting DATABRICKS_CLI_PATH is done in main, not in a package init,
+	// so that importing CLI packages (e.g. from test binaries or generators)
+	// does not mutate the process environment.
+	//
+	// This test lives in the main package because this is where
+	// all commands are imported.
+	//
+	// Test binaries run by their absolute path, which is exactly the condition
+	// under which main exports the variable; an import-time export would
+	// therefore have set it to this test binary's path by now.
+	require.NotEqual(t, filepath.Base(os.Args[0]), os.Args[0])
+	assert.NotEqual(t, os.Args[0], os.Getenv("DATABRICKS_CLI_PATH"))
 }
 
 func TestFilePath(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -29,15 +29,8 @@ func TestCommandsDontUseUnderscoreInName(t *testing.T) {
 }
 
 func TestImportDoesNotSetCliPathEnv(t *testing.T) {
-	// Exporting DATABRICKS_CLI_PATH is done in main, not in a package init,
-	// so that importing CLI packages (e.g. from test binaries or generators)
-	// does not mutate the process environment.
-	//
-	// This test lives in the main package because this is where
-	// all commands are imported.
-	//
 	// Test binaries run by their absolute path, which is exactly the condition
-	// under which main exports the variable; an import-time export would
+	// under which main exports DATABRICKS_CLI_PATH; an import-time export would
 	// therefore have set it to this test binary's path by now.
 	require.NotEqual(t, filepath.Base(os.Args[0]), os.Args[0])
 	assert.NotEqual(t, os.Args[0], os.Getenv("DATABRICKS_CLI_PATH"))


### PR DESCRIPTION
## Why

Found during a full-repo review of the CLI. Two packages mutate process-global state at import time:

- `bundle/config` has an `init()` that exports `DATABRICKS_CLI_PATH` into the process environment. This runs in every importer, including test binaries and code generators, where `os.Args[0]` is not the CLI and the resulting value is wrong.
- `libs/databrickscfg` has an `init()` that flips the process-global `ini.DefaultHeader` option, affecting every user of the ini package in the process even when no databrickscfg file is ever written.

## Changes

Before, importing these packages was enough to trigger the side effects; now they only happen when the CLI binary starts or when a config file is actually written.

- The `DATABRICKS_CLI_PATH` export moves from `bundle/config/workspace.go` to `main.go`, with the original condition and comment preserved. It runs before command execution, so it is still set before any SDK auth resolution and before any child process is spawned.
- `libs/databrickscfg/ops.go` enables `ini.DefaultHeader` lazily via `sync.OnceFunc` from `writeConfigFile`, the single function through which all profile writes (`SaveToProfile`, `DeleteProfile`) go.

Behavior is unchanged for the CLI binary itself. Existing tests lock both behaviors: `TestSaveToProfile_NewFileWithoutDefault` asserts the `[DEFAULT]` header in written files, and the no-auth and multi-profile acceptance tests assert `DATABRICKS_CLI_PATH` shows up in SDK auth error output. A new test in `main_test.go` guards against reintroducing the env export in a package init.

## Test plan

- [x] `go test . ./bundle/config ./libs/databrickscfg ./cmd/configure ./cmd/auth`
- [x] `go test ./acceptance -run 'TestAccept/bundle/run/scripts/no-auth|TestAccept/bundle/multi_profile|TestAccept/cmd/configure'` (outputs unchanged, so the binary still exports the variable before SDK config resolution and still writes the `[DEFAULT]` header)
- [x] `go test ./acceptance -run 'TestAccept/bundle/run/inline-script/no-auth|TestAccept/auth'`
- [x] New unit test `TestImportDoesNotSetCliPathEnv` in `main_test.go`
- [x] `./task fmt-q`, lint on touched packages, `./task checks`

This pull request and its description were written by Isaac.
