### PR TITLE
Fix bundle validate creating the remote file path

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,6 +13,7 @@
 * Bundle variable references now accept Unicode letters in path segments (e.g. `${var.变量}`). ([#5532](https://github.com/databricks/cli/pull/5532))
 * Ignore remote changes for vector search direct_access_index_spec.schema_json to prevent drift when the backend normalizes the schema ([#5481](https://github.com/databricks/cli/pull/5481)).
 * Remove hidden, never-functional `--existing-dashboard-id`, `--existing-dashboard-path`, `--existing-alert-id`, and `--existing-genie-space-id` alias flags from `bundle generate`; use the documented `--existing-id` / `--existing-path` flags instead ([#5591](https://github.com/databricks/cli/pull/5591)).
+* Fixed `bundle validate` creating the remote file path if it did not exist; validation no longer performs any write operations ([#5528](https://github.com/databricks/cli/pull/5528)).
 
 ### Dependency updates
 

--- a/acceptance/bundle/resource_deps/remote_app_url/output.txt
+++ b/acceptance/bundle/resource_deps/remote_app_url/output.txt
@@ -15,13 +15,6 @@ create pipelines.mypipeline
 Plan: 2 to add, 0 to change, 0 to delete, 0 unchanged
 
 >>> print_requests.py ^//import-file/
-{
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-  }
-}
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -43,6 +36,13 @@ Deployment complete!
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
   }
 }
 {

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.requests.txt
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/default/out.requests.txt
@@ -23,27 +23,3 @@
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/pat/files"
   }
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/pat/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/pat/files"
-  }
-}

--- a/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.requests.txt
+++ b/acceptance/bundle/run/inline-script/databricks-cli/target-is-passed/from_flag/out.requests.txt
@@ -51,27 +51,3 @@
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/oauth/files"
   }
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/oauth/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/oauth/files"
-  }
-}

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.requests.txt
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/default/out.requests.txt
@@ -36,27 +36,3 @@
     "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/pat/files"
   }
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/pat/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer [DATABRICKS_TOKEN]"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/pat/files"
-  }
-}

--- a/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.requests.txt
+++ b/acceptance/bundle/run/scripts/databricks-cli/target-is-passed/from_flag/out.requests.txt
@@ -64,27 +64,3 @@
     "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/oauth/files"
   }
 }
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/oauth/files"
-  }
-}
-{
-  "headers": {
-    "Authorization": [
-      "Bearer oauth-token"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/foobar/oauth/files"
-  }
-}

--- a/acceptance/bundle/templates/default-python/classic/out.requests.dev.direct.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.dev.direct.txt
@@ -48,6 +48,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.dev.terraform.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.dev.terraform.txt
@@ -48,6 +48,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.prod.direct.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.prod.direct.txt
@@ -51,6 +51,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/classic/out.requests.prod.terraform.txt
+++ b/acceptance/bundle/templates/default-python/classic/out.requests.prod.terraform.txt
@@ -51,6 +51,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.dev.direct.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.dev.direct.txt
@@ -50,6 +50,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.dev.terraform.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.dev.terraform.txt
@@ -50,6 +50,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.prod.direct.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.prod.direct.txt
@@ -53,6 +53,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files/.vscode"
   }
 }

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.prod.terraform.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.prod.terraform.txt
@@ -53,6 +53,13 @@
   "method": "POST",
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files"
+  }
+}
+{
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/files/.vscode"
   }
 }

--- a/acceptance/bundle/user_agent/output.txt
+++ b/acceptance/bundle/user_agent/output.txt
@@ -8,6 +8,7 @@ OK  	deploy.direct	/api/2.0/workspace/get-status	engine/direct
 OK  	deploy.direct	/api/2.0/workspace/get-status	engine/direct
 OK  	deploy.direct	/api/2.0/workspace/get-status	engine/direct
 OK  	deploy.direct	/api/2.0/workspace/get-status	engine/direct
+OK  	deploy.direct	/api/2.0/workspace/get-status	engine/direct
 OK  	deploy.direct	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/empty.py	engine/direct
 OK  	deploy.direct	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deploy.lock	engine/direct
 OK  	deploy.direct	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deployment.json	engine/direct
@@ -15,6 +16,7 @@ OK  	deploy.direct	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAM
 OK  	deploy.direct	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/resources.json	engine/direct
 OK  	deploy.direct	/api/2.0/workspace/delete	engine/direct
 OK  	deploy.direct	/api/2.0/workspace/delete	engine/direct
+OK  	deploy.direct	/api/2.0/workspace/mkdirs	engine/direct
 OK  	deploy.direct	/api/2.0/workspace/mkdirs	engine/direct
 OK  	deploy.direct	/api/2.1/unity-catalog/schemas	engine/direct
 MISS	deploy.direct	/.well-known/databricks-config	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]'
@@ -28,6 +30,7 @@ OK  	deploy.terraform	/api/2.0/workspace/get-status	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace/get-status	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace/get-status	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace/get-status	engine/terraform
+OK  	deploy.terraform	/api/2.0/workspace/get-status	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/empty.py	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deploy.lock	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deployment.json	engine/terraform
@@ -35,6 +38,7 @@ OK  	deploy.terraform	/api/2.0/workspace-files/import-file/Workspace/Users/[USER
 OK  	deploy.terraform	/api/2.0/workspace-files/import-file/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/terraform.tfstate	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace/delete	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace/delete	engine/terraform
+OK  	deploy.terraform	/api/2.0/workspace/mkdirs	engine/terraform
 OK  	deploy.terraform	/api/2.0/workspace/mkdirs	engine/terraform
 MISS	deploy.terraform	/.well-known/databricks-config	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]'
 MISS	deploy.terraform	/api/2.0/preview/scim/v2/Me	'databricks-tf-provider/1.117.0 databricks-sdk-go/[SDK_VERSION] go/1.25.8 os/[OS] cli/[DEV_VERSION] terraform/1.5.5 auth/pat'
@@ -132,11 +136,7 @@ MISS	summary.terraform	/api/2.0/workspace/get-status	'cli/[DEV_VERSION] databric
 MISS	summary.terraform	/.well-known/databricks-config	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]'
 MISS	validate.direct	/api/2.0/preview/scim/v2/Me	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
 MISS	validate.direct	/api/2.0/workspace/get-status	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
-MISS	validate.direct	/api/2.0/workspace/get-status	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
-MISS	validate.direct	/api/2.0/workspace/mkdirs	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
 MISS	validate.direct	/.well-known/databricks-config	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]'
 MISS	validate.terraform	/api/2.0/preview/scim/v2/Me	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
 MISS	validate.terraform	/api/2.0/workspace/get-status	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
-MISS	validate.terraform	/api/2.0/workspace/get-status	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
-MISS	validate.terraform	/api/2.0/workspace/mkdirs	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat'
 MISS	validate.terraform	/.well-known/databricks-config	'cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]'

--- a/acceptance/bundle/user_agent/simple/out.requests.deploy.direct.json
+++ b/acceptance/bundle/user_agent/simple/out.requests.deploy.direct.json
@@ -80,6 +80,18 @@
   "method": "GET",
   "path": "/api/2.0/workspace/get-status",
   "q": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
+  }
+}
+{
+  "headers": {
+    "User-Agent": [
+      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_deploy cmd-exec-id/[UUID] interactive/none engine/direct auth/pat"
+    ]
+  },
+  "method": "GET",
+  "path": "/api/2.0/workspace/get-status",
+  "q": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deploy.lock",
     "return_export_info": "true"
   }
@@ -272,6 +284,18 @@
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal"
+  }
+}
+{
+  "headers": {
+    "User-Agent": [
+      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_deploy cmd-exec-id/[UUID] interactive/none engine/direct auth/pat"
+    ]
+  },
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
   }
 }
 {

--- a/acceptance/bundle/user_agent/simple/out.requests.deploy.terraform.json
+++ b/acceptance/bundle/user_agent/simple/out.requests.deploy.terraform.json
@@ -80,6 +80,18 @@
   "method": "GET",
   "path": "/api/2.0/workspace/get-status",
   "q": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
+  }
+}
+{
+  "headers": {
+    "User-Agent": [
+      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_deploy cmd-exec-id/[UUID] interactive/none engine/terraform auth/pat"
+    ]
+  },
+  "method": "GET",
+  "path": "/api/2.0/workspace/get-status",
+  "q": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deploy.lock",
     "return_export_info": "true"
   }
@@ -298,6 +310,18 @@
   "path": "/api/2.0/workspace/mkdirs",
   "body": {
     "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/artifacts/.internal"
+  }
+}
+{
+  "headers": {
+    "User-Agent": [
+      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_deploy cmd-exec-id/[UUID] interactive/none engine/terraform auth/pat"
+    ]
+  },
+  "method": "POST",
+  "path": "/api/2.0/workspace/mkdirs",
+  "body": {
+    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
   }
 }
 {

--- a/acceptance/bundle/user_agent/simple/out.requests.validate.direct.json
+++ b/acceptance/bundle/user_agent/simple/out.requests.validate.direct.json
@@ -22,30 +22,6 @@
 {
   "headers": {
     "User-Agent": [
-      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-  }
-}
-{
-  "headers": {
-    "User-Agent": [
-      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-  }
-}
-{
-  "headers": {
-    "User-Agent": [
       "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]"
     ]
   },

--- a/acceptance/bundle/user_agent/simple/out.requests.validate.terraform.json
+++ b/acceptance/bundle/user_agent/simple/out.requests.validate.terraform.json
@@ -22,30 +22,6 @@
 {
   "headers": {
     "User-Agent": [
-      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat"
-    ]
-  },
-  "method": "GET",
-  "path": "/api/2.0/workspace/get-status",
-  "q": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-  }
-}
-{
-  "headers": {
-    "User-Agent": [
-      "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS] cmd/bundle_validate cmd-exec-id/[UUID] interactive/none auth/pat"
-    ]
-  },
-  "method": "POST",
-  "path": "/api/2.0/workspace/mkdirs",
-  "body": {
-    "path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files"
-  }
-}
-{
-  "headers": {
-    "User-Agent": [
       "cli/[DEV_VERSION] databricks-sdk-go/[SDK_VERSION] go/[GO_VERSION] os/[OS]"
     ]
   },

--- a/acceptance/bundle/validate/no_writes/databricks.yml
+++ b/acceptance/bundle/validate/no_writes/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: test-bundle

--- a/acceptance/bundle/validate/no_writes/out.test.toml
+++ b/acceptance/bundle/validate/no_writes/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/no_writes/output.txt
+++ b/acceptance/bundle/validate/no_writes/output.txt
@@ -1,0 +1,11 @@
+
+>>> [CLI] bundle validate
+Name: test-bundle
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Validation OK!
+
+>>> print_requests.py --sort //api/

--- a/acceptance/bundle/validate/no_writes/script
+++ b/acceptance/bundle/validate/no_writes/script
@@ -1,0 +1,5 @@
+# Validate must not mutate the workspace: no write requests, e.g. mkdirs for
+# a missing remote file path. print_requests.py prints all non-GET requests.
+trace $CLI bundle validate
+
+trace print_requests.py --sort //api/

--- a/acceptance/bundle/validate/no_writes/test.toml
+++ b/acceptance/bundle/validate/no_writes/test.toml
@@ -1,0 +1,1 @@
+RecordRequests = true

--- a/bundle/config/validate/files_to_sync.go
+++ b/bundle/config/validate/files_to_sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/databricks/cli/bundle/deploy/files"
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/sync"
 )
 
 func FilesToSync() bundle.ReadOnlyMutator {
@@ -26,12 +27,21 @@ func (v *filesToSync) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnost
 		return nil
 	}
 
-	sync, err := files.GetSync(ctx, b)
+	opts, err := files.GetSyncOptions(ctx, b)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	fl, err := sync.GetFileList(ctx)
+	// Validation must not mutate the workspace; a dry-run sync skips creating
+	// a missing remote file path.
+	opts.DryRun = true
+
+	s, err := sync.New(ctx, *opts)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	fl, err := s.GetFileList(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/bundle/deploy/files/sync.go
+++ b/bundle/deploy/files/sync.go
@@ -8,14 +8,6 @@ import (
 	"github.com/databricks/cli/libs/sync"
 )
 
-func GetSync(ctx context.Context, b *bundle.Bundle) (*sync.Sync, error) {
-	opts, err := GetSyncOptions(ctx, b)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get sync options: %w", err)
-	}
-	return sync.New(ctx, *opts)
-}
-
 func GetSyncOptions(ctx context.Context, b *bundle.Bundle) (*sync.SyncOptions, error) {
 	cacheDir, err := b.LocalStateDir(ctx)
 	if err != nil {


### PR DESCRIPTION
## Changes

Before, `bundle validate` created `workspace.file_path` in the workspace if it was missing; now validation performs only read-only API calls.

- The `files_to_sync` validator constructs its sync in dry-run mode, building on #5495 which made dry-run skip creating a missing remote directory. The read-only checks still run: a `file_path` pointing at an existing file, or nested under a nonexistent repo, still fails validation.
- Removed `files.GetSync`; this validator was its only caller.

One behavioral consequence, visible in the regenerated request recordings: `bundle deploy` now issues the `mkdirs` itself instead of inheriting the directory from a prior validate.

Stacked on #5495; will be retargeted to `main` once that merges.

## Why

Validation promises to be side-effect free, but issued `POST /workspace/mkdirs` whenever the remote file path didn't exist yet.

## Tests

- New acceptance test `acceptance/bundle/validate/no_writes` records HTTP requests and asserts that `bundle validate` against a missing remote path issues no write requests at all. Before the fix it recorded a `workspace/mkdirs`.
- Full local acceptance suite passes (both engines); recordings for validate/plan/run lose the mkdir + verification get-status, deploy gains them.
- Unit tests for `bundle/config/validate`, `bundle/deploy`, `libs/sync` pass; `fmt-q`, `lint-q`, `checks` clean.

This pull request and its description were written by Isaac.