### PR TITLE
Exclude Vector Search index from cloud invariant tests

### DIFF
--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -6,8 +6,9 @@ EnvMatrixExclude.no_grant_ref = ["INPUT_CONFIG=schema_grant_ref.yml.tmpl"]
 # Model permissions did not work until 0.297.0 https://github.com/databricks/cli/pull/4941
 EnvMatrixExclude.no_model_with_permissions = ["INPUT_CONFIG=model_with_permissions.yml.tmpl"]
 
-# vector_search_endpoints resource is not supported on v0.293.0
+# Vector Search resources are not supported on v0.293.0
 EnvMatrixExclude.no_vector_search_endpoint = ["INPUT_CONFIG=vector_search_endpoint.yml.tmpl"]
+EnvMatrixExclude.no_vector_search_index = ["INPUT_CONFIG=vector_search_index.yml.tmpl"]
 
 # genie_spaces resource is not supported on v0.293.0
 EnvMatrixExclude.no_genie_space = ["INPUT_CONFIG=genie_space.yml.tmpl"]

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -94,6 +94,12 @@ no_external_location_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=external_loc
 # External volumes reference external locations; excluded from cloud for the same reason
 no_external_volume_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=volume_external.yml.tmpl"]
 
+# A vector search index takes 10-20 min to create, and these tests deploy it twice
+# (deploy, then re-plan), making it by far the slowest variant on cloud. The dedicated
+# vector_search_indexes resource test already covers it on cloud (CloudSlow), so exclude
+# it here to keep the cloud invariant runs from timing out. Still exercised locally.
+no_vector_search_index_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=vector_search_index.yml.tmpl"]
+
 # Fake SQL endpoint for local tests
 [[Server]]
 Pattern = "POST /api/2.0/sql/statements/"


### PR DESCRIPTION
The `vector_search_index` variant dominates the cloud `-short` invariant run — a VS index takes 10–20 min to create and the invariant tests deploy it twice (deploy, then re-plan), a major contributor to the suite timing out and starving later tests.

The dedicated `vector_search_indexes` resource test already covers it on cloud (`CloudSlow`/nightly), so this excludes it from `no_drift` on cloud (kept locally, where it's fast against the mock). It also excludes it entirely from `continue_293`, where v0.293.0 can't deploy it anyway — the index config embeds an endpoint, and Vector Search resources aren't supported on v0.293.0. `migrate` already excluded it (no terraform converter).

This pull request and its description were written by Isaac.
