### PR TITLE
Print modern pipeline update URL from bundle run

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.
+* `bundle run` now prints the modern pipeline update URL (`/pipelines/<id>/updates/<id>`) instead of the legacy `#joblist` hash-fragment URL, mirroring the job run URL change so the printed URL uses the modern path form.
 
 ### Dependency updates
 

--- a/acceptance/bundle/run/refresh-flags/output.txt
+++ b/acceptance/bundle/run/refresh-flags/output.txt
@@ -7,7 +7,7 @@ Deployment complete!
 
 === Running pipeline with --refresh flag and specific tables
 >>> [CLI] bundle run my_pipeline --refresh table1,table2
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -25,7 +25,7 @@ Update ID: [UUID]
 
 === Running pipeline with --full-refresh-all flag
 >>> [CLI] bundle run my_pipeline --full-refresh-all
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -40,7 +40,7 @@ Update ID: [UUID]
 
 === Running pipeline with --full-refresh flag and specific tables
 >>> [CLI] bundle run my_pipeline --full-refresh table1,table2
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -58,7 +58,7 @@ Update ID: [UUID]
 
 === Running pipeline with --full-refresh flag and --refresh flag
 >>> [CLI] bundle run my_pipeline --full-refresh table1,table2 --refresh table3,table4
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/acceptance/pipelines/dry-run/dry-run-pipeline/output.txt
+++ b/acceptance/pipelines/dry-run/dry-run-pipeline/output.txt
@@ -12,7 +12,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 {
@@ -29,7 +29,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 {

--- a/acceptance/pipelines/dry-run/no-wait/output.txt
+++ b/acceptance/pipelines/dry-run/no-wait/output.txt
@@ -12,6 +12,6 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]

--- a/acceptance/pipelines/dry-run/restart/output.txt
+++ b/acceptance/pipelines/dry-run/restart/output.txt
@@ -12,7 +12,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/acceptance/pipelines/e2e/output.txt
+++ b/acceptance/pipelines/e2e/output.txt
@@ -29,7 +29,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -80,7 +80,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/acceptance/pipelines/run/no-wait/output.txt
+++ b/acceptance/pipelines/run/no-wait/output.txt
@@ -12,7 +12,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/acceptance/pipelines/run/refresh-flags/output.txt
+++ b/acceptance/pipelines/run/refresh-flags/output.txt
@@ -12,7 +12,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -39,7 +39,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -63,7 +63,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 
@@ -90,7 +90,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/acceptance/pipelines/run/restart/output.txt
+++ b/acceptance/pipelines/run/restart/output.txt
@@ -12,7 +12,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/acceptance/pipelines/run/run-info/output.txt
+++ b/acceptance/pipelines/run/run-info/output.txt
@@ -12,7 +12,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/test-update-123
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/test-update-123
 
 [TIMESTAMP] update_progress  "Update test-update-123 is COMPLETED."
 [TIMESTAMP] update_progress  "Update test-update-123 is RUNNING."

--- a/acceptance/pipelines/stop/output.txt
+++ b/acceptance/pipelines/stop/output.txt
@@ -11,7 +11,7 @@ Recommendation: This command runs the last deployed version of the code
 
 If you've made local changes, run 'databricks pipelines deploy' first to ensure they are included.
 
-Update URL: [DATABRICKS_URL]/#joblist/pipelines/[UUID]/updates/[UUID]
+Update URL: [DATABRICKS_URL]/pipelines/[UUID]/updates/[UUID]
 
 Update ID: [UUID]
 

--- a/bundle/run/progress/pipeline_events.go
+++ b/bundle/run/progress/pipeline_events.go
@@ -1,6 +1,10 @@
 package progress
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/databricks/cli/libs/workspaceurls"
+)
 
 type PipelineUpdateUrlEvent struct {
 	Type       string `json:"type"`
@@ -14,7 +18,7 @@ func NewPipelineUpdateUrlEvent(host, updateId, pipelineId string) *PipelineUpdat
 		Type:       "pipeline_update_url",
 		UpdateId:   updateId,
 		PipelineId: pipelineId,
-		Url:        fmt.Sprintf("%s/#joblist/pipelines/%s/updates/%s", host, pipelineId, updateId),
+		Url:        fmt.Sprintf("%s/%s", host, workspaceurls.PipelineUpdatePath(pipelineId, updateId)),
 	}
 }
 

--- a/libs/workspaceurls/urls.go
+++ b/libs/workspaceurls/urls.go
@@ -81,6 +81,21 @@ func JobRunPath(jobID, runID string) string {
 	return fmt.Sprintf("jobs/%s/runs/%s", jobID, runID)
 }
 
+// PipelineUpdatePath returns the modern workspace path for a pipeline update, of
+// the form
+//
+//	pipelines/<pipelineID>/updates/<updateID>
+//
+// Callers join this onto a workspace base URL. The CLI historically emitted a
+// legacy hash-fragment URL (#joblist/pipelines/<id>/updates/<id>); this switches
+// to the modern path form for consistency with the rest of the package and with
+// the job run URL fix, where the legacy fragment form was found not to resolve
+// for non-admin users permitted to view the run.
+// See https://github.com/databricks/cli/issues/5142.
+func PipelineUpdatePath(pipelineID, updateID string) string {
+	return fmt.Sprintf("pipelines/%s/updates/%s", pipelineID, updateID)
+}
+
 // ResourceURL constructs a workspace URL for a named resource type and ID.
 func ResourceURL(baseURL url.URL, resourceType, id string) string {
 	resourceType = resolveAlias(resourceType)

--- a/libs/workspaceurls/urls_test.go
+++ b/libs/workspaceurls/urls_test.go
@@ -35,6 +35,10 @@ func TestJobRunPath(t *testing.T) {
 	assert.Equal(t, "jobs/123/runs/456", JobRunPath("123", "456"))
 }
 
+func TestPipelineUpdatePath(t *testing.T) {
+	assert.Equal(t, "pipelines/abc-def/updates/upd-1", PipelineUpdatePath("abc-def", "upd-1"))
+}
+
 func TestResourceTypes(t *testing.T) {
 	types := ResourceTypes()
 	assert.NotEmpty(t, types)


### PR DESCRIPTION
## Changes

`bundle run` now prints the modern pipeline update URL (`/pipelines/<id>/updates/<id>`) instead of the legacy `#joblist/pipelines/<id>/updates/<id>` hash-fragment URL.

- Add a `PipelineUpdatePath(pipelineID, updateID)` builder in `libs/workspaceurls`, mirroring `JobRunPath`.
- Emit the modern path form from `NewPipelineUpdateUrlEvent` instead of constructing the `#joblist` fragment inline.

> Stacked on #5629 (`issue-5142-job-run-url`).

## Why

The CLI historically emitted a legacy hash-fragment URL for pipeline updates. This switches to the modern path form for consistency with the rest of the CLI's workspace URLs and with the job run URL change in #5142, where the legacy fragment form was found not to resolve for non-admin users permitted to view the run.

See https://github.com/databricks/cli/issues/5142.

## Tests

- Added `TestPipelineUpdatePath` unit test.
- Updated acceptance test outputs for pipeline `run`/`dry-run`/`stop` commands to the modern URL form.