### PR TITLE
aitools: state schema v2 (plugin + file provenance records)

### DIFF
--- a/libs/aitools/agents/detect.go
+++ b/libs/aitools/agents/detect.go
@@ -80,11 +80,11 @@ func (a *Agent) DisplayState(ctx context.Context) DisplayState {
 	}
 }
 
-// Preselect reports whether the agent should be pre-checked in the picker. Only
+// IsPreselected reports whether the agent should be pre-checked in the picker. Only
 // agents that can complete an install automatically (a plugin agent with its
 // binary on PATH) and files-only agents whose config dir exists are pre-checked;
 // manual-only and binary-missing agents are shown but left unchecked.
-func (a *Agent) Preselect(ctx context.Context) bool {
+func (a *Agent) IsPreselected(ctx context.Context) bool {
 	switch a.DisplayState(ctx) {
 	case StateAvailable:
 		return true

--- a/libs/aitools/agents/detect_test.go
+++ b/libs/aitools/agents/detect_test.go
@@ -99,7 +99,7 @@ func TestDisplayState(t *testing.T) {
 	}
 }
 
-func TestPreselect(t *testing.T) {
+func TestIsPreselected(t *testing.T) {
 	ctx := t.Context()
 
 	tests := []struct {
@@ -122,7 +122,7 @@ func TestPreselect(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			stubLookPath(t, tc.onPath...)
 			a := &Agent{Binary: tc.binary, Plugin: tc.plugin, ConfigDir: configDir(t, tc.hasCfg)}
-			assert.Equal(t, tc.expected, a.Preselect(ctx))
+			assert.Equal(t, tc.expected, a.IsPreselected(ctx))
 		})
 	}
 }

--- a/libs/aitools/installer/installer.go
+++ b/libs/aitools/installer/installer.go
@@ -272,7 +272,7 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 	// previous installs (e.g., experimental skills from a prior run) are preserved.
 	if state == nil {
 		state = &InstallState{
-			SchemaVersion: 1,
+			SchemaVersion: schemaVersionV2,
 			Skills:        make(map[string]string, len(targetSkills)),
 			RepoDirs:      make(map[string]string, len(targetSkills)),
 		}

--- a/libs/aitools/installer/installer_test.go
+++ b/libs/aitools/installer/installer_test.go
@@ -317,7 +317,7 @@ func TestInstallSkillsForAgentsWritesState(t *testing.T) {
 	state, err := LoadState(globalDir)
 	require.NoError(t, err)
 	require.NotNil(t, state)
-	assert.Equal(t, 1, state.SchemaVersion)
+	assert.Equal(t, schemaVersionV2, state.SchemaVersion)
 	assert.Equal(t, testSkillsRef, state.Release)
 	assert.Len(t, state.Skills, 2)
 	assert.Equal(t, "0.1.0", state.Skills["databricks-sql"])

--- a/libs/aitools/installer/state.go
+++ b/libs/aitools/installer/state.go
@@ -14,6 +14,10 @@ import (
 
 const stateFileName = ".state.json"
 
+// schemaVersionV2 is the current on-disk state schema version. v2 adds the
+// additive Plugins and Files maps; v1 state loads forward without data changes.
+const schemaVersionV2 = 2
+
 // Scope constants for skill installation.
 const (
 	ScopeGlobal  = "global"
@@ -29,6 +33,44 @@ type InstallState struct {
 	Skills              map[string]string `json:"skills"`
 	RepoDirs            map[string]string `json:"repo_dirs,omitempty"`
 	Scope               string            `json:"scope,omitempty"`
+
+	// Plugins records databricks plugins installed through an agent's own CLI,
+	// keyed by registry agent name (e.g. "claude-code"). Added in schema v2;
+	// omitted for files-only installs.
+	Plugins map[string]PluginRecord `json:"plugins,omitempty"`
+	// Files records provenance for skill files the CLI wrote, keyed by the
+	// file path relative to the scope's canonical skills dir (forward slashes,
+	// e.g. "databricks/SKILL.md"). Added in schema v2; used to prune only the
+	// skills we wrote that the user hasn't modified.
+	Files map[string]FileRecord `json:"files,omitempty"`
+}
+
+// PluginRecord records a databricks plugin installed for an agent through the
+// agent's own plugin CLI, so update/uninstall act on exactly where we
+// installed and list/version can report real plugin state.
+type PluginRecord struct {
+	// Marketplace is the marketplace registry name the plugin was installed from.
+	Marketplace string `json:"marketplace"`
+	// Plugin is the installed plugin id (e.g. "databricks").
+	Plugin string `json:"plugin"`
+	// Scope is the agent-native install scope (e.g. "user" or "project").
+	Scope string `json:"scope,omitempty"`
+	// Version is the last seen plugin/release version, when known.
+	Version string `json:"version,omitempty"`
+	// InstalledMarketplace is true when this CLI registered the marketplace,
+	// so uninstall may de-register it. False when it was already present and we
+	// must leave it for whatever else shares it.
+	InstalledMarketplace bool `json:"installed_marketplace,omitempty"`
+}
+
+// FileRecord records provenance for a single skill file the CLI wrote, so
+// update can prune a vanished skill only when the on-disk file still matches
+// what we wrote (i.e. the user hasn't modified it).
+type FileRecord struct {
+	// SHA256 is the hex-encoded checksum of the file content the CLI wrote.
+	SHA256 string `json:"sha256"`
+	// Origin is the skills ref the file was fetched from, when known.
+	Origin string `json:"origin,omitempty"`
 }
 
 // LoadState reads install state from the given directory.
@@ -46,7 +88,18 @@ func LoadState(dir string) (*InstallState, error) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, fmt.Errorf("failed to parse state file: %w", err)
 	}
+	migrateState(&state)
 	return &state, nil
+}
+
+// migrateState brings a loaded state forward to the current schema version. It
+// is forward-only and idempotent. v1 -> v2 needs no data transformation (the
+// Plugins/Files maps are additive and optional), so it only stamps the version;
+// writers lazily initialize the maps, matching how RepoDirs is handled.
+func migrateState(state *InstallState) {
+	if state.SchemaVersion < schemaVersionV2 {
+		state.SchemaVersion = schemaVersionV2
+	}
 }
 
 // SaveState writes install state to the given directory atomically.

--- a/libs/aitools/installer/state_test.go
+++ b/libs/aitools/installer/state_test.go
@@ -113,10 +113,15 @@ func TestLoadStateMigratesV1ToV2(t *testing.T) {
 }
 
 func TestMigrateStateIsIdempotent(t *testing.T) {
-	state := &InstallState{SchemaVersion: schemaVersionV2, Skills: map[string]string{"databricks": "1.0.0"}}
-	before := *state
+	// Start at v1 so this exercises the real v1 -> v2 migration, then confirm a
+	// second migrateState is a no-op.
+	state := &InstallState{SchemaVersion: 1, Skills: map[string]string{"databricks": "1.0.0"}}
 	migrateState(state)
-	assert.Equal(t, before, *state)
+	assert.Equal(t, schemaVersionV2, state.SchemaVersion)
+
+	migrated := *state
+	migrateState(state)
+	assert.Equal(t, migrated, *state)
 }
 
 func TestSaveAndLoadStateWithPluginAndFileRecords(t *testing.T) {

--- a/libs/aitools/installer/state_test.go
+++ b/libs/aitools/installer/state_test.go
@@ -20,7 +20,7 @@ func TestLoadStateNonexistentFile(t *testing.T) {
 func TestSaveAndLoadStateRoundtrip(t *testing.T) {
 	dir := t.TempDir()
 	original := &InstallState{
-		SchemaVersion: 1,
+		SchemaVersion: schemaVersionV2,
 		Release:       "v0.2.0",
 		LastUpdated:   time.Date(2026, 3, 22, 10, 0, 0, 0, time.UTC),
 		Skills: map[string]string{
@@ -97,10 +97,61 @@ func TestProjectSkillsDirReturnsCwdBased(t *testing.T) {
 	assert.Equal(t, filepath.Join(cwd, ".databricks", "aitools", "skills"), dir)
 }
 
+func TestLoadStateMigratesV1ToV2(t *testing.T) {
+	dir := t.TempDir()
+	// A v1 state on disk has no plugins/files keys.
+	v1 := `{"schema_version":1,"release":"v0.2.0","last_updated":"2026-03-22T10:00:00Z","skills":{"databricks":"1.0.0"},"repo_dirs":{"databricks":"skills"}}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, stateFileName), []byte(v1), 0o644))
+
+	loaded, err := LoadState(dir)
+	require.NoError(t, err)
+	assert.Equal(t, schemaVersionV2, loaded.SchemaVersion)
+	// Migration is additive: existing data is untouched and the new maps stay nil.
+	assert.Equal(t, map[string]string{"databricks": "1.0.0"}, loaded.Skills)
+	assert.Nil(t, loaded.Plugins)
+	assert.Nil(t, loaded.Files)
+}
+
+func TestMigrateStateIsIdempotent(t *testing.T) {
+	state := &InstallState{SchemaVersion: schemaVersionV2, Skills: map[string]string{"databricks": "1.0.0"}}
+	before := *state
+	migrateState(state)
+	assert.Equal(t, before, *state)
+}
+
+func TestSaveAndLoadStateWithPluginAndFileRecords(t *testing.T) {
+	dir := t.TempDir()
+	original := &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Release:       "v0.2.6",
+		LastUpdated:   time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC),
+		Skills:        map[string]string{"databricks": "1.0.0"},
+		RepoDirs:      map[string]string{"databricks": stableSkillsRepoPath},
+		Plugins: map[string]PluginRecord{
+			"claude-code": {
+				Marketplace:          "databricks-agent-skills",
+				Plugin:               "databricks",
+				Scope:                "user",
+				Version:              "0.2.6",
+				InstalledMarketplace: true,
+			},
+		},
+		Files: map[string]FileRecord{
+			"databricks/SKILL.md": {SHA256: "abc123", Origin: "v0.2.6"},
+		},
+	}
+
+	require.NoError(t, SaveState(dir, original))
+
+	loaded, err := LoadState(dir)
+	require.NoError(t, err)
+	assert.Equal(t, original, loaded)
+}
+
 func TestSaveAndLoadStateWithOptionalFields(t *testing.T) {
 	dir := t.TempDir()
 	original := &InstallState{
-		SchemaVersion:       1,
+		SchemaVersion:       schemaVersionV2,
 		IncludeExperimental: true,
 		Release:             "v0.3.0",
 		LastUpdated:         time.Date(2026, 3, 22, 12, 30, 0, 0, time.UTC),


### PR DESCRIPTION
<!-- aitools-stack -->
### Stack

Part of the `aitools` plugin-first redesign. Merge bottom to top:

- #5734 Detection & registry (plugin metadata + capability detection)
- **#5736 State schema v2 (plugin + file provenance records)  ← this PR**
- #5737 Plugin engine, checksums, `--path` dump (library)
- #5738 Plugin-first install command
- #5739 Update + prune of vanished skills
- #5740 Uninstall teardown + legacy skills cleanup
- #5741 list + version plugin state
<!-- /aitools-stack -->

## Why

The plugin-first `aitools` redesign needs `.state.json` to record two new things: which plugins we installed through each agent's own CLI (so `update`/`uninstall`/`list` act on exactly where we installed), and provenance for the skill files we wrote (so a later `update` can prune a skill that vanished from the release only when the user hasn't modified it). This PR adds that schema, additively, ahead of the install/update/uninstall changes that consume it.

Stacked on #5734 (detection foundation).

## Changes

Before: `InstallState` tracked only `skills`/`repo_dirs` (schema v1).

Now: schema v2 adds two optional maps, and existing state migrates forward transparently.

- `PluginRecord` (in `InstallState.Plugins`, keyed by agent name): marketplace, plugin id, agent-native scope, last-seen version, and `installed_marketplace` (whether this CLI registered the marketplace, so uninstall knows if it may de-register it).
- `FileRecord` (in `InstallState.Files`, keyed by canonical-relative path like `databricks/SKILL.md`): per-file `sha256` + `origin` ref.
- Both maps are `json:",omitempty"`, so a files-only install serializes byte-identically to today.
- `LoadState` runs `migrateState`: forward-only and idempotent. v1 → v2 needs no data transformation (the maps are additive and optional), so it only stamps the version; writers lazily initialize the maps the same way `RepoDirs` is handled.
- The fresh-install writer now stamps v2 so the on-disk and in-memory versions agree.

## Test plan

- [x] Unit tests: v1→v2 migration is additive (existing skills untouched, new maps nil), migration is idempotent, and a state with populated `Plugins`/`Files` round-trips through save/load. Existing round-trip fixtures updated to v2.
- [x] `go test ./libs/aitools/... ./cmd/aitools/...` passes.
- [x] `go test ./acceptance -run TestAccept/experimental/aitools` passes (`.state.json` is in `Ignore`, so the version bump doesn't touch goldens).
- [x] `./task fmt-q`, `./task lint-q` (0 issues), `./task checks` (no dead code) clean.

This pull request and its description were written by Isaac.
