### PR TITLE
sandbox: drop the gateway-host heuristic and the `--gateway` flag

### DIFF
--- a/acceptance/cmd/sandbox/register/success/out.test.toml
+++ b/acceptance/cmd/sandbox/register/success/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/cmd/sandbox/register/success/output.txt
+++ b/acceptance/cmd/sandbox/register/success/output.txt
@@ -1,0 +1,9 @@
+  ✓ Generated SSH key at [TEST_TMP_DIR]/.ssh/sandbox_ed25519
+  ✓ SSH key registered
+  skipped SSH config update (non-interactive); re-run `databricks sandbox register` from a terminal to add the `Host us-west-2.service-direct.dev.databricks.com` block
+
+  Run databricks sandbox ssh to connect.
+
+{
+  "[DATABRICKS_URL]": "us-west-2.service-direct.dev.databricks.com"
+}

--- a/acceptance/cmd/sandbox/register/success/script
+++ b/acceptance/cmd/sandbox/register/success/script
@@ -1,0 +1,6 @@
+$CLI sandbox register --name test-machine
+
+# Verify the gateway host was cached in the local state file.
+# The framework Ignores the .databricks directory by default, so we
+# print the cached value to stdout for assertion instead.
+cat "$HOME/.databricks/sandbox.json" | jq -r '.gatewayHosts // {}'

--- a/acceptance/cmd/sandbox/register/success/test.toml
+++ b/acceptance/cmd/sandbox/register/success/test.toml
@@ -1,0 +1,17 @@
+[[Server]]
+Pattern = "POST /api/2.0/lakebox/ssh-keys"
+Response.Body = '''
+{
+  "keyHash": "a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3",
+  "name": "test-machine",
+  "createTime": "2026-06-10T17:00:00Z",
+  "gatewayHost": "us-west-2.service-direct.dev.databricks.com"
+}
+'''
+
+# Pin the synthetic test hash so the framework's generic 3+-digit-run →
+# [NUMID] regex doesn't mangle it.
+[[Repls]]
+Old = 'a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3'
+New = '[KEY_HASH]'
+Order = 5

--- a/acceptance/cmd/sandbox/test.toml
+++ b/acceptance/cmd/sandbox/test.toml
@@ -1,8 +1,9 @@
 # Acceptance tests for `databricks sandbox` subcommands.
 #
-# Ignore the local state file the CLI writes (sandbox.json) so it
-# doesn't bleed into the test directory's diff.
-Ignore = [".databricks"]
+# Ignore the local state file the CLI writes (sandbox.json) and the
+# generated SSH key + managed SSH config — register-path tests would
+# otherwise produce these on every run.
+Ignore = [".databricks", ".ssh"]
 
 # Sandbox commands are independent of the bundle engine. Override the
 # root EnvMatrix so the two engines don't both run in parallel for

--- a/cmd/sandbox/ssh.go
+++ b/cmd/sandbox/ssh.go
@@ -17,24 +17,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defaultGatewayHost        = "uw2.dbrx.dev"
-	stagingDefaultGatewayHost = "ue1.s.dbrx.dev"
-	defaultGatewayPort        = "2222"
-)
-
-// resolveGatewayHost picks the SSH gateway hostname based on the workspace host.
-// Staging workspaces (*.staging.cloud.databricks.com etc.) route through
-// ue1.s.dbrx.dev; everything else uses uw2.dbrx.dev.
-func resolveGatewayHost(workspaceHost string) string {
-	if strings.Contains(workspaceHost, ".staging.") {
-		return stagingDefaultGatewayHost
-	}
-	return defaultGatewayHost
-}
+const defaultGatewayPort = "2222"
 
 func newSSHCommand() *cobra.Command {
-	var gatewayHost string
 	var gatewayPort string
 
 	cmd := &cobra.Command{
@@ -167,17 +152,17 @@ Examples:
 				}
 			}
 
-			// Resolution precedence: --gateway flag → fresh API response →
-			// cached value for this profile → workspace-host heuristic.
-			host := gatewayHost
-			if host == "" {
-				host = sandboxGatewayHost
-			}
+			// Resolution precedence: fresh API response → cached value
+			// for this profile. The server stamps the workspace's
+			// gateway on every Sandbox / SshKey response, so the cache
+			// is populated after the first call against the workspace
+			// (sandbox register / list / create / etc.).
+			host := sandboxGatewayHost
 			if host == "" {
 				host = getGatewayHost(ctx, profile)
 			}
 			if host == "" {
-				host = resolveGatewayHost(w.Config.Host)
+				return errors.New("could not resolve the sandbox SSH gateway — run `databricks sandbox register` first")
 			}
 
 			// Persist whatever the server just told us, so the next invocation
@@ -195,7 +180,6 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&gatewayHost, "gateway", "", "Sandbox gateway hostname (auto-detected from profile if empty)")
 	cmd.Flags().StringVar(&gatewayPort, "port", defaultGatewayPort, "Sandbox gateway SSH port")
 
 	return cmd

--- a/cmd/sandbox/sshconfig_test.go
+++ b/cmd/sandbox/sshconfig_test.go
@@ -1,12 +1,17 @@
 package sandbox
 
 import (
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,6 +146,28 @@ func TestEnsureMainIncludesManagedPreservesUserConfigBelow(t *testing.T) {
 	require.GreaterOrEqual(t, beginIdx, 0)
 	require.GreaterOrEqual(t, userIdx, 0)
 	assert.Less(t, beginIdx, userIdx, "managed block must precede the user's existing config")
+}
+
+// An empty gatewayHost must short-circuit before any disk I/O so the
+// "server forgot to stamp gateway_host" case can't accidentally create
+// a malformed Host block (e.g. `Host \n`). Pins the order of the two
+// checks at the top of maybeWriteSSHConfig — a future refactor that
+// swaps them would silently write garbage.
+func TestMaybeWriteSSHConfigSkipsOnEmptyGateway(t *testing.T) {
+	home := t.TempDir()
+	ctx := env.WithUserHomeDir(t.Context(), home)
+	ctx = cmdio.InContext(ctx, cmdio.NewIO(ctx, flags.OutputText,
+		io.NopCloser(strings.NewReader("")), io.Discard, io.Discard, "", ""))
+
+	require.NoError(t, maybeWriteSSHConfig(ctx, filepath.Join(home, ".ssh", "sandbox_ed25519"), ""))
+
+	// No managed file should have been created.
+	_, err := os.Stat(filepath.Join(home, ".ssh", sshIncludeFileName))
+	assert.ErrorIs(t, err, fs.ErrNotExist, "managed include file must not be created when gateway is empty")
+
+	// And ~/.ssh/config must not have been touched either.
+	_, err = os.Stat(filepath.Join(home, ".ssh", "config"))
+	assert.ErrorIs(t, err, fs.ErrNotExist, "main ssh config must not be created when gateway is empty")
 }
 
 func TestHasOurMarkedBlock(t *testing.T) {


### PR DESCRIPTION
## Summary

Now that the server stamps `gateway_host` on every SshKey and Sandbox response, `register` always populates the cache, and every subsequent operation that touches the API gets the workspace's real gateway directly. Two things become dead weight:

1. **The hardcoded heuristic** `resolveGatewayHost(workspaceHost)` that returned `uw2.dbrx.dev` for non-staging workspaces and `ue1.s.dbrx.dev` for staging. Produced a wrong answer for any workspace whose gateway didn't match those two values.

2. **The `--gateway` flag** on `sandbox ssh`. It was a manual override that made sense only when the CLI couldn't learn the gateway itself; with the cache always populated post-register, the only thing the flag now does is let a user typo their way into dialing a random host. Footgun outweighs the override value.

## Removes

- `defaultGatewayHost = "uw2.dbrx.dev"`
- `stagingDefaultGatewayHost = "ue1.s.dbrx.dev"`
- `resolveGatewayHost(workspaceHost string) string` and all callers
- `--gateway` flag and the `gatewayHost` local var in `newSSHCommand`

## New resolution chain in `sandbox ssh`

Fresh API response (populated by the `api.get` of the resolved sandbox ID we already do) → cached value (set by any prior `register` / `list` / `create` / `get` / `start` / `stop`).

If both are empty:

```
Error: could not resolve the sandbox SSH gateway —
run `databricks sandbox register` first
```

That path is unreachable in practice — `ssh` does an `api.get` of the resolved sandbox ID before this line, which populates the fresh-response variable. The guard is here to fail loudly rather than silently dial a wrong host if something upstream changes.

## Test plan

- [x] `go test ./cmd/sandbox/...` passes
- [x] `go test ./acceptance -run TestAccept/cmd/sandbox` passes
- [x] `go build ./...` clean
- [x] `./task lint` clean

This pull request and its description were written by Isaac.