### PR TITLE
Add experimental auth doctor and access explain commands

### DIFF
--- a/acceptance/experimental/access/explain/out.test.toml
+++ b/acceptance/experimental/access/explain/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/experimental/access/explain/output.txt
+++ b/acceptance/experimental/access/explain/output.txt
@@ -3,9 +3,9 @@
 >>> [CLI] experimental access explain --on prod.sales.transactions --principal alice@databricks.test
 DENIED for alice@databricks.test (user) on prod.sales.transactions (SELECT)
 Why:
-  ✓ CATALOG prod: USE_CATALOG granted directly
+  ✓ CATALOG prod: USE_CATALOG granted on this catalog
   ✗ SCHEMA prod.sales: missing USE_SCHEMA
-  ✓ TABLE prod.sales.transactions: SELECT granted directly
+  ✓ TABLE prod.sales.transactions: SELECT granted on this table
 Masking:
   ⚠ column ssn is masked by policy pii_mask
 Fix:
@@ -30,7 +30,7 @@ Fix:
         }
       ],
       "satisfied": true,
-      "satisfied_by": "USE_CATALOG granted directly"
+      "satisfied_by": "USE_CATALOG granted on this catalog"
     },
     {
       "type": "SCHEMA",
@@ -49,7 +49,7 @@ Fix:
         }
       ],
       "satisfied": true,
-      "satisfied_by": "SELECT granted directly"
+      "satisfied_by": "SELECT granted on this table"
     }
   ],
   "masks": [

--- a/acceptance/experimental/access/explain/output.txt
+++ b/acceptance/experimental/access/explain/output.txt
@@ -1,0 +1,66 @@
+
+=== access explain: DENIED (has SELECT but missing USE SCHEMA), with mask and GRANT fix
+>>> [CLI] experimental access explain --on prod.sales.transactions --principal alice@databricks.test
+DENIED for alice@databricks.test (user) on prod.sales.transactions (SELECT)
+Why:
+  ✓ CATALOG prod: USE_CATALOG granted directly
+  ✗ SCHEMA prod.sales: missing USE_SCHEMA
+  ✓ TABLE prod.sales.transactions: SELECT granted directly
+Masking:
+  ⚠ column ssn is masked by policy pii_mask
+Fix:
+  GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`
+
+=== access explain (json)
+>>> [CLI] experimental access explain --on prod.sales.transactions --principal alice@databricks.test --output json
+{
+  "principal": "alice@databricks.test",
+  "principal_kind": "user",
+  "securable": "prod.sales.transactions",
+  "action": "SELECT",
+  "allowed": false,
+  "levels": [
+    {
+      "type": "CATALOG",
+      "full_name": "prod",
+      "needed": "USE_CATALOG",
+      "held": [
+        {
+          "name": "USE_CATALOG"
+        }
+      ],
+      "satisfied": true,
+      "satisfied_by": "USE_CATALOG granted directly"
+    },
+    {
+      "type": "SCHEMA",
+      "full_name": "prod.sales",
+      "needed": "USE_SCHEMA",
+      "held": null,
+      "satisfied": false
+    },
+    {
+      "type": "TABLE",
+      "full_name": "prod.sales.transactions",
+      "needed": "SELECT",
+      "held": [
+        {
+          "name": "SELECT"
+        }
+      ],
+      "satisfied": true,
+      "satisfied_by": "SELECT granted directly"
+    }
+  ],
+  "masks": [
+    {
+      "column": "ssn",
+      "policy": "pii_mask",
+      "function": "main.default.mask_ssn",
+      "applies": true
+    }
+  ],
+  "fixes": [
+    "GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`"
+  ]
+}

--- a/acceptance/experimental/access/explain/script
+++ b/acceptance/experimental/access/explain/script
@@ -1,0 +1,7 @@
+sethome "./home"
+
+title "access explain: DENIED (has SELECT but missing USE SCHEMA), with mask and GRANT fix"
+trace $CLI experimental access explain --on prod.sales.transactions --principal alice@databricks.test
+
+title "access explain (json)"
+trace $CLI experimental access explain --on prod.sales.transactions --principal alice@databricks.test --output json

--- a/acceptance/experimental/access/explain/test.toml
+++ b/acceptance/experimental/access/explain/test.toml
@@ -1,0 +1,35 @@
+Ignore = [
+    "home",
+]
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = []
+
+# The effective-permissions and policies endpoints are not modeled by the
+# testserver, so stub them. The principal holds USE_CATALOG and SELECT but not
+# USE_SCHEMA, so access is denied at the schema level.
+
+# Principal existence check: alice resolves to a user.
+[[Server]]
+Pattern = "GET /api/2.0/preview/scim/v2/Users"
+Response.Body = '{"Resources":[{"userName":"alice@databricks.test","id":"100"}],"totalResults":1,"startIndex":1,"itemsPerPage":1}'
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/effective-permissions/CATALOG/prod"
+Response.Body = '{"privilege_assignments":[{"principal":"alice@databricks.test","privileges":[{"privilege":"USE_CATALOG"}]}]}'
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/effective-permissions/SCHEMA/prod.sales"
+Response.Body = '{"privilege_assignments":[]}'
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/effective-permissions/TABLE/prod.sales.transactions"
+Response.Body = '{"privilege_assignments":[{"principal":"alice@databricks.test","privileges":[{"privilege":"SELECT"}]}]}'
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/policies/TABLE/prod.sales.transactions"
+Response.Body = '{"policies":[{"name":"pii_mask","policy_type":"POLICY_TYPE_COLUMN_MASK","column_mask":{"function_name":"main.default.mask_ssn","on_column":"ssn"},"to_principals":[]}]}'
+
+[[Server]]
+Pattern = "GET /api/2.1/unity-catalog/tables/prod.sales.transactions"
+Response.Body = '{"full_name":"prod.sales.transactions","columns":[{"name":"ssn"},{"name":"amount"}]}'

--- a/acceptance/experimental/auth/doctor/out.test.toml
+++ b/acceptance/experimental/auth/doctor/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/experimental/auth/doctor/output.txt
+++ b/acceptance/experimental/auth/doctor/output.txt
@@ -1,0 +1,77 @@
+
+=== doctor --all diagnoses every profile (text)
+>>> [CLI] experimental auth doctor --all
+Profile "ws"  host=[DATABRICKS_URL]  auth=pat
+✓ Resolved profile "ws" from --all
+    host=[DATABRICKS_URL], auth_type=pat
+✓ Host is a workspace URL
+    [DATABRICKS_URL]
+⚠ Token does not look like a Databricks PAT
+    Databricks personal access tokens start with "dapi".
+Overall: WARNING
+
+Profile "acct-noid"  host=https://accounts.cloud.databricks.test  auth=pat
+✓ Resolved profile "acct-noid" from --all
+    host=https://accounts.cloud.databricks.test, auth_type=pat
+✗ Account console host without an account id
+    https://accounts.cloud.databricks.test is the account console, but no account_id is set. Account commands need account_id; workspace commands need a workspace URL.
+    Fix: databricks auth login --host <account-console-url> --account-id <account-id>
+✓ Personal access token is present
+Overall: ERROR
+
+=== doctor --all (json)
+>>> [CLI] experimental auth doctor --all --output json
+[
+  {
+    "profile": "ws",
+    "host": "[DATABRICKS_URL]",
+    "auth_type": "pat",
+    "overall": "warn",
+    "findings": [
+      {
+        "check": "resolution",
+        "level": "ok",
+        "title": "Resolved profile \"ws\" from --all",
+        "detail": "host=[DATABRICKS_URL], auth_type=pat"
+      },
+      {
+        "check": "host",
+        "level": "ok",
+        "title": "Host is a workspace URL",
+        "detail": "[DATABRICKS_URL]"
+      },
+      {
+        "check": "auth_type",
+        "level": "warn",
+        "title": "Token does not look like a Databricks PAT",
+        "detail": "Databricks personal access tokens start with \"dapi\"."
+      }
+    ]
+  },
+  {
+    "profile": "acct-noid",
+    "host": "https://accounts.cloud.databricks.test",
+    "auth_type": "pat",
+    "overall": "error",
+    "findings": [
+      {
+        "check": "resolution",
+        "level": "ok",
+        "title": "Resolved profile \"acct-noid\" from --all",
+        "detail": "host=https://accounts.cloud.databricks.test, auth_type=pat"
+      },
+      {
+        "check": "host",
+        "level": "error",
+        "title": "Account console host without an account id",
+        "detail": "https://accounts.cloud.databricks.test is the account console, but no account_id is set. Account commands need account_id; workspace commands need a workspace URL.",
+        "fix": "databricks auth login --host \u003caccount-console-url\u003e --account-id \u003caccount-id\u003e"
+      },
+      {
+        "check": "auth_type",
+        "level": "ok",
+        "title": "Personal access token is present"
+      }
+    ]
+  }
+]

--- a/acceptance/experimental/auth/doctor/script
+++ b/acceptance/experimental/auth/doctor/script
@@ -1,0 +1,28 @@
+sethome "./home"
+
+# Capture the test server creds, then resolve auth purely from the config file
+# so the diagnosis is deterministic (no env overrides, no network probe under
+# --all). Pin the bundle root at the cwd (no databricks.yml) so the bundle
+# walk-up does not pick up a stray bundle on the host running the test.
+HOST="$DATABRICKS_HOST"
+TOKEN="$DATABRICKS_TOKEN"
+unset DATABRICKS_HOST
+unset DATABRICKS_TOKEN
+unset DATABRICKS_CONFIG_PROFILE
+export DATABRICKS_BUNDLE_ROOT="$PWD"
+
+cat > "./home/.databrickscfg" <<EOF
+[ws]
+host  = $HOST
+token = $TOKEN
+
+[acct-noid]
+host  = https://accounts.cloud.databricks.test
+token = dapifaketoken1234
+EOF
+
+title "doctor --all diagnoses every profile (text)"
+trace $CLI experimental auth doctor --all
+
+title "doctor --all (json)"
+trace $CLI experimental auth doctor --all --output json

--- a/acceptance/experimental/auth/doctor/test.toml
+++ b/acceptance/experimental/auth/doctor/test.toml
@@ -1,0 +1,6 @@
+Ignore = [
+    "home",
+]
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = []

--- a/cmd/experimental/experimental.go
+++ b/cmd/experimental/experimental.go
@@ -1,7 +1,9 @@
 package experimental
 
 import (
+	accessexplaincmd "github.com/databricks/cli/experimental/accessexplain/cmd"
 	aitoolscmd "github.com/databricks/cli/experimental/aitools/cmd"
+	authdoctorcmd "github.com/databricks/cli/experimental/authdoctor/cmd"
 	geniecmd "github.com/databricks/cli/experimental/genie/cmd"
 	postgrescmd "github.com/databricks/cli/experimental/postgres/cmd"
 	"github.com/spf13/cobra"
@@ -22,7 +24,9 @@ These commands provide early access to new features that are still under
 development. They may change or be removed in future versions without notice.`,
 	}
 
+	cmd.AddCommand(accessexplaincmd.New())
 	cmd.AddCommand(aitoolscmd.NewAitoolsCmd())
+	cmd.AddCommand(authdoctorcmd.New())
 	cmd.AddCommand(geniecmd.NewGenieCmd())
 	cmd.AddCommand(postgrescmd.New())
 	cmd.AddCommand(newWorkspaceOpenCommand())

--- a/experimental/accessexplain/cmd/cmd.go
+++ b/experimental/accessexplain/cmd/cmd.go
@@ -131,16 +131,17 @@ func explain(ctx context.Context, reader accessReader, on, principal, privilege 
 		in.Levels = append(in.Levels, accessexplain.Level{LevelSpec: spec, Held: held})
 	}
 
-	// Column masks only apply to a table leaf. Surface both ABAC policies and
-	// legacy function-based masks attached to the table's columns.
+	// Column masks only apply to a table leaf. They are supplementary to the
+	// allow/deny verdict, so a failure to read them (commonly a missing READ
+	// METADATA grant on the table) is logged and skipped, not fatal.
 	if leaf := specs[len(specs)-1]; leaf.Type == accessexplain.SecurableTable {
 		policyMasks, err := reader.ColumnMasks(ctx, leaf.FullName, principal)
 		if err != nil {
-			return accessexplain.Verdict{}, fmt.Errorf("list masking policies on %s: %w", leaf.FullName, err)
+			log.Warnf(ctx, "access explain: could not list masking policies on %s, mask detection skipped: %v", leaf.FullName, err)
 		}
 		legacyMasks, err := reader.LegacyColumnMasks(ctx, leaf.FullName)
 		if err != nil {
-			return accessexplain.Verdict{}, fmt.Errorf("read column masks on %s: %w", leaf.FullName, err)
+			log.Warnf(ctx, "access explain: could not read column masks on %s, mask detection skipped: %v", leaf.FullName, err)
 		}
 		in.Masks = mergeMasks(policyMasks, legacyMasks)
 	}
@@ -247,15 +248,11 @@ func columnMaskFromPolicy(p catalog.PolicyInfo, principal string) (accessexplain
 // LegacyColumnMasks reports the function-based column masks attached directly
 // to the table's columns (ColumnInfo.Mask), the pre-ABAC masking mechanism.
 // These have no policy name and apply to all readers, so no Targets are set.
-//
-// Masks are supplementary to the allow/deny verdict, so a failed table read is
-// non-fatal; it is logged at warn (not debug) so the user knows mask detection
-// did not run rather than seeing a silent, incomplete result.
+// A read error is returned for the caller to treat as best-effort.
 func (r *sdkReader) LegacyColumnMasks(ctx context.Context, tableFullName string) ([]accessexplain.Mask, error) {
 	table, err := r.w.Tables.GetByFullName(ctx, tableFullName)
 	if err != nil {
-		log.Warnf(ctx, "access explain: could not read table %s for column masks, mask detection skipped: %v", tableFullName, err)
-		return nil, nil
+		return nil, err
 	}
 	var masks []accessexplain.Mask
 	for _, c := range table.Columns {

--- a/experimental/accessexplain/cmd/cmd.go
+++ b/experimental/accessexplain/cmd/cmd.go
@@ -1,0 +1,403 @@
+// Package cmd wires the access-explain engine into the experimental command
+// tree. It reads effective permissions and masking policies via the SDK and
+// feeds a plain trace to accessexplain.Evaluate, which computes the verdict.
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/experimental/accessexplain"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/listing"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/spf13/cobra"
+)
+
+// accessReader supplies the effective permissions, column masks, and current
+// user for the trace. It is an interface so the command orchestration can be
+// tested without a live workspace.
+type accessReader interface {
+	Effective(ctx context.Context, securableType, fullName, principal string) ([]accessexplain.HeldPrivilege, error)
+	ColumnMasks(ctx context.Context, tableFullName, principal string) ([]accessexplain.Mask, error)
+	LegacyColumnMasks(ctx context.Context, tableFullName string) ([]accessexplain.Mask, error)
+	CurrentUser(ctx context.Context) (string, error)
+	// ResolvePrincipal reports a principal's type ("user", "group", or
+	// "service principal") and whether it exists. A non-nil error means
+	// existence could not be determined (e.g. the caller lacks list permission),
+	// which callers treat as "proceed without verifying".
+	ResolvePrincipal(ctx context.Context, name string) (kind string, found bool, err error)
+}
+
+// New returns the experimental "access" command group with the explain subcommand.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "access",
+		Short: "Access (authorization) diagnostics",
+		Long:  "Access diagnostics that trace why a principal can or cannot access a Unity Catalog securable.",
+	}
+	cmd.AddCommand(newExplainCommand())
+	return cmd
+}
+
+func newExplainCommand() *cobra.Command {
+	var (
+		on        string
+		principal string
+		privilege string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "explain",
+		Short: "Explain why a principal can or cannot access a Unity Catalog securable",
+		Long: `Trace the access decision for a Unity Catalog securable and explain the
+verdict, with the exact GRANT to fix a denial.
+
+The securable is a dotted name: a catalog, catalog.schema, or
+catalog.schema.table. Access requires USE CATALOG, USE SCHEMA, and the leaf
+privilege (SELECT for a table by default). Without --principal the current user
+is used; --principal requires the caller to be privileged on the securable
+(Unity Catalog has no impersonation).`,
+		Args:    cobra.NoArgs,
+		PreRunE: root.MustWorkspaceClient,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if on == "" {
+				return errors.New("--on is required (catalog[.schema[.table]])")
+			}
+			ctx := cmd.Context()
+			reader := &sdkReader{w: cmdctx.WorkspaceClient(ctx)}
+			verdict, err := explain(ctx, reader, on, principal, privilege)
+			if err != nil {
+				return err
+			}
+			return renderVerdict(ctx, cmd, verdict)
+		},
+	}
+
+	cmd.Flags().StringVar(&on, "on", "", "Securable to explain: catalog[.schema[.table]]")
+	cmd.Flags().StringVar(&principal, "principal", "", "Principal to explain access for (default: current user)")
+	cmd.Flags().StringVar(&privilege, "privilege", "", "Privilege to check at the leaf securable (default: SELECT for tables)")
+	return cmd
+}
+
+// explain assembles the trace and computes the verdict.
+func explain(ctx context.Context, reader accessReader, on, principal, privilege string) (accessexplain.Verdict, error) {
+	specs, err := accessexplain.ParseSecurable(on, privilege)
+	if err != nil {
+		return accessexplain.Verdict{}, err
+	}
+
+	var principalKind string
+	if principal == "" {
+		principal, err = reader.CurrentUser(ctx)
+		if err != nil {
+			return accessexplain.Verdict{}, fmt.Errorf("resolve current user: %w", err)
+		}
+	} else {
+		// An explicitly named principal is verified so a typo reads as "not
+		// found" instead of a misleading DENIED with no privileges anywhere.
+		kind, found, rerr := reader.ResolvePrincipal(ctx, principal)
+		switch {
+		case rerr != nil:
+			// Could not verify (e.g. no list permission); proceed unverified.
+			log.Debugf(ctx, "access explain: could not verify principal %q: %v", principal, rerr)
+		case !found:
+			return accessexplain.Verdict{}, fmt.Errorf("principal %q was not found as a user, group, or service principal", principal)
+		default:
+			principalKind = kind
+		}
+	}
+
+	in := accessexplain.Input{
+		Principal: principal,
+		Securable: on,
+		Action:    specs[len(specs)-1].Needed,
+	}
+	for _, spec := range specs {
+		held, err := reader.Effective(ctx, spec.Type, spec.FullName, principal)
+		if err != nil {
+			return accessexplain.Verdict{}, fmt.Errorf("read effective permissions on %s %s: %w", spec.Type, spec.FullName, err)
+		}
+		in.Levels = append(in.Levels, accessexplain.Level{LevelSpec: spec, Held: held})
+	}
+
+	// Column masks only apply to a table leaf. Surface both ABAC policies and
+	// legacy function-based masks attached to the table's columns.
+	if leaf := specs[len(specs)-1]; leaf.Type == accessexplain.SecurableTable {
+		policyMasks, err := reader.ColumnMasks(ctx, leaf.FullName, principal)
+		if err != nil {
+			return accessexplain.Verdict{}, fmt.Errorf("list masking policies on %s: %w", leaf.FullName, err)
+		}
+		legacyMasks, err := reader.LegacyColumnMasks(ctx, leaf.FullName)
+		if err != nil {
+			return accessexplain.Verdict{}, fmt.Errorf("read column masks on %s: %w", leaf.FullName, err)
+		}
+		in.Masks = mergeMasks(policyMasks, legacyMasks)
+	}
+
+	verdict := accessexplain.Evaluate(in)
+	verdict.PrincipalKind = principalKind
+	return verdict, nil
+}
+
+// mergeMasks combines ABAC policy masks and legacy column masks, keeping at
+// most one entry per column (the ABAC policy wins, since it is the active
+// mechanism when both are present).
+func mergeMasks(policyMasks, legacyMasks []accessexplain.Mask) []accessexplain.Mask {
+	seen := map[string]bool{}
+	var out []accessexplain.Mask
+	for _, m := range append(policyMasks, legacyMasks...) {
+		if seen[m.Column] {
+			continue
+		}
+		seen[m.Column] = true
+		out = append(out, m)
+	}
+	return out
+}
+
+// sdkReader is the production accessReader backed by a workspace client.
+type sdkReader struct {
+	w *databricks.WorkspaceClient
+}
+
+func (r *sdkReader) Effective(ctx context.Context, securableType, fullName, principal string) ([]accessexplain.HeldPrivilege, error) {
+	var held []accessexplain.HeldPrivilege
+	pageToken := ""
+	for {
+		resp, err := r.w.Grants.GetEffective(ctx, catalog.GetEffectiveRequest{
+			SecurableType: securableType,
+			FullName:      fullName,
+			Principal:     principal,
+			PageToken:     pageToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, pa := range resp.PrivilegeAssignments {
+			for _, p := range pa.Privileges {
+				held = append(held, accessexplain.HeldPrivilege{
+					Name:              string(p.Privilege),
+					InheritedFromType: string(p.InheritedFromType),
+					InheritedFromName: p.InheritedFromName,
+				})
+			}
+		}
+		// Pagination is across principals; a missing or unchanged token ends it.
+		if resp.NextPageToken == "" || resp.NextPageToken == pageToken {
+			return held, nil
+		}
+		pageToken = resp.NextPageToken
+	}
+}
+
+func (r *sdkReader) ColumnMasks(ctx context.Context, tableFullName, principal string) ([]accessexplain.Mask, error) {
+	policies, err := listing.ToSlice(ctx, r.w.Policies.ListPolicies(ctx, catalog.ListPoliciesRequest{
+		OnSecurableType:     accessexplain.SecurableTable,
+		OnSecurableFullname: tableFullName,
+		IncludeInherited:    true,
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	var masks []accessexplain.Mask
+	for _, p := range policies {
+		if m, ok := columnMaskFromPolicy(p, principal); ok {
+			masks = append(masks, m)
+		}
+	}
+	return masks, nil
+}
+
+// columnMaskFromPolicy converts an ABAC policy to a Mask, reporting whether it
+// should be surfaced. Only column-mask policies that do not explicitly except
+// the principal are surfaced. A policy targeting a group is kept (with its
+// Targets) rather than dropped, because group membership cannot be resolved
+// locally and silently hiding a mask would understate what is masked.
+func columnMaskFromPolicy(p catalog.PolicyInfo, principal string) (accessexplain.Mask, bool) {
+	if p.PolicyType != catalog.PolicyTypePolicyTypeColumnMask || p.ColumnMask == nil {
+		return accessexplain.Mask{}, false
+	}
+	if slices.Contains(p.ExceptPrincipals, principal) {
+		return accessexplain.Mask{}, false
+	}
+	// Definitely applies when it targets everyone or names the principal
+	// directly; otherwise it may only apply via an unresolved group target.
+	applies := len(p.ToPrincipals) == 0 || slices.Contains(p.ToPrincipals, principal)
+	return accessexplain.Mask{
+		Column:   p.ColumnMask.OnColumn,
+		Policy:   p.Name,
+		Function: p.ColumnMask.FunctionName,
+		Targets:  p.ToPrincipals,
+		Applies:  applies,
+	}, true
+}
+
+// LegacyColumnMasks reports the function-based column masks attached directly
+// to the table's columns (ColumnInfo.Mask), the pre-ABAC masking mechanism.
+// These have no policy name and apply to all readers, so no Targets are set.
+//
+// Masks are supplementary to the allow/deny verdict, so a failed table read is
+// non-fatal; it is logged at warn (not debug) so the user knows mask detection
+// did not run rather than seeing a silent, incomplete result.
+func (r *sdkReader) LegacyColumnMasks(ctx context.Context, tableFullName string) ([]accessexplain.Mask, error) {
+	table, err := r.w.Tables.GetByFullName(ctx, tableFullName)
+	if err != nil {
+		log.Warnf(ctx, "access explain: could not read table %s for column masks, mask detection skipped: %v", tableFullName, err)
+		return nil, nil
+	}
+	var masks []accessexplain.Mask
+	for _, c := range table.Columns {
+		if c.Mask == nil {
+			continue
+		}
+		masks = append(masks, accessexplain.Mask{
+			Column:   c.Name,
+			Function: c.Mask.FunctionName,
+			// Legacy column masks are attached to the column itself and apply to
+			// every reader.
+			Applies: true,
+		})
+	}
+	return masks, nil
+}
+
+func (r *sdkReader) CurrentUser(ctx context.Context) (string, error) {
+	me, err := r.w.CurrentUser.Me(ctx, iam.MeRequest{})
+	if err != nil {
+		return "", err
+	}
+	return me.UserName, nil
+}
+
+// ResolvePrincipal looks the name up in SCIM as a user (by userName), group, or
+// service principal (both by displayName). It only needs existence, so it reads
+// the first match rather than draining every page. A list error on any lookup
+// is returned so the caller can proceed unverified rather than reporting a real
+// principal as missing.
+func (r *sdkReader) ResolvePrincipal(ctx context.Context, name string) (string, bool, error) {
+	userFilter := fmt.Sprintf("userName eq %q", name)
+	if found, err := iteratorHasMatch(ctx, r.w.UsersV2.List(ctx, iam.ListUsersRequest{Filter: userFilter})); err != nil {
+		return "", false, err
+	} else if found {
+		return "user", true, nil
+	}
+
+	nameFilter := fmt.Sprintf("displayName eq %q", name)
+	if found, err := iteratorHasMatch(ctx, r.w.GroupsV2.List(ctx, iam.ListGroupsRequest{Filter: nameFilter})); err != nil {
+		return "", false, err
+	} else if found {
+		return "group", true, nil
+	}
+
+	if found, err := iteratorHasMatch(ctx, r.w.ServicePrincipalsV2.List(ctx, iam.ListServicePrincipalsRequest{Filter: nameFilter})); err != nil {
+		return "", false, err
+	} else if found {
+		return "service principal", true, nil
+	}
+
+	return "", false, nil
+}
+
+// iteratorHasMatch reports whether a listing iterator yields at least one item.
+// It reads only the first item (no full drain) and surfaces a page-fetch error.
+func iteratorHasMatch[T any](ctx context.Context, it listing.Iterator[T]) (bool, error) {
+	if !it.HasNext(ctx) {
+		return false, nil
+	}
+	// HasNext is also true when the page fetch failed; Next then returns the
+	// error, which we propagate so the caller treats it as "could not verify".
+	if _, err := it.Next(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func renderVerdict(ctx context.Context, cmd *cobra.Command, v accessexplain.Verdict) error {
+	switch root.OutputType(cmd) {
+	case flags.OutputText:
+		renderText(ctx, cmd, v)
+		return nil
+	case flags.OutputJSON:
+		buf, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = cmd.OutOrStdout().Write(append(buf, '\n'))
+		return err
+	default:
+		return fmt.Errorf("unknown output type %s", root.OutputType(cmd))
+	}
+}
+
+func renderText(ctx context.Context, cmd *cobra.Command, v accessexplain.Verdict) {
+	out := cmd.OutOrStdout()
+
+	decision := cmdio.Green(ctx, "ALLOWED")
+	if !v.Allowed {
+		decision = cmdio.Red(ctx, "DENIED")
+	}
+	principal := v.Principal
+	if v.PrincipalKind != "" {
+		principal += " (" + v.PrincipalKind + ")"
+	}
+	fmt.Fprintf(out, "%s for %s on %s (%s)\n", decision, cmdio.Bold(ctx, principal), cmdio.Bold(ctx, v.Securable), v.Action)
+
+	fmt.Fprintln(out, "Why:")
+	for _, l := range v.Levels {
+		if l.Satisfied {
+			fmt.Fprintf(out, "  %s %s %s: %s\n", cmdio.Green(ctx, "✓"), l.Type, l.FullName, l.SatisfiedBy)
+		} else {
+			fmt.Fprintf(out, "  %s %s %s: missing %s\n", cmdio.Red(ctx, "✗"), l.Type, l.FullName, l.Needed)
+		}
+	}
+
+	if len(v.Masks) > 0 {
+		fmt.Fprintln(out, "Masking:")
+		for _, m := range v.Masks {
+			verb := "is masked by"
+			if !m.Applies {
+				verb = "may be masked by"
+			}
+			fmt.Fprintf(out, "  %s column %s %s %s\n", cmdio.Yellow(ctx, "⚠"), m.Column, verb, maskSource(m))
+		}
+	}
+
+	if len(v.Fixes) > 0 {
+		fmt.Fprintln(out, "Fix:")
+		for _, f := range v.Fixes {
+			fmt.Fprintf(out, "  %s\n", cmdio.Cyan(ctx, f))
+		}
+	}
+}
+
+// maskSource describes what masks a column: an ABAC policy by name, or a legacy
+// function-based mask (which has no policy name). A policy that targets specific
+// principals/groups (not everyone) is annotated, since group membership is not
+// resolved locally and the mask may or may not apply to this principal.
+func maskSource(m accessexplain.Mask) string {
+	var src string
+	switch {
+	case m.Policy != "":
+		src = "policy " + m.Policy
+	case m.Function != "":
+		src = "function " + m.Function
+	default:
+		src = "a column mask"
+	}
+	if len(m.Targets) > 0 {
+		src += fmt.Sprintf(" (targets %s)", strings.Join(m.Targets, ", "))
+	}
+	return src
+}

--- a/experimental/accessexplain/cmd/cmd_test.go
+++ b/experimental/accessexplain/cmd/cmd_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/databricks/cli/experimental/accessexplain"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeReader is an accessReader stub keyed by securable full name.
+type fakeReader struct {
+	user        string
+	effective   map[string][]accessexplain.HeldPrivilege
+	masks       []accessexplain.Mask
+	legacyMasks []accessexplain.Mask
+	// principal resolution. Defaults to a found user; set principalMissing to
+	// simulate a non-existent principal, or resolveErr for an unverifiable lookup.
+	principalKind    string
+	principalMissing bool
+	resolveErr       error
+}
+
+func (f *fakeReader) ResolvePrincipal(ctx context.Context, name string) (string, bool, error) {
+	if f.resolveErr != nil {
+		return "", false, f.resolveErr
+	}
+	if f.principalMissing {
+		return "", false, nil
+	}
+	kind := f.principalKind
+	if kind == "" {
+		kind = "user"
+	}
+	return kind, true, nil
+}
+
+func (f *fakeReader) Effective(ctx context.Context, securableType, fullName, principal string) ([]accessexplain.HeldPrivilege, error) {
+	return f.effective[fullName], nil
+}
+
+func (f *fakeReader) ColumnMasks(ctx context.Context, tableFullName, principal string) ([]accessexplain.Mask, error) {
+	return f.masks, nil
+}
+
+func (f *fakeReader) LegacyColumnMasks(ctx context.Context, tableFullName string) ([]accessexplain.Mask, error) {
+	return f.legacyMasks, nil
+}
+
+func (f *fakeReader) CurrentUser(ctx context.Context) (string, error) {
+	return f.user, nil
+}
+
+func held(names ...string) []accessexplain.HeldPrivilege {
+	var out []accessexplain.HeldPrivilege
+	for _, n := range names {
+		out = append(out, accessexplain.HeldPrivilege{Name: n})
+	}
+	return out
+}
+
+func TestExplainAllowed(t *testing.T) {
+	r := &fakeReader{
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":                    held(accessexplain.PrivUseCatalog),
+			"prod.sales":              held(accessexplain.PrivUseSchema),
+			"prod.sales.transactions": held(accessexplain.PrivSelect),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales.transactions", "alice@databricks.test", "")
+	require.NoError(t, err)
+	assert.True(t, v.Allowed)
+	assert.Equal(t, "alice@databricks.test", v.Principal)
+	assert.Equal(t, accessexplain.PrivSelect, v.Action)
+}
+
+func TestExplainDeniedMissingUseSchema(t *testing.T) {
+	r := &fakeReader{
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":                    held(accessexplain.PrivUseCatalog),
+			"prod.sales.transactions": held(accessexplain.PrivSelect),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales.transactions", "alice@databricks.test", "")
+	require.NoError(t, err)
+	assert.False(t, v.Allowed)
+	require.Len(t, v.Fixes, 1)
+	assert.Equal(t, "GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`", v.Fixes[0])
+}
+
+func TestExplainDefaultsToCurrentUser(t *testing.T) {
+	r := &fakeReader{
+		user: "me@databricks.test",
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":       held(accessexplain.PrivUseCatalog),
+			"prod.sales": held(accessexplain.PrivUseSchema),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "me@databricks.test", v.Principal)
+	assert.True(t, v.Allowed)
+}
+
+func TestExplainSurfacesMasks(t *testing.T) {
+	r := &fakeReader{
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":                    held(accessexplain.PrivUseCatalog),
+			"prod.sales":              held(accessexplain.PrivUseSchema),
+			"prod.sales.transactions": held(accessexplain.PrivSelect),
+		},
+		masks: []accessexplain.Mask{{Column: "ssn", Policy: "pii_mask"}},
+	}
+	v, err := explain(t.Context(), r, "prod.sales.transactions", "alice@databricks.test", "")
+	require.NoError(t, err)
+	assert.True(t, v.Allowed)
+	require.Len(t, v.Masks, 1)
+	assert.Equal(t, "pii_mask", v.Masks[0].Policy)
+}
+
+func TestExplainMergesLegacyAndPolicyMasks(t *testing.T) {
+	r := &fakeReader{
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":                    held(accessexplain.PrivUseCatalog),
+			"prod.sales":              held(accessexplain.PrivUseSchema),
+			"prod.sales.transactions": held(accessexplain.PrivSelect),
+		},
+		masks:       []accessexplain.Mask{{Column: "ssn", Policy: "pii_mask"}},
+		legacyMasks: []accessexplain.Mask{{Column: "email", Function: "main.default.mask_email"}, {Column: "ssn", Function: "legacy_ssn"}},
+	}
+	v, err := explain(t.Context(), r, "prod.sales.transactions", "alice@databricks.test", "")
+	require.NoError(t, err)
+	// ssn appears once (policy wins over legacy), email from the legacy mask.
+	require.Len(t, v.Masks, 2)
+	byCol := map[string]accessexplain.Mask{}
+	for _, m := range v.Masks {
+		byCol[m.Column] = m
+	}
+	assert.Equal(t, "pii_mask", byCol["ssn"].Policy)
+	assert.Equal(t, "main.default.mask_email", byCol["email"].Function)
+}
+
+func TestColumnMaskFromPolicy(t *testing.T) {
+	colMask := func(name, col string, to, except []string) catalog.PolicyInfo {
+		return catalog.PolicyInfo{
+			Name:             name,
+			PolicyType:       catalog.PolicyTypePolicyTypeColumnMask,
+			ColumnMask:       &catalog.ColumnMaskOptions{OnColumn: col, FunctionName: "f"},
+			ToPrincipals:     to,
+			ExceptPrincipals: except,
+		}
+	}
+
+	t.Run("targets everyone", func(t *testing.T) {
+		m, ok := columnMaskFromPolicy(colMask("p", "ssn", nil, nil), "alice@x")
+		require.True(t, ok)
+		assert.Equal(t, "ssn", m.Column)
+		assert.Empty(t, m.Targets)
+	})
+
+	t.Run("group-targeted is kept with targets", func(t *testing.T) {
+		m, ok := columnMaskFromPolicy(colMask("p", "ssn", []string{"data-scientists"}, nil), "alice@x")
+		require.True(t, ok)
+		assert.Equal(t, []string{"data-scientists"}, m.Targets)
+	})
+
+	t.Run("excepted principal is dropped", func(t *testing.T) {
+		_, ok := columnMaskFromPolicy(colMask("p", "ssn", nil, []string{"alice@x"}), "alice@x")
+		assert.False(t, ok)
+	})
+
+	t.Run("row filter policy is not a column mask", func(t *testing.T) {
+		_, ok := columnMaskFromPolicy(catalog.PolicyInfo{PolicyType: catalog.PolicyTypePolicyTypeRowFilter}, "alice@x")
+		assert.False(t, ok)
+	})
+}
+
+func TestExplainInvalidSecurable(t *testing.T) {
+	r := &fakeReader{}
+	_, err := explain(t.Context(), r, "a..b", "alice@databricks.test", "")
+	assert.Error(t, err)
+}
+
+func TestExplainPrincipalNotFound(t *testing.T) {
+	r := &fakeReader{principalMissing: true}
+	_, err := explain(t.Context(), r, "prod.sales.transactions", "typo@databricks.test", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestExplainPrincipalUnverifiableProceeds(t *testing.T) {
+	// A list-permission error must not block the explanation.
+	r := &fakeReader{
+		resolveErr: errors.New("permission denied"),
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":       held(accessexplain.PrivUseCatalog),
+			"prod.sales": held(accessexplain.PrivUseSchema),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales", "alice@databricks.test", "")
+	require.NoError(t, err)
+	assert.True(t, v.Allowed)
+	assert.Empty(t, v.PrincipalKind) // unverified, so no kind reported
+}
+
+func TestExplainReportsPrincipalKind(t *testing.T) {
+	r := &fakeReader{
+		principalKind: "group",
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":       held(accessexplain.PrivUseCatalog),
+			"prod.sales": held(accessexplain.PrivUseSchema),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales", "data-scientists", "")
+	require.NoError(t, err)
+	assert.Equal(t, "group", v.PrincipalKind)
+}
+
+func TestExplainCurrentUserNotResolved(t *testing.T) {
+	// The current-user path does not run principal resolution.
+	r := &fakeReader{
+		user:             "me@databricks.test",
+		principalMissing: true,
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":       held(accessexplain.PrivUseCatalog),
+			"prod.sales": held(accessexplain.PrivUseSchema),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, "me@databricks.test", v.Principal)
+}
+
+func newRenderCmd(t *testing.T, output flags.Output) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	out := output
+	cmd.Flags().Var(&out, "output", "")
+	cmd.SetContext(t.Context())
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	return cmd, buf
+}
+
+var deniedVerdict = accessexplain.Verdict{
+	Principal: "alice@databricks.test",
+	Securable: "prod.sales.transactions",
+	Action:    "SELECT",
+	Allowed:   false,
+	Levels: []accessexplain.LevelResult{
+		{Type: "CATALOG", FullName: "prod", Needed: "USE_CATALOG", Satisfied: true, SatisfiedBy: "USE_CATALOG granted directly"},
+		{Type: "SCHEMA", FullName: "prod.sales", Needed: "USE_SCHEMA", Satisfied: false},
+		{Type: "TABLE", FullName: "prod.sales.transactions", Needed: "SELECT", Satisfied: true, SatisfiedBy: "SELECT granted directly"},
+	},
+	Masks: []accessexplain.Mask{{Column: "ssn", Policy: "pii_mask", Applies: true}},
+	Fixes: []string{"GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`"},
+}
+
+func TestRenderVerdictText(t *testing.T) {
+	cmd, buf := newRenderCmd(t, flags.OutputText)
+	require.NoError(t, renderVerdict(cmd.Context(), cmd, deniedVerdict))
+
+	s := buf.String()
+	assert.Contains(t, s, "DENIED")
+	assert.Contains(t, s, "missing USE_SCHEMA")
+	assert.Contains(t, s, "column ssn is masked by policy pii_mask")
+	assert.Contains(t, s, "GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`")
+}
+
+func TestRenderVerdictGroupTargetedMask(t *testing.T) {
+	cmd, buf := newRenderCmd(t, flags.OutputText)
+	v := accessexplain.Verdict{
+		Principal: "alice@databricks.test",
+		Securable: "prod.sales.transactions",
+		Action:    "SELECT",
+		Allowed:   true,
+		Masks:     []accessexplain.Mask{{Column: "ssn", Policy: "pii_mask", Targets: []string{"data-scientists"}, Applies: false}},
+	}
+	require.NoError(t, renderVerdict(cmd.Context(), cmd, v))
+	s := buf.String()
+	// A group-targeted policy is reported as a possibility, not asserted.
+	assert.Contains(t, s, "column ssn may be masked by policy pii_mask (targets data-scientists)")
+}
+
+func TestRenderVerdictJSON(t *testing.T) {
+	cmd, buf := newRenderCmd(t, flags.OutputJSON)
+	require.NoError(t, renderVerdict(cmd.Context(), cmd, deniedVerdict))
+
+	var got accessexplain.Verdict
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.False(t, got.Allowed)
+	assert.Len(t, got.Levels, 3)
+	assert.Len(t, got.Fixes, 1)
+}

--- a/experimental/accessexplain/cmd/cmd_test.go
+++ b/experimental/accessexplain/cmd/cmd_test.go
@@ -26,6 +26,7 @@ type fakeReader struct {
 	principalKind    string
 	principalMissing bool
 	resolveErr       error
+	maskErr          error
 }
 
 func (f *fakeReader) ResolvePrincipal(ctx context.Context, name string) (string, bool, error) {
@@ -47,7 +48,7 @@ func (f *fakeReader) Effective(ctx context.Context, securableType, fullName, pri
 }
 
 func (f *fakeReader) ColumnMasks(ctx context.Context, tableFullName, principal string) ([]accessexplain.Mask, error) {
-	return f.masks, nil
+	return f.masks, f.maskErr
 }
 
 func (f *fakeReader) LegacyColumnMasks(ctx context.Context, tableFullName string) ([]accessexplain.Mask, error) {
@@ -186,6 +187,23 @@ func TestExplainInvalidSecurable(t *testing.T) {
 	r := &fakeReader{}
 	_, err := explain(t.Context(), r, "a..b", "alice@databricks.test", "")
 	assert.Error(t, err)
+}
+
+func TestExplainMaskErrorIsNonFatal(t *testing.T) {
+	// A failure listing masks (e.g. no READ METADATA) must not abort the
+	// verdict, which is the command's core value.
+	r := &fakeReader{
+		maskErr: errors.New("User does not have READ METADATA on Table"),
+		effective: map[string][]accessexplain.HeldPrivilege{
+			"prod":                    held(accessexplain.PrivUseCatalog),
+			"prod.sales":              held(accessexplain.PrivUseSchema),
+			"prod.sales.transactions": held(accessexplain.PrivSelect),
+		},
+	}
+	v, err := explain(t.Context(), r, "prod.sales.transactions", "alice@databricks.test", "")
+	require.NoError(t, err)
+	assert.True(t, v.Allowed)
+	assert.Empty(t, v.Masks)
 }
 
 func TestExplainPrincipalNotFound(t *testing.T) {

--- a/experimental/accessexplain/cmd/cmd_test.go
+++ b/experimental/accessexplain/cmd/cmd_test.go
@@ -273,9 +273,9 @@ var deniedVerdict = accessexplain.Verdict{
 	Action:    "SELECT",
 	Allowed:   false,
 	Levels: []accessexplain.LevelResult{
-		{Type: "CATALOG", FullName: "prod", Needed: "USE_CATALOG", Satisfied: true, SatisfiedBy: "USE_CATALOG granted directly"},
+		{Type: "CATALOG", FullName: "prod", Needed: "USE_CATALOG", Satisfied: true, SatisfiedBy: "USE_CATALOG granted on this catalog"},
 		{Type: "SCHEMA", FullName: "prod.sales", Needed: "USE_SCHEMA", Satisfied: false},
-		{Type: "TABLE", FullName: "prod.sales.transactions", Needed: "SELECT", Satisfied: true, SatisfiedBy: "SELECT granted directly"},
+		{Type: "TABLE", FullName: "prod.sales.transactions", Needed: "SELECT", Satisfied: true, SatisfiedBy: "SELECT granted on this table"},
 	},
 	Masks: []accessexplain.Mask{{Column: "ssn", Policy: "pii_mask", Applies: true}},
 	Fixes: []string{"GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`"},

--- a/experimental/accessexplain/explain.go
+++ b/experimental/accessexplain/explain.go
@@ -209,18 +209,21 @@ func Evaluate(in Input) Verdict {
 func satisfies(level Level) (bool, string) {
 	for _, h := range level.Held {
 		if h.Name == level.Needed || h.Name == PrivAllPrivileges {
-			return true, satisfiedByLabel(h)
+			return true, satisfiedByLabel(h, level.Type)
 		}
 	}
 	return false, ""
 }
 
-// satisfiedByLabel describes how a privilege was conveyed.
-func satisfiedByLabel(h HeldPrivilege) string {
+// satisfiedByLabel describes how a privilege is conveyed: inherited from a
+// parent securable, or assigned at this securable. It deliberately does not say
+// "directly", because the effective-permissions API does not reveal whether the
+// privilege is granted to the principal itself or to a group it belongs to.
+func satisfiedByLabel(h HeldPrivilege, securableType string) string {
 	if h.InheritedFromName != "" {
 		return fmt.Sprintf("%s inherited from %s %s", h.Name, strings.ToLower(h.InheritedFromType), h.InheritedFromName)
 	}
-	return h.Name + " granted directly"
+	return fmt.Sprintf("%s granted on this %s", h.Name, strings.ToLower(securableType))
 }
 
 // grantStatement builds the UC GRANT that confers the needed privilege. The

--- a/experimental/accessexplain/explain.go
+++ b/experimental/accessexplain/explain.go
@@ -1,0 +1,278 @@
+// Package accessexplain traces why a principal can or cannot access a Unity
+// Catalog securable and explains the verdict in plain language, with the exact
+// GRANT to fix a denial.
+//
+// As with the auth doctor, the engine is pure: ParseSecurable builds the
+// required-privilege chain, the cmd layer fills in the effective privileges and
+// masking policies via the SDK, and Evaluate computes the verdict
+// deterministically. Unity Catalog has no boolean "can P do A on S?" endpoint,
+// so the verdict is computed by checking the effective-privilege set returned
+// by Grants.GetEffective against the required set (USE CATALOG + USE SCHEMA +
+// the leaf privilege).
+package accessexplain
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Securable types, matching the SDK SecurableType enum string values.
+const (
+	SecurableCatalog = "CATALOG"
+	SecurableSchema  = "SCHEMA"
+	SecurableTable   = "TABLE"
+)
+
+// Privileges, matching the SDK Privilege enum string values.
+const (
+	PrivUseCatalog    = "USE_CATALOG"
+	PrivUseSchema     = "USE_SCHEMA"
+	PrivSelect        = "SELECT"
+	PrivAllPrivileges = "ALL_PRIVILEGES"
+)
+
+// LevelSpec is one securable in the privilege chain the principal must satisfy,
+// with the privilege required at that level. The cmd layer queries effective
+// permissions per spec.
+type LevelSpec struct {
+	Type     string `json:"type"`
+	FullName string `json:"full_name"`
+	Needed   string `json:"needed"`
+}
+
+// HeldPrivilege is one effective privilege a principal holds at a securable,
+// with its inheritance source (empty when granted directly).
+type HeldPrivilege struct {
+	Name              string `json:"name"`
+	InheritedFromType string `json:"inherited_from_type,omitempty"`
+	InheritedFromName string `json:"inherited_from_name,omitempty"`
+}
+
+// Level is a LevelSpec plus the privileges the principal effectively holds there.
+type Level struct {
+	LevelSpec
+	Held []HeldPrivilege `json:"held"`
+}
+
+// Mask is a column-masking policy on the table. Targets lists the principals
+// the policy applies to (empty means everyone). Applies is true when the policy
+// definitely covers the requested principal (it targets everyone or names the
+// principal directly); it is false when the policy targets other
+// principals/groups and may only apply via group membership, which cannot be
+// resolved locally. Such policies are reported (not dropped) with Applies=false
+// so the explanation neither hides a possible mask nor asserts a false one.
+type Mask struct {
+	Column   string   `json:"column"`
+	Policy   string   `json:"policy"`
+	Function string   `json:"function,omitempty"`
+	Targets  []string `json:"targets,omitempty"`
+	Applies  bool     `json:"applies"`
+}
+
+// Input is the full trace the verdict is computed from.
+type Input struct {
+	Principal string  `json:"principal"`
+	Securable string  `json:"securable"`
+	Action    string  `json:"action"`
+	Levels    []Level `json:"levels"`
+	Masks     []Mask  `json:"masks,omitempty"`
+}
+
+// LevelResult is the per-level verdict.
+type LevelResult struct {
+	Type        string          `json:"type"`
+	FullName    string          `json:"full_name"`
+	Needed      string          `json:"needed"`
+	Held        []HeldPrivilege `json:"held"`
+	Satisfied   bool            `json:"satisfied"`
+	SatisfiedBy string          `json:"satisfied_by,omitempty"`
+}
+
+// Verdict is the explained access decision.
+type Verdict struct {
+	Principal string `json:"principal"`
+	// PrincipalKind is the resolved principal type ("user", "group", or
+	// "service principal") when it could be verified via SCIM; empty otherwise.
+	PrincipalKind string        `json:"principal_kind,omitempty"`
+	Securable     string        `json:"securable"`
+	Action        string        `json:"action"`
+	Allowed       bool          `json:"allowed"`
+	Levels        []LevelResult `json:"levels"`
+	Masks         []Mask        `json:"masks,omitempty"`
+	// Fixes are GRANT statements that resolve a denial, one per missing level.
+	Fixes []string `json:"fixes,omitempty"`
+}
+
+// ParseSecurable builds the required-privilege chain for a dotted securable
+// name. A 1-part name is a catalog, 2-part a schema, 3-part a table.
+//
+// The USE hierarchy is always required: USE CATALOG on the catalog and (for a
+// schema or table) USE SCHEMA on the schema. action is an ADDITIONAL privilege
+// required at the leaf securable. When action is empty it defaults to the
+// natural read action: USE CATALOG for a catalog, USE SCHEMA for a schema,
+// SELECT for a table. A non-default action adds a level rather than replacing
+// the USE privilege, so e.g. CREATE_TABLE on a schema still requires USE SCHEMA.
+func ParseSecurable(name, action string) ([]LevelSpec, error) {
+	parts := strings.Split(name, ".")
+	for _, p := range parts {
+		if strings.TrimSpace(p) == "" {
+			return nil, fmt.Errorf("invalid securable %q: empty name component", name)
+		}
+	}
+
+	action = normalizePrivilege(action)
+	catalog := parts[0]
+
+	switch len(parts) {
+	case 1:
+		return withLeafAction([]LevelSpec{
+			{Type: SecurableCatalog, FullName: catalog, Needed: PrivUseCatalog},
+		}, SecurableCatalog, catalog, action, PrivUseCatalog), nil
+	case 2:
+		schema := catalog + "." + parts[1]
+		return withLeafAction([]LevelSpec{
+			{Type: SecurableCatalog, FullName: catalog, Needed: PrivUseCatalog},
+			{Type: SecurableSchema, FullName: schema, Needed: PrivUseSchema},
+		}, SecurableSchema, schema, action, PrivUseSchema), nil
+	case 3:
+		schema := catalog + "." + parts[1]
+		table := schema + "." + parts[2]
+		// A table has no USE privilege of its own; the leaf action (SELECT by
+		// default) is the table-level requirement on top of the USE hierarchy.
+		return []LevelSpec{
+			{Type: SecurableCatalog, FullName: catalog, Needed: PrivUseCatalog},
+			{Type: SecurableSchema, FullName: schema, Needed: PrivUseSchema},
+			{Type: SecurableTable, FullName: table, Needed: orDefault(action, PrivSelect)},
+		}, nil
+	default:
+		return nil, fmt.Errorf("invalid securable %q: expected catalog[.schema[.table]], got %d parts", name, len(parts))
+	}
+}
+
+// withLeafAction appends an extra leaf-level requirement when action is set and
+// differs from the leaf's USE privilege (which the chain already requires).
+func withLeafAction(specs []LevelSpec, leafType, leafName, action, usePriv string) []LevelSpec {
+	if action != "" && action != usePriv {
+		specs = append(specs, LevelSpec{Type: leafType, FullName: leafName, Needed: action})
+	}
+	return specs
+}
+
+// orDefault returns action when non-empty, else the default privilege.
+func orDefault(action, def string) string {
+	if action != "" {
+		return action
+	}
+	return def
+}
+
+// normalizePrivilege canonicalizes a user-supplied privilege to the SDK enum
+// form: upper-cased with spaces replaced by underscores, so "use schema",
+// "USE SCHEMA", and "USE_SCHEMA" all become "USE_SCHEMA".
+func normalizePrivilege(p string) string {
+	return strings.ReplaceAll(strings.ToUpper(strings.TrimSpace(p)), " ", "_")
+}
+
+// Evaluate computes the access verdict from the trace. A level is satisfied
+// when the principal holds the needed privilege (directly or by inheritance) or
+// ALL_PRIVILEGES. Access is allowed only when every level is satisfied.
+func Evaluate(in Input) Verdict {
+	v := Verdict{
+		Principal: in.Principal,
+		Securable: in.Securable,
+		Action:    in.Action,
+		Allowed:   true,
+		Masks:     in.Masks,
+	}
+
+	for _, level := range in.Levels {
+		held, by := satisfies(level)
+		lr := LevelResult{
+			Type:        level.Type,
+			FullName:    level.FullName,
+			Needed:      level.Needed,
+			Held:        level.Held,
+			Satisfied:   held,
+			SatisfiedBy: by,
+		}
+		v.Levels = append(v.Levels, lr)
+		if !held {
+			v.Allowed = false
+			v.Fixes = append(v.Fixes, grantStatement(level.Needed, level.Type, level.FullName, in.Principal))
+		}
+	}
+
+	return v
+}
+
+// satisfies reports whether the level's needed privilege is held, and how.
+func satisfies(level Level) (bool, string) {
+	for _, h := range level.Held {
+		if h.Name == level.Needed || h.Name == PrivAllPrivileges {
+			return true, satisfiedByLabel(h)
+		}
+	}
+	return false, ""
+}
+
+// satisfiedByLabel describes how a privilege was conveyed.
+func satisfiedByLabel(h HeldPrivilege) string {
+	if h.InheritedFromName != "" {
+		return fmt.Sprintf("%s inherited from %s %s", h.Name, strings.ToLower(h.InheritedFromType), h.InheritedFromName)
+	}
+	return h.Name + " granted directly"
+}
+
+// grantStatement builds the UC GRANT that confers the needed privilege. The
+// principal is always backtick-quoted (it is an identifier in GRANT TO); the
+// securable name's parts are quoted only when they need it. Embedded backticks
+// are escaped by doubling, so the statement stays valid SQL for unusual names.
+func grantStatement(privilege, securableType, fullName, principal string) string {
+	return fmt.Sprintf("GRANT %s ON %s %s TO %s", grantPrivilege(privilege), securableType, quoteSecurable(fullName), quoteIdentifier(principal))
+}
+
+// grantPrivilege renders an SDK privilege enum (USE_SCHEMA) as GRANT syntax
+// (USE SCHEMA).
+func grantPrivilege(privilege string) string {
+	return strings.ReplaceAll(privilege, "_", " ")
+}
+
+// quoteSecurable backtick-quotes each dot-separated part of a securable name
+// that needs quoting, leaving simple identifiers unquoted for readability.
+func quoteSecurable(fullName string) string {
+	parts := strings.Split(fullName, ".")
+	for i, p := range parts {
+		if needsQuoting(p) {
+			parts[i] = quoteIdentifier(p)
+		}
+	}
+	return strings.Join(parts, ".")
+}
+
+// quoteIdentifier backtick-quotes an identifier, escaping embedded backticks by
+// doubling them per the SQL identifier-quoting rule.
+func quoteIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// needsQuoting reports whether a securable name part must be delimited: it is
+// empty, contains a character outside [A-Za-z0-9_], or is all digits (Databricks
+// SQL requires all-digit identifiers to be quoted).
+func needsQuoting(part string) bool {
+	if part == "" {
+		return true
+	}
+	allDigits := true
+	for _, r := range part {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+		isDigit := r >= '0' && r <= '9'
+		if !isLetter && !isDigit && r != '_' {
+			return true
+		}
+		if !isDigit {
+			allDigits = false
+		}
+	}
+	// Databricks SQL requires an all-digit identifier to be delimited.
+	return allDigits
+}

--- a/experimental/accessexplain/explain_test.go
+++ b/experimental/accessexplain/explain_test.go
@@ -1,0 +1,209 @@
+package accessexplain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSecurable(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		action string
+		want   []LevelSpec
+	}{
+		{
+			name: "catalog",
+			in:   "prod",
+			want: []LevelSpec{{SecurableCatalog, "prod", PrivUseCatalog}},
+		},
+		{
+			name: "schema",
+			in:   "prod.sales",
+			want: []LevelSpec{
+				{SecurableCatalog, "prod", PrivUseCatalog},
+				{SecurableSchema, "prod.sales", PrivUseSchema},
+			},
+		},
+		{
+			name: "table",
+			in:   "prod.sales.transactions",
+			want: []LevelSpec{
+				{SecurableCatalog, "prod", PrivUseCatalog},
+				{SecurableSchema, "prod.sales", PrivUseSchema},
+				{SecurableTable, "prod.sales.transactions", PrivSelect},
+			},
+		},
+		{
+			name:   "table with action override",
+			in:     "prod.sales.transactions",
+			action: "modify",
+			want: []LevelSpec{
+				{SecurableCatalog, "prod", PrivUseCatalog},
+				{SecurableSchema, "prod.sales", PrivUseSchema},
+				{SecurableTable, "prod.sales.transactions", "MODIFY"},
+			},
+		},
+		{
+			// A non-default action on a schema must NOT drop USE SCHEMA.
+			name:   "schema with action keeps USE SCHEMA",
+			in:     "prod.sales",
+			action: "create table",
+			want: []LevelSpec{
+				{SecurableCatalog, "prod", PrivUseCatalog},
+				{SecurableSchema, "prod.sales", PrivUseSchema},
+				{SecurableSchema, "prod.sales", "CREATE_TABLE"},
+			},
+		},
+		{
+			name:   "catalog with action keeps USE CATALOG",
+			in:     "prod",
+			action: "CREATE_SCHEMA",
+			want: []LevelSpec{
+				{SecurableCatalog, "prod", PrivUseCatalog},
+				{SecurableCatalog, "prod", "CREATE_SCHEMA"},
+			},
+		},
+		{
+			name:   "action equal to use privilege is not duplicated",
+			in:     "prod.sales",
+			action: "use schema",
+			want: []LevelSpec{
+				{SecurableCatalog, "prod", PrivUseCatalog},
+				{SecurableSchema, "prod.sales", PrivUseSchema},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSecurable(tt.in, tt.action)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseSecurableInvalid(t *testing.T) {
+	for _, in := range []string{"", "a.", ".b", "a..b", "a.b.c.d"} {
+		_, err := ParseSecurable(in, "")
+		assert.Error(t, err, "expected error for %q", in)
+	}
+}
+
+// tableLevels builds a 3-level table trace with the given held privileges.
+func tableLevels(catalogP, schemaP, tableP []HeldPrivilege) []Level {
+	return []Level{
+		{LevelSpec: LevelSpec{SecurableCatalog, "prod", PrivUseCatalog}, Held: catalogP},
+		{LevelSpec: LevelSpec{SecurableSchema, "prod.sales", PrivUseSchema}, Held: schemaP},
+		{LevelSpec: LevelSpec{SecurableTable, "prod.sales.transactions", PrivSelect}, Held: tableP},
+	}
+}
+
+func held(names ...string) []HeldPrivilege {
+	var out []HeldPrivilege
+	for _, n := range names {
+		out = append(out, HeldPrivilege{Name: n})
+	}
+	return out
+}
+
+func TestEvaluateAllowed(t *testing.T) {
+	in := Input{
+		Principal: "alice@databricks.test",
+		Securable: "prod.sales.transactions",
+		Action:    PrivSelect,
+		Levels: tableLevels(
+			held(PrivUseCatalog),
+			held(PrivUseSchema),
+			held(PrivSelect),
+		),
+	}
+	v := Evaluate(in)
+	assert.True(t, v.Allowed)
+	assert.Empty(t, v.Fixes)
+	for _, l := range v.Levels {
+		assert.True(t, l.Satisfied)
+	}
+}
+
+func TestEvaluateMissingUseSchema(t *testing.T) {
+	// The classic gotcha: SELECT on the table but no USE SCHEMA on the schema.
+	in := Input{
+		Principal: "alice@databricks.test",
+		Securable: "prod.sales.transactions",
+		Action:    PrivSelect,
+		Levels: tableLevels(
+			held(PrivUseCatalog),
+			nil,
+			held(PrivSelect),
+		),
+	}
+	v := Evaluate(in)
+	assert.False(t, v.Allowed)
+	require.Len(t, v.Fixes, 1)
+	assert.Equal(t, "GRANT USE SCHEMA ON SCHEMA prod.sales TO `alice@databricks.test`", v.Fixes[0])
+
+	// The schema level is the only unsatisfied one.
+	assert.True(t, v.Levels[0].Satisfied)
+	assert.False(t, v.Levels[1].Satisfied)
+	assert.True(t, v.Levels[2].Satisfied)
+}
+
+func TestEvaluateInheritedSatisfaction(t *testing.T) {
+	in := Input{
+		Principal: "alice@databricks.test",
+		Securable: "prod.sales.transactions",
+		Action:    PrivSelect,
+		Levels: tableLevels(
+			held(PrivUseCatalog),
+			held(PrivUseSchema),
+			[]HeldPrivilege{{Name: PrivSelect, InheritedFromType: "CATALOG", InheritedFromName: "prod"}},
+		),
+	}
+	v := Evaluate(in)
+	assert.True(t, v.Allowed)
+	assert.Equal(t, "SELECT inherited from catalog prod", v.Levels[2].SatisfiedBy)
+}
+
+func TestEvaluateAllPrivileges(t *testing.T) {
+	in := Input{
+		Principal: "alice@databricks.test",
+		Securable: "prod.sales.transactions",
+		Action:    PrivSelect,
+		Levels: tableLevels(
+			held(PrivAllPrivileges),
+			held(PrivAllPrivileges),
+			held(PrivAllPrivileges),
+		),
+	}
+	v := Evaluate(in)
+	assert.True(t, v.Allowed)
+	assert.Contains(t, v.Levels[2].SatisfiedBy, "ALL_PRIVILEGES")
+}
+
+func TestEvaluateCarriesMasks(t *testing.T) {
+	in := Input{
+		Principal: "alice@databricks.test",
+		Securable: "prod.sales.transactions",
+		Action:    PrivSelect,
+		Levels:    tableLevels(held(PrivUseCatalog), held(PrivUseSchema), held(PrivSelect)),
+		Masks:     []Mask{{Column: "ssn", Policy: "pii_mask", Function: "main.default.mask_ssn"}},
+	}
+	v := Evaluate(in)
+	assert.True(t, v.Allowed)
+	require.Len(t, v.Masks, 1)
+	assert.Equal(t, "ssn", v.Masks[0].Column)
+}
+
+func TestGrantStatement(t *testing.T) {
+	assert.Equal(t, "GRANT USE CATALOG ON CATALOG prod TO `g`", grantStatement(PrivUseCatalog, SecurableCatalog, "prod", "g"))
+	assert.Equal(t, "GRANT SELECT ON TABLE prod.s.t TO `u@x`", grantStatement(PrivSelect, SecurableTable, "prod.s.t", "u@x"))
+	// A backtick in the principal is escaped by doubling.
+	assert.Equal(t, "GRANT SELECT ON TABLE prod.s.t TO `we``ird`", grantStatement(PrivSelect, SecurableTable, "prod.s.t", "we`ird"))
+	// A securable name part with special characters is quoted; simple parts are not.
+	assert.Equal(t, "GRANT SELECT ON TABLE prod.`my-schema`.t TO `g`", grantStatement(PrivSelect, SecurableTable, "prod.my-schema.t", "g"))
+	// An all-digit name part must be delimited.
+	assert.Equal(t, "GRANT SELECT ON TABLE prod.`123`.t TO `g`", grantStatement(PrivSelect, SecurableTable, "prod.123.t", "g"))
+}

--- a/experimental/authdoctor/checks.go
+++ b/experimental/authdoctor/checks.go
@@ -193,18 +193,18 @@ func checkHost(s Snapshot) []Finding {
 			Detail: s.Host + " serves both account and workspace APIs.",
 		}}
 	default:
-		f := Finding{
+		// account_id on a workspace host is harmless for workspace commands (it
+		// is only used for account-scoped operations), so it is noted, not warned.
+		detail := s.Host
+		if s.AccountID != "" {
+			detail = fmt.Sprintf("%s (account_id=%s is set; used only for account-scoped commands).", s.Host, s.AccountID)
+		}
+		return []Finding{{
 			Check:  checkNameHost,
 			Level:  LevelOK,
 			Title:  "Host is a workspace URL",
-			Detail: s.Host,
-		}
-		if s.AccountID != "" {
-			f.Level = LevelWarn
-			f.Title = "account_id set on a workspace host"
-			f.Detail = fmt.Sprintf("%s is a workspace URL but account_id=%s is set; account commands will not work against a workspace host.", s.Host, s.AccountID)
-		}
-		return []Finding{f}
+			Detail: detail,
+		}}
 	}
 }
 
@@ -276,11 +276,14 @@ func checkToken(s Snapshot) []Finding {
 		expired := !s.Token.Expiry.IsZero() && !s.Token.Expiry.After(s.Now)
 		switch {
 		case expired && s.Token.HasRefresh:
+			// The cached access token expires hourly; with a refresh token this
+			// is the normal state and renews transparently on the next call, so
+			// it is not a problem worth flagging.
 			out = append(out, Finding{
 				Check:  checkNameToken,
-				Level:  LevelWarn,
-				Title:  "Access token expired but a refresh token is present",
-				Detail: fmt.Sprintf("Expired at %s. The CLI should refresh it automatically on the next call.", formatExpiry(s.Token.Expiry, s.Now)),
+				Level:  LevelOK,
+				Title:  "Cached access token expired; will auto-refresh",
+				Detail: fmt.Sprintf("Expired at %s, but a refresh token is present, so the CLI renews it on the next call.", formatExpiry(s.Token.Expiry, s.Now)),
 			})
 		case expired && !s.Token.HasRefresh:
 			out = append(out, Finding{

--- a/experimental/authdoctor/checks.go
+++ b/experimental/authdoctor/checks.go
@@ -1,0 +1,439 @@
+package authdoctor
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/libs/shellquote"
+)
+
+// Check names, used as the Check field on findings and as stable keys for JSON
+// consumers and tests.
+const (
+	checkNameResolution   = "resolution"
+	checkNameHost         = "host"
+	checkNameAuthType     = "auth_type"
+	checkNameToken        = "token"
+	checkNameScopes       = "scopes"
+	checkNameClock        = "clock"
+	checkNameConnectivity = "connectivity"
+)
+
+// clockSkewThreshold is how far the local clock may drift from the server before
+// the doctor warns; OAuth/token validation typically tolerates a few minutes.
+const clockSkewThreshold = 5 * time.Minute
+
+// Host classifications. Exported so the cmd layer fills Snapshot.HostType with
+// the same labels checkHost compares on.
+const (
+	HostTypeWorkspace = "workspace"
+	HostTypeAccount   = "account"
+	HostTypeUnified   = "unified"
+)
+
+// checkResolution reports the effective profile/host/auth type and flags the
+// cases where the CLI's divergent resolution paths would pick different
+// credentials from the same environment. This is the doctor's signature check.
+func checkResolution(s Snapshot) []Finding {
+	var out []Finding
+
+	if s.Host == "" && s.Profile == "" {
+		return []Finding{{
+			Check:  checkNameResolution,
+			Level:  LevelError,
+			Title:  "No profile or host resolved",
+			Detail: "Neither a profile nor a host could be resolved from flags, environment variables, or ~/.databrickscfg.",
+			Fix:    "databricks auth login --host <workspace-url>",
+		}}
+	}
+
+	profile := s.Profile
+	if profile == "" {
+		profile = "(none)"
+	}
+	out = append(out, Finding{
+		Check:  checkNameResolution,
+		Level:  LevelOK,
+		Title:  fmt.Sprintf("Resolved profile %q from %s", profile, s.ProfileSource),
+		Detail: fmt.Sprintf("host=%s, auth_type=%s", emptyDash(s.Host), emptyDash(s.AuthType)),
+	})
+
+	// Config that did not validate still resolves partial values above, but the
+	// SDK would reject it, so surface the error rather than letting it look fine.
+	if s.ConfigError != "" {
+		out = append(out, Finding{
+			Check:  checkNameResolution,
+			Level:  LevelError,
+			Title:  "Configuration did not resolve cleanly",
+			Detail: s.ConfigError,
+			Fix:    loginFix(s.Profile),
+		})
+	}
+
+	// DATABRICKS_HOST overrides the profile's host (env attributes take
+	// precedence over the profile in the SDK), while the profile still supplies
+	// the token/auth type, so the token can be sent to the wrong host. --profile
+	// does NOT undo this: the env attribute still wins, so the only fix is to
+	// unset DATABRICKS_HOST. This env-first ordering also means `databricks auth
+	// token` lands on the env host, so it diverges from the profile too.
+	if s.EnvHost != "" && s.ProfileHost != "" && !sameHost(s.EnvHost, s.ProfileHost) {
+		out = append(out, Finding{
+			Check:  checkNameResolution,
+			Level:  LevelWarn,
+			Title:  "DATABRICKS_HOST overrides the profile host",
+			Detail: fmt.Sprintf("Environment host %s shadows profile %q host %s; the profile's credentials are sent to the environment host.", s.EnvHost, s.Profile, s.ProfileHost),
+			Fix:    "unset DATABRICKS_HOST (or set it to the profile host)",
+		})
+	}
+
+	// DATABRICKS_TOKEN interacts with the profile differently depending on
+	// whether the profile pins auth_type. With no explicit auth_type the SDK
+	// tries PAT first, so the env token wins; with auth_type pinned to a
+	// non-pat type the SDK uses only that strategy, so the env token is ignored.
+	if s.EnvToken != "" && s.Profile != "" {
+		if s.ExplicitAuthType != "" && !strings.EqualFold(s.ExplicitAuthType, "pat") {
+			out = append(out, Finding{
+				Check:  checkNameResolution,
+				Level:  LevelWarn,
+				Title:  "DATABRICKS_TOKEN is set but ignored",
+				Detail: fmt.Sprintf("Profile %q pins auth_type=%s, so the CLI uses that and ignores the personal access token in DATABRICKS_TOKEN.", s.Profile, s.ExplicitAuthType),
+				Fix:    "unset DATABRICKS_TOKEN, or remove auth_type to use the token",
+			})
+		} else {
+			out = append(out, Finding{
+				Check:  checkNameResolution,
+				Level:  LevelWarn,
+				Title:  "DATABRICKS_TOKEN overrides the profile credentials",
+				Detail: fmt.Sprintf("DATABRICKS_TOKEN is set, so the CLI authenticates with that personal access token instead of profile %q's configured credentials.", s.Profile),
+				Fix:    "unset DATABRICKS_TOKEN to use the profile's credentials",
+			})
+		}
+	}
+
+	out = append(out, checkBundleDivergence(s)...)
+
+	return out
+}
+
+// checkBundleDivergence flags a databricks.yml bundle whose workspace settings
+// would route bundle commands to different credentials than the doctor
+// resolved for normal commands.
+func checkBundleDivergence(s Snapshot) []Finding {
+	if s.BundlePath == "" {
+		return nil
+	}
+
+	// A value that still contains a "${...}" reference, or a target-specific
+	// override, is not resolved here; report the bundle's presence rather than
+	// risk a wrong comparison.
+	unevaluated := func(v string) bool { return strings.Contains(v, "${") }
+
+	switch {
+	case s.BundleProfile != "" && !unevaluated(s.BundleProfile) && s.BundleProfile != s.Profile:
+		return []Finding{{
+			Check:  checkNameResolution,
+			Level:  LevelWarn,
+			Title:  "A bundle pins a different profile",
+			Detail: fmt.Sprintf("%s sets workspace.profile=%q; bundle commands (databricks bundle ...) use it instead of profile %q.", s.BundlePath, s.BundleProfile, emptyDash(s.Profile)),
+		}}
+	case s.BundleHost != "" && !unevaluated(s.BundleHost) && !sameHost(s.BundleHost, s.Host):
+		return []Finding{{
+			Check:  checkNameResolution,
+			Level:  LevelWarn,
+			Title:  "A bundle pins a different host",
+			Detail: fmt.Sprintf("%s sets workspace.host=%s; bundle commands use it instead of %s.", s.BundlePath, s.BundleHost, emptyDash(s.Host)),
+		}}
+	default:
+		return []Finding{{
+			Check:  checkNameResolution,
+			Level:  LevelOK,
+			Title:  "A bundle is present in the working directory",
+			Detail: s.BundlePath + ": bundle commands resolve auth from the bundle and selected target, which the doctor does not fully evaluate. Run `databricks bundle validate` to see the bundle's resolved host.",
+		}}
+	}
+}
+
+// checkHost validates that the resolved host matches the kind of command the
+// user is likely running and that account scope has an account id.
+func checkHost(s Snapshot) []Finding {
+	if s.Host == "" {
+		return []Finding{{
+			Check:  checkNameHost,
+			Level:  LevelError,
+			Title:  "No host resolved",
+			Detail: "A host is required to authenticate.",
+			Fix:    "databricks auth login --host <workspace-url>",
+		}}
+	}
+
+	switch s.HostType {
+	case HostTypeAccount:
+		if s.AccountID == "" {
+			return []Finding{{
+				Check:  checkNameHost,
+				Level:  LevelError,
+				Title:  "Account console host without an account id",
+				Detail: s.Host + " is the account console, but no account_id is set. Account commands need account_id; workspace commands need a workspace URL.",
+				Fix:    "databricks auth login --host <account-console-url> --account-id <account-id>",
+			}}
+		}
+		return []Finding{{
+			Check:  checkNameHost,
+			Level:  LevelOK,
+			Title:  "Host is the account console",
+			Detail: fmt.Sprintf("%s with account_id=%s. Workspace-scoped commands will fail against this host.", s.Host, s.AccountID),
+		}}
+	case HostTypeUnified:
+		return []Finding{{
+			Check:  checkNameHost,
+			Level:  LevelOK,
+			Title:  "Host is a unified (account + workspace) host",
+			Detail: s.Host + " serves both account and workspace APIs.",
+		}}
+	default:
+		f := Finding{
+			Check:  checkNameHost,
+			Level:  LevelOK,
+			Title:  "Host is a workspace URL",
+			Detail: s.Host,
+		}
+		if s.AccountID != "" {
+			f.Level = LevelWarn
+			f.Title = "account_id set on a workspace host"
+			f.Detail = fmt.Sprintf("%s is a workspace URL but account_id=%s is set; account commands will not work against a workspace host.", s.Host, s.AccountID)
+		}
+		return []Finding{f}
+	}
+}
+
+// checkAuthType validates the credentials specific to the active auth type.
+func checkAuthType(s Snapshot) []Finding {
+	switch strings.ToLower(s.AuthType) {
+	case "pat":
+		if !s.PATPresent {
+			return []Finding{{
+				Check: checkNameAuthType,
+				Level: LevelError,
+				Title: "PAT auth selected but no token is set",
+				Fix:   "set DATABRICKS_TOKEN or add token to the profile",
+			}}
+		}
+		if !s.PATLooksValid {
+			return []Finding{{
+				Check:  checkNameAuthType,
+				Level:  LevelWarn,
+				Title:  "Token does not look like a Databricks PAT",
+				Detail: "Databricks personal access tokens start with \"dapi\".",
+			}}
+		}
+		return []Finding{{
+			Check: checkNameAuthType,
+			Level: LevelOK,
+			Title: "Personal access token is present",
+		}}
+	case "oauth-m2m":
+		if !s.ClientIDPresent || !s.ClientSecretPresent {
+			return []Finding{{
+				Check:  checkNameAuthType,
+				Level:  LevelError,
+				Title:  "OAuth M2M selected but client credentials are incomplete",
+				Detail: fmt.Sprintf("client_id present=%t, client_secret present=%t.", s.ClientIDPresent, s.ClientSecretPresent),
+				Fix:    "set client_id and client_secret (DATABRICKS_CLIENT_ID / DATABRICKS_CLIENT_SECRET)",
+			}}
+		}
+		return []Finding{{
+			Check: checkNameAuthType,
+			Level: LevelOK,
+			Title: "OAuth M2M client credentials are present",
+		}}
+	default:
+		return nil
+	}
+}
+
+// checkToken inspects the cached U2M token: presence, real expiry, and whether
+// a refresh token is available to renew it.
+func checkToken(s Snapshot) []Finding {
+	var out []Finding
+
+	if !s.Token.Found {
+		f := Finding{
+			Check: checkNameToken,
+			Level: LevelError,
+			Title: "No cached OAuth token",
+			Fix:   loginFix(s.Profile),
+		}
+		switch {
+		case s.Token.NotFoundHint != "":
+			f.Detail = s.Token.NotFoundHint
+		case s.Token.LookupErr != "":
+			f.Detail = "Token cache lookup failed: " + s.Token.LookupErr
+		}
+		out = append(out, f)
+	} else {
+		expired := !s.Token.Expiry.IsZero() && !s.Token.Expiry.After(s.Now)
+		switch {
+		case expired && s.Token.HasRefresh:
+			out = append(out, Finding{
+				Check:  checkNameToken,
+				Level:  LevelWarn,
+				Title:  "Access token expired but a refresh token is present",
+				Detail: fmt.Sprintf("Expired at %s. The CLI should refresh it automatically on the next call.", formatExpiry(s.Token.Expiry, s.Now)),
+			})
+		case expired && !s.Token.HasRefresh:
+			out = append(out, Finding{
+				Check:  checkNameToken,
+				Level:  LevelError,
+				Title:  "Access token expired and no refresh token is present",
+				Detail: fmt.Sprintf("Expired at %s and cannot be refreshed silently.", formatExpiry(s.Token.Expiry, s.Now)),
+				Fix:    loginFix(s.Profile),
+			})
+		default:
+			detail := fmt.Sprintf("Valid until %s.", formatExpiry(s.Token.Expiry, s.Now))
+			if !s.Token.HasRefresh {
+				detail += " No refresh token present (offline_access not granted), so it will not refresh after expiry."
+			}
+			out = append(out, Finding{
+				Check:  checkNameToken,
+				Level:  LevelOK,
+				Title:  "Cached OAuth token is valid",
+				Detail: detail,
+			})
+		}
+	}
+
+	if s.KeyringReachable != nil && !*s.KeyringReachable {
+		out = append(out, Finding{
+			Check:  checkNameToken,
+			Level:  LevelWarn,
+			Title:  "OS keyring is not reachable",
+			Detail: fmt.Sprintf("Token storage is %q but the keyring probe failed: %s. Token reads may fail.", s.StorageMode, emptyDash(s.KeyringProbeErr)),
+		})
+	}
+
+	return out
+}
+
+// checkScopes reports whether the profile is downscoped and explains the fix
+// for the OAuth scope errors downscoping produces.
+func checkScopes(s Snapshot) []Finding {
+	if len(s.ConfiguredScopes) == 0 || containsScope(s.ConfiguredScopes, scopeAllApis) {
+		return []Finding{{
+			Check:  checkNameScopes,
+			Level:  LevelOK,
+			Title:  "No OAuth scope restriction",
+			Detail: "The profile requests all-apis; commands are not limited by token scope.",
+		}}
+	}
+
+	// Remediation must remove the restriction, not re-request the same scopes
+	// (that would leave the profile downscoped). all-apis clears it; the user
+	// can instead pass the specific scope they need.
+	return []Finding{{
+		Check:  checkNameScopes,
+		Level:  LevelWarn,
+		Title:  "Profile is downscoped",
+		Detail: fmt.Sprintf("OAuth token is limited to scopes: %s. Commands needing another scope fail with an OAuth access_denied error.", joinScopes(s.ConfiguredScopes)),
+		Fix:    scopeFixCommand(s.Profile, []string{scopeAllApis}) + " (or add the specific scope you need)",
+	}}
+}
+
+// checkClock warns when the local clock has drifted far enough from the server
+// to break token validity windows (a cause of cryptic auth failures).
+func checkClock(s Snapshot) []Finding {
+	skew := s.ClockSkew
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew < clockSkewThreshold {
+		return []Finding{{
+			Check: checkNameClock,
+			Level: LevelOK,
+			Title: "Local clock is in sync with the server",
+		}}
+	}
+	return []Finding{{
+		Check:  checkNameClock,
+		Level:  LevelWarn,
+		Title:  "Local clock differs from the server",
+		Detail: fmt.Sprintf("Local time is off by %s from the server; large skew can break token validation. Sync your system clock (NTP).", roundDuration(skew)),
+	}}
+}
+
+// checkConnectivity interprets the best-effort connectivity probe, classifying
+// OAuth scope errors so the doctor explains downscoping failures the SDK hits.
+func checkConnectivity(s Snapshot) []Finding {
+	if s.ProbeErr == nil {
+		title := "Authenticated successfully"
+		if s.ProbeUser != "" {
+			title = "Authenticated as " + s.ProbeUser
+		}
+		return []Finding{{
+			Check: checkNameConnectivity,
+			Level: LevelOK,
+			Title: title,
+		}}
+	}
+
+	if kind, scopes, ok := ClassifyScopeError(s.ProbeErr); ok {
+		return []Finding{{
+			Check:  checkNameConnectivity,
+			Level:  LevelError,
+			Title:  scopeErrorTitle(kind),
+			Detail: scopeErrorDetail(kind, scopes, s.ProbeErr),
+			Fix:    scopeFixCommand(s.Profile, scopeFixScopes(kind, scopes, s.ConfiguredScopes)),
+		}}
+	}
+
+	return []Finding{{
+		Check:  checkNameConnectivity,
+		Level:  LevelError,
+		Title:  "Authentication check failed",
+		Detail: s.ProbeErr.Error(),
+		Fix:    loginFix(s.Profile),
+	}}
+}
+
+// loginFix builds the re-login command for a profile. The profile name is
+// shell-quoted so a name with spaces or metacharacters stays copy-paste-safe.
+func loginFix(profile string) string {
+	if profile == "" {
+		return "databricks auth login"
+	}
+	return "databricks auth login --profile " + shellquote.BashArg(profile)
+}
+
+// emptyDash renders empty strings as a dash for readable output.
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// sameHost reports whether two host strings point at the same host, ignoring
+// scheme, case, trailing slash, and query/fragment.
+func sameHost(a, b string) bool {
+	return canonicalHost(a) == canonicalHost(b)
+}
+
+func canonicalHost(h string) string {
+	h = strings.TrimSpace(strings.ToLower(h))
+	if h == "" {
+		return ""
+	}
+	if !strings.Contains(h, "://") {
+		h = "https://" + h
+	}
+	u, err := url.Parse(h)
+	if err != nil {
+		return strings.TrimSuffix(h, "/")
+	}
+	// Drop an explicit default port so ":443"/":80" compares equal to no port.
+	if port := u.Port(); (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
+		return u.Hostname()
+	}
+	return u.Host
+}

--- a/experimental/authdoctor/cmd/cmd.go
+++ b/experimental/authdoctor/cmd/cmd.go
@@ -1,0 +1,621 @@
+// Package cmd wires the auth doctor engine into the experimental command tree.
+// It owns all the I/O (config resolution, token cache, keyring, env, network
+// probe) and feeds a plain Snapshot to authdoctor.Analyze, which produces the
+// verdict deterministically.
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/experimental/authdoctor"
+	"github.com/databricks/cli/libs/auth"
+	"github.com/databricks/cli/libs/auth/storage"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/databrickscfg"
+	"github.com/databricks/cli/libs/databrickscfg/profile"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/yamlloader"
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/credentials/u2m/cache"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/spf13/cobra"
+)
+
+// probeTimeout bounds the best-effort connectivity probe so the doctor never
+// blocks for long on an unreachable host.
+const probeTimeout = 30 * time.Second
+
+// SDK auth-type strings used for local auth-type inference.
+const (
+	authTypePAT = "pat"
+	authTypeM2M = "oauth-m2m"
+	// authTypeUnknown marks a profile that carries non-U2M credentials we don't
+	// classify further; it gates out the U2M-only checks without claiming a type.
+	authTypeUnknown = "unknown"
+	patPrefix       = "dapi"
+	patTokenName    = "DATABRICKS_TOKEN"
+)
+
+// probeAuth performs the connectivity probe. It is a package variable so tests
+// can stub out the network call.
+var probeAuth = runProbe
+
+// New returns the experimental "auth" command group with the doctor subcommand.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authentication diagnostics",
+		Long:  "Authentication diagnostics that explain why auth is broken and how to fix it.",
+	}
+	cmd.AddCommand(newDoctorCommand())
+	return cmd
+}
+
+func newDoctorCommand() *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose why authentication is broken and print the fix",
+		Long: `Diagnose authentication for the active (or selected) profile and print ranked
+findings, each with a one-line fix.
+
+The doctor is best-effort and never aborts on a failed login: it resolves the
+configuration locally, reads the cached OAuth token, probes the keyring, and
+reports. In single-profile mode it also makes a best-effort authenticated call
+(bounded by a short timeout) to validate the credentials end-to-end and surface
+OAuth scope errors; --all skips that network probe.
+
+Use --profile to target a specific profile or --all for every profile.`,
+		Args: cobra.NoArgs,
+		// No PreRunE: the doctor must run even when auth is broken, so it does
+		// not gate on root.MustWorkspaceClient.
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			var reports []authdoctor.Report
+			if all {
+				profiles, err := profile.GetProfiler(ctx).LoadProfiles(ctx, profile.MatchAllProfiles)
+				if err != nil && !errors.Is(err, profile.ErrNoConfiguration) {
+					// Honor the never-abort contract: report the read failure as a
+					// finding rather than returning a bare error.
+					reports = append(reports, configErrorReport(err))
+				}
+				for _, p := range profiles {
+					s := buildSnapshot(ctx, cmd, p.Name, sourceAll, false)
+					reports = append(reports, authdoctor.Analyze(s))
+				}
+			} else {
+				name, src := resolveProfile(ctx, cmd)
+				s := buildSnapshot(ctx, cmd, name, src, true)
+				reports = append(reports, authdoctor.Analyze(s))
+			}
+
+			return renderReports(ctx, cmd, reports)
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "Diagnose every profile in the config file")
+	return cmd
+}
+
+// sourceAll is the ProfileSource label for profiles selected by --all.
+const sourceAll = "--all"
+
+// configErrorReport wraps a config-file read failure as a report so --all keeps
+// the doctor's never-abort contract instead of returning a bare error.
+func configErrorReport(err error) authdoctor.Report {
+	return authdoctor.Report{
+		Overall: authdoctor.LevelError,
+		Findings: []authdoctor.Finding{{
+			Check:  "resolution",
+			Level:  authdoctor.LevelError,
+			Title:  "Could not read the config file",
+			Detail: err.Error(),
+			Fix:    "check ~/.databrickscfg (or DATABRICKS_CONFIG_FILE) for syntax errors",
+		}},
+	}
+}
+
+// resolveProfile mirrors the normal-command profile precedence (Path A) and
+// reports which source produced the profile, so the doctor can flag the
+// [DEFAULT]-section case that `databricks api` resolves differently.
+func resolveProfile(ctx context.Context, cmd *cobra.Command) (name, source string) {
+	if f := cmd.Flag("profile"); f != nil && f.Changed && f.Value.String() != "" {
+		return f.Value.String(), authdoctor.SourceFlag
+	}
+	if p := env.Get(ctx, "DATABRICKS_CONFIG_PROFILE"); p != "" {
+		return p, authdoctor.SourceEnvProfile
+	}
+	// Pass the DATABRICKS_CONFIG_FILE path explicitly: GetConfiguredDefaultProfile
+	// defaults an empty path to ~/.databrickscfg, while ResolveDefaultProfile and
+	// the SDK honor the env var. Reading different files would let the doctor
+	// report a profile the SDK never loads.
+	configPath := env.Get(ctx, "DATABRICKS_CONFIG_FILE")
+	if dp, err := databrickscfg.GetConfiguredDefaultProfile(ctx, configPath); err == nil && dp != "" {
+		return dp, authdoctor.SourceDefaultProfile
+	}
+	if resolved := databrickscfg.ResolveDefaultProfile(ctx); resolved != "" {
+		return resolved, authdoctor.SourceDefaultSection
+	}
+	return "", authdoctor.SourceNone
+}
+
+// buildSnapshot assembles the locally observable auth state for one profile.
+// All I/O happens here; the analysis in authdoctor.Analyze stays pure.
+func buildSnapshot(ctx context.Context, cmd *cobra.Command, profileName, source string, probe bool) authdoctor.Snapshot {
+	s := authdoctor.Snapshot{
+		Profile:       profileName,
+		ProfileSource: source,
+		Now:           time.Now(),
+		EnvHost:       env.Get(ctx, "DATABRICKS_HOST"),
+		EnvToken:      env.Get(ctx, patTokenName),
+	}
+
+	// Resolve config locally. EnsureResolved would otherwise fetch host
+	// metadata over the network (and can block for minutes on an unreachable
+	// host); a no-op resolver keeps the doctor fast and offline-safe.
+	cfg := &config.Config{
+		Profile:              profileName,
+		HostMetadataResolver: func(context.Context, string) (*config.HostMetadata, error) { return nil, nil },
+	}
+	if err := cfg.EnsureResolved(); err != nil {
+		s.ConfigError = err.Error()
+	}
+	s.Host = cfg.Host
+	s.AccountID = cfg.AccountID
+	s.HostType = classifyHostType(cfg.Host)
+	s.AuthType = effectiveAuthType(cfg)
+	// cfg.AuthType is set only when explicitly pinned (profile auth_type or
+	// DATABRICKS_AUTH_TYPE); inference does not populate it.
+	s.ExplicitAuthType = cfg.AuthType
+	s.PATPresent = cfg.Token != ""
+	s.PATLooksValid = strings.HasPrefix(cfg.Token, patPrefix)
+	s.ClientIDPresent = cfg.ClientID != ""
+	s.ClientSecretPresent = cfg.ClientSecret != ""
+
+	// The profile's declared host (pre env-override) and persisted OAuth scopes
+	// come from the config file, not the resolved config.
+	if profileName != "" {
+		if p, ok := loadProfileEntry(ctx, profileName); ok {
+			s.ProfileHost = p.Host
+			s.ConfiguredScopes = splitScopes(p.Scopes)
+		}
+	}
+
+	s.BundlePath, s.BundleHost, s.BundleProfile = detectBundle(ctx)
+
+	if authdoctor.IsU2M(s.AuthType) {
+		s.Token = lookupToken(ctx, profileName)
+		fillStorageState(ctx, &s)
+	}
+
+	if probe && s.Host != "" {
+		s.ProbeAttempted = true
+		res := probeAuth(ctx, profileName, s.HostType, s.Host)
+		s.ProbeUser = res.user
+		s.ProbeErr = res.err
+		if res.hostType != "" {
+			s.HostType = res.hostType
+		}
+		if res.clockSkewKnown {
+			s.ClockSkew = res.clockSkew
+			s.ClockSkewKnown = true
+		}
+		// Reuse the CLI's shared remediation copy for ordinary auth failures so
+		// the doctor's advice matches what every other command prints. Scope
+		// errors keep the doctor's downscoping-specific fix instead.
+		if s.ProbeErr != nil {
+			if _, _, ok := authdoctor.ClassifyScopeError(s.ProbeErr); !ok {
+				s.ProbeErr = auth.EnrichAuthError(ctx, cfg, s.ProbeErr)
+			}
+		}
+	}
+
+	return s
+}
+
+// bundleFileNames are the bundle root marker filenames, matching
+// bundle/config.FileNames.
+var bundleFileNames = []string{"databricks.yml", "databricks.yaml"}
+
+// detectBundle finds the nearest databricks.yml in the working-directory tree
+// (honoring DATABRICKS_BUNDLE_ROOT) and reads its top-level workspace.host and
+// workspace.profile, best-effort. Targets, includes, and variables are not
+// expanded; values are returned verbatim so the engine can flag unevaluated
+// "${...}" references rather than compare them. Returns empty strings when no
+// bundle is present.
+func detectBundle(ctx context.Context) (path, host, profileName string) {
+	root := bundleRoot(ctx)
+	if root == "" {
+		return "", "", ""
+	}
+	for _, name := range bundleFileNames {
+		candidate := filepath.Join(root, name)
+		if _, err := os.Stat(candidate); err != nil {
+			continue
+		}
+		host, profileName = readBundleWorkspace(ctx, candidate)
+		return filepath.ToSlash(candidate), host, profileName
+	}
+	return "", "", ""
+}
+
+// bundleRoot returns the directory holding the bundle: DATABRICKS_BUNDLE_ROOT
+// when set, otherwise the nearest ancestor of the working directory containing
+// a bundle file.
+func bundleRoot(ctx context.Context) string {
+	if r := env.Get(ctx, "DATABRICKS_BUNDLE_ROOT"); r != "" {
+		return r
+	}
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		for _, name := range bundleFileNames {
+			if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// readBundleWorkspace reads workspace.host and workspace.profile from a bundle
+// file. Read failures are non-fatal (the doctor still reports the bundle's
+// presence), logged at debug.
+func readBundleWorkspace(ctx context.Context, path string) (host, profileName string) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		log.Debugf(ctx, "auth doctor: read bundle %s: %v", path, err)
+		return "", ""
+	}
+	v, err := yamlloader.LoadYAML(path, strings.NewReader(string(contents)))
+	if err != nil {
+		log.Debugf(ctx, "auth doctor: parse bundle %s: %v", path, err)
+		return "", ""
+	}
+	return bundleString(v, "host"), bundleString(v, "profile")
+}
+
+// bundleString reads workspace.<key> as a string from a bundle dyn.Value.
+func bundleString(v dyn.Value, key string) string {
+	got, err := dyn.Get(v, "workspace."+key)
+	if err != nil {
+		return ""
+	}
+	s, ok := got.AsString()
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// loadProfileEntry loads a single profile's config-file entry by name.
+func loadProfileEntry(ctx context.Context, name string) (profile.Profile, bool) {
+	profiles, err := profile.GetProfiler(ctx).LoadProfiles(ctx, profile.WithName(name))
+	if err != nil || len(profiles) == 0 {
+		return profile.Profile{}, false
+	}
+	return profiles[0], true
+}
+
+// lookupToken reads the cached U2M token for a profile. The cache key is the
+// profile name, so a host-only configuration (no profile) cannot be keyed and
+// returns an empty state.
+func lookupToken(ctx context.Context, profileName string) authdoctor.TokenState {
+	if profileName == "" {
+		return authdoctor.TokenState{}
+	}
+	store, mode, err := storage.ResolveStore(ctx, "")
+	if err != nil {
+		return authdoctor.TokenState{LookupErr: err.Error()}
+	}
+	tc := storage.OAuthTokenCache(ctx, store, mode)
+	tok, err := tc.Lookup(profileName)
+	if err != nil {
+		if errors.Is(err, cache.ErrNotFound) {
+			return authdoctor.TokenState{NotFoundHint: storage.HintForNotFound(err)}
+		}
+		return authdoctor.TokenState{LookupErr: err.Error()}
+	}
+	return authdoctor.TokenState{
+		Found:      true,
+		Expiry:     tok.Expiry,
+		HasRefresh: tok.RefreshToken != "",
+	}
+}
+
+// fillStorageState records the token-cache backend and, for secure storage,
+// whether the OS keyring is reachable.
+func fillStorageState(ctx context.Context, s *authdoctor.Snapshot) {
+	mode, src, err := storage.ResolveStorageModeWithSource(ctx, "")
+	if err != nil {
+		log.Debugf(ctx, "auth doctor: resolve storage mode: %v", err)
+		return
+	}
+	s.StorageMode = string(mode)
+	s.StorageSource = src.String()
+	if mode == storage.StorageModeSecure {
+		probeErr := storage.ProbeKeyringRead()
+		reachable := probeErr == nil
+		s.KeyringReachable = &reachable
+		if probeErr != nil {
+			s.KeyringProbeErr = probeErr.Error()
+		}
+	}
+}
+
+// probeResult is the outcome of the best-effort connectivity probe.
+type probeResult struct {
+	user string
+	// hostType is the metadata-refined classification (may be "unified"); empty
+	// keeps the prefix-based classification.
+	hostType       string
+	clockSkew      time.Duration
+	clockSkewKnown bool
+	err            error
+}
+
+// runProbe makes a best-effort identity call to validate the credentials
+// end-to-end. It builds a fresh client config from the profile so the SDK
+// performs real OIDC discovery (needed to refresh an expired U2M token) rather
+// than the no-op host-metadata resolver buildSnapshot uses for offline-safe
+// local resolution.
+//
+// The whole probe runs in a goroutine bounded by probeTimeout: client
+// construction triggers the SDK's host-metadata fetch, which uses its own
+// background context and would otherwise be unbounded on an unreachable host.
+// On timeout the goroutine is abandoned (acceptable in a short-lived CLI).
+func runProbe(ctx context.Context, profileName, hostType, host string) probeResult {
+	ch := make(chan probeResult, 1)
+	go func() {
+		ch <- doProbe(ctx, profileName, hostType, host)
+	}()
+
+	select {
+	case r := <-ch:
+		return r
+	case <-time.After(probeTimeout):
+		return probeResult{err: fmt.Errorf("authentication check timed out after %s", probeTimeout)}
+	}
+}
+
+// doProbe builds a client for the profile, calls an identity endpoint, and
+// gathers the metadata-refined host type and clock skew along the way.
+func doProbe(ctx context.Context, profileName, hostType, host string) probeResult {
+	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	res := probeResult{}
+	if skew, ok := measureClockSkew(ctx, host); ok {
+		res.clockSkew = skew
+		res.clockSkewKnown = true
+	}
+
+	if hostType == authdoctor.HostTypeAccount {
+		a, err := databricks.NewAccountClient(&databricks.Config{Profile: profileName})
+		if err != nil {
+			res.err = err
+			return res
+		}
+		// Account hosts have no Me endpoint; a successful list validates the
+		// credentials, but there is no user identity to report.
+		_, res.err = a.Workspaces.List(ctx)
+		return res
+	}
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{Profile: profileName})
+	if err != nil {
+		res.err = err
+		return res
+	}
+	me, err := w.CurrentUser.Me(ctx, iam.MeRequest{})
+	if err != nil {
+		res.err = err
+		return res
+	}
+	res.user = me.UserName
+	// Refine the host classification from resolved metadata (detects unified
+	// SPOG hosts that the URL-prefix heuristic cannot).
+	res.hostType = classifyViaMetadata(ctx, w.Config)
+	return res
+}
+
+// classifyViaMetadata maps the SDK host-metadata host type to the doctor's
+// labels, or returns "" when it cannot be resolved.
+func classifyViaMetadata(ctx context.Context, cfg *config.Config) string {
+	meta, err := cfg.DefaultHostMetadataResolver()(ctx, cfg.CanonicalHostName())
+	if err != nil || meta == nil {
+		return ""
+	}
+	switch meta.HostType {
+	case config.UnifiedHost:
+		return authdoctor.HostTypeUnified
+	case config.AccountHost:
+		return authdoctor.HostTypeAccount
+	case config.WorkspaceHost:
+		return authdoctor.HostTypeWorkspace
+	default:
+		return ""
+	}
+}
+
+// measureClockSkew reads the server's Date header via a HEAD request and returns
+// local-minus-server time. Best-effort: any failure returns ok=false.
+func measureClockSkew(ctx context.Context, host string) (time.Duration, bool) {
+	if host == "" {
+		return 0, false
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, host, nil)
+	if err != nil {
+		return 0, false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, false
+	}
+	defer resp.Body.Close()
+	serverTime, err := http.ParseTime(resp.Header.Get("Date"))
+	if err != nil {
+		return 0, false
+	}
+	return time.Since(serverTime), true
+}
+
+// effectiveAuthType returns the auth type the doctor should reason about. The
+// SDK only assigns the definitive auth type while authenticating (which the
+// doctor avoids to stay local), so when it is not set explicitly we infer it
+// from the credentials that are present. We only default to databricks-cli
+// (U2M) when there is no other credential signal at all; a profile carrying
+// basic, Azure, Google, or metadata-service config authenticates through one of
+// those strategies and must not be diagnosed as a U2M profile missing a token.
+func effectiveAuthType(cfg *config.Config) string {
+	if cfg.AuthType != "" {
+		return cfg.AuthType
+	}
+	switch {
+	case cfg.Token != "":
+		return authTypePAT
+	case cfg.ClientID != "" && cfg.ClientSecret != "":
+		return authTypeM2M
+	case hasNonU2MAuthSignal(cfg):
+		return authTypeUnknown
+	default:
+		return authdoctor.AuthTypeDatabricksCLI
+	}
+}
+
+// hasNonU2MAuthSignal reports whether the config carries credentials for a
+// non-U2M strategy (basic, Azure, Google, or metadata service). Field set per
+// the SDK config attributes (databricks-sdk-go/config/config.go).
+func hasNonU2MAuthSignal(cfg *config.Config) bool {
+	return cfg.Username != "" || cfg.Password != "" ||
+		cfg.AzureResourceID != "" || cfg.AzureClientID != "" ||
+		cfg.AzureClientSecret != "" || cfg.AzureTenantID != "" ||
+		cfg.GoogleServiceAccount != "" || cfg.GoogleCredentials != "" ||
+		cfg.MetadataServiceURL != ""
+}
+
+// accountHostPrefixes are the host prefixes that identify the account console.
+// This mirrors the heuristic in the SDK's (now deprecated) Config.HostType; the
+// doctor classifies the host for display, which is precisely the URL-pattern
+// use the SDK deprecation steers product code away from.
+var accountHostPrefixes = []string{"https://accounts.", "https://accounts-dod."}
+
+// classifyHostType labels a host as the account console or a workspace by URL
+// pattern. It does not detect unified hosts (that needs a network metadata
+// lookup the doctor avoids).
+func classifyHostType(host string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if h != "" && !strings.Contains(h, "://") {
+		h = "https://" + h
+	}
+	for _, prefix := range accountHostPrefixes {
+		if strings.HasPrefix(h, prefix) {
+			return authdoctor.HostTypeAccount
+		}
+	}
+	return authdoctor.HostTypeWorkspace
+}
+
+// splitScopes splits the comma-separated scopes persisted on a profile.
+func splitScopes(scopes string) []string {
+	var out []string
+	for s := range strings.SplitSeq(scopes, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func renderReports(ctx context.Context, cmd *cobra.Command, reports []authdoctor.Report) error {
+	switch root.OutputType(cmd) {
+	case flags.OutputText:
+		renderText(ctx, cmd, reports)
+		return nil
+	case flags.OutputJSON:
+		buf, err := json.MarshalIndent(reports, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = cmd.OutOrStdout().Write(append(buf, '\n'))
+		return err
+	default:
+		return fmt.Errorf("unknown output type %s", root.OutputType(cmd))
+	}
+}
+
+func renderText(ctx context.Context, cmd *cobra.Command, reports []authdoctor.Report) {
+	out := cmd.OutOrStdout()
+	if len(reports) == 0 {
+		fmt.Fprintln(out, "No profiles found.")
+		return
+	}
+	for i, r := range reports {
+		if i > 0 {
+			fmt.Fprintln(out)
+		}
+		header := fmt.Sprintf("Profile %q  host=%s  auth=%s", emptyDash(r.Profile), emptyDash(r.Host), emptyDash(r.AuthType))
+		fmt.Fprintln(out, cmdio.Bold(ctx, header))
+		for _, f := range r.Findings {
+			fmt.Fprintf(out, "%s %s\n", glyph(ctx, f.Level), f.Title)
+			if f.Detail != "" {
+				fmt.Fprintf(out, "    %s\n", f.Detail)
+			}
+			if f.Fix != "" {
+				fmt.Fprintf(out, "    Fix: %s\n", cmdio.Cyan(ctx, f.Fix))
+			}
+		}
+		fmt.Fprintf(out, "Overall: %s\n", coloredLevel(ctx, r.Overall))
+	}
+}
+
+// glyph returns the colored status glyph for a finding level.
+func glyph(ctx context.Context, l authdoctor.Level) string {
+	switch l {
+	case authdoctor.LevelOK:
+		return cmdio.Green(ctx, "✓")
+	case authdoctor.LevelWarn:
+		return cmdio.Yellow(ctx, "⚠")
+	default:
+		return cmdio.Red(ctx, "✗")
+	}
+}
+
+func coloredLevel(ctx context.Context, l authdoctor.Level) string {
+	switch l {
+	case authdoctor.LevelOK:
+		return cmdio.Green(ctx, "OK")
+	case authdoctor.LevelWarn:
+		return cmdio.Yellow(ctx, "WARNING")
+	default:
+		return cmdio.Red(ctx, "ERROR")
+	}
+}
+
+func emptyDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/experimental/authdoctor/cmd/cmd_test.go
+++ b/experimental/authdoctor/cmd/cmd_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/databricks/cli/experimental/authdoctor"
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitScopes(t *testing.T) {
+	assert.Nil(t, splitScopes(""))
+	assert.Equal(t, []string{"all-apis"}, splitScopes("all-apis"))
+	assert.Equal(t, []string{"jobs", "sql"}, splitScopes(" jobs , sql "))
+	assert.Equal(t, []string{"jobs"}, splitScopes("jobs,,"))
+}
+
+func TestEffectiveAuthType(t *testing.T) {
+	assert.Equal(t, "pat", effectiveAuthType(&config.Config{AuthType: "pat"}))
+	assert.Equal(t, "pat", effectiveAuthType(&config.Config{Token: "dapi123"}))
+	assert.Equal(t, "oauth-m2m", effectiveAuthType(&config.Config{ClientID: "a", ClientSecret: "b"}))
+	assert.Equal(t, authdoctor.AuthTypeDatabricksCLI, effectiveAuthType(&config.Config{}))
+	// An explicit auth_type wins over inferred credentials.
+	assert.Equal(t, "azure-cli", effectiveAuthType(&config.Config{AuthType: "azure-cli", Token: "dapi"}))
+	// A non-U2M credential signal without an explicit auth_type must NOT be
+	// inferred as databricks-cli (would trigger spurious U2M token checks).
+	assert.Equal(t, authTypeUnknown, effectiveAuthType(&config.Config{AzureResourceID: "/subscriptions/x"}))
+	assert.Equal(t, authTypeUnknown, effectiveAuthType(&config.Config{Username: "u", Password: "p"}))
+	assert.Equal(t, authTypeUnknown, effectiveAuthType(&config.Config{MetadataServiceURL: "http://localhost"}))
+	assert.False(t, authdoctor.IsU2M(authTypeUnknown))
+}
+
+func TestClassifyHostType(t *testing.T) {
+	assert.Equal(t, authdoctor.HostTypeAccount, classifyHostType("https://accounts.cloud.databricks.com"))
+	assert.Equal(t, authdoctor.HostTypeAccount, classifyHostType("accounts.cloud.databricks.com"))
+	assert.Equal(t, authdoctor.HostTypeWorkspace, classifyHostType("https://myws.cloud.databricks.com"))
+	assert.Equal(t, authdoctor.HostTypeWorkspace, classifyHostType(""))
+}
+
+func TestResolveProfileFlag(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+	require.NoError(t, cmd.Flags().Set("profile", "myprofile"))
+	cmd.SetContext(t.Context())
+
+	name, src := resolveProfile(cmd.Context(), cmd)
+	assert.Equal(t, "myprofile", name)
+	assert.Equal(t, authdoctor.SourceFlag, src)
+}
+
+func TestResolveProfileEnv(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+	ctx := env.Set(t.Context(), "DATABRICKS_CONFIG_PROFILE", "envprofile")
+	cmd.SetContext(ctx)
+
+	name, src := resolveProfile(ctx, cmd)
+	assert.Equal(t, "envprofile", name)
+	assert.Equal(t, authdoctor.SourceEnvProfile, src)
+}
+
+func newRenderCmd(t *testing.T, output flags.Output) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	out := output
+	cmd.Flags().Var(&out, "output", "")
+	cmd.SetContext(t.Context())
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	return cmd, buf
+}
+
+var sampleReports = []authdoctor.Report{{
+	Profile:  "DEFAULT",
+	Host:     "https://myworkspace.cloud.databricks.test",
+	AuthType: "databricks-cli",
+	Overall:  authdoctor.LevelWarn,
+	Findings: []authdoctor.Finding{
+		{Check: "host", Level: authdoctor.LevelOK, Title: "Host is a workspace URL"},
+		{Check: "scopes", Level: authdoctor.LevelWarn, Title: "Profile is downscoped", Detail: "limited to jobs", Fix: "databricks auth login --scopes 'all-apis'"},
+	},
+}}
+
+func TestRenderReportsJSON(t *testing.T) {
+	cmd, buf := newRenderCmd(t, flags.OutputJSON)
+	require.NoError(t, renderReports(cmd.Context(), cmd, sampleReports))
+
+	var got []authdoctor.Report
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "DEFAULT", got[0].Profile)
+	assert.Equal(t, authdoctor.LevelWarn, got[0].Overall)
+	assert.Len(t, got[0].Findings, 2)
+}
+
+func TestRenderReportsText(t *testing.T) {
+	cmd, buf := newRenderCmd(t, flags.OutputText)
+	require.NoError(t, renderReports(cmd.Context(), cmd, sampleReports))
+
+	s := buf.String()
+	assert.Contains(t, s, "Profile \"DEFAULT\"")
+	assert.Contains(t, s, "Host is a workspace URL")
+	assert.Contains(t, s, "Profile is downscoped")
+	assert.Contains(t, s, "Fix: databricks auth login --scopes 'all-apis'")
+	assert.Contains(t, s, "Overall:")
+}
+
+func TestRenderReportsTextEmpty(t *testing.T) {
+	cmd, buf := newRenderCmd(t, flags.OutputText)
+	require.NoError(t, renderReports(cmd.Context(), cmd, nil))
+	assert.Contains(t, buf.String(), "No profiles found.")
+}

--- a/experimental/authdoctor/doctor.go
+++ b/experimental/authdoctor/doctor.go
@@ -1,0 +1,226 @@
+// Package authdoctor diagnoses why CLI authentication is broken (or about to
+// break) and prints the exact command to fix it.
+//
+// The package is split in two: Analyze is a pure function over a Snapshot of
+// locally observable state (resolved config, cached token, keyring, env vars),
+// so the verdict is deterministic and unit-testable. The cmd subpackage owns
+// all the I/O that fills the Snapshot. This mirrors the "trace then narrate"
+// design: the engine produces the trace, the verdict never depends on a model.
+package authdoctor
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// AuthTypeDatabricksCLI is the SDK auth type for U2M (OAuth) login. Only this
+// auth type uses the CLI's token cache, keyring, and downscoping scopes.
+const AuthTypeDatabricksCLI = "databricks-cli"
+
+// Profile-source labels. These describe where the effective profile was
+// resolved from and double as the human-readable ProfileSource shown in output.
+// They are exported so the cmd layer sets the same labels Analyze compares on.
+const (
+	SourceFlag           = "--profile flag"
+	SourceEnvProfile     = "DATABRICKS_CONFIG_PROFILE"
+	SourceDefaultProfile = "[__settings__].default_profile"
+	SourceDefaultSection = "[DEFAULT] section"
+	SourceNone           = "no profile (host/env only)"
+)
+
+// Level ranks a finding from best to worst. Analyze sorts and summarizes on it.
+type Level string
+
+const (
+	LevelOK    Level = "ok"
+	LevelWarn  Level = "warn"
+	LevelError Level = "error"
+)
+
+// rank orders levels so the worst finding wins the summary.
+func (l Level) rank() int {
+	switch l {
+	case LevelError:
+		return 2
+	case LevelWarn:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// Finding is one diagnosis with an optional one-line remediation command.
+type Finding struct {
+	Check  string `json:"check"`
+	Level  Level  `json:"level"`
+	Title  string `json:"title"`
+	Detail string `json:"detail,omitempty"`
+	// Fix is a copy-pasteable command that resolves the finding. Empty for OK
+	// findings and for findings the user cannot fix with a single command.
+	Fix string `json:"fix,omitempty"`
+}
+
+// TokenState is the result of looking up the cached U2M token for a profile.
+// The cmd layer fills it; Analyze only interprets it. It is meaningful only
+// when the active auth type is databricks-cli.
+type TokenState struct {
+	// Found is true when a token was present in the cache.
+	Found bool
+	// Expiry is the access-token expiry; zero when unknown.
+	Expiry time.Time
+	// HasRefresh is true when the cached token carries a refresh token. Without
+	// one, an expired access token cannot be renewed silently.
+	HasRefresh bool
+	// LookupErr is the non-not-found error from the cache lookup, if any.
+	LookupErr string
+	// NotFoundHint carries the storage layer's upgrade-aware hint when the token
+	// was not found (e.g. credentials from an older CLI are no longer used).
+	NotFoundHint string
+}
+
+// Snapshot is the locally observable auth state for a single profile. Every
+// field is plain data so Analyze stays pure and testable.
+type Snapshot struct {
+	// Profile is the effective profile name. Empty when none was resolved.
+	Profile string
+	// ProfileSource describes where Profile came from (flag, env, default_profile,
+	// the [DEFAULT] section, or none).
+	ProfileSource string
+	// Host, AuthType, AccountID are the resolved effective values. AuthType is
+	// the doctor's best-effort effective auth type (inferred when not pinned).
+	Host      string
+	AuthType  string
+	AccountID string
+	// ExplicitAuthType is the auth type the config explicitly pins (profile
+	// auth_type or DATABRICKS_AUTH_TYPE), empty when none is set. With an
+	// explicit auth type the SDK uses only that strategy, so DATABRICKS_TOKEN is
+	// ignored unless the pinned type is pat.
+	ExplicitAuthType string
+	// HostType is the host classification of Host: "workspace" or "account".
+	HostType string
+	// ConfigError is the EnsureResolved error string, if config did not validate.
+	ConfigError string
+
+	// ProfileHost is the host declared for this profile in the config file,
+	// before env overrides. Used to detect DATABRICKS_HOST shadowing the profile.
+	ProfileHost string
+	// ConfiguredScopes are the OAuth scopes persisted on the profile (split).
+	ConfiguredScopes []string
+
+	// Bundle* describe a databricks.yml bundle found in the working-directory
+	// tree, if any. Bundle commands resolve auth from the bundle, diverging from
+	// normal commands. BundleProfile/BundleHost are the top-level workspace
+	// settings read best-effort; targets, includes, and variables are NOT
+	// expanded, so a value containing "${" is reported as unevaluated.
+	BundlePath    string
+	BundleProfile string
+	BundleHost    string
+
+	// EnvHost and EnvToken hold the auth-related environment variables that the
+	// resolution checks compare against the profile.
+	EnvHost  string
+	EnvToken string
+
+	// PAT / M2M presence, computed without retaining the secret value.
+	PATPresent          bool
+	PATLooksValid       bool
+	ClientIDPresent     bool
+	ClientSecretPresent bool
+
+	// Token is the cached U2M token state (databricks-cli auth only).
+	Token TokenState
+	// StorageMode and StorageSource describe the token cache backend + provenance.
+	StorageMode   string
+	StorageSource string
+	// KeyringReachable is nil when not probed (non-U2M auth), else the probe result.
+	KeyringReachable *bool
+	KeyringProbeErr  string
+
+	// Probe* hold the best-effort connectivity probe result. ProbeAttempted is
+	// false when the probe was skipped (e.g. under --all or no host).
+	ProbeAttempted bool
+	ProbeUser      string
+	ProbeErr       error
+
+	// ClockSkew is local-minus-server time; ClockSkewKnown is false when it
+	// could not be measured (e.g. under --all or no network).
+	ClockSkew      time.Duration
+	ClockSkewKnown bool
+
+	// Now is the reference time for expiry comparisons. Injected for determinism.
+	Now time.Time
+}
+
+// Report is the full diagnosis for one profile.
+type Report struct {
+	Profile  string    `json:"profile,omitempty"`
+	Host     string    `json:"host,omitempty"`
+	AuthType string    `json:"auth_type,omitempty"`
+	Overall  Level     `json:"overall"`
+	Findings []Finding `json:"findings"`
+}
+
+// Analyze runs every check against the snapshot and returns a ranked report.
+// It performs no I/O: the verdict is a deterministic function of the snapshot.
+func Analyze(s Snapshot) Report {
+	r := Report{
+		Profile:  s.Profile,
+		Host:     s.Host,
+		AuthType: s.AuthType,
+	}
+
+	r.Findings = append(r.Findings, checkResolution(s)...)
+	r.Findings = append(r.Findings, checkHost(s)...)
+	r.Findings = append(r.Findings, checkAuthType(s)...)
+	if IsU2M(s.AuthType) {
+		r.Findings = append(r.Findings, checkToken(s)...)
+		r.Findings = append(r.Findings, checkScopes(s)...)
+	}
+	if s.ClockSkewKnown {
+		r.Findings = append(r.Findings, checkClock(s)...)
+	}
+	if s.ProbeAttempted {
+		r.Findings = append(r.Findings, checkConnectivity(s)...)
+	}
+
+	r.Overall = LevelOK
+	for _, f := range r.Findings {
+		if f.Level.rank() > r.Overall.rank() {
+			r.Overall = f.Level
+		}
+	}
+	return r
+}
+
+// IsU2M reports whether authType is the U2M (OAuth) login that uses the CLI
+// token cache, keyring, and downscoping scopes.
+func IsU2M(authType string) bool {
+	return authType == AuthTypeDatabricksCLI
+}
+
+// formatExpiry renders an absolute timestamp plus a relative hint, e.g.
+// "2026-06-25 14:00:00 UTC (in 42m)" or "... (expired 2h ago)".
+func formatExpiry(expiry, now time.Time) string {
+	abs := expiry.UTC().Format("2006-01-02 15:04:05 MST")
+	d := expiry.Sub(now)
+	// d > 0 (not >=) so the boundary matches checkToken's expiry test
+	// (!Expiry.After(Now)): at exactly now, the token is expired.
+	if d > 0 {
+		return fmt.Sprintf("%s (in %s)", abs, roundDuration(d))
+	}
+	return fmt.Sprintf("%s (expired %s ago)", abs, roundDuration(-d))
+}
+
+// roundDuration trims a duration to a human-friendly unit.
+func roundDuration(d time.Duration) string {
+	if d >= time.Hour {
+		return d.Round(time.Minute).String()
+	}
+	return d.Round(time.Second).String()
+}
+
+// joinScopes renders a scope list for display.
+func joinScopes(scopes []string) string {
+	return strings.Join(scopes, ", ")
+}

--- a/experimental/authdoctor/doctor_test.go
+++ b/experimental/authdoctor/doctor_test.go
@@ -173,9 +173,11 @@ func TestAnalyzeTokenStates(t *testing.T) {
 		wantFix   bool
 	}{
 		{
+			// Expired access token with a refresh token is the normal hourly
+			// state and self-heals, so it is OK, not a warning.
 			name:      "expired with refresh",
 			mutate:    func(s *Snapshot) { s.Token.Expiry = refTime.Add(-time.Hour); s.Token.HasRefresh = true },
-			wantLevel: LevelWarn,
+			wantLevel: LevelOK,
 		},
 		{
 			name:      "expired no refresh",
@@ -271,12 +273,14 @@ func TestAnalyzeAccountHost(t *testing.T) {
 }
 
 func TestAnalyzeAccountIDOnWorkspaceHost(t *testing.T) {
+	// account_id on a workspace host is harmless for workspace commands, so it
+	// is noted informationally (OK), not warned.
 	s := healthySnapshot()
 	s.AccountID = "abc-123"
 	r := Analyze(s)
 	f := findOne(t, r, checkNameHost)
-	assert.Equal(t, LevelWarn, f.Level)
-	assert.Contains(t, f.Title, "account_id set on a workspace host")
+	assert.Equal(t, LevelOK, f.Level)
+	assert.Contains(t, f.Detail, "account-scoped")
 }
 
 func TestAnalyzeAuthTypePAT(t *testing.T) {

--- a/experimental/authdoctor/doctor_test.go
+++ b/experimental/authdoctor/doctor_test.go
@@ -1,0 +1,366 @@
+package authdoctor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var refTime = time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+// healthySnapshot returns a fully working U2M snapshot that Analyze rates OK.
+// Tests mutate one aspect to exercise a single check.
+func healthySnapshot() Snapshot {
+	reachable := true
+	return Snapshot{
+		Profile:          "DEFAULT",
+		ProfileSource:    SourceDefaultProfile,
+		Host:             "https://myworkspace.cloud.databricks.test",
+		ProfileHost:      "https://myworkspace.cloud.databricks.test",
+		HostType:         HostTypeWorkspace,
+		AuthType:         AuthTypeDatabricksCLI,
+		ConfiguredScopes: nil,
+		Token: TokenState{
+			Found:      true,
+			Expiry:     refTime.Add(time.Hour),
+			HasRefresh: true,
+		},
+		StorageMode:      "secure",
+		KeyringReachable: &reachable,
+		Now:              refTime,
+	}
+}
+
+// findOne returns the first finding for a check, requiring it exists.
+func findOne(t *testing.T, r Report, check string) Finding {
+	t.Helper()
+	for _, f := range r.Findings {
+		if f.Check == check {
+			return f
+		}
+	}
+	require.Failf(t, "missing finding", "no finding for check %q", check)
+	return Finding{}
+}
+
+func TestAnalyzeHealthyIsOK(t *testing.T) {
+	r := Analyze(healthySnapshot())
+	assert.Equal(t, LevelOK, r.Overall)
+	for _, f := range r.Findings {
+		assert.Equal(t, LevelOK, f.Level, "finding %q should be OK", f.Check)
+	}
+}
+
+func TestAnalyzeNoProfileNoHost(t *testing.T) {
+	s := Snapshot{ProfileSource: SourceNone, Now: refTime}
+	r := Analyze(s)
+	assert.Equal(t, LevelError, r.Overall)
+	f := findOne(t, r, checkNameResolution)
+	assert.Equal(t, LevelError, f.Level)
+	assert.Contains(t, f.Fix, "databricks auth login")
+}
+
+func TestAnalyzeDefaultSectionDoesNotWarn(t *testing.T) {
+	// All four resolution paths (normal, api, auth token, bundle) resolve the
+	// [DEFAULT] section identically via databrickscfg.ResolveDefaultProfile, so
+	// resolving from [DEFAULT] is not a divergence and must not warn.
+	s := healthySnapshot()
+	s.ProfileSource = SourceDefaultSection
+	r := Analyze(s)
+	assert.Equal(t, LevelOK, r.Overall)
+	for _, f := range r.Findings {
+		assert.NotContains(t, f.Detail, "databricks api")
+	}
+}
+
+func TestAnalyzeEnvHostOverridesProfile(t *testing.T) {
+	s := healthySnapshot()
+	s.EnvHost = "https://other.cloud.databricks.test"
+	r := Analyze(s)
+	assert.Equal(t, LevelWarn, r.Overall)
+
+	var titles []string
+	for _, f := range r.Findings {
+		if f.Check == checkNameResolution && f.Level == LevelWarn {
+			titles = append(titles, f.Title)
+		}
+	}
+	assert.Contains(t, titles, "DATABRICKS_HOST overrides the profile host")
+}
+
+func TestAnalyzeBundleDivergence(t *testing.T) {
+	t.Run("different profile warns", func(t *testing.T) {
+		s := healthySnapshot()
+		s.BundlePath = "/work/databricks.yml"
+		s.BundleProfile = "prod"
+		r := Analyze(s)
+		assert.Equal(t, LevelWarn, r.Overall)
+		var found bool
+		for _, f := range r.Findings {
+			if f.Title == "A bundle pins a different profile" {
+				assert.Contains(t, f.Detail, "prod")
+				found = true
+			}
+		}
+		assert.True(t, found)
+	})
+
+	t.Run("unevaluated variable does not warn", func(t *testing.T) {
+		s := healthySnapshot()
+		s.BundlePath = "/work/databricks.yml"
+		s.BundleProfile = "${var.profile}"
+		r := Analyze(s)
+		// Falls through to the informational "bundle is present" finding.
+		assert.Equal(t, LevelOK, r.Overall)
+		var found bool
+		for _, f := range r.Findings {
+			if f.Title == "A bundle is present in the working directory" {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	})
+
+	t.Run("matching profile is informational", func(t *testing.T) {
+		s := healthySnapshot()
+		s.BundlePath = "/work/databricks.yml"
+		s.BundleProfile = s.Profile
+		r := Analyze(s)
+		assert.Equal(t, LevelOK, r.Overall)
+	})
+}
+
+func TestAnalyzeEnvTokenOverridesProfile(t *testing.T) {
+	s := healthySnapshot()
+	s.EnvToken = "dapi123"
+	r := Analyze(s)
+
+	var found bool
+	for _, f := range r.Findings {
+		if f.Title == "DATABRICKS_TOKEN overrides the profile credentials" {
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestAnalyzeEnvTokenIgnoredWhenAuthTypePinned(t *testing.T) {
+	s := healthySnapshot()
+	s.EnvToken = "dapi123"
+	s.ExplicitAuthType = "databricks-cli"
+	r := Analyze(s)
+
+	var ignored, overrides bool
+	for _, f := range r.Findings {
+		switch f.Title {
+		case "DATABRICKS_TOKEN is set but ignored":
+			ignored = true
+		case "DATABRICKS_TOKEN overrides the profile credentials":
+			overrides = true
+		}
+	}
+	assert.True(t, ignored, "pinned non-pat auth_type should report the token as ignored")
+	assert.False(t, overrides)
+}
+
+func TestAnalyzeTokenStates(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Snapshot)
+		wantLevel Level
+		wantFix   bool
+	}{
+		{
+			name:      "expired with refresh",
+			mutate:    func(s *Snapshot) { s.Token.Expiry = refTime.Add(-time.Hour); s.Token.HasRefresh = true },
+			wantLevel: LevelWarn,
+		},
+		{
+			name:      "expired no refresh",
+			mutate:    func(s *Snapshot) { s.Token.Expiry = refTime.Add(-time.Hour); s.Token.HasRefresh = false },
+			wantLevel: LevelError,
+			wantFix:   true,
+		},
+		{
+			name:      "missing",
+			mutate:    func(s *Snapshot) { s.Token = TokenState{} },
+			wantLevel: LevelError,
+			wantFix:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := healthySnapshot()
+			tt.mutate(&s)
+			r := Analyze(s)
+			f := findOne(t, r, checkNameToken)
+			assert.Equal(t, tt.wantLevel, f.Level)
+			if tt.wantFix {
+				assert.Contains(t, f.Fix, "databricks auth login --profile DEFAULT")
+			}
+		})
+	}
+}
+
+func TestAnalyzeValidTokenNoRefreshNote(t *testing.T) {
+	s := healthySnapshot()
+	s.Token.HasRefresh = false
+	r := Analyze(s)
+	f := findOne(t, r, checkNameToken)
+	assert.Equal(t, LevelOK, f.Level)
+	assert.Contains(t, f.Detail, "will not refresh")
+}
+
+func TestAnalyzeKeyringUnreachable(t *testing.T) {
+	s := healthySnapshot()
+	reachable := false
+	s.KeyringReachable = &reachable
+	s.KeyringProbeErr = "keyring locked"
+	r := Analyze(s)
+	assert.Equal(t, LevelWarn, r.Overall)
+
+	var found bool
+	for _, f := range r.Findings {
+		if f.Title == "OS keyring is not reachable" {
+			assert.Contains(t, f.Detail, "keyring locked")
+			found = true
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestAnalyzeDownscoped(t *testing.T) {
+	s := healthySnapshot()
+	s.ConfiguredScopes = []string{"jobs", "sql"}
+	r := Analyze(s)
+	f := findOne(t, r, checkNameScopes)
+	assert.Equal(t, LevelWarn, f.Level)
+	assert.Contains(t, f.Detail, "jobs, sql")
+	// The fix must remove the restriction, not re-request the same scopes.
+	assert.Contains(t, f.Fix, "--scopes 'all-apis'")
+	assert.NotContains(t, f.Fix, "'jobs,sql'")
+}
+
+func TestAnalyzeAllApisIsOK(t *testing.T) {
+	s := healthySnapshot()
+	s.ConfiguredScopes = []string{"all-apis"}
+	r := Analyze(s)
+	assert.Equal(t, LevelOK, findOne(t, r, checkNameScopes).Level)
+}
+
+func TestAnalyzeAccountHost(t *testing.T) {
+	t.Run("no account id", func(t *testing.T) {
+		s := healthySnapshot()
+		s.HostType = HostTypeAccount
+		s.Host = "https://accounts.cloud.databricks.test"
+		r := Analyze(s)
+		f := findOne(t, r, checkNameHost)
+		assert.Equal(t, LevelError, f.Level)
+		assert.Contains(t, f.Fix, "--account-id")
+	})
+	t.Run("with account id", func(t *testing.T) {
+		s := healthySnapshot()
+		s.HostType = HostTypeAccount
+		s.Host = "https://accounts.cloud.databricks.test"
+		s.AccountID = "abc-123"
+		r := Analyze(s)
+		assert.Equal(t, LevelOK, findOne(t, r, checkNameHost).Level)
+	})
+}
+
+func TestAnalyzeAccountIDOnWorkspaceHost(t *testing.T) {
+	s := healthySnapshot()
+	s.AccountID = "abc-123"
+	r := Analyze(s)
+	f := findOne(t, r, checkNameHost)
+	assert.Equal(t, LevelWarn, f.Level)
+	assert.Contains(t, f.Title, "account_id set on a workspace host")
+}
+
+func TestAnalyzeAuthTypePAT(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Snapshot)
+		wantLevel Level
+	}{
+		{"valid", func(s *Snapshot) { s.PATPresent = true; s.PATLooksValid = true }, LevelOK},
+		{"missing", func(s *Snapshot) { s.PATPresent = false }, LevelError},
+		{"malformed", func(s *Snapshot) { s.PATPresent = true; s.PATLooksValid = false }, LevelWarn},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := healthySnapshot()
+			s.AuthType = "pat"
+			tt.mutate(&s)
+			r := Analyze(s)
+			assert.Equal(t, tt.wantLevel, findOne(t, r, checkNameAuthType).Level)
+		})
+	}
+}
+
+func TestAnalyzeAuthTypeM2M(t *testing.T) {
+	s := healthySnapshot()
+	s.AuthType = "oauth-m2m"
+	s.ClientIDPresent = true
+	s.ClientSecretPresent = false
+	r := Analyze(s)
+	f := findOne(t, r, checkNameAuthType)
+	assert.Equal(t, LevelError, f.Level)
+	assert.Contains(t, f.Fix, "client_id and client_secret")
+}
+
+func TestAnalyzeSkipsTokenChecksForNonU2M(t *testing.T) {
+	s := healthySnapshot()
+	s.AuthType = "pat"
+	s.PATPresent = true
+	s.PATLooksValid = true
+	s.Token = TokenState{} // would be an error finding under U2M
+	r := Analyze(s)
+	for _, f := range r.Findings {
+		assert.NotEqual(t, checkNameToken, f.Check, "PAT auth should not run token checks")
+		assert.NotEqual(t, checkNameScopes, f.Check, "PAT auth should not run scope checks")
+	}
+}
+
+func TestAnalyzeUnifiedHost(t *testing.T) {
+	s := healthySnapshot()
+	s.HostType = HostTypeUnified
+	r := Analyze(s)
+	f := findOne(t, r, checkNameHost)
+	assert.Equal(t, LevelOK, f.Level)
+	assert.Contains(t, f.Title, "unified")
+}
+
+func TestAnalyzeClockSkew(t *testing.T) {
+	t.Run("in sync", func(t *testing.T) {
+		s := healthySnapshot()
+		s.ClockSkewKnown = true
+		s.ClockSkew = 30 * time.Second
+		r := Analyze(s)
+		assert.Equal(t, LevelOK, findOne(t, r, checkNameClock).Level)
+	})
+	t.Run("skewed", func(t *testing.T) {
+		s := healthySnapshot()
+		s.ClockSkewKnown = true
+		s.ClockSkew = -10 * time.Minute
+		r := Analyze(s)
+		f := findOne(t, r, checkNameClock)
+		assert.Equal(t, LevelWarn, f.Level)
+		assert.Contains(t, f.Detail, "10m0s")
+	})
+	t.Run("not measured skips the check", func(t *testing.T) {
+		s := healthySnapshot()
+		r := Analyze(s)
+		for _, f := range r.Findings {
+			assert.NotEqual(t, checkNameClock, f.Check)
+		}
+	})
+}
+
+func TestFormatExpiry(t *testing.T) {
+	assert.Contains(t, formatExpiry(refTime.Add(90*time.Minute), refTime), "in 1h30m0s")
+	assert.Contains(t, formatExpiry(refTime.Add(-2*time.Hour), refTime), "expired 2h0m0s ago")
+	assert.Contains(t, formatExpiry(refTime.Add(time.Hour), refTime), "2026-06-25 13:00:00 UTC")
+}

--- a/experimental/authdoctor/scope.go
+++ b/experimental/authdoctor/scope.go
@@ -1,0 +1,205 @@
+package authdoctor
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/databricks/cli/libs/shellquote"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"golang.org/x/oauth2"
+)
+
+// ScopeErrorKind classifies an OAuth token-downscoping failure. These map to
+// the real, client-visible shapes (there is no "SCOPE_MISMATCH" error):
+//   - access_denied at the token endpoint: requested scopes the client lacks.
+//   - invalid_scope at the token endpoint: an unknown/malformed scope.
+//   - HTTP 403 at the API route: the token lacks a scope the route requires.
+//
+// See go/downscoping and the auth-access-doctor design doc, resolved Q5.
+type ScopeErrorKind string
+
+const (
+	ScopeErrorNotAssigned    ScopeErrorKind = "scopes_not_assigned"
+	ScopeErrorInvalid        ScopeErrorKind = "invalid_scope"
+	ScopeErrorMissingAtRoute ScopeErrorKind = "missing_required_scopes"
+)
+
+// OAuth2 error codes (RFC 6749 'error' parameter), as returned by the
+// /oidc/v1/token endpoint.
+const (
+	oauthErrAccessDenied = "access_denied"
+	oauthErrInvalidScope = "invalid_scope"
+)
+
+// scopeAllApis is the wildcard scope that removes any downscoping restriction.
+const scopeAllApis = "all-apis"
+
+// Documented substrings of the downscoping error descriptions. We branch on the
+// structured ErrorCode / StatusCode first; these refine the classification and
+// drive scope extraction for the fix command.
+const (
+	notAssignedPhrase    = "are not assigned to the client"
+	invalidScopePhrase   = "invalid scope:"
+	requiredScopesPhrase = "does not have required scopes:"
+)
+
+// ClassifyScopeError reports whether err is an OAuth scope/downscoping failure,
+// its kind, and the scope list named in the error (best-effort, for display and
+// the fix command). It branches on structured error fields, not on Error()
+// text, except for the route-level 403 which has no structured scope code.
+func ClassifyScopeError(err error) (ScopeErrorKind, string, bool) {
+	if err == nil {
+		return "", "", false
+	}
+
+	if re, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
+		desc := re.ErrorDescription
+		switch re.ErrorCode {
+		case oauthErrInvalidScope:
+			return ScopeErrorInvalid, extractAfter(desc, invalidScopePhrase), true
+		case oauthErrAccessDenied:
+			if containsFold(desc, notAssignedPhrase) {
+				return ScopeErrorNotAssigned, extractQuoted(desc), true
+			}
+		}
+	}
+
+	if ae, ok := errors.AsType[*apierr.APIError](err); ok {
+		// The route-level scope error is a plain 403 with a documented message
+		// and no structured scope code, so match the documented phrase.
+		if ae.StatusCode == http.StatusForbidden && containsFold(ae.Message, requiredScopesPhrase) {
+			return ScopeErrorMissingAtRoute, extractAfter(ae.Message, requiredScopesPhrase), true
+		}
+	}
+
+	return "", "", false
+}
+
+func scopeErrorTitle(kind ScopeErrorKind) string {
+	switch kind {
+	case ScopeErrorInvalid:
+		return "OAuth login requested an invalid scope"
+	case ScopeErrorMissingAtRoute:
+		return "OAuth token is missing a scope this command needs"
+	default:
+		return "OAuth token is missing required scopes"
+	}
+}
+
+func scopeErrorDetail(kind ScopeErrorKind, scopes string, err error) string {
+	switch kind {
+	case ScopeErrorInvalid:
+		return fmt.Sprintf("The authorization server rejected scope %q as invalid.", scopes)
+	case ScopeErrorMissingAtRoute:
+		return fmt.Sprintf("The request was rejected (403); the token lacks scope(s): %s.", emptyDash(scopes))
+	default:
+		return fmt.Sprintf("Scopes %q are not assigned to this OAuth client.", scopes)
+	}
+}
+
+// scopeFixScopes picks the scopes to request in the remediation command for a
+// scope error. An invalid scope must NOT be re-requested (it would fail the
+// same way), so for that kind we suggest the configured scopes alone (or
+// all-apis if none); for the other kinds we add the missing scope.
+func scopeFixScopes(kind ScopeErrorKind, fromError string, configured []string) []string {
+	if kind == ScopeErrorInvalid {
+		if len(configured) == 0 {
+			return []string{scopeAllApis}
+		}
+		return configured
+	}
+	return neededScopes(fromError, configured)
+}
+
+// neededScopes computes the scope set to request in the fix command: the union
+// of the currently configured scopes and the scope(s) named in the error.
+// Falls back to all-apis when nothing usable was parsed.
+func neededScopes(fromError string, configured []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	for _, s := range configured {
+		add(s)
+	}
+	for _, s := range splitScopeList(fromError) {
+		add(s)
+	}
+	if len(out) == 0 {
+		return []string{scopeAllApis}
+	}
+	return out
+}
+
+// scopeFixCommand builds the auth login command that requests the given scopes.
+// The profile name is shell-quoted so a name with spaces or metacharacters
+// stays copy-paste-safe.
+func scopeFixCommand(profile string, scopes []string) string {
+	if len(scopes) == 0 {
+		scopes = []string{scopeAllApis}
+	}
+	cmd := "databricks auth login"
+	if profile != "" {
+		cmd += " --profile " + shellquote.BashArg(profile)
+	}
+	return fmt.Sprintf("%s --scopes '%s'", cmd, strings.Join(scopes, ","))
+}
+
+func containsScope(scopes []string, want string) bool {
+	for _, s := range scopes {
+		if strings.EqualFold(strings.TrimSpace(s), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(s, sub string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(sub))
+}
+
+// extractQuoted returns the content of the first single- or double-quoted run
+// in s, or "" if none.
+func extractQuoted(s string) string {
+	for _, q := range []byte{'\'', '"'} {
+		if i := strings.IndexByte(s, q); i >= 0 {
+			if j := strings.IndexByte(s[i+1:], q); j >= 0 {
+				return s[i+1 : i+1+j]
+			}
+		}
+	}
+	return ""
+}
+
+// extractAfter returns the text following the (case-insensitive) marker,
+// trimmed, or "" if the marker is absent.
+func extractAfter(s, marker string) string {
+	idx := strings.Index(strings.ToLower(s), strings.ToLower(marker))
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(strings.Trim(s[idx+len(marker):], " '\"."))
+}
+
+// splitScopeList splits a scope list that may be comma- or space-separated.
+func splitScopeList(s string) []string {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == ' '
+	})
+	var out []string
+	for _, f := range fields {
+		f = strings.Trim(f, " '\".")
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/experimental/authdoctor/scope_test.go
+++ b/experimental/authdoctor/scope_test.go
@@ -1,0 +1,147 @@
+package authdoctor
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func TestClassifyScopeError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantKind   ScopeErrorKind
+		wantScopes string
+		wantOK     bool
+	}{
+		{
+			name:       "access_denied scopes not assigned",
+			err:        &oauth2.RetrieveError{ErrorCode: "access_denied", ErrorDescription: "Scopes 'jobs' are not assigned to the client abc-123"},
+			wantKind:   ScopeErrorNotAssigned,
+			wantScopes: "jobs",
+			wantOK:     true,
+		},
+		{
+			name:       "invalid_scope",
+			err:        &oauth2.RetrieveError{ErrorCode: "invalid_scope", ErrorDescription: "Invalid scope: bogus"},
+			wantKind:   ScopeErrorInvalid,
+			wantScopes: "bogus",
+			wantOK:     true,
+		},
+		{
+			name:       "route level missing scopes 403",
+			err:        &apierr.APIError{StatusCode: 403, Message: "Provided OAuth token does not have required scopes: sql"},
+			wantKind:   ScopeErrorMissingAtRoute,
+			wantScopes: "sql",
+			wantOK:     true,
+		},
+		{
+			name:       "wrapped oauth error",
+			err:        fmt.Errorf("login: %w", &oauth2.RetrieveError{ErrorCode: "access_denied", ErrorDescription: "Scopes 'iam.users:read' are not assigned to the client x"}),
+			wantKind:   ScopeErrorNotAssigned,
+			wantScopes: "iam.users:read",
+			wantOK:     true,
+		},
+		{
+			name:   "access_denied without scope phrase is not a scope error",
+			err:    &oauth2.RetrieveError{ErrorCode: "access_denied", ErrorDescription: "user is not allowed"},
+			wantOK: false,
+		},
+		{
+			name:   "plain 401 is not a scope error",
+			err:    &apierr.APIError{StatusCode: 401, Message: "invalid token"},
+			wantOK: false,
+		},
+		{
+			name:   "nil",
+			err:    nil,
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, scopes, ok := ClassifyScopeError(tt.err)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantKind, kind)
+				assert.Equal(t, tt.wantScopes, scopes)
+			}
+		})
+	}
+}
+
+func TestCheckConnectivity(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		s := healthySnapshot()
+		s.ProbeAttempted = true
+		s.ProbeUser = "alice@databricks.test"
+		r := Analyze(s)
+		f := findOne(t, r, checkNameConnectivity)
+		assert.Equal(t, LevelOK, f.Level)
+		assert.Contains(t, f.Title, "alice@databricks.test")
+	})
+
+	t.Run("scope error produces fix", func(t *testing.T) {
+		s := healthySnapshot()
+		s.ConfiguredScopes = []string{"sql"}
+		s.ProbeAttempted = true
+		s.ProbeErr = &oauth2.RetrieveError{ErrorCode: "access_denied", ErrorDescription: "Scopes 'jobs' are not assigned to the client abc"}
+		r := Analyze(s)
+		f := findOne(t, r, checkNameConnectivity)
+		assert.Equal(t, LevelError, f.Level)
+		// Fix should request both the configured and the missing scope.
+		assert.Contains(t, f.Fix, "sql")
+		assert.Contains(t, f.Fix, "jobs")
+	})
+
+	t.Run("invalid scope is not re-requested in the fix", func(t *testing.T) {
+		s := healthySnapshot()
+		s.ConfiguredScopes = []string{"sql"}
+		s.ProbeAttempted = true
+		s.ProbeErr = &oauth2.RetrieveError{ErrorCode: "invalid_scope", ErrorDescription: "Invalid scope: bogus"}
+		r := Analyze(s)
+		f := findOne(t, r, checkNameConnectivity)
+		assert.Equal(t, LevelError, f.Level)
+		assert.Contains(t, f.Fix, "sql")
+		assert.NotContains(t, f.Fix, "bogus")
+	})
+
+	t.Run("generic error", func(t *testing.T) {
+		s := healthySnapshot()
+		s.ProbeAttempted = true
+		s.ProbeErr = errors.New("connection refused")
+		r := Analyze(s)
+		f := findOne(t, r, checkNameConnectivity)
+		assert.Equal(t, LevelError, f.Level)
+		assert.Contains(t, f.Detail, "connection refused")
+	})
+}
+
+func TestNeededScopes(t *testing.T) {
+	assert.Equal(t, []string{"all-apis"}, neededScopes("", nil))
+	assert.Equal(t, []string{"sql", "jobs"}, neededScopes("jobs", []string{"sql"}))
+	// Dedup keeps the configured order then appends new ones.
+	assert.Equal(t, []string{"sql", "jobs"}, neededScopes("sql, jobs", []string{"sql"}))
+}
+
+func TestScopeFixCommand(t *testing.T) {
+	assert.Equal(t, "databricks auth login --profile P --scopes 'jobs,sql'", scopeFixCommand("P", []string{"jobs", "sql"}))
+	assert.Equal(t, "databricks auth login --scopes 'all-apis'", scopeFixCommand("", nil))
+	// A profile name with a space is shell-quoted so the command stays safe.
+	assert.Equal(t, "databricks auth login --profile 'my profile' --scopes 'all-apis'", scopeFixCommand("my profile", []string{"all-apis"}))
+}
+
+func TestLoginFixQuotesProfile(t *testing.T) {
+	assert.Equal(t, "databricks auth login", loginFix(""))
+	assert.Equal(t, "databricks auth login --profile P", loginFix("P"))
+	assert.Equal(t, "databricks auth login --profile 'my profile'", loginFix("my profile"))
+}
+
+func TestContainsScope(t *testing.T) {
+	assert.True(t, containsScope([]string{"All-Apis"}, "all-apis"))
+	assert.False(t, containsScope([]string{"jobs"}, "all-apis"))
+}


### PR DESCRIPTION
## Why

Authentication and authorization are the two most common ways a Databricks session fails, and today both are debugged by reading docs, guessing, pinging #help, or filing a ticket. "Why won't my auth work?" and "why can't I access this table?" have no single command that answers them.

This adds two experimental commands that do, and prints the exact command to fix the problem. They ship under the hidden `experimental` namespace so we can iterate before committing to a stable surface.

## Changes

Before: a failed login or a denied query meant reading `~/.databrickscfg` by hand, cross-referencing UC grants, and guessing. Now: one command tells you what is wrong and the exact fix.

**`databricks experimental auth doctor`** diagnoses the active (or selected) profile and prints ranked findings, each with a one-line fix. It is best-effort and never aborts on a failed login (it resolves config locally with a no-op host-metadata resolver so it cannot hang). Checks:

- Profile resolution and resolver divergence (DATABRICKS_HOST overriding the profile host, DATABRICKS_TOKEN overriding vs. ignored, a `databricks.yml` bundle pinning a different profile/host).
- Host sanity: workspace vs. account console (with unified/SPOG detection from host metadata during the probe), and `account_id` presence.
- Cached U2M token state: real expiry, refresh-token presence, keyring reachability, stale-post-upgrade hint.
- Scopes / downscoping: configured scopes plus classification of the real OAuth2 errors (`access_denied`, `invalid_scope`, the route-level 403), with the exact `auth login --scopes` fix.
- Clock skew (a cause of cryptic token failures) and auth-type specifics (PAT format, M2M client credentials).
- A best-effort connectivity probe (single-profile mode, bounded by a short timeout) that validates the credentials end-to-end and reuses the CLI's shared auth-error remediation.

**`databricks experimental access explain --on catalog.schema.table`** traces why a principal can or cannot access a Unity Catalog securable:

- Reads effective permissions per level via `Grants.GetEffective` (paginated), using inheritance provenance to build the "why" chain.
- Computes the verdict against the required set (`USE CATALOG` + `USE SCHEMA` + the leaf privilege), catching the classic gotcha: has `SELECT` but missing `USE SCHEMA`.
- Surfaces column masks (ABAC `Policies.*` and legacy `ColumnInfo.Mask`); group-targeted policies are shown as "may be masked" rather than hidden or falsely asserted.
- Verifies an explicitly named `--principal` exists via SCIM (so a typo reads as "not found", not a misleading DENIED), and prints the exact `GRANT` to fix a denial (identifiers escaped for SQL).

Both commands are deterministic (the verdict is a pure function of a snapshot; no model is involved), support `--output json`, and split a pure analysis engine from the I/O layer so the verdict logic is unit-tested in isolation. LLM narration is intentionally left as a follow-up.

The implementation was reviewed with a multi-agent adversarial pass and three rounds of an external GPT-5.5 review; findings were fixed (including a real false-positive divergence warning).

## Test plan

- [x] Unit tests for the engines (verdict logic, scope-error classification, securable parsing, GRANT escaping) and the cmd orchestration (with fakes).
- [x] Acceptance tests for both commands (text and `--output json`): `acceptance/experimental/auth/doctor` and `acceptance/experimental/access/explain`, including the denied-with-mask scenario.
- [x] `./task checks` (no dead code), `./task lint-q` (0 issues), `./task fmt-q` clean.
- [x] Manual end-to-end runs against fixture profiles.

No `NEXT_CHANGELOG.md` entry: these are experimental commands and add one when they graduate.

This pull request and its description were written by Isaac.
