### PR TITLE
cd into the workspace home folder on `ssh connect`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,7 @@
 ### CLI
 * `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected ([#5687](https://github.com/databricks/cli/pull/5687)).
 
-* `databricks ssh connect` interactive sessions now start in the user's workspace home folder (`/Workspace/Users/<email>`) instead of the OS home directory, falling back to the OS home when that folder is unavailable.
+* `databricks ssh connect` interactive sessions now start in the user's workspace home folder (`/Workspace/Users/<email>`) instead of the OS home directory, falling back to the OS home when that folder is unavailable ([#5688](https://github.com/databricks/cli/pull/5688)).
 
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,8 @@
 ### CLI
 * `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected ([#5687](https://github.com/databricks/cli/pull/5687)).
 
+* `databricks ssh connect` interactive sessions now start in the user's workspace home folder (`/Workspace/Users/<email>`) instead of the OS home directory, falling back to the OS home when that folder is unavailable.
+
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.
 * Fix missing field descriptions in the bundle JSON schema for fields whose upstream API docs arrived after the field was first annotated (e.g. `vector_search_endpoints.*.target_qps`); stale placeholder markers no longer hide them ([#5588](https://github.com/databricks/cli/pull/5588)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Notable Changes
 
 ### CLI
-* `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected.
+* `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected ([#5687](https://github.com/databricks/cli/pull/5687)).
 
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Notable Changes
 
 ### CLI
+* `databricks ssh connect` now opens an interactive `bash` login shell by default instead of the compute image's default `/bin/sh`, falling back gracefully when `bash` is unavailable. Passing an explicit remote command (`-- <cmd>`) is unaffected.
 
 ### Bundles
 * `bundle run` now prints the modern job run URL (`/jobs/<id>/runs/<id>`) so that non-admin users permitted to view the run are taken to the run instead of the workspace homepage.

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -612,20 +612,49 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts.TaskStartupTimeout)
 }
 
-// buildRemoteShellArgs returns the ssh arguments that follow the hostname.
+// buildRemoteShellArgs returns the remote command for the ssh client.
 //
-// For the interactive case (no remote command given), it forces PTY allocation
-// and launches a login bash, because the default login shell on Databricks
-// compute images is /bin/sh. If bash is unavailable it falls back to $SHELL or
-// /bin/sh so the connection never breaks.
+// For the interactive case (no remote command given), it returns a command that
+// launches a login bash, because the default login shell on Databricks compute
+// images is /bin/sh. If bash is unavailable it falls back to $SHELL or /bin/sh
+// so the connection never breaks.
 //
 // For the non-interactive case (e.g. `databricks ssh connect ... -- ls -la`),
 // the user's command is returned verbatim so behavior is unchanged.
+//
+// Note: PTY allocation (-t) is added to the ssh options before the destination
+// by buildSSHArgs; -t placed after the host would be parsed as part of the
+// remote command, not as ssh's flag.
 func buildRemoteShellArgs(opts ClientOptions) []string {
 	if len(opts.AdditionalArgs) > 0 {
 		return opts.AdditionalArgs
 	}
-	return []string{"-t", `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+	return []string{`command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+}
+
+// buildSSHArgs assembles the argument list for the ssh client. Options come
+// first, then the destination host, then the remote command (if any). PTY
+// allocation (-t) for the interactive case is added before the host: ssh stops
+// parsing options at the destination, so a -t placed after the host would be
+// treated as part of the remote command rather than as ssh's force-PTY flag.
+func buildSSHArgs(userName, privateKeyPath, proxyCommand, hostName string, opts ClientOptions) []string {
+	sshArgs := []string{
+		"-l", userName,
+		"-i", privateKeyPath,
+		"-o", "IdentitiesOnly=yes",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ConnectTimeout=360",
+		"-o", "ProxyCommand=" + proxyCommand,
+	}
+	if opts.UserKnownHostsFile != "" {
+		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
+	}
+	if len(opts.AdditionalArgs) == 0 {
+		sshArgs = append(sshArgs, "-t")
+	}
+	sshArgs = append(sshArgs, hostName)
+	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
+	return sshArgs
 }
 
 func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, userName, privateKeyPath string, serverPort int, clusterID string, opts ClientOptions) error {
@@ -640,19 +669,7 @@ func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, use
 
 	hostName := opts.SessionIdentifier()
 
-	sshArgs := []string{
-		"-l", userName,
-		"-i", privateKeyPath,
-		"-o", "IdentitiesOnly=yes",
-		"-o", "StrictHostKeyChecking=accept-new",
-		"-o", "ConnectTimeout=360",
-		"-o", "ProxyCommand=" + proxyCommand,
-	}
-	if opts.UserKnownHostsFile != "" {
-		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
-	}
-	sshArgs = append(sshArgs, hostName)
-	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
+	sshArgs := buildSSHArgs(userName, privateKeyPath, proxyCommand, hostName, opts)
 
 	log.Debugf(ctx, "Launching SSH client: ssh %s", strings.Join(sshArgs, " "))
 	sshCmd := exec.CommandContext(ctx, "ssh", sshArgs...)

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -612,6 +612,22 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts.TaskStartupTimeout)
 }
 
+// buildRemoteShellArgs returns the ssh arguments that follow the hostname.
+//
+// For the interactive case (no remote command given), it forces PTY allocation
+// and launches a login bash, because the default login shell on Databricks
+// compute images is /bin/sh. If bash is unavailable it falls back to $SHELL or
+// /bin/sh so the connection never breaks.
+//
+// For the non-interactive case (e.g. `databricks ssh connect ... -- ls -la`),
+// the user's command is returned verbatim so behavior is unchanged.
+func buildRemoteShellArgs(opts ClientOptions) []string {
+	if len(opts.AdditionalArgs) > 0 {
+		return opts.AdditionalArgs
+	}
+	return []string{"-t", `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+}
+
 func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, userName, privateKeyPath string, serverPort int, clusterID string, opts ClientOptions) error {
 	// Create a copy with metadata for the ProxyCommand
 	optsWithMetadata := opts
@@ -636,7 +652,7 @@ func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, use
 		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
 	}
 	sshArgs = append(sshArgs, hostName)
-	sshArgs = append(sshArgs, opts.AdditionalArgs...)
+	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
 
 	log.Debugf(ctx, "Launching SSH client: ssh %s", strings.Join(sshArgs, " "))
 	sshCmd := exec.CommandContext(ctx, "ssh", sshArgs...)

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -612,20 +612,32 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts.TaskStartupTimeout)
 }
 
+// shellSingleQuote wraps s in single quotes for safe inclusion in a shell
+// command, escaping any embedded single quotes.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // buildRemoteShellArgs returns the ssh arguments that follow the hostname.
 //
 // For the interactive case (no remote command given), it forces PTY allocation
 // and launches a login bash, because the default login shell on Databricks
 // compute images is /bin/sh. If bash is unavailable it falls back to $SHELL or
-// /bin/sh so the connection never breaks.
+// /bin/sh so the connection never breaks. When wsHome is set, the shell first
+// changes into the user's workspace home folder; if that directory is missing
+// the cd is ignored and the shell still launches from $HOME.
 //
 // For the non-interactive case (e.g. `databricks ssh connect ... -- ls -la`),
 // the user's command is returned verbatim so behavior is unchanged.
-func buildRemoteShellArgs(opts ClientOptions) []string {
+func buildRemoteShellArgs(opts ClientOptions, wsHome string) []string {
 	if len(opts.AdditionalArgs) > 0 {
 		return opts.AdditionalArgs
 	}
-	return []string{"-t", `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`}
+	cmd := `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`
+	if wsHome != "" {
+		cmd = "cd " + shellSingleQuote(wsHome) + " 2>/dev/null; " + cmd
+	}
+	return []string{"-t", cmd}
 }
 
 func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, userName, privateKeyPath string, serverPort int, clusterID string, opts ClientOptions) error {
@@ -651,8 +663,20 @@ func spawnSSHClient(ctx context.Context, client *databricks.WorkspaceClient, use
 	if opts.UserKnownHostsFile != "" {
 		sshArgs = append(sshArgs, "-o", "UserKnownHostsFile="+opts.UserKnownHostsFile)
 	}
+	// For an interactive session, land the shell in the user's workspace home folder
+	// (/Workspace/Users/<email>) instead of the OS home. Only needed when no remote
+	// command is given; skip the lookup otherwise.
+	var wsHome string
+	if len(opts.AdditionalArgs) == 0 {
+		if currentUser, err := client.CurrentUser.Me(ctx, iam.MeRequest{}); err != nil {
+			log.Warnf(ctx, "Failed to resolve current user for workspace home directory: %v", err)
+		} else {
+			wsHome = "/Workspace/Users/" + currentUser.UserName
+		}
+	}
+
 	sshArgs = append(sshArgs, hostName)
-	sshArgs = append(sshArgs, buildRemoteShellArgs(opts)...)
+	sshArgs = append(sshArgs, buildRemoteShellArgs(opts, wsHome)...)
 
 	log.Debugf(ctx, "Launching SSH client: ssh %s", strings.Join(sshArgs, " "))
 	sshCmd := exec.CommandContext(ctx, "ssh", sshArgs...)

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -199,18 +199,49 @@ func TestHostKeyChangedHint(t *testing.T) {
 }
 
 func TestBuildRemoteShellArgs(t *testing.T) {
-	t.Run("interactive launches login bash with PTY", func(t *testing.T) {
+	const bashCmd = `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`
+
+	t.Run("interactive returns login bash command", func(t *testing.T) {
 		args := buildRemoteShellArgs(ClientOptions{})
-		require.Len(t, args, 2)
-		assert.Equal(t, "-t", args[0])
-		assert.Equal(t, `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`, args[1])
+		require.Len(t, args, 1)
+		assert.Equal(t, bashCmd, args[0])
 	})
 
 	t.Run("non-interactive passes additional args verbatim", func(t *testing.T) {
 		additional := []string{"ls", "-la"}
 		args := buildRemoteShellArgs(ClientOptions{AdditionalArgs: additional})
 		assert.Equal(t, additional, args)
-		assert.NotContains(t, args, "-t")
+	})
+}
+
+func TestBuildSSHArgsPTYPlacement(t *testing.T) {
+	indexOf := func(args []string, want string) int {
+		for i, a := range args {
+			if a == want {
+				return i
+			}
+		}
+		return -1
+	}
+
+	t.Run("interactive forces a PTY before the destination", func(t *testing.T) {
+		args := buildSSHArgs("user", "/key", "proxy command", "myhost", ClientOptions{})
+		ptyIdx := indexOf(args, "-t")
+		hostIdx := indexOf(args, "myhost")
+		require.NotEqual(t, -1, ptyIdx, "-t must be present for interactive sessions")
+		require.NotEqual(t, -1, hostIdx)
+		assert.Less(t, ptyIdx, hostIdx, "-t must precede the destination host")
+		// The remote command is the final arg, after the host.
+		assert.Greater(t, len(args)-1, hostIdx)
+		assert.Contains(t, args[len(args)-1], "exec bash -l")
+	})
+
+	t.Run("non-interactive does not force a PTY", func(t *testing.T) {
+		args := buildSSHArgs("user", "/key", "proxy command", "myhost", ClientOptions{AdditionalArgs: []string{"ls", "-la"}})
+		assert.Equal(t, -1, indexOf(args, "-t"), "no PTY for non-interactive passthrough")
+		hostIdx := indexOf(args, "myhost")
+		require.NotEqual(t, -1, hostIdx)
+		assert.Equal(t, []string{"ls", "-la"}, args[hostIdx+1:], "additional args follow the host verbatim")
 	})
 }
 

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -198,6 +198,22 @@ func TestHostKeyChangedHint(t *testing.T) {
 	}
 }
 
+func TestBuildRemoteShellArgs(t *testing.T) {
+	t.Run("interactive launches login bash with PTY", func(t *testing.T) {
+		args := buildRemoteShellArgs(ClientOptions{})
+		require.Len(t, args, 2)
+		assert.Equal(t, "-t", args[0])
+		assert.Equal(t, `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`, args[1])
+	})
+
+	t.Run("non-interactive passes additional args verbatim", func(t *testing.T) {
+		additional := []string{"ls", "-la"}
+		args := buildRemoteShellArgs(ClientOptions{AdditionalArgs: additional})
+		assert.Equal(t, additional, args)
+		assert.NotContains(t, args, "-t")
+	})
+}
+
 func TestTailWriterRetainsTail(t *testing.T) {
 	t.Run("retains only the tail", func(t *testing.T) {
 		w := &tailWriter{maxBytes: 4}

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -199,16 +199,25 @@ func TestHostKeyChangedHint(t *testing.T) {
 }
 
 func TestBuildRemoteShellArgs(t *testing.T) {
+	const bashCmd = `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`
+
 	t.Run("interactive launches login bash with PTY", func(t *testing.T) {
-		args := buildRemoteShellArgs(ClientOptions{})
+		args := buildRemoteShellArgs(ClientOptions{}, "")
 		require.Len(t, args, 2)
 		assert.Equal(t, "-t", args[0])
-		assert.Equal(t, `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`, args[1])
+		assert.Equal(t, bashCmd, args[1])
+	})
+
+	t.Run("interactive cds into workspace home when set", func(t *testing.T) {
+		args := buildRemoteShellArgs(ClientOptions{}, "/Workspace/Users/me@example.com")
+		require.Len(t, args, 2)
+		assert.Equal(t, "-t", args[0])
+		assert.Equal(t, `cd '/Workspace/Users/me@example.com' 2>/dev/null; `+bashCmd, args[1])
 	})
 
 	t.Run("non-interactive passes additional args verbatim", func(t *testing.T) {
 		additional := []string{"ls", "-la"}
-		args := buildRemoteShellArgs(ClientOptions{AdditionalArgs: additional})
+		args := buildRemoteShellArgs(ClientOptions{AdditionalArgs: additional}, "/Workspace/Users/me@example.com")
 		assert.Equal(t, additional, args)
 		assert.NotContains(t, args, "-t")
 	})


### PR DESCRIPTION
## Summary
For interactive `databricks ssh connect` sessions, the shell now changes into the user's workspace home folder (`/Workspace/Users/<email>`) before launching, instead of landing in the OS home (`/root` etc).

- The `cd` is best-effort (`cd '<wsHome>' 2>/dev/null;`): if the folder isn't mounted/available the shell still launches from `$HOME`.
- Non-interactive invocations (`databricks ssh connect ... -- ls -la`) are unaffected — no `cd`, command passed verbatim.
- The workspace home path is derived from `client.CurrentUser.Me` (the same identity `runIDE` / `vscode.LaunchIDE` already use), and the lookup is skipped entirely when a remote command is supplied.
- The IDE (VS Code/Cursor) path already opens `/Workspace/Users/<email>/` as the remote folder (`vscode.LaunchIDE`), so no change is needed there.

> **Stacked on #5687** (bash-default-shell). This PR's base is `anekipelov/ssh-connect-bash-shell-v2`; it should be retargeted to `main` once #5687 merges. The `cd` composes onto the bash-launch mechanism introduced there.

## Test plan
- [x] `go test ./experimental/ssh/internal/client/` — `TestBuildRemoteShellArgs` covers the `cd` prefix, the no-`cd` (empty wsHome) case, and the non-interactive passthrough.
- [x] Manual: `databricks ssh connect --cluster=<id>` then `pwd` shows `/Workspace/Users/<email>`; `databricks ssh connect --cluster=<id> -- pwd` is unchanged.

Jira: DECO-27477