### PR TITLE
acceptance: Poll for deleted genie space after trash-space

### DIFF
--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/script
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/script
@@ -14,5 +14,17 @@ echo "$GENIE_SPACE_ID:GENIE_SPACE_ID" >> ACC_REPLS
 # instead of failing.
 trace $CLI genie trash-space $GENIE_SPACE_ID
 
+# On a real workspace trashing propagates asynchronously: GET keeps returning
+# the space as live for tens of seconds before flipping to 404 ("Space ... has
+# been trashed"). Poll until the deletion is visible so the plan below
+# deterministically sees the space as gone. The local mock trashes
+# synchronously, so the first probe already fails and the loop exits at once.
+for _ in {1..60}; do
+    if ! $CLI genie get-space $GENIE_SPACE_ID >> LOG.trash_poll 2>&1; then
+        break
+    fi
+    sleep 2
+done
+
 title "Plan after remote deletion should recreate the space"
 trace $CLI bundle plan


### PR DESCRIPTION
## Changes
Poll until the genie space is trashed before attempting to run `bundle` again

## Why
Cloud tests failing when trash takes too long

## Tests
`deco env run -i -n aws-prod-ucws -- go test ./acceptance -run TestAccept/bundle/resources/genie_spaces/recreate_when_gone -v -tail`
```
        LOG.trash_poll: {
        LOG.trash_poll:   "parent_path": "/Users/b76b6808-9e10-43b3-be20-6b6d19ed1af0",
        LOG.trash_poll:   "space_id": "01f165773d141195a9f0e3c5148d22bf",
        LOG.trash_poll:   "title": "Recreate When Gone",
        LOG.trash_poll:   "warehouse_id": "ca46a3458140daa8"
        LOG.trash_poll: }
        LOG.trash_poll: {
        LOG.trash_poll:   "parent_path": "/Users/b76b6808-9e10-43b3-be20-6b6d19ed1af0",
        LOG.trash_poll:   "space_id": "01f165773d141195a9f0e3c5148d22bf",
        LOG.trash_poll:   "title": "Recreate When Gone",
        LOG.trash_poll:   "warehouse_id": "ca46a3458140daa8"
        LOG.trash_poll: }
        LOG.trash_poll: {
        LOG.trash_poll:   "parent_path": "/Users/b76b6808-9e10-43b3-be20-6b6d19ed1af0",
        LOG.trash_poll:   "space_id": "01f165773d141195a9f0e3c5148d22bf",
        LOG.trash_poll:   "title": "Recreate When Gone",
        LOG.trash_poll:   "warehouse_id": "ca46a3458140daa8"
        LOG.trash_poll: }
        LOG.trash_poll: {
        LOG.trash_poll:   "parent_path": "/Users/b76b6808-9e10-43b3-be20-6b6d19ed1af0",
        LOG.trash_poll:   "space_id": "01f165773d141195a9f0e3c5148d22bf",
        LOG.trash_poll:   "title": "Recreate When Gone",
        LOG.trash_poll:   "warehouse_id": "ca46a3458140daa8"
        LOG.trash_poll: }
        LOG.trash_poll: Error: Space 01f165773d141195a9f0e3c5148d22bf has been trashed. Remove from trash to access.
```