### PR TITLE
acc: run deployment/bind/job/generate-and-bind locally

### DIFF
--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/test.toml
@@ -1,7 +1,7 @@
-# This test is using a workspace import API to load a notebook file.
-# This API has a logic on how to accept notebook files and distinguishes them from regular python files.
-# To succeed locally we would need to replicate this logic in the fake_workspace
-Local = false
+# This test uses the workspace import API to load a notebook file. The testserver
+# models the SOURCE import format (notebook with an explicit language), so it runs
+# locally in addition to cloud.
+Local = true
 Cloud = true
 
 Ignore = [

--- a/acceptance/bundle/resource_deps/jobs_update/output.txt
+++ b/acceptance/bundle/resource_deps/jobs_update/output.txt
@@ -90,7 +90,7 @@ Destroy complete!
 }
 
 >>> musterr [CLI] jobs get [FOO_ID]
-Error: Not Found
+Error: Job [FOO_ID] does not exist.
 
 >>> musterr [CLI] jobs get [BAR_ID]
-Error: Not Found
+Error: Job [BAR_ID] does not exist.

--- a/acceptance/bundle/resource_deps/pipelines_recreate/output.txt
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/output.txt
@@ -136,4 +136,4 @@ Error: The specified pipeline [FOO_ID] was not found.
 Error: The specified pipeline [FOO_ID_2] was not found.
 
 >>> musterr [CLI] jobs get [BAR_ID]
-Error: Not Found
+Error: Job [BAR_ID] does not exist.

--- a/acceptance/bundle/resources/jobs/update/output.txt
+++ b/acceptance/bundle/resources/jobs/update/output.txt
@@ -99,4 +99,4 @@ Destroy complete!
 }
 
 >>> musterr [CLI] jobs get [FOO_ID]
-Error: Not Found
+Error: Job [FOO_ID] does not exist.

--- a/acceptance/bundle/resources/jobs/update_single_node/output.txt
+++ b/acceptance/bundle/resources/jobs/update_single_node/output.txt
@@ -99,4 +99,4 @@ Destroy complete!
 }
 
 >>> musterr [CLI] jobs get [FOO_ID]
-Error: Not Found
+Error: Job [FOO_ID] does not exist.

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -478,8 +478,16 @@ func (s *FakeWorkspace) WorkspaceFilesImportFile(filePath string, body []byte, o
 		}
 	}
 
-	// Add all directories in the path to the directories map
-	for dir := path.Dir(workspacePath); dir != "/"; dir = path.Dir(dir) {
+	s.addAncestorDirectories(workspacePath)
+
+	return Response{}
+}
+
+// addAncestorDirectories registers every parent directory of objectPath in the
+// directories map, mirroring the real workspace API which materializes parent
+// directories when an object is imported. The caller must hold the lock.
+func (s *FakeWorkspace) addAncestorDirectories(objectPath string) {
+	for dir := path.Dir(objectPath); dir != "/"; dir = path.Dir(dir) {
 		if _, exists := s.directories[dir]; !exists {
 			s.directories[dir] = workspace.ObjectInfo{
 				ObjectType: "DIRECTORY",
@@ -488,6 +496,39 @@ func (s *FakeWorkspace) WorkspaceFilesImportFile(filePath string, body []byte, o
 			}
 		}
 	}
+}
+
+// WorkspaceImportNotebook stores a notebook imported with the SOURCE format.
+// Unlike AUTO format, SOURCE keeps the path as-is (no extension stripping) and
+// the notebook language is provided explicitly rather than sniffed from a
+// "# Databricks notebook source" header.
+func (s *FakeWorkspace) WorkspaceImportNotebook(filePath string, body []byte, language workspace.Language, overwrite bool) Response {
+	if !strings.HasPrefix(filePath, "/") {
+		filePath = "/" + filePath
+	}
+
+	defer s.LockUnlock()()
+
+	if !overwrite {
+		if _, exists := s.files[filePath]; exists {
+			return Response{
+				StatusCode: 409,
+				Body:       map[string]string{"message": fmt.Sprintf("File already exists at (%s).", filePath)},
+			}
+		}
+	}
+
+	s.files[filePath] = FileEntry{
+		Info: workspace.ObjectInfo{
+			ObjectType: "NOTEBOOK",
+			Path:       filePath,
+			Language:   language,
+			ObjectId:   nextID(),
+		},
+		Data: body,
+	}
+
+	s.addAncestorDirectories(filePath)
 
 	return Response{}
 }

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -143,13 +143,6 @@ func AddDefaultHandlers(server *Server) {
 			}
 		}
 
-		if request.Format != workspace.ImportFormatAuto {
-			return Response{
-				Body:       "internal error: The test server only supports auto format.",
-				StatusCode: http.StatusInternalServerError,
-			}
-		}
-
 		// The /workspace/import endpoint expects the content as base64 encoded string.
 		// We need to decode it to get the actual content.
 		decoded, err := base64.StdEncoding.DecodeString(request.Content)
@@ -160,7 +153,21 @@ func AddDefaultHandlers(server *Server) {
 			}
 		}
 
-		return req.Workspace.WorkspaceFilesImportFile(request.Path, decoded, request.Overwrite)
+		switch request.Format {
+		case workspace.ImportFormatAuto:
+			return req.Workspace.WorkspaceFilesImportFile(request.Path, decoded, request.Overwrite)
+		case workspace.ImportFormatSource, "":
+			// SOURCE imports a single notebook with an explicit language, e.g.
+			// `databricks workspace import --language PYTHON`. The CLI leaves the
+			// format empty in that case and treats empty as SOURCE (see
+			// cmd/workspace/workspace/overrides.go).
+			return req.Workspace.WorkspaceImportNotebook(request.Path, decoded, request.Language, request.Overwrite)
+		default:
+			return Response{
+				Body:       "internal error: The test server only supports auto and source formats.",
+				StatusCode: http.StatusInternalServerError,
+			}
+		}
 	})
 
 	server.Handle("GET", "/api/2.0/workspace-files/{path...}", func(req Request) any {

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -195,7 +195,11 @@ func (s *FakeWorkspace) JobsGet(req Request) Response {
 
 	job, ok := s.Jobs[jobIdInt]
 	if !ok {
-		return Response{StatusCode: 404}
+		// Match the real Jobs API, which echoes the job id in the error message.
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": fmt.Sprintf("Job %d does not exist.", jobIdInt)},
+		}
 	}
 
 	job = setSourceIfNotSet(job)


### PR DESCRIPTION
## Changes

Enables the `bundle/deployment/bind/job/generate-and-bind` acceptance test to run against the local testserver (in addition to cloud), by closing two testserver gaps:

- **`workspace/import` SOURCE format.** The `/api/2.0/workspace/import` handler now handles the `SOURCE` format (and the empty format the CLI sends for `databricks workspace import --language PYTHON`), storing the object as a `NOTEBOOK` with the provided language. Previously it only accepted `AUTO` and returned an internal error otherwise. The parent-directory registration shared with the `AUTO` path was extracted into an `addAncestorDirectories` helper.
- **`jobs.get` not-found message.** A missing job now returns the cloud-accurate `Job <id> does not exist.` message (HTTP status unchanged at 404), instead of a bare `Not Found`.
- Flips the test to `Local = true` and regenerates four existing local goldens whose `Error: Not Found` assertions now match cloud: `resource_deps/jobs_update`, `resource_deps/pipelines_recreate`, `resources/jobs/update`, `resources/jobs/update_single_node`.

## Why

The test was cloud-only because the testserver couldn't model two behaviors it exercises:

- `databricks workspace import --language PYTHON` sends the `SOURCE` (empty) format, which the testserver rejected — so importing the notebook the job depends on failed immediately.
- The final assertion checks that the job is gone after destroy via `jobs get`, expecting the cloud error `Job <id> does not exist.`, but the testserver returned `Not Found`.

Closing these gaps lets the test run locally (fast, no cloud account needed) and makes the testserver behave more like the real API, which also brings the four existing local job goldens in line with cloud. Keeping the 404 status code means engine missing-detection via `apierr.IsMissing` is unaffected.

## Tests

- `go test ./acceptance -run TestAccept/bundle/deployment/bind/job/generate-and-bind` passes locally on both `terraform` and `direct` engines.
- The four regenerated job tests pass.
- `libs/testserver` builds and its unit tests pass.
- Related notebook-import tests are unaffected: `bind/job/python-job`, `unbind/python-job`, `bind/job/job-spark-python-task`.