### PR TITLE
Disable SQL warehouse lifecycle tests on cloud

### DIFF
--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
@@ -1,4 +1,4 @@
 Local = true
-Cloud = true
+Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/test.toml
@@ -1,6 +1,8 @@
 Local = true
-Cloud = true
 RecordRequests = false
+
+# This test performs static validation; no need to run on cloud.
+Cloud = false
 
 Ignore = [".databricks", "databricks.yml"]
 

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
@@ -1,4 +1,4 @@
 Local = true
-Cloud = true
+Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/test.toml
@@ -1,6 +1,9 @@
 Local = true
-Cloud = true
 RecordRequests = true
+
+# Starting warehouses can take a while on infra under load.
+# Omit this test to avoid timeouts.
+Cloud = false
 
 Ignore = [".databricks", "databricks.yml"]
 

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
@@ -1,4 +1,4 @@
 Local = true
-Cloud = true
+Cloud = false
 CloudSlow = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/test.toml
@@ -1,6 +1,9 @@
 Local = true
-Cloud = true
 RecordRequests = true
+
+# Starting warehouses can take a while on infra under load.
+# Omit this test to avoid timeouts.
+Cloud = false
 
 Ignore = [".databricks", "databricks.yml"]
 


### PR DESCRIPTION
These tests can time out under load. The local only versions give enough signal.