### PR TITLE
Fix missing git info for bundles deployed from the new type of in-workspace Git folder

### DIFF
--- a/acceptance/bundle/git-info/databricks.yml
+++ b/acceptance/bundle/git-info/databricks.yml
@@ -1,0 +1,2 @@
+bundle:
+  name: git-info

--- a/acceptance/bundle/git-info/out.test.toml
+++ b/acceptance/bundle/git-info/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = true
+RunsOnDbr = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/git-info/output.txt
+++ b/acceptance/bundle/git-info/output.txt
@@ -1,0 +1,18 @@
+
+=== Provenance read from the on-disk .git
+
+>>> [CLI] bundle validate -o json
+{
+  "actual_branch": "main",
+  "branch": "main",
+  "bundle_root_path": ".",
+  "commit": "4fa481d6502eb6104d62c33a693ef8a134e765e0",
+  "origin_url": "https://github.com/databricks/bundle-examples.git"
+}
+
+=== No .git: provenance degrades to empty without failing
+
+>>> [CLI] bundle validate -o json
+{
+  "bundle_root_path": "."
+}

--- a/acceptance/bundle/git-info/output.txt
+++ b/acceptance/bundle/git-info/output.txt
@@ -10,6 +10,17 @@
   "origin_url": "https://github.com/databricks/bundle-examples.git"
 }
 
+=== Subdirectory of the git folder resolves to the same git folder
+
+>>> withdir subdir/nested [CLI] bundle validate -o json
+{
+  "actual_branch": "main",
+  "branch": "main",
+  "bundle_root_path": "subdir/nested",
+  "commit": "4fa481d6502eb6104d62c33a693ef8a134e765e0",
+  "origin_url": "https://github.com/databricks/bundle-examples.git"
+}
+
 === No .git: provenance degrades to empty without failing
 
 >>> [CLI] bundle validate -o json

--- a/acceptance/bundle/git-info/script
+++ b/acceptance/bundle/git-info/script
@@ -1,6 +1,8 @@
-# A .git written by hand rather than by `git init`: git cannot operate on the
-# /Workspace FUSE mount ("detected dubious ownership"), but libs/git reads these
-# files directly, so this is what the new in-workspace Git folders look like to it.
+# A .git written by hand rather than by `git init`: the harness sets
+# GIT_CONFIG_GLOBAL=/dev/null for hermeticity, which drops the safe.directory=*
+# that DBR ships, so on the workspace mount (owned by root, uid != ours) every git
+# command fails with "detected dubious ownership". libs/git reads these files
+# directly, which is what a Git in Dataplane folder's real .git looks like to it.
 origin_url=https://github.com/databricks/bundle-examples.git
 commit=4fa481d6502eb6104d62c33a693ef8a134e765e0
 
@@ -11,6 +13,11 @@ printf '%s\n' "$commit" > .git/refs/heads/main
 
 title "Provenance read from the on-disk .git\n"
 trace $CLI bundle validate -o json | jq '.bundle.git'
+
+title "Subdirectory of the git folder resolves to the same git folder\n"
+mkdir -p subdir/nested
+cp databricks.yml subdir/nested/
+trace withdir subdir/nested $CLI bundle validate -o json | jq '.bundle.git'
 
 rm -rf .git
 

--- a/acceptance/bundle/git-info/script
+++ b/acceptance/bundle/git-info/script
@@ -1,0 +1,18 @@
+# A .git written by hand rather than by `git init`: git cannot operate on the
+# /Workspace FUSE mount ("detected dubious ownership"), but libs/git reads these
+# files directly, so this is what the new in-workspace Git folders look like to it.
+origin_url=https://github.com/databricks/bundle-examples.git
+commit=4fa481d6502eb6104d62c33a693ef8a134e765e0
+
+mkdir -p .git/refs/heads
+printf 'ref: refs/heads/main\n' > .git/HEAD
+printf '[core]\n\trepositoryformatversion = 1\n[remote "origin"]\n\turl = %s\n' "$origin_url" > .git/config
+printf '%s\n' "$commit" > .git/refs/heads/main
+
+title "Provenance read from the on-disk .git\n"
+trace $CLI bundle validate -o json | jq '.bundle.git'
+
+rm -rf .git
+
+title "No .git: provenance degrades to empty without failing\n"
+trace $CLI bundle validate -o json | jq '.bundle.git'

--- a/acceptance/bundle/git-info/test.toml
+++ b/acceptance/bundle/git-info/test.toml
@@ -1,0 +1,25 @@
+# Covers bundle git provenance (bundle.git) as recorded by libs/git.FetchRepositoryInfo.
+#
+# The bundle root here carries a hand-built .git, which is readable both locally and on
+# the /Workspace FUSE mount of a DBR session. That makes the on-disk path the one under
+# test in both environments, so the assertions and output are identical:
+#
+#   - Local / non-DBR: fetchRepositoryInfoDotGit reads .git, as it always has.
+#   - On DBR: the new type of in-workspace Git folder exposes a real .git on the FUSE
+#     mount, so FetchRepositoryInfo prefers it over get-status, which returns only
+#     id+path for these folders. This is what the hasDotGit check selects.
+#
+# The API path itself (classic Repos and older Git folders, which have no .git on the
+# mount) cannot be provisioned from a test: those folder types are created by the
+# control plane, not by writing files. It is covered by unit tests in
+# libs/git/info_test.go.
+#
+# Cloud=true is required because RunsOnDbr tests also run in the cloud suite.
+Local = true
+Cloud = true
+RunsOnDbr = true
+
+# RunsOnDbr is incompatible with RecordRequests (serverless can't reach the proxy).
+RecordRequests = false
+
+Ignore = [".git"]

--- a/acceptance/bundle/git-info/test.toml
+++ b/acceptance/bundle/git-info/test.toml
@@ -1,18 +1,20 @@
 # Covers bundle git provenance (bundle.git) as recorded by libs/git.FetchRepositoryInfo.
 #
 # The bundle root here carries a hand-built .git, which is readable both locally and on
-# the /Workspace FUSE mount of a DBR session. That makes the on-disk path the one under
-# test in both environments, so the assertions and output are identical:
+# the workspace mount of a DBR session. That makes the on-disk path the one under test
+# in both environments, so the assertions and output are identical:
 #
 #   - Local / non-DBR: fetchRepositoryInfoDotGit reads .git, as it always has.
-#   - On DBR: the new type of in-workspace Git folder exposes a real .git on the FUSE
-#     mount, so FetchRepositoryInfo prefers it over get-status, which returns only
-#     id+path for these folders. This is what the hasDotGit check selects.
+#   - On DBR: a Git in Dataplane folder exposes a real .git on the mount while
+#     get-status returns only id+path for it, so FetchRepositoryInfo prefers the .git.
+#     This is what the hasDotGit check selects.
 #
-# The API path itself (classic Repos and older Git folders, which have no .git on the
-# mount) cannot be provisioned from a test: those folder types are created by the
-# control plane, not by writing files. It is covered by unit tests in
-# libs/git/info_test.go.
+# See the script for why the fixture is hand-built rather than `git init`ed.
+#
+# The API path itself (classic Repos, which have no .git on the mount) cannot be
+# provisioned from a test: those folders are created by the control plane, not by
+# writing files. It is covered by unit tests in libs/git/info_test.go, along with the
+# boundary that keeps an unrelated .git above the Git folder from being picked up.
 #
 # Cloud=true is required because RunsOnDbr tests also run in the cloud suite.
 Local = true
@@ -22,4 +24,4 @@ RunsOnDbr = true
 # RunsOnDbr is incompatible with RecordRequests (serverless can't reach the proxy).
 RecordRequests = false
 
-Ignore = [".git"]
+Ignore = [".git", "subdir"]

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/databricks/cli/libs/auth"
@@ -21,8 +20,7 @@ import (
 )
 
 // Prefix of the workspace file system mount, as seen from a DBR session.
-// Overridden by tests, which cannot create files under the real mount point.
-var workspaceMountPrefix = "/Workspace/"
+const workspaceMountPrefix = "/Workspace/"
 
 type RepositoryInfo struct {
 	// Various metadata about the repo. Each could be "" if it could not be read. No error is returned for such case.
@@ -55,7 +53,7 @@ type response struct {
 func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
 	var info RepositoryInfo
 	var err error
-	if isWorkspaceMountPath(path) && dbr.RunsOnRuntime(ctx) && !hasDotGit(ctx, path) {
+	if strings.HasPrefix(path, workspaceMountPrefix) && dbr.RunsOnRuntime(ctx) && !hasDotGit(ctx, path) {
 		info, err = fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
 		info, err = fetchRepositoryInfoDotGit(ctx, path)
@@ -149,15 +147,9 @@ func hasDotGit(ctx context.Context, path string) bool {
 
 // findDotGitBelow returns the directory holding .git at or below dir, stopping before
 // ceiling, or "" if there is none. A non-nil error means the lookup itself failed.
-// ceiling is compared in slash form, so it matches regardless of separator.
 func findDotGitBelow(dir, ceiling string) (string, error) {
-	dir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", err
-	}
-
-	for filepath.ToSlash(dir) != ceiling {
-		_, err := os.Stat(filepath.Join(dir, GitDirectoryName))
+	for dir != ceiling {
+		_, err := os.Stat(path.Join(dir, GitDirectoryName))
 		if err == nil {
 			return dir, nil
 		}
@@ -165,7 +157,7 @@ func findDotGitBelow(dir, ceiling string) (string, error) {
 			return "", err
 		}
 
-		next := filepath.Dir(dir)
+		next := path.Dir(dir)
 		if dir == next {
 			return "", nil
 		}
@@ -174,17 +166,11 @@ func findDotGitBelow(dir, ceiling string) (string, error) {
 	return "", nil
 }
 
-// isWorkspaceMountPath reports whether path lives on the workspace mount. Compared in
-// slash form so a Windows-style path is recognised too.
-func isWorkspaceMountPath(path string) bool {
-	return strings.HasPrefix(filepath.ToSlash(path), workspaceMountPrefix)
-}
-
-// ownerRoot returns the workspace directory that owns path's Git folders, e.g.
+// ownerRoot returns the workspace directory that owns p's Git folders, e.g.
 // /Workspace/Users/me@databricks.com or /Workspace/Shared. Git folders are created
-// inside it, never at it. The result is in slash form, like every workspace path.
-func ownerRoot(path string) string {
-	rest, ok := strings.CutPrefix(filepath.ToSlash(path), workspaceMountPrefix)
+// inside it, never at it.
+func ownerRoot(p string) string {
+	rest, ok := strings.CutPrefix(p, workspaceMountPrefix)
 	if !ok {
 		return strings.TrimSuffix(workspaceMountPrefix, "/")
 	}
@@ -204,7 +190,7 @@ func ownerRoot(path string) string {
 }
 
 func ensureWorkspacePrefix(p string) string {
-	if !isWorkspaceMountPath(p) {
+	if !strings.HasPrefix(p, workspaceMountPrefix) {
 		return path.Join("/Workspace", p)
 	}
 	return p

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -49,7 +49,7 @@ type response struct {
 func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
 	var info RepositoryInfo
 	var err error
-	if strings.HasPrefix(path, "/Workspace/") && dbr.RunsOnRuntime(ctx) {
+	if strings.HasPrefix(path, "/Workspace/") && dbr.RunsOnRuntime(ctx) && !hasDotGit(path) {
 		info, err = fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
 		info, err = fetchRepositoryInfoDotGit(ctx, path)
@@ -113,6 +113,20 @@ func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.Work
 	}
 
 	return result, nil
+}
+
+// hasDotGit reports whether a .git directory is reachable from path, walking up
+// to the filesystem root the same way fetchRepositoryInfoDotGit does.
+//
+// The new type of in-workspace Git folder exposes a real .git on the /Workspace
+// FUSE mount, and get-status returns only id+path for it, omitting the origin URL,
+// branch and commit. Reading .git recovers all three, and is much cheaper than the
+// API: these stat calls cost fractions of a millisecond against ~80ms for
+// get-status. Classic Repos and older Git folders have no .git on the mount and
+// still go through the API, which returns their git info inline.
+func hasDotGit(path string) bool {
+	_, err := folders.FindDirWithLeaf(path, GitDirectoryName)
+	return err == nil
 }
 
 func ensureWorkspacePrefix(p string) string {

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -55,7 +55,7 @@ type response struct {
 func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
 	var info RepositoryInfo
 	var err error
-	if strings.HasPrefix(path, workspaceMountPrefix) && dbr.RunsOnRuntime(ctx) && !hasDotGit(ctx, path) {
+	if isWorkspaceMountPath(path) && dbr.RunsOnRuntime(ctx) && !hasDotGit(ctx, path) {
 		info, err = fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
 		info, err = fetchRepositoryInfoDotGit(ctx, path)
@@ -149,13 +149,14 @@ func hasDotGit(ctx context.Context, path string) bool {
 
 // findDotGitBelow returns the directory holding .git at or below dir, stopping before
 // ceiling, or "" if there is none. A non-nil error means the lookup itself failed.
+// ceiling is compared in slash form, so it matches regardless of separator.
 func findDotGitBelow(dir, ceiling string) (string, error) {
 	dir, err := filepath.Abs(dir)
 	if err != nil {
 		return "", err
 	}
 
-	for dir != ceiling {
+	for filepath.ToSlash(dir) != ceiling {
 		_, err := os.Stat(filepath.Join(dir, GitDirectoryName))
 		if err == nil {
 			return dir, nil
@@ -173,13 +174,19 @@ func findDotGitBelow(dir, ceiling string) (string, error) {
 	return "", nil
 }
 
+// isWorkspaceMountPath reports whether path lives on the workspace mount. Compared in
+// slash form so a Windows-style path is recognised too.
+func isWorkspaceMountPath(path string) bool {
+	return strings.HasPrefix(filepath.ToSlash(path), workspaceMountPrefix)
+}
+
 // ownerRoot returns the workspace directory that owns path's Git folders, e.g.
 // /Workspace/Users/me@databricks.com or /Workspace/Shared. Git folders are created
-// inside it, never at it.
+// inside it, never at it. The result is in slash form, like every workspace path.
 func ownerRoot(path string) string {
 	rest, ok := strings.CutPrefix(filepath.ToSlash(path), workspaceMountPrefix)
 	if !ok {
-		return workspaceMountPrefix
+		return strings.TrimSuffix(workspaceMountPrefix, "/")
 	}
 
 	// Users and Repos are keyed by principal, so the owner root includes it.
@@ -193,11 +200,11 @@ func ownerRoot(path string) string {
 	if len(segments) > depth {
 		segments = segments[:depth]
 	}
-	return filepath.FromSlash(workspaceMountPrefix + strings.Join(segments, "/"))
+	return workspaceMountPrefix + strings.Join(segments, "/")
 }
 
 func ensureWorkspacePrefix(p string) string {
-	if !strings.HasPrefix(p, workspaceMountPrefix) {
+	if !isWorkspaceMountPath(p) {
 		return path.Join("/Workspace", p)
 	}
 	return p

--- a/libs/git/info.go
+++ b/libs/git/info.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"io/fs"
 	"net/http"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/databricks/cli/libs/auth"
@@ -17,6 +19,10 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/client"
 )
+
+// Prefix of the workspace file system mount, as seen from a DBR session.
+// Overridden by tests, which cannot create files under the real mount point.
+var workspaceMountPrefix = "/Workspace/"
 
 type RepositoryInfo struct {
 	// Various metadata about the repo. Each could be "" if it could not be read. No error is returned for such case.
@@ -49,7 +55,7 @@ type response struct {
 func FetchRepositoryInfo(ctx context.Context, path string, w *databricks.WorkspaceClient) (RepositoryInfo, error) {
 	var info RepositoryInfo
 	var err error
-	if strings.HasPrefix(path, "/Workspace/") && dbr.RunsOnRuntime(ctx) && !hasDotGit(path) {
+	if strings.HasPrefix(path, workspaceMountPrefix) && dbr.RunsOnRuntime(ctx) && !hasDotGit(ctx, path) {
 		info, err = fetchRepositoryInfoAPI(ctx, path, w)
 	} else {
 		info, err = fetchRepositoryInfoDotGit(ctx, path)
@@ -115,22 +121,83 @@ func fetchRepositoryInfoAPI(ctx context.Context, path string, w *databricks.Work
 	return result, nil
 }
 
-// hasDotGit reports whether a .git directory is reachable from path, walking up
-// to the filesystem root the same way fetchRepositoryInfoDotGit does.
+// hasDotGit reports whether a .git belonging to path's own Git folder is readable
+// on the workspace mount.
 //
-// The new type of in-workspace Git folder exposes a real .git on the /Workspace
-// FUSE mount, and get-status returns only id+path for it, omitting the origin URL,
-// branch and commit. Reading .git recovers all three, and is much cheaper than the
-// API: these stat calls cost fractions of a millisecond against ~80ms for
-// get-status. Classic Repos and older Git folders have no .git on the mount and
-// still go through the API, which returns their git info inline.
-func hasDotGit(path string) bool {
-	_, err := folders.FindDirWithLeaf(path, GitDirectoryName)
-	return err == nil
+// The new type of in-workspace Git folder (Git in Dataplane) exposes a real .git on
+// the /Workspace mount, while get-status returns only id+path for it, omitting the
+// origin URL, branch and commit. Reading .git recovers all three. Classic Repos have
+// no .git on the mount and still go through the API, which returns their git info
+// inline.
+//
+// The search stops below the owner root (/Workspace/Users/<user>, /Workspace/Shared,
+// ...) rather than walking to the filesystem root: a Git folder always carries its
+// .git at its own root, which lives inside the owner root, so anything found at or
+// above it belongs to a different repository. Without the bound, an unrelated .git in
+// the user's workspace home would be reported as this bundle's provenance and could
+// fail the deploy in ValidateGitDetails.
+func hasDotGit(ctx context.Context, path string) bool {
+	root, err := findDotGitBelow(path, ownerRoot(path))
+	if err != nil {
+		// Anything other than "not found" (a permission or mount error) leaves the
+		// state on disk unknown, so fall back to the API rather than guess.
+		log.Debugf(ctx, "failed to look for %s under %s: %s", GitDirectoryName, path, err)
+		return false
+	}
+	return root != ""
+}
+
+// findDotGitBelow returns the directory holding .git at or below dir, stopping before
+// ceiling, or "" if there is none. A non-nil error means the lookup itself failed.
+func findDotGitBelow(dir, ceiling string) (string, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	for dir != ceiling {
+		_, err := os.Stat(filepath.Join(dir, GitDirectoryName))
+		if err == nil {
+			return dir, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", err
+		}
+
+		next := filepath.Dir(dir)
+		if dir == next {
+			return "", nil
+		}
+		dir = next
+	}
+	return "", nil
+}
+
+// ownerRoot returns the workspace directory that owns path's Git folders, e.g.
+// /Workspace/Users/me@databricks.com or /Workspace/Shared. Git folders are created
+// inside it, never at it.
+func ownerRoot(path string) string {
+	rest, ok := strings.CutPrefix(filepath.ToSlash(path), workspaceMountPrefix)
+	if !ok {
+		return workspaceMountPrefix
+	}
+
+	// Users and Repos are keyed by principal, so the owner root includes it.
+	depth := 1
+	scope, _, _ := strings.Cut(rest, "/")
+	if scope == "Users" || scope == "Repos" {
+		depth = 2
+	}
+
+	segments := strings.Split(rest, "/")
+	if len(segments) > depth {
+		segments = segments[:depth]
+	}
+	return filepath.FromSlash(workspaceMountPrefix + strings.Join(segments, "/"))
 }
 
 func ensureWorkspacePrefix(p string) string {
-	if !strings.HasPrefix(p, "/Workspace/") {
+	if !strings.HasPrefix(p, workspaceMountPrefix) {
 		return path.Join("/Workspace", p)
 	}
 	return p

--- a/libs/git/info_test.go
+++ b/libs/git/info_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync/atomic"
 	"testing"
 
@@ -24,8 +23,6 @@ const (
 	testWorktreeRoot = "/Workspace/Users/test/bundle-examples"
 	testRepoID       = int64(2884540697170475)
 	testOriginURL    = "https://github.com/databricks/bundle-examples.git"
-	// Commit id written into the .git fixture; must be a full SHA-1 to parse.
-	testDotGitCommit = "4fa481d6502eb6104d62c33a693ef8a134e765e0"
 )
 
 func newTestWorkspaceClient(t *testing.T, server *testserver.Server) *databricks.WorkspaceClient {
@@ -44,123 +41,10 @@ func runtimeContext(t *testing.T) context.Context {
 	return dbr.MockRuntime(t.Context(), dbr.Environment{IsDbr: true, Version: "15.4"})
 }
 
-// mockWorkspaceMount relocates the workspace mount point into a temporary directory
-// and returns it. Without this the paths below do not start with the mount prefix, so
-// FetchRepositoryInfo takes the on-disk branch on the prefix check alone and never
-// reaches the .git lookup the tests are exercising.
-func mockWorkspaceMount(t *testing.T) string {
-	t.Helper()
-	mount := filepath.Join(t.TempDir(), "Workspace")
-	original := workspaceMountPrefix
-	// Slash form, matching the real prefix and what the path helpers compare against.
-	workspaceMountPrefix = filepath.ToSlash(mount) + "/"
-	t.Cleanup(func() { workspaceMountPrefix = original })
-	return mount
-}
-
-// mockGitFolder creates a Git folder at <mount>/Users/<user>/<name> holding a .git,
-// plus the nested bundle root inside it, and returns both paths.
-func mockGitFolder(t *testing.T, mount, name, branch, commit string) (gitFolder, bundleRoot string) {
-	t.Helper()
-	gitFolder = filepath.Join(mount, "Users", "test@databricks.com", name)
-	bundleRoot = filepath.Join(gitFolder, "dabs_in_ws_bundle")
-	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
-	writeDotGit(t, gitFolder, testOriginURL, branch, commit)
-	return gitFolder, bundleRoot
-}
-
-// writeDotGit lays down the subset of .git that fetchRepositoryInfoDotGit reads.
-// A Git in Dataplane folder exposes a complete .git on the workspace mount (objects,
-// index, packed-refs and all); libs/git only reads HEAD, config and the branch ref,
-// so those three are all a fixture needs.
-func writeDotGit(t *testing.T, root, originURL, branch, commit string) {
-	t.Helper()
-	gitDir := filepath.Join(root, GitDirectoryName)
-	require.NoError(t, os.MkdirAll(filepath.Join(gitDir, "refs", "heads"), 0o755))
-
-	write := func(name, content string) {
-		t.Helper()
-		require.NoError(t, os.WriteFile(filepath.Join(gitDir, name), []byte(content), 0o600))
-	}
-	write("HEAD", "ref: refs/heads/"+branch+"\n")
-	write("config", "[core]\n\trepositoryformatversion = 1\n[remote \"origin\"]\n\turl = "+originURL+"\n")
-	write(filepath.Join("refs", "heads", branch), commit+"\n")
-}
-
-// newGetStatusServer returns a test server whose get-status records whether it was
-// called and answers with the id+path-only git_info of a Git in Dataplane folder.
-func newGetStatusServer(t *testing.T) (*testserver.Server, *atomic.Bool) {
-	t.Helper()
-	server := testserver.New(t)
-	var called atomic.Bool
-	server.Handle("GET", "/api/2.0/workspace/get-status", func(_ testserver.Request) any {
-		called.Store(true)
-		return testserver.Response{Body: map[string]any{
-			"git_info": map[string]any{"id": testRepoID, "path": testGitFolderRaw},
-		}}
-	})
-	return server, &called
-}
-
-// On DBR, a bundle root whose Git folder has a readable .git is served from disk:
-// Git in Dataplane folders expose one on the workspace mount, and get-status returns
-// only id+path for them, so the API cannot supply the provenance anyway.
-func TestFetchRepositoryInfoDbrPrefersDotGit(t *testing.T) {
-	mount := mockWorkspaceMount(t)
-	// The bundle root is a subdirectory, so the .git lookup has to walk up to find it.
-	gitFolder, bundleRoot := mockGitFolder(t, mount, "bundle-examples", "main", testDotGitCommit)
-
-	server, apiCalled := newGetStatusServer(t)
-
-	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
-	require.NoError(t, err)
-	assert.False(t, apiCalled.Load(), "get-status should not be called when .git is readable")
-	assert.Equal(t, testOriginURL, info.OriginURL)
-	assert.Equal(t, "main", info.CurrentBranch)
-	assert.Equal(t, testDotGitCommit, info.LatestCommit)
-	assert.Equal(t, gitFolder, info.WorktreeRoot)
-}
-
-// The counterpart of the test above: on the same mount, a bundle root with no .git
-// anywhere below the Git folder boundary must still reach the API. Without this the
-// assertion above passes for any routing rule that happens to prefer disk.
-func TestFetchRepositoryInfoDbrWithoutDotGitUsesAPI(t *testing.T) {
-	mount := mockWorkspaceMount(t)
-	bundleRoot := filepath.Join(mount, "Users", "test@databricks.com", "plain-dir", "dabs_in_ws_bundle")
-	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
-
-	server, apiCalled := newGetStatusServer(t)
-
-	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
-	require.NoError(t, err)
-	assert.True(t, apiCalled.Load(), "get-status must be called when no .git is reachable")
-	assert.Equal(t, testWorktreeRoot, info.WorktreeRoot)
-}
-
-// A .git above the Git folder boundary belongs to a different repository, so it must
-// not be reported as this bundle's provenance. Reproduced on DBR: a `git init` in the
-// user's workspace home otherwise makes every bundle below it report that repo's
-// origin, branch and commit, which can also fail the deploy in ValidateGitDetails.
-func TestFetchRepositoryInfoDbrIgnoresDotGitAboveGitFolder(t *testing.T) {
-	mount := mockWorkspaceMount(t)
-	userHome := filepath.Join(mount, "Users", "test@databricks.com")
-	bundleRoot := filepath.Join(userHome, "plain-dir", "dabs_in_ws_bundle")
-	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
-	// An unrelated repository in the user's workspace home, above the boundary.
-	writeDotGit(t, userHome, "https://github.com/unrelated/other.git", "other-branch", testDotGitCommit)
-
-	server, apiCalled := newGetStatusServer(t)
-
-	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
-	require.NoError(t, err)
-	assert.True(t, apiCalled.Load(), "get-status must be called instead of reading an unrelated .git")
-	assert.Empty(t, info.OriginURL)
-	assert.Empty(t, info.CurrentBranch)
-	assert.Equal(t, testWorktreeRoot, info.WorktreeRoot)
-}
-
-// Without a .git on the mount, the API path still owns classic Repos, which return
-// their git info inline.
+// A /Workspace path on DBR with no reachable .git goes to the API, which owns classic
+// Repos (they return their git info inline) and is also all a Git in Dataplane folder
+// has left when its .git cannot be read. The test host has no /Workspace, so hasDotGit
+// finds nothing and every case here exercises the API branch.
 func TestFetchRepositoryInfoAPI(t *testing.T) {
 	tests := []struct {
 		name string
@@ -201,8 +85,9 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 			wantWorktreeRoot: testWorktreeRoot,
 		},
 		{
-			// A Git in Dataplane folder whose .git is not readable: get-status
-			// carries only id+path, so there is no provenance to report.
+			// The Git in Dataplane response this change exists for: id+path only, so
+			// there is no provenance to report and the .git on the mount is the only
+			// source. Covered end to end by acceptance/bundle/git-info on DBR.
 			name: "id-only git info yields no provenance",
 			gitInfo: map[string]any{
 				"id":   testRepoID,
@@ -227,7 +112,9 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := testserver.New(t)
+			var apiCalled atomic.Bool
 			server.Handle("GET", "/api/2.0/workspace/get-status", func(_ testserver.Request) any {
+				apiCalled.Store(true)
 				body := map[string]any{}
 				if tt.gitInfo != nil {
 					body["git_info"] = tt.gitInfo
@@ -237,6 +124,7 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 
 			info, err := FetchRepositoryInfo(runtimeContext(t), testBundleRoot, newTestWorkspaceClient(t, server))
 			require.NoError(t, err)
+			assert.True(t, apiCalled.Load(), "no .git is reachable, so get-status must be called")
 			assert.Equal(t, tt.wantBranch, info.CurrentBranch)
 			assert.Equal(t, tt.wantCommit, info.LatestCommit)
 			assert.Equal(t, tt.wantOriginURL, info.OriginURL)
@@ -245,32 +133,38 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 	}
 }
 
-func TestHasDotGit(t *testing.T) {
-	mount := mockWorkspaceMount(t)
-	gitFolder, bundleRoot := mockGitFolder(t, mount, "bundle-examples", "main", testDotGitCommit)
-	ctx := t.Context()
+// findDotGitBelow is what decides whether provenance comes from disk, and its ceiling
+// is what keeps a .git outside the bundle's own Git folder from being picked up.
+func TestFindDotGitBelow(t *testing.T) {
+	// Stands in for the owner root (/Workspace/Users/<user>): Git folders live inside
+	// it, so a .git at or above it belongs to a different repository.
+	ceiling := filepath.ToSlash(t.TempDir())
+	gitFolder := filepath.Join(ceiling, "bundle-examples")
+	bundleRoot := filepath.Join(gitFolder, "dabs_in_ws_bundle", "nested")
+	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
 
-	assert.True(t, hasDotGit(ctx, gitFolder))
-	assert.True(t, hasDotGit(ctx, bundleRoot), "should walk up to find .git")
-	assert.False(t, hasDotGit(ctx, filepath.Join(mount, "Users", "test@databricks.com", "no-git-here")))
-}
+	// No .git anywhere yet.
+	root, err := findDotGitBelow(filepath.ToSlash(bundleRoot), ceiling)
+	require.NoError(t, err)
+	assert.Empty(t, root)
 
-// Workspace paths are always slash-separated, but on Windows the bundle root reaches
-// these helpers with backslashes, so every comparison must normalize first. Without it
-// the mount prefix never matches and the walk escapes the owner root. Windows-only:
-// filepath.ToSlash is a no-op elsewhere, so there is nothing to convert.
-func TestPathHelpersNormalizeSeparators(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("path separator normalization only differs on Windows")
-	}
+	// A .git at the ceiling itself is out of bounds: without the bound this would be
+	// reported as the bundle's provenance, and could fail the deploy in
+	// ValidateGitDetails by comparing against an unrelated repository's branch.
+	require.NoError(t, os.MkdirAll(filepath.Join(ceiling, GitDirectoryName), 0o755))
+	root, err = findDotGitBelow(filepath.ToSlash(bundleRoot), ceiling)
+	require.NoError(t, err)
+	assert.Empty(t, root, "a .git at the owner root must not be picked up")
 
-	original := workspaceMountPrefix
-	workspaceMountPrefix = "C:/tmp/Workspace/"
-	t.Cleanup(func() { workspaceMountPrefix = original })
+	// The Git folder's own .git is found, including by walking up from a subdirectory.
+	require.NoError(t, os.MkdirAll(filepath.Join(gitFolder, GitDirectoryName), 0o755))
+	root, err = findDotGitBelow(filepath.ToSlash(bundleRoot), ceiling)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.ToSlash(gitFolder), root)
 
-	backslashed := `C:\tmp\Workspace\Users\me@databricks.com\repo\bundle`
-	assert.True(t, isWorkspaceMountPath(backslashed))
-	assert.Equal(t, "C:/tmp/Workspace/Users/me@databricks.com", ownerRoot(backslashed))
+	root, err = findDotGitBelow(filepath.ToSlash(gitFolder), ceiling)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.ToSlash(gitFolder), root)
 }
 
 func TestOwnerRoot(t *testing.T) {
@@ -293,4 +187,9 @@ func TestOwnerRoot(t *testing.T) {
 			assert.Equal(t, tt.want, ownerRoot(tt.path))
 		})
 	}
+}
+
+func TestHasDotGit(t *testing.T) {
+	// A /Workspace path cannot exist on the test host, so nothing is reachable.
+	assert.False(t, hasDotGit(t.Context(), testBundleRoot))
 }

--- a/libs/git/info_test.go
+++ b/libs/git/info_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 
@@ -51,7 +52,8 @@ func mockWorkspaceMount(t *testing.T) string {
 	t.Helper()
 	mount := filepath.Join(t.TempDir(), "Workspace")
 	original := workspaceMountPrefix
-	workspaceMountPrefix = mount + string(os.PathSeparator)
+	// Slash form, matching the real prefix and what the path helpers compare against.
+	workspaceMountPrefix = filepath.ToSlash(mount) + "/"
 	t.Cleanup(func() { workspaceMountPrefix = original })
 	return mount
 }
@@ -253,6 +255,24 @@ func TestHasDotGit(t *testing.T) {
 	assert.False(t, hasDotGit(ctx, filepath.Join(mount, "Users", "test@databricks.com", "no-git-here")))
 }
 
+// Workspace paths are always slash-separated, but on Windows the bundle root reaches
+// these helpers with backslashes, so every comparison must normalize first. Without it
+// the mount prefix never matches and the walk escapes the owner root. Windows-only:
+// filepath.ToSlash is a no-op elsewhere, so there is nothing to convert.
+func TestPathHelpersNormalizeSeparators(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("path separator normalization only differs on Windows")
+	}
+
+	original := workspaceMountPrefix
+	workspaceMountPrefix = "C:/tmp/Workspace/"
+	t.Cleanup(func() { workspaceMountPrefix = original })
+
+	backslashed := `C:\tmp\Workspace\Users\me@databricks.com\repo\bundle`
+	assert.True(t, isWorkspaceMountPath(backslashed))
+	assert.Equal(t, "C:/tmp/Workspace/Users/me@databricks.com", ownerRoot(backslashed))
+}
+
 func TestOwnerRoot(t *testing.T) {
 	tests := []struct {
 		path string
@@ -265,12 +285,12 @@ func TestOwnerRoot(t *testing.T) {
 		{"/Workspace/Shared/repo/bundle", "/Workspace/Shared"},
 		{"/Workspace/Users", "/Workspace/Users"},
 		// Not under the mount at all: nothing above the mount is ever searched.
-		{"/tmp/local/bundle", "/Workspace/"},
+		{"/tmp/local/bundle", "/Workspace"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			assert.Equal(t, filepath.FromSlash(tt.want), ownerRoot(tt.path))
+			assert.Equal(t, tt.want, ownerRoot(tt.path))
 		})
 	}
 }

--- a/libs/git/info_test.go
+++ b/libs/git/info_test.go
@@ -1,0 +1,170 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/databricks/cli/libs/dbr"
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Bundle root passed to FetchRepositoryInfo: a subdirectory of the git folder.
+	testBundleRoot = "/Workspace/Users/test/bundle-examples/dabs_in_ws_bundle"
+	// Git folder path as get-status returns it (without the /Workspace prefix).
+	testGitFolderRaw = "/Users/test/bundle-examples"
+	// Expected worktree root after ensureWorkspacePrefix is applied.
+	testWorktreeRoot = "/Workspace/Users/test/bundle-examples"
+	testRepoID       = int64(2884540697170475)
+	testOriginURL    = "https://github.com/databricks/bundle-examples.git"
+	// Commit id written into the .git fixture; must be a full SHA-1 to parse.
+	testDotGitCommit = "4fa481d6502eb6104d62c33a693ef8a134e765e0"
+)
+
+func newTestWorkspaceClient(t *testing.T, server *testserver.Server) *databricks.WorkspaceClient {
+	t.Helper()
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:  server.URL,
+		Token: "testtoken",
+	})
+	require.NoError(t, err)
+	return w
+}
+
+// runtimeContext forces the in-workspace API branch of FetchRepositoryInfo
+// without needing a real /databricks directory on the test host.
+func runtimeContext(t *testing.T) context.Context {
+	return dbr.MockRuntime(t.Context(), dbr.Environment{IsDbr: true, Version: "15.4"})
+}
+
+// writeDotGit lays down the subset of .git that fetchRepositoryInfoDotGit reads,
+// matching what the new in-workspace Git folders expose on the FUSE mount.
+func writeDotGit(t *testing.T, root, originURL, branch, commit string) {
+	t.Helper()
+	gitDir := filepath.Join(root, GitDirectoryName)
+	require.NoError(t, os.MkdirAll(filepath.Join(gitDir, "refs", "heads"), 0o755))
+
+	write := func(name, content string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, name), []byte(content), 0o600))
+	}
+	write("HEAD", "ref: refs/heads/"+branch+"\n")
+	write("config", "[core]\n\trepositoryformatversion = 1\n[remote \"origin\"]\n\turl = "+originURL+"\n")
+	write(filepath.Join("refs", "heads", branch), commit+"\n")
+}
+
+// On DBR, a bundle root with a readable .git is served from disk: the new type of
+// in-workspace Git folder exposes one on the /Workspace FUSE mount, and get-status
+// returns only id+path for it, so the API cannot supply the provenance anyway.
+func TestFetchRepositoryInfoDbrPrefersDotGit(t *testing.T) {
+	// The bundle root is a subdirectory, so the .git lookup has to walk up to find it.
+	gitFolder := filepath.Join(t.TempDir(), "bundle-examples")
+	bundleRoot := filepath.Join(gitFolder, "dabs_in_ws_bundle")
+	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
+	writeDotGit(t, gitFolder, testOriginURL, "main", testDotGitCommit)
+
+	server := testserver.New(t)
+	var apiCalled atomic.Bool
+	server.Handle("GET", "/api/2.0/workspace/get-status", func(_ testserver.Request) any {
+		apiCalled.Store(true)
+		return testserver.Response{Body: map[string]any{}}
+	})
+
+	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
+	require.NoError(t, err)
+	assert.False(t, apiCalled.Load(), "get-status should not be called when .git is readable")
+	assert.Equal(t, testOriginURL, info.OriginURL)
+	assert.Equal(t, "main", info.CurrentBranch)
+	assert.Equal(t, testDotGitCommit, info.LatestCommit)
+	assert.Equal(t, gitFolder, info.WorktreeRoot)
+}
+
+// Without a .git on the mount, the API path still owns classic Repos and the older
+// workspace Git folders, which return their git info inline.
+func TestFetchRepositoryInfoAPI(t *testing.T) {
+	tests := []struct {
+		name string
+		// gitInfo is the git_info object returned by get-status; nil means it is omitted.
+		gitInfo map[string]any
+
+		wantBranch       string
+		wantCommit       string
+		wantOriginURL    string
+		wantWorktreeRoot string
+	}{
+		{
+			name: "git folder returns full git info inline",
+			gitInfo: map[string]any{
+				"id":             testRepoID,
+				"path":           testGitFolderRaw,
+				"branch":         "main",
+				"head_commit_id": "abc123",
+				"url":            testOriginURL,
+			},
+			wantBranch:       "main",
+			wantCommit:       "abc123",
+			wantOriginURL:    testOriginURL,
+			wantWorktreeRoot: testWorktreeRoot,
+		},
+		{
+			// A remoteless folder has no origin URL to report.
+			name: "remoteless git folder reports branch and commit but no url",
+			gitInfo: map[string]any{
+				"id":             testRepoID,
+				"path":           testGitFolderRaw,
+				"branch":         "main",
+				"head_commit_id": "abc123",
+			},
+			wantBranch:       "main",
+			wantCommit:       "abc123",
+			wantOriginURL:    "",
+			wantWorktreeRoot: testWorktreeRoot,
+		},
+		{
+			// A plain workspace directory: no git info, and no error either.
+			name:             "no git info degrades to empty provenance",
+			gitInfo:          nil,
+			wantBranch:       "",
+			wantCommit:       "",
+			wantOriginURL:    "",
+			wantWorktreeRoot: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := testserver.New(t)
+			server.Handle("GET", "/api/2.0/workspace/get-status", func(_ testserver.Request) any {
+				body := map[string]any{}
+				if tt.gitInfo != nil {
+					body["git_info"] = tt.gitInfo
+				}
+				return testserver.Response{Body: body}
+			})
+
+			info, err := FetchRepositoryInfo(runtimeContext(t), testBundleRoot, newTestWorkspaceClient(t, server))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBranch, info.CurrentBranch)
+			assert.Equal(t, tt.wantCommit, info.LatestCommit)
+			assert.Equal(t, tt.wantOriginURL, info.OriginURL)
+			assert.Equal(t, tt.wantWorktreeRoot, info.WorktreeRoot)
+		})
+	}
+}
+
+func TestHasDotGit(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "repo", "nested", "bundle")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "repo", GitDirectoryName), 0o755))
+
+	assert.True(t, hasDotGit(filepath.Join(root, "repo")))
+	assert.True(t, hasDotGit(nested), "should walk up to find .git")
+	assert.False(t, hasDotGit(filepath.Join(t.TempDir(), "no-git-here")))
+}

--- a/libs/git/info_test.go
+++ b/libs/git/info_test.go
@@ -43,8 +43,34 @@ func runtimeContext(t *testing.T) context.Context {
 	return dbr.MockRuntime(t.Context(), dbr.Environment{IsDbr: true, Version: "15.4"})
 }
 
-// writeDotGit lays down the subset of .git that fetchRepositoryInfoDotGit reads,
-// matching what the new in-workspace Git folders expose on the FUSE mount.
+// mockWorkspaceMount relocates the workspace mount point into a temporary directory
+// and returns it. Without this the paths below do not start with the mount prefix, so
+// FetchRepositoryInfo takes the on-disk branch on the prefix check alone and never
+// reaches the .git lookup the tests are exercising.
+func mockWorkspaceMount(t *testing.T) string {
+	t.Helper()
+	mount := filepath.Join(t.TempDir(), "Workspace")
+	original := workspaceMountPrefix
+	workspaceMountPrefix = mount + string(os.PathSeparator)
+	t.Cleanup(func() { workspaceMountPrefix = original })
+	return mount
+}
+
+// mockGitFolder creates a Git folder at <mount>/Users/<user>/<name> holding a .git,
+// plus the nested bundle root inside it, and returns both paths.
+func mockGitFolder(t *testing.T, mount, name, branch, commit string) (gitFolder, bundleRoot string) {
+	t.Helper()
+	gitFolder = filepath.Join(mount, "Users", "test@databricks.com", name)
+	bundleRoot = filepath.Join(gitFolder, "dabs_in_ws_bundle")
+	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
+	writeDotGit(t, gitFolder, testOriginURL, branch, commit)
+	return gitFolder, bundleRoot
+}
+
+// writeDotGit lays down the subset of .git that fetchRepositoryInfoDotGit reads.
+// A Git in Dataplane folder exposes a complete .git on the workspace mount (objects,
+// index, packed-refs and all); libs/git only reads HEAD, config and the branch ref,
+// so those three are all a fixture needs.
 func writeDotGit(t *testing.T, root, originURL, branch, commit string) {
 	t.Helper()
 	gitDir := filepath.Join(root, GitDirectoryName)
@@ -59,22 +85,30 @@ func writeDotGit(t *testing.T, root, originURL, branch, commit string) {
 	write(filepath.Join("refs", "heads", branch), commit+"\n")
 }
 
-// On DBR, a bundle root with a readable .git is served from disk: the new type of
-// in-workspace Git folder exposes one on the /Workspace FUSE mount, and get-status
-// returns only id+path for it, so the API cannot supply the provenance anyway.
-func TestFetchRepositoryInfoDbrPrefersDotGit(t *testing.T) {
-	// The bundle root is a subdirectory, so the .git lookup has to walk up to find it.
-	gitFolder := filepath.Join(t.TempDir(), "bundle-examples")
-	bundleRoot := filepath.Join(gitFolder, "dabs_in_ws_bundle")
-	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
-	writeDotGit(t, gitFolder, testOriginURL, "main", testDotGitCommit)
-
+// newGetStatusServer returns a test server whose get-status records whether it was
+// called and answers with the id+path-only git_info of a Git in Dataplane folder.
+func newGetStatusServer(t *testing.T) (*testserver.Server, *atomic.Bool) {
+	t.Helper()
 	server := testserver.New(t)
-	var apiCalled atomic.Bool
+	var called atomic.Bool
 	server.Handle("GET", "/api/2.0/workspace/get-status", func(_ testserver.Request) any {
-		apiCalled.Store(true)
-		return testserver.Response{Body: map[string]any{}}
+		called.Store(true)
+		return testserver.Response{Body: map[string]any{
+			"git_info": map[string]any{"id": testRepoID, "path": testGitFolderRaw},
+		}}
 	})
+	return server, &called
+}
+
+// On DBR, a bundle root whose Git folder has a readable .git is served from disk:
+// Git in Dataplane folders expose one on the workspace mount, and get-status returns
+// only id+path for them, so the API cannot supply the provenance anyway.
+func TestFetchRepositoryInfoDbrPrefersDotGit(t *testing.T) {
+	mount := mockWorkspaceMount(t)
+	// The bundle root is a subdirectory, so the .git lookup has to walk up to find it.
+	gitFolder, bundleRoot := mockGitFolder(t, mount, "bundle-examples", "main", testDotGitCommit)
+
+	server, apiCalled := newGetStatusServer(t)
 
 	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
 	require.NoError(t, err)
@@ -85,8 +119,46 @@ func TestFetchRepositoryInfoDbrPrefersDotGit(t *testing.T) {
 	assert.Equal(t, gitFolder, info.WorktreeRoot)
 }
 
-// Without a .git on the mount, the API path still owns classic Repos and the older
-// workspace Git folders, which return their git info inline.
+// The counterpart of the test above: on the same mount, a bundle root with no .git
+// anywhere below the Git folder boundary must still reach the API. Without this the
+// assertion above passes for any routing rule that happens to prefer disk.
+func TestFetchRepositoryInfoDbrWithoutDotGitUsesAPI(t *testing.T) {
+	mount := mockWorkspaceMount(t)
+	bundleRoot := filepath.Join(mount, "Users", "test@databricks.com", "plain-dir", "dabs_in_ws_bundle")
+	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
+
+	server, apiCalled := newGetStatusServer(t)
+
+	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
+	require.NoError(t, err)
+	assert.True(t, apiCalled.Load(), "get-status must be called when no .git is reachable")
+	assert.Equal(t, testWorktreeRoot, info.WorktreeRoot)
+}
+
+// A .git above the Git folder boundary belongs to a different repository, so it must
+// not be reported as this bundle's provenance. Reproduced on DBR: a `git init` in the
+// user's workspace home otherwise makes every bundle below it report that repo's
+// origin, branch and commit, which can also fail the deploy in ValidateGitDetails.
+func TestFetchRepositoryInfoDbrIgnoresDotGitAboveGitFolder(t *testing.T) {
+	mount := mockWorkspaceMount(t)
+	userHome := filepath.Join(mount, "Users", "test@databricks.com")
+	bundleRoot := filepath.Join(userHome, "plain-dir", "dabs_in_ws_bundle")
+	require.NoError(t, os.MkdirAll(bundleRoot, 0o755))
+	// An unrelated repository in the user's workspace home, above the boundary.
+	writeDotGit(t, userHome, "https://github.com/unrelated/other.git", "other-branch", testDotGitCommit)
+
+	server, apiCalled := newGetStatusServer(t)
+
+	info, err := FetchRepositoryInfo(runtimeContext(t), bundleRoot, newTestWorkspaceClient(t, server))
+	require.NoError(t, err)
+	assert.True(t, apiCalled.Load(), "get-status must be called instead of reading an unrelated .git")
+	assert.Empty(t, info.OriginURL)
+	assert.Empty(t, info.CurrentBranch)
+	assert.Equal(t, testWorktreeRoot, info.WorktreeRoot)
+}
+
+// Without a .git on the mount, the API path still owns classic Repos, which return
+// their git info inline.
 func TestFetchRepositoryInfoAPI(t *testing.T) {
 	tests := []struct {
 		name string
@@ -127,6 +199,19 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 			wantWorktreeRoot: testWorktreeRoot,
 		},
 		{
+			// A Git in Dataplane folder whose .git is not readable: get-status
+			// carries only id+path, so there is no provenance to report.
+			name: "id-only git info yields no provenance",
+			gitInfo: map[string]any{
+				"id":   testRepoID,
+				"path": testGitFolderRaw,
+			},
+			wantBranch:       "",
+			wantCommit:       "",
+			wantOriginURL:    "",
+			wantWorktreeRoot: testWorktreeRoot,
+		},
+		{
 			// A plain workspace directory: no git info, and no error either.
 			name:             "no git info degrades to empty provenance",
 			gitInfo:          nil,
@@ -159,12 +244,33 @@ func TestFetchRepositoryInfoAPI(t *testing.T) {
 }
 
 func TestHasDotGit(t *testing.T) {
-	root := t.TempDir()
-	nested := filepath.Join(root, "repo", "nested", "bundle")
-	require.NoError(t, os.MkdirAll(nested, 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "repo", GitDirectoryName), 0o755))
+	mount := mockWorkspaceMount(t)
+	gitFolder, bundleRoot := mockGitFolder(t, mount, "bundle-examples", "main", testDotGitCommit)
+	ctx := t.Context()
 
-	assert.True(t, hasDotGit(filepath.Join(root, "repo")))
-	assert.True(t, hasDotGit(nested), "should walk up to find .git")
-	assert.False(t, hasDotGit(filepath.Join(t.TempDir(), "no-git-here")))
+	assert.True(t, hasDotGit(ctx, gitFolder))
+	assert.True(t, hasDotGit(ctx, bundleRoot), "should walk up to find .git")
+	assert.False(t, hasDotGit(ctx, filepath.Join(mount, "Users", "test@databricks.com", "no-git-here")))
+}
+
+func TestOwnerRoot(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/Workspace/Users/me@databricks.com/repo/bundle", "/Workspace/Users/me@databricks.com"},
+		{"/Workspace/Users/me@databricks.com/repo", "/Workspace/Users/me@databricks.com"},
+		{"/Workspace/Users/me@databricks.com", "/Workspace/Users/me@databricks.com"},
+		{"/Workspace/Repos/me@databricks.com/repo", "/Workspace/Repos/me@databricks.com"},
+		{"/Workspace/Shared/repo/bundle", "/Workspace/Shared"},
+		{"/Workspace/Users", "/Workspace/Users"},
+		// Not under the mount at all: nothing above the mount is ever searched.
+		{"/tmp/local/bundle", "/Workspace/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, filepath.FromSlash(tt.want), ownerRoot(tt.path))
+		})
+	}
 }


### PR DESCRIPTION
## Changes
The new type of in-workspace Git folder returns only `id` and `path` from `get-status?return_git_info=true` (no url/branch/commit), so bundles deployed from one recorded empty git provenance. Classic Repos and existing workspace Git folders return full git info inline and were not affected.

These folders do expose a real, readable `.git` on the `/Workspace` FUSE mount, so `FetchRepositoryInfo` now reads provenance from disk when a `.git` is reachable, and takes the existing `get-status` path otherwise. No new API call is added.

## Why
The `.git` check is a `stat` walk-up — the same one the on-disk reader already does — so guarding with it is free: a fraction of a millisecond, against ~80ms for `get-status`. Reading the folder's own `.git` needs no extra permissions, and the local check is cheaper than any API-based recovery of the same fields.

Verified on Azure dogfood serverless against a real git-in-dataplane folder: provenance is recorded correctly (origin URL, branch, and commit all present, matching the folder's actual git state), and `bundle validate` in that folder drops from ~3.2s to ~0.45s.

Note that on-disk `.git` reflects the checkout rather than server-side state. For recording what was actually deployed, that is arguably the more accurate source.

## Tests
`libs/git/info_test.go`: `.git` present on a DBR path means `get-status` is not called and provenance comes from disk, including walking up from a subdirectory; a `/Workspace` path with no `.git` still uses the API, covering inline git info, a remoteless folder with no origin URL, and a plain directory with no git info at all (empty provenance, no error); plus `hasDotGit` itself.

`acceptance/bundle/git-info`: covers `bundle.git` end to end. The bundle root carries a hand-built `.git`, which is readable both locally and on the FUSE mount of a DBR session, so the test runs with one expected output in both environments (`Local`, `Cloud`, `RunsOnDbr`). It asserts full provenance from disk, then removes `.git` and asserts provenance degrades to empty without failing.

_This PR was written by Claude Code._
