### PR TITLE
acceptance: also set HTTP_PROXY to block plain-HTTP external calls

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -779,8 +779,9 @@ func runTest(t *testing.T,
 			// it immediately clear which test caused the internet access.
 			proxyURL = internal.StartRejectingProxy(t, "")
 		}
-		// Only block HTTPS: the local test server is plain HTTP (http://127.0.0.1:PORT)
-		// so HTTP_PROXY would intercept its traffic. All real external calls use HTTPS.
+		// Block both HTTP and HTTPS external traffic. NO_PROXY below exempts the
+		// local test server (http://127.0.0.1:PORT) so its traffic is not intercepted.
+		cmd.Env = append(cmd.Env, "HTTP_PROXY="+proxyURL)
 		cmd.Env = append(cmd.Env, "HTTPS_PROXY="+proxyURL)
 		// Python's urllib does not automatically bypass the proxy for loopback
 		// addresses the way Go does, so the test-server helper scripts


### PR DESCRIPTION
Closes the TODO from https://github.com/databricks/cli/pull/5483#discussion_r3395703332.

`NO_PROXY=127.0.0.1,localhost` already exempts the local test server, so there is no reason to leave plain-HTTP external traffic unblocked. Adding `HTTP_PROXY` alongside `HTTPS_PROXY` ensures the sandbox catches rogue HTTP calls too.