### PR TITLE
aitools: plugin engine, file checksums, and --path dump (library)

### DIFF
--- a/libs/aitools/agents/agents.go
+++ b/libs/aitools/agents/agents.go
@@ -100,6 +100,17 @@ func (a *Agent) ProjectSkillsDir(cwd string) string {
 	return filepath.Join(cwd, a.ProjectConfigDir, subdir)
 }
 
+// Registry agent names. Behavior keyed on a specific agent (e.g. per-agent
+// plugin command shapes) references these instead of bare string literals.
+const (
+	NameClaudeCode  = "claude-code"
+	NameCursor      = "cursor"
+	NameCodex       = "codex"
+	NameOpenCode    = "opencode"
+	NameCopilot     = "copilot"
+	NameAntigravity = "antigravity"
+)
+
 // Databricks plugin identity, shared across the agents that ship a plugin.
 // The verified install commands are e.g.
 //
@@ -124,7 +135,7 @@ func databricksPlugin() *PluginSpec {
 // Registry contains all supported agents.
 var Registry = []Agent{
 	{
-		Name:                 "claude-code",
+		Name:                 NameClaudeCode,
 		DisplayName:          "Claude Code",
 		ConfigDir:            homeSubdir(".claude"),
 		SupportsProjectScope: true,
@@ -133,7 +144,7 @@ var Registry = []Agent{
 		Plugin:               databricksPlugin(),
 	},
 	{
-		Name:                 "cursor",
+		Name:                 NameCursor,
 		DisplayName:          "Cursor",
 		ConfigDir:            homeSubdir(".cursor"),
 		SupportsProjectScope: true,
@@ -150,14 +161,14 @@ var Registry = []Agent{
 		},
 	},
 	{
-		Name:        "codex",
+		Name:        NameCodex,
 		DisplayName: "Codex CLI",
 		ConfigDir:   homeSubdir(".codex"),
 		Binary:      "codex",
 		Plugin:      databricksPlugin(),
 	},
 	{
-		Name:        "opencode",
+		Name:        NameOpenCode,
 		DisplayName: "OpenCode",
 		ConfigDir:   openCodeConfigDir,
 		Binary:      "opencode",
@@ -166,14 +177,14 @@ var Registry = []Agent{
 		// skills-only (Plugin nil).
 	},
 	{
-		Name:        "copilot",
+		Name:        NameCopilot,
 		DisplayName: "GitHub Copilot",
 		ConfigDir:   homeSubdir(".copilot"),
 		Binary:      "copilot",
 		Plugin:      databricksPlugin(),
 	},
 	{
-		Name:         "antigravity",
+		Name:         NameAntigravity,
 		DisplayName:  "Antigravity",
 		ConfigDir:    homeSubdir(".gemini", "antigravity"),
 		SkillsSubdir: "global_skills",

--- a/libs/aitools/installer/dump.go
+++ b/libs/aitools/installer/dump.go
@@ -1,0 +1,50 @@
+package installer
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/databricks/cli/libs/cmdio"
+)
+
+// DumpSkillsToPath writes resolved skill files into destDir and returns the
+// number of skills written. It is a dumb dump: no agents, no .state.json, no
+// lifecycle (update/list/uninstall ignore it). It honors DATABRICKS_SKILLS_REF,
+// the cli-compat version pin, --skills cherry-picks, and --experimental exactly
+// as the agent install path does, since it reuses resolveSkills.
+func DumpSkillsToPath(ctx context.Context, src ManifestSource, destDir string, opts InstallOptions) (int, error) {
+	ref, explicit, err := GetSkillsRef(ctx)
+	if err != nil {
+		return 0, err
+	}
+	cmdio.LogString(ctx, "Using skills version "+strings.TrimPrefix(ref, "v"))
+
+	manifest, ref, err := FetchSkillsManifestWithFallback(ctx, src, ref, !explicit)
+	if err != nil {
+		return 0, err
+	}
+
+	targetSkills, err := resolveSkills(ctx, manifest.Skills, opts)
+	if err != nil {
+		return 0, err
+	}
+
+	names := slices.Sorted(maps.Keys(targetSkills))
+	for _, name := range names {
+		meta := targetSkills[name]
+		if _, err := installSkillToDir(ctx, ref, meta.RepoDir, meta.SourceName, filepath.Join(destDir, name), meta.Files); err != nil {
+			return 0, err
+		}
+	}
+
+	noun := "skills"
+	if len(names) == 1 {
+		noun = "skill"
+	}
+	cmdio.LogString(ctx, fmt.Sprintf("Wrote %d %s to %s", len(names), noun, filepath.ToSlash(destDir)))
+	return len(names), nil
+}

--- a/libs/aitools/installer/dump_test.go
+++ b/libs/aitools/installer/dump_test.go
@@ -1,0 +1,52 @@
+package installer
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDumpSkillsToPathWritesFilesNoState(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	setupFetchMock(t)
+	t.Setenv("DATABRICKS_SKILLS_REF", testSkillsRef)
+
+	dest := filepath.Join(t.TempDir(), "out")
+	src := &mockManifestSource{manifest: testManifest()}
+
+	n, err := DumpSkillsToPath(ctx, src, dest, InstallOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	for _, name := range []string{"databricks-sql", "databricks-jobs"} {
+		_, err := os.Stat(filepath.Join(dest, name, "SKILL.md"))
+		assert.NoError(t, err)
+	}
+
+	// A dumb dump writes no state and no agent dirs.
+	_, err = os.Stat(filepath.Join(dest, stateFileName))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestDumpSkillsToPathCherryPick(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	setupFetchMock(t)
+	t.Setenv("DATABRICKS_SKILLS_REF", testSkillsRef)
+
+	dest := filepath.Join(t.TempDir(), "out")
+	src := &mockManifestSource{manifest: testManifest()}
+
+	n, err := DumpSkillsToPath(ctx, src, dest, InstallOptions{SpecificSkills: []string{"databricks-sql"}})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	_, err = os.Stat(filepath.Join(dest, "databricks-sql", "SKILL.md"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dest, "databricks-jobs"))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}

--- a/libs/aitools/installer/installer.go
+++ b/libs/aitools/installer/installer.go
@@ -2,6 +2,8 @@ package installer
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -250,6 +252,10 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 	// Install each skill in sorted order for determinism.
 	skillNames := slices.Sorted(maps.Keys(targetSkills))
 
+	// Accumulate file provenance for skills we (re)fetch this run. Skipped
+	// (already-installed) skills keep their existing records via the merge below.
+	fileRecords := map[string]FileRecord{}
+
 	for _, name := range skillNames {
 		meta := targetSkills[name]
 
@@ -263,9 +269,11 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 			}
 		}
 
-		if err := installSkillForAgents(ctx, name, meta, targetAgents, params); err != nil {
+		records, err := installSkillForAgents(ctx, name, meta, targetAgents, params)
+		if err != nil {
 			return err
 		}
+		maps.Copy(fileRecords, records)
 	}
 
 	// Save state. Merge into existing state (loaded above) so skills from
@@ -280,6 +288,9 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 	if state.RepoDirs == nil {
 		state.RepoDirs = make(map[string]string, len(state.Skills)+len(targetSkills))
 	}
+	if state.Files == nil {
+		state.Files = make(map[string]FileRecord, len(fileRecords))
+	}
 	state.Release = ref
 	state.LastUpdated = time.Now()
 	// IncludeExperimental reflects the last invocation's flag value. The Skills
@@ -291,6 +302,7 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 		state.Skills[name] = meta.Version
 		state.RepoDirs[name] = meta.RepoDir
 	}
+	maps.Copy(state.Files, fileRecords)
 	if err := SaveState(baseDir, state); err != nil {
 		return err
 	}
@@ -466,10 +478,11 @@ type installParams struct {
 	ref     string
 }
 
-func installSkillForAgents(ctx context.Context, skillName string, meta SkillMeta, detectedAgents []*agents.Agent, params installParams) error {
+func installSkillForAgents(ctx context.Context, skillName string, meta SkillMeta, detectedAgents []*agents.Agent, params installParams) (map[string]FileRecord, error) {
 	canonicalDir := filepath.Join(params.baseDir, skillName)
-	if err := installSkillToDir(ctx, params.ref, meta.RepoDir, meta.SourceName, canonicalDir, meta.Files); err != nil {
-		return err
+	records, err := installSkillToDir(ctx, params.ref, meta.RepoDir, meta.SourceName, canonicalDir, meta.Files)
+	if err != nil {
+		return nil, err
 	}
 
 	// For project scope, always symlink. For global, symlink when multiple agents.
@@ -516,7 +529,7 @@ func installSkillForAgents(ctx context.Context, skillName string, meta SkillMeta
 		}
 	}
 
-	return nil
+	return records, nil
 }
 
 // agentSkillsDirForScope returns the agent's skills directory for the given scope.
@@ -566,15 +579,22 @@ func backupThirdPartySkill(ctx context.Context, destDir, canonicalDir, skillName
 	return nil
 }
 
-func installSkillToDir(ctx context.Context, ref, repoDir, skillName, destDir string, files []string) error {
+// installSkillToDir downloads a skill's files into destDir and returns a
+// FileRecord per file (keyed by "<skillName>/<file>", forward slashes) capturing
+// the sha256 of the bytes written, so a later update can prune only the files we
+// wrote that the user hasn't modified.
+func installSkillToDir(ctx context.Context, ref, repoDir, skillName, destDir string, files []string) (map[string]FileRecord, error) {
 	// remove existing skill directory for clean install
 	if err := os.RemoveAll(destDir); err != nil {
-		return fmt.Errorf("failed to remove existing skill: %w", err)
+		return nil, fmt.Errorf("failed to remove existing skill: %w", err)
 	}
 
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
+		return nil, fmt.Errorf("failed to create directory: %w", err)
 	}
+
+	var mu sync.Mutex
+	records := make(map[string]FileRecord, len(files))
 
 	// Fetch files concurrently. Each file is a separate HTTPS GET, so
 	// wall-clock time is dominated by per-request TLS handshakes rather
@@ -595,10 +615,20 @@ func installSkillToDir(ctx context.Context, ref, repoDir, skillName, destDir str
 			if err := os.WriteFile(destPath, content, 0o644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", file, err)
 			}
+			sum := sha256.Sum256(content)
+			mu.Lock()
+			records[skillName+"/"+filepath.ToSlash(file)] = FileRecord{
+				SHA256: hex.EncodeToString(sum[:]),
+				Origin: ref,
+			}
+			mu.Unlock()
 			return nil
 		})
 	}
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return records, nil
 }
 
 // copyDir copies all files from src to dest, recreating the directory structure.

--- a/libs/aitools/installer/installer.go
+++ b/libs/aitools/installer/installer.go
@@ -255,6 +255,7 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 	// Accumulate file provenance for skills we (re)fetch this run. Skipped
 	// (already-installed) skills keep their existing records via the merge below.
 	fileRecords := map[string]FileRecord{}
+	var refetched []string
 
 	for _, name := range skillNames {
 		meta := targetSkills[name]
@@ -274,6 +275,7 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 			return err
 		}
 		maps.Copy(fileRecords, records)
+		refetched = append(refetched, name)
 	}
 
 	// Save state. Merge into existing state (loaded above) so skills from
@@ -301,6 +303,11 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 	for name, meta := range targetSkills {
 		state.Skills[name] = meta.Version
 		state.RepoDirs[name] = meta.RepoDir
+	}
+	// Drop stale provenance for refetched skills before recording the fresh set,
+	// so files removed/renamed in a new version don't leave orphaned records.
+	for _, name := range refetched {
+		clearFileRecords(state.Files, name)
 	}
 	maps.Copy(state.Files, fileRecords)
 	if err := SaveState(baseDir, state); err != nil {

--- a/libs/aitools/installer/installer_test.go
+++ b/libs/aitools/installer/installer_test.go
@@ -217,7 +217,8 @@ func TestInstallSkillToDirFetchesFilesConcurrently(t *testing.T) {
 	destDir := filepath.Join(t.TempDir(), "databricks-test")
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- installSkillToDir(ctx, testSkillsRef, stableSkillsRepoPath, "databricks-test", destDir, []string{"one.md", "two.md"})
+		_, err := installSkillToDir(ctx, testSkillsRef, stableSkillsRepoPath, "databricks-test", destDir, []string{"one.md", "two.md"})
+		errCh <- err
 	}()
 
 	fetched := make(map[string]bool, 2)
@@ -276,7 +277,8 @@ func TestInstallSkillToDirCancelsInFlightFetchesOnError(t *testing.T) {
 	destDir := filepath.Join(t.TempDir(), "databricks-test")
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- installSkillToDir(ctx, testSkillsRef, stableSkillsRepoPath, "databricks-test", destDir, []string{"blocked.md", "fail.md"})
+		_, err := installSkillToDir(ctx, testSkillsRef, stableSkillsRepoPath, "databricks-test", destDir, []string{"blocked.md", "fail.md"})
+		errCh <- err
 	}()
 
 	var err error
@@ -322,6 +324,11 @@ func TestInstallSkillsForAgentsWritesState(t *testing.T) {
 	assert.Len(t, state.Skills, 2)
 	assert.Equal(t, "0.1.0", state.Skills["databricks-sql"])
 	assert.Equal(t, "0.1.0", state.Skills["databricks-jobs"])
+
+	// File provenance is captured for the prune safeguard.
+	require.Contains(t, state.Files, "databricks-sql/SKILL.md")
+	assert.NotEmpty(t, state.Files["databricks-sql/SKILL.md"].SHA256)
+	assert.Equal(t, testSkillsRef, state.Files["databricks-sql/SKILL.md"].Origin)
 
 	assert.Contains(t, stderr.String(), "Installed 2 skills.")
 }

--- a/libs/aitools/installer/installer_test.go
+++ b/libs/aitools/installer/installer_test.go
@@ -333,6 +333,37 @@ func TestInstallSkillsForAgentsWritesState(t *testing.T) {
 	assert.Contains(t, stderr.String(), "Installed 2 skills.")
 }
 
+func TestInstallPurgesStaleFileRecordsOnRefetch(t *testing.T) {
+	tmp := setupTestHome(t)
+	ctx := cmdio.MockDiscard(t.Context())
+	setupFetchMock(t)
+	t.Setenv("DATABRICKS_SKILLS_REF", testSkillsRef)
+
+	agent := testAgent(tmp)
+	globalDir := filepath.Join(tmp, ".databricks", "aitools", "skills")
+
+	// v1: the skill ships two files.
+	m1 := &Manifest{Version: "1", Skills: map[string]SkillMeta{
+		"databricks-sql": {Version: "0.1.0", Files: []string{"a.md", "b.md"}},
+	}}
+	require.NoError(t, InstallSkillsForAgents(ctx, &mockManifestSource{manifest: m1}, []*agents.Agent{agent}, InstallOptions{SpecificSkills: []string{"databricks-sql"}}))
+	st, err := LoadState(globalDir)
+	require.NoError(t, err)
+	require.Contains(t, st.Files, "databricks-sql/a.md")
+	require.Contains(t, st.Files, "databricks-sql/b.md")
+
+	// v2 drops b.md. Refetching must purge the stale record.
+	t.Setenv("DATABRICKS_SKILLS_REF", "v0.2.0")
+	m2 := &Manifest{Version: "2", Skills: map[string]SkillMeta{
+		"databricks-sql": {Version: "0.2.0", Files: []string{"a.md"}},
+	}}
+	require.NoError(t, InstallSkillsForAgents(ctx, &mockManifestSource{manifest: m2}, []*agents.Agent{agent}, InstallOptions{SpecificSkills: []string{"databricks-sql"}}))
+	st2, err := LoadState(globalDir)
+	require.NoError(t, err)
+	assert.Contains(t, st2.Files, "databricks-sql/a.md")
+	assert.NotContains(t, st2.Files, "databricks-sql/b.md")
+}
+
 func TestInstallSkillForSingleWritesState(t *testing.T) {
 	tmp := setupTestHome(t)
 	ctx, stderr := cmdio.NewTestContextWithStderr(t.Context())

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/databricks/cli/libs/aitools/agents"
+	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/process"
 )
 
@@ -96,6 +97,20 @@ func marketplaceAddArgs(spec *agents.PluginSpec) []string {
 	return []string{"plugin", "marketplace", "add", spec.Source}
 }
 
+// marketplaceRegistered reports whether the named marketplace is already listed
+// by the agent's plugin CLI. On any uncertainty (command unsupported, error) it
+// returns true, so we never claim to have added a marketplace we didn't, which
+// keeps uninstall from de-registering a marketplace another plugin may share.
+// The `plugin marketplace list` output shape is pending per-agent verification;
+// until then the conservative default applies.
+func marketplaceRegistered(ctx context.Context, bin, marketplace string) bool {
+	out, err := runAgentCmd(ctx, pluginProbeTimeout, []string{bin, "plugin", "marketplace", "list"})
+	if err != nil {
+		return true
+	}
+	return strings.Contains(out, marketplace)
+}
+
 // marketplaceRemoveArgs builds the `plugin marketplace remove <name>` argv (sans binary).
 func marketplaceRemoveArgs(spec *agents.PluginSpec) []string {
 	return []string{"plugin", "marketplace", "remove", spec.Marketplace}
@@ -173,13 +188,23 @@ func InstallPluginForAgent(ctx context.Context, agent *agents.Agent, nativeScope
 		return PluginRecord{}, err
 	}
 
-	// Register the marketplace. Record InstalledMarketplace only when our add
-	// succeeded, so uninstall never de-registers a marketplace that was already
-	// present (and may be shared by another plugin).
+	// Register the marketplace. We only record InstalledMarketplace (and thus
+	// later de-register on uninstall) when the marketplace was absent before and
+	// our add succeeded, so we never remove a marketplace another plugin shares.
+	// On any uncertainty marketplaceRegistered returns true, keeping us off the
+	// de-register path.
+	alreadyPresent := marketplaceRegistered(ctx, bin, agent.Plugin.Marketplace)
 	_, addErr := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceAddArgs(agent.Plugin)))
-	installedMarketplace := addErr == nil
+	installedMarketplace := addErr == nil && !alreadyPresent
 
 	if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, pluginInstallArgs(agent, nativeScope))); err != nil {
+		// Roll back a marketplace we just added so a failed install doesn't
+		// leave an orphaned, untracked marketplace registration behind.
+		if installedMarketplace {
+			if _, rmErr := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceRemoveArgs(agent.Plugin))); rmErr != nil {
+				log.Warnf(ctx, "%s plugin install failed and the marketplace could not be de-registered: %v", agent.DisplayName, rmErr)
+			}
+		}
 		return PluginRecord{}, &BlockedError{Agent: agent.Name, Reason: ReasonInstallFailed, Detail: stderrOf(err)}
 	}
 

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -1,0 +1,241 @@
+package installer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/libs/aitools/agents"
+	"github.com/databricks/cli/libs/process"
+)
+
+// lookPath resolves a binary on PATH. It is a package-level var so tests can
+// inject a fake resolver without depending on the host PATH.
+var lookPath = exec.LookPath
+
+const (
+	// pluginProbeTimeout bounds the `<agent> plugin --help` capability check.
+	pluginProbeTimeout = 5 * time.Second
+	// pluginCmdTimeout bounds an install/update/uninstall command, which may
+	// clone the marketplace repo, so it gets more headroom than the probe.
+	pluginCmdTimeout = 60 * time.Second
+)
+
+// BlockedError reports that a plugin operation could not be performed for an
+// agent. The command layer maps Reason to a user-facing message and decides
+// whether to skip-with-warning or hard-fail (per the non-TTY policy). It never
+// causes a silent fall back to skills.
+type BlockedError struct {
+	Agent  string
+	Reason string
+	Detail string
+}
+
+// Reasons a plugin operation can be blocked.
+const (
+	// ReasonCLINotOnPath: the agent's CLI binary is not on PATH, or its CLI does
+	// not expose a working `plugin` subcommand.
+	ReasonCLINotOnPath = "cli-not-on-path"
+	// ReasonInstallFailed: the agent's plugin CLI ran but returned an error.
+	ReasonInstallFailed = "install-failed"
+	// ReasonManualOnly: the agent has a plugin but no headless install path (Cursor).
+	ReasonManualOnly = "manual-only"
+)
+
+func (e *BlockedError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("%s: %s: %s", e.Agent, e.Reason, e.Detail)
+	}
+	return fmt.Sprintf("%s: %s", e.Agent, e.Reason)
+}
+
+// runAgentCmd runs an agent CLI command with a timeout, returning stdout and any
+// error. Errors are *process.ProcessError, which carries the captured stderr.
+func runAgentCmd(ctx context.Context, timeout time.Duration, argv []string) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return process.Background(cctx, argv)
+}
+
+// stderrOf returns the captured stderr of a failed agent command, falling back
+// to the error's own message. Callers must not branch on this string.
+func stderrOf(err error) string {
+	if perr, ok := errors.AsType[*process.ProcessError](err); ok {
+		if s := strings.TrimSpace(perr.Stderr); s != "" {
+			return s
+		}
+	}
+	return err.Error()
+}
+
+// resolveAgentBinary resolves the agent's CLI binary to an absolute path.
+// It refuses a binary that resolves only relative to the current directory
+// (exec.ErrDot), so a malicious ./claude is never executed.
+func resolveAgentBinary(agent *agents.Agent) (string, error) {
+	if agent.Binary == "" {
+		return "", fmt.Errorf("%s has no CLI binary", agent.DisplayName)
+	}
+	path, err := lookPath(agent.Binary)
+	if err != nil {
+		return "", fmt.Errorf("could not resolve %s on PATH: %w", agent.Binary, err)
+	}
+	return path, nil
+}
+
+// installTarget is the `<plugin>@<marketplace>` argument the agent CLIs accept,
+// e.g. "databricks@databricks-agent-skills".
+func installTarget(spec *agents.PluginSpec) string {
+	return spec.ID + "@" + spec.Marketplace
+}
+
+// marketplaceAddArgs builds the `plugin marketplace add <source>` argv (sans binary).
+func marketplaceAddArgs(spec *agents.PluginSpec) []string {
+	return []string{"plugin", "marketplace", "add", spec.Source}
+}
+
+// marketplaceRemoveArgs builds the `plugin marketplace remove <name>` argv (sans binary).
+func marketplaceRemoveArgs(spec *agents.PluginSpec) []string {
+	return []string{"plugin", "marketplace", "remove", spec.Marketplace}
+}
+
+// pluginInstallArgs builds the per-agent install argv (sans binary). Codex uses
+// `plugin add`; Claude is the only agent that accepts `--scope`.
+func pluginInstallArgs(agent *agents.Agent, scope string) []string {
+	target := installTarget(agent.Plugin)
+	switch agent.Name {
+	case agents.NameCodex:
+		return []string{"plugin", "add", target}
+	case agents.NameClaudeCode:
+		args := []string{"plugin", "install", target}
+		if scope != "" {
+			args = append(args, "--scope", scope)
+		}
+		return args
+	default:
+		return []string{"plugin", "install", target}
+	}
+}
+
+// pluginUpdateSteps builds the ordered per-agent update argv sets (sans binary).
+// Codex updates in two steps: refresh the marketplace, then re-add.
+func pluginUpdateSteps(agent *agents.Agent) [][]string {
+	target := installTarget(agent.Plugin)
+	switch agent.Name {
+	case agents.NameCodex:
+		return [][]string{
+			{"plugin", "marketplace", "upgrade"},
+			{"plugin", "add", target},
+		}
+	default:
+		return [][]string{{"plugin", "update", target}}
+	}
+}
+
+// pluginUninstallArgs builds the per-agent uninstall argv (sans binary).
+// Codex removes with `plugin remove`; the others use `plugin uninstall`.
+func pluginUninstallArgs(agent *agents.Agent) []string {
+	target := installTarget(agent.Plugin)
+	switch agent.Name {
+	case agents.NameCodex:
+		return []string{"plugin", "remove", target}
+	default:
+		return []string{"plugin", "uninstall", target}
+	}
+}
+
+// probePluginCLI resolves the agent's binary and confirms its CLI exposes the
+// plugin subcommand, so we don't register a marketplace on a CLI that can't
+// install plugins. Returns the resolved absolute path.
+func probePluginCLI(ctx context.Context, agent *agents.Agent) (string, error) {
+	bin, err := resolveAgentBinary(agent)
+	if err != nil {
+		return "", &BlockedError{Agent: agent.Name, Reason: ReasonCLINotOnPath, Detail: err.Error()}
+	}
+	if _, err := runAgentCmd(ctx, pluginProbeTimeout, []string{bin, "plugin", "--help"}); err != nil {
+		return "", &BlockedError{Agent: agent.Name, Reason: ReasonCLINotOnPath, Detail: stderrOf(err)}
+	}
+	return bin, nil
+}
+
+// InstallPluginForAgent registers the databricks marketplace and installs the
+// plugin through the agent's own CLI, returning the record to persist in state.
+// It never falls back to skills: a blocked install returns a *BlockedError.
+func InstallPluginForAgent(ctx context.Context, agent *agents.Agent, nativeScope, ref string) (PluginRecord, error) {
+	if agent.Plugin == nil || agent.Plugin.ManualOnly {
+		return PluginRecord{}, &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
+	}
+
+	bin, err := probePluginCLI(ctx, agent)
+	if err != nil {
+		return PluginRecord{}, err
+	}
+
+	// Register the marketplace. Record InstalledMarketplace only when our add
+	// succeeded, so uninstall never de-registers a marketplace that was already
+	// present (and may be shared by another plugin).
+	_, addErr := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceAddArgs(agent.Plugin)))
+	installedMarketplace := addErr == nil
+
+	if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, pluginInstallArgs(agent, nativeScope))); err != nil {
+		return PluginRecord{}, &BlockedError{Agent: agent.Name, Reason: ReasonInstallFailed, Detail: stderrOf(err)}
+	}
+
+	return PluginRecord{
+		Marketplace:          agent.Plugin.Marketplace,
+		Plugin:               agent.Plugin.ID,
+		Scope:                nativeScope,
+		Version:              strings.TrimPrefix(ref, "v"),
+		InstalledMarketplace: installedMarketplace,
+	}, nil
+}
+
+// UpdatePluginForAgent updates the plugin through the agent's own CLI. The
+// plugin's own update handles content the release dropped, so there is no
+// per-skill prune for plugin agents.
+func UpdatePluginForAgent(ctx context.Context, agent *agents.Agent) error {
+	if agent.Plugin == nil || agent.Plugin.ManualOnly {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
+	}
+	bin, err := resolveAgentBinary(agent)
+	if err != nil {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonCLINotOnPath, Detail: err.Error()}
+	}
+	for _, args := range pluginUpdateSteps(agent) {
+		if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, args)); err != nil {
+			return &BlockedError{Agent: agent.Name, Reason: ReasonInstallFailed, Detail: stderrOf(err)}
+		}
+	}
+	return nil
+}
+
+// UninstallPluginForAgent removes the plugin through the agent's own CLI, and
+// de-registers the marketplace only when this CLI registered it and the caller
+// did not ask to keep it. It never removes a marketplace another plugin shares.
+func UninstallPluginForAgent(ctx context.Context, agent *agents.Agent, rec PluginRecord, keepMarketplace bool) error {
+	if agent.Plugin == nil || agent.Plugin.ManualOnly {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
+	}
+	bin, err := resolveAgentBinary(agent)
+	if err != nil {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonCLINotOnPath, Detail: err.Error()}
+	}
+	if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, pluginUninstallArgs(agent))); err != nil {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonInstallFailed, Detail: stderrOf(err)}
+	}
+	if rec.InstalledMarketplace && !keepMarketplace {
+		if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceRemoveArgs(agent.Plugin))); err != nil {
+			return fmt.Errorf("removed plugin but failed to de-register marketplace for %s: %w", agent.DisplayName, err)
+		}
+	}
+	return nil
+}
+
+// prepend returns a fresh argv with bin as argv[0] followed by args.
+func prepend(bin string, args []string) []string {
+	argv := make([]string, 0, len(args)+1)
+	argv = append(argv, bin)
+	return append(argv, args...)
+}

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -1,0 +1,188 @@
+package installer
+
+import (
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/aitools/agents"
+	"github.com/databricks/cli/libs/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stubAgentLookPath(t *testing.T, found bool) {
+	t.Helper()
+	orig := lookPath
+	lookPath = func(name string) (string, error) {
+		if found {
+			return filepath.Join("/usr/bin", name), nil
+		}
+		return "", exec.ErrNotFound
+	}
+	t.Cleanup(func() { lookPath = orig })
+}
+
+func pluginAgent(name, display, binary string) *agents.Agent {
+	return &agents.Agent{
+		Name:        name,
+		DisplayName: display,
+		Binary:      binary,
+		Plugin: &agents.PluginSpec{
+			Marketplace: "databricks-agent-skills",
+			ID:          "databricks",
+			Source:      "databricks/databricks-agent-skills",
+		},
+	}
+}
+
+func claudeAgent() *agents.Agent { return pluginAgent(agents.NameClaudeCode, "Claude Code", "claude") }
+func codexAgent() *agents.Agent  { return pluginAgent(agents.NameCodex, "Codex CLI", "codex") }
+
+func cursorAgent() *agents.Agent {
+	return &agents.Agent{
+		Name:        agents.NameCursor,
+		DisplayName: "Cursor",
+		Binary:      "cursor-agent",
+		Plugin:      &agents.PluginSpec{ManualOnly: true, ManualInstructions: "run /add-plugin databricks in Cursor"},
+	}
+}
+
+func TestInstallPluginForAgentClaudeSuccess(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	rec, err := InstallPluginForAgent(ctx, claudeAgent(), "user", "v0.2.6")
+	require.NoError(t, err)
+	assert.Equal(t, "databricks-agent-skills", rec.Marketplace)
+	assert.Equal(t, "databricks", rec.Plugin)
+	assert.Equal(t, "user", rec.Scope)
+	assert.Equal(t, "0.2.6", rec.Version)
+	assert.True(t, rec.InstalledMarketplace)
+
+	cmds := stub.Commands()
+	assert.Contains(t, cmds, "claude plugin --help")
+	assert.Contains(t, cmds, "claude plugin marketplace add databricks/databricks-agent-skills")
+	assert.Contains(t, cmds, "claude plugin install databricks@databricks-agent-skills --scope user")
+}
+
+func TestInstallPluginForAgentCodexUsesAddNoScope(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	_, err := InstallPluginForAgent(ctx, codexAgent(), "user", "v0.2.6")
+	require.NoError(t, err)
+
+	cmds := stub.Commands()
+	assert.Contains(t, cmds, "codex plugin add databricks@databricks-agent-skills")
+	for _, c := range cmds {
+		assert.NotContains(t, c, "--scope")
+	}
+}
+
+func TestInstallPluginForAgentManualOnly(t *testing.T) {
+	_, err := InstallPluginForAgent(t.Context(), cursorAgent(), "user", "v0.2.6")
+	var be *BlockedError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, ReasonManualOnly, be.Reason)
+}
+
+func TestInstallPluginForAgentCLINotOnPath(t *testing.T) {
+	stubAgentLookPath(t, false)
+	ctx, stub := process.WithStub(t.Context())
+
+	_, err := InstallPluginForAgent(ctx, claudeAgent(), "user", "v0.2.6")
+	var be *BlockedError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, ReasonCLINotOnPath, be.Reason)
+	assert.Equal(t, 0, stub.Len(), "a missing CLI must not be executed")
+}
+
+func TestInstallPluginForAgentInstallFails(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	stub.WithStderrFor("claude plugin install", "you must run `copilot login`").
+		WithFailureFor("claude plugin install", errors.New("exit status 1"))
+
+	_, err := InstallPluginForAgent(ctx, claudeAgent(), "user", "v0.2.6")
+	var be *BlockedError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, ReasonInstallFailed, be.Reason)
+	// The agent's own stderr is surfaced verbatim, not classified by us.
+	assert.Equal(t, "you must run `copilot login`", be.Detail)
+}
+
+func TestInstallPluginForAgentMarketplaceAlreadyPresent(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	// marketplace add fails (already present), but install still succeeds.
+	stub.WithFailureFor("plugin marketplace add", errors.New("already added"))
+
+	rec, err := InstallPluginForAgent(ctx, claudeAgent(), "user", "v0.2.6")
+	require.NoError(t, err)
+	assert.False(t, rec.InstalledMarketplace, "we did not add the marketplace, so we must not record that we did")
+}
+
+func TestUpdatePluginForAgentCodexTwoStep(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	require.NoError(t, UpdatePluginForAgent(ctx, codexAgent()))
+	cmds := stub.Commands()
+	assert.Contains(t, cmds, "codex plugin marketplace upgrade")
+	assert.Contains(t, cmds, "codex plugin add databricks@databricks-agent-skills")
+}
+
+func TestUpdatePluginForAgentClaudeOneStep(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	require.NoError(t, UpdatePluginForAgent(ctx, claudeAgent()))
+	assert.Contains(t, stub.Commands(), "claude plugin update databricks@databricks-agent-skills")
+}
+
+func TestUninstallPluginDeregistersMarketplaceWhenInstalledByUs(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	rec := PluginRecord{Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true}
+	require.NoError(t, UninstallPluginForAgent(ctx, claudeAgent(), rec, false))
+
+	cmds := stub.Commands()
+	assert.Contains(t, cmds, "claude plugin uninstall databricks@databricks-agent-skills")
+	assert.Contains(t, cmds, "claude plugin marketplace remove databricks-agent-skills")
+}
+
+func TestUninstallPluginKeepsSharedMarketplace(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	rec := PluginRecord{Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: false}
+	require.NoError(t, UninstallPluginForAgent(ctx, claudeAgent(), rec, false))
+
+	for _, c := range stub.Commands() {
+		assert.NotContains(t, c, "marketplace remove")
+	}
+}
+
+func TestUninstallPluginKeepMarketplaceFlag(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	rec := PluginRecord{Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true}
+	require.NoError(t, UninstallPluginForAgent(ctx, claudeAgent(), rec, true))
+
+	for _, c := range stub.Commands() {
+		assert.NotContains(t, c, "marketplace remove")
+	}
+}

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -120,12 +120,28 @@ func TestInstallPluginForAgentMarketplaceAlreadyPresent(t *testing.T) {
 	stubAgentLookPath(t, true)
 	ctx, stub := process.WithStub(t.Context())
 	stub.WithCallback(func(*exec.Cmd) error { return nil })
-	// marketplace add fails (already present), but install still succeeds.
-	stub.WithFailureFor("plugin marketplace add", errors.New("already added"))
+	// The marketplace is already registered, so even though `add` succeeds we must
+	// not claim ownership (and must not de-register it on uninstall).
+	stub.WithStdoutFor("plugin marketplace list", "databricks-agent-skills\n")
 
 	rec, err := InstallPluginForAgent(ctx, claudeAgent(), "user", "v0.2.6")
 	require.NoError(t, err)
-	assert.False(t, rec.InstalledMarketplace, "we did not add the marketplace, so we must not record that we did")
+	assert.False(t, rec.InstalledMarketplace, "a pre-existing marketplace must not be recorded as ours")
+}
+
+func TestInstallPluginRollsBackMarketplaceOnInstallFailure(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	// Marketplace absent (empty list) so we add it; then the plugin install fails.
+	stub.WithFailureFor("plugin install", errors.New("boom"))
+
+	_, err := InstallPluginForAgent(ctx, claudeAgent(), "user", "v0.2.6")
+	var be *BlockedError
+	require.ErrorAs(t, err, &be)
+	assert.Equal(t, ReasonInstallFailed, be.Reason)
+	// We added the marketplace, so a failed install must de-register it again.
+	assert.Contains(t, stub.Commands(), "claude plugin marketplace remove databricks-agent-skills")
 }
 
 func TestUpdatePluginForAgentCodexTwoStep(t *testing.T) {

--- a/libs/aitools/installer/state.go
+++ b/libs/aitools/installer/state.go
@@ -7,10 +7,23 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/databricks/cli/libs/env"
 )
+
+// clearFileRecords removes all file-provenance entries belonging to a skill
+// (keys are "<skill>/<file>"), so refetching or removing a skill never leaves
+// orphaned records behind.
+func clearFileRecords(files map[string]FileRecord, skillName string) {
+	prefix := skillName + "/"
+	for path := range files {
+		if strings.HasPrefix(path, prefix) {
+			delete(files, path)
+		}
+	}
+}
 
 const stateFileName = ".state.json"
 

--- a/libs/aitools/installer/update.go
+++ b/libs/aitools/installer/update.go
@@ -172,11 +172,14 @@ func UpdateSkills(ctx context.Context, src ManifestSource, targetAgents []*agent
 		ref:     latestTag,
 	}
 
+	fileRecords := map[string]FileRecord{}
 	for _, change := range allChanges {
 		meta := manifest.Skills[change.Name]
-		if err := installSkillForAgents(ctx, change.Name, meta, targetAgents, params); err != nil {
+		records, err := installSkillForAgents(ctx, change.Name, meta, targetAgents, params)
+		if err != nil {
 			return nil, err
 		}
+		maps.Copy(fileRecords, records)
 	}
 
 	// Update state.
@@ -185,11 +188,15 @@ func UpdateSkills(ctx context.Context, src ManifestSource, targetAgents []*agent
 	if state.RepoDirs == nil {
 		state.RepoDirs = make(map[string]string, len(state.Skills)+len(allChanges))
 	}
+	if state.Files == nil {
+		state.Files = make(map[string]FileRecord, len(fileRecords))
+	}
 	for _, change := range allChanges {
 		meta := manifest.Skills[change.Name]
 		state.Skills[change.Name] = change.NewVersion
 		state.RepoDirs[change.Name] = meta.RepoDir
 	}
+	maps.Copy(state.Files, fileRecords)
 	if err := SaveState(baseDir, state); err != nil {
 		return nil, err
 	}

--- a/libs/aitools/installer/update.go
+++ b/libs/aitools/installer/update.go
@@ -195,6 +195,9 @@ func UpdateSkills(ctx context.Context, src ManifestSource, targetAgents []*agent
 		meta := manifest.Skills[change.Name]
 		state.Skills[change.Name] = change.NewVersion
 		state.RepoDirs[change.Name] = meta.RepoDir
+		// Drop stale provenance before recording the refetched files, so a file
+		// removed/renamed in the new version doesn't leave an orphaned record.
+		clearFileRecords(state.Files, change.Name)
 	}
 	maps.Copy(state.Files, fileRecords)
 	if err := SaveState(baseDir, state); err != nil {


### PR DESCRIPTION
<!-- aitools-stack -->
### Stack

Part of the `aitools` plugin-first redesign. Merge bottom to top:

- #5734 Detection & registry (plugin metadata + capability detection)
- #5736 State schema v2 (plugin + file provenance records)
- **#5737 Plugin engine, checksums, `--path` dump (library)  ← this PR**
- #5738 Plugin-first install command
- #5739 Update + prune of vanished skills
- #5740 Uninstall teardown + legacy skills cleanup
- #5741 list + version plugin state
<!-- /aitools-stack -->

## Why

The plugin-first redesign installs the databricks plugin by driving each agent's own plugin CLI (`claude plugin install`, etc.), and on `update` it needs to be able to prune a skill that vanished from a release without clobbering files the user edited. This PR adds the library layer for both, with no command wiring yet, so the engine can be reviewed and unit-tested on its own. The install/update/uninstall commands call into it in later PRs.

Stacked on #5736 (state schema v2).

## Changes

- `plugin.go` — the plugin engine. It drives each agent's CLI through `libs/process` (so tests mock it with `process.WithStub`):
  - `InstallPluginForAgent` registers the marketplace and installs the plugin, recording whether *we* added the marketplace.
  - `UpdatePluginForAgent` runs the per-agent update (Codex's two-step `marketplace upgrade` then `plugin add` is encoded).
  - `UninstallPluginForAgent` removes the plugin and de-registers the marketplace **only** when this CLI registered it and `--keep-marketplace` wasn't set — never a marketplace another plugin may share.
  - Argv is built per agent (Codex uses `plugin add`; Claude is the only `--scope` agent) and run by absolute path; a cwd-relative binary (`exec.ErrDot`) is refused, never executed.
  - A blocked operation returns a typed `*BlockedError` (`CLINotOnPath` / `InstallFailed` / `ManualOnly`), so the command layer can report it and decide skip-vs-fail — it never silently falls back to skills. The agent's own stderr is surfaced via `errors.AsType`, never string-matched.
- `installer.go` — `installSkillToDir` now records a sha256 `FileRecord` per file it writes (origin = ref); `InstallSkillsForAgents` and `UpdateSkills` persist these to `state.Files` for the prune safeguard. The symlink-vs-copy rules are unchanged.
- `dump.go` — `DumpSkillsToPath`, a dumb `--path` dump (no agents, no `.state.json`, no lifecycle) that reuses the existing manifest/resolve/fetch path.

## Test plan

- [x] `plugin_test.go` via `process.WithStub` + injected `lookPath`: Claude success (marketplace add + `--scope user` install), Codex uses `plugin add` with no `--scope`, manual-only (Cursor) → `ManualOnly`, CLI-not-on-path → `CLINotOnPath` with zero executions, install failure → `InstallFailed` surfacing stderr verbatim, marketplace-already-present leaves `InstalledMarketplace=false`, Codex two-step update, marketplace de-register only when we installed it and `--keep-marketplace` honored.
- [x] `dump_test.go`: writes files, writes no state, honors `--skills` cherry-pick.
- [x] `installer_test.go`: install captures file checksums into `state.Files`.
- [x] `go test ./libs/aitools/... ./cmd/aitools/...` and `go test ./acceptance -run TestAccept/experimental/aitools` pass.
- [x] `./task fmt-q`, `./task lint-q` (0 issues), `./task checks` (no dead code — engine funcs are reachable via tests until the command layer lands) clean.

This pull request and its description were written by Isaac.
