### PR TITLE
internal/cligen: format and normalize whitespace during generation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -419,10 +419,6 @@ jobs:
         with:
           cache-key: validate-generated
 
-      # generate-cligen formats the regenerated stubs with goimports, which adds
-      # imports it can only resolve from the module cache (e.g. cobra in
-      # cmd/workspace/cmd.go). Seed it first: on a cold cache goimports silently
-      # omits the import and the regenerated tree fails to build.
       - name: Download Go modules
         run: go mod download
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -773,11 +773,10 @@ tasks:
   # Regenerates the CLI command stubs (cmd/workspace/**, cmd/account/**) and
   # .gitattributes from the checked-in .codegen/cli.json. No universe checkout,
   # no spec download, no network: cli.json is the self-describing spec
-  # produced upstream by `generate-clijson`. internal/cligen renders
-  # the same templates genkit's cli_v0 generator uses, then formats with
-  # goimports + gofmt. The final `ws` strips trailing whitespace (e.g. the
-  # comment-banner blank lines) so the result matches byte-for-byte, exactly as
-  # the old generate-genkit task did.
+  # produced upstream by `generate-clijson`. internal/cligen renders the
+  # templates derived from genkit's cli_v0 generator and formats the output
+  # in-process (whitespace normalization, unused-import pruning, gofmt), so
+  # the result matches the committed files byte-for-byte.
   generate-cligen:
     desc: Regenerate CLI command stubs from .codegen/cli.json
     sources:
@@ -791,7 +790,6 @@ tasks:
       - .gitattributes
     cmds:
       - go run ./internal/cligen --input .codegen/cli.json --output .
-      - task: ws
 
   # Refreshes .codegen/cli.json from the OpenAPI spec at .codegen/_openapi_sha.
   # cli.json is a genkit SDK target like any other (mode cli_v1 in .codegen.json):

--- a/internal/cligen/cligen.go
+++ b/internal/cligen/cligen.go
@@ -2,9 +2,10 @@
 // cmd/account/**) from the cli.json spec produced by genkit.
 //
 // It is the CLI-owned replacement for running genkit's cli_v0 generator against
-// a universe checkout: it renders the same templates (templates/*.tmpl, copied
-// verbatim) against a model decoded from cli.json's "commands" block. It has no
-// dependency on genkit or any upstream spec at run time.
+// a universe checkout: it renders templates derived from genkit's cli_v0
+// templates (templates/*.tmpl) against a model decoded from cli.json's
+// "commands" block, then formats the output in-process. It has no dependency on
+// genkit or any upstream spec at run time.
 package main
 
 import (
@@ -13,7 +14,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -29,9 +29,6 @@ func main() {
 	files, err := Generate(*input, *output)
 	if err != nil {
 		log.Fatalf("cligen: %v", err)
-	}
-	if err := format(*output, files); err != nil {
-		log.Fatalf("cligen: format: %v", err)
 	}
 	if err := writeGitAttributes(*output, files); err != nil {
 		log.Fatalf("cligen: .gitattributes: %v", err)
@@ -58,27 +55,6 @@ func writeGitAttributes(dir string, files []string) error {
 		sb.WriteString(" linguist-generated=true\n")
 	}
 	return os.WriteFile(filepath.Join(dir, ".gitattributes"), []byte(sb.String()), 0o644)
-}
-
-// format applies the same formatter genkit's cli_v0 generator used to produce
-// the committed command files: goimports (prunes the conditionally-unused
-// imports the template always emits, e.g. "time") followed by gofmt.
-func format(dir string, files []string) error {
-	abs := make([]string, len(files))
-	for i, f := range files {
-		abs[i] = filepath.Join(dir, f)
-	}
-	// Run goimports from the pinned tools module (tools/go.mod) instead of
-	// @latest, so generation is deterministic and works offline.
-	modfile := filepath.Join(dir, "tools", "go.mod")
-	goimports := append([]string{"tool", "-modfile=" + modfile, "goimports", "-w"}, abs...)
-	if out, err := exec.Command("go", goimports...).CombinedOutput(); err != nil {
-		return fmt.Errorf("goimports: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("gofmt", append([]string{"-w"}, abs...)...).CombinedOutput(); err != nil {
-		return fmt.Errorf("gofmt: %v\n%s", err, out)
-	}
-	return nil
 }
 
 // Generate reads the cli.json spec at jsonPath and writes the command stubs

--- a/internal/cligen/format.go
+++ b/internal/cligen/format.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// formatSource returns gofmt-formatted src with unused imports removed. It
+// replaces the goimports+gofmt pass genkit ran over the generated files, which
+// dominated generation time (goimports rescans the module for every fix). The
+// templates emit a fixed import block covering every package any branch may
+// reference, so formatting only ever needs to delete imports, never add them.
+func formatSource(src []byte) ([]byte, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	// An import is used iff its package name appears as a selector qualifier.
+	// Generated code never shadows an imported package name (locals are
+	// suffixed: xxxReq, xxxJson, xxxParam, ...), so this scan is exact.
+	used := make(map[string]bool)
+	ast.Inspect(f, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			if id, ok := sel.X.(*ast.Ident); ok {
+				used[id.Name] = true
+			}
+		}
+		return true
+	})
+
+	drop := make(map[int]bool)
+	for _, imp := range f.Imports {
+		if !used[importName(imp)] {
+			for l := fset.Position(imp.Pos()).Line; l <= fset.Position(imp.End()).Line; l++ {
+				drop[l] = true
+			}
+		}
+	}
+
+	lines := strings.Split(string(src), "\n")
+	keep := lines[:0]
+	for i, line := range lines {
+		if !drop[i+1] {
+			keep = append(keep, line)
+		}
+	}
+	return format.Source([]byte(strings.Join(keep, "\n")))
+}
+
+// importName returns the identifier an import is referenced by: the explicit
+// name when present, the import path base otherwise. Every template import
+// either has base == package name or carries an explicit name.
+func importName(imp *ast.ImportSpec) string {
+	if imp.Name != nil {
+		return imp.Name.Name
+	}
+	p, _ := strconv.Unquote(imp.Path.Value)
+	return path.Base(p)
+}

--- a/internal/cligen/format_test.go
+++ b/internal/cligen/format_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// importsOf re-parses formatted source and returns its import paths, asserting
+// the result is valid Go (formatSource must never emit something that won't
+// parse).
+func importsOf(t *testing.T, src []byte) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		t.Fatalf("formatSource produced invalid Go: %v\n%s", err, src)
+	}
+	var paths []string
+	for _, imp := range f.Imports {
+		p, _ := strconv.Unquote(imp.Path.Value)
+		paths = append(paths, p)
+	}
+	return paths
+}
+
+func TestFormatSourcePrunesUnusedImports(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "drops unused, keeps selector-used",
+			in: `package p
+
+import (
+	"bytes"
+	"fmt"
+)
+
+var _ = fmt.Sprint
+`,
+			want: []string{"fmt"},
+		},
+		{
+			name: "keeps import used only as a type qualifier",
+			in: `package p
+
+import "bytes"
+
+var _ bytes.Buffer
+`,
+			want: []string{"bytes"},
+		},
+		{
+			name: "keeps aliased import used by alias, drops unused alias",
+			in: `package p
+
+import (
+	keep "bytes"
+	drop "strings"
+)
+
+var _ = keep.NewBuffer
+`,
+			want: []string{"bytes"},
+		},
+		{
+			// The reason every template import carries an explicit alias when its
+			// path base collides: prune keys on the referenced name, not the path.
+			name: "distinguishes packages sharing a path base via alias",
+			in: `package p
+
+import (
+	"time"
+	sdktime "example.test/sdk/time"
+)
+
+var _ = sdktime.Now
+`,
+			want: []string{"example.test/sdk/time"},
+		},
+		{
+			name: "drops an entire unused group",
+			in: `package p
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+`,
+			want: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := formatSource([]byte(c.in))
+			if err != nil {
+				t.Fatalf("formatSource: %v", err)
+			}
+			if got := importsOf(t, out); !slices.Equal(got, c.want) {
+				t.Errorf("imports = %v, want %v\noutput:\n%s", got, c.want, out)
+			}
+		})
+	}
+}
+
+func TestFormatSourceRejectsInvalidGo(t *testing.T) {
+	if _, err := formatSource([]byte("package p\nfunc (")); err == nil {
+		t.Fatal("expected an error for unparseable input, got nil")
+	}
+}
+
+func TestImportName(t *testing.T) {
+	src := `package p
+
+import (
+	"encoding/json"
+	"github.com/databricks/cli/libs/cmdio"
+	sdktime "github.com/databricks/databricks-sdk-go/common/types/time"
+)
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"json", "cmdio", "sdktime"}
+	for i, imp := range f.Imports {
+		if got := importName(imp); got != want[i] {
+			t.Errorf("importName(%s) = %q, want %q", imp.Path.Value, got, want[i])
+		}
+	}
+}

--- a/internal/cligen/model.go
+++ b/internal/cligen/model.go
@@ -6,8 +6,8 @@ import (
 )
 
 // This file defines the CLI-side view of the "commands" block of the cli.json
-// spec. The structs mirror, field-for-field, the dot-paths that
-// the cliv0 templates (templates/*.tmpl, copied verbatim from genkit) access.
+// spec. The structs mirror, field-for-field, the dot-paths that the templates
+// (templates/*.tmpl, derived from genkit's cliv0 templates) access.
 //
 // Design rules that keep output byte-for-byte identical to genkit:
 //   - Casings (Kebab/Pascal/Snake/Camel/Constant/Title) are derived at render

--- a/internal/cligen/render.go
+++ b/internal/cligen/render.go
@@ -65,16 +65,39 @@ func parseTemplate(name, path string) *template.Template {
 	return template.Must(t.ParseFS(templates, path))
 }
 
-// renderToFile renders the named template with data to fileName. It mirrors
-// genkit's render.RenderToFile: a skipThisFile panic surfaces as an error that
-// callers match with errors.Is(err, ErrSkipThisFile).
+// renderToFile renders the named template with data, normalizes whitespace,
+// formats the result (formatSource), and writes it to fileName. A skipThisFile
+// panic during rendering surfaces as an error that callers match with
+// errors.Is(err, ErrSkipThisFile). Whitespace is normalized before formatting so
+// that indentation-only template lines become empty lines, which gofmt treats as
+// import group separators; gofmt introduces no trailing whitespace of its own
+// (raw string contents are already clean).
 func renderToFile(data any, t *template.Template, templateName, fileName string) error {
 	sb := strings.Builder{}
 	if err := t.ExecuteTemplate(&sb, templateName, data); err != nil {
 		return err
 	}
+	src, err := formatSource([]byte(stripTrailingWhitespace(sb.String())))
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(fileName), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(fileName, []byte(sb.String()), 0o644)
+	return os.WriteFile(fileName, src, 0o644)
+}
+
+// stripTrailingWhitespace removes trailing whitespace from every line and
+// normalizes the file to end in exactly one newline. The committed command
+// files are whitespace-normalized (tools/validate_whitespace.py); genkit relied
+// on a separate `task ws` pass for this, cligen produces clean output directly.
+// Note this also normalizes inside raw string literals (help text), where the
+// templates and genkit's comment wrapping leave trailing spaces and
+// whitespace-only paragraph breaks.
+func stripTrailingWhitespace(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
 }

--- a/internal/cligen/templates/cmds-account.go.tmpl
+++ b/internal/cligen/templates/cmds-account.go.tmpl
@@ -5,9 +5,8 @@ package account
 {{$excludes := list}}
 
 import (
-	"github.com/databricks/cli/cmd/root"
 	"github.com/spf13/cobra"
-    {{range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}{{if not (in $excludes .KebabName) }}
+	{{range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}{{if not (in $excludes .KebabName) }}
 	{{.SnakeName}} "github.com/databricks/cli/cmd/account/{{(.TrimPrefix "account").KebabName}}"{{end}}{{end}}{{end}}
 
 	account_groups "github.com/databricks/cli/cmd/account/groups"

--- a/internal/cligen/templates/cmds-workspace.go.tmpl
+++ b/internal/cligen/templates/cmds-workspace.go.tmpl
@@ -13,9 +13,9 @@ package workspace
 }}
 
 import (
-	"github.com/databricks/cli/cmd/root"
-    {{range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}{{if not (in $excludes .KebabName) }}
+	{{- range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}{{if not (in $excludes .KebabName) }}
 	{{.SnakeName}} "github.com/databricks/cli/cmd/workspace/{{.KebabName}}"{{end}}{{end}}{{end}}
+	"github.com/spf13/cobra"
 
 	groups "github.com/databricks/cli/cmd/workspace/groups"
 	service_principals "github.com/databricks/cli/cmd/workspace/service-principals"

--- a/internal/cligen/templates/service.go.tmpl
+++ b/internal/cligen/templates/service.go.tmpl
@@ -3,18 +3,18 @@
 package {{(.TrimPrefix "account").SnakeName}}
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
-    "github.com/databricks/cli/libs/cmdio"
-    "github.com/databricks/cli/libs/cmdctx"
-    "github.com/databricks/cli/libs/flags"
-	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/flags"
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/databricks-sdk-go/experimental/api"
 	"github.com/databricks/databricks-sdk-go/common/types/fieldmask"
 	sdktime "github.com/databricks/databricks-sdk-go/common/types/time"
-	"github.com/databricks/databricks-sdk-go/common/types/duration"
 	"github.com/databricks/databricks-sdk-go/service/{{.Package.Name}}"
 	"github.com/spf13/cobra"
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -237,7 +237,6 @@ tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/google/yamlfmt/cmd/yamlfmt
 	golang.org/x/tools/cmd/deadcode
-	golang.org/x/tools/cmd/goimports
 	golang.org/x/vuln/cmd/govulncheck
 	gotest.tools/gotestsum
 )


### PR DESCRIPTION
cligen now produces final output on its own, instead of leaning on a separate `task ws` pass and a `goimports`/`gofmt` subprocess.

- Whitespace normalized in `renderToFile`; drops the `task ws` step.
- Formatting moved in-process (`go/format` + unused-import prune); ~4.3s → ~0.3s.
- Pruning never adds imports, so templates must keep their import lists complete.

This pull request and its description were written by Isaac.
