### PR TITLE
acceptance: Preserve ConfigFile in proxy

### DIFF
--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -97,6 +97,12 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 			cfg = &sdkconfig.Config{
 				Host:  host,
 				Token: token,
+				// Preserve the resolved config-file path (e.g. deco sets it to /dev/null)
+				// so the CLI subprocess stays isolated from the developer's ~/.databrickscfg,
+				// matching the non-proxy path. Otherwise the subprocess re-reads the default
+				// config and can fall back to a default_profile (e.g. via [__settings__]),
+				// which breaks auth on cloud record-requests runs.
+				ConfigFile: cfg.ConfigFile,
 			}
 		}
 


### PR DESCRIPTION
## Changes
Preserve ConfigFile

## Why
Without it, the config file set to /dev/null by `deco env run` isn't respected and falls back to developer's `~/.databrickscfg`. If that one has `[__settings__].default_profile` set, calls fail.

#5616 attempted to fix this, but if the host is in .databrickscfg with no auth in cache, the token still isn't respected. Once that is solved, we can revert this PR

## Tests
`deco env run`