### PR TITLE
aitools: plugin teardown on uninstall + legacy skills cleanup on install

### DIFF
--- a/cmd/aitools/install.go
+++ b/cmd/aitools/install.go
@@ -20,6 +20,7 @@ var (
 	installSkillsForAgentsFn = installer.InstallSkillsForAgents
 	installPluginForAgentFn  = installer.InstallPluginForAgent
 	recordPluginInstallsFn   = installer.RecordPluginInstalls
+	cleanupLegacyFn          = installer.RemoveLegacyRawSkills
 )
 
 // delivery is how the databricks tools are delivered to one agent.
@@ -348,6 +349,11 @@ func executePlan(ctx context.Context, src installer.ManifestSource, plan []agent
 			}
 			records[it.agent.Name] = rec
 			pluginCount++
+			// Remove any raw skills we previously dropped on this agent so the
+			// plugin and leftover files don't surface the same skills twice.
+			if err := cleanupLegacyFn(ctx, it.agent, opts.Scope); err != nil {
+				log.Debugf(ctx, "Legacy skill cleanup for %s failed: %v", it.agent.DisplayName, err)
+			}
 			cmdio.LogString(ctx, fmt.Sprintf("  %s  databricks plugin v%s", it.agent.DisplayName, rec.Version))
 		}
 		if len(records) > 0 {

--- a/cmd/aitools/install.go
+++ b/cmd/aitools/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/databricks/cli/libs/aitools/agents"
 	"github.com/databricks/cli/libs/aitools/installer"
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/log"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/aitools/uninstall.go
+++ b/cmd/aitools/uninstall.go
@@ -14,7 +14,7 @@ var uninstallSkillsFn = func(ctx context.Context, opts installer.UninstallOption
 
 func NewUninstallCmd() *cobra.Command {
 	var skillsFlag, scopeFlag string
-	var projectFlag, globalFlag bool
+	var projectFlag, globalFlag, keepMarketplace bool
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
@@ -46,7 +46,8 @@ By default, removes all skills. Use --skills to remove specific skills only.`,
 			}
 
 			opts := installer.UninstallOptions{
-				Scope: scope,
+				Scope:           scope,
+				KeepMarketplace: keepMarketplace,
 			}
 			opts.Skills = splitAndTrim(skillsFlag)
 			return uninstallSkillsFn(ctx, opts)
@@ -54,6 +55,7 @@ By default, removes all skills. Use --skills to remove specific skills only.`,
 	}
 
 	cmd.Flags().StringVar(&skillsFlag, "skills", "", "Specific skills to uninstall (comma-separated)")
+	cmd.Flags().BoolVar(&keepMarketplace, "keep-marketplace", false, "Keep the marketplace registration when removing a plugin")
 	cmd.Flags().StringVar(&scopeFlag, "scope", "", "Uninstall scope: project or global")
 	cmd.Flags().BoolVar(&projectFlag, "project", false, "Uninstall project-scoped skills")
 	cmd.Flags().BoolVar(&globalFlag, "global", false, "Uninstall globally-scoped skills")

--- a/libs/aitools/installer/cleanup.go
+++ b/libs/aitools/installer/cleanup.go
@@ -2,13 +2,10 @@ package installer
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/databricks/cli/libs/aitools/agents"
 	"github.com/databricks/cli/libs/log"
@@ -17,9 +14,9 @@ import (
 // RemoveLegacyRawSkills removes raw skill directories the CLI previously placed
 // in a plugin agent's skills dir, so installing the plugin doesn't leave the
 // same skills duplicated as loose files. It only removes our own content: a
-// symlink pointing into our canonical dir, or a copied skill whose files all
-// match the checksums we recorded. User-modified or third-party directories,
-// and copies with no recorded provenance, are left untouched.
+// symlink into our canonical dir, or a copied skill whose contents exactly match
+// the recorded checksums. User-modified or third-party directories, dirs with
+// extra files, and copies with no recorded provenance are left untouched.
 func RemoveLegacyRawSkills(ctx context.Context, agent *agents.Agent, scope string) error {
 	baseDir, err := skillsDir(ctx, scope)
 	if err != nil {
@@ -53,69 +50,16 @@ func RemoveLegacyRawSkills(ctx context.Context, agent *agents.Agent, scope strin
 
 	for _, entry := range entries {
 		entryPath := filepath.Join(agentDir, entry.Name())
-		fi, err := os.Lstat(entryPath)
-		if err != nil {
+		canonicalDir := filepath.Join(baseDir, entry.Name())
+		if !exposureRemovable(entryPath, canonicalDir, entry.Name(), state) {
 			continue
 		}
-
-		if fi.Mode()&os.ModeSymlink != 0 {
-			if symlinkPointsInto(entryPath, baseDir) {
-				if err := os.Remove(entryPath); err != nil {
-					log.Warnf(ctx, "Failed to remove legacy skill symlink %s: %v", entryPath, err)
-				} else {
-					log.Debugf(ctx, "Removed legacy skill symlink %s for %s", entry.Name(), agent.DisplayName)
-				}
-			}
-			continue
-		}
-
-		if fi.IsDir() && state != nil && skillCopyUnmodified(entryPath, entry.Name(), state) {
-			if err := os.RemoveAll(entryPath); err != nil {
-				log.Warnf(ctx, "Failed to remove legacy skill %s: %v", entryPath, err)
-			} else {
-				log.Debugf(ctx, "Removed legacy skill copy %s for %s", entry.Name(), agent.DisplayName)
-			}
+		// RemoveAll on a symlink removes the link, not its target.
+		if err := os.RemoveAll(entryPath); err != nil {
+			log.Warnf(ctx, "Failed to remove legacy skill %s: %v", entryPath, err)
+		} else {
+			log.Debugf(ctx, "Removed legacy skill %s for %s", entry.Name(), agent.DisplayName)
 		}
 	}
 	return nil
-}
-
-// symlinkPointsInto reports whether linkPath is a symlink resolving into baseDir.
-func symlinkPointsInto(linkPath, baseDir string) bool {
-	target, err := os.Readlink(linkPath)
-	if err != nil {
-		return false
-	}
-	if !filepath.IsAbs(target) {
-		target = filepath.Clean(filepath.Join(filepath.Dir(linkPath), target))
-	}
-	return target == baseDir || strings.HasPrefix(target, baseDir+string(os.PathSeparator))
-}
-
-// skillCopyUnmodified reports whether every file the CLI recorded for a skill is
-// present in dir with its recorded sha256. Returns false when there is no
-// recorded provenance, so unverifiable copies are kept.
-func skillCopyUnmodified(dir, skillName string, state *InstallState) bool {
-	prefix := skillName + "/"
-	var recorded []string
-	for path := range state.Files {
-		if strings.HasPrefix(path, prefix) {
-			recorded = append(recorded, path)
-		}
-	}
-	if len(recorded) == 0 {
-		return false
-	}
-	for _, relPath := range recorded {
-		file := filepath.Join(dir, filepath.FromSlash(strings.TrimPrefix(relPath, prefix)))
-		data, err := os.ReadFile(file)
-		if err != nil {
-			return false
-		}
-		sum := sha256.Sum256(data)
-		if hex.EncodeToString(sum[:]) != state.Files[relPath].SHA256 {
-			return false
-		}
-	}
-	return true
 }

--- a/libs/aitools/installer/cleanup.go
+++ b/libs/aitools/installer/cleanup.go
@@ -1,0 +1,121 @@
+package installer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/libs/aitools/agents"
+	"github.com/databricks/cli/libs/log"
+)
+
+// RemoveLegacyRawSkills removes raw skill directories the CLI previously placed
+// in a plugin agent's skills dir, so installing the plugin doesn't leave the
+// same skills duplicated as loose files. It only removes our own content: a
+// symlink pointing into our canonical dir, or a copied skill whose files all
+// match the checksums we recorded. User-modified or third-party directories,
+// and copies with no recorded provenance, are left untouched.
+func RemoveLegacyRawSkills(ctx context.Context, agent *agents.Agent, scope string) error {
+	baseDir, err := skillsDir(ctx, scope)
+	if err != nil {
+		return err
+	}
+	state, err := LoadState(baseDir)
+	if err != nil {
+		return err
+	}
+
+	var cwd string
+	if scope == ScopeProject {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	}
+	agentDir, err := agentSkillsDirForScope(ctx, agent, scope, cwd)
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(agentDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		// No skills dir for this agent; nothing to clean up.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		entryPath := filepath.Join(agentDir, entry.Name())
+		fi, err := os.Lstat(entryPath)
+		if err != nil {
+			continue
+		}
+
+		if fi.Mode()&os.ModeSymlink != 0 {
+			if symlinkPointsInto(entryPath, baseDir) {
+				if err := os.Remove(entryPath); err != nil {
+					log.Warnf(ctx, "Failed to remove legacy skill symlink %s: %v", entryPath, err)
+				} else {
+					log.Debugf(ctx, "Removed legacy skill symlink %s for %s", entry.Name(), agent.DisplayName)
+				}
+			}
+			continue
+		}
+
+		if fi.IsDir() && state != nil && skillCopyUnmodified(entryPath, entry.Name(), state) {
+			if err := os.RemoveAll(entryPath); err != nil {
+				log.Warnf(ctx, "Failed to remove legacy skill %s: %v", entryPath, err)
+			} else {
+				log.Debugf(ctx, "Removed legacy skill copy %s for %s", entry.Name(), agent.DisplayName)
+			}
+		}
+	}
+	return nil
+}
+
+// symlinkPointsInto reports whether linkPath is a symlink resolving into baseDir.
+func symlinkPointsInto(linkPath, baseDir string) bool {
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		return false
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Clean(filepath.Join(filepath.Dir(linkPath), target))
+	}
+	return target == baseDir || strings.HasPrefix(target, baseDir+string(os.PathSeparator))
+}
+
+// skillCopyUnmodified reports whether every file the CLI recorded for a skill is
+// present in dir with its recorded sha256. Returns false when there is no
+// recorded provenance, so unverifiable copies are kept.
+func skillCopyUnmodified(dir, skillName string, state *InstallState) bool {
+	prefix := skillName + "/"
+	var recorded []string
+	for path := range state.Files {
+		if strings.HasPrefix(path, prefix) {
+			recorded = append(recorded, path)
+		}
+	}
+	if len(recorded) == 0 {
+		return false
+	}
+	for _, relPath := range recorded {
+		file := filepath.Join(dir, filepath.FromSlash(strings.TrimPrefix(relPath, prefix)))
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return false
+		}
+		sum := sha256.Sum256(data)
+		if hex.EncodeToString(sum[:]) != state.Files[relPath].SHA256 {
+			return false
+		}
+	}
+	return true
+}

--- a/libs/aitools/installer/cleanup_test.go
+++ b/libs/aitools/installer/cleanup_test.go
@@ -1,0 +1,82 @@
+package installer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/aitools/agents"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sha(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestRemoveLegacyRawSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	ctx := cmdio.MockDiscard(t.Context())
+
+	baseDir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, "alpha"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(baseDir, "alpha", "SKILL.md"), []byte("alpha"), 0o644))
+
+	agentDir := filepath.Join(home, ".claude", "skills")
+	require.NoError(t, os.MkdirAll(agentDir, 0o755))
+
+	// alpha: a symlink into our canonical dir -> removed.
+	require.NoError(t, os.Symlink(filepath.Join(baseDir, "alpha"), filepath.Join(agentDir, "alpha")))
+	// beta: a copy whose file matches the recorded checksum -> removed.
+	require.NoError(t, os.MkdirAll(filepath.Join(agentDir, "beta"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "beta", "SKILL.md"), []byte("beta-content"), 0o644))
+	// gamma: recorded but the on-disk file differs (user edited) -> kept.
+	require.NoError(t, os.MkdirAll(filepath.Join(agentDir, "gamma"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "gamma", "SKILL.md"), []byte("user edited"), 0o644))
+	// thirdparty: no recorded provenance -> kept.
+	require.NoError(t, os.MkdirAll(filepath.Join(agentDir, "thirdparty"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "thirdparty", "SKILL.md"), []byte("tp"), 0o644))
+
+	require.NoError(t, SaveState(baseDir, &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Files: map[string]FileRecord{
+			"alpha/SKILL.md": {SHA256: sha("alpha")},
+			"beta/SKILL.md":  {SHA256: sha("beta-content")},
+			"gamma/SKILL.md": {SHA256: sha("gamma-original")},
+		},
+	}))
+
+	agent := &agents.Agent{
+		Name:        agents.NameClaudeCode,
+		DisplayName: "Claude Code",
+		ConfigDir:   func(_ context.Context) (string, error) { return filepath.Join(home, ".claude"), nil },
+	}
+
+	require.NoError(t, RemoveLegacyRawSkills(ctx, agent, ScopeGlobal))
+
+	assertGone(t, filepath.Join(agentDir, "alpha"))
+	assertGone(t, filepath.Join(agentDir, "beta"))
+	assertExists(t, filepath.Join(agentDir, "gamma"))
+	assertExists(t, filepath.Join(agentDir, "thirdparty"))
+}
+
+func assertGone(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Lstat(path)
+	assert.ErrorIs(t, err, fs.ErrNotExist, "%s should be removed", path)
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Lstat(path)
+	assert.NoError(t, err, "%s should be kept", path)
+}

--- a/libs/aitools/installer/cleanup_test.go
+++ b/libs/aitools/installer/cleanup_test.go
@@ -45,6 +45,10 @@ func TestRemoveLegacyRawSkills(t *testing.T) {
 	// thirdparty: no recorded provenance -> kept.
 	require.NoError(t, os.MkdirAll(filepath.Join(agentDir, "thirdparty"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "thirdparty", "SKILL.md"), []byte("tp"), 0o644))
+	// delta: recorded file matches but the user added an extra file -> kept.
+	require.NoError(t, os.MkdirAll(filepath.Join(agentDir, "delta"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "delta", "SKILL.md"), []byte("delta-content"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(agentDir, "delta", "extra.md"), []byte("mine"), 0o644))
 
 	require.NoError(t, SaveState(baseDir, &InstallState{
 		SchemaVersion: schemaVersionV2,
@@ -52,6 +56,7 @@ func TestRemoveLegacyRawSkills(t *testing.T) {
 			"alpha/SKILL.md": {SHA256: sha("alpha")},
 			"beta/SKILL.md":  {SHA256: sha("beta-content")},
 			"gamma/SKILL.md": {SHA256: sha("gamma-original")},
+			"delta/SKILL.md": {SHA256: sha("delta-content")},
 		},
 	}))
 
@@ -67,6 +72,7 @@ func TestRemoveLegacyRawSkills(t *testing.T) {
 	assertGone(t, filepath.Join(agentDir, "beta"))
 	assertExists(t, filepath.Join(agentDir, "gamma"))
 	assertExists(t, filepath.Join(agentDir, "thirdparty"))
+	assertExists(t, filepath.Join(agentDir, "delta"))
 }
 
 func assertGone(t *testing.T, path string) {

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -240,6 +240,12 @@ func UpdatePluginForAgent(ctx context.Context, agent *agents.Agent) error {
 // UninstallPluginForAgent removes the plugin through the agent's own CLI, and
 // de-registers the marketplace only when this CLI registered it and the caller
 // did not ask to keep it. It never removes a marketplace another plugin shares.
+//
+// A returned error means the plugin itself could not be removed, so the caller
+// should keep its state record. Once the plugin is removed, a failure to
+// de-register the marketplace is only warned about (not returned): the plugin is
+// gone, so the record is cleared, and the leftover marketplace registration is
+// harmless and can be removed manually.
 func UninstallPluginForAgent(ctx context.Context, agent *agents.Agent, rec PluginRecord, keepMarketplace bool) error {
 	if agent.Plugin == nil || agent.Plugin.ManualOnly {
 		return &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
@@ -253,7 +259,7 @@ func UninstallPluginForAgent(ctx context.Context, agent *agents.Agent, rec Plugi
 	}
 	if rec.InstalledMarketplace && !keepMarketplace {
 		if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceRemoveArgs(agent.Plugin))); err != nil {
-			return fmt.Errorf("removed plugin but failed to de-register marketplace for %s: %w", agent.DisplayName, err)
+			log.Warnf(ctx, "Removed the %s plugin but could not de-register its marketplace (remove it manually if needed): %v", agent.DisplayName, stderrOf(err))
 		}
 	}
 	return nil

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -244,6 +244,56 @@ func TestUninstallKeepMarketplace(t *testing.T) {
 	}
 }
 
+func TestUninstallKeepsUnknownAgentRecord(t *testing.T) {
+	setupTestHome(t)
+	ctx := cmdio.MockDiscard(t.Context())
+
+	dir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+	require.NoError(t, SaveState(dir, &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Plugins: map[string]PluginRecord{
+			"mystery-agent": {Marketplace: "databricks-agent-skills", Plugin: "databricks"},
+		},
+	}))
+
+	// An unknown agent can't be torn down; its record (and the state file) must be
+	// kept rather than silently dropped while the plugin may still exist.
+	require.NoError(t, UninstallSkillsOpts(ctx, UninstallOptions{Scope: ScopeGlobal}))
+
+	st, err := LoadState(dir)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Contains(t, st.Plugins, "mystery-agent")
+}
+
+func TestUninstallClearsRecordWhenMarketplaceRemoveFails(t *testing.T) {
+	setupTestHome(t)
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	// The plugin uninstall succeeds; only the marketplace de-register fails.
+	stub.WithFailureFor("plugin marketplace remove", errors.New("boom"))
+	ctx = cmdio.MockDiscard(ctx)
+
+	dir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+	require.NoError(t, SaveState(dir, &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Plugins: map[string]PluginRecord{
+			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true},
+		},
+	}))
+
+	require.NoError(t, UninstallSkillsOpts(ctx, UninstallOptions{Scope: ScopeGlobal}))
+
+	// The plugin is gone, so the record is cleared even though the marketplace
+	// de-register failed (otherwise a retry would be stuck).
+	st, err := LoadState(dir)
+	require.NoError(t, err)
+	assert.Nil(t, st)
+}
+
 func TestUpdateInstalledPlugins(t *testing.T) {
 	setupTestHome(t)
 	stubAgentLookPath(t, true)

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -191,6 +191,59 @@ func TestUninstallPluginKeepsSharedMarketplace(t *testing.T) {
 	}
 }
 
+func TestUninstallSkillsOptsTearsDownPlugin(t *testing.T) {
+	setupTestHome(t)
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	ctx, stderr := cmdio.NewTestContextWithStderr(ctx)
+
+	dir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+	require.NoError(t, SaveState(dir, &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Release:       "v0.2.6",
+		Plugins: map[string]PluginRecord{
+			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", Scope: "user", InstalledMarketplace: true},
+		},
+	}))
+
+	require.NoError(t, UninstallSkillsOpts(ctx, UninstallOptions{Scope: ScopeGlobal}))
+
+	cmds := stub.Commands()
+	assert.Contains(t, cmds, "claude plugin uninstall databricks@databricks-agent-skills")
+	assert.Contains(t, cmds, "claude plugin marketplace remove databricks-agent-skills")
+	assert.Contains(t, stderr.String(), "Uninstalled the plugin from 1 agent.")
+
+	// State file removed since nothing remains.
+	state, err := LoadState(dir)
+	require.NoError(t, err)
+	assert.Nil(t, state)
+}
+
+func TestUninstallKeepMarketplace(t *testing.T) {
+	setupTestHome(t)
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	ctx = cmdio.MockDiscard(ctx)
+
+	dir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+	require.NoError(t, SaveState(dir, &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Plugins: map[string]PluginRecord{
+			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true},
+		},
+	}))
+
+	require.NoError(t, UninstallSkillsOpts(ctx, UninstallOptions{Scope: ScopeGlobal, KeepMarketplace: true}))
+
+	for _, c := range stub.Commands() {
+		assert.NotContains(t, c, "marketplace remove")
+	}
+}
+
 func TestUpdateInstalledPlugins(t *testing.T) {
 	setupTestHome(t)
 	stubAgentLookPath(t, true)

--- a/libs/aitools/installer/uninstall.go
+++ b/libs/aitools/installer/uninstall.go
@@ -70,7 +70,9 @@ func UninstallSkillsOpts(ctx context.Context, opts UninstallOptions) error {
 		for _, name := range slices.Sorted(maps.Keys(state.Plugins)) {
 			agent := agents.ByName(name)
 			if agent == nil {
-				delete(state.Plugins, name)
+				// We can't tear down an agent we don't know; keep the record (and
+				// the state file) rather than silently dropping a live plugin.
+				log.Warnf(ctx, "Leaving plugin record for unknown agent %q; remove its plugin manually", name)
 				continue
 			}
 			rec := state.Plugins[name]

--- a/libs/aitools/installer/uninstall.go
+++ b/libs/aitools/installer/uninstall.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/databricks/cli/libs/aitools/agents"
@@ -16,8 +18,9 @@ import (
 
 // UninstallOptions controls the behavior of UninstallSkillsOpts.
 type UninstallOptions struct {
-	Skills []string // empty = all
-	Scope  string   // ScopeGlobal or ScopeProject (default: global)
+	Skills          []string // empty = all
+	Scope           string   // ScopeGlobal or ScopeProject (default: global)
+	KeepMarketplace bool     // keep the marketplace registration when removing a plugin
 }
 
 // UninstallSkills removes all installed skills, their symlinks, and the state file.
@@ -59,6 +62,32 @@ func UninstallSkillsOpts(ctx context.Context, opts UninstallOptions) error {
 		return errors.New("no skills installed")
 	}
 
+	// A full uninstall (no --skills filter) also tears down plugins.
+	fullUninstall := len(opts.Skills) == 0
+
+	pluginCount := 0
+	if fullUninstall {
+		for _, name := range slices.Sorted(maps.Keys(state.Plugins)) {
+			agent := agents.ByName(name)
+			if agent == nil {
+				delete(state.Plugins, name)
+				continue
+			}
+			rec := state.Plugins[name]
+			if err := UninstallPluginForAgent(ctx, agent, rec, opts.KeepMarketplace); err != nil {
+				log.Warnf(ctx, "Skipped %s: %v", agent.DisplayName, err)
+				continue
+			}
+			delete(state.Plugins, name)
+			pluginCount++
+			note := " + marketplace"
+			if opts.KeepMarketplace || !rec.InstalledMarketplace {
+				note = ""
+			}
+			cmdio.LogString(ctx, fmt.Sprintf("  %s  removed databricks plugin%s", agent.DisplayName, note))
+		}
+	}
+
 	// Determine which skills to remove.
 	var toRemove []string
 	if len(opts.Skills) > 0 {
@@ -79,8 +108,6 @@ func UninstallSkillsOpts(ctx context.Context, opts UninstallOptions) error {
 		}
 	}
 
-	removeAll := len(toRemove) == len(state.Skills)
-
 	// Remove skill directories and symlinks for each skill.
 	for _, name := range toRemove {
 		canonicalDir := filepath.Join(baseDir, name)
@@ -90,27 +117,41 @@ func UninstallSkillsOpts(ctx context.Context, opts UninstallOptions) error {
 		}
 		delete(state.Skills, name)
 		delete(state.RepoDirs, name)
+		for path := range state.Files {
+			if strings.HasPrefix(path, name+"/") {
+				delete(state.Files, path)
+			}
+		}
 	}
 
-	if removeAll {
-		// Clean up orphaned symlinks and delete state file.
+	// If nothing remains in this scope, clean up orphaned symlinks and delete the
+	// state file; otherwise persist the trimmed state.
+	if len(state.Skills) == 0 && len(state.Plugins) == 0 {
 		cleanOrphanedSymlinks(ctx, baseDir, scope, cwd)
 		stateFile := filepath.Join(baseDir, stateFileName)
 		if err := os.Remove(stateFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("failed to remove state file: %w", err)
 		}
 	} else {
-		// Update state to reflect remaining skills.
 		if err := SaveState(baseDir, state); err != nil {
 			return err
 		}
 	}
 
-	noun := "skills"
-	if len(toRemove) == 1 {
-		noun = "skill"
+	if pluginCount > 0 {
+		noun := "agent"
+		if pluginCount != 1 {
+			noun = "agents"
+		}
+		cmdio.LogString(ctx, fmt.Sprintf("Uninstalled the plugin from %d %s.", pluginCount, noun))
 	}
-	cmdio.LogString(ctx, fmt.Sprintf("Uninstalled %d %s.", len(toRemove), noun))
+	if len(toRemove) > 0 {
+		noun := "skills"
+		if len(toRemove) == 1 {
+			noun = "skill"
+		}
+		cmdio.LogString(ctx, fmt.Sprintf("Uninstalled %d %s.", len(toRemove), noun))
+	}
 	return nil
 }
 

--- a/libs/aitools/installer/update.go
+++ b/libs/aitools/installer/update.go
@@ -362,6 +362,9 @@ func exposureRemovable(entry, canonicalDir, skillName string, state *InstallStat
 // files). Returns false when there is no recorded provenance, so unverifiable
 // content is never deleted.
 func dirMatchesRecords(dir, skillName string, state *InstallState) bool {
+	if state == nil {
+		return false
+	}
 	prefix := skillName + "/"
 	recorded := map[string]string{}
 	for path, rec := range state.Files {


### PR DESCRIPTION
<!-- aitools-stack -->
### Stack

Part of the `aitools` plugin-first redesign. Open PRs, merge bottom to top:

- **#5740 Uninstall teardown + legacy skills cleanup  ← this PR**
- #5741 list + version plugin state
- #5745 Bug bash (wording, latest-by-default skills, project-scope plan, version reporting)
- #5746 Bug bash round 2 (uninstall confirm, picker, Cursor, official marketplace, version scope)

Merged: #5734, #5736, #5737, #5738, #5739.
<!-- /aitools-stack -->

## Why

To finish the lifecycle: `uninstall` has to remove the plugin we installed (not just skills), and `install` has to clean up any raw skills a user had from the old skills-everywhere model, so a plugin agent doesn't end up with the plugin *and* leftover loose skill files showing the same skills twice.

Stacked on #5739 (update).

## Changes

- **Uninstall tears down plugins.** On a full uninstall (no `--skills` filter), each agent recorded in `state.Plugins` has its plugin removed through the agent's own CLI, and the marketplace is de-registered, but only when this CLI registered it and `--keep-marketplace` wasn't passed, so we never remove a marketplace another plugin may share. Skills teardown is unchanged for file agents; the state file is removed only when no skills and no plugins remain in the scope.
- **Install cleans up legacy raw skills.** After installing the plugin for an agent, `RemoveLegacyRawSkills` removes skill dirs the CLI previously dropped there: a symlink pointing into our canonical dir, or a copy whose files all match the recorded checksums. User-modified dirs, third-party dirs, and copies with no recorded provenance are left untouched.
- New `--keep-marketplace` flag on `uninstall`.

## Test plan

- [x] Unit tests: uninstall tears down the plugin and de-registers the marketplace, removing the state file when nothing remains; `--keep-marketplace` skips the de-register; `RemoveLegacyRawSkills` removes our symlink and a checksum-matched copy while keeping a user-modified copy and a third-party dir.
- [x] Existing skills-uninstall tests still pass byte-for-byte ("Uninstalled N skills.", selective removal, orphan cleanup, "no skills installed").
- [x] `go test ./libs/aitools/... ./cmd/aitools/...` passes.
- [x] `./task fmt-q`, `./task lint-q` (0 issues), `./task checks` (no dead code) clean.

This pull request and its description were written by Isaac.



