### PR TITLE
lintdiff: use git diff --merge-base in one step

### DIFF
--- a/tools/lintdiff.py
+++ b/tools/lintdiff.py
@@ -45,13 +45,11 @@ def main():
     if gitroot:
         os.chdir(gitroot[0])
 
-    # Resolve the merge base between the ref and HEAD so that we only lint
-    # files changed on this branch, not files that changed on the ref since
-    # the branch point.
-    merge_base = parse_lines(["git", "merge-base", args.ref, "HEAD"])
-    base = merge_base[0] if merge_base else args.ref
-
-    changed = parse_lines(["git", "diff", "--name-only", base, "--", "."])
+    # Diff the merge base against the working tree so we only lint files changed
+    # on this branch, not files that advanced on the ref since the branch point.
+    # Unlike testmask's three-dot "ref...HEAD" form (tools/testmask/git.go), this
+    # includes the dirty tree's uncommitted changes, which is the point of --fix.
+    changed = parse_lines(["git", "diff", "--name-only", "--merge-base", args.ref, "--", "."])
 
     cmd = args.args[:]
 


### PR DESCRIPTION
`lintdiff.py` resolved the merge base in two git calls (`git merge-base` then `git diff <base>`); `--merge-base` does the same in one. Output is byte-for-byte identical on the success path.

This follows up the reviewer note on #5551, which switched testmask to the three-dot `ref...HEAD` form for the same "diff against the branch point, not the ref tip" reason and pointed at `lintdiff.py` as the other merge-base site. Unlike three-dot (which compares two commits), lintdiff keeps diffing against the working tree so the `--fix` flow still lints uncommitted changes — now noted in the comment.

This pull request and its description were written by Isaac.
