### PR TITLE
acc: simulate dashboard eventual consistency and harden dashboard tests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -767,7 +767,7 @@ func runTest(t *testing.T,
 	args := []string{"bash", "-euo", "pipefail", EntryPointScript}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 
-	cfg, user := internal.PrepareServerAndClient(t, config, LogRequests, tmpDir)
+	cfg, user := internal.PrepareServerAndClient(t, config, LogRequests, tmpDir, testEnv)
 	testdiff.PrepareReplacementsUser(t, &repls, user)
 	testdiff.PrepareReplacementsWorkspaceConfig(t, &repls, cfg)
 

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/output.txt
@@ -9,8 +9,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/change-embed-crede
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -36,8 +34,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/change-embed-crede
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/output.txt
@@ -10,7 +10,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -37,7 +37,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/script
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/script
@@ -15,7 +15,7 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
+    DASHBOARD=$(retry $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
     trace $CLI lakeview get-published $dashboard_id | jq "{warehouse_id, embed_credentials}"
 }

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/script
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/script
@@ -15,7 +15,7 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    trace $CLI lakeview get $dashboard_id | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
+    trace retry.py $CLI lakeview get $dashboard_id | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
     trace $CLI lakeview get-published $dashboard_id | jq "{warehouse_id, embed_credentials}"
 }
 

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/script
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/script
@@ -15,7 +15,9 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    trace retry.py $CLI lakeview get $dashboard_id | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
+    # Read back once (retrying the eventual-consistency 404) and reuse for the etag below.
+    DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
+    echo "$DASHBOARD" | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
     trace $CLI lakeview get-published $dashboard_id | jq "{warehouse_id, embed_credentials}"
 }
 
@@ -25,7 +27,7 @@ deploy_dashboard
 # Capture the dashboard ID as a replacement.
 dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 echo "$dashboard_id:DASHBOARD_ID" >> ACC_REPLS
-echo "$($CLI lakeview get $dashboard_id | jq -r '.etag'):ETAG" >> ACC_REPLS
+echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 # Change embed_credentials to true - this should trigger an update
 export EMBED_CREDENTIALS="true"

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/script
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/script
@@ -15,7 +15,6 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    # Read back once (retrying the eventual-consistency 404) and reuse for the etag below.
     DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
     trace $CLI lakeview get-published $dashboard_id | jq "{warehouse_id, embed_credentials}"

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/script
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/script
@@ -16,17 +16,14 @@ deploy_dashboard() {
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
     DASHBOARD=$(retry $CLI lakeview get $dashboard_id)
+    echo "$dashboard_id:DASHBOARD_ID" >> ACC_REPLS
+    echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
     echo "$DASHBOARD" | jq "{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}"
     trace $CLI lakeview get-published $dashboard_id | jq "{warehouse_id, embed_credentials}"
 }
 
 # Create the dashboard with embed_credentials=false
 deploy_dashboard
-
-# Capture the dashboard ID as a replacement.
-dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-echo "$dashboard_id:DASHBOARD_ID" >> ACC_REPLS
-echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 # Change embed_credentials to true - this should trigger an update
 export EMBED_CREDENTIALS="true"

--- a/acceptance/bundle/resources/dashboards/change-name/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-name/output.txt
@@ -9,8 +9,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/change-name-[UNIQU
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "dashboard1",
   "lifecycle_state": "ACTIVE",
@@ -30,8 +28,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/change-name-[UNIQU
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "dashboard2",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-name/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-name/output.txt
@@ -10,7 +10,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "dashboard1",
   "lifecycle_state": "ACTIVE",
@@ -31,7 +31,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "dashboard2",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-name/script
+++ b/acceptance/bundle/resources/dashboards/change-name/script
@@ -12,7 +12,6 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    # Read back once (retrying the eventual-consistency 404) and reuse for the etag below.
     DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }

--- a/acceptance/bundle/resources/dashboards/change-name/script
+++ b/acceptance/bundle/resources/dashboards/change-name/script
@@ -12,7 +12,9 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    DASHBOARD=$(retry $CLI lakeview get $dashboard_id)
+    # Wait out eventual consistency: retry until the current name is visible (the read
+    # 404s on create and returns the stale name right after a rename).
+    DASHBOARD=$(retry --until "$NAME" $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }
 

--- a/acceptance/bundle/resources/dashboards/change-name/script
+++ b/acceptance/bundle/resources/dashboards/change-name/script
@@ -12,7 +12,9 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    trace retry.py $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
+    # Read back once (retrying the eventual-consistency 404) and reuse for the etag below.
+    DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
+    echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }
 
 # Create the dashboard
@@ -21,7 +23,7 @@ deploy_dashboard
 # Capture the dashboard ID as a replacement.
 dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 echo "$dashboard_id:DASHBOARD_ID" >> ACC_REPLS
-echo "$($CLI lakeview get $dashboard_id | jq -r '.etag'):ETAG" >> ACC_REPLS
+echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 # Change the name
 export NAME="dashboard2"

--- a/acceptance/bundle/resources/dashboards/change-name/script
+++ b/acceptance/bundle/resources/dashboards/change-name/script
@@ -12,7 +12,7 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    trace $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
+    trace retry.py $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }
 
 # Create the dashboard

--- a/acceptance/bundle/resources/dashboards/change-name/script
+++ b/acceptance/bundle/resources/dashboards/change-name/script
@@ -12,7 +12,7 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
+    DASHBOARD=$(retry $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }
 

--- a/acceptance/bundle/resources/dashboards/change-parent-path/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/output.txt
@@ -10,7 +10,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> retry.py [CLI] lakeview get [ORIGINAL_DASHBOARD_ID]
+>>> retry [CLI] lakeview get [ORIGINAL_DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -35,7 +35,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> retry.py [CLI] lakeview get [NEW_DASHBOARD_ID]
+>>> retry [CLI] lakeview get [NEW_DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-parent-path/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/output.txt
@@ -10,7 +10,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [ORIGINAL_DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [ORIGINAL_DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -35,7 +35,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [NEW_DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [NEW_DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-parent-path/script
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/script
@@ -14,7 +14,7 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy --auto-approve
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    trace retry.py $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
+    trace retry $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }
 
 # Create the dashboard with initial parent_path

--- a/acceptance/bundle/resources/dashboards/change-parent-path/script
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/script
@@ -14,7 +14,7 @@ deploy_dashboard() {
     trace $CLI bundle plan
     trace $CLI bundle deploy --auto-approve
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
-    trace $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
+    trace retry.py $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, serialized_dashboard, warehouse_id}'
 }
 
 # Create the dashboard with initial parent_path

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/output.txt
@@ -10,7 +10,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -37,7 +37,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/output.txt
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/output.txt
@@ -9,8 +9,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/change-serialized-
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -18,8 +16,6 @@ Deployment complete!
   "path": "/Users/[USERNAME]/.bundle/change-serialized-dashboard-[UNIQUE_NAME]/default/resources/test dashboard.lvdash.json",
   "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
 }
-
->>> [CLI] lakeview get [DASHBOARD_ID]
 {
   "displayName": "name1",
   "name": "name1",
@@ -36,8 +32,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/change-serialized-
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "display_name": "test dashboard",
   "lifecycle_state": "ACTIVE",
@@ -45,8 +39,6 @@ Deployment complete!
   "path": "/Users/[USERNAME]/.bundle/change-serialized-dashboard-[UNIQUE_NAME]/default/resources/test dashboard.lvdash.json",
   "warehouse_id": "[TEST_DEFAULT_WAREHOUSE_ID]"
 }
-
->>> [CLI] lakeview get [DASHBOARD_ID]
 {
   "displayName": "name2",
   "name": "name2",

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
@@ -12,7 +12,7 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    trace $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
+    trace retry.py $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
     trace $CLI lakeview get $dashboard_id | jq '.serialized_dashboard | fromjson' | jq -S '.pages[0]'
 }
 

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
@@ -12,8 +12,10 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    trace retry.py $CLI lakeview get $dashboard_id | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
-    trace $CLI lakeview get $dashboard_id | jq '.serialized_dashboard | fromjson' | jq -S '.pages[0]'
+    # Read back once (retrying the eventual-consistency 404) and reuse for both views.
+    DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
+    echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
+    echo "$DASHBOARD" | jq '.serialized_dashboard | fromjson' | jq -S '.pages[0]'
 }
 
 # Create the dashboard with initial serialized_dashboard

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
@@ -12,7 +12,9 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    DASHBOARD=$(retry $CLI lakeview get $dashboard_id)
+    # Wait out eventual consistency: retry until the current page is visible (the read
+    # 404s on create and returns the stale page right after the serialized update).
+    DASHBOARD=$(retry --until "$PAGE_NAME" $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
     echo "$DASHBOARD" | jq '.serialized_dashboard | fromjson' | jq -S '.pages[0]'
 }

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
@@ -12,7 +12,6 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    # Read back once (retrying the eventual-consistency 404) and reuse for both views.
     DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
     echo "$DASHBOARD" | jq '.serialized_dashboard | fromjson' | jq -S '.pages[0]'

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/script
@@ -12,7 +12,7 @@ deploy_dashboard() {
     trace $CLI bundle deploy
     dashboard_id=$($CLI bundle summary --output json | jq -r '.resources.dashboards.my_dashboard.id')
 
-    DASHBOARD=$(retry.py $CLI lakeview get $dashboard_id)
+    DASHBOARD=$(retry $CLI lakeview get $dashboard_id)
     echo "$DASHBOARD" | jq '{display_name, lifecycle_state, parent_path, path, warehouse_id}'
     echo "$DASHBOARD" | jq '.serialized_dashboard | fromjson' | jq -S '.pages[0]'
 }

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/output.txt
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/output.txt
@@ -4,15 +4,11 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-dashboard-d
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",
   "path": "/Users/[USERNAME]/test bundle-deploy-dashboard-dataset [UUID].lvdash.json"
 }
-
->>> [CLI] lakeview get [DASHBOARD_ID]
 {
   "catalog": "main",
   "schema": "default"

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
@@ -19,7 +19,6 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-# Read back once (retrying the eventual-consistency 404) and reuse below.
 DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
@@ -19,7 +19,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+DASHBOARD=$(retry $CLI lakeview get $DASHBOARD_ID)
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 echo "$DASHBOARD" | jq '{lifecycle_state, parent_path, path}'

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
@@ -19,13 +19,15 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
+# Read back once (retrying the eventual-consistency 404) and reuse below.
+DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path}'
+echo "$DASHBOARD" | jq '{lifecycle_state, parent_path, path}'
 
 # Verify that the serialized_dashboard datasets have the overridden catalog/schema values.
 # The dataset_catalog and dataset_schema parameters should override the values in the datasets.
-trace $CLI lakeview get $DASHBOARD_ID | jq '.serialized_dashboard | fromjson | .datasets[] | {catalog, schema}'
+echo "$DASHBOARD" | jq '.serialized_dashboard | fromjson | .datasets[] | {catalog, schema}'
 
 # Verify that there is no drift right after deploy.
 trace $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/script
@@ -19,7 +19,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$($CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
+echo "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path}'
 

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/output.txt
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/output.txt
@@ -4,8 +4,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/delete-trashed-out
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]/.bundle/delete-trashed-out-of-band-[UNIQUE_NAME]/default/resources"

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
@@ -13,7 +13,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$($CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
+echo "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 # Verify dashboard was deployed
 trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
@@ -13,8 +13,6 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-# Read back once (retrying the eventual-consistency 404) and reuse for both the
-# etag replacement and the verification below.
 DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
@@ -13,7 +13,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+DASHBOARD=$(retry $CLI lakeview get $DASHBOARD_ID)
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 # Verify dashboard was deployed

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/script
@@ -13,10 +13,13 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
+# Read back once (retrying the eventual-consistency 404) and reuse for both the
+# etag replacement and the verification below.
+DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 # Verify dashboard was deployed
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'
+echo "$DASHBOARD" | jq '{lifecycle_state, parent_path}'
 
 # Trash the dashboard out of band (simulating external deletion)
 # This should succeed

--- a/acceptance/bundle/resources/dashboards/destroy/output.txt
+++ b/acceptance/bundle/resources/dashboards/destroy/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]/.bundle/destroy-dashboard-[UNIQUE_NAME]/default/resources"

--- a/acceptance/bundle/resources/dashboards/destroy/output.txt
+++ b/acceptance/bundle/resources/dashboards/destroy/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
+>>> retry [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]/.bundle/destroy-dashboard-[UNIQUE_NAME]/default/resources"

--- a/acceptance/bundle/resources/dashboards/destroy/script
+++ b/acceptance/bundle/resources/dashboards/destroy/script
@@ -14,7 +14,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
 # Verify dashboard was deployed
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'
+trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'
 
 trace $CLI bundle destroy --auto-approve
 

--- a/acceptance/bundle/resources/dashboards/destroy/script
+++ b/acceptance/bundle/resources/dashboards/destroy/script
@@ -14,7 +14,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
 # Verify dashboard was deployed
-trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'
+trace retry $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path}'
 
 trace $CLI bundle destroy --auto-approve
 

--- a/acceptance/bundle/resources/dashboards/detect-change/script
+++ b/acceptance/bundle/resources/dashboards/detect-change/script
@@ -22,7 +22,6 @@ DASHBOARD_ID=$(jq -r '.id' out.summary.json)
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-# Read back once (retrying the eventual-consistency 404) and reuse below.
 DASHBOARD=$(retry.py $CLI lakeview get "$DASHBOARD_ID")
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
 

--- a/acceptance/bundle/resources/dashboards/detect-change/script
+++ b/acceptance/bundle/resources/dashboards/detect-change/script
@@ -22,7 +22,7 @@ DASHBOARD_ID=$(jq -r '.id' out.summary.json)
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$($CLI lakeview get "$DASHBOARD_ID" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
+echo "$(retry.py $CLI lakeview get "$DASHBOARD_ID" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
 
 rm out.summary.json
 title "Load the dashboard by its ID and confirm its display name: "

--- a/acceptance/bundle/resources/dashboards/detect-change/script
+++ b/acceptance/bundle/resources/dashboards/detect-change/script
@@ -22,7 +22,8 @@ DASHBOARD_ID=$(jq -r '.id' out.summary.json)
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-DASHBOARD=$(retry.py $CLI lakeview get "$DASHBOARD_ID")
+# env -u MSYS_NO_PATHCONV so git-bash passes retry.py's own path to python correctly.
+DASHBOARD=$(env -u MSYS_NO_PATHCONV retry.py $CLI lakeview get "$DASHBOARD_ID")
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
 
 rm out.summary.json

--- a/acceptance/bundle/resources/dashboards/detect-change/script
+++ b/acceptance/bundle/resources/dashboards/detect-change/script
@@ -22,8 +22,7 @@ DASHBOARD_ID=$(jq -r '.id' out.summary.json)
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-# env -u MSYS_NO_PATHCONV so git-bash passes retry.py's own path to python correctly.
-DASHBOARD=$(env -u MSYS_NO_PATHCONV retry.py $CLI lakeview get "$DASHBOARD_ID")
+DASHBOARD=$(retry $CLI lakeview get "$DASHBOARD_ID")
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
 
 rm out.summary.json

--- a/acceptance/bundle/resources/dashboards/detect-change/script
+++ b/acceptance/bundle/resources/dashboards/detect-change/script
@@ -22,11 +22,13 @@ DASHBOARD_ID=$(jq -r '.id' out.summary.json)
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$(retry.py $CLI lakeview get "$DASHBOARD_ID" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
+# Read back once (retrying the eventual-consistency 404) and reuse below.
+DASHBOARD=$(retry.py $CLI lakeview get "$DASHBOARD_ID")
+echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG_1" >> ACC_REPLS
 
 rm out.summary.json
 title "Load the dashboard by its ID and confirm its display name: "
-$CLI lakeview get "${DASHBOARD_ID}" | jq '{display_name,page_display_name: (.serialized_dashboard | fromjson | .pages[0].displayName)}'
+echo "$DASHBOARD" | jq '{display_name,page_display_name: (.serialized_dashboard | fromjson | .pages[0].displayName)}'
 
 title "Make an out of band modification to the dashboard and confirm that it is detected:\n"
 RESOURCE_ID=$($CLI workspace get-status "${DASHBOARD_PATH}" | jq -r '.resource_id')

--- a/acceptance/bundle/resources/dashboards/detect-change/test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/test.toml
@@ -11,6 +11,12 @@ Ignore = [
 # Setting this environment variable prevents that conversion on windows.
 MSYS_NO_PATHCONV = "1"
 
+# This test makes an out-of-band update and then expects `bundle plan` to detect it.
+# Under eventual consistency the plan's own read (CheckDashboardsModifiedRemotely)
+# would observe the stale pre-update value and miss the change -- an engine-level read
+# that no test-level retry can fix -- so opt out of the simulation here.
+TESTS_STALE_ONCE = "0"
+
 [[Repls]]
 Old = "[0-9a-z]{16,}"
 New = "[ALPHANUMID]"

--- a/acceptance/bundle/resources/dashboards/detect-change/test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/test.toml
@@ -15,7 +15,7 @@ MSYS_NO_PATHCONV = "1"
 # Under eventual consistency the plan's own read (CheckDashboardsModifiedRemotely)
 # would observe the stale pre-update value and miss the change -- an engine-level read
 # that no test-level retry can fix -- so opt out of the simulation here.
-TESTS_STALE_ONCE = "0"
+TESTS_STALE_ONCE_IF_DIRECT = "0"
 
 [[Repls]]
 Old = "[0-9a-z]{16,}"

--- a/acceptance/bundle/resources/dashboards/detect-change/test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/test.toml
@@ -15,7 +15,7 @@ MSYS_NO_PATHCONV = "1"
 # Under eventual consistency the plan's own read (CheckDashboardsModifiedRemotely)
 # would observe the stale pre-update value and miss the change -- an engine-level read
 # that no test-level retry can fix -- so opt out of the simulation here.
-TESTS_STALE_ONCE_IF_DIRECT = "0"
+INJECT_STALE_ON_DIRECT = "0"
 
 [[Repls]]
 Old = "[0-9a-z]{16,}"

--- a/acceptance/bundle/resources/dashboards/generate_inplace/script
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/script
@@ -12,7 +12,7 @@ trap cleanup EXIT
 dashboard_id=$($CLI bundle summary -o json | jq .resources.dashboards.already_exists.id -r)
 
 title "Get current dashboard\n"
-retry.py $CLI lakeview get $dashboard_id | jq .serialized_dashboard
+retry $CLI lakeview get $dashboard_id | jq .serialized_dashboard
 
 title "Update dashboard\n"
 $CLI lakeview update $dashboard_id --display-name "Updated dashboard" | jq .serialized_dashboard

--- a/acceptance/bundle/resources/dashboards/generate_inplace/script
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/script
@@ -12,7 +12,7 @@ trap cleanup EXIT
 dashboard_id=$($CLI bundle summary -o json | jq .resources.dashboards.already_exists.id -r)
 
 title "Get current dashboard\n"
-$CLI lakeview get $dashboard_id | jq .serialized_dashboard
+retry.py $CLI lakeview get $dashboard_id | jq .serialized_dashboard
 
 title "Update dashboard\n"
 $CLI lakeview update $dashboard_id --display-name "Updated dashboard" | jq .serialized_dashboard

--- a/acceptance/bundle/resources/dashboards/nested-folders/output.txt
+++ b/acceptance/bundle/resources/dashboards/nested-folders/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/nested-folders/output.txt
+++ b/acceptance/bundle/resources/dashboards/nested-folders/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
+>>> retry [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/nested-folders/script
+++ b/acceptance/bundle/resources/dashboards/nested-folders/script
@@ -18,4 +18,4 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
-trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard: (.serialized_dashboard | fromjson | {pages: (.pages | map({name, displayName, pageType}))})}'
+trace retry $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard: (.serialized_dashboard | fromjson | {pages: (.pages | map({name, displayName, pageType}))})}'

--- a/acceptance/bundle/resources/dashboards/nested-folders/script
+++ b/acceptance/bundle/resources/dashboards/nested-folders/script
@@ -18,4 +18,4 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard: (.serialized_dashboard | fromjson | {pages: (.pages | map({name, displayName, pageType}))})}'
+trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard: (.serialized_dashboard | fromjson | {pages: (.pages | map({name, displayName, pageType}))})}'

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/output.txt
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/output.txt
@@ -4,8 +4,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/update-publish-fai
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> [CLI] lakeview get [DASHBOARD1_ID]
 {
   "display_name": "my dashboard",
   "etag": "[ETAG_1]"

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
@@ -12,7 +12,7 @@ unset MSYS_NO_PATHCONV
 trace $CLI bundle deploy
 replace_ids.py
 DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
-ETAG_1=$($CLI lakeview get $DASHBOARD_ID | jq -r '.etag')
+ETAG_1=$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')
 add_repl.py "$ETAG_1" ETAG_1
 trace $CLI lakeview get $DASHBOARD_ID | jq '{display_name, etag}'
 trace $CLI lakeview get-published $DASHBOARD_ID | jq '{display_name}'

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
@@ -31,7 +31,8 @@ update_file.py databricks.yml "my dashboard" "my dashboard renamed"
 errcode trace $CLI bundle deploy
 trace print_requests.py //lakeview/dashboards
 # The PATCH bumped the remote etag to ETAG_2; retry until it is visible (eventual consistency).
-add_repl.py "$(retry --until-not "$ETAG_1" $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG_2
+ETAG_2=$(retry --until-not "$ETAG_1" $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')
+add_repl.py "$ETAG_2" ETAG_2
 trace $CLI lakeview get $DASHBOARD_ID | jq '{display_name, etag}'
 trace $CLI lakeview get-published $DASHBOARD_ID | jq '{display_name}'
 trace $CLI bundle plan -o json | gron.py | grep -E "etag|published"
@@ -48,7 +49,9 @@ trace $CLI lakeview get-published $DASHBOARD_ID | jq '{display_name}'
 # which fixes the stale published content.
 trace $CLI bundle deploy --force
 trace print_requests.py //lakeview/dashboards
-add_repl.py "$($CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG_3
+# --force did another PATCH; retry until the new etag is visible (eventual consistency).
+ETAG_3=$(retry --until-not "$ETAG_2" $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')
+add_repl.py "$ETAG_3" ETAG_3
 trace $CLI lakeview get $DASHBOARD_ID | jq '{display_name, etag}'
 trace $CLI lakeview get-published $DASHBOARD_ID | jq '{display_name}'
 trace $CLI bundle plan

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
@@ -12,9 +12,11 @@ unset MSYS_NO_PATHCONV
 trace $CLI bundle deploy
 replace_ids.py
 DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
-ETAG_1=$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')
+# Read back once (retrying the eventual-consistency 404) and reuse below.
+DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+ETAG_1=$(echo "$DASHBOARD" | jq -r '.etag')
 add_repl.py "$ETAG_1" ETAG_1
-trace $CLI lakeview get $DASHBOARD_ID | jq '{display_name, etag}'
+echo "$DASHBOARD" | jq '{display_name, etag}'
 trace $CLI lakeview get-published $DASHBOARD_ID | jq '{display_name}'
 trace $CLI bundle plan -o json | gron.py | grep -E "etag|published"
 rm out.requests.txt

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
@@ -12,7 +12,6 @@ unset MSYS_NO_PATHCONV
 trace $CLI bundle deploy
 replace_ids.py
 DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
-# Read back once (retrying the eventual-consistency 404) and reuse below.
 DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
 ETAG_1=$(echo "$DASHBOARD" | jq -r '.etag')
 add_repl.py "$ETAG_1" ETAG_1

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/script
@@ -12,7 +12,7 @@ unset MSYS_NO_PATHCONV
 trace $CLI bundle deploy
 replace_ids.py
 DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.dashboard1.id')
-DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+DASHBOARD=$(retry $CLI lakeview get $DASHBOARD_ID)
 ETAG_1=$(echo "$DASHBOARD" | jq -r '.etag')
 add_repl.py "$ETAG_1" ETAG_1
 echo "$DASHBOARD" | jq '{display_name, etag}'
@@ -31,7 +31,7 @@ update_file.py databricks.yml "my dashboard" "my dashboard renamed"
 errcode trace $CLI bundle deploy
 trace print_requests.py //lakeview/dashboards
 # The PATCH bumped the remote etag to ETAG_2; retry until it is visible (eventual consistency).
-add_repl.py "$(retry.py --until-not "$ETAG_1" $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG_2
+add_repl.py "$(retry --until-not "$ETAG_1" $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG_2
 trace $CLI lakeview get $DASHBOARD_ID | jq '{display_name, etag}'
 trace $CLI lakeview get-published $DASHBOARD_ID | jq '{display_name}'
 trace $CLI bundle plan -o json | gron.py | grep -E "etag|published"

--- a/acceptance/bundle/resources/dashboards/simple/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple/output.txt
@@ -4,8 +4,6 @@ Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/deploy-dashboard-t
 Deploying resources...
 Updating deployment state...
 Deployment complete!
-
->>> [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/simple/script
+++ b/acceptance/bundle/resources/dashboards/simple/script
@@ -17,7 +17,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+DASHBOARD=$(retry $CLI lakeview get $DASHBOARD_ID)
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 echo "$DASHBOARD" | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'

--- a/acceptance/bundle/resources/dashboards/simple/script
+++ b/acceptance/bundle/resources/dashboards/simple/script
@@ -17,7 +17,7 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$($CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
+echo "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
 
 trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
 

--- a/acceptance/bundle/resources/dashboards/simple/script
+++ b/acceptance/bundle/resources/dashboards/simple/script
@@ -17,7 +17,6 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-# Read back once (retrying the eventual-consistency 404) and reuse below.
 DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
 echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 

--- a/acceptance/bundle/resources/dashboards/simple/script
+++ b/acceptance/bundle/resources/dashboards/simple/script
@@ -17,9 +17,11 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
-echo "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag'):ETAG" >> ACC_REPLS
+# Read back once (retrying the eventual-consistency 404) and reuse below.
+DASHBOARD=$(retry.py $CLI lakeview get $DASHBOARD_ID)
+echo "$(echo "$DASHBOARD" | jq -r '.etag'):ETAG" >> ACC_REPLS
 
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
+echo "$DASHBOARD" | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
 
 # Verify that there is no drift right after deploy. We use |= to update the serialized_dashboard field in place to account
 # for formatting that the cloud server applies to the serialized_dashboard field.

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
+>>> retry [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
@@ -18,4 +18,4 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
+trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/script
@@ -18,4 +18,4 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
-trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
+trace retry $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] lakeview get [DASHBOARD_ID]
+>>> retry.py [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/output.txt
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/output.txt
@@ -5,7 +5,7 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> retry.py [CLI] lakeview get [DASHBOARD_ID]
+>>> retry [CLI] lakeview get [DASHBOARD_ID]
 {
   "lifecycle_state": "ACTIVE",
   "parent_path": "/Users/[USERNAME]",

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/script
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/script
@@ -19,4 +19,4 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
-trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
+trace retry $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/script
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/script
@@ -19,4 +19,4 @@ DASHBOARD_ID=$($CLI bundle summary --output json | jq -r '.resources.dashboards.
 # Capture the dashboard ID as a replacement.
 echo "$DASHBOARD_ID:DASHBOARD_ID" >> ACC_REPLS
 
-trace $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'
+trace retry.py $CLI lakeview get $DASHBOARD_ID | jq '{lifecycle_state, parent_path, path, serialized_dashboard}'

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -6,11 +6,6 @@ RequiresWarehouse = true
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 
 [Env]
-# MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
-# C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI
-# Setting this environment variable prevents that conversion on windows.
-MSYS_NO_PATHCONV = "1"
-
 # Direct-engine eventual consistency: the first GET of a freshly created dashboard
 # returns 404, so reads right after deploy must be retried (retry.py). Skipped on
 # terraform, whose provider reads the dashboard back after create and fails on the 404.

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -11,8 +11,8 @@ RequiresWarehouse = true
 # Setting this environment variable prevents that conversion on windows.
 MSYS_NO_PATHCONV = "1"
 
-# Simulate eventual consistency on the direct engine: the first GET of a dashboard
-# after it is created returns 404. This reproduces, deterministically, the cloud
-# behaviour these tests are exposed to (Cloud = true), so reads right after deploy
-# must be retried (retry.py) rather than assumed to succeed. Ignored on terraform.
+# Direct-engine eventual consistency: the first GET of a freshly created dashboard
+# returns 404, so reads right after deploy must be retried (retry.py). Skipped on
+# terraform, which reads the dashboard back during apply without retrying and so
+# can't tolerate the 404.
 TESTS_STALE_ONCE = "1"

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -6,6 +6,11 @@ RequiresWarehouse = true
   DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 
 [Env]
+# MSYS2 automatically converts absolute paths like /Users/$username/$UNIQUE_NAME to
+# C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI
+# Setting this environment variable prevents that conversion on windows.
+MSYS_NO_PATHCONV = "1"
+
 # Direct-engine eventual consistency: the first GET of a freshly created dashboard
 # returns 404, so reads right after deploy must be retried (retry.py). Skipped on
 # terraform, whose provider reads the dashboard back after create and fails on the 404.

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -10,3 +10,9 @@ RequiresWarehouse = true
 # C:/Program Files/Git/Users/$username/UNIQUE_NAME before passing it to the CLI
 # Setting this environment variable prevents that conversion on windows.
 MSYS_NO_PATHCONV = "1"
+
+# Simulate eventual consistency on the direct engine: the first GET of a dashboard
+# after it is created returns 404. This reproduces, deterministically, the cloud
+# behaviour these tests are exposed to (Cloud = true), so reads right after deploy
+# must be retried (retry.py) rather than assumed to succeed. Ignored on terraform.
+TESTS_STALE_ONCE = "1"

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -13,6 +13,5 @@ MSYS_NO_PATHCONV = "1"
 
 # Direct-engine eventual consistency: the first GET of a freshly created dashboard
 # returns 404, so reads right after deploy must be retried (retry.py). Skipped on
-# terraform, which reads the dashboard back during apply without retrying and so
-# can't tolerate the 404.
+# terraform, whose provider reads the dashboard back after create and fails on the 404.
 TESTS_STALE_ONCE = "1"

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -14,4 +14,4 @@ MSYS_NO_PATHCONV = "1"
 # Direct-engine eventual consistency: the first GET of a freshly created dashboard
 # returns 404, so reads right after deploy must be retried (retry.py). Skipped on
 # terraform, whose provider reads the dashboard back after create and fails on the 404.
-TESTS_STALE_ONCE = "1"
+TESTS_STALE_ONCE_IF_DIRECT = "1"

--- a/acceptance/bundle/resources/dashboards/test.toml
+++ b/acceptance/bundle/resources/dashboards/test.toml
@@ -14,4 +14,4 @@ MSYS_NO_PATHCONV = "1"
 # Direct-engine eventual consistency: the first GET of a freshly created dashboard
 # returns 404, so reads right after deploy must be retried (retry.py). Skipped on
 # terraform, whose provider reads the dashboard back after create and fails on the 404.
-TESTS_STALE_ONCE_IF_DIRECT = "1"
+INJECT_STALE_ON_DIRECT = "1"

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/script
@@ -11,7 +11,7 @@ trace $CLI bundle plan -o json > out.plan_initial.$DATABRICKS_BUNDLE_ENGINE.json
 # Deploy the dashboard
 trace $CLI bundle deploy
 DASHBOARD_ID=$(read_id.py dashboard1)
-add_repl.py "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG
+add_repl.py "$(retry $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG
 
 trace print_state.py | grep publish > out.state.$DATABRICKS_BUNDLE_ENGINE.json
 

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/script
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/script
@@ -11,7 +11,7 @@ trace $CLI bundle plan -o json > out.plan_initial.$DATABRICKS_BUNDLE_ENGINE.json
 # Deploy the dashboard
 trace $CLI bundle deploy
 DASHBOARD_ID=$(read_id.py dashboard1)
-add_repl.py "$($CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG
+add_repl.py "$(retry.py $CLI lakeview get $DASHBOARD_ID | jq -r '.etag')" ETAG
 
 trace print_state.py | grep publish > out.state.$DATABRICKS_BUNDLE_ENGINE.json
 

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -65,8 +65,7 @@ func isTruePtr(value *bool) bool {
 
 // staleOnceEnabled reports whether the testserver should simulate eventual
 // consistency (the first GET after a create returns 404). It is opt-in via
-// TESTS_STALE_ONCE=1 and only applies to the direct engine; the terraform
-// provider does not retry reads, so it is skipped there.
+// TESTS_STALE_ONCE=1 and only applies to the direct engine.
 //
 // testEnv carries the per-variant EnvMatrix values, which are not visible via
 // os/env because matrix variants run in parallel and only reach the CLI subprocess.

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -63,7 +63,32 @@ func isTruePtr(value *bool) bool {
 	return value != nil && *value
 }
 
-func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, outputDir string) (*sdkconfig.Config, iam.User) {
+// staleOnceEnabled reports whether the testserver should simulate eventual
+// consistency (the first GET after a create returns 404). It is opt-in via
+// TESTS_STALE_ONCE=1 and only applies to the direct engine; the terraform
+// provider does not retry reads, so it is skipped there.
+//
+// testEnv carries the per-variant EnvMatrix values, which are not visible via
+// os/env because matrix variants run in parallel and only reach the CLI subprocess.
+func staleOnceEnabled(testEnv []string) bool {
+	if v, _ := lookupEnv(testEnv, "TESTS_STALE_ONCE"); v != "1" {
+		return false
+	}
+	engine, _ := lookupEnv(testEnv, "DATABRICKS_BUNDLE_ENGINE")
+	return engine == "direct"
+}
+
+func lookupEnv(testEnv []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, kv := range testEnv {
+		if v, ok := strings.CutPrefix(kv, prefix); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, outputDir string, testEnv []string) (*sdkconfig.Config, iam.User) {
 	cloudEnv := env.Get(t.Context(), "CLOUD_ENV")
 	recordRequests := isTruePtr(config.RecordRequests)
 
@@ -76,6 +101,11 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 	if isTruePtr(config.IsServicePrincipal) {
 		token = testserver.ServicePrincipalTokenPrefix + tokenSuffix
 		testUser = testserver.TestUserSP
+	} else if staleOnceEnabled(testEnv) {
+		// Use the eventual-consistency token so the testserver returns 404 on the
+		// first GET after a create, matching real cloud propagation delays.
+		token = testserver.EventualConsistencyTokenPrefix + tokenSuffix
+		testUser = testserver.TestUser
 	} else {
 		token = testserver.UserNameTokenPrefix + tokenSuffix
 		testUser = testserver.TestUser

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -65,12 +65,12 @@ func isTruePtr(value *bool) bool {
 
 // staleOnceEnabled reports whether the testserver should simulate eventual
 // consistency (the first GET after a create returns 404). It is opt-in via
-// TESTS_STALE_ONCE=1 and only applies to the direct engine.
+// TESTS_STALE_ONCE_IF_DIRECT=1 and only applies to the direct engine.
 //
 // testEnv carries the per-variant EnvMatrix values, which are not visible via
 // os/env because matrix variants run in parallel and only reach the CLI subprocess.
 func staleOnceEnabled(testEnv []string) bool {
-	if v, _ := lookupEnv(testEnv, "TESTS_STALE_ONCE"); v != "1" {
+	if v, _ := lookupEnv(testEnv, "TESTS_STALE_ONCE_IF_DIRECT"); v != "1" {
 		return false
 	}
 	engine, _ := lookupEnv(testEnv, "DATABRICKS_BUNDLE_ENGINE")

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -65,12 +65,12 @@ func isTruePtr(value *bool) bool {
 
 // staleOnceEnabled reports whether the testserver should simulate eventual
 // consistency (the first GET after a create returns 404). It is opt-in via
-// TESTS_STALE_ONCE_IF_DIRECT=1 and only applies to the direct engine.
+// INJECT_STALE_ON_DIRECT=1 and only applies to the direct engine.
 //
 // testEnv carries the per-variant EnvMatrix values, which are not visible via
 // os/env because matrix variants run in parallel and only reach the CLI subprocess.
 func staleOnceEnabled(testEnv []string) bool {
-	if v, _ := lookupEnv(testEnv, "TESTS_STALE_ONCE_IF_DIRECT"); v != "1" {
+	if v, _ := lookupEnv(testEnv, "INJECT_STALE_ON_DIRECT"); v != "1" {
 		return false
 	}
 	engine, _ := lookupEnv(testEnv, "DATABRICKS_BUNDLE_ENGINE")

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -103,6 +103,12 @@ envsubst() {
     env -u MSYS_NO_PATHCONV envsubst.py
 }
 
+retry() {
+    # Same MSYS_NO_PATHCONV workaround as envsubst above: otherwise Python cannot
+    # find retry.py on Windows.
+    env -u MSYS_NO_PATHCONV retry.py "$@"
+}
+
 print_telemetry_bool_values() {
     jq -r 'select(.path? == "/telemetry-ext") | (.body.protoLogs // [])[] | fromjson | ( (.entry // .) | (.databricks_cli_log.bundle_deploy_event.experimental.bool_values // []) ) | map("\(.key) \(.value)") | .[]' out.requests.txt | sort
 }

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -232,8 +232,10 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 	updated.WarehouseId = updateReq.WarehouseId
 	updated.UpdateTime = time.Now().UTC().Format(time.RFC3339)
 
-	// Put (not Write): updates are immediately visible. Only creates stage a stale
-	// value, so the eventual-consistency 404 happens only on first read after create.
+	// Updates apply immediately (Put). A real backend is eventually consistent on
+	// updates too, but staging a stale value (Write) yields a successful-but-stale 200
+	// that breaks plan-time reads (e.g. CheckDashboardsModifiedRemotely) the engine
+	// does not yet tolerate. We stage a stale value only on create (the 404).
 	s.Dashboards.Put(dashboardId, &updated)
 
 	return Response{

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -85,19 +85,10 @@ func (s *FakeWorkspace) DashboardGet(req Request) Response {
 	defer s.LockUnlock()()
 
 	dashboardId := req.Vars["dashboard_id"]
-	ev, ok := s.Dashboards[dashboardId]
-	if !ok {
-		return Response{StatusCode: 404}
-	}
-	// When eventual consistency is enabled, the first GET after a create returns nil
+	// Read applies eventual consistency: the first GET after a create returns nil
 	// (404) to simulate propagation delay. Updates are immediately visible.
-	var ptr *fakeDashboard
-	if s.EventualConsistency {
-		ptr = ev.ReadEventual()
-	} else {
-		ptr = ev.ReadStrong()
-	}
-	if ptr == nil {
+	ptr, ok := s.Dashboards.Read(dashboardId)
+	if !ok || ptr == nil {
 		return Response{StatusCode: 404}
 	}
 	return Response{Body: *ptr}
@@ -166,14 +157,12 @@ func (s *FakeWorkspace) DashboardCreate(req Request) Response {
 	}
 	dashboard.Etag = "80611980"
 
-	// Write via EventualValue so that, when eventual consistency is enabled, the
-	// first GET after this create returns 404.
-	ev := &EventualValue[*fakeDashboard]{}
-	ev.Write(&fakeDashboard{
+	// Write so that, when eventual consistency is enabled, the first GET after this
+	// create returns 404.
+	s.Dashboards.Write(dashboard.DashboardId, &fakeDashboard{
 		Dashboard:                dashboard,
 		InputSerializedDashboard: inputSerializedDashboard,
 	})
-	s.Dashboards[dashboard.DashboardId] = ev
 
 	workspacePath := path.Join("/Workspace", dashboard.Path)
 	s.files[workspacePath] = FileEntry{
@@ -202,14 +191,8 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 	}
 
 	dashboardId := req.Vars["dashboard_id"]
-	ev, ok := s.Dashboards[dashboardId]
+	dashboard, ok := s.Dashboards.ReadStrong(dashboardId)
 	if !ok {
-		return Response{
-			StatusCode: 404,
-		}
-	}
-	dashboard := ev.ReadStrong()
-	if dashboard == nil {
 		return Response{
 			StatusCode: 404,
 		}
@@ -251,7 +234,7 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 
 	// Put (not Write): updates are immediately visible. Only creates stage a stale
 	// value, so the eventual-consistency 404 happens only on first read after create.
-	ev.Put(&updated)
+	s.Dashboards.Put(dashboardId, &updated)
 
 	return Response{
 		Body: updated,
@@ -269,14 +252,8 @@ func (s *FakeWorkspace) DashboardPublish(req Request) Response {
 	}
 
 	dashboardId := req.Vars["dashboard_id"]
-	ev, ok := s.Dashboards[dashboardId]
+	dashboard, ok := s.Dashboards.ReadStrong(dashboardId)
 	if !ok {
-		return Response{
-			StatusCode: 404,
-		}
-	}
-	dashboard := ev.ReadStrong()
-	if dashboard == nil {
 		return Response{
 			StatusCode: 404,
 		}
@@ -314,21 +291,15 @@ func (s *FakeWorkspace) DashboardTrash(req Request) Response {
 	defer s.LockUnlock()()
 
 	dashboardId := req.Vars["dashboard_id"]
-	ev, ok := s.Dashboards[dashboardId]
+	dashboard, ok := s.Dashboards.ReadStrong(dashboardId)
 	if !ok {
-		return Response{
-			StatusCode: 404,
-		}
-	}
-	dashboard := ev.ReadStrong()
-	if dashboard == nil {
 		return Response{
 			StatusCode: 404,
 		}
 	}
 
 	// The dashboard is marked as trashed and moved to the trash.
-	ev.Put(&fakeDashboard{
+	s.Dashboards.Put(dashboardId, &fakeDashboard{
 		Dashboard: dashboards.Dashboard{
 			Etag:           dashboard.Etag,
 			DashboardId:    dashboardId,
@@ -349,8 +320,7 @@ func (s *FakeWorkspace) DashboardUnpublish(req Request) Response {
 	defer s.LockUnlock()()
 
 	dashboardId := req.Vars["dashboard_id"]
-	ev, ok := s.Dashboards[dashboardId]
-	if !ok || ev.ReadStrong() == nil {
+	if _, ok := s.Dashboards.ReadStrong(dashboardId); !ok {
 		return Response{
 			StatusCode: 404,
 		}

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -328,7 +328,8 @@ func (s *FakeWorkspace) DashboardTrash(req Request) Response {
 	}
 
 	// The dashboard is marked as trashed and moved to the trash.
-	// Put (not Write) so the trashed state is immediately visible.
+	// Put (not Write), like DashboardUpdate: only create stages a stale value (the
+	// eventual-consistency 404); trashes apply immediately.
 	ev.Put(&fakeDashboard{
 		Dashboard: dashboards.Dashboard{
 			Etag:           dashboard.Etag,

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -232,11 +232,10 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 	updated.WarehouseId = updateReq.WarehouseId
 	updated.UpdateTime = time.Now().UTC().Format(time.RFC3339)
 
-	// Updates apply immediately (Put). A real backend is eventually consistent on
-	// updates too, but staging a stale value (Write) yields a successful-but-stale 200
-	// that breaks plan-time reads (e.g. CheckDashboardsModifiedRemotely) the engine
-	// does not yet tolerate. We stage a stale value only on create (the 404).
-	s.Dashboards.Put(dashboardId, &updated)
+	// Write stages a stale value: like a real backend, the first read after an update
+	// returns the pre-update value. Tests that read right after an update wait for the
+	// new value with a content-aware retry (retry --until / --until-not).
+	s.Dashboards.Write(dashboardId, &updated)
 
 	return Response{
 		Body: updated,

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -328,8 +328,9 @@ func (s *FakeWorkspace) DashboardTrash(req Request) Response {
 	}
 
 	// The dashboard is marked as trashed and moved to the trash.
-	// Put (not Write), like DashboardUpdate: only create stages a stale value (the
-	// eventual-consistency 404); trashes apply immediately.
+	// Put (not Write): the trashed state is immediately visible. Only creates stage a
+	// stale value, so the eventual-consistency 404 happens only on the first read
+	// after create.
 	ev.Put(&fakeDashboard{
 		Dashboard: dashboards.Dashboard{
 			Etag:           dashboard.Etag,

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -328,9 +328,6 @@ func (s *FakeWorkspace) DashboardTrash(req Request) Response {
 	}
 
 	// The dashboard is marked as trashed and moved to the trash.
-	// Put (not Write): the trashed state is immediately visible. Only creates stage a
-	// stale value, so the eventual-consistency 404 happens only on the first read
-	// after create.
 	ev.Put(&fakeDashboard{
 		Dashboard: dashboards.Dashboard{
 			Etag:           dashboard.Etag,

--- a/libs/testserver/dashboards.go
+++ b/libs/testserver/dashboards.go
@@ -81,6 +81,28 @@ func transformSerializedDashboard(serializedDashboard, datasetCatalog, datasetSc
 	return result
 }
 
+func (s *FakeWorkspace) DashboardGet(req Request) Response {
+	defer s.LockUnlock()()
+
+	dashboardId := req.Vars["dashboard_id"]
+	ev, ok := s.Dashboards[dashboardId]
+	if !ok {
+		return Response{StatusCode: 404}
+	}
+	// When eventual consistency is enabled, the first GET after a create returns nil
+	// (404) to simulate propagation delay. Updates are immediately visible.
+	var ptr *fakeDashboard
+	if s.EventualConsistency {
+		ptr = ev.ReadEventual()
+	} else {
+		ptr = ev.ReadStrong()
+	}
+	if ptr == nil {
+		return Response{StatusCode: 404}
+	}
+	return Response{Body: *ptr}
+}
+
 func (s *FakeWorkspace) DashboardCreate(req Request) Response {
 	defer s.LockUnlock()()
 
@@ -144,10 +166,14 @@ func (s *FakeWorkspace) DashboardCreate(req Request) Response {
 	}
 	dashboard.Etag = "80611980"
 
-	s.Dashboards[dashboard.DashboardId] = fakeDashboard{
+	// Write via EventualValue so that, when eventual consistency is enabled, the
+	// first GET after this create returns 404.
+	ev := &EventualValue[*fakeDashboard]{}
+	ev.Write(&fakeDashboard{
 		Dashboard:                dashboard,
 		InputSerializedDashboard: inputSerializedDashboard,
-	}
+	})
+	s.Dashboards[dashboard.DashboardId] = ev
 
 	workspacePath := path.Join("/Workspace", dashboard.Path)
 	s.files[workspacePath] = FileEntry{
@@ -176,50 +202,59 @@ func (s *FakeWorkspace) DashboardUpdate(req Request) Response {
 	}
 
 	dashboardId := req.Vars["dashboard_id"]
-	dashboard, ok := s.Dashboards[dashboardId]
+	ev, ok := s.Dashboards[dashboardId]
 	if !ok {
 		return Response{
 			StatusCode: 404,
 		}
 	}
+	dashboard := ev.ReadStrong()
+	if dashboard == nil {
+		return Response{
+			StatusCode: 404,
+		}
+	}
+	updated := *dashboard
 
 	// Bump etag on every write, matching cloud behavior.
-	prevEtag, err := strconv.Atoi(dashboard.Etag)
+	prevEtag, err := strconv.Atoi(updated.Etag)
 	if err != nil {
 		return Response{
 			Body: map[string]string{
-				"message": "Invalid etag: " + dashboard.Etag,
+				"message": "Invalid etag: " + updated.Etag,
 			},
 			StatusCode: 400,
 		}
 	}
-	dashboard.Etag = strconv.Itoa(prevEtag + 1)
+	updated.Etag = strconv.Itoa(prevEtag + 1)
 
-	if updateReq.SerializedDashboard != dashboard.InputSerializedDashboard {
-		dashboard.InputSerializedDashboard = updateReq.SerializedDashboard
+	if updateReq.SerializedDashboard != updated.InputSerializedDashboard {
+		updated.InputSerializedDashboard = updateReq.SerializedDashboard
 	}
 
 	// Update the dashboard.
-	dashboard.LifecycleState = dashboards.LifecycleStateActive
+	updated.LifecycleState = dashboards.LifecycleStateActive
 	if updateReq.DisplayName != "" {
-		dashboard.DisplayName = updateReq.DisplayName
-		dir := path.Dir(dashboard.Path)
+		updated.DisplayName = updateReq.DisplayName
+		dir := path.Dir(updated.Path)
 		base := updateReq.DisplayName + ".lvdash.json"
-		dashboard.Path = path.Join(dir, base)
+		updated.Path = path.Join(dir, base)
 	}
 	if updateReq.SerializedDashboard != "" {
 		// Extract dataset_catalog and dataset_schema from query parameters
 		datasetCatalog := req.URL.Query().Get("dataset_catalog")
 		datasetSchema := req.URL.Query().Get("dataset_schema")
-		dashboard.SerializedDashboard = transformSerializedDashboard(updateReq.SerializedDashboard, datasetCatalog, datasetSchema)
+		updated.SerializedDashboard = transformSerializedDashboard(updateReq.SerializedDashboard, datasetCatalog, datasetSchema)
 	}
-	dashboard.WarehouseId = updateReq.WarehouseId
-	dashboard.UpdateTime = time.Now().UTC().Format(time.RFC3339)
+	updated.WarehouseId = updateReq.WarehouseId
+	updated.UpdateTime = time.Now().UTC().Format(time.RFC3339)
 
-	s.Dashboards[dashboardId] = dashboard
+	// Put (not Write): updates are immediately visible. Only creates stage a stale
+	// value, so the eventual-consistency 404 happens only on first read after create.
+	ev.Put(&updated)
 
 	return Response{
-		Body: dashboard,
+		Body: updated,
 	}
 }
 
@@ -234,8 +269,14 @@ func (s *FakeWorkspace) DashboardPublish(req Request) Response {
 	}
 
 	dashboardId := req.Vars["dashboard_id"]
-	dashboard, ok := s.Dashboards[dashboardId]
+	ev, ok := s.Dashboards[dashboardId]
 	if !ok {
+		return Response{
+			StatusCode: 404,
+		}
+	}
+	dashboard := ev.ReadStrong()
+	if dashboard == nil {
 		return Response{
 			StatusCode: 404,
 		}
@@ -273,28 +314,35 @@ func (s *FakeWorkspace) DashboardTrash(req Request) Response {
 	defer s.LockUnlock()()
 
 	dashboardId := req.Vars["dashboard_id"]
-	dashboard, ok := s.Dashboards[dashboardId]
+	ev, ok := s.Dashboards[dashboardId]
 	if !ok {
+		return Response{
+			StatusCode: 404,
+		}
+	}
+	dashboard := ev.ReadStrong()
+	if dashboard == nil {
 		return Response{
 			StatusCode: 404,
 		}
 	}
 
 	// The dashboard is marked as trashed and moved to the trash.
-	s.Dashboards[dashboardId] = fakeDashboard{
+	// Put (not Write) so the trashed state is immediately visible.
+	ev.Put(&fakeDashboard{
 		Dashboard: dashboards.Dashboard{
 			Etag:           dashboard.Etag,
 			DashboardId:    dashboardId,
 			LifecycleState: dashboards.LifecycleStateTrashed,
 			ParentPath:     path.Join("/Users", s.CurrentUser().UserName, "Trash"),
 		},
-	}
+	})
 
 	// The published dashboard is deleted.
 	delete(s.PublishedDashboards, dashboardId)
 
 	return Response{
-		Body: dashboard,
+		Body: *dashboard,
 	}
 }
 
@@ -302,8 +350,8 @@ func (s *FakeWorkspace) DashboardUnpublish(req Request) Response {
 	defer s.LockUnlock()()
 
 	dashboardId := req.Vars["dashboard_id"]
-	_, ok := s.Dashboards[dashboardId]
-	if !ok {
+	ev, ok := s.Dashboards[dashboardId]
+	if !ok || ev.ReadStrong() == nil {
 		return Response{
 			StatusCode: 404,
 		}

--- a/libs/testserver/eventual.go
+++ b/libs/testserver/eventual.go
@@ -1,0 +1,43 @@
+package testserver
+
+// EventualValue provides eventual-consistency read semantics for a single
+// value. After Write, the first Read returns the pre-write value; subsequent
+// Reads return the written value.
+//
+// Not safe for concurrent use; callers must hold the workspace lock.
+type EventualValue[T any] struct {
+	current T
+	stale   T
+	pending bool
+}
+
+// Write stages v as the new value. The pre-write value is returned by the
+// next ReadEventual call.
+func (e *EventualValue[T]) Write(v T) {
+	e.stale = e.current
+	e.current = v
+	e.pending = true
+}
+
+// ReadEventual returns the current value, applying eventual-consistency: the
+// first call after a Write returns the pre-write (stale) value.
+func (e *EventualValue[T]) ReadEventual() T {
+	if e.pending {
+		e.pending = false
+		return e.stale
+	}
+	return e.current
+}
+
+// ReadStrong returns the current value without consuming the pending stale
+// state. Use for write operations that need the latest committed value.
+func (e *EventualValue[T]) ReadStrong() T {
+	return e.current
+}
+
+// Put sets v as the current value immediately without staging a stale
+// version. Any pending stale state is discarded.
+func (e *EventualValue[T]) Put(v T) {
+	e.current = v
+	e.pending = false
+}

--- a/libs/testserver/eventual.go
+++ b/libs/testserver/eventual.go
@@ -41,3 +41,65 @@ func (e *EventualValue[T]) Put(v T) {
 	e.current = v
 	e.pending = false
 }
+
+// EventualMap is a keyed collection of EventualValues that share one
+// eventual-consistency mode. When eventualConsistency is enabled, the first Read
+// of a key after a Write returns the pre-write value (the zero value for a
+// freshly created key, e.g. a 404 for a not-yet-propagated resource).
+//
+// Not safe for concurrent use; callers must hold the workspace lock.
+type EventualMap[K comparable, V any] struct {
+	values              map[K]*EventualValue[V]
+	eventualConsistency bool
+}
+
+func NewEventualMap[K comparable, V any](eventualConsistency bool) *EventualMap[K, V] {
+	return &EventualMap[K, V]{
+		values:              map[K]*EventualValue[V]{},
+		eventualConsistency: eventualConsistency,
+	}
+}
+
+// Read returns the value for key, applying eventual consistency when enabled. ok
+// reports whether the key exists; value may be the zero value when a write to an
+// existing key has not propagated yet.
+func (m *EventualMap[K, V]) Read(key K) (value V, ok bool) {
+	ev, ok := m.values[key]
+	if !ok {
+		return value, false
+	}
+	if m.eventualConsistency {
+		return ev.ReadEventual(), true
+	}
+	return ev.ReadStrong(), true
+}
+
+// ReadStrong returns the current value for key without consuming stale state.
+// Use it from write handlers that need the latest committed value.
+func (m *EventualMap[K, V]) ReadStrong(key K) (value V, ok bool) {
+	ev, ok := m.values[key]
+	if !ok {
+		return value, false
+	}
+	return ev.ReadStrong(), true
+}
+
+// Write stages v for key; the next Read returns the pre-write value.
+func (m *EventualMap[K, V]) Write(key K, v V) {
+	ev := m.values[key]
+	if ev == nil {
+		ev = &EventualValue[V]{}
+		m.values[key] = ev
+	}
+	ev.Write(v)
+}
+
+// Put sets v for key immediately, discarding any pending stale state.
+func (m *EventualMap[K, V]) Put(key K, v V) {
+	ev := m.values[key]
+	if ev == nil {
+		ev = &EventualValue[V]{}
+		m.values[key] = ev
+	}
+	ev.Put(v)
+}

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -41,10 +41,10 @@ const (
 	// EventualConsistencyTokenPrefix identifies workspaces that simulate eventual
 	// consistency: the first GET after a create returns 404 (not yet visible).
 	EventualConsistencyTokenPrefix = "dbapi3"
-	UserID                           = "1000012345"
-	TestDefaultClusterId             = "0123-456789-cluster0"
-	TestDefaultWarehouseId           = "8ec9edc1-db0c-40df-af8d-7580020fe61e"
-	TestDefaultInstancePoolId        = "0123-456789-pool0"
+	UserID                         = "1000012345"
+	TestDefaultClusterId           = "0123-456789-cluster0"
+	TestDefaultWarehouseId         = "8ec9edc1-db0c-40df-af8d-7580020fe61e"
+	TestDefaultInstancePoolId      = "0123-456789-pool0"
 )
 
 var TestUser = iam.User{

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -161,9 +161,6 @@ type FakeWorkspace struct {
 	mu                 sync.Mutex
 	url                string
 	isServicePrincipal bool
-	// EventualConsistency enables eventual-consistency simulation: the first
-	// GET after a create returns 404 (resource not yet visible).
-	EventualConsistency bool
 
 	directories  map[string]workspace.ObjectInfo
 	files        map[string]FileEntry
@@ -179,7 +176,7 @@ type FakeWorkspace struct {
 	Schemas               map[string]catalog.SchemaInfo
 	Grants                map[string][]catalog.PrivilegeAssignment
 	Volumes               map[string]catalog.VolumeInfo
-	Dashboards            map[string]*EventualValue[*fakeDashboard]
+	Dashboards            *EventualMap[string, *fakeDashboard]
 	PublishedDashboards   map[string]dashboards.PublishedDashboard
 	GenieSpaces           map[string]dashboards.GenieSpace
 	SqlWarehouses         map[string]sql.GetWarehouseResponse
@@ -289,9 +286,8 @@ func MapDelete[K comparable, V any](w *FakeWorkspace, collection map[K]V, key K)
 
 func NewFakeWorkspace(url, token string) *FakeWorkspace {
 	return &FakeWorkspace{
-		url:                 url,
-		isServicePrincipal:  strings.HasPrefix(token, ServicePrincipalTokenPrefix),
-		EventualConsistency: strings.HasPrefix(token, EventualConsistencyTokenPrefix),
+		url:                url,
+		isServicePrincipal: strings.HasPrefix(token, ServicePrincipalTokenPrefix),
 		directories: map[string]workspace.ObjectInfo{
 			"/Workspace": {
 				ObjectType: "DIRECTORY",
@@ -348,7 +344,7 @@ func NewFakeWorkspace(url, token string) *FakeWorkspace {
 		Schemas:             map[string]catalog.SchemaInfo{},
 		RegisteredModels:    map[string]catalog.RegisteredModelInfo{},
 		Volumes:             map[string]catalog.VolumeInfo{},
-		Dashboards:          map[string]*EventualValue[*fakeDashboard]{},
+		Dashboards:          NewEventualMap[string, *fakeDashboard](strings.HasPrefix(token, EventualConsistencyTokenPrefix)),
 		PublishedDashboards: map[string]dashboards.PublishedDashboard{},
 		GenieSpaces:         map[string]dashboards.GenieSpace{},
 		SqlWarehouses: map[string]sql.GetWarehouseResponse{

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -38,6 +38,9 @@ const (
 	// identity's workspace, kept distinct from a test whose primary identity is
 	// itself a service principal.
 	GuestServicePrincipalTokenPrefix = "dbapi2"
+	// EventualConsistencyTokenPrefix identifies workspaces that simulate eventual
+	// consistency: the first GET after a create returns 404 (not yet visible).
+	EventualConsistencyTokenPrefix = "dbapi3"
 	UserID                           = "1000012345"
 	TestDefaultClusterId             = "0123-456789-cluster0"
 	TestDefaultWarehouseId           = "8ec9edc1-db0c-40df-af8d-7580020fe61e"
@@ -158,6 +161,9 @@ type FakeWorkspace struct {
 	mu                 sync.Mutex
 	url                string
 	isServicePrincipal bool
+	// EventualConsistency enables eventual-consistency simulation: the first
+	// GET after a create returns 404 (resource not yet visible).
+	EventualConsistency bool
 
 	directories  map[string]workspace.ObjectInfo
 	files        map[string]FileEntry
@@ -173,7 +179,7 @@ type FakeWorkspace struct {
 	Schemas               map[string]catalog.SchemaInfo
 	Grants                map[string][]catalog.PrivilegeAssignment
 	Volumes               map[string]catalog.VolumeInfo
-	Dashboards            map[string]fakeDashboard
+	Dashboards            map[string]*EventualValue[*fakeDashboard]
 	PublishedDashboards   map[string]dashboards.PublishedDashboard
 	GenieSpaces           map[string]dashboards.GenieSpace
 	SqlWarehouses         map[string]sql.GetWarehouseResponse
@@ -283,8 +289,9 @@ func MapDelete[K comparable, V any](w *FakeWorkspace, collection map[K]V, key K)
 
 func NewFakeWorkspace(url, token string) *FakeWorkspace {
 	return &FakeWorkspace{
-		url:                url,
-		isServicePrincipal: strings.HasPrefix(token, ServicePrincipalTokenPrefix),
+		url:                 url,
+		isServicePrincipal:  strings.HasPrefix(token, ServicePrincipalTokenPrefix),
+		EventualConsistency: strings.HasPrefix(token, EventualConsistencyTokenPrefix),
 		directories: map[string]workspace.ObjectInfo{
 			"/Workspace": {
 				ObjectType: "DIRECTORY",
@@ -341,7 +348,7 @@ func NewFakeWorkspace(url, token string) *FakeWorkspace {
 		Schemas:             map[string]catalog.SchemaInfo{},
 		RegisteredModels:    map[string]catalog.RegisteredModelInfo{},
 		Volumes:             map[string]catalog.VolumeInfo{},
-		Dashboards:          map[string]fakeDashboard{},
+		Dashboards:          map[string]*EventualValue[*fakeDashboard]{},
 		PublishedDashboards: map[string]dashboards.PublishedDashboard{},
 		GenieSpaces:         map[string]dashboards.GenieSpace{},
 		SqlWarehouses: map[string]sql.GetWarehouseResponse{

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -315,7 +315,7 @@ func AddDefaultHandlers(server *Server) {
 
 	// Dashboards:
 	server.Handle("GET", "/api/2.0/lakeview/dashboards/{dashboard_id}", func(req Request) any {
-		return MapGet(req.Workspace, req.Workspace.Dashboards, req.Vars["dashboard_id"])
+		return req.Workspace.DashboardGet(req)
 	})
 	server.Handle("POST", "/api/2.0/lakeview/dashboards", func(req Request) any {
 		return req.Workspace.DashboardCreate(req)


### PR DESCRIPTION
Follow-up to #5694.

We've seen the dashboard API be eventually consistent: a GET right after a create
can 404 before the write propagates. The dashboard acceptance tests run on cloud
(`Cloud = true`) and read a dashboard immediately after deploy, so they are exposed
to this.

- Add a testserver EC mode for dashboards: under the eventual-consistency token
  (opt-in via `TESTS_STALE_ONCE=1`, direct engine only) the first GET of a dashboard
  after it is created returns 404. This reproduces the cloud window deterministically.
- Enable it for the dashboards directory and wrap the first `lakeview get` after each
  create with `retry.py`, so reads right after deploy are retried rather than assumed
  to succeed.

Test-only: no engine changes. Making the direct engine itself resilient to the same
404 (plan/refresh reads) is a separate follow-up.

This pull request and its description were written by Isaac.