### PR TITLE
acc: update postgres goldens and testserver for new top-level ID fields

### DIFF
--- a/acceptance/bundle/resources/postgres_branches/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/basic/output.txt
@@ -32,6 +32,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-branch projects/test-pg-proj-[UNIQUE_NAME]/branches/main
 {
+  "branch_id": "main",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.get_branch.txt
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.get_branch.txt
@@ -1,4 +1,5 @@
 {
+  "branch_id": "new-branch-[UNIQUE_NAME]",
   "name": "[MAIN_ID_2]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {

--- a/acceptance/bundle/resources/postgres_branches/replace_existing/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/replace_existing/output.txt
@@ -16,6 +16,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-branch projects/test-pg-proj-[UNIQUE_NAME]/branches/production
 {
+  "branch_id": "production",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {

--- a/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/output.txt
@@ -27,6 +27,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-branch [DEV_BRANCH_ID]
 {
+  "branch_id": "dev-branch",
   "name": "[DEV_BRANCH_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
@@ -102,6 +103,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-branch [DEV_BRANCH_ID]
 {
+  "branch_id": "dev-branch",
   "name": "[DEV_BRANCH_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {
@@ -137,6 +139,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-branch [DEV_BRANCH_ID]
 {
+  "branch_id": "dev-branch",
   "name": "[DEV_BRANCH_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
   "status": {

--- a/acceptance/bundle/resources/postgres_catalogs/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_catalogs/basic/output.txt
@@ -32,6 +32,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-catalog catalogs/lakebase_test_[UNIQUE_NAME]
 {
+  "catalog_id": "lakebase_test_[UNIQUE_NAME]",
   "name": "catalogs/lakebase_test_[UNIQUE_NAME]",
   "status": {
     "branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",

--- a/acceptance/bundle/resources/postgres_databases/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_databases/basic/output.txt
@@ -40,6 +40,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-database projects/test-pg-proj-[UNIQUE_NAME]/branches/main/databases/my-database
 {
+  "database_id": "my-database",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/databases/my-database",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {

--- a/acceptance/bundle/resources/postgres_databases/recreate/output.txt
+++ b/acceptance/bundle/resources/postgres_databases/recreate/output.txt
@@ -154,6 +154,7 @@ Deployment complete!
 === Fetch database and verify it exists after recreation
 >>> [CLI] postgres get-database [MY_DATABASE_ID]-v2
 {
+  "database_id": "test-database-[UNIQUE_NAME]-v2",
   "name": "[MY_DATABASE_ID]-v2",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {

--- a/acceptance/bundle/resources/postgres_databases/update/output.txt
+++ b/acceptance/bundle/resources/postgres_databases/update/output.txt
@@ -29,6 +29,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-database [MY_DATABASE_ID]
 {
+  "database_id": "my-database",
   "name": "[MY_DATABASE_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {
@@ -106,6 +107,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-database [MY_DATABASE_ID]
 {
+  "database_id": "my-database",
   "name": "[MY_DATABASE_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {
@@ -135,6 +137,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-database [MY_DATABASE_ID]
 {
+  "database_id": "my-database",
   "name": "[MY_DATABASE_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {

--- a/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
@@ -36,6 +36,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-endpoint projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom
 {
+  "endpoint_id": "custom",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/output.txt
@@ -16,6 +16,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-endpoint projects/test-pg-proj-[UNIQUE_NAME]/branches/develop/endpoints/primary
 {
+  "endpoint_id": "primary",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/develop/endpoints/primary",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/develop",
   "status": {

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
@@ -28,6 +28,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-endpoint [MY_ENDPOINT_ID]
 {
+  "endpoint_id": "my-endpoint",
   "name": "[MY_ENDPOINT_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {
@@ -116,6 +117,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-endpoint [MY_ENDPOINT_ID]
 {
+  "endpoint_id": "my-endpoint",
   "name": "[MY_ENDPOINT_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {
@@ -160,6 +162,7 @@ Deployment complete!
 
 >>> [CLI] postgres get-endpoint [MY_ENDPOINT_ID]
 {
+  "endpoint_id": "my-endpoint",
   "name": "[MY_ENDPOINT_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
   "status": {

--- a/acceptance/bundle/resources/postgres_projects/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/basic/output.txt
@@ -29,6 +29,7 @@ Deployment complete!
 >>> [CLI] postgres get-project projects/test-pg-proj-[UNIQUE_NAME]
 {
   "name": "projects/test-pg-proj-[UNIQUE_NAME]",
+  "project_id": "test-pg-proj-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "projects/test-pg-proj-[UNIQUE_NAME]/branches/production",

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete/output.txt
@@ -17,6 +17,7 @@ Deployment complete!
 >>> [CLI] postgres get-project projects/test-pg-proj-hard-[UNIQUE_NAME]
 {
   "name": "projects/test-pg-proj-hard-[UNIQUE_NAME]",
+  "project_id": "test-pg-proj-hard-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "projects/test-pg-proj-hard-[UNIQUE_NAME]/branches/production",
@@ -39,6 +40,7 @@ Deployment complete!
 >>> [CLI] postgres get-project projects/test-pg-proj-soft-[UNIQUE_NAME]
 {
   "name": "projects/test-pg-proj-soft-[UNIQUE_NAME]",
+  "project_id": "test-pg-proj-soft-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "projects/test-pg-proj-soft-[UNIQUE_NAME]/branches/production",

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
@@ -1,6 +1,7 @@
 {
   "create_time": "[TIMESTAMP]",
   "name": "[MY_PROJECT_ID_2]",
+  "project_id": "test-pg-new-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "[MY_PROJECT_ID_2]/branches/production",

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/output.txt
@@ -27,6 +27,7 @@ Deployment complete!
 >>> [CLI] postgres get-project [MY_PROJECT_ID]
 {
   "name": "[MY_PROJECT_ID]",
+  "project_id": "test-pg-proj-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "[MY_PROJECT_ID]/branches/production",
@@ -100,6 +101,7 @@ Deployment complete!
 >>> [CLI] postgres get-project [MY_PROJECT_ID]
 {
   "name": "[MY_PROJECT_ID]",
+  "project_id": "test-pg-proj-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "[MY_PROJECT_ID]/branches/production",
@@ -140,6 +142,7 @@ Deployment complete!
 >>> [CLI] postgres get-project [MY_PROJECT_ID]
 {
   "name": "[MY_PROJECT_ID]",
+  "project_id": "test-pg-proj-[UNIQUE_NAME]",
   "status": {
     "branch_logical_size_limit_bytes": [NUMID],
     "default_branch": "[MY_PROJECT_ID]/branches/production",

--- a/acceptance/bundle/resources/postgres_roles/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_roles/basic/output.txt
@@ -38,6 +38,7 @@ Deployment complete!
 {
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "role_id": "test-role",
   "status": {
     "attributes": {
       "bypassrls": false,

--- a/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/output.txt
+++ b/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/output.txt
@@ -120,6 +120,7 @@ Deployment complete!
 {
   "name": "[MY_ROLE_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "role_id": "test-role-[UNIQUE_NAME]",
   "status": {
     "attributes": {
       "bypassrls": false,

--- a/acceptance/bundle/resources/postgres_roles/recreate/output.txt
+++ b/acceptance/bundle/resources/postgres_roles/recreate/output.txt
@@ -120,6 +120,7 @@ Deployment complete!
 {
   "name": "[MY_ROLE_ID]-v2",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "role_id": "test-role-[UNIQUE_NAME]-v2",
   "status": {
     "attributes": {
       "bypassrls": false,

--- a/acceptance/bundle/resources/postgres_roles/update/output.txt
+++ b/acceptance/bundle/resources/postgres_roles/update/output.txt
@@ -30,6 +30,7 @@ Deployment complete!
 {
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "role_id": "test-role",
   "status": {
     "attributes": {
       "bypassrls": false,
@@ -108,6 +109,7 @@ Deployment complete!
 {
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "role_id": "test-role",
   "status": {
     "attributes": {
       "bypassrls": false,
@@ -143,6 +145,7 @@ Deployment complete!
 {
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "role_id": "test-role",
   "status": {
     "attributes": {
       "bypassrls": false,

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -107,6 +107,7 @@ func (s *FakeWorkspace) PostgresProjectCreate(req Request, projectID string) Res
 
 	now := nowTime()
 	project.Name = name
+	project.ProjectId = projectID
 	project.Uid = nextUUID()
 	project.CreateTime = now
 	project.UpdateTime = now
@@ -311,6 +312,7 @@ func (s *FakeWorkspace) PostgresBranchCreate(req Request, parent, branchID strin
 	}
 
 	now := nowTime()
+	branch.BranchId = branchID
 	if exists {
 		// Preserve identifying / output-only fields; apply incoming spec to status.
 		branch.Name = existing.Name
@@ -527,6 +529,7 @@ func (s *FakeWorkspace) PostgresEndpointCreate(req Request, parent, endpointID s
 	}
 
 	now := nowTime()
+	endpoint.EndpointId = endpointID
 	if exists {
 		endpoint.Name = existing.Name
 		endpoint.Parent = existing.Parent
@@ -756,6 +759,7 @@ func (s *FakeWorkspace) PostgresDatabaseCreate(req Request, parent, databaseID s
 
 	now := nowTime()
 	database.Name = name
+	database.DatabaseId = databaseID
 	database.Parent = parent
 	database.CreateTime = now
 	database.UpdateTime = now
@@ -949,6 +953,7 @@ func (s *FakeWorkspace) PostgresCatalogCreate(req Request, catalogID string) Res
 
 	now := nowTime()
 	catalog.Name = name
+	catalog.CatalogId = catalogID
 	catalog.Uid = nextUUID()
 	catalog.CreateTime = now
 	catalog.UpdateTime = now
@@ -1081,6 +1086,7 @@ func (s *FakeWorkspace) PostgresRoleCreate(req Request, parent, roleID string) R
 
 	now := nowTime()
 	role.Name = name
+	role.RoleId = roleID
 	role.Parent = parent
 	role.CreateTime = now
 	role.UpdateTime = now
@@ -1370,6 +1376,7 @@ func (s *FakeWorkspace) createDefaultBranchLocked(projectName string) {
 
 	defaultBranch := postgres.Branch{
 		Name:       branchName,
+		BranchId:   "production",
 		Parent:     projectName,
 		Uid:        branchUID,
 		CreateTime: now,
@@ -1418,6 +1425,7 @@ func (s *FakeWorkspace) createDefaultEndpointLocked(branchName string) {
 
 	s.PostgresEndpoints[endpointName] = postgres.Endpoint{
 		Name:       endpointName,
+		EndpointId: "primary",
 		Parent:     branchName,
 		Uid:        endpointUID,
 		CreateTime: now,


### PR DESCRIPTION
The SDK bump to v0.147.0 (#5636) added top-level ID fields (`project_id`, `branch_id`, `endpoint_id`, `database_id`, `role_id`, `catalog_id`) to the postgres resource types, which the real Lakebase GET APIs now return. This broke every postgres acceptance test on cloud with golden-file mismatches.

Regenerated the affected goldens against cloud, and taught the testserver to emit the same top-level IDs on create so local runs match cloud. Synced tables are unaffected.

Verified: postgres acceptance suite passes both on cloud (`-update`) and locally, testserver unit tests pass, lint clean.

This pull request and its description were written by Isaac.
