### PR TITLE
Route sandbox CLI reviews through team:eng-sandbox

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -22,8 +22,8 @@
 /acceptance/apps/           team:eng-apps-devex
 
 # Sandbox
-/cmd/sandbox/               @pietern @akshaysingla-db @shuochen0311
-/acceptance/cmd/sandbox/    @pietern @akshaysingla-db @shuochen0311
+/cmd/sandbox/               team:eng-sandbox
+/acceptance/cmd/sandbox/    team:eng-sandbox
 
 # Auth
 /cmd/auth/                  team:platform

--- a/.github/OWNERTEAMS
+++ b/.github/OWNERTEAMS
@@ -10,7 +10,9 @@
 #   bundle:          https://github.com/orgs/databricks/teams/cli-maintainers
 #   platform:        https://github.com/orgs/databricks/teams/cli-platform
 #   eng-apps-devex:  https://github.com/orgs/databricks/teams/eng-apps-devex
+#   eng-sandbox:     https://github.com/orgs/databricks/teams/eng-sandbox
 
 team:bundle     @andrewnester @anton-107 @denik @janniklasrose @pietern @shreyas-goenka
 team:platform   @simonfaltum @renaudhartert-db @hectorcast-db @parthban-db @tanmay-db @Divyansh-db @tejaskochar-db @mihaimitrea-db @chrisst @rauchy
 team:eng-apps-devex @fjakobs @Shridhad @atilafassina @keugenek @igrekun @pkosiec @MarioCadenas @pffigueiredo @ditadi @calvarjorge
+team:eng-sandbox @pietern @shuochen0311 @akshaysingla-db


### PR DESCRIPTION
## Summary
- The `eng-sandbox` GitHub team now exists ([databricks/teams/eng-sandbox](https://github.com/orgs/databricks/teams/eng-sandbox/members)) and is the right grain for sandbox CLI ownership.
- Add a static `team:eng-sandbox` roster to `.github/OWNERTEAMS` — the maintainer-approval workflow can't resolve GitHub team membership via `GITHUB_TOKEN`, so this file is the source of truth and has to mirror the team's actual roster.
- Switch the `/cmd/sandbox/` and `/acceptance/cmd/sandbox/` rules in `.github/OWNERS` from individual @-mentions to `team:eng-sandbox` so reviews route through the team as it rotates.

## Test plan
- [x] `git diff` confirms only the two sandbox rules and the new roster line change; every other section is untouched.
- [x] Roster matches the current GitHub team (verified via `gh api /orgs/databricks/teams/eng-sandbox/members`).
- [ ] CI's maintainer-approval workflow resolves the new alias the same way it resolves `team:platform` / `team:bundle` / `team:eng-apps-devex`.

This pull request and its description were written by Isaac.