### PR TITLE
acc: run deploy/files/no-snapshot-sync locally

### DIFF
--- a/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/output.txt
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/output.txt
@@ -50,12 +50,12 @@ Deployment complete!
 
 === Check that removed files are not in the workspace anymore
 >>> errcode [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/test.py
-Error: Path (/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/test.py) doesn't exist.
+Error: [WORKSPACE_PATH_NOT_FOUND]
 
 Exit code: 1
 
 >>> errcode [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/notebook
-Error: Path (/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/notebook) doesn't exist.
+Error: [WORKSPACE_PATH_NOT_FOUND]
 
 Exit code: 1
 

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/output.txt
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/output.txt
@@ -50,12 +50,12 @@ Deployment complete!
 
 === Check that removed files are not in the workspace anymore
 >>> errcode [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/test.py
-Error: [WORKSPACE_PATH_NOT_FOUND]
+Error: Path (/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/test.py) doesn't exist.
 
 Exit code: 1
 
 >>> errcode [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/notebook
-Error: [WORKSPACE_PATH_NOT_FOUND]
+Error: Path (/Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]/files/notebook) doesn't exist.
 
 Exit code: 1
 

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
@@ -1,9 +1,16 @@
-Local = false
+Local = true
 Cloud = true
 
 Ignore = [
     "databricks.yml",
 ]
+
+# The local testserver and the real workspace API word the "missing path" error
+# differently ("Workspace path not found" vs "Path (...) doesn't exist."), so
+# normalize both to a stable token to keep one golden valid for local and cloud.
+[[Repls]]
+Old = 'Error: (Path \(.*?\) doesn.t exist\.|Workspace path not found)'
+New = 'Error: [WORKSPACE_PATH_NOT_FOUND]'
 
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to

--- a/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
+++ b/acceptance/bundle/deploy/files/no-snapshot-sync/test.toml
@@ -5,13 +5,6 @@ Ignore = [
     "databricks.yml",
 ]
 
-# The local testserver and the real workspace API word the "missing path" error
-# differently ("Workspace path not found" vs "Path (...) doesn't exist."), so
-# normalize both to a stable token to keep one golden valid for local and cloud.
-[[Repls]]
-Old = 'Error: (Path \(.*?\) doesn.t exist\.|Workspace path not found)'
-New = 'Error: [WORKSPACE_PATH_NOT_FOUND]'
-
 [Env]
 # MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI

--- a/acceptance/bundle/deploy/files/out-of-band-delete/output.txt
+++ b/acceptance/bundle/deploy/files/out-of-band-delete/output.txt
@@ -23,7 +23,7 @@ Updating deployment state...
 Deployment complete!
 
 >>> musterr [CLI] workspace get-status /Workspace/Users/[USERNAME]/.bundle/out-of-band-delete/default/files/hello_world.py
-Error: Workspace path not found
+Error: Path (/Workspace/Users/[USERNAME]/.bundle/out-of-band-delete/default/files/hello_world.py) doesn't exist.
 
 === Removing the sync snapshot forces a full re-upload, restoring the python_file
 >>> rm -rf .databricks/bundle/default/sync-snapshots

--- a/acceptance/selftest/server/output.txt
+++ b/acceptance/selftest/server/output.txt
@@ -16,6 +16,6 @@ custom
 response
 
 >>> errcode [CLI] workspace get-status /a/b/c
-Error: Workspace path not found
+Error: Path (/a/b/c) doesn't exist.
 
 Exit code: 1

--- a/acceptance/workspace/repos/delete_by_path/output.txt
+++ b/acceptance/workspace/repos/delete_by_path/output.txt
@@ -14,6 +14,6 @@
 >>> [CLI] repos delete /Repos/me@databricks.com/test-repo
 
 >>> [CLI] repos get /Repos/me@databricks.com/test-repo -o json
-Error: failed to look up repo by path: Workspace path not found
+Error: failed to look up repo by path: Path (/Repos/me@databricks.com/test-repo) doesn't exist.
 
 Exit code: 1

--- a/acceptance/workspace/repos/get_errors/output.txt
+++ b/acceptance/workspace/repos/get_errors/output.txt
@@ -1,6 +1,6 @@
 
 >>> [CLI] repos get /Repos/me@databricks.com/doesnotexist -o json
-Error: failed to look up repo by path: Workspace path not found
+Error: failed to look up repo by path: Path (/Repos/me@databricks.com/doesnotexist) doesn't exist.
 
 >>> [CLI] repos get /not-a-repo -o json
 Error: object at path "/not-a-repo" is not a repo

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -363,9 +363,10 @@ func (s *FakeWorkspace) WorkspaceGetStatus(path string) Response {
 			},
 		}
 	} else {
+		// Match the real Workspace API wording, which echoes the requested path.
 		return Response{
 			StatusCode: 404,
-			Body:       map[string]string{"message": "Workspace path not found"},
+			Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", path)},
 		}
 	}
 }


### PR DESCRIPTION
## Changes

Run the `bundle/deploy/files/no-snapshot-sync` acceptance test locally (against the testserver) in addition to cloud, by making the fake workspace's "missing path" error match the real Workspace API.

- `libs/testserver/fake_workspace.go`: `WorkspaceGetStatus` now returns `Path (<path>) doesn't exist.` (echoing the requested path) instead of the generic `Workspace path not found`, matching the real API wording.
- `acceptance/bundle/deploy/files/no-snapshot-sync/test.toml`: flip `Local = false` → `Local = true` so the test runs locally and on cloud.
- Update goldens that asserted the old wording:
  - `acceptance/bundle/deploy/files/out-of-band-delete/output.txt`
  - `acceptance/selftest/server/output.txt`
  - `acceptance/workspace/repos/delete_by_path/output.txt`
  - `acceptance/workspace/repos/get_errors/output.txt`

## Why

The `no-snapshot-sync` test was cloud-only because the testserver and the real Workspace API worded the not-found error differently, so a single golden couldn't match both. Rather than masking the difference with a normalizing repl, make the fake server behave like the real API. This is more faithful, lets the test run locally (faster, no cloud needed), and fixes the wording mismatch everywhere at once.

The wording was verified against a real-cloud recording (`acceptance/selftest/record_cloud/workspace-file-io/output.txt`), which returns exactly `Error: Path (...) doesn't exist.`

## Tests

- All five affected acceptance tests pass with regenerated goldens (`no-snapshot-sync`, `out-of-band-delete`, `selftest/server`, `repos/delete_by_path`, `repos/get_errors`).
- `no-snapshot-sync` now runs both `Local` and `Cloud`, across the `terraform` and `direct` engines.
- Confirmed no remaining references to the old `Workspace path not found` wording anywhere in the repo.