### PR TITLE
Add bundle_root_path to deployment metadata workspace info

### DIFF
--- a/bundle/deploy/lock/deployment_metadata_service.go
+++ b/bundle/deploy/lock/deployment_metadata_service.go
@@ -379,6 +379,10 @@ func workspaceInfo(b *bundle.Bundle) *tmpdms.WorkspaceInfo {
 	// folder; it stays empty for local deploys.
 	if b.WorktreeRoot != nil && strings.HasPrefix(b.WorktreeRoot.Native(), "/Workspace/") {
 		info.GitFolderPath = b.WorktreeRoot.Native()
+		// BundleRootPath defaults to "." (filepath.Rel returns "." when the
+		// bundle root equals the worktree root), so it is only meaningful for
+		// workspace Git-folder deploys and is recorded alongside git_folder_path.
+		info.BundleRootPath = b.Config.Bundle.Git.BundleRootPath
 	}
 	return info
 }

--- a/bundle/deploy/lock/deployment_metadata_service_test.go
+++ b/bundle/deploy/lock/deployment_metadata_service_test.go
@@ -90,6 +90,7 @@ func TestWorkspaceInfo(t *testing.T) {
 	assert.Equal(t, "/Workspace/Users/me@databricks.com/.bundle/my-bundle/prod/files", info.FilePath)
 	assert.False(t, info.SourceLinked)
 	assert.Empty(t, info.GitFolderPath)
+	assert.Empty(t, info.BundleRootPath)
 }
 
 func TestWorkspaceInfoSourceLinked(t *testing.T) {
@@ -122,10 +123,11 @@ func TestWorkspaceInfoGitFolderPath(t *testing.T) {
 	}
 	gitFolderPath := "/Workspace/Users/me@databricks.com/git_folder"
 	b := &bundle.Bundle{
-		Config:       config.Root{},
 		WorktreeRoot: vfs.MustNew(gitFolderPath),
 	}
+	b.Config.Bundle.Git.BundleRootPath = "subdir/bundle"
 
 	info := workspaceInfo(b)
 	assert.Equal(t, gitFolderPath, info.GitFolderPath)
+	assert.Equal(t, "subdir/bundle", info.BundleRootPath)
 }

--- a/libs/tmpdms/types.go
+++ b/libs/tmpdms/types.go
@@ -145,10 +145,11 @@ type GitInfo struct {
 // version. It mirrors the WorkspaceInfo proto message in the deployment
 // metadata service and carries the same values the CLI writes to metadata.json.
 type WorkspaceInfo struct {
-	RootPath      string `json:"root_path,omitempty"`
-	FilePath      string `json:"file_path,omitempty"`
-	SourceLinked  bool   `json:"source_linked,omitempty"`
-	GitFolderPath string `json:"git_folder_path,omitempty"`
+	RootPath       string `json:"root_path,omitempty"`
+	FilePath       string `json:"file_path,omitempty"`
+	SourceLinked   bool   `json:"source_linked,omitempty"`
+	GitFolderPath  string `json:"git_folder_path,omitempty"`
+	BundleRootPath string `json:"bundle_root_path,omitempty"`
 }
 
 type Operation struct {


### PR DESCRIPTION
## Changes
Add `bundle_root_path` to the deployment metadata `WorkspaceInfo` — both the `tmpdms` type sent on `CreateVersion` and the populating logic in `workspaceInfo()`. It records the bundle root path relative to the git folder, sourced from `b.Config.Bundle.Git.BundleRootPath`.

## Why
The deployment-details UI links a deployment's "Source" to the bundle folder (the folder containing `databricks.yml`). Today only `git_folder_path` (the git repo root) is recorded, so the link resolves the repo root instead of the bundle root when the bundle lives in a subfolder. Recording `bundle_root_path` lets the UI resolve the actual bundle folder via `join(git_folder_path, bundle_root_path)`. Mirrors the value already written to `metadata.json`.

Gated on the same workspace Git-folder condition as `git_folder_path`: `BundleRootPath` defaults to `"."` (`filepath.Rel` returns `"."` when bundle root == worktree root), so it is only meaningful for workspace Git-folder deploys. This intentionally diverges from `metadata.json` (which writes it unconditionally under `git`).

Needs the matching `bundle_root_path` field on the DMS proto (separate universe PR).

## Tests
Extended the existing `workspaceInfo` unit tests: local deploy asserts `bundle_root_path` stays empty; git-folder deploy asserts it round-trips.