### PR TITLE
Run push-to-main integration tests in short mode

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -556,12 +556,15 @@ jobs:
             -f pull_request_number=${{ github.event.pull_request.number }} \
             -f commit_sha=${{ github.event.pull_request.head.sha }}
 
+      # Use the PR workflow (which runs in short mode) so commits to main do not
+      # trigger the slow CloudSlow integration tests. Those run only on the
+      # nightly schedule (and on workflow-file changes), not on every commit.
       - name: Trigger integration tests (push to main)
         if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |-
-          gh workflow run cli-isolated-nightly.yml -R ${{ secrets.ORG_NAME }}/${{ secrets.REPO_NAME }} \
+          gh workflow run cli-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{ secrets.REPO_NAME }} \
             --ref main \
             -f commit_sha=${{ github.event.after }}
 


### PR DESCRIPTION
Commits to main currently dispatch `cli-isolated-nightly.yml`, which runs the full integration suite including the slow `CloudSlow` cloud tests (vector search indexes, Lakebase, model serving, app runs, wheel integration). Those routinely overflow the 2h test-binary budget and time out, putting spurious red X's on main commits.

This points the push-to-main trigger at `cli-isolated-pr.yml` instead, which runs in short mode (`-short`), so `CloudSlow` tests skip themselves. Commits to main now get fast, reliable signal. The full `CloudSlow` suite still runs on the nightly schedule and on workflow-file changes — just not on every commit.

This pull request and its description were written by Isaac.
