### PR TITLE
docs: add project URLs to pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,6 +14,12 @@ license = { file = "LICENSE" }
 dependencies = [
 ]
 
+[project.urls]
+Changelog = "https://github.com/databricks/cli/blob/main/CHANGELOG.md"
+Documentation = "https://databricks.github.io/cli/python/"
+Issues = "https://github.com/databricks/cli/issues"
+Repository = "https://github.com/databricks/cli/tree/main/python"
+
 [build-system]
 requires = ["flit_core==3.12.0"]
 build-backend = "flit_core.buildapi"


### PR DESCRIPTION
## Summary

Adds "Changelog", "Documentation", "Issues" and "Repository" links to the `project.urls` section of the pyproject.toml file.

## Why

These links appear on the PyPI project page. They're also useful for tools like [Renovate](https://docs.renovatebot.com) which read this metadata.

See [the PyPA docs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls) for details on this section and commonly provided links.

## How is this tested?

N/A

---

NO_CHANGELOG=true