### PR TITLE
acc: fix [TIMESTAMP] regex to match negative timezone offsets

### DIFF
--- a/acceptance/test.toml
+++ b/acceptance/test.toml
@@ -76,14 +76,14 @@ Order = 10
 
 [[Repls]]
 # "2025-10-23T14:26:43.499488Z"
-Old = '2\d\d\d-\d\d-\d\d(T| )\d\d:\d\d:\d\d\.\d+(Z|\+\d\d:\d\d)?'
+Old = '2\d\d\d-\d\d-\d\d(T| )\d\d:\d\d:\d\d\.\d+(Z|[+-]\d\d:\d\d)?'
 New = "[TIMESTAMP]"
 Order = 9
 
 [[Repls]]
 # "2025-10-23T14:26:43"
 # "2025-10-23T14:26:43Z"
-Old = '2\d\d\d-\d\d-\d\d(T| )\d\d:\d\d:\d\dZ?'
+Old = '2\d\d\d-\d\d-\d\d(T| )\d\d:\d\d:\d\d(Z|[+-]\d\d:\d\d)?'
 New = "[TIMESTAMP]"
 Order = 9
 


### PR DESCRIPTION
The `[TIMESTAMP]` replacement patterns only matched `Z` or `+xx:xx` timezone suffixes. On machines in US timezones (e.g. `-07:00`), the suffix was left as a literal, producing `[TIMESTAMP]-07:00` in output instead of `[TIMESTAMP]`.

This pull request and its description were written by Isaac.