### PR TITLE
upgrade ruff from 0.9.1 to 0.15.17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run ruff (Python linter and formatter)
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          version: "0.9.1"
+          version: "0.15.17"
           args: "format --check"
 
       - name: "task fmt: Python and Go formatting"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -173,7 +173,7 @@ tasks:
       # Pinned to match the version used by the `ruff format --check` step in
       # .github/workflows/check.yml — newer ruff versions reformat files that
       # CI considers already formatted.
-      - "uvx ruff@0.9.1 format -n"
+      - "uvx ruff@0.15.17 format -n"
 
   # `golangci-lint fmt` walks the filesystem and doesn't typecheck, so it
   # formats files across all nested modules (tools/, bundle/internal/tf/codegen/)


### PR DESCRIPTION
Bumps the pinned ruff version in CI and `Taskfile.yml` from 0.9.1 to 0.15.17. No Python files were reformatted by the new version.

This pull request and its description were written by Isaac.