### PR TITLE
bundle: add env var to enable experimental record_deployment_history

### DIFF
--- a/acceptance/bundle/experimental/record_deployment_history/databricks.yml
+++ b/acceptance/bundle/experimental/record_deployment_history/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: test-bundle

--- a/acceptance/bundle/experimental/record_deployment_history/out.test.toml
+++ b/acceptance/bundle/experimental/record_deployment_history/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/experimental/record_deployment_history/output.txt
+++ b/acceptance/bundle/experimental/record_deployment_history/output.txt
@@ -1,0 +1,8 @@
+
+=== record_deployment_history is unset by default
+>>> [CLI] bundle validate -o json
+null
+
+=== DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY enables record_deployment_history
+>>> [CLI] bundle validate -o json
+true

--- a/acceptance/bundle/experimental/record_deployment_history/script
+++ b/acceptance/bundle/experimental/record_deployment_history/script
@@ -1,0 +1,9 @@
+title "record_deployment_history is unset by default"
+
+trace $CLI bundle validate -o json | jq .experimental
+
+title "DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY enables record_deployment_history"
+
+export DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY=true
+
+trace $CLI bundle validate -o json | jq .experimental.record_deployment_history

--- a/bundle/config/mutator/apply_record_deployment_history_env.go
+++ b/bundle/config/mutator/apply_record_deployment_history_env.go
@@ -1,0 +1,36 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/env"
+	"github.com/databricks/cli/libs/diag"
+)
+
+type applyRecordDeploymentHistoryEnv struct{}
+
+// ApplyRecordDeploymentHistoryEnv enables the experimental record_deployment_history
+// setting when the DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY environment variable is
+// set. This lets the feature be toggled per invocation without editing the bundle
+// configuration; it never disables a setting that the configuration already enabled.
+func ApplyRecordDeploymentHistoryEnv() bundle.Mutator {
+	return &applyRecordDeploymentHistoryEnv{}
+}
+
+func (m *applyRecordDeploymentHistoryEnv) Name() string {
+	return "ApplyRecordDeploymentHistoryEnv"
+}
+
+func (m *applyRecordDeploymentHistoryEnv) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	if _, ok := env.RecordDeploymentHistory(ctx); !ok {
+		return nil
+	}
+
+	if b.Config.Experimental == nil {
+		b.Config.Experimental = &config.Experimental{}
+	}
+	b.Config.Experimental.RecordDeploymentHistory = true
+	return nil
+}

--- a/bundle/config/mutator/apply_record_deployment_history_env_test.go
+++ b/bundle/config/mutator/apply_record_deployment_history_env_test.go
@@ -1,0 +1,67 @@
+package mutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/libs/env"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyRecordDeploymentHistoryEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		envSet       bool
+		experimental *config.Experimental
+		want         bool
+	}{
+		{
+			name:   "env not set leaves config untouched",
+			envSet: false,
+			want:   false,
+		},
+		{
+			name:     "env set enables the experimental setting",
+			envValue: "true",
+			envSet:   true,
+			want:     true,
+		},
+		{
+			name:         "env set enables it even when experimental is already present",
+			envValue:     "true",
+			envSet:       true,
+			experimental: &config.Experimental{PythonWheelWrapper: true},
+			want:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			if tc.envSet {
+				ctx = env.Set(ctx, "DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY", tc.envValue)
+			}
+
+			b := &bundle.Bundle{
+				Config: config.Root{
+					Experimental: tc.experimental,
+				},
+			}
+
+			diags := bundle.Apply(ctx, b, mutator.ApplyRecordDeploymentHistoryEnv())
+			require.NoError(t, diags.Error())
+
+			if tc.want {
+				require.NotNil(t, b.Config.Experimental)
+				assert.True(t, b.Config.Experimental.RecordDeploymentHistory)
+			} else {
+				// When the env var is unset the mutator must not allocate Experimental.
+				assert.Nil(t, b.Config.Experimental)
+			}
+		})
+	}
+}

--- a/bundle/env/record_deployment_history.go
+++ b/bundle/env/record_deployment_history.go
@@ -1,0 +1,17 @@
+package env
+
+import "context"
+
+// recordDeploymentHistoryVariable names the environment variable that opts the
+// bundle into recording deployment history. It is the environment-variable
+// equivalent of setting experimental.record_deployment_history in the bundle
+// configuration.
+const recordDeploymentHistoryVariable = "DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY"
+
+// RecordDeploymentHistory returns the environment variable that opts the bundle
+// into recording deployment history.
+func RecordDeploymentHistory(ctx context.Context) (string, bool) {
+	return get(ctx, []string{
+		recordDeploymentHistoryVariable,
+	})
+}

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -34,6 +34,11 @@ func Initialize(ctx context.Context, b *bundle.Bundle) {
 		validate.ValidateEngine(),
 		validate.Scripts(),
 
+		// Updates (typed): b.Config.Experimental.RecordDeploymentHistory
+		// Enables the experimental record_deployment_history setting from the
+		// DATABRICKS_BUNDLE_RECORD_DEPLOYMENT_HISTORY environment variable.
+		mutator.ApplyRecordDeploymentHistoryEnv(),
+
 		// Updates (dynamic): sync.{paths,include,exclude} (makes them relative to bundle root rather than to definition file)
 		// Rewrites sync paths to be relative to the bundle root instead of the file they were defined in.
 		mutator.RewriteSyncPaths(),


### PR DESCRIPTION
## Why

`experimental.record_deployment_history` is the opt-in for the (experimental) deployment-history feature, but it could only be set in the bundle config. This adds an environment-variable equivalent so the feature can be toggled per invocation — useful for CI and needed for DABs in workspace.
\