### PR TITLE
Fix config-remote-sync writing dashboard etag into YAML

### DIFF
--- a/acceptance/bundle/config-remote-sync/dashboard_etag/dashboard.lvdash.json
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/dashboard.lvdash.json
@@ -1,0 +1,34 @@
+{
+  "pages": [
+    {
+      "displayName": "New Page",
+      "layout": [
+        {
+          "position": {
+            "height": 2,
+            "width": 6,
+            "x": 0,
+            "y": 0
+          },
+          "widget": {
+            "name": "82eb9107",
+            "textbox_spec": "# I'm a title"
+          }
+        },
+        {
+          "position": {
+            "height": 2,
+            "width": 6,
+            "x": 0,
+            "y": 2
+          },
+          "widget": {
+            "name": "ffa6de4f",
+            "textbox_spec": "Text"
+          }
+        }
+      ],
+      "name": "fdd21a3c"
+    }
+  ]
+}

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/databricks.yml.tmpl
@@ -1,0 +1,9 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+resources:
+  dashboards:
+    my_dashboard:
+      display_name: test-dashboard-$UNIQUE_NAME
+      file_path: ./dashboard.lvdash.json
+      warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = true
+RequiresWarehouse = true
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/output.txt
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/output.txt
@@ -1,0 +1,32 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Modify the dashboard out of band to bump its remote etag
+{
+  "lifecycle_state": "ACTIVE"
+}
+
+=== Detect changes: etag drift must not be reported
+
+>>> [CLI] bundle config-remote-sync
+No changes detected.
+
+
+=== Save changes: config must not be modified
+
+>>> [CLI] bundle config-remote-sync --save
+No changes detected.
+
+
+>>> diff.py databricks.yml.backup databricks.yml
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.dashboards.my_dashboard
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/script
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/script
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+dashboard_id=$(read_id.py my_dashboard)
+
+title "Modify the dashboard out of band to bump its remote etag"
+echo
+# Keep only lifecycle_state: the full response carries a nondeterministic etag
+# and update_time that would churn the snapshot.
+$CLI lakeview update "$dashboard_id" --json '{"serialized_dashboard": "{}", "warehouse_id": "'$TEST_DEFAULT_WAREHOUSE_ID'"}' | jq '{lifecycle_state}'
+
+title "Detect changes: etag drift must not be reported"
+echo
+trace $CLI bundle config-remote-sync
+
+title "Save changes: config must not be modified"
+echo
+cp databricks.yml databricks.yml.backup
+trace $CLI bundle config-remote-sync --save
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/dashboard_etag/test.toml
+++ b/acceptance/bundle/config-remote-sync/dashboard_etag/test.toml
@@ -1,0 +1,12 @@
+Cloud = true
+RequiresWarehouse = true
+
+RecordRequests = false
+
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/bundle/configsync/defaults.go
+++ b/bundle/configsync/defaults.go
@@ -95,6 +95,13 @@ var serverSideDefaults = map[string]any{
 	// Pipeline fields
 	"resources.pipelines.*.storage":    alwaysSkip,
 	"resources.pipelines.*.continuous": false,
+
+	// Dashboard fields
+	// etag is output-only and never present in config. The plan re-promotes etag
+	// drift to Update via ResourceDashboard.OverrideChangeDesc (needed for deploy's
+	// modified-remotely detection), so configsync cannot rely on the plan's Skip
+	// action and must exclude the field explicitly.
+	"resources.dashboards.*.etag": alwaysSkip,
 }
 
 // shouldSkipField checks if a field should be skipped in change detection.

--- a/bundle/configsync/diff_test.go
+++ b/bundle/configsync/diff_test.go
@@ -83,6 +83,14 @@ func TestConvertChangeDesc(t *testing.T) {
 	}
 }
 
+func TestShouldSkipFieldDashboardEtag(t *testing.T) {
+	// etag is output-only: alwaysSkip must apply regardless of hasConfigValue,
+	// otherwise out-of-band etag drift is written back into the user's YAML.
+	path := "resources.dashboards.my_dashboard.etag"
+	assert.True(t, shouldSkipField(path, "some-etag", false))
+	assert.True(t, shouldSkipField(path, "some-etag", true))
+}
+
 func TestStripNamePrefix(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Changes

`bundle config-remote-sync` no longer writes the dashboard `etag` field into bundle configuration when the remote etag drifts 

Added `resources.dashboards.*.etag` to the configsync skip table. This is an intentionally minimal fix; a follow-up PR migrates the whole table to the resource lifecycle metadata in `resources.yml`.

## Why

`etag` is output-only and never present in configuration. The deploy plan re-promotes etag drift to `Update` via `ResourceDashboard.OverrideChangeDesc` (required for deploy's modified-remotely detection), so configsync cannot rely on the plan's `Skip` action and must exclude the field explicitly. Without this, `config-remote-sync --save` hardcodes a stale etag into the dashboard YAML; the config then fails validation ("Etags must not be set in bundle configuration"), breaking subsequent deploys and even `bundle destroy`, and leaves CI/state/remote permanently inconsistent.

## Tests

New acceptance test `acceptance/bundle/config-remote-sync/dashboard_etag` (local + cloud, both engines): deploys a dashboard, simulates an out-of-band modification via `lakeview update` (bumps the remote etag), and asserts `config-remote-sync` reports no changes and `--save` leaves the YAML untouched. Before the fix the test reproduces the leak (`etag: add` reported and written to `databricks.yml`). Also a unit test pinning the skip rule.

Verified on a real workspace via the cloud acceptance run for `bundle/config-remote-sync`.
