### PR TITLE
acc: run three resource tests locally

### DIFF
--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RunsOnDbr = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RequiresWarehouse = true
 CloudEnvs.gcp = false

--- a/acceptance/bundle/resources/permissions/dashboards/create/test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/test.toml
@@ -1,6 +1,10 @@
-Local = false
+Local = true
 RequiresWarehouse = true
 Cloud = true
+
+# Force the local deploy identity to a service principal so the auto-added
+# CAN_MANAGE ACL serializes as service_principal_name, matching the cloud golden.
+IsServicePrincipal = true
 
 # The current user on GCP is a user and not a SP. This causes different permissions to be set.
 # Thus we skip this test on GCP.

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true

--- a/acceptance/bundle/resources/volumes/recreate/test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RecordRequests = false
 RunsOnDbr = true


### PR DESCRIPTION
Flip `volumes/recreate`, `jobs/shared-root-path`, and `permissions/dashboards/create` to `Local = true`; the testserver already handles them.

`permissions/dashboards/create` sets `IsServicePrincipal = true` so the CAN_MANAGE ACL matches the cloud golden.

This pull request and its description were written by Isaac.
