### PR TITLE
acc: run run_as/job_default locally on all clouds

### DIFF
--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/job_default/test.toml
+++ b/acceptance/bundle/run_as/job_default/test.toml
@@ -1,7 +1,7 @@
 Badness = "run_as is still set even though it's not in bundle and not in reset request"
 Ignore = [".databricks/.gitignore"]
 
-Local = false
+Local = true
 Cloud = true
 RecordRequests = true
 

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -105,6 +105,14 @@ func (s *FakeWorkspace) JobsReset(req Request) Response {
 		return Response{StatusCode: 403, Body: "{}"}
 	}
 
+	// The Jobs reset API treats run_as as sticky: omitting it from new_settings
+	// keeps the previously configured identity rather than clearing it (unlike
+	// other fields, which reset fully). Mirror that so a removed run_as in the
+	// bundle does not drop the value on the fake.
+	if request.NewSettings.RunAs == nil {
+		request.NewSettings.RunAs = prevjob.Settings.RunAs
+	}
+
 	s.Jobs[jobId] = jobs.Job{
 		JobId:           jobId,
 		CreatorUserName: prevjob.CreatorUserName,

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -105,10 +105,10 @@ func (s *FakeWorkspace) JobsReset(req Request) Response {
 		return Response{StatusCode: 403, Body: "{}"}
 	}
 
-	// The Jobs reset API treats run_as as sticky: omitting it from new_settings
-	// keeps the previously configured identity rather than clearing it (unlike
-	// other fields, which reset fully). Mirror that so a removed run_as in the
-	// bundle does not drop the value on the fake.
+	// Known cloud quirk (see the test's Badness note): jobs/reset is a full
+	// replace, but omitting run_as from new_settings does NOT clear it — cloud
+	// keeps the previously configured identity. Mirror that so the local
+	// testserver matches cloud against one golden.
 	if request.NewSettings.RunAs == nil {
 		request.NewSettings.RunAs = prevjob.Settings.RunAs
 	}


### PR DESCRIPTION
## Why
Running this acceptance test locally (not just on cloud) makes it faster and free to run in CI/dev against the testserver.

## Changes
- Flip `run_as/job_default` to `Local = true`.
- In the jobs fake (`libs/testserver/jobs.go`), mirror cloud's sticky `run_as`: on `jobs/reset`, keep the previous value when `new_settings` omits it (the only local/cloud divergence).

## Tests
- `run_as/job_default` now runs on both local and cloud against one golden, no regressions.