### PR TITLE
Remove non-functional hidden alias flags from bundle generate

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,6 +12,7 @@
 * direct: Fix resolving a resource reference that is used more than once within the same field ([#5558](https://github.com/databricks/cli/pull/5558)).
 * Bundle variable references now accept Unicode letters in path segments (e.g. `${var.变量}`). ([#5532](https://github.com/databricks/cli/pull/5532))
 * Ignore remote changes for vector search direct_access_index_spec.schema_json to prevent drift when the backend normalizes the schema ([#5481](https://github.com/databricks/cli/pull/5481)).
+* Remove hidden, never-functional `--existing-dashboard-id`, `--existing-dashboard-path`, `--existing-alert-id`, and `--existing-genie-space-id` alias flags from `bundle generate`; use the documented `--existing-id` / `--existing-path` flags instead ([#XXXX](https://github.com/databricks/cli/pull/XXXX)).
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,7 +12,7 @@
 * direct: Fix resolving a resource reference that is used more than once within the same field ([#5558](https://github.com/databricks/cli/pull/5558)).
 * Bundle variable references now accept Unicode letters in path segments (e.g. `${var.变量}`). ([#5532](https://github.com/databricks/cli/pull/5532))
 * Ignore remote changes for vector search direct_access_index_spec.schema_json to prevent drift when the backend normalizes the schema ([#5481](https://github.com/databricks/cli/pull/5481)).
-* Remove hidden, never-functional `--existing-dashboard-id`, `--existing-dashboard-path`, `--existing-alert-id`, and `--existing-genie-space-id` alias flags from `bundle generate`; use the documented `--existing-id` / `--existing-path` flags instead ([#XXXX](https://github.com/databricks/cli/pull/XXXX)).
+* Remove hidden, never-functional `--existing-dashboard-id`, `--existing-dashboard-path`, `--existing-alert-id`, and `--existing-genie-space-id` alias flags from `bundle generate`; use the documented `--existing-id` / `--existing-path` flags instead ([#5591](https://github.com/databricks/cli/pull/5591)).
 
 ### Dependency updates
 

--- a/cmd/bundle/generate/alert.go
+++ b/cmd/bundle/generate/alert.go
@@ -57,11 +57,6 @@ After generation, you can deploy this alert to other targets using:
 	cmd.Flags().StringVar(&alertID, "existing-id", "", `ID of the alert to generate configuration for`)
 	cmd.MarkFlagRequired("existing-id")
 
-	// Alias lookup flag that includes the resource type name.
-	// Included for symmetry with the other generate commands, but we prefer the shorter flag.
-	cmd.Flags().StringVar(&alertID, "existing-alert-id", "", `ID of the alert to generate configuration for`)
-	cmd.Flags().MarkHidden("existing-alert-id")
-
 	cmd.Flags().StringVarP(&configDir, "config-dir", "d", "resources", `directory to write the configuration to`)
 	cmd.Flags().StringVarP(&sourceDir, "source-dir", "s", "src", `directory to write the alert definition to`)
 	cmd.Flags().BoolVarP(&force, "force", "f", false, `force overwrite existing files in the output directory`)

--- a/cmd/bundle/generate/dashboard.go
+++ b/cmd/bundle/generate/dashboard.go
@@ -525,13 +525,6 @@ bundle files automatically, useful during active dashboard development.`,
 	cmd.Flags().StringVar(&d.existingID, "existing-id", "", `ID of the dashboard to generate configuration for`)
 	cmd.Flags().StringVar(&d.resource, "resource", "", `resource key of dashboard to watch for changes`)
 
-	// Alias lookup flags that include the resource type name.
-	// Included for symmetry with the other generate commands, but we prefer the shorter flags.
-	cmd.Flags().StringVar(&d.existingPath, "existing-dashboard-path", "", `workspace path of the dashboard to generate configuration for`)
-	cmd.Flags().StringVar(&d.existingID, "existing-dashboard-id", "", `ID of the dashboard to generate configuration for`)
-	cmd.Flags().MarkHidden("existing-dashboard-path")
-	cmd.Flags().MarkHidden("existing-dashboard-id")
-
 	// Output flags.
 	cmd.Flags().StringVarP(&d.resourceDir, "resource-dir", "d", "resources", `directory to write the configuration to`)
 	cmd.Flags().StringVarP(&d.dashboardDir, "dashboard-dir", "s", "src", `directory to write the dashboard representation to`)

--- a/cmd/bundle/generate/genie_space.go
+++ b/cmd/bundle/generate/genie_space.go
@@ -441,10 +441,6 @@ bundle files automatically, useful during active Genie space development.`,
 	cmd.Flags().StringVar(&g.existingID, "existing-id", "", `ID of the Genie space to generate configuration for`)
 	cmd.Flags().StringVar(&g.resource, "resource", "", `resource key of Genie space to watch for changes`)
 
-	// Alias lookup flag that includes the resource type name.
-	cmd.Flags().StringVar(&g.existingID, "existing-genie-space-id", "", `ID of the Genie space to generate configuration for`)
-	cmd.Flags().MarkHidden("existing-genie-space-id")
-
 	// Output flags.
 	cmd.Flags().StringVarP(&g.resourceDir, "resource-dir", "d", "resources", `directory to write the configuration to`)
 	cmd.Flags().StringVarP(&g.genieSpaceDir, "genie-space-dir", "s", "src", `directory to write the Genie space representation to`)


### PR DESCRIPTION
## Changes

Remove the hidden `--existing-dashboard-id`, `--existing-dashboard-path`, `--existing-alert-id`, and `--existing-genie-space-id` alias flags from `bundle generate dashboard|alert|genie-space`. These aliased the canonical `--existing-id` / `--existing-path` flags by registering a second flag bound to the same variable ("included for symmetry with the other generate commands"), but they were never wired into the cobra requirement groups (`MarkFlagsOneRequired` / `MarkFlagRequired`). Cobra validates those groups on the named flags' `Changed` state, so an alias-only invocation always failed flag validation before reaching the command:

```
$ databricks bundle generate genie-space --existing-genie-space-id abc123
Error: at least one of the flags in the group [existing-id resource] is required
```

The aliases were broken from the commit that introduced each of them (#1847 for dashboard, #4108 for alert, #5282 for genie-space), are hidden from help output, and are referenced nowhere in docs, examples, or tests — no working invocation ever depended on them. With this change, passing one yields cobra's `unknown flag` error plus usage listing the canonical flags, instead of the misleading requirement-group error.

The canonical long-form flags of the other generate commands (`--existing-job-id`, `--existing-pipeline-id`, `--existing-app-name`) are unaffected.

## Tests

- Manual: each removed alias now fails with `unknown flag`; canonical `--existing-id` / `--existing-path` invocations still pass flag validation.
- `go test ./cmd/bundle/generate/...` and `go test ./acceptance -run TestAccept/bundle/generate` pass with no golden output changes (hidden flags never appeared in help output).

This pull request and its description were written by Isaac, an AI coding agent.