### PR TITLE
Use deployed name for synced database tables in bundle summary

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 ### Bundles
+* `bundle summary` now reports the deployed name and URL for `synced_database_tables` (loaded from state) instead of the raw `${resources...}` reference when the configured name embeds another resource's name, matching the existing behavior of `postgres_synced_tables` ([#5639](https://github.com/databricks/cli/pull/5639)).
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.
 * Fix missing field descriptions in the bundle JSON schema for fields whose upstream API docs arrived after the field was first annotated (e.g. `vector_search_endpoints.*.target_qps`); stale placeholder markers no longer hide them ([#5588](https://github.com/databricks/cli/pull/5588)).
 

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.summary.txt
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.summary.txt
@@ -14,5 +14,5 @@ Resources:
       URL:  [DATABRICKS_URL]/compute/database-instances/test-db-synced-table-[UNIQUE_NAME]
   Synced database tables:
     my_synced_table:
-      Name: ${resources.database_catalogs.my_catalog.name}.${resources.database_catalogs.my_catalog.database_name}.my_synced_table
-      URL:  [DATABRICKS_URL]/explore/data/$%7Bresources.database_catalogs.my_catalog.name%7D.$%7Bresources.database_catalogs.my_catalog.database_name%7D.my_synced_table
+      Name: my_catalog_[UNIQUE_NAME].my_database.my_synced_table
+      URL:  [DATABRICKS_URL]/explore/data/my_catalog_[UNIQUE_NAME].my_database.my_synced_table

--- a/acceptance/bundle/resources/synced_database_tables/basic/output.txt
+++ b/acceptance/bundle/resources/synced_database_tables/basic/output.txt
@@ -21,7 +21,7 @@ Resources:
   Synced database tables:
     my_synced_table:
       Name: ${resources.database_catalogs.my_catalog.name}.${resources.database_catalogs.my_catalog.database_name}.my_synced_table
-      URL:  [DATABRICKS_URL]/explore/data/$%7Bresources.database_catalogs.my_catalog.name%7D.$%7Bresources.database_catalogs.my_catalog.database_name%7D.my_synced_table
+      URL:  (not deployed)
 
 >>> [CLI] bundle validate
 Name: deploy-lakebase-synced-table-[UNIQUE_NAME]

--- a/acceptance/bundle/resources/synced_database_tables/basic/test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/test.toml
@@ -1,6 +1,5 @@
 Local = true
 Cloud = true
-Badness = "post deployment, bundle summary should print actual name that is fully resolved"
 
 RecordRequests = false
 

--- a/bundle/config/resources/synced_database_table.go
+++ b/bundle/config/resources/synced_database_table.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"net/url"
+	"strings"
 
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/workspaceurls"
@@ -35,6 +36,14 @@ func (s *SyncedDatabaseTable) ResourceDescription() ResourceDescription {
 }
 
 func (s *SyncedDatabaseTable) GetName() string {
+	// A synced table's id is its three-part name (catalog.schema.table), so the
+	// id IS the name. Prefer the post-deploy id so bundle summary renders the
+	// resolved name even when the configured name still has unresolved
+	// cross-resource references like ${resources.X.Y.Z}. Mirrors
+	// PostgresSyncedTable.GetName.
+	if s.ID != "" {
+		return s.ID
+	}
 	return s.Name
 }
 
@@ -43,8 +52,11 @@ func (s *SyncedDatabaseTable) GetURL() string {
 }
 
 func (s *SyncedDatabaseTable) InitializeURL(baseURL url.URL) {
-	if s.Name == "" {
+	// Bail if the name isn't a fully resolved three-part identifier; an
+	// unresolved ${...} reference would otherwise produce a misleading URL.
+	name := s.GetName()
+	if strings.Count(name, ".") != 2 {
 		return
 	}
-	s.URL = workspaceurls.ResourceURL(baseURL, "synced_database_tables", s.Name)
+	s.URL = workspaceurls.ResourceURL(baseURL, "synced_database_tables", name)
 }

--- a/bundle/config/resources/synced_database_table_test.go
+++ b/bundle/config/resources/synced_database_table_test.go
@@ -1,0 +1,43 @@
+package resources
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncedDatabaseTableGetName(t *testing.T) {
+	s := &SyncedDatabaseTable{
+		SyncedDatabaseTable: database.SyncedDatabaseTable{
+			Name: "${resources.database_catalogs.cat.name}.public.t",
+		},
+	}
+
+	// Before deploy the configured name (with its unresolved reference) is used.
+	assert.Equal(t, "${resources.database_catalogs.cat.name}.public.t", s.GetName())
+
+	// After deploy the resolved name is loaded into the id and preferred.
+	s.ID = "my_catalog.public.t"
+	assert.Equal(t, "my_catalog.public.t", s.GetName())
+}
+
+func TestSyncedDatabaseTableInitializeURL(t *testing.T) {
+	baseURL := url.URL{Scheme: "https", Host: "example.com"}
+
+	s := &SyncedDatabaseTable{
+		SyncedDatabaseTable: database.SyncedDatabaseTable{
+			Name: "${resources.database_catalogs.cat.name}.public.t",
+		},
+	}
+
+	// An unresolved reference is not a three-part name, so no URL is produced.
+	s.InitializeURL(baseURL)
+	assert.Empty(t, s.URL)
+
+	// The resolved three-part id yields a URL.
+	s.ID = "my_catalog.public.t"
+	s.InitializeURL(baseURL)
+	assert.Contains(t, s.URL, "my_catalog.public.t")
+}


### PR DESCRIPTION
## Changes
`bundle summary` now reports the deployed name and URL for a `synced_database_tables` resource whose configured name embeds another resource's name, instead of printing the raw `${resources...}` reference.

For example:

```yaml
resources:
  database_catalogs:
    my_catalog:
      name: my_catalog
  synced_database_tables:
    my_synced_table:
      name: ${resources.database_catalogs.my_catalog.name}.public.my_synced_table
```

Before (post-deploy summary):

```
  Synced database tables:
    my_synced_table:
      Name: ${resources.database_catalogs.my_catalog.name}.public.my_synced_table
      URL:  .../explore/data/$%7Bresources.database_catalogs.my_catalog.name%7D...
```

After:

```
  Synced database tables:
    my_synced_table:
      Name: my_catalog.public.my_synced_table
      URL:  .../explore/data/my_catalog.public.my_synced_table
```

The fix is in the resource itself: `SyncedDatabaseTable.GetName()` now prefers the post-deploy `id` (the deployed three-part name, which `StateToBundle` already loads from state) over the configured `Name`, and `InitializeURL` derives the URL from it and skips names that aren't a fully-resolved three-part identifier. This mirrors `PostgresSyncedTable.GetName()`, which already handles this exact case.

## Why
A synced table's name embeds another resource's name via a `${resources...}` reference. The `resources` prefix is intentionally not resolved into config during initialize (some such references are only known after deploy), so `bundle summary` (including the in-workspace Bundle resources view, which calls `bundle summary`) showed the raw reference and a broken percent-encoded URL.

The deployed name is already available — `StateToBundle` loads it into the resource `id` — so the resource just needs to prefer it for display, the same way `PostgresSyncedTable` does. Reading from state (rather than re-resolving against config) keeps the summary consistent with what was actually deployed.

## Tests
* Updated `acceptance/bundle/resources/synced_database_tables/basic`: post-deploy summary now shows the resolved name and URL (and the pre-deploy URL is omitted instead of percent-encoding an unresolved reference).
* New unit tests `TestSyncedDatabaseTableGetName` / `TestSyncedDatabaseTableInitializeURL` cover preferring the deployed id and skipping the URL for an unresolved name.
