### PR TITLE
testmask: diff against the merge base so unrelated changes don't widen the test set

### DIFF
--- a/tools/testmask/git.go
+++ b/tools/testmask/git.go
@@ -6,9 +6,22 @@ import (
 	"strings"
 )
 
-// GetChangedFiles returns the list of files changed between two git refs.
+// GetChangedFiles returns the files that headRef changes relative to baseRef.
+//
+// It uses git's three-dot form (baseRef...headRef), which diffs headRef against
+// the merge base of the two refs rather than against the current tip of baseRef.
+// This matters in CI: baseRef is the live tip of the target branch (e.g. the PR
+// event's base.sha, which tracks origin/main). A two-dot "git diff baseRef
+// headRef" would then also report every file that advanced on main after the
+// branch was cut, none of which the PR actually touches — inflating the changed
+// set and triggering test jobs (and integration tests) that the change doesn't
+// require. Diffing against the merge base yields only the PR's own changes.
+//
+// "git diff baseRef...headRef" is equivalent to
+// "git diff $(git merge-base baseRef headRef) headRef".
+// See the <commit>...<commit> form at https://git-scm.com/docs/git-diff.
 func GetChangedFiles(headRef, baseRef string) ([]string, error) {
-	cmd := exec.Command("git", "diff", "--name-only", baseRef, headRef)
+	cmd := exec.Command("git", "diff", "--name-only", baseRef+"..."+headRef)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get diff between %s and %s: %w", baseRef, headRef, err)

--- a/tools/testmask/git_test.go
+++ b/tools/testmask/git_test.go
@@ -1,38 +1,62 @@
 package main
 
 import (
+	"os"
+	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// gitEmptyTreeSHA is the well-known SHA of the empty tree object. Git resolves
-// it without requiring a commit to reference it, so diffing against it works
-// even on shallow clones where HEAD~N is unavailable (as in CI).
-const gitEmptyTreeSHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
 func TestGetChangedFiles(t *testing.T) {
-	// Test with HEAD to HEAD - should return empty list
-	result, err := GetChangedFiles("HEAD", "HEAD")
-	if err != nil {
-		t.Skipf("unable to run git: %q", err)
-		return
-	}
-	if len(result) > 0 {
-		t.Errorf("expected empty list, got %q", result)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available: %v", err)
 	}
 
-	// Test against the empty tree - should produce non-empty result (all files in HEAD)
-	result, err = GetChangedFiles("HEAD", gitEmptyTreeSHA)
-	if err != nil {
-		t.Errorf("unable to run git: %q", err)
-		return
+	// Build a repository where main advances after a feature branch is cut.
+	// This is the situation GetChangedFiles must handle correctly: the diff
+	// should report only the feature branch's own changes, not files that moved
+	// on main in the meantime. The repository is self-contained so the test does
+	// not depend on the depth of the surrounding clone.
+	t.Chdir(t.TempDir())
+
+	git := func(args ...string) {
+		t.Helper()
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
 	}
-	if len(result) == 0 {
-		t.Errorf("expected non-empty list, got %q", result)
+	commit := func(file, contents string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(file, []byte(contents), 0o600))
+		git("add", file)
+		git("commit", "-q", "-m", file)
 	}
 
-	// Test with invalid refs - should error
+	git("init", "-q", "-b", "main")
+	git("config", "user.email", "test@example.invalid")
+	git("config", "user.name", "Test")
+
+	commit("base.txt", "base") // common ancestor
+	git("checkout", "-q", "-b", "feature")
+	commit("feature.txt", "feature") // the change that belongs to the PR
+	git("checkout", "-q", "main")
+	commit("main-only.txt", "main-only") // main advances after the branch was cut
+
+	// base is main's tip; head is the feature branch. A two-dot diff would also
+	// list main-only.txt (absent on the feature side); the three-dot diff must
+	// report only feature.txt.
+	files, err := GetChangedFiles("feature", "main")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"feature.txt"}, files)
+
+	// Identical refs produce no changes.
+	files, err = GetChangedFiles("feature", "feature")
+	require.NoError(t, err)
+	assert.Empty(t, files)
+
+	// Invalid refs error.
 	_, err = GetChangedFiles("invalid-ref-12345", "invalid-ref-67890")
-	if err == nil {
-		t.Error("expected error for invalid refs")
-	}
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Changes

`testmask` now computes changed files with a three-dot diff (`baseRef...headRef`) instead of two-dot, so it diffs the PR head against the merge base rather than against the current tip of the base branch. The unit test is rewritten to build a self-contained temp repo (independent of clone depth) that verifies only the branch's own changes are reported.

## Why

In CI the base ref is the live tip of `main`, so a two-dot diff also reported every file that advanced on `main` after the branch was cut. Those phantom files matched no specific target and forced the broad `test` target, which both ran the full test matrix and triggered integration tests on changes that didn't need them. Diffing against the merge base yields only the PR's actual changes. The old test relied on the empty-tree SHA, which is incompatible with three-dot (it's a tree, not a commit), hence the rewrite.

## Tests

Unit test passes and now exercises the merge-base behavior directly.

Verified end-to-end against a branch that lagged `main`.

This pull request and its description were written by Isaac.