### PR TITLE
Add --select flag to bundle config-remote-sync

### DIFF
--- a/acceptance/bundle/config-remote-sync/select_basic/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/select_basic/databricks.yml.tmpl
@@ -1,0 +1,30 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+resources:
+  jobs:
+    job_one:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/job1
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+    job_two:
+      max_concurrent_runs: 2
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/job2
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+targets:
+  default:
+    mode: development

--- a/acceptance/bundle/config-remote-sync/select_basic/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/select_basic/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = true
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/select_basic/output.txt
+++ b/acceptance/bundle/config-remote-sync/select_basic/output.txt
@@ -38,19 +38,19 @@ Resource: resources.jobs.job_two
 
 
 === An unknown resource id is rejected
->>> [CLI] bundle config-remote-sync --select jobs:no-such-id-123
+>>> [CLI] bundle config-remote-sync --select-ids jobs:no-such-id-123
 Error: no deployed jobs resource with id no-such-id-123
 
 Exit code: 1
 
 === A selector without a type is rejected
->>> [CLI] bundle config-remote-sync --select no-such-id-123
-Error: invalid --select value "no-such-id-123", expected <type>:<id> (e.g. jobs:[NUMID])
+>>> [CLI] bundle config-remote-sync --select-ids no-such-id-123
+Error: invalid --select-ids value "no-such-id-123", expected <type>:<id> (e.g. jobs:[NUMID])
 
 Exit code: 1
 
 === An id that exists under a different type is rejected (no cross-type collision)
->>> [CLI] bundle config-remote-sync --select pipelines:[JOB_ONE_ID]
+>>> [CLI] bundle config-remote-sync --select-ids pipelines:[JOB_ONE_ID]
 Error: no deployed pipelines resource with id [JOB_ONE_ID]
 
 Exit code: 1

--- a/acceptance/bundle/config-remote-sync/select_basic/output.txt
+++ b/acceptance/bundle/config-remote-sync/select_basic/output.txt
@@ -1,0 +1,66 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Modify both jobs remotely
+=== Sync only job_one, selected by its type and deployed resource id
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.job_one
+  max_concurrent_runs: replace
+
+
+
+=== Only job_one is updated; job_two is left untouched
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -5,5 +5,5 @@
+   jobs:
+     job_one:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 5
+       tasks:
+         - task_key: main
+
+=== Selecting job_one again is idempotent
+No changes detected.
+
+
+=== Unfiltered sync still detects the job_two drift (no lost updates)
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.job_two
+  max_concurrent_runs: replace
+
+
+
+=== An unknown resource id is rejected
+>>> [CLI] bundle config-remote-sync --select jobs:no-such-id-123
+Error: no deployed jobs resource with id no-such-id-123
+
+Exit code: 1
+
+=== A selector without a type is rejected
+>>> [CLI] bundle config-remote-sync --select no-such-id-123
+Error: invalid --select value "no-such-id-123", expected <type>:<id> (e.g. jobs:[NUMID])
+
+Exit code: 1
+
+=== An id that exists under a different type is rejected (no cross-type collision)
+>>> [CLI] bundle config-remote-sync --select pipelines:[JOB_ONE_ID]
+Error: no deployed pipelines resource with id [JOB_ONE_ID]
+
+Exit code: 1
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.job_one
+  delete resources.jobs.job_two
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/select_basic/script
+++ b/acceptance/bundle/config-remote-sync/select_basic/script
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+job_one_id="$(read_id.py job_one)"
+job_two_id="$(read_id.py job_two)"
+
+title "Modify both jobs remotely"
+edit_resource.py jobs $job_one_id <<EOF
+r["max_concurrent_runs"] = 5
+EOF
+
+edit_resource.py jobs $job_two_id <<EOF
+r["max_concurrent_runs"] = 10
+EOF
+
+title "Sync only job_one, selected by its type and deployed resource id"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --select "jobs:$job_one_id" --save
+
+title "Only job_one is updated; job_two is left untouched"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+title "Selecting job_one again is idempotent"
+echo
+$CLI bundle config-remote-sync --select "jobs:$job_one_id"
+
+title "Unfiltered sync still detects the job_two drift (no lost updates)"
+echo
+$CLI bundle config-remote-sync
+
+title "An unknown resource id is rejected"
+errcode trace $CLI bundle config-remote-sync --select jobs:no-such-id-123
+
+title "A selector without a type is rejected"
+errcode trace $CLI bundle config-remote-sync --select no-such-id-123
+
+title "An id that exists under a different type is rejected (no cross-type collision)"
+errcode trace $CLI bundle config-remote-sync --select "pipelines:$job_one_id"

--- a/acceptance/bundle/config-remote-sync/select_basic/script
+++ b/acceptance/bundle/config-remote-sync/select_basic/script
@@ -23,7 +23,7 @@ EOF
 title "Sync only job_one, selected by its type and deployed resource id"
 echo
 cp databricks.yml databricks.yml.backup
-$CLI bundle config-remote-sync --select "jobs:$job_one_id" --save
+$CLI bundle config-remote-sync --select-ids "jobs:$job_one_id" --save
 
 title "Only job_one is updated; job_two is left untouched"
 echo
@@ -32,17 +32,17 @@ rm databricks.yml.backup
 
 title "Selecting job_one again is idempotent"
 echo
-$CLI bundle config-remote-sync --select "jobs:$job_one_id"
+$CLI bundle config-remote-sync --select-ids "jobs:$job_one_id"
 
 title "Unfiltered sync still detects the job_two drift (no lost updates)"
 echo
 $CLI bundle config-remote-sync
 
 title "An unknown resource id is rejected"
-errcode trace $CLI bundle config-remote-sync --select jobs:no-such-id-123
+errcode trace $CLI bundle config-remote-sync --select-ids jobs:no-such-id-123
 
 title "A selector without a type is rejected"
-errcode trace $CLI bundle config-remote-sync --select no-such-id-123
+errcode trace $CLI bundle config-remote-sync --select-ids no-such-id-123
 
 title "An id that exists under a different type is rejected (no cross-type collision)"
-errcode trace $CLI bundle config-remote-sync --select "pipelines:$job_one_id"
+errcode trace $CLI bundle config-remote-sync --select-ids "pipelines:$job_one_id"

--- a/acceptance/bundle/config-remote-sync/select_basic/test.toml
+++ b/acceptance/bundle/config-remote-sync/select_basic/test.toml
@@ -1,0 +1,10 @@
+Cloud = true
+
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/select_multiple/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/select_multiple/databricks.yml.tmpl
@@ -1,0 +1,41 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+resources:
+  jobs:
+    job_a:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/job_a
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+    job_b:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/job_b
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+    job_c:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/job_c
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+targets:
+  default:
+    mode: development

--- a/acceptance/bundle/config-remote-sync/select_multiple/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/select_multiple/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = true
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/select_multiple/output.txt
+++ b/acceptance/bundle/config-remote-sync/select_multiple/output.txt
@@ -23,7 +23,7 @@ Resource: resources.jobs.job_c
 
 
 
-=== Save with repeated --select flags
+=== Save with repeated --select-ids flags
 Detected changes in 2 resource(s):
 
 Resource: resources.jobs.job_a

--- a/acceptance/bundle/config-remote-sync/select_multiple/output.txt
+++ b/acceptance/bundle/config-remote-sync/select_multiple/output.txt
@@ -1,0 +1,74 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Modify all three jobs remotely
+=== Comma-separated selectors preview two of three resources
+Detected changes in 2 resource(s):
+
+Resource: resources.jobs.job_a
+  max_concurrent_runs: replace
+
+Resource: resources.jobs.job_b
+  max_concurrent_runs: replace
+
+
+
+=== Repeating the same selector dedupes silently
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.job_c
+  max_concurrent_runs: replace
+
+
+
+=== Save with repeated --select flags
+Detected changes in 2 resource(s):
+
+Resource: resources.jobs.job_a
+  max_concurrent_runs: replace
+
+Resource: resources.jobs.job_b
+  max_concurrent_runs: replace
+
+
+
+=== job_a and job_b are updated, job_c is untouched
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -5,5 +5,5 @@
+   jobs:
+     job_a:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 5
+       tasks:
+         - task_key: main
+@@ -16,5 +16,5 @@
+
+     job_b:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 5
+       tasks:
+         - task_key: main
+
+=== Unfiltered sync still detects the job_c drift
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.job_c
+  max_concurrent_runs: replace
+
+
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.job_a
+  delete resources.jobs.job_b
+  delete resources.jobs.job_c
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/select_multiple/script
+++ b/acceptance/bundle/config-remote-sync/select_multiple/script
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+job_a_id="$(read_id.py job_a)"
+job_b_id="$(read_id.py job_b)"
+job_c_id="$(read_id.py job_c)"
+
+title "Modify all three jobs remotely"
+for id in $job_a_id $job_b_id $job_c_id; do
+edit_resource.py jobs $id <<EOF
+r["max_concurrent_runs"] = 5
+EOF
+done
+
+title "Comma-separated selectors preview two of three resources"
+echo
+$CLI bundle config-remote-sync --select "jobs:$job_a_id,jobs:$job_b_id"
+
+title "Repeating the same selector dedupes silently"
+echo
+$CLI bundle config-remote-sync --select "jobs:$job_c_id,jobs:$job_c_id"
+
+title "Save with repeated --select flags"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --select "jobs:$job_a_id" --select "jobs:$job_b_id" --save
+
+title "job_a and job_b are updated, job_c is untouched"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+title "Unfiltered sync still detects the job_c drift"
+echo
+$CLI bundle config-remote-sync

--- a/acceptance/bundle/config-remote-sync/select_multiple/script
+++ b/acceptance/bundle/config-remote-sync/select_multiple/script
@@ -21,16 +21,16 @@ done
 
 title "Comma-separated selectors preview two of three resources"
 echo
-$CLI bundle config-remote-sync --select "jobs:$job_a_id,jobs:$job_b_id"
+$CLI bundle config-remote-sync --select-ids "jobs:$job_a_id,jobs:$job_b_id"
 
 title "Repeating the same selector dedupes silently"
 echo
-$CLI bundle config-remote-sync --select "jobs:$job_c_id,jobs:$job_c_id"
+$CLI bundle config-remote-sync --select-ids "jobs:$job_c_id,jobs:$job_c_id"
 
-title "Save with repeated --select flags"
+title "Save with repeated --select-ids flags"
 echo
 cp databricks.yml databricks.yml.backup
-$CLI bundle config-remote-sync --select "jobs:$job_a_id" --select "jobs:$job_b_id" --save
+$CLI bundle config-remote-sync --select-ids "jobs:$job_a_id" --select-ids "jobs:$job_b_id" --save
 
 title "job_a and job_b are updated, job_c is untouched"
 echo

--- a/acceptance/bundle/config-remote-sync/select_multiple/test.toml
+++ b/acceptance/bundle/config-remote-sync/select_multiple/test.toml
@@ -1,0 +1,10 @@
+Cloud = true
+
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/telemetry/config-remote-sync-error/output.txt
+++ b/acceptance/bundle/telemetry/config-remote-sync-error/output.txt
@@ -1,12 +1,12 @@
 
 >>> errcode [CLI] bundle config-remote-sync
-Error: failed to detect changes: state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found
+Error: state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found
 
 Exit code: 1
 
 >>> cat out.requests.txt
 {
   "engine": "terraform",
-  "error_message": "failed to detect changes: state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found",
+  "error_message": "state snapshot not available: resources state snapshot not found remotely at resources-config-sync-snapshot.json: state snapshot not found",
   "error_category": "STATE_NOT_FOUND"
 }

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -153,9 +153,9 @@ func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.En
 	return deployBundle, nil
 }
 
-// ChangesFromPlan converts a deploy plan into the map of remote-vs-config
-// changes. engine selects the LocalEdit comparison below.
-func ChangesFromPlan(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
+// ExtractChanges extracts the map of remote-vs-config changes from a deploy
+// plan. engine selects the LocalEdit comparison below.
+func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
 	changes := make(Changes)
 
 	for resourceKey, entry := range plan.Plan {

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -134,7 +134,7 @@ func convertChangeDesc(path string, cd *deployplan.ChangeDesc) (*ConfigChangeDes
 // reading. For the direct engine the caller (process.go) has already opened
 // b.DeploymentBundle; for the terraform engine the config snapshot is opened
 // here. Both yield read-mode state, so GetResourceID and Data.State are usable.
-// Open the state once per command and pass it to DetectChanges and
+// Open the state once per command and pass it to CalculatePlan and
 // ResolveResourceSelectors so the terraform snapshot is read only once.
 func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) (*direct.DeploymentBundle, error) {
 	if err := ensureSnapshotAvailable(ctx, b, engine); err != nil {
@@ -153,16 +153,10 @@ func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.En
 	return deployBundle, nil
 }
 
-// DetectChanges compares current remote state with the last deployed state
-// and returns a map of resource changes. deployBundle must already be open
-// (see OpenDeploymentState); engine selects the LocalEdit comparison below.
-func DetectChanges(ctx context.Context, b *bundle.Bundle, deployBundle *direct.DeploymentBundle, engine engine.EngineType) (Changes, error) {
+// ChangesFromPlan converts a deploy plan into the map of remote-vs-config
+// changes. engine selects the LocalEdit comparison below.
+func ChangesFromPlan(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
 	changes := make(Changes)
-
-	plan, err := deployBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to calculate plan: %w", err)
-	}
 
 	for resourceKey, entry := range plan.Plan {
 		resourceChanges := make(ResourceChanges)

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -130,27 +130,34 @@ func convertChangeDesc(path string, cd *deployplan.ChangeDesc) (*ConfigChangeDes
 	}, nil
 }
 
-// DetectChanges compares current remote state with the last deployed state
-// and returns a map of resource changes.
-func DetectChanges(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) (Changes, error) {
-	changes := make(Changes)
-
-	err := ensureSnapshotAvailable(ctx, b, engine)
-	if err != nil {
+// OpenDeploymentState returns the deployment bundle whose StateDB is open for
+// reading. For the direct engine the caller (process.go) has already opened
+// b.DeploymentBundle; for the terraform engine the config snapshot is opened
+// here. Both yield read-mode state, so GetResourceID and Data.State are usable.
+// Open the state once per command and pass it to DetectChanges and
+// ResolveResourceSelectors so the terraform snapshot is read only once.
+func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) (*direct.DeploymentBundle, error) {
+	if err := ensureSnapshotAvailable(ctx, b, engine); err != nil {
 		return nil, fmt.Errorf("state snapshot not available: %w", err)
 	}
 
-	var deployBundle *direct.DeploymentBundle
 	if engine.IsDirect() {
-		// For direct engine, state is already opened by the caller (process.go).
-		deployBundle = &b.DeploymentBundle
-	} else {
-		deployBundle = &direct.DeploymentBundle{}
-		_, statePath := b.StateFilenameConfigSnapshot(ctx)
-		if err := deployBundle.StateDB.Open(ctx, statePath, dstate.WithRecovery(true), dstate.WithWrite(false)); err != nil {
-			return nil, fmt.Errorf("failed to open state: %w", err)
-		}
+		return &b.DeploymentBundle, nil
 	}
+
+	deployBundle := &direct.DeploymentBundle{}
+	_, statePath := b.StateFilenameConfigSnapshot(ctx)
+	if err := deployBundle.StateDB.Open(ctx, statePath, dstate.WithRecovery(true), dstate.WithWrite(false)); err != nil {
+		return nil, fmt.Errorf("failed to open state: %w", err)
+	}
+	return deployBundle, nil
+}
+
+// DetectChanges compares current remote state with the last deployed state
+// and returns a map of resource changes. deployBundle must already be open
+// (see OpenDeploymentState); engine selects the LocalEdit comparison below.
+func DetectChanges(ctx context.Context, b *bundle.Bundle, deployBundle *direct.DeploymentBundle, engine engine.EngineType) (Changes, error) {
+	changes := make(Changes)
 
 	plan, err := deployBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
 	if err != nil {

--- a/bundle/configsync/select.go
+++ b/bundle/configsync/select.go
@@ -1,0 +1,94 @@
+package configsync
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/databricks/cli/bundle/direct"
+)
+
+// ResolveResourceSelectors maps "<type>:<id>" selectors to their plan keys
+// ("resources.<type>.<name>") using the open deployment state (see
+// OpenDeploymentState).
+//
+// Selection uses both the resource type and the deployed resource id (a job id,
+// pipeline id, dashboard id, ...) — the pair the workspace UI knows from a
+// resource's page. The type is required because a resource id is only unique
+// within a type: an id that happens to collide across types (e.g. a job and a
+// warehouse) would otherwise select the wrong resource. <type> is the bundle
+// resource type as it appears in the plan key, e.g. "jobs" or "pipelines". This
+// is also why selection is independent from `bundle deploy --select`, which
+// matches "type.name" keys.
+//
+// A selector that matches no deployed resource is an error: only deployed
+// resources have an id, so a selector matching nothing is a caller mistake.
+// Duplicate selectors are deduplicated; the returned keys preserve the order in
+// which their selectors first appear.
+func ResolveResourceSelectors(deployBundle *direct.DeploymentBundle, selectors []string) ([]string, error) {
+	// Index deployed resources by "<type>:<id>". State keys have the form
+	// "resources.<type>.<name>"; indexing by the <type> component means a
+	// selector can only ever match a resource of that exact type, never an id
+	// that happens to collide across types.
+	byTypeID := make(map[string]string)
+	for key := range deployBundle.StateDB.Data.State {
+		id := deployBundle.StateDB.GetResourceID(key)
+		if id == "" {
+			continue
+		}
+		typeAndName, ok := strings.CutPrefix(key, "resources.")
+		if !ok {
+			continue
+		}
+		resourceType, _, ok := strings.Cut(typeAndName, ".")
+		if !ok {
+			continue
+		}
+		byTypeID[resourceType+":"+id] = key
+	}
+
+	keys := make([]string, 0, len(selectors))
+	for _, selector := range selectors {
+		resourceType, id, ok := strings.Cut(selector, ":")
+		if !ok || resourceType == "" || id == "" {
+			return nil, fmt.Errorf("invalid --select value %q, expected <type>:<id> (e.g. jobs:123456789)", selector)
+		}
+		key, ok := byTypeID[selector]
+		if !ok {
+			return nil, fmt.Errorf("no deployed %s resource with id %s", resourceType, id)
+		}
+		if !slices.Contains(keys, key) {
+			keys = append(keys, key)
+		}
+	}
+	return keys, nil
+}
+
+// FilterChanges returns the subset of changes that belong to the resources in
+// selected, a list of plan keys ("resources.<type>.<name>") as returned by
+// ResolveResourceSelectors. Change keys are plan keys too.
+//
+// Selection is at the resource level: a change node is kept when it is the
+// selected resource itself or any node beneath it, matched by prefix on the "."
+// path boundary. This groups a resource's permissions/grants sub-nodes
+// ("resources.<type>.<name>.permissions") with their parent, so selecting a
+// resource never silently skips its permissions. The "." boundary stops
+// "resources.jobs.foo" from also matching an unrelated "resources.jobs.foobar".
+//
+// Only the selected resources' own nodes are kept: unlike deploy's plan
+// filtering, the selection is not expanded to transitive dependencies, because
+// dependencies matter only when planning (DetectChanges always plans the full
+// resource set so ${resources.*} references resolve), not when deciding which
+// resources' configuration may be rewritten.
+func FilterChanges(changes Changes, selected []string) Changes {
+	filtered := make(Changes)
+	for key, resourceChanges := range changes {
+		for _, sel := range selected {
+			if key == sel || strings.HasPrefix(key, sel+".") {
+				filtered[key] = resourceChanges
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/bundle/configsync/select.go
+++ b/bundle/configsync/select.go
@@ -5,7 +5,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/databricks/cli/bundle/direct"
+	"github.com/databricks/cli/bundle/direct/dstate"
 )
 
 // ResolveResourceSelectors maps "<type>:<id>" selectors to their plan keys
@@ -25,14 +25,14 @@ import (
 // resources have an id, so a selector matching nothing is a caller mistake.
 // Duplicate selectors are deduplicated; the returned keys preserve the order in
 // which their selectors first appear.
-func ResolveResourceSelectors(deployBundle *direct.DeploymentBundle, selectors []string) ([]string, error) {
+func ResolveResourceSelectors(state *dstate.DeploymentState, selectors []string) ([]string, error) {
 	// Index deployed resources by "<type>:<id>". State keys have the form
 	// "resources.<type>.<name>"; indexing by the <type> component means a
 	// selector can only ever match a resource of that exact type, never an id
 	// that happens to collide across types.
 	byTypeID := make(map[string]string)
-	for key := range deployBundle.StateDB.Data.State {
-		id := deployBundle.StateDB.GetResourceID(key)
+	for key := range state.Data.State {
+		id := state.GetResourceID(key)
 		if id == "" {
 			continue
 		}
@@ -51,7 +51,7 @@ func ResolveResourceSelectors(deployBundle *direct.DeploymentBundle, selectors [
 	for _, selector := range selectors {
 		resourceType, id, ok := strings.Cut(selector, ":")
 		if !ok || resourceType == "" || id == "" {
-			return nil, fmt.Errorf("invalid --select value %q, expected <type>:<id> (e.g. jobs:123456789)", selector)
+			return nil, fmt.Errorf("invalid --select-ids value %q, expected <type>:<id> (e.g. jobs:123456789)", selector)
 		}
 		key, ok := byTypeID[selector]
 		if !ok {

--- a/bundle/configsync/select.go
+++ b/bundle/configsync/select.go
@@ -77,7 +77,7 @@ func ResolveResourceSelectors(state *dstate.DeploymentState, selectors []string)
 //
 // Only the selected resources' own nodes are kept: unlike deploy's plan
 // filtering, the selection is not expanded to transitive dependencies, because
-// dependencies matter only when planning (DetectChanges always plans the full
+// dependencies matter only when planning (the plan always covers the full
 // resource set so ${resources.*} references resolve), not when deciding which
 // resources' configuration may be rewritten.
 func FilterChanges(changes Changes, selected []string) Changes {

--- a/bundle/configsync/select_test.go
+++ b/bundle/configsync/select_test.go
@@ -1,0 +1,94 @@
+package configsync
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterChanges(t *testing.T) {
+	changes := Changes{
+		"resources.jobs.foo": {
+			"max_concurrent_runs": {Operation: OperationReplace, Value: 5},
+		},
+		"resources.jobs.foo.permissions": {
+			"[0].level": {Operation: OperationReplace, Value: "CAN_MANAGE"},
+		},
+		// Boundary: shares the "resources.jobs.foo" prefix but is a different
+		// resource, so selecting "resources.jobs.foo" must not pull it in.
+		"resources.jobs.foobar": {
+			"name": {Operation: OperationReplace, Value: "foobar"},
+		},
+		"resources.jobs.bar": {
+			"name": {Operation: OperationReplace, Value: "bar"},
+		},
+		"resources.schemas.baz": {
+			"comment": {Operation: OperationAdd, Value: "c"},
+		},
+		"resources.schemas.baz.grants": {
+			"[0].principal": {Operation: OperationAdd, Value: "users"},
+		},
+		// A resource whose name is literally "permissions" is the resource itself,
+		// not a sub-node, and is kept only when selected by its own key.
+		"resources.jobs.permissions": {
+			"name": {Operation: OperationReplace, Value: "p"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		selected []string
+		wantKeys []string
+	}{
+		{
+			name:     "resource groups its permissions sub-node by prefix, excludes the foobar sibling",
+			selected: []string{"resources.jobs.foo"},
+			wantKeys: []string{"resources.jobs.foo", "resources.jobs.foo.permissions"},
+		},
+		{
+			name:     "resource without sub-nodes",
+			selected: []string{"resources.jobs.bar"},
+			wantKeys: []string{"resources.jobs.bar"},
+		},
+		{
+			name:     "grants sub-node follows its parent",
+			selected: []string{"resources.schemas.baz"},
+			wantKeys: []string{"resources.schemas.baz", "resources.schemas.baz.grants"},
+		},
+		{
+			name:     "multiple selections are a union",
+			selected: []string{"resources.jobs.bar", "resources.schemas.baz"},
+			wantKeys: []string{"resources.jobs.bar", "resources.schemas.baz", "resources.schemas.baz.grants"},
+		},
+		{
+			name:     "resource with no detected changes yields empty result",
+			selected: []string{"resources.jobs.never_drifted"},
+			wantKeys: []string{},
+		},
+		{
+			name:     "resource named permissions is kept only by its own key",
+			selected: []string{"resources.jobs.permissions"},
+			wantKeys: []string{"resources.jobs.permissions"},
+		},
+		{
+			name:     "empty selection keeps nothing",
+			selected: nil,
+			wantKeys: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterChanges(changes, tt.selected)
+			assert.ElementsMatch(t, tt.wantKeys, slices.Collect(maps.Keys(got)))
+			for _, key := range tt.wantKeys {
+				assert.Equal(t, changes[key], got[key])
+			}
+		})
+	}
+
+	// The input map is never mutated.
+	assert.Len(t, changes, 7)
+}

--- a/bundle/configsync/telemetry.go
+++ b/bundle/configsync/telemetry.go
@@ -92,7 +92,7 @@ func (s *Stats) CollectChangeStats(ctx context.Context, changes Changes) {
 			perType = &protos.BundleConfigRemoteSyncResourceChanges{ResourceType: resourceType}
 			s.PerResourceType[resourceType] = perType
 		}
-		// Only Add/Replace/Remove reach this function: DetectChanges filters
+		// Only Add/Replace/Remove reach this function: ChangesFromPlan filters
 		// out Skip operations and convertChangeDesc never produces Unknown,
 		// so the totals always equal the per-operation breakdown.
 		for fieldPath, change := range resourceChanges {

--- a/bundle/configsync/telemetry.go
+++ b/bundle/configsync/telemetry.go
@@ -92,7 +92,7 @@ func (s *Stats) CollectChangeStats(ctx context.Context, changes Changes) {
 			perType = &protos.BundleConfigRemoteSyncResourceChanges{ResourceType: resourceType}
 			s.PerResourceType[resourceType] = perType
 		}
-		// Only Add/Replace/Remove reach this function: ChangesFromPlan filters
+		// Only Add/Replace/Remove reach this function: ExtractChanges filters
 		// out Skip operations and convertChangeDesc never produces Unknown,
 		// so the totals always equal the per-operation breakdown.
 		for fieldPath, change := range resourceChanges {

--- a/bundle/configsync/variables.go
+++ b/bundle/configsync/variables.go
@@ -140,7 +140,7 @@ func loadPreResolvedConfig(ctx context.Context, b *bundle.Bundle) dyn.Value {
 // deployed IDs from state. For the direct engine, the StateDB is already open
 // on b.DeploymentBundle. For the terraform engine, the config snapshot is
 // opened locally (it was downloaded by ensureSnapshotAvailable during
-// DetectChanges). Returns nil if no state is available.
+// OpenDeploymentState). Returns nil if no state is available.
 func resourceIDLookup(ctx context.Context, b *bundle.Bundle) func(string) string {
 	if b.DeploymentBundle.StateDB.Path != "" {
 		return b.DeploymentBundle.StateDB.GetResourceID

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -22,7 +22,7 @@ import (
 
 func newConfigRemoteSyncCommand() *cobra.Command {
 	var save bool
-	var selectResources []string
+	var selectIDs []string
 
 	cmd := &cobra.Command{
 		Use:   "config-remote-sync",
@@ -42,12 +42,12 @@ Examples:
   databricks bundle config-remote-sync --save
 
   # Restrict the sync to a single resource by its type and deployed resource ID
-  databricks bundle config-remote-sync --select jobs:123456789 --save`,
+  databricks bundle config-remote-sync --select-ids jobs:123456789 --save`,
 		Hidden: true, // Used by DABs in the Workspace only
 	}
 
 	cmd.Flags().BoolVar(&save, "save", false, "Write updated config files to disk")
-	cmd.Flags().StringSliceVar(&selectResources, "select", nil, "Sync only the given resources, each as <type>:<id> (e.g. jobs:123456789). Can be repeated or comma-separated.")
+	cmd.Flags().StringSliceVar(&selectIDs, "select-ids", nil, "Sync only the given resources, each as <type>:<id> (e.g. jobs:123456789). Can be repeated or comma-separated.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if runtime.GOOS == "windows" {
@@ -94,13 +94,11 @@ Examples:
 				}
 				stats.CollectChangeStats(ctx, changes)
 
-				if len(selectResources) > 0 {
-					// --select takes <type>:<id> selectors (what the workspace UI knows),
-					// resolved to plan keys against the same state DetectChanges planned.
+				if len(selectIDs) > 0 {
 					// Filter after planning, never before: the plan must cover every
 					// resource so ${resources.*} references resolve; only the emitted
 					// changes are restricted to the selected resources.
-					selected, err := configsync.ResolveResourceSelectors(deployBundle, selectResources)
+					selected, err := configsync.ResolveResourceSelectors(&deployBundle.StateDB, selectIDs)
 					if err != nil {
 						return err
 					}

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -22,6 +22,7 @@ import (
 
 func newConfigRemoteSyncCommand() *cobra.Command {
 	var save bool
+	var selectResources []string
 
 	cmd := &cobra.Command{
 		Use:   "config-remote-sync",
@@ -38,11 +39,15 @@ Examples:
   databricks bundle config-remote-sync
 
   # Show diff and save to files
-  databricks bundle config-remote-sync --save`,
+  databricks bundle config-remote-sync --save
+
+  # Restrict the sync to a single resource by its type and deployed resource ID
+  databricks bundle config-remote-sync --select jobs:123456789 --save`,
 		Hidden: true, // Used by DABs in the Workspace only
 	}
 
 	cmd.Flags().BoolVar(&save, "save", false, "Write updated config files to disk")
+	cmd.Flags().StringSliceVar(&selectResources, "select", nil, "Sync only the given resources, each as <type>:<id> (e.g. jobs:123456789). Can be repeated or comma-separated.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if runtime.GOOS == "windows" {
@@ -71,7 +76,9 @@ Examples:
 			PostStateFunc: func(ctx context.Context, b *bundle.Bundle, stateDesc *statemgmt.StateDesc) error {
 				stats.Engine = stateDesc.Engine
 
-				changes, err := configsync.DetectChanges(ctx, b, stateDesc.Engine)
+				// Open the deployment state once and reuse it for both planning and
+				// selector resolution (avoids reading the terraform snapshot twice).
+				deployBundle, err := configsync.OpenDeploymentState(ctx, b, stateDesc.Engine)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
 					if errors.Is(err, configsync.ErrStateSnapshotNotFound) {
@@ -79,7 +86,26 @@ Examples:
 					}
 					return fmt.Errorf("failed to detect changes: %w", err)
 				}
+
+				changes, err := configsync.DetectChanges(ctx, b, deployBundle, stateDesc.Engine)
+				if err != nil {
+					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
+					return fmt.Errorf("failed to detect changes: %w", err)
+				}
 				stats.CollectChangeStats(ctx, changes)
+
+				if len(selectResources) > 0 {
+					// --select takes <type>:<id> selectors (what the workspace UI knows),
+					// resolved to plan keys against the same state DetectChanges planned.
+					// Filter after planning, never before: the plan must cover every
+					// resource so ${resources.*} references resolve; only the emitted
+					// changes are restricted to the selected resources.
+					selected, err := configsync.ResolveResourceSelectors(deployBundle, selectResources)
+					if err != nil {
+						return err
+					}
+					changes = configsync.FilterChanges(changes, selected)
+				}
 
 				fieldChanges, err := configsync.ResolveChanges(ctx, b, changes)
 				if err != nil {

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -80,14 +80,17 @@ Examples:
 				// selector resolution (avoids reading the terraform snapshot twice).
 				deployBundle, err := configsync.OpenDeploymentState(ctx, b, stateDesc.Engine)
 				if err != nil {
+					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryStateNotFound
+					return fmt.Errorf("deployment state not available: %w", err)
+				}
+
+				plan, err := deployBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
+				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
-					if errors.Is(err, configsync.ErrStateSnapshotNotFound) {
-						stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryStateNotFound
-					}
 					return fmt.Errorf("failed to detect changes: %w", err)
 				}
 
-				changes, err := configsync.DetectChanges(ctx, b, deployBundle, stateDesc.Engine)
+				changes, err := configsync.ChangesFromPlan(ctx, b, plan, stateDesc.Engine)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
 					return fmt.Errorf("failed to detect changes: %w", err)

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -80,8 +80,11 @@ Examples:
 				// selector resolution (avoids reading the terraform snapshot twice).
 				deployBundle, err := configsync.OpenDeploymentState(ctx, b, stateDesc.Engine)
 				if err != nil {
-					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryStateNotFound
-					return fmt.Errorf("deployment state not available: %w", err)
+					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
+					if errors.Is(err, configsync.ErrStateSnapshotNotFound) {
+						stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryStateNotFound
+					}
+					return err
 				}
 
 				plan, err := deployBundle.CalculatePlan(ctx, b.WorkspaceClient(ctx), &b.Config)
@@ -90,10 +93,10 @@ Examples:
 					return fmt.Errorf("failed to detect changes: %w", err)
 				}
 
-				changes, err := configsync.ChangesFromPlan(ctx, b, plan, stateDesc.Engine)
+				changes, err := configsync.ExtractChanges(ctx, b, plan, stateDesc.Engine)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryDetectChangesFailed
-					return fmt.Errorf("failed to detect changes: %w", err)
+					return fmt.Errorf("failed to extract changes: %w", err)
 				}
 				stats.CollectChangeStats(ctx, changes)
 


### PR DESCRIPTION
## Changes
Add an opt-in `--select-ids` flag to the experimental `bundle config-remote-sync` command (hidden; used by DABs in the Workspace). The flag restricts detected and saved changes to specific resources. Each selector is `<type>:<id>` (e.g. `jobs:123456789`) — the resource type plus its **deployed resource ID**. It is repeatable and/or comma-separated.

Default behavior without the flag is unchanged.

Implementation notes:
- The command is invoked from a resource's page in the workspace, which knows the resource's **type and ID** but not its bundle `type.name` key. Selection is therefore by `<type>:<id>` and is intentionally **independent** from `bundle deploy --select` (which matches keys); no logic is shared with deploy.
- The type is required: a resource ID is only unique within a type, so an ID that happens to collide across types (e.g. a job and a warehouse) would otherwise select the wrong resource. The type comes from the plan key (`resources.<type>.<name>`), so a selector can only ever match its own type.
- Selectors are resolved to plan keys against the deployment state **after** planning. `DetectChanges` still plans the full resource set so `${resources.*}` references resolve; only the emitted change set is then restricted. A selector that matches no deployed resource is an error.
- Selection is at the resource level: a selected resource's permissions/grants sub-nodes (and any other synthesized child node) are grouped with it by prefix on the `.` path boundary, so syncing a resource never silently skips its permissions.

## Why
A full sync diffs every resource in a bundle, so a drifted-but-unrelated resource (for example a dashboard whose etag changed remotely because someone opened the draft) can have unwanted changes written into its YAML while the user is syncing a different resource. Passing the edited resource's `<type>:<id>` via `--select-ids` limits the blast radius of one sync run to that resource.

## Tests
- Unit test for change-map filtering in `bundle/configsync`.
- Two focused acceptance directories under `acceptance/bundle/config-remote-sync/`, both run on the direct and terraform engines:
  - `select_basic`: two drifted jobs, select one by `jobs:<id>` via `--select-ids` — only that job's YAML changes, the other is left byte-identical (verified via backup + `diff.py`); re-selecting is idempotent; an unfiltered run still detects the other job's drift (no lost updates); a selector with an unknown ID, a selector with no type, and an ID under the wrong type are each rejected.
  - `select_multiple`: comma-separated selectors select two of three resources, a repeated selector dedupes, repeated `--select-ids` flags combine, and the unselected resource is untouched.
- The entire existing `config-remote-sync` acceptance tree and the `bundle/select` (deploy) tree pass unchanged on both engines — the flag is opt-in, no existing goldens changed, and the deploy selector code is untouched.
- Verified locally and against a real Unity Catalog workspace (cloud acceptance run, both engines).
