### PR TITLE
Use bash as the default shell for `ssh connect` interactive sessions

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Notable Changes
 
 ### CLI
-* `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected.
+* `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected ([#5687](https://github.com/databricks/cli/pull/5687)).
 
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Notable Changes
 
 ### CLI
+* `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected.
 
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -612,20 +612,49 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts.TaskStartupTimeout)
 }
 
-// buildRemoteShellArgs returns the ssh arguments that follow the hostname.
+// buildRemoteShellArgs returns the remote command for the ssh client.
 //
-// For the interactive case (no remote command given), it forces PTY allocation
-// and launches a login bash, because the default login shell on Databricks
-// compute images is /bin/sh. If bash is unavailable it falls back to $SHELL or
-// /bin/sh so the connection never breaks.
+// For the interactive case (no remote command given), it returns a command that
+// launches a login bash, because the default login shell on Databricks compute
+// images is /bin/sh. If bash is unavailable it falls back to $SHELL or /bin/sh
+// so the connection never breaks.
 //
 // For the non-interactive case (e.g. `databricks ssh connect ... -- ls -la`),
 // the user's command is returned verbatim so behavior is unchanged.
+//
+// Note: PTY allocation (-t) is added to the ssh options before the destination
+// by buildSSHArgs; -t placed after the host would be parsed as part of the
+// remote command, not as ssh's flag.
 func buildRemoteShellArgs(opts ClientOptions) []string {
 	if len(opts.AdditionalArgs) > 0 {
 		return opts.AdditionalArgs
 	}
-	return []string{"-t", `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+	return []string{`command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+}
+
+// buildSSHArgs assembles the argument list for the ssh client. Options come
+// first, then the destination host, then the remote command (if any). PTY
+// allocation (-t) for the interactive case is added before the host: ssh stops
+// parsing options at the destination, so a -t placed after the host would be
+// treated as part of the remote command rather than as ssh's force-PTY flag.
+func buildSSHArgs(userName, privateKeyPath, proxyCommand, hostName string, opts ClientOptions) []string {
+	sshArgs := []string{
+		"-l", userName,
+		"-i", privateKeyPath,
+		"-o", "IdentitiesOnly=yes",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ConnectTimeout=360",
+		"-o", "ProxyCommand=" + proxyCommand,
+	}
+	if opts.UserKnownHostsFile != "" {
+		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
+	}
+	if len(opts.AdditionalArgs) == 0 {
+		sshArgs = append(sshArgs, "-t")
+	}
+	sshArgs = append(sshArgs, hostName)
+	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
+	return sshArgs
 }
 
 func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, userName, privateKeyPath string, serverPort int, clusterID string, opts ClientOptions) error {
@@ -640,19 +669,7 @@ func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, use
 
 	hostName := opts.SessionIdentifier()
 
-	sshArgs := []string{
-		"-l", userName,
-		"-i", privateKeyPath,
-		"-o", "IdentitiesOnly=yes",
-		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "ConnectTimeout=360",
-		"-o", "ProxyCommand=" + proxyCommand,
-	}
-	if opts.UserKnownHostsFile != "" {
-		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
-	}
-	sshArgs = append(sshArgs, hostName)
-	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
+	sshArgs := buildSSHArgs(userName, privateKeyPath, proxyCommand, hostName, opts)
 
 	log.Debugf(ctx, "Launching SSH client: ssh %s", strings.Join(sshArgs, " "))
 	sshCmd := exec.CommandContext(ctx, "ssh", sshArgs...)

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -612,6 +612,22 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts.TaskStartupTimeout)
 }
 
+// buildRemoteShellArgs returns the ssh arguments that follow the hostname.
+//
+// For the interactive case (no remote command given), it forces PTY allocation
+// and launches a login bash, because the default login shell on Databricks
+// compute images is /bin/sh. If bash is unavailable it falls back to $SHELL or
+// /bin/sh so the connection never breaks.
+//
+// For the non-interactive case (e.g. `databricks ssh connect ... -- ls -la`),
+// the user's command is returned verbatim so behavior is unchanged.
+func buildRemoteShellArgs(opts ClientOptions) []string {
+	if len(opts.AdditionalArgs) > 0 {
+		return opts.AdditionalArgs
+	}
+	return []string{"-t", `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+}
+
 func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, userName, privateKeyPath string, serverPort int, clusterID string, opts ClientOptions) error {
 	// Create a copy with metadata for the ProxyCommand
 	optsWithMetadata := opts
@@ -636,7 +652,7 @@ func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, use
 		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
 	}
 	sshArgs = append(sshArgs, hostName)
-	sshArgs = append(sshArgs, opts.AdditionalArgs...)
+	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
 
 	log.Debugf(ctx, "Launching SSH client: ssh %s", strings.Join(sshArgs, " "))
 	sshCmd := exec.CommandContext(ctx, "ssh", sshArgs...)

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -199,18 +199,49 @@ func TestHostKeyChangedHint(t *testing.T) {
 }
 
 func TestBuildRemoteShellArgs(t *testing.T) {
-	t.Run("interactive launches login bash with PTY", func(t *testing.T) {
+	const bashCmd = `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`
+
+	t.Run("interactive returns login bash command", func(t *testing.T) {
 		args := buildRemoteShellArgs(ClientOptions{})
-		require.Len(t, args, 2)
-		assert.Equal(t, "-t", args[0])
-		assert.Equal(t, `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`, args[1])
+		require.Len(t, args, 1)
+		assert.Equal(t, bashCmd, args[0])
 	})
 
 	t.Run("non-interactive passes additional args verbatim", func(t *testing.T) {
 		additional := []string{"ls", "-la"}
 		args := buildRemoteShellArgs(ClientOptions{AdditionalArgs: additional})
 		assert.Equal(t, additional, args)
-		assert.NotContains(t, args, "-t")
+	})
+}
+
+func TestBuildSSHArgsPTYPlacement(t *testing.T) {
+	indexOf := func(args []string, want string) int {
+		for i, a := range args {
+			if a == want {
+				return i
+			}
+		}
+		return -1
+	}
+
+	t.Run("interactive forces a PTY before the destination", func(t *testing.T) {
+		args := buildSSHArgs("user", "/key", "proxy command", "myhost", ClientOptions{})
+		ptyIdx := indexOf(args, "-t")
+		hostIdx := indexOf(args, "myhost")
+		require.NotEqual(t, -1, ptyIdx, "-t must be present for interactive sessions")
+		require.NotEqual(t, -1, hostIdx)
+		assert.Less(t, ptyIdx, hostIdx, "-t must precede the destination host")
+		// The remote command is the final arg, after the host.
+		assert.Greater(t, len(args)-1, hostIdx)
+		assert.Contains(t, args[len(args)-1], "exec bash -l")
+	})
+
+	t.Run("non-interactive does not force a PTY", func(t *testing.T) {
+		args := buildSSHArgs("user", "/key", "proxy command", "myhost", ClientOptions{AdditionalArgs: []string{"ls", "-la"}})
+		assert.Equal(t, -1, indexOf(args, "-t"), "no PTY for non-interactive passthrough")
+		hostIdx := indexOf(args, "myhost")
+		require.NotEqual(t, -1, hostIdx)
+		assert.Equal(t, []string{"ls", "-la"}, args[hostIdx+1:], "additional args follow the host verbatim")
 	})
 }
 

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -198,6 +198,22 @@ func TestHostKeyChangedHint(t *testing.T) {
 	}
 }
 
+func TestBuildRemoteShellArgs(t *testing.T) {
+	t.Run("interactive launches login bash with PTY", func(t *testing.T) {
+		args := buildRemoteShellArgs(ClientOptions{})
+		require.Len(t, args, 2)
+		assert.Equal(t, "-t", args[0])
+		assert.Equal(t, `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`, args[1])
+	})
+
+	t.Run("non-interactive passes additional args verbatim", func(t *testing.T) {
+		additional := []string{"ls", "-la"}
+		args := buildRemoteShellArgs(ClientOptions{AdditionalArgs: additional})
+		assert.Equal(t, additional, args)
+		assert.NotContains(t, args, "-t")
+	})
+}
+
 func TestTailWriterRetainsTail(t *testing.T) {
 	t.Run("retains only the tail", func(t *testing.T) {
 		w := &tailWriter{maxBytes: 4}


### PR DESCRIPTION
## Summary
When `databricks ssh connect` is run with no trailing command, the CLI now explicitly launches a login `bash` shell over a PTY instead of relying on the compute image's default login shell (which is `/bin/sh` on Databricks compute images). This gives a consistent, predictable interactive shell.

- Interactive (no args): appends `-t` and runs `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`. Graceful fallback to `$SHELL`/`/bin/sh` if bash is absent.
- Non-interactive (`databricks ssh connect ... -- ls -la`): unchanged — the user's command is passed verbatim with no PTY/bash wrapper.

This supersedes #5002. That PR also tried to set bash as the login shell server-side by editing `/etc/passwd`, which @pietern correctly pointed out can never work — the `repl` user is not root. That approach is dropped; this change is purely client-side. Forcing bash inside the IDE (VS Code/Cursor) terminal is intentionally out of scope and tracked separately.

Logic is isolated in a new `buildRemoteShellArgs` helper to keep the change small and unit-testable.

## Test plan
- [x] `go test ./experimental/ssh/internal/client/` — new `TestBuildRemoteShellArgs` covers interactive + passthrough cases.
- [x] Existing `acceptance/ssh/connection/` test exercises the non-interactive path (regression guard) and is unchanged.
- [ ] Manual: `databricks ssh connect --cluster=<id>` opens a bash prompt (`echo $0`); `databricks ssh connect --cluster=<id> -- ls -la` still works.

Jira: DECO-27476