### PR TITLE
Add a few engineering rules to the agent docs

### DIFF
--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -122,6 +122,12 @@ for p := range changes {
 return fieldPaths
 ```
 
+### Encoding
+
+**RULE: When mutating an API response by round-tripping JSON, decode with `json.Decoder` + `UseNumber()`.** The naive `json.Marshal` → `map[string]any` → `Marshal` path corrupts any int64 larger than 2^53 (it degrades to a float64 mantissa — e.g. a real `spark_context_id`) and alphabetizes object keys. `libs/dyn/jsonloader` preserves key order but also lacks `UseNumber`, so it shares the int64 hazard.
+
+**RULE: Be careful with `encoding/csv` `Writer.UseCRLF = true`.** It rewrites both record terminators AND embedded newlines inside quoted fields to `\r\n`, so tests for quoted multiline fields must expect `\r\n`, not just the line endings between rows.
+
 ### Environment variables
 
 **RULE: In library and product code, use `github.com/databricks/cli/libs/env` for reading environment variables, not `os.Getenv`.** `env.Get(ctx, name)` and `env.Lookup(ctx, name)` can be overridden per-context in tests, so you don't have to mutate process-wide state to exercise a code path. `os.Getenv` is still fine in `main`, tests, and acceptance/integration harnesses where no `ctx` is available and overrides aren't needed.

--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -91,6 +91,12 @@ acceptance/cmd/fs/cp/file-to-dir/
 
 If the only reason for divergence is a server-side default that one engine sets and the other doesn't, set the field explicitly in `databricks.yml` so both engines produce identical output. Don't paper over it with per-engine files.
 
+**RULE: On Windows, Git Bash auto-converts a leading-`/` path argument (e.g. `/api/2.0/...`) into a Windows path, so `$CLI` sees the wrong path and the testserver 404s.** Set `MSYS_NO_PATHCONV = "1"` in the test directory's `test.toml` under `[Env]`. Quoting the argument in bash does NOT help — the conversion is done by the Windows binary's argument processing. Precedent: `acceptance/cmd/workspace/export-dir-*/test.toml`.
+
+**RULE: `EnvMatrix.<VAR> = []` removes that variable from the inherited matrix** (see `ExpandEnvMatrix` in `acceptance/internal/config.go`). The root `test.toml` matrixes `DATABRICKS_BUNDLE_ENGINE = [terraform, direct]`, so a non-bundle test opts out of both engine runs with `EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []`. The `out.test.toml` snapshot of inherited values is generated and committed by design.
+
+**RULE: If a test's `out.test.toml` is still in the older `[EnvMatrix]` block format, a regen rewrites it to the inline form and the post-test `git diff --exit-code` check fails** ("out.test.toml files that are out of date"). Regenerate just those files with `go test ./acceptance -run "^TestAccept$" -only-out-test-toml`, then commit.
+
 ### Reference
 
 - Tests live in `acceptance/` with a nested directory structure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,14 @@ parentPath = "/Workspace" + parentPath
 
 Where a panic is genuinely possible (e.g. `reflect.Type.Elem()` on a non-pointer, division by an empty slice's length), validate at the entry point and return an error.
 
+**RULE: Never copy a `config.Config` by value.** It embeds a `sync.Mutex`, so `go vet` copylocks fails and CI lint blocks it (govet runs with enable-all). Pass it by pointer, or mutate the resolved config in place (e.g. set `HTTPTimeoutSeconds` on it before `client.New`; there is no per-request option).
+
+**RULE: Open URLs through `libs/browser`, never `github.com/pkg/browser` directly.** `pkg/browser` ignores the `BROWSER` env var, so `BROWSER=none` and custom browser commands break. `browser.Open(ctx, url)` handles empty/none/custom in one path; branch on `browser.IsDisabled(ctx)` first if you need custom messaging. For a custom `BROWSER=<command>`, launch via `libs/exec`, not an inline `cmd /c` (that broke Windows OAuth URLs via `%...%` expansion).
+
+**RULE: For hand-written workspace-routed raw API calls (`client.Do` / `apiClient.Do`), set routing headers via `libs/auth.WorkspaceIDHeaders`.** It emits `X-Databricks-Workspace-Id` and suppresses the legacy `workspace_id = none` sentinel. Grepping only for old header names misses calls that never set any routing header but still need one.
+
+**RULE: To keep an intentionally-unreferenced exported function, mark it `//deadcode:allow <reason>` within 6 lines above the `func`.** CI runs `deadcode -test ./...`; a func reachable only from a `*_test.go` is not flagged, so unwiring a feature can leave a sibling entry point dead. (`gofmt` inserts a blank `//` line between the directive and the doc comment; that's expected and still detected.)
+
 # Error Handling
 
 **RULE: Wrap errors with context using `%w`.** Preserves the error chain so `errors.Is` and `errors.As` keep working upstream.
@@ -168,6 +176,8 @@ if err != nil && strings.Contains(err.Error(), "does not exist") {
 	return nil
 }
 ```
+
+**RULE: Error strings must not end with punctuation or a newline (golangci-lint ST1005).** Applies to `fmt.Errorf` / `errors.New`: when appending a multi-sentence hint to an error, drop the final period (mid-string periods and newlines are fine). Keep `Error()` methods unpunctuated at the end too, for consistency.
 
 # CLI UX and validation
 


### PR DESCRIPTION
## Why

A few durable engineering rules that come up repeatedly in this repo weren't captured in the agent docs yet. This adds them so they're applied consistently.

## Changes

Docs only, no code change. Adds rules to three existing files:

- `AGENTS.md`: don't copy `config.Config` by value (copylocks); open URLs via `libs/browser`, not `github.com/pkg/browser`; set routing headers via `libs/auth.WorkspaceIDHeaders` on hand-written workspace-routed calls; the `//deadcode:allow` directive; error strings must not end with punctuation (ST1005).
- `.agent/rules/style-guide-go.md`: use `json.Decoder` + `UseNumber()` when round-tripping API responses (avoids int64 > 2^53 corruption and key reordering); `encoding/csv` `UseCRLF` also rewrites embedded newlines in quoted fields.
- `.agent/rules/testing.md`: `MSYS_NO_PATHCONV` for POSIX path args on Windows; `EnvMatrix.<VAR> = []` drops a matrix variable; regenerating block-format `out.test.toml`.

## Test plan

- [x] `./task fmt-q`, `./task checks`, `./task lint-q` all pass
- Docs-only change; no code or tests affected.

This pull request and its description were written by Isaac.
