### PR TITLE
acceptance: Add Shell langugage attribute to script files

### DIFF
--- a/acceptance/.gitattributes
+++ b/acceptance/.gitattributes
@@ -12,3 +12,10 @@ out.test.toml linguist-generated=true
 # Do not mark generated files as conflicted, they should simply be regenerated.
 # Note, you need top run .gitconfig.install to enable 'ours' driver
 out* merge=ours
+
+# Acceptance test scripts have no file extension and most have no shebang, so
+# GitHub's linguist treats them as plain text. Force Shell so they get syntax
+# highlighting in blob and diff views, which makes reviewing them easier.
+script linguist-language=Shell
+script.prepare linguist-language=Shell
+script.cleanup linguist-language=Shell


### PR DESCRIPTION
## Changes
Add gitattribute for script files to mark them as `Shell`

## Why
Syntax highlighting when viewing files and diffs on PRs

## Tests
