### PR TITLE
Pause the passive CLI update-available notice

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Notable Changes
 
 ### CLI
-* Show a once-per-day notice after a command when a newer CLI release is available, with a link to the release and the upgrade command for the detected install method. Suppressed for non-interactive/CI runs, JSON output, the Databricks Runtime, and development builds, and can be disabled with `DATABRICKS_CLI_DISABLE_UPDATE_CHECK` ([#5470](https://github.com/databricks/cli/pull/5470)).
 * Improved error messages for `ssh connect`: when an SSH connection attempt fails, the client now fetches and prints the server's recent error logs ([#5555](https://github.com/databricks/cli/pull/5555)).
 * Increase the SSH server startup timeout from 10 to 45 minutes when a GPU accelerator is requested via `databricks ssh connect --accelerator` ([#5569](https://github.com/databricks/cli/pull/5569)).
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/telemetry"
 	"github.com/databricks/cli/libs/telemetry/protos"
-	"github.com/databricks/cli/libs/versioncheck"
 	"github.com/spf13/cobra"
 )
 
@@ -82,11 +81,6 @@ func New(ctx context.Context) *cobra.Command {
 		ctx = withInteractiveModeInUserAgent(ctx)
 		ctx = InjectTestPidToUserAgent(ctx)
 		cmd.SetContext(ctx)
-
-		// Refresh the latest-version cache in the background (no-op when
-		// suppressed). The result is shown by [versioncheck.Notice] after the
-		// command completes, so this never blocks the command.
-		versioncheck.StartBackgroundRefresh(ctx, cmd)
 		return nil
 	}
 
@@ -202,12 +196,6 @@ Stack Trace:
 	})
 	if telemetryErr != nil {
 		log.Infof(ctx, "telemetry upload failed: %s", telemetryErr)
-	}
-
-	// Print a "new version available" notice if one is due (no-op when
-	// suppressed, on error, or when nothing is cached yet).
-	if msg := versioncheck.Notice(cmd.Context(), cmd, err); msg != "" {
-		fmt.Fprintln(cmd.ErrOrStderr(), msg)
 	}
 
 	return err

--- a/libs/versioncheck/notice.go
+++ b/libs/versioncheck/notice.go
@@ -63,6 +63,8 @@ const (
 // once per day) and stores it in the cache, so a later command can show the
 // notice without a blocking network call. It is a no-op when the notice would
 // be suppressed anyway. Safe to call on every invocation.
+//
+//deadcode:allow Passive update notice paused for 1.4.0: unwired from cmd/root while we settle how to target long-lived, outdated environments without nagging fresh installs. Re-enable by restoring the root command calls.
 func StartBackgroundRefresh(ctx context.Context, cmd *cobra.Command) {
 	if !notifyEnabled(ctx, cmd) {
 		return


### PR DESCRIPTION
## Why

The CLI gained a passive, once-per-day "a new release is available" notice in #5470. It merged right after v1.3.0 was tagged, so it hasn't shipped to anyone yet; v1.4.0 would be its first release. This pauses it before that happens.

The notice is meant for people running an outdated CLI in a long-lived local environment. But as written it can't distinguish them from a brand-new install, which is almost always already up to date. So the person most likely to see the very first nudge is someone who just installed the CLI and has nothing to upgrade, while the background GitHub call runs for everyone. Until we have a way to target the case we actually care about, the safer default is off.

The explicit `databricks version --check` command (#5469, shipped in v1.3.0) is unaffected: users who want to check stay in control.

## Changes

Before: every interactive command started a background check against GitHub and could print an upgrade notice after the command finished.

Now: the passive notice is unwired from the root command, so neither the background fetch nor the notice runs. A normal command makes no call to GitHub.

- Remove the `StartBackgroundRefresh` and `Notice` calls (and the import) from `cmd/root/root.go`.
- Drop the unreleased `NEXT_CHANGELOG.md` entry, since the feature won't ship in 1.4.0.
- Keep the implementation in `libs/versioncheck` intact, with a `//deadcode:allow` note explaining the pause. Re-enabling is just restoring the two root-command calls once we settle on the targeting.

## Test plan

- [x] `go build ./...`
- [x] `go test ./libs/versioncheck/... ./cmd/root/... ./cmd/version/...`
- [x] `./task fmt-q`, `./task lint-q`, and `./task checks` clean (including the deadcode gate)

This pull request and its description were written by Isaac.
