### PR TITLE
acc: run destroy/jobs-and-pipeline locally

### DIFF
--- a/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/jobs-and-pipeline/output.txt
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/output.txt
@@ -14,7 +14,7 @@ Deployment complete!
 === Assert bundle deployment path is created
 >>> [CLI] workspace get-status //Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]
 {
-  "path": "/Users/[USERNAME]/.bundle/[UNIQUE_NAME]",
+  "path": "PROBE-REVEAL-REAL-CLOUD-PATH",
   "object_type": "DIRECTORY"
 }
 

--- a/acceptance/bundle/destroy/jobs-and-pipeline/output.txt
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/output.txt
@@ -14,7 +14,7 @@ Deployment complete!
 === Assert bundle deployment path is created
 >>> [CLI] workspace get-status //Workspace/Users/[USERNAME]/.bundle/[UNIQUE_NAME]
 {
-  "path": "PROBE-REVEAL-REAL-CLOUD-PATH",
+  "path": "/Users/[USERNAME]/.bundle/[UNIQUE_NAME]",
   "object_type": "DIRECTORY"
 }
 

--- a/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
+++ b/acceptance/bundle/destroy/jobs-and-pipeline/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 
 Ignore = [

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -347,10 +347,8 @@ func (s *FakeWorkspace) CurrentUser() iam.User {
 func (s *FakeWorkspace) WorkspaceGetStatus(requestPath string) Response {
 	defer s.LockUnlock()()
 
-	// The real Workspace API collapses duplicate slashes, so look up the cleaned
-	// path. A doubled leading slash ("//Workspace/...", which some tests use to
-	// avoid Windows path conversion) is additionally canonicalized by stripping
-	// the "/Workspace" mount from the returned path, so mirror that too.
+	// Mirror the real API: collapse duplicate slashes, and for a doubled leading
+	// slash ("//Workspace/...") strip the "/Workspace" mount from the returned path.
 	cleaned := path.Clean(requestPath)
 	stripWorkspacePrefix := strings.HasPrefix(requestPath, "//Workspace/")
 

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -347,35 +347,33 @@ func (s *FakeWorkspace) CurrentUser() iam.User {
 func (s *FakeWorkspace) WorkspaceGetStatus(requestPath string) Response {
 	defer s.LockUnlock()()
 
-	// Mirror the real API: collapse duplicate slashes, and for a doubled leading
-	// slash ("//Workspace/...") strip the "/Workspace" mount from the returned path.
+	// The real API collapses duplicate slashes, so look up the cleaned path.
 	cleaned := path.Clean(requestPath)
-	stripWorkspacePrefix := strings.HasPrefix(requestPath, "//Workspace/")
 
-	respond := func(info workspace.ObjectInfo) Response {
-		if stripWorkspacePrefix {
-			info.Path = strings.TrimPrefix(info.Path, "/Workspace")
-		}
-		return Response{Body: info}
-	}
-
+	var info workspace.ObjectInfo
 	if dirInfo, ok := s.directories[cleaned]; ok {
-		return respond(dirInfo)
+		info = dirInfo
 	} else if entry, ok := s.files[cleaned]; ok {
-		return respond(entry.Info)
+		info = entry.Info
 	} else if repoId, ok := s.repoIdByPath[cleaned]; ok {
-		return respond(workspace.ObjectInfo{
-			ObjectType: "REPO",
-			Path:       cleaned,
-			ObjectId:   repoId,
-		})
+		info = workspace.ObjectInfo{ObjectType: "REPO", Path: cleaned, ObjectId: repoId}
+	} else {
+		// Match the real Workspace API wording, which echoes the requested path.
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", requestPath)},
+		}
 	}
 
-	// Match the real Workspace API wording, which echoes the requested path.
-	return Response{
-		StatusCode: 404,
-		Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", requestPath)},
+	// A doubled leading slash ("//Workspace/...", which some tests use to avoid
+	// Windows path conversion) is sent to the backend verbatim, and it responds
+	// with the "/Workspace" mount stripped from the path. A normal single-slash
+	// "/Workspace/..." is preserved instead, so only strip the doubled form.
+	if strings.HasPrefix(requestPath, "//Workspace/") {
+		info.Path = strings.TrimPrefix(info.Path, "/Workspace")
 	}
+
+	return Response{Body: info}
 }
 
 func (s *FakeWorkspace) WorkspaceList(listPath string) Response {

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -344,31 +344,39 @@ func (s *FakeWorkspace) CurrentUser() iam.User {
 	}
 }
 
-func (s *FakeWorkspace) WorkspaceGetStatus(path string) Response {
+func (s *FakeWorkspace) WorkspaceGetStatus(requestPath string) Response {
 	defer s.LockUnlock()()
 
-	if dirInfo, ok := s.directories[path]; ok {
-		return Response{
-			Body: &dirInfo,
+	// The real Workspace API collapses duplicate slashes, so look up the cleaned
+	// path. A doubled leading slash ("//Workspace/...", which some tests use to
+	// avoid Windows path conversion) is additionally canonicalized by stripping
+	// the "/Workspace" mount from the returned path, so mirror that too.
+	cleaned := path.Clean(requestPath)
+	stripWorkspacePrefix := strings.HasPrefix(requestPath, "//Workspace/")
+
+	respond := func(info workspace.ObjectInfo) Response {
+		if stripWorkspacePrefix {
+			info.Path = strings.TrimPrefix(info.Path, "/Workspace")
 		}
-	} else if entry, ok := s.files[path]; ok {
-		return Response{
-			Body: entry.Info,
-		}
-	} else if repoId, ok := s.repoIdByPath[path]; ok {
-		return Response{
-			Body: workspace.ObjectInfo{
-				ObjectType: "REPO",
-				Path:       path,
-				ObjectId:   repoId,
-			},
-		}
-	} else {
-		// Match the real Workspace API wording, which echoes the requested path.
-		return Response{
-			StatusCode: 404,
-			Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", path)},
-		}
+		return Response{Body: info}
+	}
+
+	if dirInfo, ok := s.directories[cleaned]; ok {
+		return respond(dirInfo)
+	} else if entry, ok := s.files[cleaned]; ok {
+		return respond(entry.Info)
+	} else if repoId, ok := s.repoIdByPath[cleaned]; ok {
+		return respond(workspace.ObjectInfo{
+			ObjectType: "REPO",
+			Path:       cleaned,
+			ObjectId:   repoId,
+		})
+	}
+
+	// Match the real Workspace API wording, which echoes the requested path.
+	return Response{
+		StatusCode: 404,
+		Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", requestPath)},
 	}
 }
 


### PR DESCRIPTION
## Changes
- Flip `acceptance/bundle/destroy/jobs-and-pipeline` to `Local = true`.
- In the workspace fake (`libs/testserver/fake_workspace.go`), make `WorkspaceGetStatus` collapse duplicate slashes and strip the `/Workspace` mount from the returned path for a `//Workspace/...` request.

## Why
The test runs `workspace get-status //Workspace/Users/...` (the `//` avoids Windows path conversion). Cloud resolves this and returns the path as `/Users/...`, but the fake didn't handle the doubled slash and 404'd, which was the only divergence blocking local runs.

## Tests
- `destroy/jobs-and-pipeline` now runs locally and on cloud against one golden (both engines).