### PR TITLE
volumes/uppercase-name: add bundle destroy to prevent resource leak

### DIFF
--- a/acceptance/bundle/resources/volumes/uppercase-name/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/volumes/uppercase-name/databricks.yml.tmpl
@@ -1,15 +1,15 @@
 bundle:
-  name: test-bundle
+  name: test-bundle-$UNIQUE_NAME
 
 resources:
   schemas:
     schema1:
       catalog_name: main
-      name: MySCHEMA
+      name: MySCHEMA_$UNIQUE_NAME
 
   volumes:
     vol1:
       catalog_name: main
-      schema_name: MySCHEMA
+      schema_name: MySCHEMA_$UNIQUE_NAME
       name: MyVOLUME
       volume_type: MANAGED

--- a/acceptance/bundle/resources/volumes/uppercase-name/out.deploy.direct.txt
+++ b/acceptance/bundle/resources/volumes/uppercase-name/out.deploy.direct.txt
@@ -1,4 +1,4 @@
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
@@ -7,7 +7,7 @@ Deployment complete!
   "path": "/api/2.1/unity-catalog/schemas",
   "body": {
     "catalog_name": "main",
-    "name": "MySCHEMA"
+    "name": "MySCHEMA_[UNIQUE_NAME]"
   }
 }
 {
@@ -16,14 +16,14 @@ Deployment complete!
   "body": {
     "catalog_name": "main",
     "name": "MyVOLUME",
-    "schema_name": "MySCHEMA",
+    "schema_name": "MySCHEMA_[UNIQUE_NAME]",
     "volume_type": "MANAGED"
   }
 }
 === Bundle summary shows lowercase IDs after UC normalizes names
 {
-  "schema_id": "main.myschema",
-  "volume_id": "main.myschema.myvolume"
+  "schema_id": "main.myschema_[UNIQUE_NAME]",
+  "volume_id": "main.myschema_[UNIQUE_NAME].myvolume"
 }
 === Plan on no-op redeploy: mixed-case names are skipped, not recreated
 [
@@ -55,7 +55,7 @@ Deployment complete!
   }
 ]
 === Redeploy without changes - should be a no-op
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!

--- a/acceptance/bundle/resources/volumes/uppercase-name/out.deploy.terraform.txt
+++ b/acceptance/bundle/resources/volumes/uppercase-name/out.deploy.terraform.txt
@@ -7,8 +7,8 @@ Error: Provider produced inconsistent final plan
 When expanding the plan for databricks_volume.vol1 to include new values
 learned so far during apply, provider
 "registry.terraform.io/databricks/databricks" produced an invalid new value
-for .schema_name: was cty.StringVal("MySCHEMA_[UNIQUE_NAME]"), but now
-cty.StringVal("myschema_[UNIQUE_NAME]").
+for .schema_name: was cty.StringVal("MySCHEMA_[UNIQUE_NAME]"),
+but now cty.StringVal("myschema_[UNIQUE_NAME]").
 
 This is a bug in the provider, which should be reported in the provider's own
 issue tracker.

--- a/acceptance/bundle/resources/volumes/uppercase-name/out.deploy.terraform.txt
+++ b/acceptance/bundle/resources/volumes/uppercase-name/out.deploy.terraform.txt
@@ -1,4 +1,4 @@
-Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Error: terraform apply: exit status 1
 
@@ -7,8 +7,8 @@ Error: Provider produced inconsistent final plan
 When expanding the plan for databricks_volume.vol1 to include new values
 learned so far during apply, provider
 "registry.terraform.io/databricks/databricks" produced an invalid new value
-for .schema_name: was cty.StringVal("MySCHEMA"), but now
-cty.StringVal("myschema").
+for .schema_name: was cty.StringVal("MySCHEMA_[UNIQUE_NAME]"), but now
+cty.StringVal("myschema_[UNIQUE_NAME]").
 
 This is a bug in the provider, which should be reported in the provider's own
 issue tracker.
@@ -22,6 +22,6 @@ Exit code: 1
   "path": "/api/2.1/unity-catalog/schemas",
   "body": {
     "catalog_name": "main",
-    "name": "MySCHEMA"
+    "name": "MySCHEMA_[UNIQUE_NAME]"
   }
 }

--- a/acceptance/bundle/resources/volumes/uppercase-name/script
+++ b/acceptance/bundle/resources/volumes/uppercase-name/script
@@ -1,4 +1,5 @@
 echo "*" > .gitignore
+envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
     $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/volumes/uppercase-name/script
+++ b/acceptance/bundle/resources/volumes/uppercase-name/script
@@ -2,7 +2,7 @@ echo "*" > .gitignore
 envsubst < databricks.yml.tmpl > databricks.yml
 
 cleanup() {
-    $CLI bundle destroy --auto-approve
+    $CLI bundle destroy --auto-approve &> LOG.destroy
     rm -f out.requests.txt
 }
 trap cleanup EXIT

--- a/acceptance/bundle/resources/volumes/uppercase-name/script
+++ b/acceptance/bundle/resources/volumes/uppercase-name/script
@@ -1,4 +1,11 @@
 echo "*" > .gitignore
+
+cleanup() {
+    $CLI bundle destroy --auto-approve
+    rm -f out.requests.txt
+}
+trap cleanup EXIT
+
 errcode $CLI bundle deploy &> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
 print_requests.py //unity-catalog >> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
 

--- a/acceptance/bundle/resources/volumes/uppercase-name/test.toml
+++ b/acceptance/bundle/resources/volumes/uppercase-name/test.toml
@@ -3,6 +3,7 @@ RequiresUnityCatalog = true
 
 Ignore = [
     ".databricks",
+    "databricks.yml",
 ]
 
 # TF provider fails with "inconsistent final plan" when schema_name contains


### PR DESCRIPTION
Test added in #5531 never cleaned up `MySCHEMA`/`MyVOLUME`, so the first run leaked them into the shared `main` catalog. Every subsequent run found them pre-existing, skipped the POST calls, and failed the golden diff in all 4 ucws workspaces.

Fix: add a `cleanup()` trap that destroys the bundle on exit and removes `out.requests.txt` so the destroy requests don't show up as unexpected output.