### PR TITLE
acc: run deployment/bind/alert locally on all clouds

### DIFF
--- a/acceptance/bundle/deployment/bind/alert/out.test.toml
+++ b/acceptance/bundle/deployment/bind/alert/out.test.toml
@@ -1,4 +1,3 @@
-Local = false
+Local = true
 Cloud = true
-CloudEnvs.aws = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/alert/test.toml
+++ b/acceptance/bundle/deployment/bind/alert/test.toml
@@ -1,15 +1,21 @@
 Cloud = true
-Local = false
+Local = true
 
 # Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
 # Use aggressive 5-minute timeout until the issue is resolved.
 # See: https://github.com/databricks/cli/issues/4221
 TimeoutCloud = "5m"
 
-# On aws the host URL includes the workspace ID as well. Thus skipping it to keep the test simple.
-CloudEnvs.aws = false
-
 Ignore = [
     "databricks.yml",
     "alert.json",
 ]
+
+# Redact the ?[ow]=<id> workspace query param from summary URLs. The CLI appends it
+# whenever the host doesn't already carry the workspace ID in its subdomain, which is
+# the case for the local testserver (127.0.0.1) and aws hosts; azure/gcp vanity hosts
+# embed the ID and omit it. Stripping it lets one golden match local and all clouds.
+[[Repls]]
+Old = '\?[ow]=\d+'
+New = ''
+Order = 0


### PR DESCRIPTION
## Changes
Run `acceptance/bundle/deployment/bind/alert` against the local testserver in addition to cloud (`Local = true`). No testserver changes needed — alerts-v2 create/bind/unbind and `bundle summary` are already modeled by the fake (the same support the already-local `resources/alerts/{basic,with_file}` tests rely on).

The only local-vs-cloud divergence was the summary URL. `InitializeURLs` appends `?w=<workspace id>` when the host doesn't carry the ID in its subdomain — true for the local testserver (`127.0.0.1`) and aws, but not azure/gcp vanity hosts. So:
- Added a repl stripping `\?[ow]=\d+` (`Order = 0`, before the global `[NUMID]` repls), matching `resources/alerts/{basic,with_file}`.
- Dropped the now-unnecessary `CloudEnvs.aws = false` skip, since the repl normalizes aws too.

## Why
Part of converting `Local = false` acceptance tests to local+cloud. The `?w=` isn't a testserver fidelity gap — it's correct CLI behavior driven by host shape, and ~55 existing local goldens already record `?w=[NUMID]`. Redaction keeps one golden valid across local and all clouds, and net coverage increases (local + aws/azure/gcp vs cloud-only before).

## Tests
No additional tests.