### PR TITLE
AIR CLI Integration: collapse `air get run` back to `air get JOB_RUN_ID`

### DIFF
--- a/acceptance/experimental/air/get/output.txt
+++ b/acceptance/experimental/air/get/output.txt
@@ -1,6 +1,6 @@
 
 === get (text)
->>> [CLI] experimental air get run 123
+>>> [CLI] experimental air get 123
 
 ╭─ Configuration ────────────────────────────────────────────────╮
 │                                                                │
@@ -35,7 +35,7 @@ Run URL:    [DATABRICKS_URL]/jobs/runs/123?o=[NUMID]
 MLflow URL: [DATABRICKS_URL]/ml/experiments/exp1/runs/run1
 
 === get (json)
->>> [CLI] experimental air get run 123 -o json
+>>> [CLI] experimental air get 123 -o json
 {
   "v": 1,
   "ts": "[TIMESTAMP]",
@@ -52,13 +52,13 @@ MLflow URL: [DATABRICKS_URL]/ml/experiments/exp1/runs/run1
 }
 
 === invalid run id
->>> [CLI] experimental air get run notanumber
+>>> [CLI] experimental air get notanumber
 Error: invalid JOB_RUN_ID "notanumber": must be a positive integer
 
 Exit code: 1
 
 === invalid run id (json)
->>> [CLI] experimental air get run notanumber -o json
+>>> [CLI] experimental air get notanumber -o json
 {
   "v": 1,
   "ts": "[TIMESTAMP]",

--- a/acceptance/experimental/air/get/script
+++ b/acceptance/experimental/air/get/script
@@ -1,11 +1,11 @@
 title "get (text)"
-trace $CLI experimental air get run 123
+trace $CLI experimental air get 123
 
 title "get (json)"
-trace $CLI experimental air get run 123 -o json
+trace $CLI experimental air get 123 -o json
 
 title "invalid run id"
-errcode trace $CLI experimental air get run notanumber
+errcode trace $CLI experimental air get notanumber
 
 title "invalid run id (json)"
-errcode trace $CLI experimental air get run notanumber -o json
+errcode trace $CLI experimental air get notanumber -o json

--- a/acceptance/experimental/air/help/output.txt
+++ b/acceptance/experimental/air/help/output.txt
@@ -11,7 +11,7 @@ Usage:
 
 Available Commands:
   cancel         Cancel one or more runs
-  get            Show details for a specific resource
+  get            Show status, configuration, and timing details for a specific run
   list           List your recent runs (active and completed) for the current profile
   logs           Stream or fetch logs for a run
   register-image Mirror a Docker image into the workspace registry

--- a/experimental/air/cmd/get.go
+++ b/experimental/air/cmd/get.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// getData is the payload printed by `air get run`. The json-tagged fields form
+// getData is the payload printed by `air get`. The json-tagged fields form
 // the machine-readable output; fields tagged `json:"-"` are shown only in the
 // human-readable text view.
 type getData struct {
@@ -27,7 +27,7 @@ type getData struct {
 	MLflowURL       *string `json:"mlflow_url"`
 
 	// The fields below are pre-rendered text-view cells, excluded from JSON
-	// (matching `air get run --json`). Each shows "N/A" when its value is
+	// (matching `air get --json`). Each shows "N/A" when its value is
 	// missing. The styled single-run renderer (render.go) consumes them; the
 	// Run ID, Status, and MLflow Run cells it draws are styled and hyperlinked
 	// there rather than stored here.
@@ -63,20 +63,11 @@ Sweep Tasks:
 {{- end}}
 `
 
-// newGetCommand is the `get` parent group. Subcommands name the resource to
-// describe, e.g. `air get run JOB_RUN_ID`, mirroring the Python CLI.
+// newGetCommand returns the `air get JOB_RUN_ID` command, which shows status,
+// configuration, and timing details for a specific run.
 func newGetCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: "Show details for a specific resource",
-	}
-	cmd.AddCommand(newGetRunCommand())
-	return cmd
-}
-
-func newGetRunCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "run JOB_RUN_ID",
+		Use:   "get JOB_RUN_ID",
 		Args:  root.ExactArgs(1),
 		Short: "Show status, configuration, and timing details for a specific run",
 		Annotations: map[string]string{

--- a/experimental/air/cmd/get_test.go
+++ b/experimental/air/cmd/get_test.go
@@ -29,10 +29,23 @@ func renderGet(t *testing.T, data getData) string {
 	return buf.String()
 }
 
+// TestGetCommandShape locks in that `get` takes the run id directly as
+// `air get JOB_RUN_ID` and has no `run` subcommand (it was collapsed back into
+// `get`). The acceptance test exercises the happy path end to end.
+func TestGetCommandShape(t *testing.T) {
+	cmd := newGetCommand()
+	assert.Equal(t, "get JOB_RUN_ID", cmd.Use)
+	assert.Empty(t, cmd.Commands(), "get must not register subcommands")
+	// ExactArgs(1): exactly one run id is required.
+	assert.NoError(t, cmd.Args(cmd, []string{"123"}))
+	assert.Error(t, cmd.Args(cmd, []string{}))
+	assert.Error(t, cmd.Args(cmd, []string{"1", "2"}))
+}
+
 func TestGetRunInvalidID(t *testing.T) {
 	m := mocks.NewMockWorkspaceClient(t)
 	ctx := cmdctx.SetWorkspaceClient(cmdio.MockDiscard(t.Context()), m.WorkspaceClient)
-	cmd := withOutput(newGetRunCommand(), flags.OutputText)
+	cmd := withOutput(newGetCommand(), flags.OutputText)
 	cmd.SetContext(ctx)
 
 	err := cmd.RunE(cmd, []string{"abc"})
@@ -45,7 +58,7 @@ func TestGetRunNotFound(t *testing.T) {
 	m.GetMockJobsAPI().EXPECT().GetRun(mock.Anything, jobs.GetRunRequest{RunId: 5}).Return(
 		nil, apierr.ErrResourceDoesNotExist)
 	ctx := cmdctx.SetWorkspaceClient(cmdio.MockDiscard(t.Context()), m.WorkspaceClient)
-	cmd := withOutput(newGetRunCommand(), flags.OutputText)
+	cmd := withOutput(newGetCommand(), flags.OutputText)
 	cmd.SetContext(ctx)
 
 	err := cmd.RunE(cmd, []string{"5"})
@@ -60,7 +73,7 @@ func TestGetRunNotFoundJSON(t *testing.T) {
 		nil, apierr.ErrResourceDoesNotExist)
 	ctx := cmdctx.SetWorkspaceClient(t.Context(), m.WorkspaceClient)
 	ctx = cmdio.InContext(ctx, cmdio.NewIO(ctx, flags.OutputJSON, nil, &buf, &buf, "", ""))
-	cmd := withOutput(newGetRunCommand(), flags.OutputJSON)
+	cmd := withOutput(newGetCommand(), flags.OutputJSON)
 	cmd.SetContext(ctx)
 
 	// In JSON mode the not-found error is a structured envelope, not a bare error.

--- a/experimental/air/cmd/render.go
+++ b/experimental/air/cmd/render.go
@@ -130,8 +130,8 @@ func renderRunText(ctx context.Context, out io.Writer, w *databricks.WorkspaceCl
 	// stdout is not a hyperlink-capable terminal (piped, redirected, NO_COLOR).
 	// In that case the OSC 8 hyperlinks on the Run ID / MLflow Run cells
 	// degrade to plain labels and the URLs would otherwise disappear from text
-	// output, breaking workflows like `air get run X > out.txt` or
-	// `NO_COLOR=1 air get run X` that the previous `Job Link:` line supported.
+	// output, breaking workflows like `air get X > out.txt` or
+	// `NO_COLOR=1 air get X` that the previous `Job Link:` line supported.
 	if view.dashboardURL != "" {
 		fmt.Fprintf(out, "Run URL:    %s\n", view.dashboardURL)
 	}


### PR DESCRIPTION
## Why

We decided to cut the `get run` sub-resource. The run-status command is now just `air get <id>` — flat, with no `run` subcommand.

## Changes

- Removed the `get` parent group and its `run` subcommand; `newGetCommand` is the run-status command itself (`Use: "get JOB_RUN_ID"`, `ExactArgs(1)`).
- No change to output behavior — the styled config box, `JOB_RUN_ID` naming, `Job Link` header, status table, and sweep view are all unchanged.
- Regenerated the `experimental/air/get` and `experimental/air/help` acceptance outputs; updated doc comments and tests that referenced `air get run`.

## Tests

- Added `TestGetCommandShape`: asserts `Use == "get JOB_RUN_ID"`, no registered subcommands, and exactly one arg required.
- Updated the existing `get` unit tests (invalid id, not-found text/JSON, templates, `buildGetData`) to the new entry point.
- `experimental/air/{get,help}` acceptance regenerated; full air unit + acceptance suites pass.

This pull request and its description were written by Isaac.