### PR TITLE
Add Claude rule: new changelog entries go in NEXT_CHANGELOG.md

### DIFF
--- a/.agent/rules/changelog.md
+++ b/.agent/rules/changelog.md
@@ -1,0 +1,7 @@
+---
+description: New changelog entries go in NEXT_CHANGELOG.md, not CHANGELOG.md
+globs:
+  - "CHANGELOG.md"
+---
+
+**RULE: Do not add new release entries to `CHANGELOG.md`.** New entries for the upcoming release go in `NEXT_CHANGELOG.md`. `CHANGELOG.md` is updated automatically by the release process.


### PR DESCRIPTION
## Changes
Adds a file-activated Claude Code rule that fires when `CHANGELOG.md` is opened for editing, reminding that new entries belong in `NEXT_CHANGELOG.md` (updated automatically by the release process).

## Why
Noticed claude still tries to write to CHANGELOG.md