### PR TITLE
aitools: capability detection and plugin metadata in agent registry

### DIFF
--- a/libs/aitools/agents/agents.go
+++ b/libs/aitools/agents/agents.go
@@ -4,9 +4,32 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/databricks/cli/libs/env"
 )
+
+// PluginSpec describes the databricks plugin for an agent. A non-nil
+// Agent.Plugin means the agent has a databricks plugin (Claude Code, Codex,
+// Copilot, Cursor); a nil Plugin means raw skill files are the only delivery
+// (OpenCode, Antigravity).
+type PluginSpec struct {
+	// Marketplace is the marketplace registry name the plugin is served from,
+	// as registered by `<agent> plugin marketplace add` (e.g. "databricks-agent-skills").
+	Marketplace string
+	// ID is the plugin identifier that is installed/enabled (e.g. "databricks").
+	ID string
+	// Source is the argument passed to `<agent> plugin marketplace add`
+	// (e.g. "databricks/databricks-agent-skills").
+	Source string
+	// ManualOnly marks an agent that has a plugin but no headless install path
+	// (Cursor). For these agents the CLI prints ManualInstructions and copies
+	// nothing, because dropping skills alongside the plugin would duplicate them.
+	ManualOnly bool
+	// ManualInstructions is the user-facing tip for ManualOnly agents
+	// (e.g. "run /add-plugin databricks in Cursor"). Empty otherwise.
+	ManualInstructions string
+}
 
 // Agent defines a supported coding agent.
 type Agent struct {
@@ -23,6 +46,13 @@ type Agent struct {
 	// ProjectConfigDir is the config directory name relative to a project root
 	// (e.g., ".claude"). Only used when SupportsProjectScope is true.
 	ProjectConfigDir string
+	// Binary is the agent's CLI binary name on PATH, used by exec.LookPath for
+	// plugin-capability detection and as the program for the plugin probe.
+	// Empty for agents with no CLI binary (Antigravity is IDE-only).
+	Binary string
+	// Plugin describes the databricks plugin for this agent, or nil when the
+	// agent has no plugin and skills files are its native delivery.
+	Plugin *PluginSpec
 }
 
 // Detected returns true if the agent is installed on the system.
@@ -70,6 +100,27 @@ func (a *Agent) ProjectSkillsDir(cwd string) string {
 	return filepath.Join(cwd, a.ProjectConfigDir, subdir)
 }
 
+// Databricks plugin identity, shared across the agents that ship a plugin.
+// The verified install commands are e.g.
+//
+//	claude plugin marketplace add databricks/databricks-agent-skills
+//	claude plugin install        databricks@databricks-agent-skills
+const (
+	databricksMarketplace = "databricks-agent-skills"
+	databricksPluginID    = "databricks"
+	databricksPluginSrc   = "databricks/databricks-agent-skills"
+)
+
+// databricksPlugin returns the shared plugin descriptor for an agent with a
+// real headless install path (Claude, Codex, Copilot).
+func databricksPlugin() *PluginSpec {
+	return &PluginSpec{
+		Marketplace: databricksMarketplace,
+		ID:          databricksPluginID,
+		Source:      databricksPluginSrc,
+	}
+}
+
 // Registry contains all supported agents.
 var Registry = []Agent{
 	{
@@ -78,6 +129,8 @@ var Registry = []Agent{
 		ConfigDir:            homeSubdir(".claude"),
 		SupportsProjectScope: true,
 		ProjectConfigDir:     ".claude",
+		Binary:               "claude",
+		Plugin:               databricksPlugin(),
 	},
 	{
 		Name:                 "cursor",
@@ -85,28 +138,70 @@ var Registry = []Agent{
 		ConfigDir:            homeSubdir(".cursor"),
 		SupportsProjectScope: true,
 		ProjectConfigDir:     ".cursor",
+		// Cursor's CLI binary is `cursor-agent`, not `cursor` (the latter is an
+		// IDE shim that isn't on PATH unless the user ran "install shell command").
+		Binary: "cursor-agent",
+		Plugin: &PluginSpec{
+			Marketplace:        databricksMarketplace,
+			ID:                 databricksPluginID,
+			Source:             databricksPluginSrc,
+			ManualOnly:         true,
+			ManualInstructions: "run /add-plugin databricks in Cursor",
+		},
 	},
 	{
 		Name:        "codex",
 		DisplayName: "Codex CLI",
 		ConfigDir:   homeSubdir(".codex"),
+		Binary:      "codex",
+		Plugin:      databricksPlugin(),
 	},
 	{
 		Name:        "opencode",
 		DisplayName: "OpenCode",
-		ConfigDir:   homeSubdir(".config", "opencode"),
+		ConfigDir:   openCodeConfigDir,
+		Binary:      "opencode",
+		// OpenCode exposes an `opencode plugin <module>` command, but that's an
+		// npm-module system, not the agent-skills marketplace, so OpenCode stays
+		// skills-only (Plugin nil).
 	},
 	{
 		Name:        "copilot",
 		DisplayName: "GitHub Copilot",
 		ConfigDir:   homeSubdir(".copilot"),
+		Binary:      "copilot",
+		Plugin:      databricksPlugin(),
 	},
 	{
 		Name:         "antigravity",
 		DisplayName:  "Antigravity",
 		ConfigDir:    homeSubdir(".gemini", "antigravity"),
 		SkillsSubdir: "global_skills",
+		// Antigravity is IDE-only with no CLI binary, so it has no plugin path.
 	},
+}
+
+// openCodeConfigDir returns OpenCode's config directory. OpenCode stores its
+// config under %APPDATA%\opencode (Roaming AppData) on Windows, and honors
+// XDG_CONFIG_HOME on other platforms, defaulting to ~/.config/opencode. The
+// previous hardcoded ~/.config/opencode made OpenCode undetectable on Windows
+// and ignored XDG_CONFIG_HOME on Linux.
+// See https://opencode.ai/docs/config/ and the XDG Base Directory spec.
+func openCodeConfigDir(ctx context.Context) (string, error) {
+	if runtime.GOOS == "windows" {
+		if appData := env.Get(ctx, "APPDATA"); appData != "" {
+			return filepath.Join(appData, "opencode"), nil
+		}
+	}
+	home, err := env.UserHomeDir(ctx)
+	if err != nil {
+		return "", err
+	}
+	xdg := env.Get(ctx, "XDG_CONFIG_HOME")
+	if xdg == "" {
+		xdg = filepath.Join(home, ".config")
+	}
+	return filepath.Join(xdg, "opencode"), nil
 }
 
 // DetectInstalled returns all agents that are installed on the system.

--- a/libs/aitools/agents/detect.go
+++ b/libs/aitools/agents/detect.go
@@ -1,0 +1,124 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/databricks/cli/libs/process"
+)
+
+// lookPath resolves a binary on PATH. It is a package-level var so tests can
+// inject a fake resolver without depending on the host PATH. It mirrors the
+// exec.LookPath precedent in libs/python/detect.go.
+var lookPath = exec.LookPath
+
+// pluginProbeTimeout bounds the `<agent> plugin --help` capability probe so a
+// hung agent CLI cannot stall install.
+const pluginProbeTimeout = 5 * time.Second
+
+// DisplayState describes how an agent should be presented in the install
+// picker. It combines the two cheap presence signals (binary on PATH and
+// config dir on disk) without running the agent.
+type DisplayState string
+
+const (
+	// StateAvailable: the agent's CLI binary is on PATH, so its plugin can be installed.
+	StateAvailable DisplayState = "available"
+	// StateInstalledCLIMissing: the config dir exists but the CLI binary is not on PATH.
+	StateInstalledCLIMissing DisplayState = "installed-cli-missing"
+	// StateManualOnly: the agent has a plugin but no headless install path (Cursor).
+	StateManualOnly DisplayState = "manual-only"
+	// StateFilesOnly: the agent has no plugin; skill files are its only delivery.
+	StateFilesOnly DisplayState = "files-only"
+	// StateNotFound: neither presence signal is present.
+	StateNotFound DisplayState = "not-found"
+)
+
+// ErrPluginUnsupported is returned by ProbePlugin when the agent cannot install
+// the databricks plugin: it has no binary, no plugin, or its CLI does not
+// expose a working `plugin` subcommand.
+var ErrPluginUnsupported = errors.New("agent CLI does not support plugins")
+
+// HasBinary reports whether the agent's CLI binary is resolvable on PATH.
+// Agents with no CLI binary (Antigravity) always report false.
+func (a *Agent) HasBinary(_ context.Context) bool {
+	if a.Binary == "" {
+		return false
+	}
+	_, err := lookPath(a.Binary)
+	return err == nil
+}
+
+// DisplayState returns the picker presentation state for the agent. It never
+// runs the agent (that is ProbePlugin's job); it only checks the binary on
+// PATH and the config dir on disk, so it is cheap enough for every render.
+func (a *Agent) DisplayState(ctx context.Context) DisplayState {
+	if a.Plugin != nil && a.Plugin.ManualOnly {
+		return StateManualOnly
+	}
+
+	hasBinary := a.HasBinary(ctx)
+	hasConfig := a.Detected(ctx)
+
+	if a.Plugin == nil {
+		if hasBinary || hasConfig {
+			return StateFilesOnly
+		}
+		return StateNotFound
+	}
+
+	switch {
+	case hasBinary:
+		return StateAvailable
+	case hasConfig:
+		return StateInstalledCLIMissing
+	default:
+		return StateNotFound
+	}
+}
+
+// Preselect reports whether the agent should be pre-checked in the picker. Only
+// agents that can complete an install automatically (a plugin agent with its
+// binary on PATH) and files-only agents whose config dir exists are pre-checked;
+// manual-only and binary-missing agents are shown but left unchecked.
+func (a *Agent) Preselect(ctx context.Context) bool {
+	switch a.DisplayState(ctx) {
+	case StateAvailable:
+		return true
+	case StateFilesOnly:
+		return a.Detected(ctx)
+	default:
+		return false
+	}
+}
+
+// ProbePlugin checks whether the agent's CLI actually supports the plugin
+// subcommand by running `<agent> plugin --help` with a short timeout. It is the
+// only function here that executes the agent and is meant to be called once,
+// for a selected agent, right before install. It returns ErrPluginUnsupported
+// when the agent has no plugin path or its CLI lacks the subcommand.
+func (a *Agent) ProbePlugin(ctx context.Context) error {
+	if a.Binary == "" || a.Plugin == nil || a.Plugin.ManualOnly {
+		return ErrPluginUnsupported
+	}
+
+	// exec.LookPath returns exec.ErrDot (along with the path) when the binary
+	// resolves only relative to the current directory. Returning on any error,
+	// including ErrDot, means we never execute a binary resolved from cwd (a
+	// malicious ./claude dropped there is refused, not run).
+	path, err := lookPath(a.Binary)
+	if err != nil {
+		return fmt.Errorf("could not resolve %s on PATH: %w", a.Binary, err)
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, pluginProbeTimeout)
+	defer cancel()
+
+	if _, err := process.Background(cctx, []string{path, "plugin", "--help"}); err != nil {
+		return fmt.Errorf("%s plugin subcommand unavailable: %w", a.Binary, errors.Join(ErrPluginUnsupported, err))
+	}
+	return nil
+}

--- a/libs/aitools/agents/detect_test.go
+++ b/libs/aitools/agents/detect_test.go
@@ -1,0 +1,224 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/databricks/cli/libs/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLookPath replaces the package lookPath with one that resolves only the
+// named binaries, restoring the original when the test finishes.
+func stubLookPath(t *testing.T, onPath ...string) {
+	t.Helper()
+	set := make(map[string]bool, len(onPath))
+	for _, name := range onPath {
+		set[name] = true
+	}
+	orig := lookPath
+	lookPath = func(name string) (string, error) {
+		if set[name] {
+			return filepath.Join("/usr/bin", name), nil
+		}
+		return "", exec.ErrNotFound
+	}
+	t.Cleanup(func() { lookPath = orig })
+}
+
+// configDir returns a closure usable as Agent.ConfigDir. When create is true a
+// directory is materialized so Detected reports it; otherwise it points at a
+// path that does not exist.
+func configDir(t *testing.T, create bool) func(context.Context) (string, error) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "config")
+	if create {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	return func(_ context.Context) (string, error) { return dir, nil }
+}
+
+func TestHasBinary(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("empty binary is never on path", func(t *testing.T) {
+		stubLookPath(t)
+		a := &Agent{Binary: ""}
+		assert.False(t, a.HasBinary(ctx))
+	})
+
+	t.Run("resolved binary is on path", func(t *testing.T) {
+		stubLookPath(t, "claude")
+		a := &Agent{Binary: "claude"}
+		assert.True(t, a.HasBinary(ctx))
+	})
+
+	t.Run("missing binary is not on path", func(t *testing.T) {
+		stubLookPath(t)
+		a := &Agent{Binary: "claude"}
+		assert.False(t, a.HasBinary(ctx))
+	})
+}
+
+func TestDisplayState(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name     string
+		binary   string
+		onPath   []string
+		plugin   *PluginSpec
+		hasCfg   bool
+		expected DisplayState
+	}{
+		{"plugin agent, binary on path", "claude", []string{"claude"}, &PluginSpec{}, false, StateAvailable},
+		{"plugin agent, binary on path, config too", "claude", []string{"claude"}, &PluginSpec{}, true, StateAvailable},
+		{"plugin agent, no binary, config exists", "claude", nil, &PluginSpec{}, true, StateInstalledCLIMissing},
+		{"plugin agent, no binary, no config", "claude", nil, &PluginSpec{}, false, StateNotFound},
+		{"manual-only agent always manual", "cursor-agent", nil, &PluginSpec{ManualOnly: true}, false, StateManualOnly},
+		{"manual-only agent ignores presence", "cursor-agent", []string{"cursor-agent"}, &PluginSpec{ManualOnly: true}, true, StateManualOnly},
+		{"files-only agent, binary on path", "opencode", []string{"opencode"}, nil, false, StateFilesOnly},
+		{"files-only agent, config only", "opencode", nil, nil, true, StateFilesOnly},
+		{"files-only agent, neither", "opencode", nil, nil, false, StateNotFound},
+		{"files-only agent, no binary name, config", "", nil, nil, true, StateFilesOnly},
+		{"files-only agent, no binary name, no config", "", nil, nil, false, StateNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubLookPath(t, tc.onPath...)
+			a := &Agent{Binary: tc.binary, Plugin: tc.plugin, ConfigDir: configDir(t, tc.hasCfg)}
+			assert.Equal(t, tc.expected, a.DisplayState(ctx))
+		})
+	}
+}
+
+func TestPreselect(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name     string
+		binary   string
+		onPath   []string
+		plugin   *PluginSpec
+		hasCfg   bool
+		expected bool
+	}{
+		{"available is pre-checked", "claude", []string{"claude"}, &PluginSpec{}, false, true},
+		{"files-only with config is pre-checked", "opencode", nil, nil, true, true},
+		{"files-only without config is not", "opencode", []string{"opencode"}, nil, false, false},
+		{"manual-only is not pre-checked", "cursor-agent", []string{"cursor-agent"}, &PluginSpec{ManualOnly: true}, true, false},
+		{"installed-cli-missing is not pre-checked", "claude", nil, &PluginSpec{}, true, false},
+		{"not-found is not pre-checked", "claude", nil, &PluginSpec{}, false, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stubLookPath(t, tc.onPath...)
+			a := &Agent{Binary: tc.binary, Plugin: tc.plugin, ConfigDir: configDir(t, tc.hasCfg)}
+			assert.Equal(t, tc.expected, a.Preselect(ctx))
+		})
+	}
+}
+
+func TestProbePluginUnsupportedWithoutCapability(t *testing.T) {
+	ctx := t.Context()
+
+	tests := []struct {
+		name  string
+		agent *Agent
+	}{
+		{"no binary", &Agent{Binary: "", Plugin: &PluginSpec{}}},
+		{"no plugin", &Agent{Binary: "antigravity"}},
+		{"manual only", &Agent{Binary: "cursor-agent", Plugin: &PluginSpec{ManualOnly: true}}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.agent.ProbePlugin(ctx)
+			assert.ErrorIs(t, err, ErrPluginUnsupported)
+		})
+	}
+}
+
+func TestProbePluginSupported(t *testing.T) {
+	stubLookPath(t, "claude")
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	a := &Agent{Binary: "claude", Plugin: &PluginSpec{}}
+	require.NoError(t, a.ProbePlugin(ctx))
+	assert.Equal(t, []string{"claude plugin --help"}, stub.Commands())
+}
+
+func TestProbePluginCLIReportsUnsupported(t *testing.T) {
+	stubLookPath(t, "codex")
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithFailure(errors.New("unknown command: plugin"))
+
+	a := &Agent{Binary: "codex", Plugin: &PluginSpec{}}
+	err := a.ProbePlugin(ctx)
+	assert.ErrorIs(t, err, ErrPluginUnsupported)
+	assert.Equal(t, 1, stub.Len())
+}
+
+func TestProbePluginBinaryNotOnPath(t *testing.T) {
+	stubLookPath(t)
+	ctx, stub := process.WithStub(t.Context())
+
+	a := &Agent{Binary: "claude", Plugin: &PluginSpec{}}
+	err := a.ProbePlugin(ctx)
+	assert.ErrorIs(t, err, exec.ErrNotFound)
+	assert.Equal(t, 0, stub.Len(), "binary not on PATH must not be executed")
+}
+
+func TestProbePluginRefusesDotRelativeBinary(t *testing.T) {
+	// LookPath returns ErrDot (with a path) when the binary resolves only
+	// relative to cwd. ProbePlugin must refuse to run it.
+	orig := lookPath
+	lookPath = func(name string) (string, error) { return filepath.Join(".", name), exec.ErrDot }
+	t.Cleanup(func() { lookPath = orig })
+
+	ctx, stub := process.WithStub(t.Context())
+	a := &Agent{Binary: "claude", Plugin: &PluginSpec{}}
+	err := a.ProbePlugin(ctx)
+	assert.ErrorIs(t, err, exec.ErrDot)
+	assert.Equal(t, 0, stub.Len(), "a cwd-relative binary must never be executed")
+}
+
+func TestOpenCodeConfigDir(t *testing.T) {
+	ctx := t.Context()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	if runtime.GOOS == "windows" {
+		appData := t.TempDir()
+		t.Setenv("APPDATA", appData)
+		dir, err := openCodeConfigDir(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(appData, "opencode"), dir)
+		return
+	}
+
+	t.Run("honors XDG_CONFIG_HOME", func(t *testing.T) {
+		xdg := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", xdg)
+		dir, err := openCodeConfigDir(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(xdg, "opencode"), dir)
+	})
+
+	t.Run("defaults to ~/.config when XDG is unset", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", "")
+		dir, err := openCodeConfigDir(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(home, ".config", "opencode"), dir)
+	})
+}


### PR DESCRIPTION
<!-- aitools-stack -->
### Stack

Part of the `aitools` plugin-first redesign. Merge bottom to top:

- **#5734 Detection & registry (plugin metadata + capability detection)  ← this PR**
- #5736 State schema v2 (plugin + file provenance records)
- #5737 Plugin engine, checksums, `--path` dump (library)
- #5738 Plugin-first install command
- #5739 Update + prune of vanished skills
- #5740 Uninstall teardown + legacy skills cleanup
- #5741 list + version plugin state
<!-- /aitools-stack -->

## Why

`databricks aitools` is being redesigned from a raw-skills installer into a plugin-first installer. The first thing that redesign needs is better agent detection: today an agent is "detected" only if its config dir exists on disk, which misses Codex and Copilot (often used through an IDE, or installed-but-not-yet-run), and the registry has no notion of which agents have a plugin or what their CLI binary is.

This PR lays that foundation. It is deliberately behavior-neutral: no command output changes, and `DetectInstalled` still uses the same config-dir signal it does today. The picker and install rewrites that consume this come in later PRs in the stack.

## Changes

Before: the agent registry only knew each agent's config dir; detection was a single `os.Stat` on that dir.

Now: the registry also describes each agent's plugin and CLI binary, and there's a capability detector that can tell the difference between "binary on PATH" and "config dir exists."

- `Agent.Binary` — the CLI binary name on PATH (`claude`, `codex`, `copilot`, `cursor-agent`, `opencode`; empty for IDE-only Antigravity). Cursor's binary is `cursor-agent`, not `cursor` (the latter is an IDE shim that isn't on PATH).
- `Agent.Plugin *PluginSpec` — describes the databricks plugin. `Plugin != nil` means the agent has a plugin (Claude, Codex, Copilot, Cursor); `nil` means raw skills are the only delivery (OpenCode, Antigravity). `ManualOnly` marks Cursor (plugin exists, but no headless install path).
- OpenCode config dir is now per-OS: `%APPDATA%\opencode` on Windows, and honors `XDG_CONFIG_HOME` otherwise (defaulting to `~/.config/opencode`). The previous hardcoded path made OpenCode undetectable on Windows and ignored `XDG_CONFIG_HOME` on Linux.
- New `detect.go`: `HasBinary` (via `exec.LookPath`), `DisplayState` (a 5-state enum for the picker, computed from the two cheap signals without running the agent), `Preselect`, and `ProbePlugin` (runs `<agent> plugin --help` with a 5s timeout through `libs/process`; refuses a cwd-relative binary via `exec.ErrDot` so a malicious `./claude` is never executed).

## Test plan

- [x] Unit tests (`detect_test.go`): `HasBinary`, `DisplayState` across all five states, `Preselect` rules, `ProbePlugin` (supported / CLI reports unsupported / binary not on PATH / refuses dot-relative binary with zero executions), and `openCodeConfigDir` (XDG honored / `~/.config` default; Windows APPDATA branch on Windows hosts).
- [x] `go test ./libs/aitools/... ./cmd/aitools/...` passes (no behavior change to existing commands).
- [x] `./task fmt-q`, `./task lint-q` (0 issues), `./task checks` (no dead code) all clean.

This pull request and its description were written by Isaac.

