### PR TITLE
acceptance: bundle ruff in the DBR test archive

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -191,6 +191,11 @@ func hasRunFilter() bool {
 // requirePrerequisites verifies external tool prerequisites before doing any
 // work, so a stale toolchain fails fast with an actionable message instead of
 // producing confusing diffs deep into the run.
+//
+// On DBR the serverless image only provides what the test archive ships, so
+// every tool required here must also be bundled in internal/testarchive. When
+// adding a new RequireX prerequisite, add a matching downloader there too, or
+// DBR runs will fail this check before any test runs.
 func requirePrerequisites(t *testing.T) {
 	// Scripts use jq 1.7 features (the pick/1 builtin and the `.foo.[]` iteration syntax).
 	internal.RequireJQ(t, "1.7")

--- a/internal/testarchive/archive.go
+++ b/internal/testarchive/archive.go
@@ -109,12 +109,14 @@ func CreateArchive(archiveDir, binDir, repoRoot string) error {
 		GoDownloader{Arch: "amd64", BinDir: binDir, RepoRoot: repoRoot},
 		UvDownloader{Arch: "amd64", BinDir: binDir},
 		JqDownloader{Arch: "amd64", BinDir: binDir},
+		RuffDownloader{Arch: "amd64", BinDir: binDir},
 
 		// TODO: Serverless clusters do not support arm64 yet.
 		// Enable ARM64 once serverless clusters support it.
 		// GoDownloader{Arch: "arm64", BinDir: binDir, RepoRoot: repoRoot},
 		// UvDownloader{Arch: "arm64", BinDir: binDir},
 		// JqDownloader{Arch: "arm64", BinDir: binDir},
+		// RuffDownloader{Arch: "arm64", BinDir: binDir},
 	}
 
 	for _, downloader := range downloaders {

--- a/internal/testarchive/ruff.go
+++ b/internal/testarchive/ruff.go
@@ -1,0 +1,74 @@
+package testarchive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ruffVersion pins the ruff release bundled into the archive. It must match the
+// version pinned across the repo (python/pyproject.toml, Taskfile.yml) and the
+// minimum required by acceptance/internal/ruff.go, because the check-formatting
+// test's golden output assumes that formatter's behavior. Unlike uv and jq
+// (which the archive tracks at latest), ruff is pinned for that reason.
+const ruffVersion = "0.9.1"
+
+// RuffDownloader handles downloading and extracting ruff releases.
+type RuffDownloader struct {
+	BinDir string
+	Arch   string
+}
+
+// mapArchitecture maps our architecture names to ruff's naming convention.
+func (r RuffDownloader) mapArchitecture(arch string) (string, error) {
+	switch arch {
+	case "arm64":
+		return "aarch64", nil
+	case "amd64":
+		return "x86_64", nil
+	default:
+		return "", fmt.Errorf("unsupported architecture: %s (supported: arm64, amd64)", arch)
+	}
+}
+
+// Download downloads and extracts ruff for Linux.
+func (r RuffDownloader) Download() error {
+	ruffArch, err := r.mapArchitecture(r.Arch)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Join(r.BinDir, r.Arch)
+	err = os.MkdirAll(dir, 0o755)
+	if err != nil {
+		return err
+	}
+
+	// Ruff releases are tagged with the bare version (no "v" prefix).
+	// https://github.com/astral-sh/ruff/releases
+	ruffTarName := fmt.Sprintf("ruff-%s-unknown-linux-gnu", ruffArch)
+	url := fmt.Sprintf("https://github.com/astral-sh/ruff/releases/download/%s/%s.tar.gz", ruffVersion, ruffTarName)
+
+	tempFile := filepath.Join(dir, "ruff.tar.gz")
+	if err := downloadFile(url, tempFile); err != nil {
+		return err
+	}
+
+	if err := ExtractTarGz(tempFile, dir); err != nil {
+		return err
+	}
+
+	err = os.Remove(tempFile)
+	if err != nil {
+		return err
+	}
+
+	// The ruff binary is extracted into a directory named like
+	// ruff-x86_64-unknown-linux-gnu. Move the binary one level up and drop the
+	// extra directory to keep the bin layout flat, matching uv.
+	err = os.Rename(filepath.Join(dir, ruffTarName, "ruff"), filepath.Join(dir, "ruff"))
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(filepath.Join(dir, ruffTarName))
+}


### PR DESCRIPTION
## Why

Every DBR acceptance run (`./task dbr-test` → `TestDbrAcceptance`) failed before any test ran. The harness calls `requirePrerequisites` → `RequireRuff`, but the DBR test archive (`internal/testarchive`) bundled only `go`, `uv` and `jq`, and the serverless image has no ruff on PATH:

```
ruff not found on PATH (acceptance tests require ruff >= 0.9.1)
```

## What

Add a `RuffDownloader` (mirroring the uv downloader) so ruff is fetched and shipped in the archive's `bin` dir alongside the other tools. The prerequisite check then passes on DBR exactly as it does locally — no special-casing of the harness.

```go
RuffDownloader{Arch: "amd64", BinDir: binDir},
```

ruff is pinned to `0.9.1` to match the repo-wide pin (`python/pyproject.toml`, `Taskfile.yml`) and `RequireRuff`'s minimum. uv and jq track `latest` because their version floors are loose; ruff's formatter behavior is version-sensitive, so it's pinned.

## Verification

Full `TestDbrAcceptance` suite runs green on aws-prod-ucws serverless with ruff now bundled.