### PR TITLE
Persist scheme-less account login hosts as HTTPS

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -472,7 +472,7 @@ func setHostAndAccountId(ctx context.Context, existingProfile *profile.Profile, 
 		}
 	}
 
-	authArguments.Host = strings.TrimSuffix(authArguments.Host, "/")
+	authArguments.Host = normalizeLoginHost(authArguments.Host)
 
 	// Extract query parameters from the host URL (?o=workspace_id, ?a=account_id).
 	// URL params from explicit --host override stale profile values.
@@ -510,6 +510,19 @@ func setHostAndAccountId(ctx context.Context, existingProfile *profile.Profile, 
 	}
 
 	return nil
+}
+
+func normalizeLoginHost(host string) string {
+	host = strings.TrimSuffix(host, "/")
+	if strings.Contains(host, "://") {
+		return host
+	}
+
+	canonicalHost := (&config.Config{Host: host}).CanonicalHostName()
+	if auth.IsClassicAccountHost(canonicalHost) {
+		return "https://" + host
+	}
+	return host
 }
 
 // needsAccountIDPrompt reports whether the target host requires an account ID

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -150,8 +150,16 @@ func TestSetHost(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://www.host1.test", authArguments.Host)
 
+	// Test setting account console host from flag without scheme
+	authArguments.Host = "accounts.test/"
+	authArguments.AccountID = "account-id"
+	err = setHostAndAccountId(ctx, profile1, &authArguments, []string{})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://accounts.test", authArguments.Host)
+
 	// Test setting host from argument
 	authArguments.Host = ""
+	authArguments.AccountID = ""
 	err = setHostAndAccountId(ctx, profile1, &authArguments, []string{"val from [HOST]"})
 	assert.NoError(t, err)
 	assert.Equal(t, "val from [HOST]", authArguments.Host)

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -484,7 +484,7 @@ func TestToken_loadToken(t *testing.T) {
 					u2m.WithOAuthEndpointSupplier(&MockApiClient{}),
 				},
 			},
-			wantErr: "acct-dup1 and acct-dup2 match accounts.cloud.databricks.com in <in memory>. Use --profile to specify which profile to use",
+			wantErr: "acct-dup1 and acct-dup2 match https://accounts.cloud.databricks.com in <in memory>. Use --profile to specify which profile to use",
 		},
 		{
 			name: "workspace host ambiguity — multiple profiles, non-interactive",


### PR DESCRIPTION
## Changes
- normalize classic account-console login hosts without a scheme before saving the profile
- keep arbitrary workspace host inputs unchanged
- update auth token ambiguity coverage to expect the normalized account host

Fixes #1403

## Tests
- go test ./cmd/auth -run TestSetHost -count=1
- go test ./cmd/auth -count=1