### PR TITLE
fix(aitools): support Copilot project scope

### DIFF
--- a/libs/aitools/agents/agents.go
+++ b/libs/aitools/agents/agents.go
@@ -97,9 +97,11 @@ var Registry = []Agent{
 		ConfigDir:   homeSubdir(".config", "opencode"),
 	},
 	{
-		Name:        "copilot",
-		DisplayName: "GitHub Copilot",
-		ConfigDir:   homeSubdir(".copilot"),
+		Name:                 "copilot",
+		DisplayName:          "GitHub Copilot",
+		ConfigDir:            homeSubdir(".copilot"),
+		SupportsProjectScope: true,
+		ProjectConfigDir:     ".github",
 	},
 	{
 		Name:         "antigravity",

--- a/libs/aitools/installer/installer_test.go
+++ b/libs/aitools/installer/installer_test.go
@@ -892,7 +892,7 @@ func TestSupportsProjectScopeSetCorrectly(t *testing.T) {
 		"cursor":      true,
 		"codex":       false,
 		"opencode":    false,
-		"copilot":     false,
+		"copilot":     true,
 		"antigravity": false,
 	}
 
@@ -900,6 +900,24 @@ func TestSupportsProjectScopeSetCorrectly(t *testing.T) {
 		want, ok := expected[agent.Name]
 		require.True(t, ok, "missing expected entry for %s", agent.Name)
 		assert.Equal(t, want, agent.SupportsProjectScope, "SupportsProjectScope for %s", agent.Name)
+	}
+}
+
+func TestProjectScopeAgentDirectoriesSetCorrectly(t *testing.T) {
+	cwd := filepath.Join("tmp", "project")
+	expected := map[string]string{
+		"claude-code": filepath.Join(cwd, ".claude", "skills"),
+		"cursor":      filepath.Join(cwd, ".cursor", "skills"),
+		"copilot":     filepath.Join(cwd, ".github", "skills"),
+	}
+
+	for _, agent := range agents.Registry {
+		want, ok := expected[agent.Name]
+		if !ok {
+			continue
+		}
+		require.True(t, agent.SupportsProjectScope, "%s should support project scope", agent.Name)
+		assert.Equal(t, want, agent.ProjectSkillsDir(cwd), "project skills dir for %s", agent.Name)
 	}
 }
 


### PR DESCRIPTION
## Summary
Enables project-scoped Databricks AI skills installs for GitHub Copilot by mapping Copilot project skills to `.github/skills`.

## Changes
- Mark the Copilot agent as project-scope compatible
- Configure Copilot project installs under `.github/skills`
- Add regression coverage for Copilot project-scope support and path resolution

## Test Plan
- `go test ./libs/aitools/... ./cmd/aitools`
- LSP diagnostics clean on modified Go files

Fixes databricks/databricks-agent-skills#98