### PR TITLE
sandbox: drive SSH config from server-stamped `gateway_host`

### DIFF
--- a/acceptance/cmd/sandbox/ssh-key/list/with-entries/test.toml
+++ b/acceptance/cmd/sandbox/ssh-key/list/with-entries/test.toml
@@ -7,12 +7,14 @@ Response.Body = '''
       "keyHash": "98b3b2bce82049769b4ba03990460d09",
       "name": "laptop",
       "createTime": "2026-05-29T17:18:00Z",
-      "lastUseTime": "2026-05-29T17:19:00Z"
+      "lastUseTime": "2026-05-29T17:19:00Z",
+      "gatewayHost": "uw2.dbrx.dev"
     },
     {
       "keyHash": "9e0fc7c899aeee6a462e3153aeae8f30",
       "createTime": "2026-05-12T21:31:00Z",
-      "lastUseTime": "2026-05-29T17:13:00Z"
+      "lastUseTime": "2026-05-29T17:13:00Z",
+      "gatewayHost": "uw2.dbrx.dev"
     }
   ]
 }

--- a/cmd/sandbox/api.go
+++ b/cmd/sandbox/api.go
@@ -311,16 +311,28 @@ func (a *sandboxAPI) start(ctx context.Context, id string) (*sandboxEntry, error
 
 // registerKey calls POST /api/2.0/lakebox/ssh-keys. An empty `name` is
 // omitted so the server records "unset" rather than an explicit empty string.
-func (a *sandboxAPI) registerKey(ctx context.Context, publicKey, name string) error {
-	return a.c.Do(ctx, http.MethodPost, sandboxKeysAPIPath, a.headers(), nil, registerKeyRequest{PublicKey: publicKey, Name: name}, nil)
+// Returns the registered key, which carries the workspace's `GatewayHost` —
+// this is how `register` learns the gateway without a probe `list` /
+// `create` call.
+func (a *sandboxAPI) registerKey(ctx context.Context, publicKey, name string) (*sshKeyEntry, error) {
+	var resp sshKeyEntry
+	err := a.c.Do(ctx, http.MethodPost, sandboxKeysAPIPath, a.headers(), nil, registerKeyRequest{PublicKey: publicKey, Name: name}, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
-// sshKeyEntry is a single item in the ssh-key list response.
+// sshKeyEntry is a single item in the ssh-key list response. GatewayHost
+// is per-workspace (not per-key) — the server stamps the same value on
+// every response so callers can learn the SSH gateway without provisioning
+// a sandbox first.
 type sshKeyEntry struct {
 	KeyHash     string `json:"keyHash"`
 	Name        string `json:"name,omitempty"`
 	CreateTime  string `json:"createTime,omitempty"`
 	LastUseTime string `json:"lastUseTime,omitempty"`
+	GatewayHost string `json:"gatewayHost,omitempty"`
 }
 
 // listKeysResponse is the JSON body returned by GET /api/2.0/lakebox/ssh-keys.

--- a/cmd/sandbox/register.go
+++ b/cmd/sandbox/register.go
@@ -49,6 +49,11 @@ Examples:
 				return err
 			}
 
+			profile := w.Config.Profile
+			if profile == "" {
+				profile = w.Config.Host
+			}
+
 			keyPath, generated, err := ensureSandboxKey(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to ensure sandbox SSH key: %w", err)
@@ -75,16 +80,27 @@ Examples:
 
 			s := spin(ctx, "Registering key…")
 			defer s.Close()
-			if err := api.registerKey(ctx, string(pubKeyData), name); err != nil {
+			registered, err := api.registerKey(ctx, string(pubKeyData), name)
+			if err != nil {
 				s.fail("Failed to register key")
 				return fmt.Errorf("failed to register key: %w", err)
 			}
 			s.ok("SSH key registered")
 
-			// Write the shared `sandbox-gw` ~/.ssh/config alias so editor
-			// Remote-SSH and plain `ssh <id>@sandbox-gw` both work without
-			// the user pasting any config block (see maybeWriteSSHConfig).
-			if err := maybeWriteSSHConfig(ctx, keyPath, w.Config.Host); err != nil {
+			// Cache the workspace's gateway host so any subsequent
+			// command (ssh, status, ...) sees it before its own first
+			// API call.
+			if registered.GatewayHost != "" {
+				_ = setGatewayHost(ctx, profile, registered.GatewayHost)
+			}
+
+			// Write the `Host <gateway>` block to ~/.ssh/config so
+			// editor Remote-SSH ("Open in VS Code/Cursor") deep links
+			// and plain `ssh <id>@<gateway>` both work without the
+			// user pasting any config block. The gateway host comes
+			// straight from the registerKey response — no probe call
+			// needed, no heuristic.
+			if err := maybeWriteSSHConfig(ctx, keyPath, registered.GatewayHost); err != nil {
 				warn(ctx, fmt.Sprintf("Registered key, but failed to update ~/.ssh/config: %v", err))
 			}
 

--- a/cmd/sandbox/sshconfig.go
+++ b/cmd/sandbox/sshconfig.go
@@ -16,12 +16,6 @@ import (
 )
 
 const (
-	// sshConfigAlias is the SSH-config Host that all sandbox sandboxes
-	// route through. Shared with the workspace UI's "First time setup?"
-	// disclosure, so IDE Remote-SSH deep links resolve identically
-	// whether the user set up via the CLI or pasted the UI snippet.
-	sshConfigAlias = "sandbox-gw"
-
 	// sshIncludeFileName is the sandbox-managed file referenced by the
 	// user's ~/.ssh/config. The file is fully owned: we rewrite it on
 	// every `sandbox register`, so manual edits to it will not survive.
@@ -89,26 +83,29 @@ func writeSSHConfig(ctx context.Context, keyPath, gatewayHost, gatewayPort strin
 }
 
 // buildSSHConfigBlock renders the Host stanza we write to the
-// sandbox-managed include file. The -o flags here mirror buildSSHArgs
-// in ssh.go so connections that resolve through this alias (IDE
-// Remote-SSH, raw `ssh <id>@sandbox-gw`) behave identically to
-// `databricks sandbox ssh`.
+// sandbox-managed include file. Mirrors the snippet the workspace UI's
+// "First time setup?" disclosure recommends — the Host key is the
+// literal gateway hostname (so editor Remote-SSH deep links like
+// `ssh-remote+<id>@<gateway>` resolve directly), and only the two
+// directives that meaningfully differ from SSH defaults are set:
 //
-// No User directive is set, so the per-sandbox identifier travels in
-// the destination (`ssh <sandbox-id>@sandbox-gw`); a single alias
-// serves every sandbox on this profile's workspace.
+//   - Port (the gateway listens on 2222, not 22)
+//   - IdentityFile + IdentitiesOnly (pin our key so ssh doesn't offer
+//     every key in ~/.ssh/ and trip the gateway's rejection cascade)
+//
+// Notably we do NOT set StrictHostKeyChecking, UserKnownHostsFile, or
+// LogLevel — those defaults work fine for IDE / raw-ssh use and
+// matching the user's expectations beats the cosmetic suppression the
+// CLI's own `sandbox ssh` does via argv. No User directive either —
+// the per-sandbox identifier travels in the destination
+// (`ssh <sandbox-id>@<gateway>`).
 func buildSSHConfigBlock(keyPath, gatewayHost, gatewayPort string) string {
-	return fmt.Sprintf(`# Managed by `+"`databricks sandbox register`"+`.
-# Manual edits will be overwritten on the next run.
+	return fmt.Sprintf(`# Managed by `+"`databricks sandbox register`"+`. Manual edits will be overwritten.
 Host %s
-    HostName %s
     Port %s
     IdentityFile %s
     IdentitiesOnly yes
-    StrictHostKeyChecking no
-    UserKnownHostsFile /dev/null
-    LogLevel ERROR
-`, sshConfigAlias, gatewayHost, gatewayPort, keyPath)
+`, gatewayHost, gatewayPort, keyPath)
 }
 
 // writeManagedConfig writes content to path atomically with 0600
@@ -186,7 +183,17 @@ func hasOurMarkedBlock(text string) bool {
 // maybeWriteSSHConfig writes the sandbox-managed SSH config, prompting
 // for consent the first time on this machine. Re-runs silently refresh
 // the managed file. Non-interactive contexts skip the write entirely.
-func maybeWriteSSHConfig(ctx context.Context, keyPath, workspaceHost string) error {
+// The gateway host is the workspace-scoped one returned by the server
+// on the registerKey response — no heuristic, no probe call.
+func maybeWriteSSHConfig(ctx context.Context, keyPath, gatewayHost string) error {
+	if gatewayHost == "" {
+		// Server didn't stamp a gateway on the response. Old server
+		// without the gateway_host field, or genuinely no gateway
+		// available. Skip rather than guess.
+		cmdio.LogString(ctx, "  "+cmdio.Faint(ctx, "skipped SSH config update — server did not return a gateway host"))
+		return nil
+	}
+
 	already, err := sshConfigAlreadyManaged(ctx)
 	if err != nil {
 		return err
@@ -197,12 +204,12 @@ func maybeWriteSSHConfig(ctx context.Context, keyPath, workspaceHost string) err
 			return err
 		}
 		if !cmdio.IsPromptSupported(ctx) {
-			cmdio.LogString(ctx, "  "+cmdio.Faint(ctx, "skipped SSH config update (non-interactive); re-run `databricks sandbox register` from a terminal to add the `"+sshConfigAlias+"` alias"))
+			cmdio.LogString(ctx, "  "+cmdio.Faint(ctx, "skipped SSH config update (non-interactive); re-run `databricks sandbox register` from a terminal to add the `Host "+gatewayHost+"` block"))
 			return nil
 		}
 		question := fmt.Sprintf(
-			"Add a `Host %s` alias to %s? This lets editor Remote-SSH (VS Code / Cursor) and `ssh <id>@%s` connect without further setup.",
-			sshConfigAlias, mainPath, sshConfigAlias,
+			"Add a `Host %s` block to %s? This lets editor Remote-SSH (VS Code / Cursor) and `ssh <id>@%s` connect without further setup.",
+			gatewayHost, mainPath, gatewayHost,
 		)
 		confirmed, err := cmdio.AskYesOrNo(ctx, question)
 		if err != nil {
@@ -214,8 +221,7 @@ func maybeWriteSSHConfig(ctx context.Context, keyPath, workspaceHost string) err
 		}
 	}
 
-	gateway := resolveGatewayHost(workspaceHost)
-	managedPath, _, err := writeSSHConfig(ctx, keyPath, gateway, defaultGatewayPort)
+	managedPath, _, err := writeSSHConfig(ctx, keyPath, gatewayHost, defaultGatewayPort)
 	if err != nil {
 		return err
 	}

--- a/cmd/sandbox/sshconfig_test.go
+++ b/cmd/sandbox/sshconfig_test.go
@@ -14,29 +14,37 @@ import (
 func TestBuildSSHConfigBlockShape(t *testing.T) {
 	block := buildSSHConfigBlock("/home/u/.ssh/sandbox_ed25519", "uw2.dbrx.dev", "2222")
 
-	// Header marker so users know not to hand-edit, and the alias name
-	// that the UI's "First time setup?" disclosure documents.
+	// The Host key is the literal gateway hostname (so UI editor deep
+	// links like `ssh-remote+<id>@<gateway>` resolve directly), and we
+	// only set the two directives that meaningfully differ from SSH
+	// defaults: Port (the gateway is on 2222) and IdentityFile +
+	// IdentitiesOnly (pin our key, suppress the offer cascade).
 	assert.Contains(t, block, "# Managed by")
-	assert.Contains(t, block, "Host "+sshConfigAlias+"\n")
-	assert.Contains(t, block, "HostName uw2.dbrx.dev")
+	assert.Contains(t, block, "Host uw2.dbrx.dev\n")
 	assert.Contains(t, block, "Port 2222")
 	assert.Contains(t, block, "IdentityFile /home/u/.ssh/sandbox_ed25519")
+	assert.Contains(t, block, "IdentitiesOnly yes")
 
-	// Mirrors buildSSHArgs in ssh.go so connections through this alias
-	// behave identically to `databricks sandbox ssh`. If those change,
-	// this list should change too.
-	for _, expect := range []string{
-		"IdentitiesOnly yes",
-		"StrictHostKeyChecking no",
-		"UserKnownHostsFile /dev/null",
-		"LogLevel ERROR",
-	} {
-		assert.Contains(t, block, expect, "missing required SSH option %q", expect)
-	}
+	// No HostName — Host already IS the real host, so HostName would
+	// be a redundant self-reference.
+	assert.NotContains(t, block, "HostName ", "HostName must not be set when Host already equals the hostname")
 
 	// No User directive — the sandbox id travels in the destination
-	// (`ssh <id>@sandbox-gw`), so one alias serves every sandbox.
+	// (`ssh <id>@<gateway>`).
 	assert.NotContains(t, block, "\n    User ", "User directive must not be set")
+
+	// Per the design (mirrors the workspace UI's "First time setup?"
+	// snippet), we deliberately do NOT set StrictHostKeyChecking,
+	// UserKnownHostsFile, or LogLevel — IDE Remote-SSH should behave
+	// like a normal `ssh <host>` invocation (TOFU host keys, default
+	// log level).
+	for _, forbidden := range []string{
+		"StrictHostKeyChecking",
+		"UserKnownHostsFile",
+		"LogLevel",
+	} {
+		assert.NotContains(t, block, forbidden, "must not set %q — SSH defaults are correct", forbidden)
+	}
 }
 
 func TestWriteManagedConfigCreatesWithRightPerms(t *testing.T) {


### PR DESCRIPTION
## Summary

Pairs with a server-side change that adds `gateway_host` to the `SshKey` proto and stamps it on every `CreateSshKey` / `ListSshKeys` / `UpdateSshKey` response. With that landed, the CLI learns the workspace's gateway host on the first key call and stops guessing.

The previous flow had two real bugs:

1. **Hardcoded heuristic** — `resolveGatewayHost()` returned `uw2.dbrx.dev` or `ue1.s.dbrx.dev` based on the workspace URL pattern. Real workspaces use other gateways (e.g. `us-west-2.service-direct.dev.databricks.com`), so the heuristic was wrong for at least one customer-facing case.
2. **Alias / deep-link mismatch** — the CLI wrote a `Host sandbox-gw` block; UI deep links emit `ssh-remote+<id>@<actual-gateway>`. Different host keys → SSH falls through to defaults (port 22) → connection fails.

Both go away when the CLI keys the block on the literal `gateway_host` the server hands back.

## What changed

| File | Change |
|---|---|
| `api.go` | `registerKey` now returns `*sshKeyEntry` (carrying `GatewayHost`) instead of just `error`. Adds `GatewayHost` to `sshKeyEntry`. |
| `register.go` | Captures the response, caches `GatewayHost` via `setGatewayHost`, and passes it to `maybeWriteSSHConfig` directly. No probe `list`/`create` call, no heuristic. |
| `sshconfig.go` | `maybeWriteSSHConfig` takes the gateway as a parameter (was: derived inside). Block shape now matches the workspace UI's "First time setup?" snippet exactly. |
| `sshconfig_test.go` | `TestBuildSSHConfigBlockShape` asserts the minimal form (positive + negative). |
| `acceptance/.../ssh-key/list/with-entries/test.toml` | Mock returns `gatewayHost` on each key, matching the new server contract. |

## New SSH config block

Before (9 lines, synthetic alias, several overrides):
```
# Managed by `databricks sandbox register`.
# Manual edits will be overwritten on the next run.
Host sandbox-gw
    HostName uw2.dbrx.dev
    Port 2222
    IdentityFile ~/.ssh/sandbox_ed25519
    IdentitiesOnly yes
    StrictHostKeyChecking no
    UserKnownHostsFile /dev/null
    LogLevel ERROR
```

After (5 lines, literal hostname, no overrides beyond Port + Identity):
```
# Managed by `databricks sandbox register`. Manual edits will be overwritten.
Host us-west-2.service-direct.dev.databricks.com
    Port 2222
    IdentityFile ~/.ssh/sandbox_ed25519
    IdentitiesOnly yes
```

Deliberately dropped (now SSH defaults):
- `Host sandbox-gw` alias — Host is the literal hostname; IDE deep links resolve directly.
- `HostName` — would be a redundant self-reference.
- `StrictHostKeyChecking no` + `UserKnownHostsFile /dev/null` — IDE / raw-ssh use should follow SSH's TOFU default; the CLI's own `sandbox ssh` still passes `-o` flags via argv.
- `LogLevel ERROR` — default fine for these flows.

## Empty-state behavior

Even with zero sandboxes on the workspace, `register` works — `gateway_host` is workspace-scoped (per the server change). If the server is somehow older and omits the field, we log a clear "skipped SSH config update — server did not return a gateway host" and proceed; the key is still registered.

## Test plan

- [x] `go test ./cmd/sandbox/...` passes
- [x] `go test ./acceptance -run TestAccept/cmd/sandbox` passes
- [x] `go build ./...` clean
- [x] `./task lint` clean
- [ ] Live test against staging after the server change deploys: `databricks sandbox register` writes a block keyed on the real gateway host; "Open in VS Code" from the workspace UI connects without further setup.

This pull request and its description were written by Isaac.