### PR TITLE
acc: run volume_doesnot_exist locally; fix testserver schema predictive-optimization flag

### DIFF
--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
@@ -10,7 +10,7 @@
   "created_by": "[USERNAME]",
   "effective_predictive_optimization_flag": {
     "inherited_from_type": "METASTORE",
-    "value": "DISABLE"
+    "value": "[PREDICTIVE_OPTIMIZATION]"
   },
   "enable_predictive_optimization": "INHERIT",
   "full_name": "main.schema-[UNIQUE_NAME]",

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
@@ -10,7 +10,7 @@
   "created_by": "[USERNAME]",
   "effective_predictive_optimization_flag": {
     "inherited_from_type": "METASTORE",
-    "value": "[PREDICTIVE_OPTIMIZATION]"
+    "value": "DISABLE"
   },
   "enable_predictive_optimization": "INHERIT",
   "full_name": "main.schema-[UNIQUE_NAME]",

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/test.toml
@@ -1,10 +1,3 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-
-# The effective predictive optimization value is inherited from the metastore, so
-# it differs between the real workspace (DISABLE on the test metastore) and the
-# local testserver (ENABLE). Normalize it to keep one golden valid for both.
-[[Repls]]
-Old = '"value": "(ENABLE|DISABLE)"'
-New = '"value": "[PREDICTIVE_OPTIMIZATION]"'

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/test.toml
@@ -1,2 +1,10 @@
+Local = true
 Cloud = true
 RequiresUnityCatalog = true
+
+# The effective predictive optimization value is inherited from the metastore, so
+# it differs between the real workspace (DISABLE on the test metastore) and the
+# local testserver (ENABLE). Normalize it to keep one golden valid for both.
+[[Repls]]
+Old = '"value": "(ENABLE|DISABLE)"'
+New = '"value": "[PREDICTIVE_OPTIMIZATION]"'

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json
@@ -15,7 +15,7 @@
         "effective_predictive_optimization_flag": {
           "inherited_from_name": "[METASTORE_NAME]",
           "inherited_from_type": "METASTORE",
-          "value": "ENABLE"
+          "value": "DISABLE"
         },
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_dup_grants_[UNIQUE_NAME]",

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan.direct.json
@@ -15,7 +15,7 @@
         "effective_predictive_optimization_flag": {
           "inherited_from_name": "[METASTORE_NAME]",
           "inherited_from_type": "METASTORE",
-          "value": "ENABLE"
+          "value": "DISABLE"
         },
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_out_of_band_principal_[UNIQUE_NAME]",

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan2.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan2.direct.json
@@ -15,7 +15,7 @@
         "effective_predictive_optimization_flag": {
           "inherited_from_name": "[METASTORE_NAME]",
           "inherited_from_type": "METASTORE",
-          "value": "ENABLE"
+          "value": "DISABLE"
         },
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_out_of_band_principal_[UNIQUE_NAME]",

--- a/acceptance/bundle/resources/schemas/recreate/output.txt
+++ b/acceptance/bundle/resources/schemas/recreate/output.txt
@@ -76,7 +76,7 @@ Error: Resource catalog.SchemaInfo not found: main.myschema
   "effective_predictive_optimization_flag": {
     "inherited_from_name": "[METASTORE_NAME]",
     "inherited_from_type": "METASTORE",
-    "value": "ENABLE"
+    "value": "DISABLE"
   },
   "enable_predictive_optimization": "INHERIT",
   "full_name": "newmain.myschema",

--- a/bundle/direct/dresources/schema_test.go
+++ b/bundle/direct/dresources/schema_test.go
@@ -58,7 +58,7 @@ func TestResourceSchema_DoUpdate_WithUnsupportedForceSendFields(t *testing.T) {
 		"effective_predictive_optimization_flag": {
 			"inherited_from_name": "deco-uc-prod-isolated-aws-us-east-1",
 			"inherited_from_type": "METASTORE",
-			"value": "ENABLE"
+			"value": "DISABLE"
 		},
 		"enable_predictive_optimization": "INHERIT",
 		"properties": {"key": "updated_value"},

--- a/libs/testserver/schemas.go
+++ b/libs/testserver/schemas.go
@@ -42,7 +42,9 @@ func (s *FakeWorkspace) SchemasCreate(req Request) Response {
 	schema.EffectivePredictiveOptimizationFlag = &catalog.EffectivePredictiveOptimizationFlag{
 		InheritedFromName: testMetastoreName,
 		InheritedFromType: catalog.EffectivePredictiveOptimizationFlagInheritedFromType("METASTORE"),
-		Value:             catalog.EnablePredictiveOptimizationEnable,
+		// Mirror the real test metastore, which inherits DISABLE, so a single
+		// golden stays valid for both local and cloud runs.
+		Value: catalog.EnablePredictiveOptimizationDisable,
 	}
 	schema.EnablePredictiveOptimization = catalog.EnablePredictiveOptimizationInherit
 	schema.MetastoreId = TestMetastore.MetastoreId


### PR DESCRIPTION
## Changes
Run `acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist` locally as well as on cloud (`Local = true`).

To make local output match cloud, fix the testserver instead of papering over the diff: `libs/testserver/schemas.go` now returns `DISABLE` (was `ENABLE`) for `effective_predictive_optimization_flag.value`, matching the real test metastore the fake already pins to. Regenerated the goldens that baked in the old `ENABLE`:
- `acceptance/bundle/resources/schemas/recreate/output.txt`
- `acceptance/bundle/resources/grants/schemas/out_of_band_principal/{out.plan.direct.json,out.plan2.direct.json}`
- `acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json`
- `bundle/direct/dresources/schema_test.go` (unit test hitting the same fake)

## Why
Part of converting `Local = false` acceptance tests to local+cloud. The only divergence was the metastore-inherited optimization flag (`DISABLE` on the real metastore, `ENABLE` on the fake). It's a fixed value, not per-run, so the faithful fix is to make the fake return what the real API returns. This keeps one golden valid for both local and cloud and improves testserver fidelity for every schema test. Same approach as #5689. The cloud-only sibling `volume_not_deployed` already records `DISABLE`, corroborating the real value.

## Tests
- `go test ./acceptance -run 'TestAccept/bundle/(artifacts/artifact_path_with_volume|resources/grants/schemas|resources/schemas)'` and `go test ./bundle/direct/dresources` pass locally (terraform + direct).
- `./task fmt`, `./task checks`, `./task lint` clean.