### PR TITLE
experimental/ssh: add --base-environment flag to ssh connect

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### CLI
 
+ * `ssh connect` now accepts a `--base-environment` flag to run a serverless session on a custom base environment. It takes an `env.yaml` path, a `workspace-base-environments/...` resource ID, or a base environment display name, and is rejected together with `--environment-version` or `--cluster` ([#5706](https://github.com/databricks/cli/pull/5706)).
  * `databricks aitools install` is now plugin-first: it installs the Databricks plugin through each agent's own CLI (Claude Code, Codex, GitHub Copilot) instead of copying raw skill files. Agents without a plugin (OpenCode, Antigravity) still get skill files, and Cursor prints the `/add-plugin databricks` step. Use `--skills-only` to force raw skill files for every agent, or `--path <dir>` to write skills to a directory ([#5738](https://github.com/databricks/cli/pull/5738)).
  * `databricks labs list` now only shows projects that can be installed ([#5560](https://github.com/databricks/cli/pull/5560)).
 

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -18,6 +18,7 @@ func newConnectCommand() *cobra.Command {
 Connect to serverless:
   databricks ssh connect
   databricks ssh connect --accelerator=<GPU_type>   # AI Runtime
+  databricks ssh connect --environment=<name>       # custom base environment
 
 Connect to a dedicated cluster:
   databricks ssh connect --cluster=<cluster-id>`,
@@ -38,6 +39,7 @@ Connect to a dedicated cluster:
 	var liteswap string
 	var skipSettingsCheck bool
 	var environmentVersion int
+	var environment string
 	var autoApprove bool
 
 	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks dedicated cluster ID")
@@ -71,6 +73,8 @@ Connect to a dedicated cluster:
 	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for AI Runtime")
 	cmd.Flags().MarkHidden("environment-version")
 
+	cmd.Flags().StringVar(&environment, "environment", "", "Custom base environment for serverless compute: an env.yaml path, a workspace-base-environments resource ID, or a display name")
+
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
@@ -88,13 +92,19 @@ Connect to a dedicated cluster:
 		ctx := cmd.Context()
 		wsClient := cmdctx.WorkspaceClient(ctx)
 		if connectionName == "" && clusterID == "" && !proxyMode {
-			connectionName = client.GenerateDefaultConnectionName(wsClient.Config.Host, accelerator)
+			connectionName = client.GenerateDefaultConnectionName(wsClient.Config.Host, accelerator, environment)
 		}
 		// Serverless GPU compute can take much longer to provision than CPU compute,
 		// so allow extra time for the SSH server job to start.
 		startupTimeout := taskStartupTimeout
 		if accelerator != "" {
 			startupTimeout = gpuTaskStartupTimeout
+		}
+		// Only carry an explicitly-set environment version. Leaving it at 0 otherwise
+		// lets the submit path default to minEnvironmentVersion and lets Validate
+		// detect a real --environment-version + --environment conflict.
+		if !cmd.Flags().Changed("environment-version") {
+			environmentVersion = 0
 		}
 		opts := client.ClientOptions{
 			Profile:              wsClient.Config.Profile,
@@ -117,6 +127,7 @@ Connect to a dedicated cluster:
 			Liteswap:             liteswap,
 			SkipSettingsCheck:    skipSettingsCheck,
 			EnvironmentVersion:   environmentVersion,
+			Environment:          environment,
 			AdditionalArgs:       args,
 			AutoApprove:          autoApprove,
 		}

--- a/experimental/ssh/cmd/connect.go
+++ b/experimental/ssh/cmd/connect.go
@@ -18,7 +18,7 @@ func newConnectCommand() *cobra.Command {
 Connect to serverless:
   databricks ssh connect
   databricks ssh connect --accelerator=<GPU_type>   # AI Runtime
-  databricks ssh connect --environment=<name>       # custom base environment
+  databricks ssh connect --base-environment=<name>  # custom base environment
 
 Connect to a dedicated cluster:
   databricks ssh connect --cluster=<cluster-id>`,
@@ -39,7 +39,7 @@ Connect to a dedicated cluster:
 	var liteswap string
 	var skipSettingsCheck bool
 	var environmentVersion int
-	var environment string
+	var baseEnvironment string
 	var autoApprove bool
 
 	cmd.Flags().StringVar(&clusterID, "cluster", "", "Databricks dedicated cluster ID")
@@ -73,7 +73,7 @@ Connect to a dedicated cluster:
 	cmd.Flags().IntVar(&environmentVersion, "environment-version", defaultEnvironmentVersion, "Environment version for AI Runtime")
 	cmd.Flags().MarkHidden("environment-version")
 
-	cmd.Flags().StringVar(&environment, "environment", "", "Custom base environment for serverless compute: an env.yaml path, a workspace-base-environments resource ID, or a display name")
+	cmd.Flags().StringVar(&baseEnvironment, "base-environment", "", "Custom base environment for serverless compute: an env.yaml path, a workspace-base-environments resource ID, or a display name")
 
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation prompts, installing IDE extensions and applying IDE settings without asking")
 
@@ -92,7 +92,7 @@ Connect to a dedicated cluster:
 		ctx := cmd.Context()
 		wsClient := cmdctx.WorkspaceClient(ctx)
 		if connectionName == "" && clusterID == "" && !proxyMode {
-			connectionName = client.GenerateDefaultConnectionName(wsClient.Config.Host, accelerator, environment)
+			connectionName = client.GenerateDefaultConnectionName(wsClient.Config.Host, accelerator, baseEnvironment)
 		}
 		// Serverless GPU compute can take much longer to provision than CPU compute,
 		// so allow extra time for the SSH server job to start.
@@ -102,7 +102,7 @@ Connect to a dedicated cluster:
 		}
 		// Only carry an explicitly-set environment version. Leaving it at 0 otherwise
 		// lets the submit path default to minEnvironmentVersion and lets Validate
-		// detect a real --environment-version + --environment conflict.
+		// detect a real --environment-version + --base-environment conflict.
 		if !cmd.Flags().Changed("environment-version") {
 			environmentVersion = 0
 		}
@@ -127,7 +127,7 @@ Connect to a dedicated cluster:
 			Liteswap:             liteswap,
 			SkipSettingsCheck:    skipSettingsCheck,
 			EnvironmentVersion:   environmentVersion,
-			Environment:          environment,
+			BaseEnvironment:      baseEnvironment,
 			AdditionalArgs:       args,
 			AutoApprove:          autoApprove,
 		}

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -692,23 +692,6 @@ func resolveBaseEnvironment(ctx context.Context, client *databricks.WorkspaceCli
 	}
 }
 
-// baseEnvironmentKind classifies a --base-environment value into a coarse,
-// non-identifying category for telemetry. The raw value is never logged because
-// it can carry PII (env.yaml paths embed user emails, display names are free-form);
-// the category mirrors the input forms resolveBaseEnvironment recognizes.
-func baseEnvironmentKind(input string) string {
-	switch {
-	case input == "":
-		return ""
-	case strings.HasPrefix(input, "/"):
-		return "path"
-	case strings.HasPrefix(input, "workspace-base-environments/"):
-		return "resource-id"
-	default:
-		return "display-name"
-	}
-}
-
 // shellSingleQuote wraps s in single quotes for safe inclusion in a shell
 // command, escaping any embedded single quotes.
 func shellSingleQuote(s string) string {
@@ -1127,15 +1110,14 @@ func logSshTunnelEvent(ctx context.Context, opts ClientOptions, isSuccess, isRec
 
 	telemetry.Log(ctx, protos.DatabricksCliLog{
 		SshTunnelEvent: &protos.SshTunnelEvent{
-			ComputeType:         computeType,
-			AcceleratorType:     opts.Accelerator,
-			BaseEnvironmentKind: baseEnvironmentKind(opts.BaseEnvironment),
-			IdeType:             opts.IDE,
-			ClientMode:          clientMode,
-			IsReconnect:         isReconnect,
-			AutoStartCluster:    opts.AutoStartCluster,
-			ServerStartTimeMs:   serverStartTimeMs,
-			IsSuccess:           isSuccess,
+			ComputeType:       computeType,
+			AcceleratorType:   opts.Accelerator,
+			IdeType:           opts.IDE,
+			ClientMode:        clientMode,
+			IsReconnect:       isReconnect,
+			AutoStartCluster:  opts.AutoStartCluster,
+			ServerStartTimeMs: serverStartTimeMs,
+			IsSuccess:         isSuccess,
 		},
 	})
 }

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/environments"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
@@ -112,6 +113,10 @@ type ClientOptions struct {
 	SkipSettingsCheck bool
 	// Environment version for serverless compute.
 	EnvironmentVersion int
+	// Base environment for serverless compute. Accepts an env.yaml path (leading "/"),
+	// a "workspace-base-environments/..." resource ID, or a bare display name resolved
+	// against the workspace base environments. Maps to compute.Environment.BaseEnvironment.
+	Environment string
 	// If true, skip confirmation prompts for IDE extension install and IDE settings updates.
 	AutoApprove bool
 }
@@ -135,15 +140,31 @@ func (o *ClientOptions) Validate() error {
 	if o.EnvironmentVersion > 0 && o.EnvironmentVersion < minEnvironmentVersion {
 		return fmt.Errorf("environment version must be >= %d, got %d", minEnvironmentVersion, o.EnvironmentVersion)
 	}
+	// base_environment and environment_version are mutually exclusive in the SDK,
+	// and a custom base environment only applies to serverless compute.
+	if o.Environment != "" && o.EnvironmentVersion > 0 {
+		return errors.New("--environment cannot be used together with --environment-version")
+	}
+	if o.Environment != "" && o.ClusterID != "" {
+		return errors.New("--environment can only be used with serverless compute")
+	}
 	return nil
 }
 
 // GenerateDefaultConnectionName creates a deterministic connection name from
-// the workspace host and accelerator type. The name includes a hash of the
-// workspace host so that different workspaces produce different names,
-// avoiding SSH known_hosts conflicts.
-func GenerateDefaultConnectionName(host, accelerator string) string {
-	h := md5.Sum([]byte(host))
+// the workspace host, accelerator type, and base environment. The name includes
+// a hash so that different workspaces produce different names (avoiding SSH
+// known_hosts conflicts). The environment is folded into the hash because a
+// serverless server bakes in its environment at startup: distinct environments
+// must map to distinct connection names so they don't reuse each other's server.
+func GenerateDefaultConnectionName(host, accelerator, environment string) string {
+	// Keep the hash host-only when no environment is set so existing default
+	// connection names are preserved.
+	hashInput := host
+	if environment != "" {
+		hashInput = host + "\x00" + environment
+	}
+	h := md5.Sum([]byte(hashInput))
 	hashStr := hex.EncodeToString(h[:4])
 	if accelerator != "" {
 		acc := strings.ToLower(strings.ReplaceAll(accelerator, "_", "-"))
@@ -216,6 +237,12 @@ func (o *ClientOptions) ToProxyCommand() (string, error) {
 
 	if o.EnvironmentVersion > 0 {
 		proxyCommand += " --environment-version=" + strconv.Itoa(o.EnvironmentVersion)
+	}
+
+	if o.Environment != "" {
+		// Quote the value: env.yaml paths and display names may contain spaces,
+		// unlike the other (space-free) flag values serialized above.
+		proxyCommand += " --environment=" + strconv.Quote(o.Environment)
 	}
 
 	return proxyCommand, nil
@@ -601,12 +628,22 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	}
 
 	if opts.IsServerlessMode() {
+		// base_environment and environment_version are mutually exclusive: a custom
+		// base environment carries its own version, so we don't also set one.
+		var spec compute.Environment
+		if opts.Environment != "" {
+			baseEnvironment, err := resolveBaseEnvironment(ctx, client, opts.Environment)
+			if err != nil {
+				return 0, err
+			}
+			spec.BaseEnvironment = baseEnvironment
+		} else {
+			spec.EnvironmentVersion = strconv.Itoa(max(opts.EnvironmentVersion, minEnvironmentVersion))
+		}
 		submitRequest.Environments = []jobs.JobEnvironment{
 			{
 				EnvironmentKey: serverlessEnvironmentKey,
-				Spec: &compute.Environment{
-					EnvironmentVersion: strconv.Itoa(max(opts.EnvironmentVersion, minEnvironmentVersion)),
-				},
+				Spec:           &spec,
 			},
 		}
 	}
@@ -620,6 +657,37 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 
 	// Return the run ID even on error so callers can fetch the run's failure details.
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts)
+}
+
+// resolveBaseEnvironment maps the user-provided --environment value to a
+// compute.Environment.BaseEnvironment string. A leading "/" is an env.yaml path and a
+// "workspace-base-environments/" prefix is a resource ID; both are passed through
+// verbatim. Anything else is treated as a display name and resolved to its resource ID
+// via the workspace base environments listing.
+func resolveBaseEnvironment(ctx context.Context, client *databricks.WorkspaceClient, input string) (string, error) {
+	if strings.HasPrefix(input, "/") || strings.HasPrefix(input, "workspace-base-environments/") {
+		return input, nil
+	}
+
+	envs, err := client.Environments.ListWorkspaceBaseEnvironmentsAll(ctx, environments.ListWorkspaceBaseEnvironmentsRequest{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list workspace base environments: %w", err)
+	}
+
+	var matches []string
+	for _, e := range envs {
+		if e.DisplayName == input {
+			matches = append(matches, e.Name)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no workspace base environment found with display name %q", input)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("multiple workspace base environments found with display name %q", input)
+	}
 }
 
 // shellSingleQuote wraps s in single quotes for safe inclusion in a shell
@@ -1042,6 +1110,7 @@ func logSshTunnelEvent(ctx context.Context, opts ClientOptions, isSuccess, isRec
 		SshTunnelEvent: &protos.SshTunnelEvent{
 			ComputeType:       computeType,
 			AcceleratorType:   opts.Accelerator,
+			Environment:       opts.Environment,
 			IdeType:           opts.IDE,
 			ClientMode:        clientMode,
 			IsReconnect:       isReconnect,

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -116,7 +116,7 @@ type ClientOptions struct {
 	// Base environment for serverless compute. Accepts an env.yaml path (leading "/"),
 	// a "workspace-base-environments/..." resource ID, or a bare display name resolved
 	// against the workspace base environments. Maps to compute.Environment.BaseEnvironment.
-	Environment string
+	BaseEnvironment string
 	// If true, skip confirmation prompts for IDE extension install and IDE settings updates.
 	AutoApprove bool
 }
@@ -142,11 +142,11 @@ func (o *ClientOptions) Validate() error {
 	}
 	// base_environment and environment_version are mutually exclusive in the SDK,
 	// and a custom base environment only applies to serverless compute.
-	if o.Environment != "" && o.EnvironmentVersion > 0 {
-		return errors.New("--environment cannot be used together with --environment-version")
+	if o.BaseEnvironment != "" && o.EnvironmentVersion > 0 {
+		return errors.New("--base-environment cannot be used together with --environment-version")
 	}
-	if o.Environment != "" && o.ClusterID != "" {
-		return errors.New("--environment can only be used with serverless compute")
+	if o.BaseEnvironment != "" && o.ClusterID != "" {
+		return errors.New("--base-environment can only be used with serverless compute")
 	}
 	return nil
 }
@@ -157,12 +157,12 @@ func (o *ClientOptions) Validate() error {
 // known_hosts conflicts). The environment is folded into the hash because a
 // serverless server bakes in its environment at startup: distinct environments
 // must map to distinct connection names so they don't reuse each other's server.
-func GenerateDefaultConnectionName(host, accelerator, environment string) string {
-	// Keep the hash host-only when no environment is set so existing default
+func GenerateDefaultConnectionName(host, accelerator, baseEnvironment string) string {
+	// Keep the hash host-only when no base environment is set so existing default
 	// connection names are preserved.
 	hashInput := host
-	if environment != "" {
-		hashInput = host + "\x00" + environment
+	if baseEnvironment != "" {
+		hashInput = host + "\x00" + baseEnvironment
 	}
 	h := md5.Sum([]byte(hashInput))
 	hashStr := hex.EncodeToString(h[:4])
@@ -239,10 +239,12 @@ func (o *ClientOptions) ToProxyCommand() (string, error) {
 		proxyCommand += " --environment-version=" + strconv.Itoa(o.EnvironmentVersion)
 	}
 
-	if o.Environment != "" {
-		// Quote the value: env.yaml paths and display names may contain spaces,
-		// unlike the other (space-free) flag values serialized above.
-		proxyCommand += " --environment=" + strconv.Quote(o.Environment)
+	if o.BaseEnvironment != "" {
+		// Shell-quote the value: this command is persisted as an OpenSSH ProxyCommand
+		// and executed via the shell, and base environments accept user-controlled
+		// display names/paths that may contain spaces or shell metacharacters.
+		// Single-quoting (unlike strconv.Quote's double quotes) prevents any expansion.
+		proxyCommand += " --base-environment=" + shellSingleQuote(o.BaseEnvironment)
 	}
 
 	return proxyCommand, nil
@@ -631,8 +633,8 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 		// base_environment and environment_version are mutually exclusive: a custom
 		// base environment carries its own version, so we don't also set one.
 		var spec compute.Environment
-		if opts.Environment != "" {
-			baseEnvironment, err := resolveBaseEnvironment(ctx, client, opts.Environment)
+		if opts.BaseEnvironment != "" {
+			baseEnvironment, err := resolveBaseEnvironment(ctx, client, opts.BaseEnvironment)
 			if err != nil {
 				return 0, err
 			}
@@ -659,7 +661,7 @@ func submitSSHTunnelJob(ctx context.Context, client *databricks.WorkspaceClient,
 	return waiter.RunId, waitForJobToStart(ctx, client, waiter.RunId, opts)
 }
 
-// resolveBaseEnvironment maps the user-provided --environment value to a
+// resolveBaseEnvironment maps the user-provided --base-environment value to a
 // compute.Environment.BaseEnvironment string. A leading "/" is an env.yaml path and a
 // "workspace-base-environments/" prefix is a resource ID; both are passed through
 // verbatim. Anything else is treated as a display name and resolved to its resource ID
@@ -687,6 +689,23 @@ func resolveBaseEnvironment(ctx context.Context, client *databricks.WorkspaceCli
 		return matches[0], nil
 	default:
 		return "", fmt.Errorf("multiple workspace base environments found with display name %q", input)
+	}
+}
+
+// baseEnvironmentKind classifies a --base-environment value into a coarse,
+// non-identifying category for telemetry. The raw value is never logged because
+// it can carry PII (env.yaml paths embed user emails, display names are free-form);
+// the category mirrors the input forms resolveBaseEnvironment recognizes.
+func baseEnvironmentKind(input string) string {
+	switch {
+	case input == "":
+		return ""
+	case strings.HasPrefix(input, "/"):
+		return "path"
+	case strings.HasPrefix(input, "workspace-base-environments/"):
+		return "resource-id"
+	default:
+		return "display-name"
 	}
 }
 
@@ -1108,15 +1127,15 @@ func logSshTunnelEvent(ctx context.Context, opts ClientOptions, isSuccess, isRec
 
 	telemetry.Log(ctx, protos.DatabricksCliLog{
 		SshTunnelEvent: &protos.SshTunnelEvent{
-			ComputeType:       computeType,
-			AcceleratorType:   opts.Accelerator,
-			Environment:       opts.Environment,
-			IdeType:           opts.IDE,
-			ClientMode:        clientMode,
-			IsReconnect:       isReconnect,
-			AutoStartCluster:  opts.AutoStartCluster,
-			ServerStartTimeMs: serverStartTimeMs,
-			IsSuccess:         isSuccess,
+			ComputeType:         computeType,
+			AcceleratorType:     opts.Accelerator,
+			BaseEnvironmentKind: baseEnvironmentKind(opts.BaseEnvironment),
+			IdeType:             opts.IDE,
+			ClientMode:          clientMode,
+			IsReconnect:         isReconnect,
+			AutoStartCluster:    opts.AutoStartCluster,
+			ServerStartTimeMs:   serverStartTimeMs,
+			IsSuccess:           isSuccess,
 		},
 	})
 }

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/environments"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,6 +28,66 @@ func terminatedRun(runID, taskRunID int64, message, pageURL string) *jobs.Run {
 			},
 		}},
 	}
+}
+
+func TestResolveBaseEnvironment(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+
+	// Paths and resource IDs are passed through without hitting the API.
+	t.Run("env.yaml path passthrough", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		got, err := resolveBaseEnvironment(ctx, m.WorkspaceClient, "/Workspace/path/to/env.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, "/Workspace/path/to/env.yaml", got)
+	})
+
+	t.Run("resource ID passthrough", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		got, err := resolveBaseEnvironment(ctx, m.WorkspaceClient, "workspace-base-environments/dbe_123")
+		require.NoError(t, err)
+		assert.Equal(t, "workspace-base-environments/dbe_123", got)
+	})
+
+	t.Run("display name resolves to resource ID", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		m.GetMockEnvironmentsAPI().EXPECT().
+			ListWorkspaceBaseEnvironmentsAll(mock.Anything, environments.ListWorkspaceBaseEnvironmentsRequest{}).
+			Return([]environments.WorkspaceBaseEnvironment{
+				{DisplayName: "other", Name: "workspace-base-environments/dbe_other"},
+				{DisplayName: "my-env", Name: "workspace-base-environments/dbe_mine"},
+			}, nil)
+
+		got, err := resolveBaseEnvironment(ctx, m.WorkspaceClient, "my-env")
+		require.NoError(t, err)
+		assert.Equal(t, "workspace-base-environments/dbe_mine", got)
+	})
+
+	t.Run("display name not found", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		m.GetMockEnvironmentsAPI().EXPECT().
+			ListWorkspaceBaseEnvironmentsAll(mock.Anything, environments.ListWorkspaceBaseEnvironmentsRequest{}).
+			Return([]environments.WorkspaceBaseEnvironment{
+				{DisplayName: "other", Name: "workspace-base-environments/dbe_other"},
+			}, nil)
+
+		_, err := resolveBaseEnvironment(ctx, m.WorkspaceClient, "my-env")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `no workspace base environment found with display name "my-env"`)
+	})
+
+	t.Run("display name ambiguous", func(t *testing.T) {
+		m := mocks.NewMockWorkspaceClient(t)
+		m.GetMockEnvironmentsAPI().EXPECT().
+			ListWorkspaceBaseEnvironmentsAll(mock.Anything, environments.ListWorkspaceBaseEnvironmentsRequest{}).
+			Return([]environments.WorkspaceBaseEnvironment{
+				{DisplayName: "my-env", Name: "workspace-base-environments/dbe_1"},
+				{DisplayName: "my-env", Name: "workspace-base-environments/dbe_2"},
+			}, nil)
+
+		_, err := resolveBaseEnvironment(ctx, m.WorkspaceClient, "my-env")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `multiple workspace base environments found with display name "my-env"`)
+	})
 }
 
 func TestDescribeRunFailureIncludesMessageTraceAndURL(t *testing.T) {

--- a/experimental/ssh/internal/client/client_test.go
+++ b/experimental/ssh/internal/client/client_test.go
@@ -94,6 +94,24 @@ func TestValidate(t *testing.T) {
 			name: "valid environment version",
 			opts: client.ClientOptions{ClusterID: "abc-123", EnvironmentVersion: 4},
 		},
+		{
+			name:    "environment with environment version",
+			opts:    client.ClientOptions{ConnectionName: "my-conn", Environment: "my-env", EnvironmentVersion: 4},
+			wantErr: "--environment cannot be used together with --environment-version",
+		},
+		{
+			name:    "environment with cluster",
+			opts:    client.ClientOptions{ClusterID: "abc-123", Environment: "my-env"},
+			wantErr: "--environment can only be used with serverless compute",
+		},
+		{
+			name: "valid environment with connection name",
+			opts: client.ClientOptions{ConnectionName: "my-conn", Environment: "/Workspace/path/to/env.yaml"},
+		},
+		{
+			name: "environment with serverless GPU accelerator",
+			opts: client.ClientOptions{ConnectionName: "my-conn", Accelerator: "GPU_1xA10", Environment: "my-gpu-env"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -146,10 +164,23 @@ func TestGenerateDefaultConnectionName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := client.GenerateDefaultConnectionName(tt.host, tt.accelerator)
+			got := client.GenerateDefaultConnectionName(tt.host, tt.accelerator, "")
 			assert.Equal(t, tt.want, got)
 		})
 	}
+
+	// A serverless server bakes in its environment, so distinct environments must
+	// map to distinct default names (otherwise --environment is silently ignored
+	// when an existing server for the default name is reused).
+	t.Run("environment differentiates the name", func(t *testing.T) {
+		const host = "https://my-workspace.cloud.databricks.com"
+		base := client.GenerateDefaultConnectionName(host, "", "")
+		withEnv := client.GenerateDefaultConnectionName(host, "", "my-env")
+		otherEnv := client.GenerateDefaultConnectionName(host, "", "other-env")
+		assert.NotEqual(t, base, withEnv, "setting --environment must change the default name")
+		assert.NotEqual(t, withEnv, otherEnv, "different environments must produce different names")
+		assert.Equal(t, withEnv, client.GenerateDefaultConnectionName(host, "", "my-env"), "must be deterministic")
+	})
 }
 
 func TestGenerateDefaultConnectionNameMatchesRegex(t *testing.T) {
@@ -159,12 +190,15 @@ func TestGenerateDefaultConnectionNameMatchesRegex(t *testing.T) {
 		"https://workspace3.gcp.databricks.com",
 	}
 	accelerators := []string{"", "GPU_1xA10", "GPU_8xH100"}
+	environments := []string{"", "my-env", "/Workspace/Users/me@example.com/env.yaml"}
 	nameRegex := regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
 	for _, host := range hosts {
 		for _, acc := range accelerators {
-			name := client.GenerateDefaultConnectionName(host, acc)
-			assert.Regexp(t, nameRegex, name, "host=%q accelerator=%q name=%q", host, acc, name)
+			for _, env := range environments {
+				name := client.GenerateDefaultConnectionName(host, acc, env)
+				assert.Regexp(t, nameRegex, name, "host=%q accelerator=%q environment=%q name=%q", host, acc, env, name)
+			}
 		}
 	}
 }
@@ -223,6 +257,11 @@ func TestToProxyCommand(t *testing.T) {
 			name: "with environment version",
 			opts: client.ClientOptions{ClusterID: "abc-123", EnvironmentVersion: 4},
 			want: quoted + " ssh connect --proxy --cluster=abc-123 --auto-start-cluster=false --shutdown-delay=0s --environment-version=4",
+		},
+		{
+			name: "serverless with environment",
+			opts: client.ClientOptions{ConnectionName: "my-conn", Environment: "my env", ShutdownDelay: 2 * time.Minute},
+			want: quoted + ` ssh connect --proxy --name=my-conn --shutdown-delay=2m0s --environment="my env"`,
 		},
 	}
 

--- a/experimental/ssh/internal/client/client_test.go
+++ b/experimental/ssh/internal/client/client_test.go
@@ -95,22 +95,22 @@ func TestValidate(t *testing.T) {
 			opts: client.ClientOptions{ClusterID: "abc-123", EnvironmentVersion: 4},
 		},
 		{
-			name:    "environment with environment version",
-			opts:    client.ClientOptions{ConnectionName: "my-conn", Environment: "my-env", EnvironmentVersion: 4},
-			wantErr: "--environment cannot be used together with --environment-version",
+			name:    "base environment with environment version",
+			opts:    client.ClientOptions{ConnectionName: "my-conn", BaseEnvironment: "my-env", EnvironmentVersion: 4},
+			wantErr: "--base-environment cannot be used together with --environment-version",
 		},
 		{
-			name:    "environment with cluster",
-			opts:    client.ClientOptions{ClusterID: "abc-123", Environment: "my-env"},
-			wantErr: "--environment can only be used with serverless compute",
+			name:    "base environment with cluster",
+			opts:    client.ClientOptions{ClusterID: "abc-123", BaseEnvironment: "my-env"},
+			wantErr: "--base-environment can only be used with serverless compute",
 		},
 		{
-			name: "valid environment with connection name",
-			opts: client.ClientOptions{ConnectionName: "my-conn", Environment: "/Workspace/path/to/env.yaml"},
+			name: "valid base environment with connection name",
+			opts: client.ClientOptions{ConnectionName: "my-conn", BaseEnvironment: "/Workspace/path/to/env.yaml"},
 		},
 		{
-			name: "environment with serverless GPU accelerator",
-			opts: client.ClientOptions{ConnectionName: "my-conn", Accelerator: "GPU_1xA10", Environment: "my-gpu-env"},
+			name: "base environment with serverless GPU accelerator",
+			opts: client.ClientOptions{ConnectionName: "my-conn", Accelerator: "GPU_1xA10", BaseEnvironment: "my-gpu-env"},
 		},
 	}
 
@@ -169,15 +169,15 @@ func TestGenerateDefaultConnectionName(t *testing.T) {
 		})
 	}
 
-	// A serverless server bakes in its environment, so distinct environments must
-	// map to distinct default names (otherwise --environment is silently ignored
-	// when an existing server for the default name is reused).
-	t.Run("environment differentiates the name", func(t *testing.T) {
+	// A serverless server bakes in its base environment, so distinct environments
+	// must map to distinct default names (otherwise --base-environment is silently
+	// ignored when an existing server for the default name is reused).
+	t.Run("base environment differentiates the name", func(t *testing.T) {
 		const host = "https://my-workspace.cloud.databricks.com"
 		base := client.GenerateDefaultConnectionName(host, "", "")
 		withEnv := client.GenerateDefaultConnectionName(host, "", "my-env")
 		otherEnv := client.GenerateDefaultConnectionName(host, "", "other-env")
-		assert.NotEqual(t, base, withEnv, "setting --environment must change the default name")
+		assert.NotEqual(t, base, withEnv, "setting --base-environment must change the default name")
 		assert.NotEqual(t, withEnv, otherEnv, "different environments must produce different names")
 		assert.Equal(t, withEnv, client.GenerateDefaultConnectionName(host, "", "my-env"), "must be deterministic")
 	})
@@ -259,9 +259,17 @@ func TestToProxyCommand(t *testing.T) {
 			want: quoted + " ssh connect --proxy --cluster=abc-123 --auto-start-cluster=false --shutdown-delay=0s --environment-version=4",
 		},
 		{
-			name: "serverless with environment",
-			opts: client.ClientOptions{ConnectionName: "my-conn", Environment: "my env", ShutdownDelay: 2 * time.Minute},
-			want: quoted + ` ssh connect --proxy --name=my-conn --shutdown-delay=2m0s --environment="my env"`,
+			name: "serverless with base environment",
+			opts: client.ClientOptions{ConnectionName: "my-conn", BaseEnvironment: "my env", ShutdownDelay: 2 * time.Minute},
+			want: quoted + ` ssh connect --proxy --name=my-conn --shutdown-delay=2m0s --base-environment='my env'`,
+		},
+		{
+			// The proxy command is executed via the shell, so a base environment
+			// containing shell metacharacters must be single-quoted (and embedded
+			// single quotes escaped) so nothing is expanded or word-split.
+			name: "serverless with base environment containing shell metacharacters",
+			opts: client.ClientOptions{ConnectionName: "my-conn", BaseEnvironment: `$(touch pwned) '; rm -rf /`, ShutdownDelay: 2 * time.Minute},
+			want: quoted + ` ssh connect --proxy --name=my-conn --shutdown-delay=2m0s --base-environment='$(touch pwned) '\''; rm -rf /'`,
 		},
 	}
 

--- a/libs/telemetry/protos/ssh_tunnel.go
+++ b/libs/telemetry/protos/ssh_tunnel.go
@@ -26,11 +26,6 @@ type SshTunnelEvent struct {
 	// GPU accelerator type for serverless compute.
 	AcceleratorType string `json:"accelerator_type,omitempty"`
 
-	// Coarse category of the --base-environment input for serverless compute:
-	// "path", "resource-id", or "display-name". The raw value is intentionally not
-	// logged because it can contain PII (paths embed user emails, names are free-form).
-	BaseEnvironmentKind string `json:"base_environment_kind,omitempty"`
-
 	// IDE that initiated the connection (e.g., "vscode", "cursor").
 	IdeType string `json:"ide_type,omitempty"`
 

--- a/libs/telemetry/protos/ssh_tunnel.go
+++ b/libs/telemetry/protos/ssh_tunnel.go
@@ -26,9 +26,10 @@ type SshTunnelEvent struct {
 	// GPU accelerator type for serverless compute.
 	AcceleratorType string `json:"accelerator_type,omitempty"`
 
-	// Base environment specified for serverless compute (raw --environment input:
-	// an env.yaml path, a workspace-base-environments resource ID, or a display name).
-	Environment string `json:"environment,omitempty"`
+	// Coarse category of the --base-environment input for serverless compute:
+	// "path", "resource-id", or "display-name". The raw value is intentionally not
+	// logged because it can contain PII (paths embed user emails, names are free-form).
+	BaseEnvironmentKind string `json:"base_environment_kind,omitempty"`
 
 	// IDE that initiated the connection (e.g., "vscode", "cursor").
 	IdeType string `json:"ide_type,omitempty"`

--- a/libs/telemetry/protos/ssh_tunnel.go
+++ b/libs/telemetry/protos/ssh_tunnel.go
@@ -26,6 +26,10 @@ type SshTunnelEvent struct {
 	// GPU accelerator type for serverless compute.
 	AcceleratorType string `json:"accelerator_type,omitempty"`
 
+	// Base environment specified for serverless compute (raw --environment input:
+	// an env.yaml path, a workspace-base-environments resource ID, or a display name).
+	Environment string `json:"environment,omitempty"`
+
 	// IDE that initiated the connection (e.g., "vscode", "cursor").
 	IdeType string `json:"ide_type,omitempty"`
 


### PR DESCRIPTION
## Changes

Adds a user-facing `--base-environment` flag to `databricks ssh connect` that maps to `compute.Environment.BaseEnvironment` in the serverless submit path. It accepts three input forms:

- an `env.yaml` path (leading `/`),
- a `workspace-base-environments/...` resource ID,
- a bare display name, resolved via `Environments.ListWorkspaceBaseEnvironmentsAll`.

Supporting behavior:
- Rejects `--base-environment` together with `--environment-version` (mutually exclusive in the SDK) or with `--cluster` (serverless only).
- Serializes the flag through `ToProxyCommand` so it survives serverless reconnect. The value is shell-single-quoted (not just double-quoted) because the proxy command is persisted into SSH config and executed via the shell, and the value is user-controlled — single-quoting prevents any expansion of paths/display names containing spaces or shell metacharacters.
- Folds the environment into the default connection name so distinct environments map to distinct servers, mirroring how `--accelerator` is handled.
- No telemetry is emitted for the base environment yet. The `SshTunnelEvent` struct mirrors a lumberjack proto defined in universe, which has no field for it, so any value would be dropped by the backend until a companion universe change adds one. A coarse, non-PII `base_environment_kind` (`path` / `resource-id` / `display-name`) can be added then.

## Why

Implements DECO-27423. Serverless SSH users could pin an environment *version* but not point the session at a custom base environment (their own `env.yaml` or a workspace base environment). No SDK bump is needed — `databricks-sdk-go` already exposes `BaseEnvironment` and the workspace-base-environments listing API.

Because a serverless server bakes in its environment at startup, the environment is part of the server's identity; folding it into the default connection name avoids silently reusing a server started with a different environment. The remaining explicit-`--name` reuse case and the interactive-shell Python path are tracked as follow-ups (DECO-27498, DECO-27499).

## Usage

`--base-environment` applies to **serverless compute only**. The examples below install a distinctive package (`cowsay`) in a base environment and verify it from the SSH session. Once connected, the environment's Python interpreter is at `$DATABRICKS_VIRTUAL_ENV` (an absolute path to the binary, not on `PATH`), so the dependencies are invoked as:

```sh
"$DATABRICKS_VIRTUAL_ENV" -c "import cowsay; cowsay.cow('hello from a custom base environment')"
```

A base environment points at an `env.yaml` in the workspace and is created per accelerator class (`--base-environment-type CPU` or `GPU`); a CPU base environment cannot be used with a GPU accelerator and vice versa. `--base-environment` itself accepts three forms: the display name, the `workspace-base-environments/...` resource ID printed on create, or the `env.yaml` path directly.

### Serverless CPU

```sh
cat > env.yaml <<'YAML'
environment_version: "4"
dependencies:
  - cowsay==6.1
YAML
databricks workspace import /Workspace/Users/me@example.com/env.yaml --file env.yaml --format RAW

databricks environments create-workspace-base-environment "ssh-cowsay-cpu" \
  --filepath /Workspace/Users/me@example.com/env.yaml --base-environment-type CPU

databricks ssh connect --base-environment "ssh-cowsay-cpu"
```

### Serverless GPU

Requires a **GPU**-type base environment (a CPU one is rejected against a GPU accelerator). Use a distinct `env.yaml` path, since the filepath must be unique per base environment:

```sh
databricks workspace import /Workspace/Users/me@example.com/env-gpu.yaml --file env.yaml --format RAW

databricks environments create-workspace-base-environment "ssh-cowsay-gpu" \
  --filepath /Workspace/Users/me@example.com/env-gpu.yaml --base-environment-type GPU

databricks ssh connect --accelerator=GPU_1xA10 --base-environment "ssh-cowsay-gpu"
```

### Dedicated cluster

`--base-environment` is **not** supported here — it's serverless-only, and combining it with `--cluster` is rejected:

```sh
databricks ssh connect --cluster=<cluster-id>

# error: --base-environment can only be used with serverless compute
databricks ssh connect --cluster=<cluster-id> --base-environment "ssh-cowsay-cpu"
```

## Tests

- Unit tests for `Validate` (both incompatibility errors, valid serverless/GPU cases), `ToProxyCommand` round-trip (including a shell-metacharacter case proving the value is shell-safe), default-connection-name differentiation, and `resolveBaseEnvironment` (path/ID passthrough, display-name resolution, not-found, ambiguous) using the SDK mock client.
- `./task test-exp-ssh` (unit + `TestAccept/ssh` acceptance) passes; `./task lint-q` clean.

### Manual validation

Ran `ssh connect` end-to-end against a dogfood workspace across all three compute types, using a base environment that installs a distinctive package (`cowsay==6.1`) and verifying it from the session via `$DATABRICKS_VIRTUAL_ENV`:

| Scenario | Result |
| --- | --- |
| Serverless CPU + `--base-environment` (CPU base env, display-name form) | ✅ connected; `cowsay 6.1` importable |
| Serverless GPU + `--base-environment` (GPU base env, `--accelerator=GPU_1xA10`) | ✅ connected on `NVIDIA A10G`; `cowsay 6.1` importable |
| Dedicated cluster (`--cluster`, no base environment) | ✅ connected; remote command ran |
| `--cluster` + `--base-environment` | ✅ rejected: *"--base-environment can only be used with serverless compute"* |
| `--base-environment` + `--environment-version` | ✅ rejected: *"--base-environment cannot be used together with --environment-version"* |
| GPU accelerator + a **CPU** base environment | ✅ backend incompatibility surfaced cleanly by the CLI |

A custom base environment must match the accelerator class — a CPU base environment cannot be paired with a GPU accelerator, so GPU runs need a `--base-environment-type GPU` environment. The serverless paths exercise the new flag directly; the dedicated-cluster path is unaffected by this change and was checked for no regression.

_This pull request and its description were written by Isaac._





