### PR TITLE
Use idiomatic httptest handler failures in labs installer tests

### DIFF
--- a/cmd/labs/project/installer_test.go
+++ b/cmd/labs/project/installer_test.go
@@ -193,8 +193,8 @@ func TestInstallerWorksForReleases(t *testing.T) {
 			})
 			return
 		}
-		t.Logf("Requested: %s", r.URL.Path)
-		t.FailNow()
+		t.Errorf("unexpected request: %s", r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
@@ -262,8 +262,8 @@ func TestOfflineInstallerWorksForReleases(t *testing.T) {
 			})
 			return
 		}
-		t.Logf("Requested: %s", r.URL.Path)
-		t.FailNow()
+		t.Errorf("unexpected request: %s", r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
@@ -362,8 +362,8 @@ func TestInstallerWorksForDevelopment(t *testing.T) {
 			})
 			return
 		}
-		t.Logf("Requested: %s", r.URL.Path)
-		t.FailNow()
+		t.Errorf("unexpected request: %s", r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
@@ -453,8 +453,8 @@ func TestUpgraderWorksForReleases(t *testing.T) {
 			})
 			return
 		}
-		t.Logf("Requested: %s", r.URL.Path)
-		t.FailNow()
+		t.Errorf("unexpected request: %s", r.URL.Path)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
@@ -496,7 +496,6 @@ func TestUpgraderWorksForReleases(t *testing.T) {
 		}
 	}
 	if !pi {
-		t.Logf(`Expected stub command 'python[\S]+ -m pip install --upgrade --upgrade-strategy eager .' not found`)
-		t.FailNow()
+		t.Fatal(`Expected stub command 'python[\S]+ -m pip install --upgrade --upgrade-strategy eager .' not found`)
 	}
 }


### PR DESCRIPTION
Follow-up to a review comment on #5559.

`t.FailNow()` is documented as only legal on the goroutine running the test. The labs installer tests call it from inside `httptest` handler goroutines as the "unexpected request" fallback, where it only runs `runtime.Goexit` on the handler goroutine: the test is not actually failed and the client sees a dropped connection, which surfaces as a confusing error rather than a clear message.

This replaces the four handler-goroutine occurrences with the idiomatic shape — `t.Errorf(...)` to record the failure on the test, plus `http.Error(w, "unexpected request", http.StatusInternalServerError)` to return a clear response. The one remaining `t.FailNow()` is on the test goroutine (a `t.Logf` / `t.FailNow` pair after the runner returns) and is collapsed to `t.Fatal`.

Test-only change; no user-facing behavior changes.

This pull request and its description were written by Isaac, an AI coding agent.
