### PR TITLE
aitools: plugin-first install command (picker, scope, --path/--skills-only)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### CLI
 
+ * `databricks aitools install` is now plugin-first: it installs the Databricks plugin through each agent's own CLI (Claude Code, Codex, GitHub Copilot) instead of copying raw skill files. Agents without a plugin (OpenCode, Antigravity) still get skill files, and Cursor prints the `/add-plugin databricks` step. Use `--skills-only` to force raw skill files for every agent, or `--path <dir>` to write skills to a directory (PR_LINK_PLACEHOLDER).
+
 ### Bundles
 
  * direct: Cluster resize now falls back to regular update if resize fails due to `INVALID_STATE` ([#5716](https://github.com/databricks/cli/pull/5716)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### CLI
 
- * `databricks aitools install` is now plugin-first: it installs the Databricks plugin through each agent's own CLI (Claude Code, Codex, GitHub Copilot) instead of copying raw skill files. Agents without a plugin (OpenCode, Antigravity) still get skill files, and Cursor prints the `/add-plugin databricks` step. Use `--skills-only` to force raw skill files for every agent, or `--path <dir>` to write skills to a directory (PR_LINK_PLACEHOLDER).
+ * `databricks aitools install` is now plugin-first: it installs the Databricks plugin through each agent's own CLI (Claude Code, Codex, GitHub Copilot) instead of copying raw skill files. Agents without a plugin (OpenCode, Antigravity) still get skill files, and Cursor prints the `/add-plugin databricks` step. Use `--skills-only` to force raw skill files for every agent, or `--path <dir>` to write skills to a directory ([#5738](https://github.com/databricks/cli/pull/5738)).
 
 ### Bundles
 

--- a/acceptance/experimental/aitools/skills/install-experimental-empty/output.txt
+++ b/acceptance/experimental/aitools/skills/install-experimental-empty/output.txt
@@ -1,6 +1,6 @@
 
 === --experimental against a manifest with no experimental skills logs a nudge
->>> [CLI] experimental aitools install --global --experimental
+>>> [CLI] experimental aitools install --skills-only --global --experimental
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...

--- a/acceptance/experimental/aitools/skills/install-experimental-empty/script
+++ b/acceptance/experimental/aitools/skills/install-experimental-empty/script
@@ -2,4 +2,4 @@
 mkdir -p "${USERPROFILE:-$HOME}/.claude"
 
 title "--experimental against a manifest with no experimental skills logs a nudge"
-trace $CLI experimental aitools install --global --experimental
+trace $CLI experimental aitools install --skills-only --global --experimental

--- a/acceptance/experimental/aitools/skills/install-experimental-empty/script
+++ b/acceptance/experimental/aitools/skills/install-experimental-empty/script
@@ -1,3 +1,5 @@
+# Isolate HOME so parallel aitools tests don't race on a shared ~/.databricks.
+sethome home
 # Agent detection needs ~/.claude; prefer USERPROFILE on Windows.
 mkdir -p "${USERPROFILE:-$HOME}/.claude"
 

--- a/acceptance/experimental/aitools/skills/install-experimental-empty/test.toml
+++ b/acceptance/experimental/aitools/skills/install-experimental-empty/test.toml
@@ -2,7 +2,7 @@ Env.DATABRICKS_SKILLS_BASE_URL = "$DATABRICKS_HOST"
 Env.DATABRICKS_SKILLS_REF = "test-ref"
 
 Ignore = [
-    ".databricks/aitools/skills/.state.json",
+    "home",
 ]
 
 [EnvMatrix]

--- a/acceptance/experimental/aitools/skills/install-specific/output.txt
+++ b/acceptance/experimental/aitools/skills/install-specific/output.txt
@@ -1,6 +1,6 @@
 
 === install only one specific stable skill via --skills
->>> [CLI] experimental aitools install --global --skills test-stable-a
+>>> [CLI] experimental aitools install --skills-only --global --skills test-stable-a
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...
@@ -8,7 +8,7 @@ Using skills version test-ref
 Installed 1 skill.
 
 === install a specific experimental skill
->>> [CLI] experimental aitools install --global --skills test-exp --experimental
+>>> [CLI] experimental aitools install --skills-only --global --skills test-exp --experimental
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...
@@ -16,7 +16,7 @@ Using skills version test-ref
 Installed 1 skill.
 
 === asking for an experimental skill without --experimental flag errors out
->>> [CLI] experimental aitools install --global --skills test-exp
+>>> [CLI] experimental aitools install --skills-only --global --skills test-exp
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...

--- a/acceptance/experimental/aitools/skills/install-specific/script
+++ b/acceptance/experimental/aitools/skills/install-specific/script
@@ -2,10 +2,10 @@
 mkdir -p "${USERPROFILE:-$HOME}/.claude"
 
 title "install only one specific stable skill via --skills"
-trace $CLI experimental aitools install --global --skills test-stable-a
+trace $CLI experimental aitools install --skills-only --global --skills test-stable-a
 
 title "install a specific experimental skill"
-trace $CLI experimental aitools install --global --skills test-exp --experimental
+trace $CLI experimental aitools install --skills-only --global --skills test-exp --experimental
 
 title "asking for an experimental skill without --experimental flag errors out"
-errcode trace $CLI experimental aitools install --global --skills test-exp
+errcode trace $CLI experimental aitools install --skills-only --global --skills test-exp

--- a/acceptance/experimental/aitools/skills/install-specific/script
+++ b/acceptance/experimental/aitools/skills/install-specific/script
@@ -1,3 +1,5 @@
+# Isolate HOME so parallel aitools tests don't race on a shared ~/.databricks.
+sethome home
 # Agent detection needs ~/.claude; prefer USERPROFILE on Windows.
 mkdir -p "${USERPROFILE:-$HOME}/.claude"
 

--- a/acceptance/experimental/aitools/skills/install-specific/test.toml
+++ b/acceptance/experimental/aitools/skills/install-specific/test.toml
@@ -2,7 +2,7 @@ Env.DATABRICKS_SKILLS_BASE_URL = "$DATABRICKS_HOST"
 Env.DATABRICKS_SKILLS_REF = "test-ref"
 
 Ignore = [
-    ".databricks/aitools/skills/.state.json",
+    "home",
 ]
 
 [EnvMatrix]

--- a/acceptance/experimental/aitools/skills/install/output.txt
+++ b/acceptance/experimental/aitools/skills/install/output.txt
@@ -1,6 +1,6 @@
 
 === stable-only install (no --experimental flag) installs 1 skill
->>> [CLI] experimental aitools install --global
+>>> [CLI] experimental aitools install --skills-only --global
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...
@@ -8,7 +8,7 @@ Using skills version test-ref
 Installed 1 skill.
 
 === re-run with --experimental installs the experimental one too
->>> [CLI] experimental aitools install --global --experimental
+>>> [CLI] experimental aitools install --skills-only --global --experimental
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...
@@ -16,7 +16,7 @@ Using skills version test-ref
 Installed 2 skills.
 
 === no-op re-run is idempotent (no new fetches, no errors)
->>> [CLI] experimental aitools install --global --experimental
+>>> [CLI] experimental aitools install --skills-only --global --experimental
 Command "install" is deprecated, use "databricks aitools install" instead.
 Flag --global has been deprecated, use --scope=global
 Installing Databricks AI skills for Claude Code...

--- a/acceptance/experimental/aitools/skills/install/script
+++ b/acceptance/experimental/aitools/skills/install/script
@@ -2,10 +2,10 @@
 mkdir -p "${USERPROFILE:-$HOME}/.claude"
 
 title "stable-only install (no --experimental flag) installs 1 skill"
-trace $CLI experimental aitools install --global
+trace $CLI experimental aitools install --skills-only --global
 
 title "re-run with --experimental installs the experimental one too"
-trace $CLI experimental aitools install --global --experimental
+trace $CLI experimental aitools install --skills-only --global --experimental
 
 title "no-op re-run is idempotent (no new fetches, no errors)"
-trace $CLI experimental aitools install --global --experimental
+trace $CLI experimental aitools install --skills-only --global --experimental

--- a/acceptance/experimental/aitools/skills/install/script
+++ b/acceptance/experimental/aitools/skills/install/script
@@ -1,3 +1,5 @@
+# Isolate HOME so parallel aitools tests don't race on a shared ~/.databricks.
+sethome home
 # Agent detection needs ~/.claude; prefer USERPROFILE on Windows.
 mkdir -p "${USERPROFILE:-$HOME}/.claude"
 

--- a/acceptance/experimental/aitools/skills/install/test.toml
+++ b/acceptance/experimental/aitools/skills/install/test.toml
@@ -3,7 +3,7 @@ Env.DATABRICKS_SKILLS_BASE_URL = "$DATABRICKS_HOST"
 Env.DATABRICKS_SKILLS_REF = "test-ref"
 
 Ignore = [
-    ".databricks/aitools/skills/.state.json",
+    "home",
 ]
 
 [EnvMatrix]

--- a/acceptance/experimental/aitools/skills/path-dump/out.test.toml
+++ b/acceptance/experimental/aitools/skills/path-dump/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/experimental/aitools/skills/path-dump/output.txt
+++ b/acceptance/experimental/aitools/skills/path-dump/output.txt
@@ -1,0 +1,10 @@
+
+=== dump skills to a directory
+>>> [CLI] experimental aitools install --path dumped
+Command "install" is deprecated, use "databricks aitools install" instead.
+Using skills version test-ref
+Wrote 1 skill to dumped
+
+=== the skill files were written
+>>> find.py dumped.*SKILL.md --expect 1
+dumped/test-stable/SKILL.md

--- a/acceptance/experimental/aitools/skills/path-dump/script
+++ b/acceptance/experimental/aitools/skills/path-dump/script
@@ -1,0 +1,6 @@
+# --path is a dumb dump: no agents, no state, just the files.
+title "dump skills to a directory"
+trace $CLI experimental aitools install --path dumped
+
+title "the skill files were written"
+trace find.py 'dumped.*SKILL.md' --expect 1

--- a/acceptance/experimental/aitools/skills/path-dump/test.toml
+++ b/acceptance/experimental/aitools/skills/path-dump/test.toml
@@ -1,0 +1,37 @@
+# Mock server replaces raw.githubusercontent.com for manifest + skill files.
+Env.DATABRICKS_SKILLS_BASE_URL = "$DATABRICKS_HOST"
+Env.DATABRICKS_SKILLS_REF = "test-ref"
+
+# --path writes files into the working directory; don't diff them.
+Ignore = [
+    "dumped",
+]
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = []
+
+[[Server]]
+Pattern = "GET /test-ref/manifest.json"
+Response.Body = '''
+{
+  "version": "2",
+  "updated_at": "2026-01-01T00:00:00Z",
+  "skills": {
+    "test-stable": {
+      "version": "1.0.0",
+      "description": "Stable test skill",
+      "files": ["SKILL.md"],
+      "repo_dir": "skills"
+    }
+  }
+}
+'''
+
+[[Server]]
+Pattern = "GET /test-ref/skills/test-stable/SKILL.md"
+Response.Body = '''---
+name: test-stable
+---
+
+# Test stable skill
+'''

--- a/cmd/aitools/install.go
+++ b/cmd/aitools/install.go
@@ -10,139 +10,146 @@ import (
 	"github.com/databricks/cli/libs/aitools/agents"
 	"github.com/databricks/cli/libs/aitools/installer"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/log"
 	"github.com/spf13/cobra"
 )
 
-// Package-level for testability. Tests in this package override them via
-// helpers in install_test.go.
+// Package-level seams for testability. Tests override these via helpers in
+// install_test.go.
 var (
 	promptAgentSelection     = defaultPromptAgentSelection
 	installSkillsForAgentsFn = installer.InstallSkillsForAgents
+	installPluginForAgentFn  = installer.InstallPluginForAgent
+	recordPluginInstallsFn   = installer.RecordPluginInstalls
 )
 
-func defaultPromptAgentSelection(ctx context.Context, detected []*agents.Agent) ([]*agents.Agent, error) {
-	options := make([]huh.Option[string], 0, len(detected))
-	agentsByName := make(map[string]*agents.Agent, len(detected))
-	for _, a := range detected {
-		options = append(options, huh.NewOption(a.DisplayName, a.Name).Selected(true))
-		agentsByName[a.Name] = a
-	}
+// delivery is how the databricks tools are delivered to one agent.
+type delivery int
 
-	var selected []string
-	err := huh.NewMultiSelect[string]().
-		Title("Select coding agents to install skills for").
-		Description("space to toggle, enter to confirm").
-		Options(options...).
-		Value(&selected).
-		Run()
-	if err != nil {
-		return nil, err
-	}
+const (
+	// deliveryPlugin installs the databricks plugin through the agent's own CLI.
+	deliveryPlugin delivery = iota
+	// deliverySkills copies raw skill files (no-plugin agents, or --skills-only).
+	deliverySkills
+	// deliveryManualCursor prints the /add-plugin tip and copies nothing (Cursor).
+	deliveryManualCursor
+	// deliverySkip does nothing for the agent and explains why.
+	deliverySkip
+)
 
-	if len(selected) == 0 {
-		return nil, errors.New("at least one agent must be selected")
-	}
+// agentPlanItem is the resolved plan for one agent: what we'll do and why.
+type agentPlanItem struct {
+	agent    *agents.Agent
+	delivery delivery
+	scope    string // agent-native plugin scope (deliveryPlugin only)
+	reason   string // why skipped or what the manual step is
+	explicit bool   // named via --agents (blocking it is an error)
+}
 
-	result := make([]*agents.Agent, 0, len(selected))
-	for _, name := range selected {
-		result = append(result, agentsByName[name])
-	}
-	return result, nil
+// agentChoice is one row in the interactive agent picker.
+type agentChoice struct {
+	agent     *agents.Agent
+	label     string
+	preselect bool
 }
 
 func NewInstallCmd() *cobra.Command {
-	var skillsFlag, agentsFlag, scopeFlag string
-	var includeExperimental bool
+	var skillsFlag, agentsFlag, scopeFlag, pathFlag string
+	var includeExperimental, skillsOnly bool
 	var projectFlag, globalFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
-		Short: "Install AI skills for coding agents",
-		Long: `Install Databricks AI skills for detected coding agents.
+		Short: "Install Databricks AI tools for coding agents",
+		Long: `Install Databricks AI tools for detected coding agents.
 
-By default, skills are installed globally to each agent's skills directory.
-Use --scope=project to install to the current project directory instead.
-When multiple agents are detected, skills are stored in a canonical location
-and symlinked to each agent to avoid duplication.
+By default this installs the databricks plugin through each agent's own CLI
+(Claude Code, Codex, GitHub Copilot). Agents with no plugin (OpenCode,
+Antigravity) get raw skill files. Cursor has a plugin but no headless install,
+so the CLI prints the '/add-plugin databricks' step instead of copying files.
 
-Use --skills name1,name2 to install specific skills.
+Escape hatches:
+  --skills-only          Force raw skill files for every agent (no plugin).
+  --skills name1,name2   Install only the named skills (with --skills-only/--path).
+  --path <dir>           Write resolved skill files to a directory (no agents, no state).
 
 Agent selection:
-  --agents <name>[,<name>...]   Install only for the named agents.
-  (unset, interactive)          Multi-select prompt over detected agents.
-  (unset, non-interactive)      Install for every detected agent.
-
-The list of agents the command will act on is always logged to stderr before
-the install runs, so callers can verify what was picked.
+  --agents <name>[,...]  Act only on the named agents (works for undetected ones).
+  (unset, interactive)   A picker over all known agents, detected ones pre-checked.
+  (unset, non-interactive) Act on every detected agent.
 
 Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Antigravity`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
+			if skillsOnly && pathFlag != "" {
+				return errors.New("cannot use --skills-only with --path; --path always writes raw skill files")
+			}
+
+			opts := installer.InstallOptions{
+				IncludeExperimental: includeExperimental,
+				SpecificSkills:      splitAndTrim(skillsFlag),
+			}
+
+			src := &installer.GitHubManifestSource{}
+
+			// --path is a dumb dump: no agents, no scope, no state.
+			if pathFlag != "" {
+				_, err := installer.DumpSkillsToPath(ctx, src, pathFlag, opts)
+				return err
+			}
+
 			projectFlag, globalFlag, err := parseScopeFlag(scopeFlag, projectFlag, globalFlag, false)
 			if err != nil {
 				return err
 			}
-
-			// Resolve scope.
 			scope, err := resolveScopeWithPrompt(ctx, projectFlag, globalFlag)
 			if err != nil {
 				return err
 			}
+			opts.Scope = scope
 
-			// Resolve target agents.
+			// Resolve the agents to act on.
 			var targetAgents []*agents.Agent
-			if agentsFlag != "" {
+			explicit := agentsFlag != ""
+			if explicit {
 				targetAgents, err = resolveAgentNames(ctx, agentsFlag)
 				if err != nil {
 					return err
 				}
 			} else {
-				detected := agents.DetectInstalled(ctx)
-				if len(detected) == 0 {
+				targetAgents = selectAgents(ctx, scope, skillsOnly)
+				if len(targetAgents) == 0 {
 					printNoAgentsMessage(ctx)
 					return nil
 				}
+			}
 
-				// For project scope, pre-filter to compatible agents before prompting.
-				if scope == installer.ScopeProject {
-					detected = filterProjectScopeAgents(detected)
-					if len(detected) == 0 {
-						return errors.New("no detected agents support project-scoped skills")
-					}
+			plan := buildPlan(targetAgents, scope, skillsOnly, explicit)
+
+			// In the interactive picker path, show a plan summary and confirm.
+			if !explicit && cmdio.IsPromptSupported(ctx) {
+				printPlanSummary(ctx, plan, scope)
+				proceed, err := cmdio.AskYesOrNo(ctx, "Proceed?")
+				if err != nil {
+					return err
 				}
-
-				switch {
-				case len(detected) == 1:
-					targetAgents = detected
-				case cmdio.IsPromptSupported(ctx):
-					targetAgents, err = promptAgentSelection(ctx, detected)
-					if err != nil {
-						return err
-					}
-				default:
-					targetAgents = detected
+				if !proceed {
+					cmdio.LogString(ctx, "Cancelled.")
+					return nil
 				}
 			}
 
-			// Build install options.
-			opts := installer.InstallOptions{
-				IncludeExperimental: includeExperimental,
-				Scope:               scope,
-			}
-			opts.SpecificSkills = splitAndTrim(skillsFlag)
-
-			installer.PrintInstallingFor(ctx, targetAgents)
-
-			src := &installer.GitHubManifestSource{}
-			return installSkillsForAgentsFn(ctx, src, targetAgents, opts)
+			return executePlan(ctx, src, plan, opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&skillsFlag, "skills", "", "Specific skills to install (comma-separated)")
 	cmd.Flags().StringVar(&agentsFlag, "agents", "", "Agents to install for (comma-separated, e.g. claude-code,cursor)")
 	cmd.Flags().BoolVar(&includeExperimental, "experimental", false, "Include experimental skills")
+	cmd.Flags().BoolVar(&skillsOnly, "skills-only", false, "Force raw skill files for every agent instead of the plugin")
+	cmd.Flags().StringVar(&pathFlag, "path", "", "Write resolved skill files to this directory (no agents, no state)")
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "Install scope: project or global (default: global, or prompt when interactive)")
 	cmd.Flags().BoolVar(&projectFlag, "project", false, "Install to project directory (cwd)")
 	cmd.Flags().BoolVar(&globalFlag, "global", false, "Install globally (default)")
@@ -150,9 +157,229 @@ Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Anti
 	return cmd
 }
 
+// selectAgents returns the agents to act on when --agents is not given. The
+// interactive path shows a picker over all known agents; the non-interactive
+// path acts on detected agents, matching today's default. Skills delivery only
+// needs a config dir, so in --skills-only mode an agent is "detected" by its
+// config dir (PATH-independent); plugin delivery additionally detects agents by
+// their CLI binary on PATH, which fixes the Codex/Copilot config-dir miss.
+func selectAgents(ctx context.Context, scope string, skillsOnly bool) []*agents.Agent {
+	if cmdio.IsPromptSupported(ctx) {
+		choices := agentChoices(ctx)
+		selected, err := promptAgentSelection(ctx, choices)
+		if err != nil {
+			log.Warnf(ctx, "Agent selection failed: %v", err)
+			return nil
+		}
+		return selected
+	}
+
+	var selected []*agents.Agent
+	for i := range agents.Registry {
+		a := &agents.Registry[i]
+		detected := a.Detected(ctx)
+		if !skillsOnly {
+			detected = detected || a.HasBinary(ctx)
+		}
+		if detected {
+			selected = append(selected, a)
+		}
+	}
+	return selected
+}
+
+// agentChoices builds the interactive picker rows over every known agent.
+func agentChoices(ctx context.Context) []agentChoice {
+	cmdio.LogString(ctx, "Detecting coding agents...")
+	choices := make([]agentChoice, 0, len(agents.Registry))
+	for i := range agents.Registry {
+		a := &agents.Registry[i]
+		choices = append(choices, agentChoice{
+			agent:     a,
+			label:     a.DisplayName + "  " + agentStateLabel(a.DisplayState(ctx)),
+			preselect: a.IsPreselected(ctx),
+		})
+		cmdio.LogString(ctx, fmt.Sprintf("  %-16s %s", a.DisplayName, agentStateLabel(a.DisplayState(ctx))))
+	}
+	return choices
+}
+
+// agentStateLabel is the short human label for a detection state.
+func agentStateLabel(s agents.DisplayState) string {
+	switch s {
+	case agents.StateAvailable:
+		return "plugin"
+	case agents.StateInstalledCLIMissing:
+		return "plugin · CLI not found"
+	case agents.StateManualOnly:
+		return "plugin · add manually with /add-plugin"
+	case agents.StateFilesOnly:
+		return "skills"
+	default:
+		return "not found"
+	}
+}
+
+func defaultPromptAgentSelection(_ context.Context, choices []agentChoice) ([]*agents.Agent, error) {
+	options := make([]huh.Option[string], 0, len(choices))
+	byName := make(map[string]*agents.Agent, len(choices))
+	for _, c := range choices {
+		options = append(options, huh.NewOption(c.label, c.agent.Name).Selected(c.preselect))
+		byName[c.agent.Name] = c.agent
+	}
+
+	var selected []string
+	err := huh.NewMultiSelect[string]().
+		Title("Select agents to set up").
+		Description("space to toggle, enter to confirm").
+		Options(options...).
+		Value(&selected).
+		Run()
+	if err != nil {
+		return nil, err
+	}
+	if len(selected) == 0 {
+		return nil, errors.New("at least one agent must be selected")
+	}
+
+	result := make([]*agents.Agent, 0, len(selected))
+	for _, name := range selected {
+		result = append(result, byName[name])
+	}
+	return result, nil
+}
+
+// buildPlan resolves the per-agent delivery and scope. Plugin-first: an agent
+// with a plugin gets the plugin (or the manual step for Cursor); --skills-only
+// forces skills everywhere; agents with no plugin always get skills.
+func buildPlan(targetAgents []*agents.Agent, scope string, skillsOnly, explicit bool) []agentPlanItem {
+	plan := make([]agentPlanItem, 0, len(targetAgents))
+	for _, a := range targetAgents {
+		item := agentPlanItem{agent: a, explicit: explicit}
+		switch {
+		case skillsOnly || a.Plugin == nil:
+			item.delivery = deliverySkills
+		case a.Plugin.ManualOnly:
+			item.delivery = deliveryManualCursor
+			item.reason = a.Plugin.ManualInstructions
+		default:
+			nativeScope, ok, reason := mapAgentScope(a, scope)
+			if !ok {
+				item.delivery = deliverySkip
+				item.reason = reason
+			} else {
+				item.delivery = deliveryPlugin
+				item.scope = nativeScope
+			}
+		}
+		plan = append(plan, item)
+	}
+	return plan
+}
+
+// printPlanSummary renders the interactive plan summary before the confirm.
+func printPlanSummary(ctx context.Context, plan []agentPlanItem, scope string) {
+	cmdio.LogString(ctx, "")
+	cmdio.LogString(ctx, "Plan ("+scope+" scope):")
+	for _, it := range plan {
+		switch it.delivery {
+		case deliveryPlugin:
+			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  install the databricks plugin")
+		case deliverySkills:
+			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  install skills")
+		case deliveryManualCursor:
+			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  manual: "+it.reason)
+		case deliverySkip:
+			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  skip ("+it.reason+")")
+		}
+	}
+	cmdio.LogString(ctx, "")
+}
+
+// executePlan carries out the plan. Skills installs go through the existing
+// skills path (preserving its output). Plugin installs are reported but never
+// silently fall back to skills: a blocked install is a warning (exit 0), unless
+// the agent was explicitly named via --agents, which is an error.
+func executePlan(ctx context.Context, src installer.ManifestSource, plan []agentPlanItem, opts installer.InstallOptions) error {
+	var skillsAgents []*agents.Agent
+	var pluginItems, manualItems, skipItems []agentPlanItem
+	for _, it := range plan {
+		switch it.delivery {
+		case deliverySkills:
+			skillsAgents = append(skillsAgents, it.agent)
+		case deliveryPlugin:
+			pluginItems = append(pluginItems, it)
+		case deliveryManualCursor:
+			manualItems = append(manualItems, it)
+		case deliverySkip:
+			skipItems = append(skipItems, it)
+		}
+	}
+
+	var explicitErrs []error
+
+	if len(skillsAgents) > 0 {
+		installer.PrintInstallingFor(ctx, skillsAgents)
+		if err := installSkillsForAgentsFn(ctx, src, skillsAgents, opts); err != nil {
+			return err
+		}
+	}
+
+	pluginCount := 0
+	if len(pluginItems) > 0 {
+		ref, _, err := installer.GetSkillsRef(ctx)
+		if err != nil {
+			return err
+		}
+		records := map[string]installer.PluginRecord{}
+		for _, it := range pluginItems {
+			rec, err := installPluginForAgentFn(ctx, it.agent, it.scope, ref)
+			if err != nil {
+				cmdio.LogString(ctx, cmdio.Yellow(ctx, fmt.Sprintf("Skipped %s: %v", it.agent.DisplayName, err)))
+				if it.explicit {
+					explicitErrs = append(explicitErrs, err)
+				}
+				continue
+			}
+			records[it.agent.Name] = rec
+			pluginCount++
+			cmdio.LogString(ctx, fmt.Sprintf("  %s  databricks plugin v%s", it.agent.DisplayName, rec.Version))
+		}
+		if len(records) > 0 {
+			if err := recordPluginInstallsFn(ctx, opts.Scope, records, ref); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, it := range manualItems {
+		cmdio.LogString(ctx, fmt.Sprintf("  %s  manual: %s", it.agent.DisplayName, it.reason))
+	}
+
+	for _, it := range skipItems {
+		cmdio.LogString(ctx, cmdio.Yellow(ctx, "Skipped "+it.agent.DisplayName+": "+it.reason))
+		if it.explicit {
+			explicitErrs = append(explicitErrs, fmt.Errorf("%s: %s", it.agent.DisplayName, it.reason))
+		}
+	}
+
+	if pluginCount > 0 {
+		noun := "agent"
+		if pluginCount != 1 {
+			noun = "agents"
+		}
+		cmdio.LogString(ctx, fmt.Sprintf("Installed the plugin for %d %s.", pluginCount, noun))
+	}
+
+	if len(explicitErrs) > 0 {
+		return errors.Join(explicitErrs...)
+	}
+	return nil
+}
+
 // resolveAgentNames parses a comma-separated list of agent names and validates
 // them against the registry. Returns an error for unrecognized names.
-func resolveAgentNames(ctx context.Context, names string) ([]*agents.Agent, error) {
+func resolveAgentNames(_ context.Context, names string) ([]*agents.Agent, error) {
 	available := make(map[string]*agents.Agent, len(agents.Registry))
 	var availableNames []string
 	for i := range agents.Registry {
@@ -182,21 +409,10 @@ func resolveAgentNames(ctx context.Context, names string) ([]*agents.Agent, erro
 	return result, nil
 }
 
-// filterProjectScopeAgents returns only agents that support project-scoped skills.
-func filterProjectScopeAgents(detected []*agents.Agent) []*agents.Agent {
-	var compatible []*agents.Agent
-	for _, a := range detected {
-		if a.SupportsProjectScope {
-			compatible = append(compatible, a)
-		}
-	}
-	return compatible
-}
-
 // printNoAgentsMessage prints the "no agents detected" message.
 func printNoAgentsMessage(ctx context.Context) {
-	cmdio.LogString(ctx, cmdio.Yellow(ctx, "No supported coding agents detected."))
+	cmdio.LogString(ctx, cmdio.Yellow(ctx, "No supported coding agents found on PATH."))
 	cmdio.LogString(ctx, "")
-	cmdio.LogString(ctx, "Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Antigravity")
-	cmdio.LogString(ctx, "Please install at least one coding agent first.")
+	cmdio.LogString(ctx, "Supported: Claude Code, Codex CLI, GitHub Copilot, Cursor, OpenCode, Antigravity.")
+	cmdio.LogString(ctx, "Install one, then re-run 'databricks aitools install'.")
 }

--- a/cmd/aitools/install.go
+++ b/cmd/aitools/install.go
@@ -10,7 +10,6 @@ import (
 	"github.com/databricks/cli/libs/aitools/agents"
 	"github.com/databricks/cli/libs/aitools/installer"
 	"github.com/databricks/cli/libs/cmdio"
-	"github.com/databricks/cli/libs/log"
 	"github.com/spf13/cobra"
 )
 
@@ -92,6 +91,13 @@ Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Anti
 				SpecificSkills:      splitAndTrim(skillsFlag),
 			}
 
+			// --skills cherry-picks individual skill files, which only applies to
+			// raw-skills delivery. The plugin is installed in full, so reject
+			// --skills unless raw skills were requested via --skills-only or --path.
+			if len(opts.SpecificSkills) > 0 && !skillsOnly && pathFlag == "" {
+				return errors.New("--skills requires --skills-only or --path; the databricks plugin is installed in full")
+			}
+
 			src := &installer.GitHubManifestSource{}
 
 			// --path is a dumb dump: no agents, no scope, no state.
@@ -119,7 +125,10 @@ Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Anti
 					return err
 				}
 			} else {
-				targetAgents = selectAgents(ctx, scope, skillsOnly)
+				targetAgents, err = selectAgents(ctx, scope, skillsOnly)
+				if err != nil {
+					return err
+				}
 				if len(targetAgents) == 0 {
 					printNoAgentsMessage(ctx)
 					return nil
@@ -163,15 +172,11 @@ Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub Copilot, Anti
 // needs a config dir, so in --skills-only mode an agent is "detected" by its
 // config dir (PATH-independent); plugin delivery additionally detects agents by
 // their CLI binary on PATH, which fixes the Codex/Copilot config-dir miss.
-func selectAgents(ctx context.Context, scope string, skillsOnly bool) []*agents.Agent {
+func selectAgents(ctx context.Context, scope string, skillsOnly bool) ([]*agents.Agent, error) {
+	// Interactive: the picker decides; a prompt error or empty selection is a real
+	// error, not a "nothing detected" no-op.
 	if cmdio.IsPromptSupported(ctx) {
-		choices := agentChoices(ctx)
-		selected, err := promptAgentSelection(ctx, choices)
-		if err != nil {
-			log.Warnf(ctx, "Agent selection failed: %v", err)
-			return nil
-		}
-		return selected
+		return promptAgentSelection(ctx, agentChoices(ctx))
 	}
 
 	var selected []*agents.Agent
@@ -185,7 +190,7 @@ func selectAgents(ctx context.Context, scope string, skillsOnly bool) []*agents.
 			selected = append(selected, a)
 		}
 	}
-	return selected
+	return selected, nil
 }
 
 // agentChoices builds the interactive picker rows over every known agent.

--- a/cmd/aitools/install_test.go
+++ b/cmd/aitools/install_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/databricks/cli/libs/aitools/agents"
@@ -13,6 +14,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func drainReader(r *bufio.Reader) {
+	buf := make([]byte, 4096)
+	for {
+		if _, err := r.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
+// --- Test helpers ---
+
+type installCall struct {
+	agents []string
+	opts   installer.InstallOptions
+}
 
 func setupInstallMock(t *testing.T) *[]installCall {
 	t.Helper()
@@ -31,6 +48,29 @@ func setupInstallMock(t *testing.T) *[]installCall {
 	return &calls
 }
 
+type pluginCall struct {
+	agent string
+	scope string
+}
+
+func setupPluginMock(t *testing.T) *[]pluginCall {
+	t.Helper()
+	origInstall := installPluginForAgentFn
+	origRecord := recordPluginInstallsFn
+	t.Cleanup(func() {
+		installPluginForAgentFn = origInstall
+		recordPluginInstallsFn = origRecord
+	})
+
+	var calls []pluginCall
+	installPluginForAgentFn = func(_ context.Context, a *agents.Agent, scope, ref string) (installer.PluginRecord, error) {
+		calls = append(calls, pluginCall{agent: a.Name, scope: scope})
+		return installer.PluginRecord{Marketplace: "databricks-agent-skills", Plugin: "databricks", Scope: scope, Version: "0.2.6"}, nil
+	}
+	recordPluginInstallsFn = func(context.Context, string, map[string]installer.PluginRecord, string) error { return nil }
+	return &calls
+}
+
 func setupScopeMock(t *testing.T, scope string) *bool {
 	t.Helper()
 	orig := promptScopeSelection
@@ -44,90 +84,241 @@ func setupScopeMock(t *testing.T, scope string) *bool {
 	return &called
 }
 
-type installCall struct {
-	agents []string
-	opts   installer.InstallOptions
-}
-
+// setupTestAgents creates config dirs for Claude and Cursor under a temp HOME.
 func setupTestAgents(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
-	// Create config dirs for two agents.
 	require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".claude"), 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".cursor"), 0o755))
 	return tmp
 }
 
-func TestInstallAllSkillsForAllAgents(t *testing.T) {
+// fakeBinsOnPath replaces PATH with a temp dir holding stub executables for the
+// named agent binaries, so HasBinary detects exactly those agents.
+func fakeBinsOnPath(t *testing.T, binaries ...string) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range binaries {
+		p := filepath.Join(dir, name)
+		if runtime.GOOS == "windows" {
+			p += ".exe"
+		}
+		require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755))
+	}
+	t.Setenv("PATH", dir)
+}
+
+func testPluginAgent(name, display, binary string, manual bool) *agents.Agent {
+	spec := &agents.PluginSpec{Marketplace: "databricks-agent-skills", ID: "databricks", Source: "databricks/databricks-agent-skills", ManualOnly: manual}
+	if manual {
+		spec.ManualInstructions = "run /add-plugin databricks in Cursor"
+	}
+	a := &agents.Agent{Name: name, DisplayName: display, Binary: binary, Plugin: spec}
+	if name == agents.NameClaudeCode {
+		a.SupportsProjectScope = true
+	}
+	return a
+}
+
+// --- buildPlan / mapAgentScope / executePlan unit tests (no detection) ---
+
+func TestBuildPlanDeliveries(t *testing.T) {
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
+	cursor := testPluginAgent(agents.NameCursor, "Cursor", "cursor-agent", true)
+	opencode := &agents.Agent{Name: agents.NameOpenCode, DisplayName: "OpenCode", Binary: "opencode"}
+	targets := []*agents.Agent{claude, cursor, opencode}
+
+	plan := buildPlan(targets, installer.ScopeGlobal, false, false)
+	assert.Equal(t, deliveryPlugin, plan[0].delivery)
+	assert.Equal(t, agentScopeUser, plan[0].scope)
+	assert.Equal(t, deliveryManualCursor, plan[1].delivery)
+	assert.Equal(t, deliverySkills, plan[2].delivery)
+
+	// --skills-only forces skills for every agent.
+	skillsPlan := buildPlan(targets, installer.ScopeGlobal, true, false)
+	for _, it := range skillsPlan {
+		assert.Equal(t, deliverySkills, it.delivery)
+	}
+}
+
+func TestBuildPlanProjectScopeSkipsUserOnlyAgent(t *testing.T) {
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
+	codex := testPluginAgent(agents.NameCodex, "Codex CLI", "codex", false)
+
+	plan := buildPlan([]*agents.Agent{claude, codex}, installer.ScopeProject, false, false)
+	assert.Equal(t, deliveryPlugin, plan[0].delivery)
+	assert.Equal(t, agentScopeProject, plan[0].scope)
+	assert.Equal(t, deliverySkip, plan[1].delivery)
+	assert.Contains(t, plan[1].reason, "user-only")
+}
+
+func TestMapAgentScope(t *testing.T) {
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
+	codex := testPluginAgent(agents.NameCodex, "Codex CLI", "codex", false)
+
+	scope, ok, _ := mapAgentScope(claude, installer.ScopeGlobal)
+	assert.True(t, ok)
+	assert.Equal(t, agentScopeUser, scope)
+
+	scope, ok, _ = mapAgentScope(claude, installer.ScopeProject)
+	assert.True(t, ok)
+	assert.Equal(t, agentScopeProject, scope)
+
+	_, ok, reason := mapAgentScope(codex, installer.ScopeProject)
+	assert.False(t, ok)
+	assert.Contains(t, reason, "user-only")
+}
+
+func TestExecutePlanSkipBlockedPluginExit0(t *testing.T) {
+	t.Setenv("DATABRICKS_SKILLS_REF", "v0.2.6")
+	orig := installPluginForAgentFn
+	origRec := recordPluginInstallsFn
+	t.Cleanup(func() { installPluginForAgentFn = orig; recordPluginInstallsFn = origRec })
+	installPluginForAgentFn = func(_ context.Context, a *agents.Agent, _, _ string) (installer.PluginRecord, error) {
+		return installer.PluginRecord{}, &installer.BlockedError{Agent: a.Name, Reason: installer.ReasonCLINotOnPath}
+	}
+	recordPluginInstallsFn = func(context.Context, string, map[string]installer.PluginRecord, string) error { return nil }
+
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
+	ctx := cmdio.MockDiscard(t.Context())
+
+	// Non-explicit blocked install is a warning, not an error.
+	plan := buildPlan([]*agents.Agent{claude}, installer.ScopeGlobal, false, false)
+	require.NoError(t, executePlan(ctx, nil, plan, installer.InstallOptions{Scope: installer.ScopeGlobal}))
+
+	// Explicit (--agents) blocked install is an error.
+	planExplicit := buildPlan([]*agents.Agent{claude}, installer.ScopeGlobal, false, true)
+	require.Error(t, executePlan(ctx, nil, planExplicit, installer.InstallOptions{Scope: installer.ScopeGlobal}))
+}
+
+// --- RunE: skills-only path (config-dir detection, no plugin) ---
+
+func TestInstallSkillsOnlyAllAgents(t *testing.T) {
 	setupTestAgents(t)
 	calls := setupInstallMock(t)
 
 	ctx := cmdio.MockDiscard(t.Context())
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--skills-only"})
 
-	err := cmd.RunE(cmd, nil)
-	require.NoError(t, err)
-
+	require.NoError(t, cmd.Execute())
 	require.Len(t, *calls, 1)
 	assert.Len(t, (*calls)[0].agents, 2)
 	assert.Nil(t, (*calls)[0].opts.SpecificSkills)
 }
 
-func TestInstallSpecificSkills(t *testing.T) {
+func TestInstallSkillsOnlySpecificSkills(t *testing.T) {
 	setupTestAgents(t)
 	calls := setupInstallMock(t)
 
 	ctx := cmdio.MockDiscard(t.Context())
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--skills", "databricks,databricks-apps"})
+	cmd.SetArgs([]string{"--skills-only", "--skills", "databricks,databricks-apps"})
 
-	err := cmd.Execute()
-	require.NoError(t, err)
-
+	require.NoError(t, cmd.Execute())
 	require.Len(t, *calls, 1)
 	assert.Equal(t, []string{"databricks", "databricks-apps"}, (*calls)[0].opts.SpecificSkills)
 }
 
-func TestInstallSingleSkill(t *testing.T) {
+func TestInstallSkillsOnlyExperimental(t *testing.T) {
 	setupTestAgents(t)
 	calls := setupInstallMock(t)
 
 	ctx := cmdio.MockDiscard(t.Context())
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--skills", "databricks"})
+	cmd.SetArgs([]string{"--skills-only", "--experimental"})
 
-	err := cmd.Execute()
-	require.NoError(t, err)
-
+	require.NoError(t, cmd.Execute())
 	require.Len(t, *calls, 1)
-	assert.Equal(t, []string{"databricks"}, (*calls)[0].opts.SpecificSkills)
+	assert.True(t, (*calls)[0].opts.IncludeExperimental)
 }
 
-func TestInstallSpecificAgents(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
+// --- RunE: plugin-first default path ---
+
+func TestInstallPluginFirstDefault(t *testing.T) {
+	setupTestAgents(t) // ~/.claude exists
+	fakeBinsOnPath(t, "claude")
+	t.Setenv("DATABRICKS_SKILLS_REF", "v0.2.6")
+	plugins := setupPluginMock(t)
+	skills := setupInstallMock(t)
 
 	ctx := cmdio.MockDiscard(t.Context())
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--agents", "claude-code"})
 
-	err := cmd.Execute()
+	require.NoError(t, cmd.Execute())
+	require.Len(t, *plugins, 1)
+	assert.Equal(t, agents.NameClaudeCode, (*plugins)[0].agent)
+	assert.Equal(t, agentScopeUser, (*plugins)[0].scope)
+	assert.Empty(t, *skills, "plugin agents must not get raw skills by default")
+}
+
+func TestInstallInteractivePickerAndConfirm(t *testing.T) {
+	setupTestAgents(t)
+	fakeBinsOnPath(t, "claude")
+	t.Setenv("DATABRICKS_SKILLS_REF", "v0.2.6")
+	plugins := setupPluginMock(t)
+	setupScopeMock(t, installer.ScopeGlobal)
+
+	origPrompt := promptAgentSelection
+	t.Cleanup(func() { promptAgentSelection = origPrompt })
+	pickerCalled := false
+	promptAgentSelection = func(_ context.Context, choices []agentChoice) ([]*agents.Agent, error) {
+		pickerCalled = true
+		for _, c := range choices {
+			if c.agent.Name == agents.NameClaudeCode {
+				return []*agents.Agent{c.agent}, nil
+			}
+		}
+		return nil, nil
+	}
+
+	ctx, test := cmdio.SetupTest(t.Context(), cmdio.TestOptions{PromptSupported: true})
+	defer test.Done()
+	go drainReader(test.Stdout)
+	go drainReader(test.Stderr)
+
+	cmd := NewInstallCmd()
+	cmd.SetContext(ctx)
+
+	errc := make(chan error, 1)
+	go func() { errc <- cmd.RunE(cmd, nil) }()
+
+	_, err := test.Stdin.WriteString("y\n")
 	require.NoError(t, err)
+	require.NoError(t, test.Stdin.Flush())
 
-	require.Len(t, *calls, 1)
-	assert.Equal(t, []string{"claude-code"}, (*calls)[0].agents)
+	require.NoError(t, <-errc)
+	assert.True(t, pickerCalled)
+	require.Len(t, *plugins, 1)
+	assert.Equal(t, agents.NameClaudeCode, (*plugins)[0].agent)
+}
+
+func TestInstallExplicitAgentWorksUndetected(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	fakeBinsOnPath(t, "codex")
+	t.Setenv("DATABRICKS_SKILLS_REF", "v0.2.6")
+	plugins := setupPluginMock(t)
+
+	ctx := cmdio.MockDiscard(t.Context())
+	cmd := NewInstallCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--agents", "codex"})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, *plugins, 1)
+	assert.Equal(t, agents.NameCodex, (*plugins)[0].agent)
 }
 
 func TestInstallUnknownAgentErrors(t *testing.T) {
 	setupTestAgents(t)
-	setupInstallMock(t)
-
 	ctx := cmdio.MockDiscard(t.Context())
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
@@ -141,128 +332,108 @@ func TestInstallUnknownAgentErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "Available agents:")
 }
 
-func TestInstallIncludeExperimental(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-
-	ctx := cmdio.MockDiscard(t.Context())
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--experimental"})
-
-	err := cmd.Execute()
-	require.NoError(t, err)
-
-	require.Len(t, *calls, 1)
-	assert.True(t, (*calls)[0].opts.IncludeExperimental)
-}
-
-func TestInstallInteractivePrompt(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-	setupScopeMock(t, installer.ScopeGlobal)
-
-	origPrompt := promptAgentSelection
-	t.Cleanup(func() { promptAgentSelection = origPrompt })
-
-	promptCalled := false
-	promptAgentSelection = func(_ context.Context, detected []*agents.Agent) ([]*agents.Agent, error) {
-		promptCalled = true
-		return detected[:1], nil
-	}
-
-	ctx, test := cmdio.SetupTest(t.Context(), cmdio.TestOptions{PromptSupported: true})
-	defer test.Done()
-
-	drain := func(r *bufio.Reader) {
-		buf := make([]byte, 4096)
-		for {
-			_, err := r.Read(buf)
-			if err != nil {
-				return
-			}
-		}
-	}
-	go drain(test.Stdout)
-	go drain(test.Stderr)
-
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-
-	err := cmd.RunE(cmd, nil)
-	require.NoError(t, err)
-
-	assert.True(t, promptCalled, "prompt should be called when 2+ agents detected and interactive")
-	require.Len(t, *calls, 1)
-	assert.Len(t, (*calls)[0].agents, 1, "only the selected agent should be passed")
-}
-
-func TestInstallNonInteractiveUsesAllAgents(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-
-	origPrompt := promptAgentSelection
-	t.Cleanup(func() { promptAgentSelection = origPrompt })
-
-	promptCalled := false
-	promptAgentSelection = func(_ context.Context, detected []*agents.Agent) ([]*agents.Agent, error) {
-		promptCalled = true
-		return detected, nil
-	}
-
-	ctx := cmdio.MockDiscard(t.Context())
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-
-	err := cmd.RunE(cmd, nil)
-	require.NoError(t, err)
-
-	assert.False(t, promptCalled, "prompt should not be called in non-interactive mode")
-	require.Len(t, *calls, 1)
-	assert.Len(t, (*calls)[0].agents, 2, "all detected agents should be used")
-}
-
 func TestInstallNoAgentsDetected(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
+	fakeBinsOnPath(t) // no agent binaries
+	plugins := setupPluginMock(t)
+	skills := setupInstallMock(t)
 
-	calls := setupInstallMock(t)
 	ctx := cmdio.MockDiscard(t.Context())
-
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
 
-	err := cmd.RunE(cmd, nil)
-	require.NoError(t, err)
-	assert.Empty(t, *calls, "install should not be called when no agents detected")
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, *plugins)
+	assert.Empty(t, *skills)
 }
 
-func TestInstallAgentsFlagSkipsPrompt(t *testing.T) {
+func TestInstallPathConflictsWithSkillsOnly(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	cmd := NewInstallCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--skills-only", "--path", "./out"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use --skills-only with --path")
+}
+
+// --- Scope flag parsing (exercised via the skills path so opts.Scope is observable) ---
+
+func TestInstallScopeFlag(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantScope string
+		wantErr   string
+	}{
+		{name: "scope project", args: []string{"--skills-only", "--scope", "project"}, wantScope: installer.ScopeProject},
+		{name: "scope global", args: []string{"--skills-only", "--scope", "global"}, wantScope: installer.ScopeGlobal},
+		{name: "scope both rejected", args: []string{"--scope", "both"}, wantErr: "--scope=both is not supported"},
+		{name: "scope invalid value", args: []string{"--scope", "all"}, wantErr: `invalid --scope "all"`},
+		{name: "scope conflicts with legacy", args: []string{"--scope", "global", "--project"}, wantErr: "cannot use --scope with --project or --global"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTestAgents(t)
+			calls := setupInstallMock(t)
+
+			ctx := cmdio.MockDiscard(t.Context())
+			cmd := NewInstallCmd()
+			cmd.SetContext(ctx)
+			cmd.SetArgs(tt.args)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, *calls, 1)
+			assert.Equal(t, tt.wantScope, (*calls)[0].opts.Scope)
+		})
+	}
+}
+
+func TestInstallGlobalAndProjectErrors(t *testing.T) {
+	setupTestAgents(t)
+	setupInstallMock(t)
+
+	ctx := cmdio.MockDiscard(t.Context())
+	cmd := NewInstallCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--global", "--project"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use --global and --project together")
+}
+
+func TestInstallNoFlagNonInteractiveUsesGlobal(t *testing.T) {
 	setupTestAgents(t)
 	calls := setupInstallMock(t)
 
-	origPrompt := promptAgentSelection
-	t.Cleanup(func() { promptAgentSelection = origPrompt })
-
-	promptCalled := false
-	promptAgentSelection = func(_ context.Context, detected []*agents.Agent) ([]*agents.Agent, error) {
-		promptCalled = true
-		return detected, nil
-	}
-
 	ctx := cmdio.MockDiscard(t.Context())
 	cmd := NewInstallCmd()
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--agents", "claude-code,cursor"})
+	cmd.SetArgs([]string{"--skills-only"})
 
-	err := cmd.Execute()
-	require.NoError(t, err)
-
-	assert.False(t, promptCalled, "prompt should not be called when --agents is specified")
+	require.NoError(t, cmd.Execute())
 	require.Len(t, *calls, 1)
-	assert.Equal(t, []string{"claude-code", "cursor"}, (*calls)[0].agents)
+	assert.Equal(t, installer.ScopeGlobal, (*calls)[0].opts.Scope)
 }
+
+// --- Positional-arg rejections ---
 
 func TestInstallRejectsPositionalArgs(t *testing.T) {
 	ctx := cmdio.MockDiscard(t.Context())
@@ -329,6 +500,8 @@ func TestVersionRejectsPositionalArgs(t *testing.T) {
 	assert.Contains(t, err.Error(), "unknown command")
 }
 
+// --- resolveAgentNames ---
+
 func TestResolveAgentNamesValid(t *testing.T) {
 	ctx := t.Context()
 	result, err := resolveAgentNames(ctx, "claude-code,cursor")
@@ -359,148 +532,6 @@ func TestResolveAgentNamesDuplicatesDeduplicates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, result, 1, "duplicate agent names should be deduplicated")
 	assert.Equal(t, "claude-code", result[0].Name)
-}
-
-// --- Scope flag tests ---
-
-func TestInstallProjectFlag(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-
-	ctx := cmdio.MockDiscard(t.Context())
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--project"})
-
-	err := cmd.Execute()
-	require.NoError(t, err)
-
-	require.Len(t, *calls, 1)
-	assert.Equal(t, installer.ScopeProject, (*calls)[0].opts.Scope)
-}
-
-func TestInstallGlobalFlag(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-
-	ctx := cmdio.MockDiscard(t.Context())
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--global"})
-
-	err := cmd.Execute()
-	require.NoError(t, err)
-
-	require.Len(t, *calls, 1)
-	assert.Equal(t, installer.ScopeGlobal, (*calls)[0].opts.Scope)
-}
-
-func TestInstallGlobalAndProjectErrors(t *testing.T) {
-	setupTestAgents(t)
-	setupInstallMock(t)
-
-	ctx := cmdio.MockDiscard(t.Context())
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"--global", "--project"})
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-
-	err := cmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot use --global and --project together")
-}
-
-func TestInstallScopeFlag(t *testing.T) {
-	tests := []struct {
-		name      string
-		args      []string
-		wantScope string
-		wantErr   string
-	}{
-		{name: "scope project", args: []string{"--scope", "project"}, wantScope: installer.ScopeProject},
-		{name: "scope global", args: []string{"--scope", "global"}, wantScope: installer.ScopeGlobal},
-		{name: "scope both rejected", args: []string{"--scope", "both"}, wantErr: "--scope=both is not supported"},
-		{name: "scope invalid value", args: []string{"--scope", "all"}, wantErr: `invalid --scope "all"`},
-		{name: "scope conflicts with legacy", args: []string{"--scope", "global", "--project"}, wantErr: "cannot use --scope with --project or --global"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			setupTestAgents(t)
-			calls := setupInstallMock(t)
-
-			ctx := cmdio.MockDiscard(t.Context())
-			cmd := NewInstallCmd()
-			cmd.SetContext(ctx)
-			cmd.SetArgs(tt.args)
-			cmd.SilenceErrors = true
-			cmd.SilenceUsage = true
-
-			err := cmd.Execute()
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			require.Len(t, *calls, 1)
-			assert.Equal(t, tt.wantScope, (*calls)[0].opts.Scope)
-		})
-	}
-}
-
-func TestInstallNoFlagNonInteractiveUsesGlobal(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-
-	ctx := cmdio.MockDiscard(t.Context())
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-
-	err := cmd.RunE(cmd, nil)
-	require.NoError(t, err)
-
-	require.Len(t, *calls, 1)
-	assert.Equal(t, installer.ScopeGlobal, (*calls)[0].opts.Scope)
-}
-
-func TestInstallNoFlagInteractiveShowsScopePrompt(t *testing.T) {
-	setupTestAgents(t)
-	calls := setupInstallMock(t)
-	scopePromptCalled := setupScopeMock(t, installer.ScopeProject)
-
-	// Also mock agent prompt since interactive mode triggers it.
-	origPrompt := promptAgentSelection
-	t.Cleanup(func() { promptAgentSelection = origPrompt })
-	promptAgentSelection = func(_ context.Context, detected []*agents.Agent) ([]*agents.Agent, error) {
-		return detected, nil
-	}
-
-	ctx, test := cmdio.SetupTest(t.Context(), cmdio.TestOptions{PromptSupported: true})
-	defer test.Done()
-
-	drain := func(r *bufio.Reader) {
-		buf := make([]byte, 4096)
-		for {
-			_, err := r.Read(buf)
-			if err != nil {
-				return
-			}
-		}
-	}
-	go drain(test.Stdout)
-	go drain(test.Stderr)
-
-	cmd := NewInstallCmd()
-	cmd.SetContext(ctx)
-
-	err := cmd.RunE(cmd, nil)
-	require.NoError(t, err)
-
-	assert.True(t, *scopePromptCalled, "scope prompt should be called in interactive mode")
-	require.Len(t, *calls, 1)
-	assert.Equal(t, installer.ScopeProject, (*calls)[0].opts.Scope)
 }
 
 func TestResolveScopeValidation(t *testing.T) {

--- a/cmd/aitools/install_test.go
+++ b/cmd/aitools/install_test.go
@@ -3,6 +3,7 @@ package aitools
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -347,6 +348,43 @@ func TestInstallNoAgentsDetected(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	assert.Empty(t, *plugins)
 	assert.Empty(t, *skills)
+}
+
+func TestInstallSkillsRequiresSkillsOnlyOrPath(t *testing.T) {
+	setupTestAgents(t)
+	ctx := cmdio.MockDiscard(t.Context())
+	cmd := NewInstallCmd()
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--skills", "databricks"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--skills requires --skills-only or --path")
+}
+
+func TestInstallInteractivePickerErrorPropagates(t *testing.T) {
+	setupTestAgents(t)
+	setupScopeMock(t, installer.ScopeGlobal)
+
+	origPrompt := promptAgentSelection
+	t.Cleanup(func() { promptAgentSelection = origPrompt })
+	promptAgentSelection = func(_ context.Context, _ []agentChoice) ([]*agents.Agent, error) {
+		return nil, errors.New("at least one agent must be selected")
+	}
+
+	ctx, test := cmdio.SetupTest(t.Context(), cmdio.TestOptions{PromptSupported: true})
+	defer test.Done()
+	go drainReader(test.Stdout)
+	go drainReader(test.Stderr)
+
+	cmd := NewInstallCmd()
+	cmd.SetContext(ctx)
+
+	err := cmd.RunE(cmd, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one agent")
 }
 
 func TestInstallPathConflictsWithSkillsOnly(t *testing.T) {

--- a/cmd/aitools/legacy_skills.go
+++ b/cmd/aitools/legacy_skills.go
@@ -45,7 +45,9 @@ func newLegacySkillsInstallCmd() *cobra.Command {
 			installCmd := NewInstallCmd()
 			installCmd.SetContext(cmd.Context())
 
-			var delegateArgs []string
+			// This legacy alias predates the plugin-first default, so it stays on
+			// raw skill files to preserve its behavior.
+			delegateArgs := []string{"--skills-only"}
 			if len(args) > 0 {
 				delegateArgs = append(delegateArgs, "--skills", args[0])
 			}

--- a/cmd/aitools/scope.go
+++ b/cmd/aitools/scope.go
@@ -8,11 +8,35 @@ import (
 	"path/filepath"
 
 	"github.com/charmbracelet/huh"
+	"github.com/databricks/cli/libs/aitools/agents"
 	"github.com/databricks/cli/libs/aitools/installer"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/env"
 	"github.com/spf13/cobra"
 )
+
+// Agent-native plugin scopes. These are distinct from installer.ScopeGlobal /
+// installer.ScopeProject, which name the on-disk skills directories; these name
+// the scope token an agent's plugin CLI understands.
+const (
+	agentScopeUser    = "user"
+	agentScopeProject = "project"
+)
+
+// mapAgentScope maps the CLI scope (global/project) to an agent's own plugin
+// scope. CLI global maps to the agent's user scope. CLI project maps to the
+// agent's project scope only when the agent supports it (Claude today); other
+// agents are skipped with a reason rather than silently falling back to user
+// scope (goals Decision #1; Copilot is user-only for v1, Codex is user-only).
+func mapAgentScope(a *agents.Agent, cliScope string) (scope string, ok bool, reason string) {
+	if cliScope == installer.ScopeProject {
+		if a.SupportsProjectScope {
+			return agentScopeProject, true, ""
+		}
+		return "", false, a.DisplayName + " is user-only; project scope is not supported"
+	}
+	return agentScopeUser, true, ""
+}
 
 // promptScopeSelection is a package-level var so tests can replace it with a mock.
 var promptScopeSelection = defaultPromptScopeSelection

--- a/libs/aitools/installer/installer.go
+++ b/libs/aitools/installer/installer.go
@@ -287,6 +287,9 @@ func InstallSkillsForAgents(ctx context.Context, src ManifestSource, targetAgent
 			RepoDirs:      make(map[string]string, len(targetSkills)),
 		}
 	}
+	if state.Skills == nil {
+		state.Skills = make(map[string]string, len(targetSkills))
+	}
 	if state.RepoDirs == nil {
 		state.RepoDirs = make(map[string]string, len(state.Skills)+len(targetSkills))
 	}

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os/exec"
 	"strings"
 	"time"
@@ -256,6 +257,31 @@ func UninstallPluginForAgent(ctx context.Context, agent *agents.Agent, rec Plugi
 		}
 	}
 	return nil
+}
+
+// RecordPluginInstalls persists plugin install records into the state file for
+// the given CLI scope (global or project), creating state if none exists. ref
+// is the resolved skills release the install corresponds to.
+func RecordPluginInstalls(ctx context.Context, cliScope string, records map[string]PluginRecord, ref string) error {
+	dir, err := skillsDir(ctx, cliScope)
+	if err != nil {
+		return err
+	}
+	state, err := LoadState(dir)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		state = &InstallState{SchemaVersion: schemaVersionV2}
+	}
+	if state.Plugins == nil {
+		state.Plugins = make(map[string]PluginRecord, len(records))
+	}
+	maps.Copy(state.Plugins, records)
+	state.Release = ref
+	state.LastUpdated = time.Now()
+	state.Scope = cliScope
+	return SaveState(dir, state)
 }
 
 // prepend returns a fresh argv with bin as argv[0] followed by args.

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -272,7 +272,14 @@ func RecordPluginInstalls(ctx context.Context, cliScope string, records map[stri
 		return err
 	}
 	if state == nil {
-		state = &InstallState{SchemaVersion: schemaVersionV2}
+		// Initialize all maps so a later skills install/update can assign into a
+		// plugin-only state without hitting a nil map.
+		state = &InstallState{
+			SchemaVersion: schemaVersionV2,
+			Skills:        map[string]string{},
+			RepoDirs:      map[string]string{},
+			Files:         map[string]FileRecord{},
+		}
 	}
 	if state.Plugins == nil {
 		state.Plugins = make(map[string]PluginRecord, len(records))

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/libs/aitools/agents"
+	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,4 +202,28 @@ func TestUninstallPluginKeepMarketplaceFlag(t *testing.T) {
 	for _, c := range stub.Commands() {
 		assert.NotContains(t, c, "marketplace remove")
 	}
+}
+
+func TestRecordPluginInstallsThenSkillsInstallNoPanic(t *testing.T) {
+	tmp := setupTestHome(t)
+	ctx := cmdio.MockDiscard(t.Context())
+	setupFetchMock(t)
+	t.Setenv("DATABRICKS_SKILLS_REF", testSkillsRef)
+
+	dir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+
+	// A pure-plugin install creates state with no skills.
+	require.NoError(t, RecordPluginInstalls(ctx, ScopeGlobal, map[string]PluginRecord{
+		agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", Version: "0.2.6"},
+	}, "v0.2.6"))
+
+	// A later raw-skills install over that plugin-only state must not panic on a
+	// nil Skills map.
+	require.NoError(t, InstallSkillsForAgents(ctx, &mockManifestSource{manifest: testManifest()}, []*agents.Agent{testAgent(tmp)}, InstallOptions{}))
+
+	st, err := LoadState(dir)
+	require.NoError(t, err)
+	assert.NotEmpty(t, st.Skills)
+	assert.Contains(t, st.Plugins, agents.NameClaudeCode)
 }


### PR DESCRIPTION
<!-- aitools-stack -->
### Stack

Part of the `aitools` plugin-first redesign. Merge bottom to top:

- #5734 Detection & registry (plugin metadata + capability detection)
- #5736 State schema v2 (plugin + file provenance records)
- #5737 Plugin engine, checksums, `--path` dump (library)
- **#5738 Plugin-first install command  ← this PR**
- #5739 Update + prune of vanished skills
- #5740 Uninstall teardown + legacy skills cleanup
- #5741 list + version plugin state
<!-- /aitools-stack -->

## Why

This is the user-visible flip of the `aitools` redesign: `databricks aitools install` now installs the Databricks plugin through each coding agent's own CLI instead of copying raw skill files into every agent. Raw skills alongside a plugin produce duplicate, hard-to-update content; the plugin is how those agents expect third-party content to arrive.

Stacked on #5737 (plugin engine).

## Changes

Before: install copied skill files into each detected agent's skills dir.

Now: install is plugin-first, with explicit escape hatches.

- **Delivery per agent:** plugin agents (Claude Code, Codex, Copilot) get the databricks plugin; agents with no plugin (OpenCode, Antigravity) get skill files; Cursor (plugin, but no headless install) prints the `/add-plugin databricks` step and copies nothing.
- **Escape hatches:** `--skills-only` forces raw skill files for every agent; `--path <dir>` is a dumb dump (no agents, no state). `--skills-only` + `--path` is rejected.
- **Scope mapping** (`mapAgentScope`): CLI `global` → agent user scope; CLI `project` → agent project scope only where supported (Claude), otherwise the agent is skipped with a reason. No silent fallback to user scope.
- **No silent fallback:** a blocked plugin install (CLI not on PATH, install failure) is reported and skipped (exit 0), never swapped for skills. It errors only when the agent was explicitly named via `--agents`.
- **Interactive picker** lists every known agent with a detection-state label (detected ones pre-checked), then shows a plan summary and a single confirm.
- **Detection:** non-interactive selection now also detects plugin agents by their CLI binary on PATH (fixing the Codex/Copilot config-dir miss); `--skills-only` selection stays config-dir based and PATH-independent.
- The legacy `experimental skills install` alias pins `--skills-only` to preserve its behavior.

## Test plan

- [x] Unit tests: `buildPlan` deliveries (plugin/skills/manual/skip) and `--skills-only` forcing skills; `mapAgentScope` matrix; `executePlan` skip-with-warning vs error-on-explicit; plugin-first default (with a controlled PATH), `--agents` for an undetected agent, no-agents no-op, `--skills-only`/`--path` conflict, scope flags, interactive picker + confirm.
- [x] Acceptance: the 3 existing `experimental aitools install` goldens switch to `--skills-only` and keep their behavior strings byte-identical (only the `>>>` echo gains the flag); a new `path-dump` test covers `--path`.
- [x] `go test ./libs/aitools/... ./cmd/aitools/... ./acceptance -run TestAccept/experimental/aitools` passes.
- [x] `./task fmt-q`, `./task lint-q` (0 issues), `./task checks` (no dead code) clean.

This pull request and its description were written by Isaac.
