### PR TITLE
Fix duplicate enum values in bundle JSON schema

### DIFF
--- a/bundle/internal/schema/annotations.go
+++ b/bundle/internal/schema/annotations.go
@@ -175,14 +175,39 @@ func assignAnnotation(s *jsonschema.Schema, a annotation.Descriptor) {
 
 	s.MarkdownDescription = convertLinksToAbsoluteUrl(a.MarkdownDescription)
 	s.Title = a.Title
-	s.Enum = a.Enum
-	s.EnumDescriptions = buildEnumDescriptions(a.Enum, a.EnumLaunchStages, a.EnumDescriptions)
+	enum := deduplicateEnumValues(a.Enum)
+	s.Enum = enum
+	s.EnumDescriptions = buildEnumDescriptions(enum, a.EnumLaunchStages, a.EnumDescriptions)
 
 	// Surface launch stage in hover tooltips. Editors only render the standard
 	// description field, so the tag is baked into the text.
 	if tag := annotation.PreviewTag(a.LaunchStage); tag != "" {
 		s.Description = prefixWithPreviewTag(s.Description, tag)
 	}
+}
+
+func deduplicateEnumValues(enum []any) []any {
+	if len(enum) < 2 {
+		return enum
+	}
+
+	out := make([]any, 0, len(enum))
+	for _, value := range enum {
+		found := false
+		for _, existing := range out {
+			if reflect.DeepEqual(existing, value) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, value)
+		}
+	}
+	if len(out) == len(enum) {
+		return enum
+	}
+	return out
 }
 
 // buildEnumDescriptions produces the parallel enumDescriptions array VSCode

--- a/bundle/internal/schema/annotations_test.go
+++ b/bundle/internal/schema/annotations_test.go
@@ -196,6 +196,19 @@ func TestAssignAnnotationLaunchStage(t *testing.T) {
 		assert.Equal(t, "Type of endpoint.", s.Description)
 		assert.Equal(t, []string{"[Public Preview]", ""}, s.EnumDescriptions)
 	})
+
+	t.Run("deduplicates enum values before building enum descriptions", func(t *testing.T) {
+		s := &jsonschema.Schema{}
+		assignAnnotation(s, annotation.Descriptor{
+			Enum: []any{"AWS_SSE_S3", "AWS_SSE_KMS", "AWS_SSE_KMS", "AWS_SSE_S3"},
+			EnumDescriptions: map[string]string{
+				"AWS_SSE_KMS": "SSE-KMS encryption.",
+				"AWS_SSE_S3":  "SSE-S3 encryption.",
+			},
+		})
+		assert.Equal(t, []any{"AWS_SSE_S3", "AWS_SSE_KMS"}, s.Enum)
+		assert.Equal(t, []string{"SSE-S3 encryption.", "SSE-KMS encryption."}, s.EnumDescriptions)
+	})
 }
 
 func TestPrefixWithPreviewTagNoDoubleTag(t *testing.T) {

--- a/bundle/schema/embed_test.go
+++ b/bundle/schema/embed_test.go
@@ -2,6 +2,7 @@ package schema_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/databricks/cli/bundle/schema"
@@ -63,4 +64,47 @@ func TestJsonSchema(t *testing.T) {
 	assert.Contains(t, providers.OneOf[0].Enum, "bitbucketCloud")
 	assert.Contains(t, providers.OneOf[0].Enum, "gitHubEnterprise")
 	assert.Contains(t, providers.OneOf[0].Enum, "bitbucketServer")
+}
+
+func TestJsonSchemaEnumsAreUnique(t *testing.T) {
+	var s any
+	err := json.Unmarshal(schema.Bytes, &s)
+	require.NoError(t, err)
+
+	duplicateEnums := duplicateEnumPaths(s, "")
+	assert.Empty(t, duplicateEnums)
+}
+
+func duplicateEnumPaths(v any, path string) []string {
+	var duplicates []string
+	switch v := v.(type) {
+	case map[string]any:
+		if enum, ok := v["enum"].([]any); ok {
+			seen := map[string]struct{}{}
+			for _, item := range enum {
+				keyBytes, err := json.Marshal(item)
+				if err != nil {
+					panic(err)
+				}
+				key := string(keyBytes)
+				if _, ok := seen[key]; ok {
+					duplicates = append(duplicates, path)
+					break
+				}
+				seen[key] = struct{}{}
+			}
+		}
+		for key, value := range v {
+			childPath := key
+			if path != "" {
+				childPath = fmt.Sprintf("%s/%s", path, key)
+			}
+			duplicates = append(duplicates, duplicateEnumPaths(value, childPath)...)
+		}
+	case []any:
+		for i, value := range v {
+			duplicates = append(duplicates, duplicateEnumPaths(value, fmt.Sprintf("%s[%d]", path, i))...)
+		}
+	}
+	return duplicates
 }

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -4706,9 +4706,7 @@
                   "description": "SSE algorithm to use for encrypting S3 objects",
                   "enum": [
                     "AWS_SSE_S3",
-                    "AWS_SSE_KMS",
-                    "AWS_SSE_KMS",
-                    "AWS_SSE_S3"
+                    "AWS_SSE_KMS"
                   ]
                 },
                 {


### PR DESCRIPTION
## Summary
- deduplicate annotation enum values before assigning them to generated JSON Schema nodes
- keep enumDescriptions aligned with the deduplicated enum order
- add regressions that catch duplicate enum arrays in the embedded bundle schema

Fixes #5713

## Root Cause
`cli.json` and `bundle/internal/schema/annotations.yml` can both supply enum values for the same annotation descriptor. The generic annotation merge concatenates sequences, so the generated schema published duplicate enum entries for `catalog.SseEncryptionDetailsAlgorithm`.

## Tests
- `go test ./bundle/internal/schema ./bundle/schema -count=1`
- `go test ./bundle/... -count=1`

Note: `./task generate-schema` could not run in this local environment because `uv` is not on PATH; I ran its Go command directly: `go run ./bundle/internal/schema ./bundle/internal/schema ./bundle/schema/jsonschema.json .codegen/cli.json`.