### PR TITLE
ci: stop canceling PR approval workflow runs

### DIFF
--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -8,9 +8,9 @@ on:
   merge_group:
     types: [checks_requested]
 
-concurrency:
-  group: pr-approval-${{ github.event.pull_request.number || github.event.merge_group.head_sha }}
-  cancel-in-progress: true
+# No concurrency group: a run cancelled by concurrency leaves a stuck failing
+# check, since each run posts its own check-run and a later passing run does not
+# clear it. The check is cheap and idempotent, so let every run finish instead.
 
 defaults:
   run:


### PR DESCRIPTION
The `PR approval` workflow canceled in-flight runs via concurrency (`cancel-in-progress: true`). A canceled run leaves its own failing `check` check-run, and since GitHub keeps one check-run per run rather than per name, a later passing run doesn't clear it — the commit stays red until that run is re-run. `cancel-in-progress: false` wouldn't be enough, since concurrency also cancels pending runs by default, so this drops the block entirely; the check is idempotent and ~20s, so letting every run finish is harmless.

Found while investigating a stray red ✗ on an unrelated PR that lingered even after the same workflow had passed.

This pull request and its description were written by Isaac.
