### PR TITLE
bundle/config: flip workspace URL test to opt-out

### DIFF
--- a/bundle/config/resources_test.go
+++ b/bundle/config/resources_test.go
@@ -116,45 +116,37 @@ func TestSupportedResources(t *testing.T) {
 	}
 }
 
-// Bundle resources whose InitializeURL() resolves via workspaceurls. When a
-// pattern key or a bundle plural name drifts, ResourceURL returns "" and this
-// test fails loudly instead of silently producing empty URLs in bundle summary.
+// All bundle resources must have a workspace URL, except those listed in noURL.
+// When a pattern key or a bundle plural name drifts, ResourceURL returns "" and
+// this test fails loudly instead of silently producing empty URLs in bundle summary.
+// When adding a new resource, add a URL pattern in libs/workspaceurls or add the
+// plural name to noURL with a comment explaining why no URL exists.
 func TestBundleResourcePluralNamesResolveInWorkspaceURLs(t *testing.T) {
-	withURLs := []string{
-		"alerts",
-		"apps",
-		"catalogs",
-		"clusters",
-		"dashboards",
-		"database_catalogs",
-		"database_instances",
-		"experiments",
-		"jobs",
-		"models",
-		"model_serving_endpoints",
-		"pipelines",
-		"postgres_catalogs",
-		"postgres_synced_tables",
-		"quality_monitors",
-		"registered_models",
-		"schemas",
-		"sql_warehouses",
-		"synced_database_tables",
-		"vector_search_endpoints",
-		"vector_search_indexes",
-		"volumes",
+	// Resources that intentionally have no workspace URL.
+	noURL := map[string]bool{
+		"external_locations": true,
+		"postgres_branches":  true,
+		"postgres_endpoints": true,
+		"postgres_projects":  true,
+		"secret_scopes":      true,
 	}
 
 	supported := SupportedResources()
-	for _, name := range withURLs {
+
+	// Catch stale noURL entries when a resource is removed from SupportedResources.
+	for name := range noURL {
 		_, ok := supported[name]
-		require.Truef(t, ok, "%q is not a bundle plural name, update SupportedResources or this test", name)
+		require.Truef(t, ok, "%q is in the noURL list but is not a supported bundle resource; remove it from noURL", name)
 	}
 
 	base := url.URL{Scheme: "https", Host: "example.com"}
-	for _, name := range withURLs {
+	for name := range supported {
 		got := workspaceurls.ResourceURL(base, name, "test-id")
-		assert.NotEmptyf(t, got, "workspaceurls.ResourceURL(%q) returned empty; pattern key renamed or alias missing", name)
+		if noURL[name] {
+			assert.Emptyf(t, got, "workspaceurls.ResourceURL(%q) returned non-empty; remove %q from noURL or remove its URL pattern", name, name)
+		} else {
+			assert.NotEmptyf(t, got, "workspaceurls.ResourceURL(%q) returned empty; add a URL pattern in libs/workspaceurls or add %q to noURL", name, name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Changes

Refactor `TestBundleResourcePluralNamesResolveInWorkspaceURLs` from an opt-in list (`withURLs`, 22 entries) to an opt-out map (`noURL`, 5 entries). The test now iterates all `SupportedResources()` automatically and asserts every resource either resolves to a non-empty workspace URL or is explicitly listed as having no URL.

## Why

Follow-up to #5346

The opt-in approach required manually adding new resources to the test list, making it easy to silently miss coverage. The opt-out approach catches omissions by default: any new resource added to `SupportedResources()` will fail the test unless it has a URL pattern in `libs/workspaceurls` or is explicitly opted out with a comment.

As a bonus, the refactor surfaces that `genie_spaces` was already present in `resourceURLPatterns` but had been inadvertently omitted from the old `withURLs` list.

A staleness check guards the `noURL` map itself: if a resource is removed from `SupportedResources()`, the test fails rather than silently carrying a dead opt-out entry.

## Tests

Existing test updated; runs as part of `./task test`.

_This PR was written by Claude Code._