### PR TITLE
direct: strip /Workspace prefix from parent_path in dashboard PATCH

### DIFF
--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.patch.requests.direct.txt
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.patch.requests.direct.txt
@@ -3,7 +3,7 @@
   "path": "/api/2.0/lakeview/dashboards/[DASHBOARD_ID]",
   "body": {
     "display_name": "test dashboard",
-    "parent_path": "/Workspace/Users/[USERNAME]/.bundle/change-embed-credentials-[UNIQUE_NAME]/default/resources",
+    "parent_path": "/Users/[USERNAME]/.bundle/change-embed-credentials-[UNIQUE_NAME]/default/resources",
     "serialized_dashboard": "{}\n",
     "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
   }

--- a/acceptance/bundle/resources/dashboards/change-name/out.patch.requests.direct.txt
+++ b/acceptance/bundle/resources/dashboards/change-name/out.patch.requests.direct.txt
@@ -3,7 +3,7 @@
   "path": "/api/2.0/lakeview/dashboards/[DASHBOARD_ID]",
   "body": {
     "display_name": "dashboard2",
-    "parent_path": "/Workspace/Users/[USERNAME]/.bundle/change-name-[UNIQUE_NAME]/default/resources",
+    "parent_path": "/Users/[USERNAME]/.bundle/change-name-[UNIQUE_NAME]/default/resources",
     "serialized_dashboard": "{}\n",
     "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
   }

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.patch.requests.direct.txt
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.patch.requests.direct.txt
@@ -3,7 +3,7 @@
   "path": "/api/2.0/lakeview/dashboards/[DASHBOARD_ID]",
   "body": {
     "display_name": "test dashboard",
-    "parent_path": "/Workspace/Users/[USERNAME]/.bundle/change-serialized-dashboard-[UNIQUE_NAME]/default/resources",
+    "parent_path": "/Users/[USERNAME]/.bundle/change-serialized-dashboard-[UNIQUE_NAME]/default/resources",
     "serialized_dashboard": "{\"pages\":[{\"name\":\"name2\",\"displayName\":\"name2\",\"pageType\":\"PAGE_TYPE_CANVAS\"}]}\n",
     "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
   }

--- a/acceptance/bundle/resources/dashboards/detect-change/out.patch.requests.direct.txt
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.patch.requests.direct.txt
@@ -11,7 +11,7 @@
   "path": "/api/2.0/lakeview/dashboards/[DASHBOARD_ID]",
   "body": {
     "display_name": "test-dashboard-[UNIQUE_NAME]",
-    "parent_path": "/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources",
+    "parent_path": "/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/resources",
     "serialized_dashboard": "{\n  \"pages\": [\n    {\n      \"displayName\": \"New Page\",\n      \"layout\": [\n        {\n          \"position\": {\n            \"height\": 2,\n            \"width\": 6,\n            \"x\": 0,\n            \"y\": 0\n          },\n          \"widget\": {\n            \"name\": \"82eb9107\",\n            \"textbox_spec\": \"# I'm a title\"\n          }\n        },\n        {\n          \"position\": {\n            \"height\": 2,\n            \"width\": 6,\n            \"x\": 0,\n            \"y\": 2\n          },\n          \"widget\": {\n            \"name\": \"ffa6de4f\",\n            \"textbox_spec\": \"Text\"\n          }\n        }\n      ],\n      \"name\": \"fdd21a3c\"\n    }\n  ]\n}\n",
     "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
   }

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/output.txt
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/output.txt
@@ -45,7 +45,7 @@ Exit code: 1
   "path": "/api/2.0/lakeview/dashboards/[DASHBOARD1_ID]",
   "body": {
     "display_name": "my dashboard renamed",
-    "parent_path": "/Workspace/Users/[USERNAME]/.bundle/update-publish-failure-stale-content/default/resources",
+    "parent_path": "/Users/[USERNAME]/.bundle/update-publish-failure-stale-content/default/resources",
     "serialized_dashboard": "{\"pages\":[{\"name\":\"test-page\",\"displayName\":\"Test Dashboard\"}]}\n",
     "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
   }
@@ -134,7 +134,7 @@ Deployment complete!
   "path": "/api/2.0/lakeview/dashboards/[DASHBOARD1_ID]",
   "body": {
     "display_name": "my dashboard renamed",
-    "parent_path": "/Workspace/Users/[USERNAME]/.bundle/update-publish-failure-stale-content/default/resources",
+    "parent_path": "/Users/[USERNAME]/.bundle/update-publish-failure-stale-content/default/resources",
     "serialized_dashboard": "{\"pages\":[{\"name\":\"test-page\",\"displayName\":\"Test Dashboard\"}]}\n",
     "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
   }

--- a/bundle/direct/dresources/dashboard.go
+++ b/bundle/direct/dresources/dashboard.go
@@ -327,6 +327,10 @@ func (r *ResourceDashboard) DoUpdate(ctx context.Context, id string, config *Das
 		return nil, err
 	}
 
+	// The Lakeview PATCH API does not accept a /Workspace/ prefix in parent_path,
+	// unlike the POST (create) API which silently strips it.
+	dashboard.ParentPath = strings.TrimPrefix(dashboard.ParentPath, "/Workspace")
+
 	// TODO: if the only thing that changed was "published", we can skip Update()?
 
 	updateResp, err := r.client.Lakeview.Update(ctx, dashboards.UpdateDashboardRequest{

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -166,6 +166,17 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 		}
 	}
 
+	// The Lakeview PATCH API does not accept a /Workspace/ prefix in parent_path
+	// (unlike the POST API which silently strips it).
+	if strings.HasPrefix(updateReq.ParentPath, "/Workspace/") {
+		return Response{
+			StatusCode: 404,
+			Body: map[string]string{
+				"message": fmt.Sprintf("Path (%s) doesn't exist.", updateReq.ParentPath),
+			},
+		}
+	}
+
 	// Bump etag on every write, matching cloud behavior.
 	prevEtag, err := strconv.Atoi(dashboard.Etag)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Dashboard renames fail on cloud for the direct engine because the Lakeview PATCH API rejects `parent_path` with a `/Workspace/` prefix (unlike the POST API which silently strips it)
- Strip the prefix in `DoUpdate` before sending the PATCH request
- Teach the testserver to reject `/Workspace/` in PATCH `parent_path` so the `change-name` test reproduces the failure locally

## Test plan

- [ ] `go test ./acceptance -run TestAccept/bundle/resources/dashboards` passes locally
- [ ] `testme-aws` cloud run passes for `bundle/resources/dashboards/change-name`

This pull request and its description were written by Isaac.