### PR TITLE
acc: run apps/inline_config locally

### DIFF
--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/inline_config/test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/test.toml
@@ -1,2 +1,2 @@
-Local = false
+Local = true
 Cloud = true

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -118,18 +118,28 @@ func (s *FakeWorkspace) AppsCreateDeployment(req Request, name string) Response 
 func (s *FakeWorkspace) AppsGetDeployment(_ Request, name, deploymentID string) Response {
 	defer s.LockUnlock()()
 
-	_, ok := s.Apps[name]
+	app, ok := s.Apps[name]
 	if !ok {
 		return Response{StatusCode: 404}
 	}
 
-	return Response{Body: apps.AppDeployment{
-		DeploymentId: deploymentID,
-		Status: &apps.AppDeploymentStatus{
-			State:   apps.AppDeploymentStateSucceeded,
-			Message: "Deployment succeeded",
-		},
-	}}
+	if app.ActiveDeployment == nil || app.ActiveDeployment.DeploymentId != deploymentID {
+		return Response{StatusCode: 404}
+	}
+
+	// Return a copy so the masking below does not mutate the stored deployment.
+	deployment := *app.ActiveDeployment
+
+	// The real GET response strips env var values, returning only the name of
+	// each variable. Reproduce that masking so the local golden matches
+	// recorded cloud behavior.
+	maskedEnvVars := make([]apps.EnvVar, len(deployment.EnvVars))
+	for i, ev := range deployment.EnvVars {
+		maskedEnvVars[i] = apps.EnvVar{Name: ev.Name}
+	}
+	deployment.EnvVars = maskedEnvVars
+
+	return Response{Body: deployment}
 }
 
 func (s *FakeWorkspace) AppsStart(_ Request, name string) Response {


### PR DESCRIPTION
`AppsGetDeployment` now returns the stored deployment (with env-var values masked) instead of an empty one, so the inline `command`/`env_vars` round-trip works against the fake.

This pull request and its description were written by Isaac.
