### PR TITLE
Add doc strings for common bundle resource fields

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 ### Bundles
+* Add documentation for the common bundle resource fields `permissions`, `lifecycle`, and `grants` in the JSON schema, so they surface in editor completions and the docs.
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.
 * Fix missing field descriptions in the bundle JSON schema for fields whose upstream API docs arrived after the field was first annotated (e.g. `vector_search_endpoints.*.target_qps`); stale placeholder markers no longer hide them ([#5588](https://github.com/databricks/cli/pull/5588)).
 * Fix `bundle deploy --plan` dropping a `postgres_role`'s `role_id`, which caused the role to be recreated on the next deploy ([#5672](https://github.com/databricks/cli/pull/5672)).

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -282,7 +282,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -354,7 +354,7 @@ resources:
             The source_code_path within git_source specifies the relative path to the app code within the repository.
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "oauth2_app_client_id":
           "description": |-
             PLACEHOLDER
@@ -521,7 +521,7 @@ resources:
             ```
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "managed_encryption_settings":
           "$fields":
             "azure_encryption_settings":
@@ -572,7 +572,7 @@ resources:
       "$fields":
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
           "$fields":
             "prevent_destroy":
               "description": |-
@@ -661,7 +661,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "lifecycle_state":
           "description": |-
             The state of the dashboard resource. Used for tracking trashed status.
@@ -729,7 +729,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "uid":
           "description": |-
             PLACEHOLDER
@@ -739,7 +739,7 @@ resources:
       "$fields":
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -781,7 +781,7 @@ resources:
       "$fields":
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -868,7 +868,7 @@ resources:
             ```
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     "genie_spaces":
       "description": |-
         PLACEHOLDER
@@ -884,7 +884,7 @@ resources:
             Local path to a `.geniespace.json` file holding the serialized Genie space definition. The contents are inlined into `serialized_space` at deploy time. Mutually exclusive with an inline `serialized_space`.
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "parent_path":
           "description": |-
             Workspace folder under which to create the Genie space. Immutable: changing this field recreates the resource.
@@ -976,7 +976,7 @@ resources:
                         Contains the Azure Data Lake Storage destination path
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
           "$fields":
             "prevent_destroy":
               "description": |-
@@ -1124,7 +1124,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -1166,7 +1166,7 @@ resources:
       "$fields":
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -1284,7 +1284,7 @@ resources:
                 This field is deprecated
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -1347,7 +1347,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "no_expiry":
           "description": |-
             PLACEHOLDER
@@ -1384,7 +1384,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "postgres_database":
           "description": |-
             PLACEHOLDER
@@ -1397,7 +1397,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "parent":
           "description": |-
             PLACEHOLDER
@@ -1431,7 +1431,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "no_suspension":
           "description": |-
             PLACEHOLDER
@@ -1474,7 +1474,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -1526,7 +1526,7 @@ resources:
             The type of the Databricks managed identity that this Role represents. Leave empty to create a regular Postgres role not associated with a Databricks identity.
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "membership_roles":
           "description": |-
             Standard roles that this role is a member of.
@@ -1557,7 +1557,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "new_pipeline_spec":
           "description": |-
             PLACEHOLDER
@@ -1621,7 +1621,7 @@ resources:
                 Granularities for aggregating data into time windows based on their timestamp. Valid values are 5 minutes, 30 minutes, 1 hour, 1 day, n weeks, 1 month, or 1 year.
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "table_name":
           "description": |-
             PLACEHOLDER
@@ -1674,7 +1674,7 @@ resources:
             ```
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     "schemas":
       "description": |-
         The schema definitions for the bundle, where each key is the name of the schema.
@@ -1746,7 +1746,7 @@ resources:
             ```
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     "secret_scopes":
       "description": |-
         The secret scope definitions for the bundle, where each key is the name of the secret scope.
@@ -1761,7 +1761,7 @@ resources:
             The metadata for the secret scope if the `backend_type` is `AZURE_KEYVAULT`
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "name":
           "description": |-
             Scope name requested by the user. Scope names are unique.
@@ -1810,7 +1810,7 @@ resources:
             Defaults to true.
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -1866,14 +1866,14 @@ resources:
                     PLACEHOLDER
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     "vector_search_endpoints":
       "description": |-
         PLACEHOLDER
       "$fields":
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
         "permissions":
           "description": |-
             The permissions to apply to this resource.
@@ -1914,7 +1914,7 @@ resources:
             ```
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     "volumes":
       "description": |-
         The volume definitions for the bundle, where each key is the name of the volume.
@@ -1960,7 +1960,7 @@ resources:
             ```
         "lifecycle":
           "description": |-
-            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+            Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
 run_as:
   "description": |-
     The identity to use when running Declarative Automation Bundles resources.

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -287,7 +287,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -365,7 +365,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -381,16 +381,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
         "resources":
           "$fields":
             "app":
@@ -506,7 +506,9 @@ resources:
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
           "markdown_description": |-
-            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+            A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).
+
+            See [\_](/data-governance/unity-catalog/manage-privileges/index.md).
           "markdown_examples": |-
             ```yaml
             grants:
@@ -582,7 +584,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -598,16 +600,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
     "dashboards":
       "description": |-
         The dashboard definitions for the bundle, where each key is the name of the dashboard.
@@ -677,7 +679,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -693,16 +695,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
         "serialized_dashboard":
           "description": |-
             The contents of the dashboard in serialized string form.
@@ -742,7 +744,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -784,7 +786,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -800,16 +802,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
     "external_locations":
       "description": |-
         PLACEHOLDER
@@ -851,7 +853,9 @@ resources:
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
           "markdown_description": |-
-            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+            A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).
+
+            See [\_](/data-governance/unity-catalog/manage-privileges/index.md).
           "markdown_examples": |-
             ```yaml
             grants:
@@ -888,7 +892,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -981,7 +985,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -997,16 +1001,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
         "run_as":
           "$fields":
             "service_principal_name":
@@ -1125,7 +1129,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -1141,16 +1145,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
     "models":
       "description": |-
         The model definitions for the bundle, where each key is the name of the model.
@@ -1167,7 +1171,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -1183,16 +1187,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
     "pipelines":
       "description": |-
         The pipeline definitions for the bundle, where each key is the name of the pipeline.
@@ -1285,7 +1289,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -1301,16 +1305,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
         "trigger":
           "deprecation_message": |-
             Use continuous instead
@@ -1475,7 +1479,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -1655,7 +1659,9 @@ resources:
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
           "markdown_description": |-
-            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+            A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).
+
+            See [\_](/data-governance/unity-catalog/manage-privileges/index.md).
           "markdown_examples": |-
             ```yaml
             grants:
@@ -1725,7 +1731,9 @@ resources:
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
           "markdown_description": |-
-            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+            A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).
+
+            See [\_](/data-governance/unity-catalog/manage-privileges/index.md).
           "markdown_examples": |-
             ```yaml
             grants:
@@ -1763,10 +1771,10 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level. This field translates to a `principal` field in secret scope ACL.
+                The name of the group granted the permission level. This field translates to a `principal` field in secret scope ACL.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
               "$type":
                 "enum":
                   - |-
@@ -1780,7 +1788,7 @@ resources:
                 The application ID of an active service principal. This field translates to a `principal` field in secret scope ACL.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level. This field translates to a `principal` field in secret scope ACL.
+                The name of the user granted the permission level. This field translates to a `principal` field in secret scope ACL.
     "sql_warehouses":
       "description": |-
         The SQL warehouse definitions for the bundle, where each key is the name of the warehouse.
@@ -1807,7 +1815,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -1823,16 +1831,16 @@ resources:
           "$fields":
             "group_name":
               "description": |-
-                The name of the group that has the permission set in level.
+                The name of the group granted the permission level.
             "level":
               "description": |-
-                The allowed permission for user, group, service principal defined for this permission.
+                The permission level to apply. The allowed levels depend on the resource type.
             "service_principal_name":
               "description": |-
-                The name of the service principal that has the permission set in level.
+                The name of the service principal granted the permission level.
             "user_name":
               "description": |-
-                The name of the user that has the permission set in level.
+                The name of the user granted the permission level.
         "tags":
           "$fields":
             "custom_tags":
@@ -1870,7 +1878,7 @@ resources:
           "description": |-
             The permissions to apply to this resource.
           "markdown_description": |-
-            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+            A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.
 
             See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
           "markdown_examples": |-
@@ -1891,7 +1899,9 @@ resources:
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
           "markdown_description": |-
-            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+            A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).
+
+            See [\_](/data-governance/unity-catalog/manage-privileges/index.md).
           "markdown_examples": |-
             ```yaml
             grants:
@@ -1935,7 +1945,9 @@ resources:
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
           "markdown_description": |-
-            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+            A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).
+
+            See [\_](/data-governance/unity-catalog/manage-privileges/index.md).
           "markdown_examples": |-
             ```yaml
             grants:

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -282,10 +282,24 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
         "schedule":
           "description": |-
             PLACEHOLDER
@@ -349,20 +363,34 @@ resources:
             PLACEHOLDER
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
         "resources":
           "$fields":
             "app":
@@ -476,10 +504,22 @@ resources:
       "$fields":
         "grants":
           "description": |-
-            PLACEHOLDER
+            The Unity Catalog privileges to grant to principals on this securable.
+          "markdown_description": |-
+            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+          "markdown_examples": |-
+            ```yaml
+            grants:
+              - principal: account users
+                privileges:
+                  - SELECT
+              - principal: data-engineers
+                privileges:
+                  - ALL_PRIVILEGES
+            ```
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "managed_encryption_settings":
           "$fields":
             "azure_encryption_settings":
@@ -540,20 +580,34 @@ resources:
                 Lifecycle setting to deploy the resource in started mode. Only supported for apps, clusters, and sql_warehouses in direct deployment mode.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
     "dashboards":
       "description": |-
         The dashboard definitions for the bundle, where each key is the name of the dashboard.
@@ -621,7 +675,21 @@ resources:
             This field is excluded in List Dashboards responses.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
@@ -672,7 +740,21 @@ resources:
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
     "experiments":
       "description": |-
         The experiment definitions for the bundle, where each key is the name of the experiment.
@@ -700,20 +782,34 @@ resources:
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
     "external_locations":
       "description": |-
         PLACEHOLDER
@@ -753,10 +849,22 @@ resources:
                         AWS_SSE_S3
         "grants":
           "description": |-
-            PLACEHOLDER
+            The Unity Catalog privileges to grant to principals on this securable.
+          "markdown_description": |-
+            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+          "markdown_examples": |-
+            ```yaml
+            grants:
+              - principal: account users
+                privileges:
+                  - SELECT
+              - principal: data-engineers
+                privileges:
+                  - ALL_PRIVILEGES
+            ```
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
     "genie_spaces":
       "description": |-
         PLACEHOLDER
@@ -772,13 +880,27 @@ resources:
             Local path to a `.geniespace.json` file holding the serialized Genie space definition. The contents are inlined into `serialized_space` at deploy time. Mutually exclusive with an inline `serialized_space`.
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "parent_path":
           "description": |-
             Workspace folder under which to create the Genie space. Immutable: changing this field recreates the resource.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
         "serialized_space":
           "description": |-
             Serialized Genie space body. May be provided inline as a JSON string (or YAML that will be marshalled to JSON) or referenced via `file_path`. To round-trip an existing space into a bundle, use `databricks bundle generate genie-space`.
@@ -857,20 +979,34 @@ resources:
                 Lifecycle setting to prevent the resource from being destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
         "run_as":
           "$fields":
             "service_principal_name":
@@ -987,20 +1123,34 @@ resources:
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
     "models":
       "description": |-
         The model definitions for the bundle, where each key is the name of the model.
@@ -1015,20 +1165,34 @@ resources:
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
     "pipelines":
       "description": |-
         The pipeline definitions for the bundle, where each key is the name of the pipeline.
@@ -1119,20 +1283,34 @@ resources:
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
         "trigger":
           "deprecation_message": |-
             Use continuous instead
@@ -1165,7 +1343,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "no_expiry":
           "description": |-
             PLACEHOLDER
@@ -1202,7 +1380,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "postgres_database":
           "description": |-
             PLACEHOLDER
@@ -1215,7 +1393,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "parent":
           "description": |-
             PLACEHOLDER
@@ -1249,7 +1427,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "no_suspension":
           "description": |-
             PLACEHOLDER
@@ -1292,10 +1470,24 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
         "pg_version":
           "description": |-
             PLACEHOLDER
@@ -1330,7 +1522,7 @@ resources:
             The type of the Databricks managed identity that this Role represents. Leave empty to create a regular Postgres role not associated with a Databricks identity.
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "membership_roles":
           "description": |-
             Standard roles that this role is a member of.
@@ -1361,7 +1553,7 @@ resources:
             PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "new_pipeline_spec":
           "description": |-
             PLACEHOLDER
@@ -1461,7 +1653,19 @@ resources:
       "$fields":
         "grants":
           "description": |-
-            PLACEHOLDER
+            The Unity Catalog privileges to grant to principals on this securable.
+          "markdown_description": |-
+            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+          "markdown_examples": |-
+            ```yaml
+            grants:
+              - principal: account users
+                privileges:
+                  - SELECT
+              - principal: data-engineers
+                privileges:
+                  - ALL_PRIVILEGES
+            ```
         "lifecycle":
           "description": |-
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
@@ -1519,7 +1723,19 @@ resources:
       "$fields":
         "grants":
           "description": |-
-            PLACEHOLDER
+            The Unity Catalog privileges to grant to principals on this securable.
+          "markdown_description": |-
+            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+          "markdown_examples": |-
+            ```yaml
+            grants:
+              - principal: account users
+                privileges:
+                  - SELECT
+              - principal: data-engineers
+                privileges:
+                  - ALL_PRIVILEGES
+            ```
         "lifecycle":
           "description": |-
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
@@ -1589,20 +1805,34 @@ resources:
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
           "$fields":
             "group_name":
               "description": |-
-                PLACEHOLDER
+                The name of the group that has the permission set in level.
             "level":
               "description": |-
-                PLACEHOLDER
+                The allowed permission for user, group, service principal defined for this permission.
             "service_principal_name":
               "description": |-
-                PLACEHOLDER
+                The name of the service principal that has the permission set in level.
             "user_name":
               "description": |-
-                PLACEHOLDER
+                The name of the user that has the permission set in level.
         "tags":
           "$fields":
             "custom_tags":
@@ -1628,27 +1858,53 @@ resources:
                     PLACEHOLDER
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
     "vector_search_endpoints":
       "description": |-
         PLACEHOLDER
       "$fields":
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
         "permissions":
           "description": |-
-            PLACEHOLDER
+            The permissions to apply to this resource.
+          "markdown_description": |-
+            A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.
+
+            See [\_](/dev-tools/bundles/settings.md#permissions) and [\_](/dev-tools/bundles/permissions.md).
+          "markdown_examples": |-
+            ```yaml
+            permissions:
+              - level: CAN_VIEW
+                group_name: test-group
+              - level: CAN_MANAGE
+                user_name: someone@example.com
+              - level: CAN_RUN
+                service_principal_name: 123456-abcdef
+            ```
     "vector_search_indexes":
       "description": |-
         PLACEHOLDER
       "$fields":
         "grants":
           "description": |-
-            PLACEHOLDER
+            The Unity Catalog privileges to grant to principals on this securable.
+          "markdown_description": |-
+            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+          "markdown_examples": |-
+            ```yaml
+            grants:
+              - principal: account users
+                privileges:
+                  - SELECT
+              - principal: data-engineers
+                privileges:
+                  - ALL_PRIVILEGES
+            ```
         "lifecycle":
           "description": |-
-            PLACEHOLDER
+            Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
     "volumes":
       "description": |-
         The volume definitions for the bundle, where each key is the name of the volume.
@@ -1677,7 +1933,19 @@ resources:
       "$fields":
         "grants":
           "description": |-
-            PLACEHOLDER
+            The Unity Catalog privileges to grant to principals on this securable.
+          "markdown_description": |-
+            A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal.
+          "markdown_examples": |-
+            ```yaml
+            grants:
+              - principal: account users
+                privileges:
+                  - SELECT
+              - principal: data-engineers
+                privileges:
+                  - ALL_PRIVILEGES
+            ```
         "lifecycle":
           "description": |-
             Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -99,6 +99,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "parent_path": {
@@ -106,7 +107,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "query_text": {
                         "description": "[Public Preview] Text of the query to be run.",
@@ -194,7 +197,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.AppPermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.AppPermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "resources": {
                         "description": "Resources for the app.",
@@ -285,15 +290,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppPermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -326,9 +335,12 @@
                         "$ref": "#/$defs/int64"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment"
+                        "description": "The Unity Catalog privileges to grant to principals on this securable.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
+                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "managed_encryption_settings": {
@@ -470,7 +482,9 @@
                         "$ref": "#/$defs/int"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ClusterPermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ClusterPermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "policy_id": {
                         "description": "The ID of the cluster policy used to create the cluster if applicable.",
@@ -536,15 +550,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterPermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -611,7 +629,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "serialized_dashboard": {
                         "description": "The contents of the dashboard in serialized string form.\nThis field is excluded in List Dashboards responses.\nUse the [get dashboard API](https://docs.databricks.com/api/workspace/lakeview/get)\nto retrieve an example response, which includes the `serialized_dashboard` field.\nThis field provides the structure of the JSON string that represents the dashboard's\nlayout and components.",
@@ -713,7 +733,9 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/database.DatabaseInstanceRef"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "retention_window_in_days": {
                         "description": "[Public Preview] The retention window for the instance. This is the time window in days\nfor which the historical data is retained. The default value is 7 days.\nValid values are 2 to 35 days.",
@@ -769,9 +791,12 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.FileEventQueue"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment"
+                        "description": "The Unity Catalog privileges to grant to principals on this securable.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
+                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -821,6 +846,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "parent_path": {
@@ -828,7 +854,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "serialized_space": {
                         "description": "Serialized Genie space body. May be provided inline as a JSON string (or YAML that will be marshalled to JSON) or referenced via `file_path`. To round-trip an existing space into a bundle, use `databricks bundle generate genie-space`.",
@@ -913,7 +941,9 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.PerformanceTarget"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.JobPermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.JobPermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "queue": {
                         "description": "The queue settings of the job.",
@@ -969,15 +999,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobPermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1050,7 +1084,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "tags": {
                         "description": "A collection of tags to set on the experiment. Maximum tag size and number of tags per request\ndepends on the storage backend. All storage backends are guaranteed to support tag keys up\nto 250 bytes in size and tag values up to 5000 bytes in size. All storage backends are also\nguaranteed to support up to 20 tags per request.",
@@ -1075,15 +1111,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/ml.ExperimentPermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1116,7 +1156,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowModelPermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowModelPermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "tags": {
                         "description": "Additional metadata for registered model.",
@@ -1141,15 +1183,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/ml.RegisteredModelPermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1197,7 +1243,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "rate_limits": {
                         "description": "Rate limits to be applied to the serving endpoint. NOTE: this field is deprecated, please use AI Gateway to manage rate limits.",
@@ -1232,15 +1280,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ServingEndpointPermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1376,7 +1428,9 @@
                         "$ref": "#/$defs/map/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.PipelinePermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.PipelinePermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "photon": {
                         "description": "Whether Photon is enabled for this pipeline.",
@@ -1452,15 +1506,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelinePermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1490,6 +1548,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "no_expiry": {
@@ -1541,6 +1600,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "postgres_database": {
@@ -1568,6 +1628,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "parent": {
@@ -1616,6 +1677,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.EndpointGroupSpec"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "no_suspension": {
@@ -1674,10 +1736,13 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/duration.Duration"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "pg_version": {
                         "$ref": "#/$defs/int"
@@ -1718,6 +1783,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.RoleIdentityType"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "membership_roles": {
@@ -1767,6 +1833,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "new_pipeline_spec": {
@@ -1923,7 +1990,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment"
+                        "description": "The Unity Catalog privileges to grant to principals on this securable.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
+                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
@@ -1985,7 +2054,9 @@
                         "$ref": "#/$defs/int64"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment"
+                        "description": "The Unity Catalog privileges to grant to principals on this securable.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
+                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
@@ -2156,7 +2227,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.SqlWarehousePermission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.SqlWarehousePermission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "spot_instance_policy": {
                         "description": "Configurations whether the endpoint should use spot instances.",
@@ -2185,15 +2258,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
+                        "description": "The name of the group that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
+                        "description": "The allowed permission for user, group, service principal defined for this permission.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/sql.WarehousePermissionLevel"
                       },
                       "service_principal_name": {
+                        "description": "The name of the service principal that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
+                        "description": "The name of the user that has the permission set in level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -2218,6 +2295,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "logical_database_name": {
@@ -2258,6 +2336,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/vectorsearch.EndpointType"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -2265,7 +2344,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "permissions": {
-                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission"
+                        "description": "The permissions to apply to this resource.",
+                        "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
+                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "target_qps": {
                         "description": "[Public Preview] Target QPS for the endpoint. Mutually exclusive with num_replicas.\nThe actual replica count is calculated at index creation/sync time based on this value.\nBest-effort target; the system does not guarantee this QPS will be achieved.",
@@ -2308,7 +2389,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment"
+                        "description": "The Unity Catalog privileges to grant to principals on this securable.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
+                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
                       },
                       "index_subtype": {
                         "description": "[Beta] The subtype of the index. Use `HYBRID` or `FULL_TEXT`. `VECTOR` is not supported.",
@@ -2319,6 +2402,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/vectorsearch.VectorIndexType"
                       },
                       "lifecycle": {
+                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -2358,7 +2442,9 @@
                         "$ref": "#/$defs/string"
                       },
                       "grants": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment"
+                        "description": "The Unity Catalog privileges to grant to principals on this securable.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
+                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -99,7 +99,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "parent_path": {
@@ -189,7 +189,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.GitSource"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.LifecycleWithStarted"
                       },
                       "name": {
@@ -340,7 +340,7 @@
                         "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "managed_encryption_settings": {
@@ -470,7 +470,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.Kind"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.LifecycleWithStarted"
                       },
                       "node_type_id": {
@@ -613,7 +613,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "lifecycle_state": {
@@ -673,7 +673,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -717,7 +717,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -796,7 +796,7 @@
                         "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -846,7 +846,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "parent_path": {
@@ -917,7 +917,7 @@
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/jobs.JobCluster"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "max_concurrent_runs": {
@@ -1076,7 +1076,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -1148,7 +1148,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -1235,7 +1235,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.EmailNotifications"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -1412,7 +1412,7 @@
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/pipelines.PipelineLibrary"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -1548,7 +1548,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "no_expiry": {
@@ -1600,7 +1600,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "postgres_database": {
@@ -1628,7 +1628,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "parent": {
@@ -1677,7 +1677,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.EndpointGroupSpec"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "no_suspension": {
@@ -1736,7 +1736,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/duration.Duration"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "permissions": {
@@ -1783,7 +1783,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.RoleIdentityType"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "membership_roles": {
@@ -1833,7 +1833,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "new_pipeline_spec": {
@@ -1903,7 +1903,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "notifications": {
@@ -1995,7 +1995,7 @@
                         "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "metastore_id": {
@@ -2059,7 +2059,7 @@
                         "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -2102,7 +2102,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/workspace.AzureKeyVaultSecretScopeMetadata"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -2211,7 +2211,7 @@
                         "deprecated": true
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.LifecycleWithStarted"
                       },
                       "max_num_clusters": {
@@ -2295,7 +2295,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "logical_database_name": {
@@ -2336,7 +2336,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/vectorsearch.EndpointType"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -2402,7 +2402,7 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/vectorsearch.VectorIndexType"
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {
@@ -2447,7 +2447,7 @@
                         "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
-                        "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
+                        "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "name": {

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -109,7 +109,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "query_text": {
                         "description": "[Public Preview] Text of the query to be run.",
@@ -199,7 +199,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.AppPermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "resources": {
                         "description": "Resources for the app.",
@@ -290,19 +290,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/apps.AppPermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -337,7 +337,7 @@
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
-                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
+                        "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
@@ -484,7 +484,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ClusterPermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "policy_id": {
                         "description": "The ID of the cluster policy used to create the cluster if applicable.",
@@ -550,19 +550,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.ClusterPermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -631,7 +631,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "serialized_dashboard": {
                         "description": "The contents of the dashboard in serialized string form.\nThis field is excluded in List Dashboards responses.\nUse the [get dashboard API](https://docs.databricks.com/api/workspace/lakeview/get)\nto retrieve an example response, which includes the `serialized_dashboard` field.\nThis field provides the structure of the JSON string that represents the dashboard's\nlayout and components.",
@@ -735,7 +735,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "retention_window_in_days": {
                         "description": "[Public Preview] The retention window for the instance. This is the time window in days\nfor which the historical data is retained. The default value is 7 days.\nValid values are 2 to 35 days.",
@@ -793,7 +793,7 @@
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
-                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
+                        "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
@@ -856,7 +856,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "serialized_space": {
                         "description": "Serialized Genie space body. May be provided inline as a JSON string (or YAML that will be marshalled to JSON) or referenced via `file_path`. To round-trip an existing space into a bundle, use `databricks bundle generate genie-space`.",
@@ -943,7 +943,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.JobPermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "queue": {
                         "description": "The queue settings of the job.",
@@ -999,19 +999,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.JobPermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1086,7 +1086,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowExperimentPermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "tags": {
                         "description": "A collection of tags to set on the experiment. Maximum tag size and number of tags per request\ndepends on the storage backend. All storage backends are guaranteed to support tag keys up\nto 250 bytes in size and tag values up to 5000 bytes in size. All storage backends are also\nguaranteed to support up to 20 tags per request.",
@@ -1111,19 +1111,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/ml.ExperimentPermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1158,7 +1158,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.MlflowModelPermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "tags": {
                         "description": "Additional metadata for registered model.",
@@ -1183,19 +1183,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/ml.RegisteredModelPermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1245,7 +1245,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.ModelServingEndpointPermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "rate_limits": {
                         "description": "Rate limits to be applied to the serving endpoint. NOTE: this field is deprecated, please use AI Gateway to manage rate limits.",
@@ -1280,19 +1280,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.ServingEndpointPermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1313,19 +1313,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/iam.PermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1430,7 +1430,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.PipelinePermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "photon": {
                         "description": "Whether Photon is enabled for this pipeline.",
@@ -1506,19 +1506,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/pipelines.PipelinePermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1742,7 +1742,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "pg_version": {
                         "$ref": "#/$defs/int"
@@ -1992,7 +1992,7 @@
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
-                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
+                        "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
@@ -2056,7 +2056,7 @@
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
-                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
+                        "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",
@@ -2131,11 +2131,11 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level. This field translates to a `principal` field in secret scope ACL.",
+                        "description": "The name of the group granted the permission level. This field translates to a `principal` field in secret scope ACL.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.SecretScopePermissionLevel"
                       },
                       "service_principal_name": {
@@ -2143,7 +2143,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level. This field translates to a `principal` field in secret scope ACL.",
+                        "description": "The name of the user granted the permission level. This field translates to a `principal` field in secret scope ACL.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -2229,7 +2229,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.SqlWarehousePermission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "spot_instance_policy": {
                         "description": "Configurations whether the endpoint should use spot instances.",
@@ -2258,19 +2258,19 @@
                     "type": "object",
                     "properties": {
                       "group_name": {
-                        "description": "The name of the group that has the permission set in level.",
+                        "description": "The name of the group granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "level": {
-                        "description": "The allowed permission for user, group, service principal defined for this permission.",
+                        "description": "The permission level to apply. The allowed levels depend on the resource type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/sql.WarehousePermissionLevel"
                       },
                       "service_principal_name": {
-                        "description": "The name of the service principal that has the permission set in level.",
+                        "description": "The name of the service principal granted the permission level.",
                         "$ref": "#/$defs/string"
                       },
                       "user_name": {
-                        "description": "The name of the user that has the permission set in level.",
+                        "description": "The name of the user granted the permission level.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -2346,7 +2346,7 @@
                       "permissions": {
                         "description": "The permissions to apply to this resource.",
                         "$ref": "#/$defs/slice/github.com/databricks/cli/bundle/config/resources.Permission",
-                        "markdownDescription": "A Sequence that defines the permissions to apply to this resource, where each item in the sequence is a permission for a specific entity.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
+                        "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "target_qps": {
                         "description": "[Public Preview] Target QPS for the endpoint. Mutually exclusive with num_replicas.\nThe actual replica count is calculated at index creation/sync time based on this value.\nBest-effort target; the system does not guarantee this QPS will be achieved.",
@@ -2391,7 +2391,7 @@
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
-                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
+                        "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "index_subtype": {
                         "description": "[Beta] The subtype of the index. Use `HYBRID` or `FULL_TEXT`. `VECTOR` is not supported.",
@@ -2444,7 +2444,7 @@
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
-                        "markdownDescription": "A Sequence that defines the Unity Catalog privilege grants for this securable, where each item grants a set of privileges to a principal."
+                        "markdownDescription": "A Sequence of Unity Catalog privilege grants on this securable, where each item grants a set of `privileges` to a `principal` (a user, group, or service principal).\n\nSee [link](https://docs.databricks.com/data-governance/unity-catalog/manage-privileges/index.html)."
                       },
                       "lifecycle": {
                         "description": "Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.",

--- a/python/databricks/bundles/catalogs/_models/catalog.py
+++ b/python/databricks/bundles/catalogs/_models/catalog.py
@@ -55,7 +55,7 @@ class Catalog(Resource):
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     managed_encryption_settings: VariableOrOptional[EncryptionSettings] = None
@@ -128,7 +128,7 @@ class CatalogDict(TypedDict, total=False):
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     managed_encryption_settings: VariableOrOptional[EncryptionSettingsParam]

--- a/python/databricks/bundles/catalogs/_models/catalog.py
+++ b/python/databricks/bundles/catalogs/_models/catalog.py
@@ -49,8 +49,14 @@ class Catalog(Resource):
     """
 
     grants: VariableOrList[PrivilegeAssignment] = field(default_factory=list)
+    """
+    The Unity Catalog privileges to grant to principals on this securable.
+    """
 
     lifecycle: VariableOrOptional[Lifecycle] = None
+    """
+    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    """
 
     managed_encryption_settings: VariableOrOptional[EncryptionSettings] = None
     """
@@ -116,8 +122,14 @@ class CatalogDict(TypedDict, total=False):
     """
 
     grants: VariableOrList[PrivilegeAssignmentParam]
+    """
+    The Unity Catalog privileges to grant to principals on this securable.
+    """
 
     lifecycle: VariableOrOptional[LifecycleParam]
+    """
+    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    """
 
     managed_encryption_settings: VariableOrOptional[EncryptionSettingsParam]
     """

--- a/python/databricks/bundles/jobs/_models/job.py
+++ b/python/databricks/bundles/jobs/_models/job.py
@@ -121,7 +121,7 @@ class Job(Resource):
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     max_concurrent_runs: VariableOrOptional[int] = None
@@ -277,7 +277,7 @@ class JobDict(TypedDict, total=False):
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     max_concurrent_runs: VariableOrOptional[int]

--- a/python/databricks/bundles/jobs/_models/job.py
+++ b/python/databricks/bundles/jobs/_models/job.py
@@ -159,6 +159,9 @@ class Job(Resource):
     """
 
     permissions: VariableOrList[JobPermission] = field(default_factory=list)
+    """
+    The permissions to apply to this resource.
+    """
 
     queue: VariableOrOptional[QueueSettings] = None
     """
@@ -312,6 +315,9 @@ class JobDict(TypedDict, total=False):
     """
 
     permissions: VariableOrList[JobPermissionParam]
+    """
+    The permissions to apply to this resource.
+    """
 
     queue: VariableOrOptional[QueueSettingsParam]
     """

--- a/python/databricks/bundles/jobs/_models/job_permission.py
+++ b/python/databricks/bundles/jobs/_models/job_permission.py
@@ -19,22 +19,22 @@ class JobPermission:
 
     level: VariableOr[JobPermissionLevel]
     """
-    The allowed permission for user, group, service principal defined for this permission.
+    The permission level to apply. The allowed levels depend on the resource type.
     """
 
     group_name: VariableOrOptional[str] = None
     """
-    The name of the group that has the permission set in level.
+    The name of the group granted the permission level.
     """
 
     service_principal_name: VariableOrOptional[str] = None
     """
-    The name of the service principal that has the permission set in level.
+    The name of the service principal granted the permission level.
     """
 
     user_name: VariableOrOptional[str] = None
     """
-    The name of the user that has the permission set in level.
+    The name of the user granted the permission level.
     """
 
     @classmethod
@@ -50,22 +50,22 @@ class JobPermissionDict(TypedDict, total=False):
 
     level: VariableOr[JobPermissionLevelParam]
     """
-    The allowed permission for user, group, service principal defined for this permission.
+    The permission level to apply. The allowed levels depend on the resource type.
     """
 
     group_name: VariableOrOptional[str]
     """
-    The name of the group that has the permission set in level.
+    The name of the group granted the permission level.
     """
 
     service_principal_name: VariableOrOptional[str]
     """
-    The name of the service principal that has the permission set in level.
+    The name of the service principal granted the permission level.
     """
 
     user_name: VariableOrOptional[str]
     """
-    The name of the user that has the permission set in level.
+    The name of the user granted the permission level.
     """
 
 

--- a/python/databricks/bundles/jobs/_models/job_permission.py
+++ b/python/databricks/bundles/jobs/_models/job_permission.py
@@ -18,12 +18,24 @@ class JobPermission:
     """"""
 
     level: VariableOr[JobPermissionLevel]
+    """
+    The allowed permission for user, group, service principal defined for this permission.
+    """
 
     group_name: VariableOrOptional[str] = None
+    """
+    The name of the group that has the permission set in level.
+    """
 
     service_principal_name: VariableOrOptional[str] = None
+    """
+    The name of the service principal that has the permission set in level.
+    """
 
     user_name: VariableOrOptional[str] = None
+    """
+    The name of the user that has the permission set in level.
+    """
 
     @classmethod
     def from_dict(cls, value: "JobPermissionDict") -> "Self":
@@ -37,12 +49,24 @@ class JobPermissionDict(TypedDict, total=False):
     """"""
 
     level: VariableOr[JobPermissionLevelParam]
+    """
+    The allowed permission for user, group, service principal defined for this permission.
+    """
 
     group_name: VariableOrOptional[str]
+    """
+    The name of the group that has the permission set in level.
+    """
 
     service_principal_name: VariableOrOptional[str]
+    """
+    The name of the service principal that has the permission set in level.
+    """
 
     user_name: VariableOrOptional[str]
+    """
+    The name of the user that has the permission set in level.
+    """
 
 
 JobPermissionParam = JobPermissionDict | JobPermission

--- a/python/databricks/bundles/pipelines/_models/pipeline.py
+++ b/python/databricks/bundles/pipelines/_models/pipeline.py
@@ -144,7 +144,7 @@ class Pipeline(Resource):
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     name: VariableOrOptional[str] = None
@@ -330,7 +330,7 @@ class PipelineDict(TypedDict, total=False):
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     name: VariableOrOptional[str]

--- a/python/databricks/bundles/pipelines/_models/pipeline.py
+++ b/python/databricks/bundles/pipelines/_models/pipeline.py
@@ -164,6 +164,9 @@ class Pipeline(Resource):
     """
 
     permissions: VariableOrList[PipelinePermission] = field(default_factory=list)
+    """
+    The permissions to apply to this resource.
+    """
 
     photon: VariableOrOptional[bool] = None
     """
@@ -347,6 +350,9 @@ class PipelineDict(TypedDict, total=False):
     """
 
     permissions: VariableOrList[PipelinePermissionParam]
+    """
+    The permissions to apply to this resource.
+    """
 
     photon: VariableOrOptional[bool]
     """

--- a/python/databricks/bundles/pipelines/_models/pipeline_permission.py
+++ b/python/databricks/bundles/pipelines/_models/pipeline_permission.py
@@ -18,12 +18,24 @@ class PipelinePermission:
     """"""
 
     level: VariableOr[PipelinePermissionLevel]
+    """
+    The allowed permission for user, group, service principal defined for this permission.
+    """
 
     group_name: VariableOrOptional[str] = None
+    """
+    The name of the group that has the permission set in level.
+    """
 
     service_principal_name: VariableOrOptional[str] = None
+    """
+    The name of the service principal that has the permission set in level.
+    """
 
     user_name: VariableOrOptional[str] = None
+    """
+    The name of the user that has the permission set in level.
+    """
 
     @classmethod
     def from_dict(cls, value: "PipelinePermissionDict") -> "Self":
@@ -37,12 +49,24 @@ class PipelinePermissionDict(TypedDict, total=False):
     """"""
 
     level: VariableOr[PipelinePermissionLevelParam]
+    """
+    The allowed permission for user, group, service principal defined for this permission.
+    """
 
     group_name: VariableOrOptional[str]
+    """
+    The name of the group that has the permission set in level.
+    """
 
     service_principal_name: VariableOrOptional[str]
+    """
+    The name of the service principal that has the permission set in level.
+    """
 
     user_name: VariableOrOptional[str]
+    """
+    The name of the user that has the permission set in level.
+    """
 
 
 PipelinePermissionParam = PipelinePermissionDict | PipelinePermission

--- a/python/databricks/bundles/pipelines/_models/pipeline_permission.py
+++ b/python/databricks/bundles/pipelines/_models/pipeline_permission.py
@@ -19,22 +19,22 @@ class PipelinePermission:
 
     level: VariableOr[PipelinePermissionLevel]
     """
-    The allowed permission for user, group, service principal defined for this permission.
+    The permission level to apply. The allowed levels depend on the resource type.
     """
 
     group_name: VariableOrOptional[str] = None
     """
-    The name of the group that has the permission set in level.
+    The name of the group granted the permission level.
     """
 
     service_principal_name: VariableOrOptional[str] = None
     """
-    The name of the service principal that has the permission set in level.
+    The name of the service principal granted the permission level.
     """
 
     user_name: VariableOrOptional[str] = None
     """
-    The name of the user that has the permission set in level.
+    The name of the user granted the permission level.
     """
 
     @classmethod
@@ -50,22 +50,22 @@ class PipelinePermissionDict(TypedDict, total=False):
 
     level: VariableOr[PipelinePermissionLevelParam]
     """
-    The allowed permission for user, group, service principal defined for this permission.
+    The permission level to apply. The allowed levels depend on the resource type.
     """
 
     group_name: VariableOrOptional[str]
     """
-    The name of the group that has the permission set in level.
+    The name of the group granted the permission level.
     """
 
     service_principal_name: VariableOrOptional[str]
     """
-    The name of the service principal that has the permission set in level.
+    The name of the service principal granted the permission level.
     """
 
     user_name: VariableOrOptional[str]
     """
-    The name of the user that has the permission set in level.
+    The name of the user granted the permission level.
     """
 
 

--- a/python/databricks/bundles/schemas/_models/schema.py
+++ b/python/databricks/bundles/schemas/_models/schema.py
@@ -51,7 +51,7 @@ class Schema(Resource):
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     properties: VariableOrDict[str] = field(default_factory=dict)
@@ -102,7 +102,7 @@ class SchemaDict(TypedDict, total=False):
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     properties: VariableOrDict[str]

--- a/python/databricks/bundles/schemas/_models/schema.py
+++ b/python/databricks/bundles/schemas/_models/schema.py
@@ -45,6 +45,9 @@ class Schema(Resource):
     """
 
     grants: VariableOrList[PrivilegeAssignment] = field(default_factory=list)
+    """
+    The Unity Catalog privileges to grant to principals on this securable.
+    """
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
@@ -93,6 +96,9 @@ class SchemaDict(TypedDict, total=False):
     """
 
     grants: VariableOrList[PrivilegeAssignmentParam]
+    """
+    The Unity Catalog privileges to grant to principals on this securable.
+    """
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """

--- a/python/databricks/bundles/volumes/_models/volume.py
+++ b/python/databricks/bundles/volumes/_models/volume.py
@@ -51,7 +51,7 @@ class Volume(Resource):
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     storage_location: VariableOrOptional[str] = None
@@ -104,7 +104,7 @@ class VolumeDict(TypedDict, total=False):
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """
-    Lifecycle is a struct that contains the lifecycle settings for a resource. It controls the behavior of the resource when it is deployed or destroyed.
+    Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
     """
 
     storage_location: VariableOrOptional[str]

--- a/python/databricks/bundles/volumes/_models/volume.py
+++ b/python/databricks/bundles/volumes/_models/volume.py
@@ -45,6 +45,9 @@ class Volume(Resource):
     """
 
     grants: VariableOrList[PrivilegeAssignment] = field(default_factory=list)
+    """
+    The Unity Catalog privileges to grant to principals on this securable.
+    """
 
     lifecycle: VariableOrOptional[Lifecycle] = None
     """
@@ -95,6 +98,9 @@ class VolumeDict(TypedDict, total=False):
     """
 
     grants: VariableOrList[PrivilegeAssignmentParam]
+    """
+    The Unity Catalog privileges to grant to principals on this securable.
+    """
 
     lifecycle: VariableOrOptional[LifecycleParam]
     """


### PR DESCRIPTION
## Changes
Document the common fields DABs injects across resources in the bundle JSON schema, which previously rendered empty tooltips/docs on many resources. The wording is aligned with the official Databricks docs ([bundle permissions](https://docs.databricks.com/aws/en/dev-tools/bundles/permissions), [Unity Catalog manage-privileges](https://docs.databricks.com/aws/en/data-governance/unity-catalog/manage-privileges/), and [UC permissions concepts](https://docs.databricks.com/aws/en/data-governance/unity-catalog/access-control/permissions-concepts)):

- **`permissions`** — fill the 8 SDK-typed variants' item subfields (`level`, `user_name`, `service_principal_name`, `group_name`) and add a field-level description + `markdown_description` + example on all resources. The description notes that each item grants one `level` to a single user/group/service principal, and that a principal cannot appear in both a resource's `permissions` and the top-level `permissions` mapping. `level` clarifies that the allowed values depend on the resource type.
- **`lifecycle`** — propagate the existing field-level description to the resources where it was still a placeholder.
- **`grants`** — add a field-level description + `markdown_description` + example on the UC resources (subfields come from the SDK), matching the resources reference wording and linking to the UC manage-privileges docs.

Regenerated `bundle/schema/jsonschema.json` and the pydabs Python bindings (`python/databricks/bundles/**`) so the generated artifacts stay in sync.

## Why
These are the cross-cutting fields DABs owns on every resource, but their docs were only partially filled, so editor completions and the docs site showed blanks inconsistently. The remaining schema placeholders are resource-specific API fields whose descriptions belong upstream in the OpenAPI spec, not as CLI-only overrides, so they are intentionally left out.

## Tests
Docs-only/schema change. `go test ./bundle/internal/schema/...` passes, which verifies regeneration from the committed annotations is a no-op (no stale or missing placeholders). `validate-generated` passes now that the pydabs bindings are regenerated.