### PR TITLE
acc: fix testserver workspace export envelope

### DIFF
--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/check-metadata/test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RecordRequests = false
 

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -94,7 +94,20 @@ func AddDefaultHandlers(server *Server) {
 
 	server.Handle("GET", "/api/2.0/workspace/export", func(req Request) any {
 		path := req.URL.Query().Get("path")
-		return req.Workspace.WorkspaceExport(path)
+		data := req.Workspace.WorkspaceExport(path)
+
+		// The filer reads the raw object body via ?direct_download=true, while
+		// the SDK's Workspace.Export (used by `databricks workspace export`)
+		// requests JSON and expects the base64-encoded content field.
+		if req.URL.Query().Get("direct_download") == "true" {
+			return data
+		}
+
+		return Response{
+			Body: workspace.ExportResponse{
+				Content: base64.StdEncoding.EncodeToString(data),
+			},
+		}
 	})
 
 	server.Handle("POST", "/api/2.0/workspace/delete", func(req Request) any {


### PR DESCRIPTION
`GET /api/2.0/workspace/export` now returns a base64 `ExportResponse` for the SDK path (raw bytes still for `direct_download=true`), so `databricks workspace export` works locally.

Lets `jobs/check-metadata` run against the fake.

This pull request and its description were written by Isaac.
