### PR TITLE
acc: drop effective_predictive_optimization_flag from schema plan golden files

### DIFF
--- a/acceptance/bundle/artifacts/artifact_path_with_volume/common_script.sh
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/common_script.sh
@@ -1,5 +1,6 @@
 export SCHEMA_NAME=schema-$UNIQUE_NAME
 trace envsubst < $TESTDIR/../databricks.yml.tmpl > databricks.yml
 trap "trace '$CLI' schemas delete main.$SCHEMA_NAME" EXIT
-trace $CLI schemas create $SCHEMA_NAME main | jq 'del(.effective_predictive_optimization_flag.inherited_from_name)'
+# effective_predictive_optimization_flag is inherited from the metastore and backend-controlled; drop it so the test does not depend on metastore settings.
+trace $CLI schemas create $SCHEMA_NAME main | jq 'del(.effective_predictive_optimization_flag)'
 trace musterr $CLI bundle deploy

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/output.txt
@@ -8,10 +8,6 @@
   "catalog_type": "MANAGED_CATALOG",
   "created_at": [UNIX_TIME_MILLIS][0],
   "created_by": "[USERNAME]",
-  "effective_predictive_optimization_flag": {
-    "inherited_from_type": "METASTORE",
-    "value": "DISABLE"
-  },
   "enable_predictive_optimization": "INHERIT",
   "full_name": "main.schema-[UNIQUE_NAME]",
   "metastore_id": "[UUID]",

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/output.txt
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/output.txt
@@ -8,10 +8,6 @@
   "catalog_type": "MANAGED_CATALOG",
   "created_at": [UNIX_TIME_MILLIS][0],
   "created_by": "[USERNAME]",
-  "effective_predictive_optimization_flag": {
-    "inherited_from_type": "METASTORE",
-    "value": "DISABLE"
-  },
   "enable_predictive_optimization": "INHERIT",
   "full_name": "main.schema-[UNIQUE_NAME]",
   "metastore_id": "[UUID]",

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json
@@ -12,11 +12,6 @@
         "catalog_type": "MANAGED_CATALOG",
         "created_at": [UNIX_TIME_MILLIS][0],
         "created_by": "[USERNAME]",
-        "effective_predictive_optimization_flag": {
-          "inherited_from_name": "[METASTORE_NAME]",
-          "inherited_from_type": "METASTORE",
-          "value": "DISABLE"
-        },
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_dup_grants_[UNIQUE_NAME]",
         "metastore_id": "[UUID]",

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/script
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/script
@@ -10,3 +10,6 @@ trap cleanup EXIT
 trace $CLI bundle deploy
 print_requests.py --get //permissions --keep > out.requests.$DATABRICKS_BUNDLE_ENGINE.txt
 trace $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
+tmp=$(mktemp)
+# effective_predictive_optimization_flag is inherited from the metastore and backend-controlled; drop it so the test does not depend on metastore settings.
+jq 'del(.plan["resources.schemas.apps_schema"].remote_state.effective_predictive_optimization_flag)' out.plan.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan.direct.json
@@ -12,11 +12,6 @@
         "catalog_type": "MANAGED_CATALOG",
         "created_at": [UNIX_TIME_MILLIS][0],
         "created_by": "[USERNAME]",
-        "effective_predictive_optimization_flag": {
-          "inherited_from_name": "[METASTORE_NAME]",
-          "inherited_from_type": "METASTORE",
-          "value": "DISABLE"
-        },
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_out_of_band_principal_[UNIQUE_NAME]",
         "metastore_id": "[UUID]",

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan2.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan2.direct.json
@@ -12,11 +12,6 @@
         "catalog_type": "MANAGED_CATALOG",
         "created_at": [UNIX_TIME_MILLIS][0],
         "created_by": "[USERNAME]",
-        "effective_predictive_optimization_flag": {
-          "inherited_from_name": "[METASTORE_NAME]",
-          "inherited_from_type": "METASTORE",
-          "value": "DISABLE"
-        },
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_out_of_band_principal_[UNIQUE_NAME]",
         "metastore_id": "[UUID]",

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/script
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/script
@@ -16,6 +16,9 @@ trace $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 # remote_state.__embed__ order is non-deterministic; extract and sort separately into per-engine file
 jq '.plan["resources.schemas.grants_schema.grants"].remote_state.__embed__' out.plan.$DATABRICKS_BUNDLE_ENGINE.json | gron.py --noindex | sort_lines.py --repl > out.embed.$DATABRICKS_BUNDLE_ENGINE.txt
 tmp=$(mktemp)
-jq 'del(.plan["resources.schemas.grants_schema.grants"].remote_state.__embed__)' out.plan.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan.$DATABRICKS_BUNDLE_ENGINE.json
+# effective_predictive_optimization_flag is inherited from the metastore and backend-controlled; drop it so the test does not depend on metastore settings.
+jq 'del(.plan["resources.schemas.grants_schema.grants"].remote_state.__embed__, .plan["resources.schemas.grants_schema"].remote_state.effective_predictive_optimization_flag)' out.plan.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
 trace $CLI bundle plan -o json > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
+tmp=$(mktemp)
+jq 'del(.plan["resources.schemas.grants_schema"].remote_state.effective_predictive_optimization_flag)' out.plan2.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan2.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/schemas/recreate/output.txt
+++ b/acceptance/bundle/resources/schemas/recreate/output.txt
@@ -76,7 +76,7 @@ Error: Resource catalog.SchemaInfo not found: main.myschema
   "effective_predictive_optimization_flag": {
     "inherited_from_name": "[METASTORE_NAME]",
     "inherited_from_type": "METASTORE",
-    "value": "DISABLE"
+    "value": "ENABLE"
   },
   "enable_predictive_optimization": "INHERIT",
   "full_name": "newmain.myschema",

--- a/bundle/direct/dresources/schema_test.go
+++ b/bundle/direct/dresources/schema_test.go
@@ -58,7 +58,7 @@ func TestResourceSchema_DoUpdate_WithUnsupportedForceSendFields(t *testing.T) {
 		"effective_predictive_optimization_flag": {
 			"inherited_from_name": "deco-uc-prod-isolated-aws-us-east-1",
 			"inherited_from_type": "METASTORE",
-			"value": "DISABLE"
+			"value": "ENABLE"
 		},
 		"enable_predictive_optimization": "INHERIT",
 		"properties": {"key": "updated_value"},

--- a/libs/testserver/schemas.go
+++ b/libs/testserver/schemas.go
@@ -42,9 +42,9 @@ func (s *FakeWorkspace) SchemasCreate(req Request) Response {
 	schema.EffectivePredictiveOptimizationFlag = &catalog.EffectivePredictiveOptimizationFlag{
 		InheritedFromName: testMetastoreName,
 		InheritedFromType: catalog.EffectivePredictiveOptimizationFlagInheritedFromType("METASTORE"),
-		// Mirror the real test metastore, which inherits DISABLE, so a single
+		// Mirror the real test metastore, which inherits ENABLE, so a single
 		// golden stays valid for both local and cloud runs.
-		Value: catalog.EnablePredictiveOptimizationDisable,
+		Value: catalog.EnablePredictiveOptimizationEnable,
 	}
 	schema.EnablePredictiveOptimization = catalog.EnablePredictiveOptimizationInherit
 	schema.MetastoreId = TestMetastore.MetastoreId


### PR DESCRIPTION
The test metastore's `effective_predictive_optimization_flag` is a backend-controlled metastore setting, not CLI behavior. Two schema grants tests (`duplicate_principals`, `out_of_band_principal`) started failing when the metastore flipped from `DISABLE` to `ENABLE`. Dropping the field from the golden files makes them immune to future metastore-level changes.

This pull request and its description were written by Isaac.