### PR TITLE
sandbox: Fix terminal cursor left hidden after `sandbox ssh`

### DIFF
--- a/cmd/sandbox/ssh.go
+++ b/cmd/sandbox/ssh.go
@@ -186,11 +186,6 @@ Examples:
 				_ = setGatewayHost(ctx, profile, sandboxGatewayHost)
 			}
 
-			// Don't print "Connected" here — ssh hasn't completed the
-			// handshake yet, so any success message would race ssh's
-			// own error output on the failure path.
-			s := spin(ctx, "Connecting to "+cmdio.Bold(ctx, sandboxID)+"…")
-			defer s.Close()
 			return execSSHDirect(sandboxID, host, gatewayPort, keyPath, extraArgs)
 		},
 	}


### PR DESCRIPTION
## Changes

`databricks sandbox ssh` no longer starts a "Connecting…" spinner immediately before exec'ing ssh.

## Why

The spinner is a Bubble Tea program, which hides the terminal cursor when it starts. `execSSHDirect` then replaces the CLI process via `execv(2)`, so the deferred `Close()` never runs and the show-cursor escape is never written — the cursor stays invisible for the entire ssh session and after it exits. Since exec replaces the process, the spinner could never animate during the handshake anyway; it only ever flashed a frozen frame.

The `ensureRunning` start-up spinner is unaffected — it closes before the exec.

## Tests

- [x] `go build ./cmd/sandbox/ && go vet ./cmd/sandbox/ && go test ./cmd/sandbox/` pass
- [x] Verified Bubble Tea v1.3.10 hides the cursor unconditionally in `initTerminal()` and only restores it on clean program shutdown

This pull request and its description were written by Isaac.