### PR TITLE
acc: Prevent lifecycle-started-terraform-error from leaking a started warehouse

### DIFF
--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/databricks.yml.tmpl
@@ -8,9 +8,6 @@ resources:
   sql_warehouses:
     mywarehouse:
       name: my-warehouse-$UNIQUE_NAME
-      # Smallest size and shortest auto-stop: this test only verifies the
-      # error path, so if a warehouse is ever created by mistake it should
-      # be as cheap and short-lived as possible.
       cluster_size: "2X-Small"
       auto_stop_mins: 10
       lifecycle:

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/databricks.yml.tmpl
@@ -8,6 +8,10 @@ resources:
   sql_warehouses:
     mywarehouse:
       name: my-warehouse-$UNIQUE_NAME
-      cluster_size: "Medium"
+      # Smallest size and shortest auto-stop: this test only verifies the
+      # error path, so if a warehouse is ever created by mistake it should
+      # be as cheap and short-lived as possible.
+      cluster_size: "2X-Small"
+      auto_stop_mins: 10
       lifecycle:
         started: true

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/output.txt
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/output.txt
@@ -2,7 +2,7 @@
 === bundle plan fails with lifecycle.started on terraform engine
 >>> errcode [CLI] bundle plan
 Error: lifecycle.started is only supported in direct deployment mode
-  in databricks.yml:17:18
+  in databricks.yml:14:18
 
 
 Exit code: 1
@@ -10,7 +10,7 @@ Exit code: 1
 === bundle deploy fails with lifecycle.started on terraform engine
 >>> errcode [CLI] bundle deploy
 Error: lifecycle.started is only supported in direct deployment mode
-  in databricks.yml:17:18
+  in databricks.yml:14:18
 
 
 Exit code: 1

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/output.txt
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/output.txt
@@ -2,7 +2,7 @@
 === bundle plan fails with lifecycle.started on terraform engine
 >>> errcode [CLI] bundle plan
 Error: lifecycle.started is only supported in direct deployment mode
-  in databricks.yml:13:18
+  in databricks.yml:17:18
 
 
 Exit code: 1
@@ -10,7 +10,10 @@ Exit code: 1
 === bundle deploy fails with lifecycle.started on terraform engine
 >>> errcode [CLI] bundle deploy
 Error: lifecycle.started is only supported in direct deployment mode
-  in databricks.yml:13:18
+  in databricks.yml:17:18
 
 
 Exit code: 1
+
+>>> [CLI] bundle destroy --auto-approve
+No active deployment found to destroy!

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/script
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/script
@@ -1,8 +1,5 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
-# The plan/deploy commands below are expected to fail before any resource is
-# created. Always destroy on exit so that a regression in that error path can
-# never leak a running warehouse into the shared cloud workspace.
 cleanup() {
     trace $CLI bundle destroy --auto-approve
 }

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/script
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/script
@@ -1,5 +1,13 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
+# The plan/deploy commands below are expected to fail before any resource is
+# created. Always destroy on exit so that a regression in that error path can
+# never leak a running warehouse into the shared cloud workspace.
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
 title "bundle plan fails with lifecycle.started on terraform engine"
 trace errcode $CLI bundle plan
 


### PR DESCRIPTION
## What

Makes `acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error` leak-proof:

- adds the `trap cleanup EXIT` / `bundle destroy --auto-approve` idiom used by its sibling tests, so any accidental partial deploy is torn down even when the script fails (verified `bundle destroy` is not blocked by the same pre-deploy validation the test exercises);
- shrinks the warehouse to `2X-Small` with `auto_stop_mins: 10` as defense-in-depth (size is irrelevant to the validation under test).

## Why

The test verifies that `lifecycle.started` fails with a clear error on the terraform engine. Today that error fires in `PreDeployChecks` (before anything is created), but the script had zero teardown — any regression that lets the deploy proceed past validation would leak a *started* `Medium` warehouse into the shared cloud test workspace on every run, while the test still "fails loudly." Leaked started warehouses exhausted the GCP local-SSD quota in the shared test project on 2026-06-11/12 and blocked terraform-provider CI for ~2 days (ref ES-1974228).

## Tests

`Local = true`: ran against the local testserver; expected output regenerated (error location shifted by the added config lines, destroy step appended) and the full `sql_warehouses` subtree passes cleanly.

This pull request and its description were written by Isaac.
