### PR TITLE
direct: test StateType/RemoteType JSON round-trip; fix found issues

### DIFF
--- a/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/output.txt
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/output.txt
@@ -36,6 +36,7 @@ Plan: 1 to add, 0 to change, 1 to delete, 1 unchanged
           "state": "ONLINE"
         },
         "endpoint_type": "STANDARD",
+        "endpoint_uuid": "[UUID]",
         "id": "[UUID]",
         "last_updated_timestamp": [UNIX_TIME_MILLIS][0],
         "last_updated_user": "[USERNAME]",

--- a/bundle/direct/dresources/all_test.go
+++ b/bundle/direct/dresources/all_test.go
@@ -239,9 +239,12 @@ var testConfig map[string]any = map[string]any{
 			DisplayName: "my-dashboard",
 			ParentPath:  "/Workspace/Users/user@example.com",
 			WarehouseId: "test-warehouse-id",
+			// Use []any/map[string]any to mirror how this any-typed field is
+			// populated in production (JSON/dyn decoding); a typed []map[string]any
+			// can never come out of that path.
 			SerializedDashboard: map[string]any{
-				"pages": []map[string]any{
-					{
+				"pages": []any{
+					map[string]any{
 						"name":        "page1",
 						"displayName": "Page 1",
 						"pageType":    "PAGE_TYPE_CANVAS",

--- a/bundle/direct/dresources/all_test.go
+++ b/bundle/direct/dresources/all_test.go
@@ -936,6 +936,10 @@ func testCRUD(t *testing.T, group string, adapter *Adapter, client *databricks.W
 	require.NoError(t, err)
 	require.NotNil(t, remote)
 
+	// RemoteType is included verbatim in the JSON plan's "remote_state" field,
+	// so it must survive a JSON round-trip without losing fields.
+	assertJSONRoundTrip(t, reflect.ValueOf(remote).Elem().Interface(), "RemoteType "+group)
+
 	remappedState, err := adapter.RemapState(remote)
 	require.NoError(t, err)
 	require.NotNil(t, remappedState)

--- a/bundle/direct/dresources/model.go
+++ b/bundle/direct/dresources/model.go
@@ -6,6 +6,7 @@ import (
 	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/libs/utils"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/ml"
 )
 
@@ -20,6 +21,16 @@ type ResourceMlflowModel struct {
 type MlflowModelRemote struct {
 	ml.ModelDatabricks
 	ModelId string `json:"model_id"`
+}
+
+// Custom marshalers needed because embedded ml.ModelDatabricks has its own
+// MarshalJSON which would otherwise take over and ignore model_id.
+func (s *MlflowModelRemote) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, s)
+}
+
+func (s MlflowModelRemote) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(s)
 }
 
 func (*ResourceMlflowModel) New(client *databricks.WorkspaceClient) *ResourceMlflowModel {

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -40,10 +40,12 @@ func assertJSONRoundTrip(t *testing.T, v any, label string) {
 	require.Empty(t, changes, "%s lost fields in JSON round-trip\nbefore: %s\nafter:  %s", label, jsonDump(v), jsonDump(back))
 }
 
-// TestStateTypeRoundTrip verifies that every resource's StateType survives a
-// json.Marshal -> json.Unmarshal cycle without losing fields. The state file is
-// persisted and reloaded through exactly this path.
-func TestStateTypeRoundTrip(t *testing.T) {
+// TestRoundtripFixtureStateType verifies that every resource's StateType
+// survives a json.Marshal -> json.Unmarshal cycle without losing fields, using
+// the per-resource fixture in testConfig. The state file is persisted and
+// reloaded through exactly this path. Complements TestRoundtripAllFieldsStateType:
+// this exercises a realistic value, that one exercises every field.
+func TestRoundtripFixtureStateType(t *testing.T) {
 	_, client := setupTestServerClient(t)
 
 	for resourceType, resource := range SupportedResources {
@@ -66,26 +68,37 @@ func TestStateTypeRoundTrip(t *testing.T) {
 	}
 }
 
-// TestRoundtripRemoteType verifies that every resource's RemoteType survives a
-// json.Marshal -> json.Unmarshal cycle without losing fields. RemoteType is
-// emitted in the plan's "remote_state" field, so a wrapper that embeds an SDK
-// type with its own MarshalJSON must define its own or its extra fields vanish.
-//
-// Unlike the StateType check, we don't have a fixture per RemoteType, so we fill
-// every field with a non-zero value via reflection. That way a dropped field is
-// always non-zero before the round-trip and zero after, regardless of which
-// fields a realistic value would populate.
-func TestRoundtripRemoteType(t *testing.T) {
+// testRoundtripAllFields fills every field of the type returned by typeOf with a
+// non-zero value and asserts it survives a JSON round-trip. Filling all fields
+// makes a dropped field always observable (non-zero before, zero after),
+// independent of which fields a realistic value would populate. StateType and
+// RemoteType are validated as pointer-to-struct by the adapter, so typeOf always
+// returns a pointer here.
+func testRoundtripAllFields(t *testing.T, label string, typeOf func(*Adapter) reflect.Type) {
 	for resourceType, resource := range SupportedResources {
 		adapter, err := NewAdapter(resource, resourceType, nil)
 		require.NoError(t, err)
 
 		t.Run(resourceType, func(t *testing.T) {
-			remote := reflect.New(adapter.RemoteType().Elem())
-			fillNonZero(remote.Elem(), 0)
-			assertJSONRoundTrip(t, remote.Interface(), "RemoteType "+resourceType)
+			v := reflect.New(typeOf(adapter).Elem())
+			fillNonZero(v.Elem(), 0)
+			assertJSONRoundTrip(t, v.Interface(), label+" "+resourceType)
 		})
 	}
+}
+
+// TestRoundtripAllFieldsStateType verifies StateType survives a JSON round-trip
+// with every field populated. StateType is persisted to the state file.
+func TestRoundtripAllFieldsStateType(t *testing.T) {
+	testRoundtripAllFields(t, "StateType", (*Adapter).StateType)
+}
+
+// TestRoundtripAllFieldsRemoteType verifies RemoteType survives a JSON round-trip
+// with every field populated. RemoteType is emitted in the plan's "remote_state"
+// field, so a wrapper embedding an SDK type with its own MarshalJSON must define
+// its own or its extra fields vanish.
+func TestRoundtripAllFieldsRemoteType(t *testing.T) {
+	testRoundtripAllFields(t, "RemoteType", (*Adapter).RemoteType)
 }
 
 // fillNonZero recursively populates v with non-zero values so that every

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -3,12 +3,30 @@ package dresources
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/databricks/cli/libs/structs/structdiff"
 	"github.com/databricks/cli/libs/structs/structtag"
 	"github.com/stretchr/testify/require"
 )
+
+// formatChanges renders a diff as one "  path: old -> new" line per change, with
+// values JSON-encoded so nested fields stay readable in the failure message.
+func formatChanges(changes []structdiff.Change) string {
+	var b strings.Builder
+	for _, c := range changes {
+		old, _ := json.Marshal(c.Old)
+		updated, _ := json.Marshal(c.New)
+		b.WriteString("\n  ")
+		b.WriteString(c.Path.String())
+		b.WriteString(":\n    old = ")
+		b.Write(old)
+		b.WriteString("\n    new = ")
+		b.Write(updated)
+	}
+	return b.String()
+}
 
 // assertJSONRoundTrip marshals v to JSON, unmarshals it back into a fresh value
 // of the same type, and asserts the two are equal field-by-field.
@@ -37,7 +55,7 @@ func assertJSONRoundTrip(t *testing.T, v any, label string) {
 	// decoding yields) so they round-trip to the same concrete type.
 	changes, err := structdiff.GetStructDiff(v, back, nil)
 	require.NoError(t, err)
-	require.Empty(t, changes, "%s lost fields in JSON round-trip\nbefore: %s\nafter:  %s", label, jsonDump(v), jsonDump(back))
+	require.Empty(t, changes, "%s lost %d field(s) in JSON round-trip:%s", label, len(changes), formatChanges(changes))
 }
 
 // TestRoundtripFixtureStateType verifies that every resource's StateType

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -1,0 +1,75 @@
+package dresources
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/databricks/cli/libs/structs/structdiff"
+	"github.com/stretchr/testify/require"
+)
+
+// assertJSONRoundTrip marshals v to JSON, unmarshals it back into a fresh value
+// of the same type, and asserts the two are equal field-by-field.
+//
+// This guards against wrapper structs (StateType, RemoteType) that embed an SDK
+// type with its own MarshalJSON but forget to define their own: the embedded
+// marshaler takes over and silently drops the wrapper's extra fields. The state
+// file round-trips through exactly this path (dstate.SaveState json.Marshal ->
+// apply.parseState json.Unmarshal), so a missing wrapper marshaler corrupts state.
+func assertJSONRoundTrip(t *testing.T, v any, label string) {
+	t.Helper()
+
+	data, err := json.Marshal(v)
+	require.NoError(t, err, "%s: Marshal failed", label)
+
+	roundTripped := reflect.New(reflect.TypeOf(v)).Interface()
+	err = json.Unmarshal(data, roundTripped)
+	require.NoError(t, err, "%s: Unmarshal failed", label)
+	back := reflect.ValueOf(roundTripped).Elem().Interface()
+
+	// Diff the Go values rather than the JSON: a wrapper that drops fields keeps
+	// them populated in v but loses them in back, so structdiff flags it even
+	// though both marshal to the same (already-truncated) JSON. structdiff skips
+	// ForceSendFields and json:"-" fields, which are intentionally not serialized.
+	changes, err := structdiff.GetStructDiff(v, back, nil)
+	require.NoError(t, err)
+
+	// A free-form any field (e.g. serialized_dashboard) decodes to a different
+	// Go concrete type than the fixture literal ([]any vs []map[string]any) while
+	// encoding to identical JSON. That's not field loss, so drop changes whose
+	// two sides are JSON-equal and keep only genuine differences.
+	var lost []structdiff.Change
+	for _, c := range changes {
+		if jsonDump(c.Old) != jsonDump(c.New) {
+			lost = append(lost, c)
+		}
+	}
+	require.Empty(t, lost, "%s lost fields in JSON round-trip\nbefore: %s\nafter:  %s", label, jsonDump(v), jsonDump(back))
+}
+
+// TestStateTypeRoundTrip verifies that every resource's StateType survives a
+// json.Marshal -> json.Unmarshal cycle without losing fields. The state file is
+// persisted and reloaded through exactly this path.
+func TestStateTypeRoundTrip(t *testing.T) {
+	_, client := setupTestServerClient(t)
+
+	for resourceType, resource := range SupportedResources {
+		adapter, err := NewAdapter(resource, resourceType, client)
+		require.NoError(t, err)
+
+		t.Run(resourceType, func(t *testing.T) {
+			inputConfig, ok := testConfig[resourceType]
+			if !ok {
+				// No populated fixture: fall back to a zero value. This still
+				// exercises the marshalers, just without field-preservation signal.
+				inputConfig = reflect.New(adapter.InputConfigType().Elem()).Interface()
+			}
+
+			newState, err := adapter.PrepareState(inputConfig)
+			require.NoError(t, err, "PrepareState failed")
+
+			assertJSONRoundTrip(t, newState, "StateType "+resourceType)
+		})
+	}
+}

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/libs/structs/structdiff"
+	"github.com/databricks/cli/libs/structs/structtag"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,5 +63,80 @@ func TestStateTypeRoundTrip(t *testing.T) {
 
 			assertJSONRoundTrip(t, newState, "StateType "+resourceType)
 		})
+	}
+}
+
+// TestRoundtripRemoteType verifies that every resource's RemoteType survives a
+// json.Marshal -> json.Unmarshal cycle without losing fields. RemoteType is
+// emitted in the plan's "remote_state" field, so a wrapper that embeds an SDK
+// type with its own MarshalJSON must define its own or its extra fields vanish.
+//
+// Unlike the StateType check, we don't have a fixture per RemoteType, so we fill
+// every field with a non-zero value via reflection. That way a dropped field is
+// always non-zero before the round-trip and zero after, regardless of which
+// fields a realistic value would populate.
+func TestRoundtripRemoteType(t *testing.T) {
+	for resourceType, resource := range SupportedResources {
+		adapter, err := NewAdapter(resource, resourceType, nil)
+		require.NoError(t, err)
+
+		t.Run(resourceType, func(t *testing.T) {
+			remote := reflect.New(adapter.RemoteType().Elem())
+			fillNonZero(remote.Elem(), 0)
+			assertJSONRoundTrip(t, remote.Interface(), "RemoteType "+resourceType)
+		})
+	}
+}
+
+// fillNonZero recursively populates v with non-zero values so that every
+// serializable field is observable in a round-trip. It skips ForceSendFields
+// (json:"-") and bounds recursion depth to avoid runaway on self-referential
+// SDK types; bounding is safe because the fields at risk (a wrapper's own
+// fields alongside an embedded SDK type) sit at the top level.
+func fillNonZero(v reflect.Value, depth int) {
+	if depth > 6 {
+		return
+	}
+	switch v.Kind() {
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v.SetUint(1)
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(1)
+	case reflect.String:
+		v.SetString("x")
+	case reflect.Pointer:
+		v.Set(reflect.New(v.Type().Elem()))
+		fillNonZero(v.Elem(), depth+1)
+	case reflect.Slice:
+		elem := reflect.New(v.Type().Elem()).Elem()
+		fillNonZero(elem, depth+1)
+		v.Set(reflect.Append(v, elem))
+	case reflect.Map:
+		v.Set(reflect.MakeMap(v.Type()))
+		val := reflect.New(v.Type().Elem()).Elem()
+		fillNonZero(val, depth+1)
+		v.SetMapIndex(reflect.ValueOf("k").Convert(v.Type().Key()), val)
+	case reflect.Interface:
+		// Free-form any fields decode to map[string]any from JSON.
+		v.Set(reflect.ValueOf(map[string]any{"k": "v"}))
+	case reflect.Struct:
+		t := v.Type()
+		for i := range t.NumField() {
+			sf := t.Field(i)
+			if !sf.IsExported() || sf.Name == "ForceSendFields" {
+				continue
+			}
+			if structtag.JSONTag(sf.Tag.Get("json")).Name() == "-" {
+				continue
+			}
+			fillNonZero(v.Field(i), depth+1)
+		}
+	default:
+		// Kinds that don't appear in SDK state/remote types (chan, func,
+		// complex, array, etc.) are left at their zero value.
 	}
 }

--- a/bundle/direct/dresources/serialize_test.go
+++ b/bundle/direct/dresources/serialize_test.go
@@ -32,20 +32,11 @@ func assertJSONRoundTrip(t *testing.T, v any, label string) {
 	// them populated in v but loses them in back, so structdiff flags it even
 	// though both marshal to the same (already-truncated) JSON. structdiff skips
 	// ForceSendFields and json:"-" fields, which are intentionally not serialized.
+	// Free-form any fields must be populated with []any/map[string]any (as JSON
+	// decoding yields) so they round-trip to the same concrete type.
 	changes, err := structdiff.GetStructDiff(v, back, nil)
 	require.NoError(t, err)
-
-	// A free-form any field (e.g. serialized_dashboard) decodes to a different
-	// Go concrete type than the fixture literal ([]any vs []map[string]any) while
-	// encoding to identical JSON. That's not field loss, so drop changes whose
-	// two sides are JSON-equal and keep only genuine differences.
-	var lost []structdiff.Change
-	for _, c := range changes {
-		if jsonDump(c.Old) != jsonDump(c.New) {
-			lost = append(lost, c)
-		}
-	}
-	require.Empty(t, lost, "%s lost fields in JSON round-trip\nbefore: %s\nafter:  %s", label, jsonDump(v), jsonDump(back))
+	require.Empty(t, changes, "%s lost fields in JSON round-trip\nbefore: %s\nafter:  %s", label, jsonDump(v), jsonDump(back))
 }
 
 // TestStateTypeRoundTrip verifies that every resource's StateType survives a

--- a/bundle/direct/dresources/vector_search_endpoint.go
+++ b/bundle/direct/dresources/vector_search_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/databricks/cli/libs/utils"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/marshal"
 	"github.com/databricks/databricks-sdk-go/service/vectorsearch"
 )
 
@@ -21,6 +22,16 @@ var (
 type VectorSearchEndpointRemote struct {
 	vectorsearch.EndpointInfo
 	EndpointUuid string `json:"endpoint_uuid"`
+}
+
+// Custom marshalers needed because embedded vectorsearch.EndpointInfo has its own
+// MarshalJSON which would otherwise take over and ignore endpoint_uuid.
+func (s *VectorSearchEndpointRemote) UnmarshalJSON(b []byte) error {
+	return marshal.Unmarshal(b, s)
+}
+
+func (s VectorSearchEndpointRemote) MarshalJSON() ([]byte, error) {
+	return marshal.Marshal(s)
 }
 
 func newVectorSearchEndpointRemote(info *vectorsearch.EndpointInfo) *VectorSearchEndpointRemote {


### PR DESCRIPTION
Direct-engine resources persist their StateType to the state file and emit RemoteType in the plan's `remote_state` field, both via `encoding/json`. A wrapper that embeds an SDK type with its own `MarshalJSON` but omits its own silently drops the wrapper's extra fields. Nothing tested this.

The same bug class was fixed manually in #5672 (`role_id`); these tests turn it into a guard across every resource.

Adds round-trip tests and fixes two resources that had this bug:
- `VectorSearchEndpointRemote` dropped `endpoint_uuid`
- `MlflowModelRemote` dropped `model_id`

Both fields carry the numeric ID the permissions API needs.

Tests:
- `TestRoundtripFixtureStateType` — StateType round-trip on a realistic per-resource fixture
- `TestRoundtripAllFieldsStateType` / `TestRoundtripAllFieldsRemoteType` — synthetic all-fields round-trip, so a dropped field is always observable regardless of fixture coverage
- plus a concrete-value RemoteType check in the existing `testCRUD`

InputType is intentionally not covered in this PR - many issues found but it is never serialized via `encoding/json` (the bundle config layer uses dyn).

This pull request and its description were written by Isaac.