### PR TITLE
Drop serverless CPU private preview warning

### DIFF
--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -230,9 +230,6 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 
 	if !opts.ProxyMode {
 		cmdio.LogString(ctx, fmt.Sprintf("Connecting to %s...", sessionID))
-		if opts.IsServerlessMode() && opts.Accelerator == "" {
-			cmdio.LogString(ctx, cmdio.Yellow(ctx, "WARNING: serverless compute without an accelerator is in private preview. If you are not enrolled, this command will likely time out with an error. Contact your Databricks account team to enroll."))
-		}
 	}
 
 	if opts.IDE != "" && !opts.ProxyMode {
@@ -323,10 +320,6 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ClientOpt
 		serverStartTime := time.Now()
 		userName, serverPort, clusterID, err = ensureSSHServerIsRunning(ctx, client, version, secretScopeName, opts)
 		if err != nil {
-			if opts.IsServerlessMode() && opts.Accelerator == "" && errors.Is(err, errServerMetadata) {
-				return fmt.Errorf("failed to ensure that ssh server is running: %w\n\n"+
-					cmdio.Yellow(ctx, "This may be because serverless compute without an accelerator is in private preview.\nContact your Databricks account team to enroll."), err)
-			}
 			return fmt.Errorf("failed to ensure that ssh server is running: %w", err)
 		}
 		serverStartTimeMs = time.Since(serverStartTime).Milliseconds()


### PR DESCRIPTION
## Changes

Serverless compute without an accelerator is moving from private to public preview. This removes the two private-preview notices in `databricks ssh connect`:

- The `WARNING: serverless compute without an accelerator is in private preview...` line printed on connect.
- The private-preview hint appended to the "failed to ensure that ssh server is running" error.

## Why

The feature is being rolled out to public preview, so the enrollment warning no longer applies.

This pull request and its description were written by Isaac.