### PR TITLE
Update OWNERS link in maintainer-approval.js

### DIFF
--- a/.github/workflows/maintainer-approval.js
+++ b/.github/workflows/maintainer-approval.js
@@ -97,7 +97,7 @@ async function checkPerPathApproval(files, rulesWithTeams, approverLogins, githu
 // --- Git history & scoring helpers ---
 
 const MENTION_REVIEWERS = false;
-const OWNERS_LINK = "[OWNERS](.github/OWNERS)";
+const OWNERS_LINK = "[OWNERS](/databricks/cli/blob/main/.github/OWNERS)";
 const MARKER = "<!-- MAINTAINER_APPROVAL -->";
 const STATUS_CONTEXT = "maintainer-approval";
 


### PR DESCRIPTION
## Changes
Make the link absolute (needs to include repo path & branch) rather than relative. 

## Why
Relative links do not render correctly in GitHub PR comments.

## Tests
- old: [OWNERS](.github/OWNERS)
  - also see [comment](https://github.com/databricks/cli/pull/5563#issuecomment-4685219133) on this PR
- new: [OWNERS](/databricks/cli/blob/main/.github/OWNERS)
