### PR TITLE
acc: drop hardcoded parent_path from genie_spaces tests

### DIFF
--- a/acceptance/bundle/resources/genie_spaces/delete_warning/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/genie_spaces/delete_warning/databricks.yml.tmpl
@@ -6,5 +6,4 @@ resources:
     sales_analytics:
       title: "Sales Analytics Genie"
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
-      parent_path: /Users/$CURRENT_USER_NAME
       file_path: "sales_analytics.geniespace.json"

--- a/acceptance/bundle/resources/genie_spaces/inline/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/genie_spaces/inline/databricks.yml.tmpl
@@ -7,7 +7,6 @@ resources:
       title: "Sales Analytics Inline Genie"
       description: "Inline serialized_space test"
       warehouse_id: "test-warehouse-id"
-      parent_path: /Users/$CURRENT_USER_NAME
       serialized_space:
         version: 1
         config:

--- a/acceptance/bundle/resources/genie_spaces/inline/out.plan.json
+++ b/acceptance/bundle/resources/genie_spaces/inline/out.plan.json
@@ -9,7 +9,7 @@
       "remote_state": {
         "description": "Inline serialized_space test",
         "etag": "1",
-        "parent_path": "/Workspace/Users/[USERNAME]",
+        "parent_path": "/Workspace/Users/[USERNAME]/.bundle/deploy-genie-space-inline-[UNIQUE_NAME]/default/resources",
         "serialized_space": "{\"config\":{\"sample_questions\":[{\"id\":\"sq-001\",\"question\":[\"What is the total revenue?\"]}]},\"data_sources\":{\"tables\":[{\"column_configs\":[{\"column_name\":\"amount\",\"get_example_values\":true}],\"identifier\":\"main.sales.orders\"}]},\"version\":2}",
         "title": "Sales Analytics Inline Genie",
         "warehouse_id": "test-warehouse-id"

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/databricks.yml.tmpl
@@ -6,6 +6,5 @@ resources:
     sales_analytics:
       title: "Recreate When Gone"
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
-      parent_path: /Users/$CURRENT_USER_NAME
       serialized_space:
         version: 1

--- a/acceptance/bundle/resources/genie_spaces/serialized_space/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/genie_spaces/serialized_space/databricks.yml.tmpl
@@ -6,12 +6,10 @@ resources:
     from_file:
       title: "From File"
       warehouse_id: "test-warehouse-id"
-      parent_path: /Users/$CURRENT_USER_NAME
       file_path: "space.geniespace.json"
     from_inline:
       title: "From Inline"
       warehouse_id: "test-warehouse-id"
-      parent_path: /Users/$CURRENT_USER_NAME
       serialized_space:
         version: 1
         data_sources:

--- a/acceptance/bundle/resources/genie_spaces/simple/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/genie_spaces/simple/databricks.yml.tmpl
@@ -7,5 +7,4 @@ resources:
       title: "Sales Analytics Genie"
       description: "AI assistant for sales data analysis"
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
-      parent_path: /Users/$CURRENT_USER_NAME
       file_path: "sales_analytics.geniespace.json"

--- a/acceptance/bundle/resources/genie_spaces/version_migration/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/genie_spaces/version_migration/databricks.yml.tmpl
@@ -6,6 +6,5 @@ resources:
     foo:
       title: "Version Migration"
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
-      parent_path: /Users/$CURRENT_USER_NAME
       serialized_space:
         version: 1


### PR DESCRIPTION
## Changes
Remove the pinned `parent_path: /Users/$CURRENT_USER_NAME` from the `genie_spaces` resource tests (`simple`, `delete_warning`, `recreate_when_gone`, `inline`, `serialized_space`, `version_migration`), letting it default to the per-bundle `workspace.resource_path`. `parent_path_update` keeps its explicit path since it tests that field.

## Why
The pinned `parent_path` is a **shared** folder, which made the cloud tests flaky with permanent title drift:

- The Genie backend de-duplicates titles within a folder by appending a `YYYY-MM-DD HH:MM:SS` suffix.
- When a concurrent sibling test or an orphaned run already held the same title in that folder, the space came back with a timestamp suffix.
- The CLI then saw unreconcilable title drift (`1 to change` forever). This is race-dependent, so it happened to surface on azure-prod-ucws.

`parent_path` already defaults to the per-bundle `workspace.resource_path`, which is unique per run — so dropping the override makes collisions impossible. The local-only fixtures can't currently hit the collision, but the override is redundant there too, and removing it defuses the footgun if any are later flipped to cloud.

## Tests
- All cloud-enabled Genie tests pass on cloud.
- Local `-update` only updates `inline/out.plan.json` to the new default path.

This pull request and its description were written by Isaac.
