### PR TITLE
acceptance: sort get-index schema_json in vector search schema_normalization test

### DIFF
--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/script
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/script
@@ -8,10 +8,11 @@ trap cleanup EXIT
 
 trace $CLI bundle deploy
 
-# The backend (and the test server) rewrite the schema on create, so
-# get-index returns Spark type names and sorted keys, not the config literal.
+# The backend (and the test server) rewrite the schema on create, so get-index
+# returns Spark type names, not the config literal. The backend does not
+# guarantee column order, so sort keys to keep this comparison stable.
 index_name="main.default.vs_index_${UNIQUE_NAME}"
-trace $CLI vector-search-indexes get-index "${index_name}" | jq -r '.direct_access_index_spec.schema_json'
+trace $CLI vector-search-indexes get-index "${index_name}" | jq -rcS '.direct_access_index_spec.schema_json | fromjson'
 
 # Re-plan must be a no-op: remote changes to schema_json are ignored
 # (ignore_remote_changes), so the immutable spec does not plan a recreate.


### PR DESCRIPTION
The test compares the raw get-index schema_json against a golden with sorted keys. The local test server sorts keys (Go encoding/json) but the cloud backend does not guarantee column order (even though it did return it sorted previously when added in #5481), so the golden was stale and the test failed on cloud. Sorting the keys in the script keeps the comparison stable regardless of backend ordering and is byte-identical to the existing golden.

Co-authored-by: Isaac
