### PR TITLE
aitools: bug bash round 2 (uninstall confirm, version scope, official marketplace)

### DIFF
--- a/cmd/aitools/aitools.go
+++ b/cmd/aitools/aitools.go
@@ -12,7 +12,10 @@ func NewAitoolsCmd() *cobra.Command {
 effectively with Databricks resources (bundles, jobs, SQL, and more).
 
 Supported agents: Claude Code, Cursor, Codex CLI, OpenCode, GitHub
-Copilot, Antigravity.`,
+Copilot, Antigravity.
+
+Skills and plugins are sourced from
+https://github.com/databricks/databricks-agent-skills`,
 	}
 
 	cmd.AddCommand(NewInstallCmd())

--- a/cmd/aitools/install.go
+++ b/cmd/aitools/install.go
@@ -30,8 +30,8 @@ type delivery int
 const (
 	// deliveryPlugin installs the databricks plugin through the agent's own CLI.
 	deliveryPlugin delivery = iota
-	// deliverySkills copies raw skill files (no-plugin agents, --skills-only, or a
-	// manual-only plugin agent like Cursor, which also gets a plugin recommendation).
+	// deliverySkills copies raw skill files (agents with no headless plugin
+	// install: OpenCode, Antigravity, Cursor; or any agent under --skills-only).
 	deliverySkills
 	// deliverySkip does nothing for the agent and explains why.
 	deliverySkip
@@ -42,7 +42,7 @@ type agentPlanItem struct {
 	agent    *agents.Agent
 	delivery delivery
 	scope    string // agent-native plugin scope (deliveryPlugin only)
-	reason   string // why skipped or what the manual step is
+	reason   string // why the agent is skipped (deliverySkip only)
 	explicit bool   // named via --agents (blocking it is an error)
 }
 
@@ -64,9 +64,8 @@ func NewInstallCmd() *cobra.Command {
 		Long: `Install Databricks skills and plugins for detected coding agents.
 
 By default this installs the databricks plugin through each agent's own CLI
-(Claude Code, Codex, GitHub Copilot). Agents with no plugin (OpenCode,
-Antigravity) get raw skill files. Cursor has a plugin but no headless install,
-so the CLI prints the '/add-plugin databricks' step instead of copying files.
+(Claude Code, Codex, GitHub Copilot). Agents without a headless plugin install
+(OpenCode, Antigravity, Cursor) get raw skill files.
 
 Escape hatches:
   --skills-only          Force raw skill files for every agent (no plugin).
@@ -241,8 +240,6 @@ func agentStateLabel(s agents.DisplayState) string {
 		return "plugin"
 	case agents.StateInstalledCLIMissing:
 		return "plugin · CLI not found"
-	case agents.StateManualOnly:
-		return "skills (plugin recommended)"
 	case agents.StateFilesOnly:
 		return "skills"
 	default:
@@ -280,8 +277,8 @@ func defaultPromptAgentSelection(_ context.Context, choices []agentChoice) ([]*a
 }
 
 // buildPlan resolves the per-agent delivery and scope. Plugin-first: an agent
-// with a plugin gets the plugin (or the manual step for Cursor); --skills-only
-// forces skills everywhere; agents with no plugin always get skills.
+// with a headless plugin install gets the plugin; --skills-only forces skills
+// everywhere; agents with no plugin always get skills.
 func buildPlan(targetAgents []*agents.Agent, scope string, skillsOnly, explicit bool) []agentPlanItem {
 	plan := make([]agentPlanItem, 0, len(targetAgents))
 	for _, a := range targetAgents {
@@ -296,11 +293,10 @@ func buildPlan(targetAgents []*agents.Agent, scope string, skillsOnly, explicit 
 func planItemFor(a *agents.Agent, scope string, skillsOnly, explicit bool) agentPlanItem {
 	item := agentPlanItem{agent: a, explicit: explicit}
 	switch {
-	case skillsOnly || a.Plugin == nil || a.Plugin.ManualOnly:
-		// Raw-skills delivery. A manual-only plugin agent (Cursor) can't be
-		// installed headlessly, so it gets skills plus a plugin recommendation at
-		// install time. Only some agents support project-scoped skills, so skip the
-		// rest up front instead of offering an option that fails at install time.
+	case skillsOnly || a.Plugin == nil:
+		// Raw-skills delivery (no-plugin agents, or --skills-only). Only some agents
+		// support project-scoped skills, so skip the rest up front instead of
+		// offering an option that fails at install time.
 		if scope == installer.ScopeProject && !a.SupportsProjectScope {
 			item.delivery = deliverySkip
 			item.reason = "does not support project-scoped skills"
@@ -329,11 +325,7 @@ func printPlanSummary(ctx context.Context, plan []agentPlanItem, scope string) {
 		case deliveryPlugin:
 			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  install the databricks plugin")
 		case deliverySkills:
-			line := "install skills"
-			if it.agent.Plugin != nil && it.agent.Plugin.ManualOnly {
-				line = "install skills (plugin recommended)"
-			}
-			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  "+line)
+			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  install skills")
 		case deliverySkip:
 			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  skip ("+it.reason+")")
 		}
@@ -365,13 +357,6 @@ func executePlan(ctx context.Context, src installer.ManifestSource, plan []agent
 		installer.PrintInstallingFor(ctx, skillsAgents)
 		if err := installSkillsForAgentsFn(ctx, src, skillsAgents, opts); err != nil {
 			return err
-		}
-		// An agent whose plugin can't be installed headlessly (Cursor) gets skills,
-		// plus a nudge toward the better plugin experience.
-		for _, a := range skillsAgents {
-			if a.Plugin != nil && a.Plugin.ManualOnly {
-				cmdio.LogString(ctx, fmt.Sprintf("  %s  recommended: %s", a.DisplayName, a.Plugin.ManualInstructions))
-			}
 		}
 	}
 

--- a/cmd/aitools/install.go
+++ b/cmd/aitools/install.go
@@ -30,10 +30,9 @@ type delivery int
 const (
 	// deliveryPlugin installs the databricks plugin through the agent's own CLI.
 	deliveryPlugin delivery = iota
-	// deliverySkills copies raw skill files (no-plugin agents, or --skills-only).
+	// deliverySkills copies raw skill files (no-plugin agents, --skills-only, or a
+	// manual-only plugin agent like Cursor, which also gets a plugin recommendation).
 	deliverySkills
-	// deliveryManualCursor prints the /add-plugin tip and copies nothing (Cursor).
-	deliveryManualCursor
 	// deliverySkip does nothing for the agent and explains why.
 	deliverySkip
 )
@@ -178,7 +177,13 @@ func selectAgents(ctx context.Context, scope string, skillsOnly bool) ([]*agents
 	// Interactive: the picker decides; a prompt error or empty selection is a real
 	// error, not a "nothing detected" no-op.
 	if cmdio.IsPromptSupported(ctx) {
-		return promptAgentSelection(ctx, agentChoices(ctx, scope, skillsOnly))
+		choices := agentChoices(ctx, scope, skillsOnly)
+		if len(choices) == 0 {
+			// Agents were detected but none can be acted on in this scope; the
+			// caller prints the no-agents message rather than showing an empty picker.
+			return nil, nil
+		}
+		return promptAgentSelection(ctx, choices)
 	}
 
 	var selected []*agents.Agent
@@ -194,22 +199,27 @@ func selectAgents(ctx context.Context, scope string, skillsOnly bool) ([]*agents
 	return selected, nil
 }
 
-// agentChoices builds the interactive picker rows over every known agent. The
-// rows are scope-aware: an agent that can't be acted on in the chosen scope
-// (e.g. a files-only agent under project scope) shows why and is not pre-checked,
-// so the picker never offers an option that would fail at install time.
+// agentChoices builds the interactive picker rows. Every detected agent is shown
+// in the detection list with its state, but only agents that can actually be
+// acted on in the chosen scope (plugin or skills delivery) become selectable
+// options. Agents that would be skipped (e.g. a files-only agent under project
+// scope) are listed with their reason but are not checkboxes, so the picker never
+// offers an option that does nothing.
 func agentChoices(ctx context.Context, scope string, skillsOnly bool) []agentChoice {
 	cmdio.LogString(ctx, "Detecting coding agents...")
-	choices := make([]agentChoice, 0, len(agents.Registry))
+	var choices []agentChoice
 	for _, a := range agents.Registry {
 		item := planItemFor(a, scope, skillsOnly, false)
 		label := agentChoiceLabel(ctx, a, item)
+		cmdio.LogString(ctx, fmt.Sprintf("  %-16s %s", a.DisplayName, label))
+		if item.delivery == deliverySkip {
+			continue
+		}
 		choices = append(choices, agentChoice{
 			agent:     a,
 			label:     a.DisplayName + "  " + label,
-			preselect: a.IsPreselected(ctx) && item.delivery != deliverySkip,
+			preselect: a.IsPreselected(ctx),
 		})
-		cmdio.LogString(ctx, fmt.Sprintf("  %-16s %s", a.DisplayName, label))
 	}
 	return choices
 }
@@ -232,7 +242,7 @@ func agentStateLabel(s agents.DisplayState) string {
 	case agents.StateInstalledCLIMissing:
 		return "plugin · CLI not found"
 	case agents.StateManualOnly:
-		return "plugin · add manually with /add-plugin"
+		return "skills (plugin recommended)"
 	case agents.StateFilesOnly:
 		return "skills"
 	default:
@@ -286,19 +296,17 @@ func buildPlan(targetAgents []*agents.Agent, scope string, skillsOnly, explicit 
 func planItemFor(a *agents.Agent, scope string, skillsOnly, explicit bool) agentPlanItem {
 	item := agentPlanItem{agent: a, explicit: explicit}
 	switch {
-	case skillsOnly || a.Plugin == nil:
-		// Raw-skills delivery. Only some agents support project-scoped skills, so
-		// skip the rest up front instead of offering an option that fails at
-		// install time (the skills installer rejects them anyway).
+	case skillsOnly || a.Plugin == nil || a.Plugin.ManualOnly:
+		// Raw-skills delivery. A manual-only plugin agent (Cursor) can't be
+		// installed headlessly, so it gets skills plus a plugin recommendation at
+		// install time. Only some agents support project-scoped skills, so skip the
+		// rest up front instead of offering an option that fails at install time.
 		if scope == installer.ScopeProject && !a.SupportsProjectScope {
 			item.delivery = deliverySkip
 			item.reason = "does not support project-scoped skills"
 		} else {
 			item.delivery = deliverySkills
 		}
-	case a.Plugin.ManualOnly:
-		item.delivery = deliveryManualCursor
-		item.reason = a.Plugin.ManualInstructions
 	default:
 		nativeScope, ok, reason := mapAgentScope(a, scope)
 		if !ok {
@@ -321,9 +329,11 @@ func printPlanSummary(ctx context.Context, plan []agentPlanItem, scope string) {
 		case deliveryPlugin:
 			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  install the databricks plugin")
 		case deliverySkills:
-			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  install skills")
-		case deliveryManualCursor:
-			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  manual: "+it.reason)
+			line := "install skills"
+			if it.agent.Plugin != nil && it.agent.Plugin.ManualOnly {
+				line = "install skills (plugin recommended)"
+			}
+			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  "+line)
 		case deliverySkip:
 			cmdio.LogString(ctx, "  "+it.agent.DisplayName+"  skip ("+it.reason+")")
 		}
@@ -337,15 +347,13 @@ func printPlanSummary(ctx context.Context, plan []agentPlanItem, scope string) {
 // the agent was explicitly named via --agents, which is an error.
 func executePlan(ctx context.Context, src installer.ManifestSource, plan []agentPlanItem, opts installer.InstallOptions) error {
 	var skillsAgents []*agents.Agent
-	var pluginItems, manualItems, skipItems []agentPlanItem
+	var pluginItems, skipItems []agentPlanItem
 	for _, it := range plan {
 		switch it.delivery {
 		case deliverySkills:
 			skillsAgents = append(skillsAgents, it.agent)
 		case deliveryPlugin:
 			pluginItems = append(pluginItems, it)
-		case deliveryManualCursor:
-			manualItems = append(manualItems, it)
 		case deliverySkip:
 			skipItems = append(skipItems, it)
 		}
@@ -357,6 +365,13 @@ func executePlan(ctx context.Context, src installer.ManifestSource, plan []agent
 		installer.PrintInstallingFor(ctx, skillsAgents)
 		if err := installSkillsForAgentsFn(ctx, src, skillsAgents, opts); err != nil {
 			return err
+		}
+		// An agent whose plugin can't be installed headlessly (Cursor) gets skills,
+		// plus a nudge toward the better plugin experience.
+		for _, a := range skillsAgents {
+			if a.Plugin != nil && a.Plugin.ManualOnly {
+				cmdio.LogString(ctx, fmt.Sprintf("  %s  recommended: %s", a.DisplayName, a.Plugin.ManualInstructions))
+			}
 		}
 	}
 
@@ -390,10 +405,6 @@ func executePlan(ctx context.Context, src installer.ManifestSource, plan []agent
 				return err
 			}
 		}
-	}
-
-	for _, it := range manualItems {
-		cmdio.LogString(ctx, fmt.Sprintf("  %s  manual: %s", it.agent.DisplayName, it.reason))
 	}
 
 	for _, it := range skipItems {

--- a/cmd/aitools/install_test.go
+++ b/cmd/aitools/install_test.go
@@ -111,11 +111,8 @@ func fakeBinsOnPath(t *testing.T, binaries ...string) {
 	t.Setenv("PATH", dir)
 }
 
-func testPluginAgent(name, display, binary string, manual bool) *agents.Agent {
-	spec := &agents.PluginSpec{Marketplace: "databricks-agent-skills", ID: "databricks", Source: "databricks/databricks-agent-skills", ManualOnly: manual}
-	if manual {
-		spec.ManualInstructions = "run /add-plugin databricks in Cursor"
-	}
+func testPluginAgent(name, display, binary string) *agents.Agent {
+	spec := &agents.PluginSpec{Marketplace: "databricks-agent-skills", ID: "databricks", Source: "databricks/databricks-agent-skills"}
 	a := &agents.Agent{Name: name, DisplayName: display, Binary: binary, Plugin: spec}
 	if name == agents.NameClaudeCode {
 		a.SupportsProjectScope = true
@@ -126,17 +123,16 @@ func testPluginAgent(name, display, binary string, manual bool) *agents.Agent {
 // --- buildPlan / mapAgentScope / executePlan unit tests (no detection) ---
 
 func TestBuildPlanDeliveries(t *testing.T) {
-	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
-	cursor := testPluginAgent(agents.NameCursor, "Cursor", "cursor-agent", true)
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude")
+	// Cursor is a skills-only agent (no headless plugin install).
+	cursor := &agents.Agent{Name: agents.NameCursor, DisplayName: "Cursor", Binary: "cursor-agent", SupportsProjectScope: true}
 	opencode := &agents.Agent{Name: agents.NameOpenCode, DisplayName: "OpenCode", Binary: "opencode"}
 	targets := []*agents.Agent{claude, cursor, opencode}
 
 	plan := buildPlan(targets, installer.ScopeGlobal, false, false)
 	assert.Equal(t, deliveryPlugin, plan[0].delivery)
 	assert.Equal(t, agentScopeUser, plan[0].scope)
-	// Cursor (manual-only plugin) installs skills and is nudged toward the plugin.
-	assert.Equal(t, deliverySkills, plan[1].delivery)
-	assert.True(t, plan[1].agent.Plugin.ManualOnly)
+	assert.Equal(t, deliverySkills, plan[1].delivery) // Cursor -> skills
 	assert.Equal(t, deliverySkills, plan[2].delivery)
 
 	// --skills-only forces skills for every agent.
@@ -167,8 +163,8 @@ func TestAgentChoicesOnlyOffersActionableAgents(t *testing.T) {
 }
 
 func TestBuildPlanProjectScopeSkipsUserOnlyAgent(t *testing.T) {
-	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
-	codex := testPluginAgent(agents.NameCodex, "Codex CLI", "codex", false)
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude")
+	codex := testPluginAgent(agents.NameCodex, "Codex CLI", "codex")
 
 	plan := buildPlan([]*agents.Agent{claude, codex}, installer.ScopeProject, false, false)
 	assert.Equal(t, deliveryPlugin, plan[0].delivery)
@@ -198,8 +194,8 @@ func TestBuildPlanProjectScopeSkipsFilesOnlyAgent(t *testing.T) {
 }
 
 func TestMapAgentScope(t *testing.T) {
-	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
-	codex := testPluginAgent(agents.NameCodex, "Codex CLI", "codex", false)
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude")
+	codex := testPluginAgent(agents.NameCodex, "Codex CLI", "codex")
 
 	scope, ok, _ := mapAgentScope(claude, installer.ScopeGlobal)
 	assert.True(t, ok)
@@ -224,7 +220,7 @@ func TestExecutePlanSkipBlockedPluginExit0(t *testing.T) {
 	}
 	recordPluginInstallsFn = func(context.Context, string, map[string]installer.PluginRecord, string) error { return nil }
 
-	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude", false)
+	claude := testPluginAgent(agents.NameClaudeCode, "Claude Code", "claude")
 	ctx := cmdio.MockDiscard(t.Context())
 
 	// Non-explicit blocked install is a warning, not an error.

--- a/cmd/aitools/install_test.go
+++ b/cmd/aitools/install_test.go
@@ -134,7 +134,9 @@ func TestBuildPlanDeliveries(t *testing.T) {
 	plan := buildPlan(targets, installer.ScopeGlobal, false, false)
 	assert.Equal(t, deliveryPlugin, plan[0].delivery)
 	assert.Equal(t, agentScopeUser, plan[0].scope)
-	assert.Equal(t, deliveryManualCursor, plan[1].delivery)
+	// Cursor (manual-only plugin) installs skills and is nudged toward the plugin.
+	assert.Equal(t, deliverySkills, plan[1].delivery)
+	assert.True(t, plan[1].agent.Plugin.ManualOnly)
 	assert.Equal(t, deliverySkills, plan[2].delivery)
 
 	// --skills-only forces skills for every agent.
@@ -142,6 +144,26 @@ func TestBuildPlanDeliveries(t *testing.T) {
 	for _, it := range skillsPlan {
 		assert.Equal(t, deliverySkills, it.delivery)
 	}
+}
+
+func TestAgentChoicesOnlyOffersActionableAgents(t *testing.T) {
+	setupTestAgents(t)
+	fakeBinsOnPath(t, "claude")
+	ctx := cmdio.MockDiscard(t.Context())
+
+	// Project scope: only Claude (plugin) and Cursor (skills) support it; the
+	// user-only plugin agents and files-only agents are not offered as choices.
+	choices := agentChoices(ctx, installer.ScopeProject, false)
+	var names []string
+	for _, c := range choices {
+		names = append(names, c.agent.Name)
+	}
+	assert.Contains(t, names, agents.NameClaudeCode)
+	assert.Contains(t, names, agents.NameCursor)
+	assert.NotContains(t, names, agents.NameCodex)
+	assert.NotContains(t, names, agents.NameOpenCode)
+	assert.NotContains(t, names, agents.NameCopilot)
+	assert.NotContains(t, names, agents.NameAntigravity)
 }
 
 func TestBuildPlanProjectScopeSkipsUserOnlyAgent(t *testing.T) {
@@ -276,7 +298,10 @@ func TestInstallPluginFirstDefault(t *testing.T) {
 	require.Len(t, *plugins, 1)
 	assert.Equal(t, agents.NameClaudeCode, (*plugins)[0].agent)
 	assert.Equal(t, agentScopeUser, (*plugins)[0].scope)
-	assert.Empty(t, *skills, "plugin agents must not get raw skills by default")
+	// Claude (a real plugin agent) must not get raw skills, but Cursor (manual-only
+	// plugin) does, plus a plugin recommendation.
+	require.Len(t, *skills, 1)
+	assert.Equal(t, []string{agents.NameCursor}, (*skills)[0].agents)
 }
 
 func TestInstallInteractivePickerAndConfirm(t *testing.T) {

--- a/cmd/aitools/list.go
+++ b/cmd/aitools/list.go
@@ -78,25 +78,19 @@ type listOutput struct {
 // agentEntry reports per-agent plugin state for `list`. It mirrors skillEntry:
 // Installed maps scope -> the plugin recorded in that scope, so a stale scoped
 // install stays visible next to an up-to-date one. Managed says whether the CLI
-// installs and tracks the plugin (false for Cursor, which is added manually).
-// Up-to-date-ness is derived by comparing each Installed version against the
-// top-level release, exactly as the skills view does, so there is no
-// precomputed cross-scope status to keep in sync.
+// installs and tracks the plugin. Up-to-date-ness is derived by comparing each
+// Installed version against the top-level release, exactly as the skills view
+// does, so there is no precomputed cross-scope status to keep in sync.
 type agentEntry struct {
 	Name      string                `json:"name"`
 	Managed   bool                  `json:"managed"`
 	Installed map[string]pluginInfo `json:"installed,omitempty"`
-	// Status carries the manual-add hint for agents whose plugin can't be
-	// installed headlessly (Cursor); empty for CLI-managed agents.
-	Status string `json:"status,omitempty"`
 }
 
 // pluginInfo is the per-scope plugin record surfaced in list output.
 type pluginInfo struct {
 	Version string `json:"version,omitempty"`
 }
-
-const statusManualAddPlugin = "manual_add_plugin"
 
 type skillEntry struct {
 	Name          string            `json:"name"`
@@ -199,18 +193,17 @@ func buildListOutput(ctx context.Context, scope string) (listOutput, error) {
 	if projectState != nil {
 		states[installer.ScopeProject] = projectState
 	}
-	out.Agents = buildAgentEntries(ctx, states)
+	out.Agents = buildAgentEntries(states)
 
 	return out, nil
 }
 
 // buildAgentEntries reports per-agent plugin state: each plugin agent with a
-// recorded install (its version per scope), plus Cursor (which is added
-// manually) when present. states maps scope -> install state and must contain
-// only non-nil states; the caller filters scopes it did not load. Status across
-// scopes is left for the renderer (and JSON consumers) to derive from the
-// per-scope versions, so no cross-scope record is merged away here.
-func buildAgentEntries(ctx context.Context, states map[string]*installer.InstallState) []agentEntry {
+// recorded install (its version per scope). states maps scope -> install state
+// and must contain only non-nil states; the caller filters scopes it did not
+// load. Status across scopes is left for the renderer (and JSON consumers) to
+// derive from the per-scope versions, so no cross-scope record is merged away here.
+func buildAgentEntries(states map[string]*installer.InstallState) []agentEntry {
 	var entries []agentEntry
 	for _, a := range agents.Registry {
 		if a.Plugin == nil {
@@ -225,11 +218,6 @@ func buildAgentEntries(ctx context.Context, states map[string]*installer.Install
 		}
 		if len(installed) > 0 {
 			entries = append(entries, agentEntry{Name: a.Name, Managed: true, Installed: installed})
-			continue
-		}
-
-		if a.Plugin.ManualOnly && (a.Detected(ctx) || a.HasBinary(ctx)) {
-			entries = append(entries, agentEntry{Name: a.Name, Status: statusManualAddPlugin})
 		}
 	}
 	return entries
@@ -319,10 +307,6 @@ func renderSkillTable(skills []skillEntry, bothScopes bool) string {
 // release) is surfaced over an up-to-date one so an outdated install is never
 // hidden; project is preferred when every scope matches release.
 func agentStatusLabel(a agentEntry, release string) string {
-	if a.Status == statusManualAddPlugin {
-		return "plugin · add manually with /add-plugin"
-	}
-
 	version, upToDate := "", true
 	for _, scope := range []string{installer.ScopeProject, installer.ScopeGlobal} {
 		info, ok := a.Installed[scope]

--- a/cmd/aitools/list_test.go
+++ b/cmd/aitools/list_test.go
@@ -3,8 +3,6 @@ package aitools
 import (
 	"bytes"
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -116,7 +114,6 @@ func TestRenderListJSONWithAgents(t *testing.T) {
 				Managed:   true,
 				Installed: map[string]pluginInfo{installer.ScopeGlobal: {Version: "0.2.6"}},
 			},
-			{Name: "cursor", Status: statusManualAddPlugin},
 		},
 	}
 
@@ -131,28 +128,16 @@ func TestRenderListJSONWithAgents(t *testing.T) {
 	assert.Contains(t, raw, "summary")
 
 	agentsRaw := raw["agents"].([]any)
-	require.Len(t, agentsRaw, 2)
-
+	require.Len(t, agentsRaw, 1)
 	first := agentsRaw[0].(map[string]any)
 	assert.Equal(t, "claude-code", first["name"])
 	assert.Equal(t, true, first["managed"])
 	installed := first["installed"].(map[string]any)
 	global := installed["global"].(map[string]any)
 	assert.Equal(t, "0.2.6", global["version"])
-
-	second := agentsRaw[1].(map[string]any)
-	assert.Equal(t, "cursor", second["name"])
-	assert.Equal(t, false, second["managed"])
-	assert.Equal(t, "manual_add_plugin", second["status"])
 }
 
 func TestBuildAgentEntries(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-	require.NoError(t, os.MkdirAll(filepath.Join(tmp, ".cursor"), 0o755))
-	ctx := cmdio.MockDiscard(t.Context())
-
 	globalState := &installer.InstallState{
 		Plugins: map[string]installer.PluginRecord{
 			"claude-code": {Plugin: "databricks", Version: "0.2.6"},
@@ -160,7 +145,7 @@ func TestBuildAgentEntries(t *testing.T) {
 		},
 	}
 
-	entries := buildAgentEntries(ctx, map[string]*installer.InstallState{
+	entries := buildAgentEntries(map[string]*installer.InstallState{
 		installer.ScopeGlobal: globalState,
 	})
 	byName := map[string]agentEntry{}
@@ -178,20 +163,11 @@ func TestBuildAgentEntries(t *testing.T) {
 	assert.Equal(t, "0.2.5", byName["codex"].Installed[installer.ScopeGlobal].Version)
 	assert.Equal(t, "plugin · v0.2.5 · update available", agentStatusLabel(byName["codex"], "0.2.6"))
 
-	// Cursor is detected (config dir) but never CLI-managed.
-	require.Contains(t, byName, "cursor")
-	assert.False(t, byName["cursor"].Managed)
-	assert.Equal(t, statusManualAddPlugin, byName["cursor"].Status)
-	assert.Empty(t, byName["cursor"].Installed)
-	assert.Equal(t, "plugin · add manually with /add-plugin", agentStatusLabel(byName["cursor"], "0.2.6"))
+	// Cursor has no plugin, so it never appears as a plugin agent entry.
+	assert.NotContains(t, byName, "cursor")
 }
 
 func TestBuildAgentEntriesRecordsPerScopeVersions(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-	ctx := cmdio.MockDiscard(t.Context())
-
 	// Same agent recorded in both scopes: global current, project stale. Both
 	// versions are recorded; no scope is merged away.
 	globalState := &installer.InstallState{Plugins: map[string]installer.PluginRecord{
@@ -201,7 +177,7 @@ func TestBuildAgentEntriesRecordsPerScopeVersions(t *testing.T) {
 		"claude-code": {Plugin: "databricks", Version: "0.2.5"},
 	}}
 
-	entries := buildAgentEntries(ctx, map[string]*installer.InstallState{
+	entries := buildAgentEntries(map[string]*installer.InstallState{
 		installer.ScopeGlobal:  globalState,
 		installer.ScopeProject: projectState,
 	})

--- a/cmd/aitools/uninstall.go
+++ b/cmd/aitools/uninstall.go
@@ -2,8 +2,11 @@ package aitools
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/databricks/cli/libs/aitools/installer"
+	"github.com/databricks/cli/libs/cmdio"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +53,25 @@ By default, removes all skills. Use --skills to remove specific skills only.`,
 				KeepMarketplace: keepMarketplace,
 			}
 			opts.Skills = splitAndTrim(skillsFlag)
+
+			// Uninstall is destructive, so confirm interactively before doing
+			// anything. Non-interactive runs (no TTY) proceed unprompted so
+			// automation is unaffected, matching how install only prompts on a TTY.
+			if cmdio.IsPromptSupported(ctx) {
+				dir := globalDir
+				if scope == installer.ScopeProject {
+					dir = projectDir
+				}
+				proceed, err := confirmUninstall(ctx, dir, opts)
+				if err != nil {
+					return err
+				}
+				if !proceed {
+					cmdio.LogString(ctx, "Cancelled.")
+					return nil
+				}
+			}
+
 			return uninstallSkillsFn(ctx, opts)
 		},
 	}
@@ -61,4 +83,51 @@ By default, removes all skills. Use --skills to remove specific skills only.`,
 	cmd.Flags().BoolVar(&globalFlag, "global", false, "Uninstall globally-scoped skills")
 	markScopeBoolsDeprecated(cmd)
 	return cmd
+}
+
+// confirmUninstall asks the user to confirm a destructive uninstall, summarizing
+// what will be removed. It returns true without prompting when nothing is
+// recorded in the scope, so the installer can surface its own "nothing installed"
+// or legacy guidance instead.
+func confirmUninstall(ctx context.Context, dir string, opts installer.UninstallOptions) (bool, error) {
+	state, err := installer.LoadState(dir)
+	if err != nil {
+		return false, err
+	}
+	msg, ask := uninstallConfirmMessage(state, opts)
+	if !ask {
+		return true, nil
+	}
+	cmdio.LogString(ctx, msg)
+	return cmdio.AskYesOrNo(ctx, "Proceed?")
+}
+
+// uninstallConfirmMessage builds the human summary of what an uninstall will
+// remove. ask is false when there is nothing recorded to confirm.
+func uninstallConfirmMessage(state *installer.InstallState, opts installer.UninstallOptions) (msg string, ask bool) {
+	if state == nil {
+		return "", false
+	}
+	if len(opts.Skills) > 0 {
+		return fmt.Sprintf("This will remove %s %s (%s scope).", plural(len(opts.Skills), "skill"), strings.Join(opts.Skills, ", "), opts.Scope), true
+	}
+	var parts []string
+	if n := len(state.Skills); n > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s", n, plural(n, "skill")))
+	}
+	if n := len(state.Plugins); n > 0 {
+		parts = append(parts, fmt.Sprintf("the databricks plugin from %d %s", n, plural(n, "agent")))
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return fmt.Sprintf("This will remove %s (%s scope).", strings.Join(parts, " and "), opts.Scope), true
+}
+
+// plural returns noun for n == 1 and noun+"s" otherwise.
+func plural(n int, noun string) string {
+	if n == 1 {
+		return noun
+	}
+	return noun + "s"
 }

--- a/cmd/aitools/uninstall_test.go
+++ b/cmd/aitools/uninstall_test.go
@@ -64,3 +64,31 @@ func TestUninstallScopeFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestUninstallConfirmMessage(t *testing.T) {
+	// Nothing recorded: no prompt (installer surfaces its own guidance).
+	_, ask := uninstallConfirmMessage(nil, installer.UninstallOptions{Scope: installer.ScopeGlobal})
+	assert.False(t, ask)
+
+	_, askEmpty := uninstallConfirmMessage(&installer.InstallState{}, installer.UninstallOptions{Scope: installer.ScopeGlobal})
+	assert.False(t, askEmpty)
+
+	st := &installer.InstallState{
+		Skills:  map[string]string{"a": "1", "b": "2"},
+		Plugins: map[string]installer.PluginRecord{"claude-code": {}},
+	}
+
+	msg, ask := uninstallConfirmMessage(st, installer.UninstallOptions{Scope: installer.ScopeGlobal})
+	require.True(t, ask)
+	assert.Contains(t, msg, "2 skills")
+	assert.Contains(t, msg, "the databricks plugin from 1 agent")
+	assert.Contains(t, msg, "(global scope)")
+
+	// --skills filter names the requested skills.
+	filtered := installer.UninstallOptions{Scope: installer.ScopeProject}
+	filtered.Skills = []string{"alpha"}
+	msg2, ask2 := uninstallConfirmMessage(st, filtered)
+	require.True(t, ask2)
+	assert.Contains(t, msg2, "skill alpha")
+	assert.Contains(t, msg2, "(project scope)")
+}

--- a/cmd/aitools/version.go
+++ b/cmd/aitools/version.go
@@ -51,30 +51,22 @@ func NewVersionCmd() *cobra.Command {
 			if err != nil {
 				log.Debugf(ctx, "could not resolve skills version: %v", err)
 			}
-			bothScopes := globalState != nil && projectState != nil
-
 			cmdio.LogString(ctx, "Databricks skills and plugins:")
 
+			// Always label the scope (global / project) for both skills and
+			// plugins so it is unambiguous where each thing is installed.
 			if globalState != nil {
-				label := "Skills"
-				if bothScopes {
-					label = "Skills (global)"
-				}
 				if len(globalState.Skills) > 0 {
-					printVersionLine(ctx, label, globalState, latestRef)
+					printVersionLine(ctx, "Skills (global)", globalState, latestRef)
 				}
-				printPluginLines(ctx, globalState)
+				printPluginLines(ctx, globalState, "global")
 			}
 
 			if projectState != nil {
-				label := "Skills"
-				if bothScopes {
-					label = "Skills (project)"
-				}
 				if len(projectState.Skills) > 0 {
-					printVersionLine(ctx, label, projectState, latestRef)
+					printVersionLine(ctx, "Skills (project)", projectState, latestRef)
 				}
-				printPluginLines(ctx, projectState)
+				printPluginLines(ctx, projectState, "project")
 			}
 
 			return nil
@@ -84,11 +76,12 @@ func NewVersionCmd() *cobra.Command {
 	return cmd
 }
 
-// printPluginLines prints one line per plugin recorded in the scope's state.
-func printPluginLines(ctx context.Context, state *installer.InstallState) {
+// printPluginLines prints one line per plugin recorded in the scope's state,
+// labeled with the scope so it is clear where the plugin is installed.
+func printPluginLines(ctx context.Context, state *installer.InstallState, scope string) {
 	for _, name := range slices.Sorted(maps.Keys(state.Plugins)) {
 		rec := state.Plugins[name]
-		cmdio.LogString(ctx, fmt.Sprintf("  Plugin (%s): %s", agentDisplayName(name), versionToken(rec.Version)))
+		cmdio.LogString(ctx, fmt.Sprintf("  Plugin (%s, %s): %s", agentDisplayName(name), scope, versionToken(rec.Version)))
 	}
 }
 

--- a/cmd/aitools/version_test.go
+++ b/cmd/aitools/version_test.go
@@ -34,7 +34,7 @@ func TestVersionShowsPlugin(t *testing.T) {
 	cmd.SetContext(ctx)
 	require.NoError(t, cmd.RunE(cmd, nil))
 
-	assert.Contains(t, stderr.String(), "Plugin (Claude Code): v0.2.6")
+	assert.Contains(t, stderr.String(), "Plugin (Claude Code, global): v0.2.6")
 }
 
 func TestVersionShowsBothScopes(t *testing.T) {
@@ -93,7 +93,7 @@ func TestVersionShowsBothScopes(t *testing.T) {
 	assert.Contains(t, output, "Last updated: 2026-03-22")
 }
 
-func TestVersionShowsSingleScopeWithoutQualifier(t *testing.T) {
+func TestVersionAlwaysLabelsScope(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("USERPROFILE", tmp)
@@ -124,8 +124,8 @@ func TestVersionShowsSingleScopeWithoutQualifier(t *testing.T) {
 	require.NoError(t, err)
 
 	output := stderr.String()
-	// Should show "Skills:" without qualifier when only one scope.
-	assert.Contains(t, output, "Skills: v0.1.0")
-	assert.NotContains(t, output, "Skills (global)")
+	// The scope is always labeled, even when only one scope is installed, so it
+	// is unambiguous where skills/plugins live.
+	assert.Contains(t, output, "Skills (global): v0.1.0")
 	assert.NotContains(t, output, "Skills (project)")
 }

--- a/libs/aitools/agents/agents.go
+++ b/libs/aitools/agents/agents.go
@@ -10,9 +10,9 @@ import (
 )
 
 // PluginSpec describes the databricks plugin for an agent. A non-nil
-// Agent.Plugin means the agent has a databricks plugin (Claude Code, Codex,
-// Copilot, Cursor); a nil Plugin means raw skill files are the only delivery
-// (OpenCode, Antigravity).
+// Agent.Plugin means the agent has a databricks plugin the CLI can install
+// headlessly (Claude Code, Codex, Copilot); a nil Plugin means raw skill files
+// are the only delivery (OpenCode, Antigravity, Cursor).
 type PluginSpec struct {
 	// Marketplace is the marketplace registry name the plugin is served from,
 	// as registered by `<agent> plugin marketplace add` (e.g. "databricks-agent-skills").
@@ -20,15 +20,9 @@ type PluginSpec struct {
 	// ID is the plugin identifier that is installed/enabled (e.g. "databricks").
 	ID string
 	// Source is the argument passed to `<agent> plugin marketplace add`
-	// (e.g. "databricks/databricks-agent-skills").
+	// (e.g. "databricks/databricks-agent-skills"). Empty marks a built-in
+	// marketplace that must not be added or de-registered.
 	Source string
-	// ManualOnly marks an agent that has a plugin but no headless install path
-	// (Cursor). For these agents the CLI prints ManualInstructions and copies
-	// nothing, because dropping skills alongside the plugin would duplicate them.
-	ManualOnly bool
-	// ManualInstructions is the user-facing tip for ManualOnly agents
-	// (e.g. "run /add-plugin databricks in Cursor"). Empty otherwise.
-	ManualInstructions string
 }
 
 // Agent defines a supported coding agent.
@@ -171,13 +165,9 @@ var Registry = []*Agent{
 		// Cursor's CLI binary is `cursor-agent`, not `cursor` (the latter is an
 		// IDE shim that isn't on PATH unless the user ran "install shell command").
 		Binary: "cursor-agent",
-		Plugin: &PluginSpec{
-			Marketplace:        databricksMarketplace,
-			ID:                 databricksPluginID,
-			Source:             databricksPluginSrc,
-			ManualOnly:         true,
-			ManualInstructions: "run /add-plugin databricks in Cursor",
-		},
+		// Cursor has a databricks plugin, but it can't be installed headlessly, so
+		// the CLI treats Cursor as a skills-only agent (Plugin nil) rather than
+		// referencing a plugin it can't act on.
 	},
 	{
 		Name:        NameCodex,

--- a/libs/aitools/agents/agents.go
+++ b/libs/aitools/agents/agents.go
@@ -120,15 +120,33 @@ const (
 	databricksMarketplace = "databricks-agent-skills"
 	databricksPluginID    = "databricks"
 	databricksPluginSrc   = "databricks/databricks-agent-skills"
+
+	// claudeOfficialMarketplace is Claude Code's built-in marketplace
+	// (anthropics/claude-plugins-official), registered by default. The databricks
+	// plugin is published there, so Claude installs from it and we never register
+	// our own marketplace for Claude. An empty PluginSpec.Source marks a built-in
+	// marketplace that must not be added.
+	claudeOfficialMarketplace = "claude-plugins-official"
 )
 
-// databricksPlugin returns the shared plugin descriptor for an agent with a
-// real headless install path (Claude, Codex, Copilot).
+// databricksPlugin returns the shared plugin descriptor for an agent that
+// installs from our own marketplace (Codex, Copilot, Cursor).
 func databricksPlugin() *PluginSpec {
 	return &PluginSpec{
 		Marketplace: databricksMarketplace,
 		ID:          databricksPluginID,
 		Source:      databricksPluginSrc,
+	}
+}
+
+// claudePlugin returns Claude's plugin descriptor. Claude installs the databricks
+// plugin from its built-in claude-plugins-official marketplace (Source empty), so
+// the CLI doesn't register a separate databricks-agent-skills marketplace for it.
+func claudePlugin() *PluginSpec {
+	return &PluginSpec{
+		Marketplace: claudeOfficialMarketplace,
+		ID:          databricksPluginID,
+		Source:      "",
 	}
 }
 
@@ -142,7 +160,7 @@ var Registry = []*Agent{
 		SupportsProjectScope: true,
 		ProjectConfigDir:     ".claude",
 		Binary:               "claude",
-		Plugin:               databricksPlugin(),
+		Plugin:               claudePlugin(),
 	},
 	{
 		Name:                 NameCursor,

--- a/libs/aitools/agents/detect.go
+++ b/libs/aitools/agents/detect.go
@@ -29,8 +29,6 @@ const (
 	StateAvailable DisplayState = "available"
 	// StateInstalledCLIMissing: the config dir exists but the CLI binary is not on PATH.
 	StateInstalledCLIMissing DisplayState = "installed-cli-missing"
-	// StateManualOnly: the agent has a plugin but no headless install path (Cursor).
-	StateManualOnly DisplayState = "manual-only"
 	// StateFilesOnly: the agent has no plugin; skill files are its only delivery.
 	StateFilesOnly DisplayState = "files-only"
 	// StateNotFound: neither presence signal is present.
@@ -56,10 +54,6 @@ func (a *Agent) HasBinary(_ context.Context) bool {
 // runs the agent (that is ProbePlugin's job); it only checks the binary on
 // PATH and the config dir on disk, so it is cheap enough for every render.
 func (a *Agent) DisplayState(ctx context.Context) DisplayState {
-	if a.Plugin != nil && a.Plugin.ManualOnly {
-		return StateManualOnly
-	}
-
 	hasBinary := a.HasBinary(ctx)
 	hasConfig := a.Detected(ctx)
 
@@ -83,7 +77,7 @@ func (a *Agent) DisplayState(ctx context.Context) DisplayState {
 // IsPreselected reports whether the agent should be pre-checked in the picker. Only
 // agents that can complete an install automatically (a plugin agent with its
 // binary on PATH) and files-only agents whose config dir exists are pre-checked;
-// manual-only and binary-missing agents are shown but left unchecked.
+// binary-missing agents are shown but left unchecked.
 func (a *Agent) IsPreselected(ctx context.Context) bool {
 	switch a.DisplayState(ctx) {
 	case StateAvailable:
@@ -101,7 +95,7 @@ func (a *Agent) IsPreselected(ctx context.Context) bool {
 // for a selected agent, right before install. It returns ErrPluginUnsupported
 // when the agent has no plugin path or its CLI lacks the subcommand.
 func (a *Agent) ProbePlugin(ctx context.Context) error {
-	if a.Binary == "" || a.Plugin == nil || a.Plugin.ManualOnly {
+	if a.Binary == "" || a.Plugin == nil {
 		return ErrPluginUnsupported
 	}
 

--- a/libs/aitools/agents/detect_test.go
+++ b/libs/aitools/agents/detect_test.go
@@ -81,8 +81,6 @@ func TestDisplayState(t *testing.T) {
 		{"plugin agent, binary on path, config too", "claude", []string{"claude"}, &PluginSpec{}, true, StateAvailable},
 		{"plugin agent, no binary, config exists", "claude", nil, &PluginSpec{}, true, StateInstalledCLIMissing},
 		{"plugin agent, no binary, no config", "claude", nil, &PluginSpec{}, false, StateNotFound},
-		{"manual-only agent always manual", "cursor-agent", nil, &PluginSpec{ManualOnly: true}, false, StateManualOnly},
-		{"manual-only agent ignores presence", "cursor-agent", []string{"cursor-agent"}, &PluginSpec{ManualOnly: true}, true, StateManualOnly},
 		{"files-only agent, binary on path", "opencode", []string{"opencode"}, nil, false, StateFilesOnly},
 		{"files-only agent, config only", "opencode", nil, nil, true, StateFilesOnly},
 		{"files-only agent, neither", "opencode", nil, nil, false, StateNotFound},
@@ -113,7 +111,6 @@ func TestIsPreselected(t *testing.T) {
 		{"available is pre-checked", "claude", []string{"claude"}, &PluginSpec{}, false, true},
 		{"files-only with config is pre-checked", "opencode", nil, nil, true, true},
 		{"files-only without config is not", "opencode", []string{"opencode"}, nil, false, false},
-		{"manual-only is not pre-checked", "cursor-agent", []string{"cursor-agent"}, &PluginSpec{ManualOnly: true}, true, false},
 		{"installed-cli-missing is not pre-checked", "claude", nil, &PluginSpec{}, true, false},
 		{"not-found is not pre-checked", "claude", nil, &PluginSpec{}, false, false},
 	}
@@ -136,7 +133,6 @@ func TestProbePluginUnsupportedWithoutCapability(t *testing.T) {
 	}{
 		{"no binary", &Agent{Binary: "", Plugin: &PluginSpec{}}},
 		{"no plugin", &Agent{Binary: "antigravity"}},
-		{"manual only", &Agent{Binary: "cursor-agent", Plugin: &PluginSpec{ManualOnly: true}}},
 	}
 
 	for _, tc := range tests {

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -43,8 +43,9 @@ const (
 	ReasonCLINotOnPath = "cli-not-on-path"
 	// ReasonInstallFailed: the agent's plugin CLI ran but returned an error.
 	ReasonInstallFailed = "install-failed"
-	// ReasonManualOnly: the agent has a plugin but no headless install path (Cursor).
-	ReasonManualOnly = "manual-only"
+	// ReasonNoPlugin: the agent has no installable plugin. Callers filter these
+	// out; it is guarded here to avoid a nil dereference.
+	ReasonNoPlugin = "no-plugin"
 )
 
 func (e *BlockedError) Error() string {
@@ -180,8 +181,8 @@ func probePluginCLI(ctx context.Context, agent *agents.Agent) (string, error) {
 // plugin through the agent's own CLI, returning the record to persist in state.
 // It never falls back to skills: a blocked install returns a *BlockedError.
 func InstallPluginForAgent(ctx context.Context, agent *agents.Agent, nativeScope, ref string) (PluginRecord, error) {
-	if agent.Plugin == nil || agent.Plugin.ManualOnly {
-		return PluginRecord{}, &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
+	if agent.Plugin == nil {
+		return PluginRecord{}, &BlockedError{Agent: agent.Name, Reason: ReasonNoPlugin}
 	}
 
 	bin, err := probePluginCLI(ctx, agent)
@@ -229,8 +230,8 @@ func InstallPluginForAgent(ctx context.Context, agent *agents.Agent, nativeScope
 // plugin's own update handles content the release dropped, so there is no
 // per-skill prune for plugin agents.
 func UpdatePluginForAgent(ctx context.Context, agent *agents.Agent) error {
-	if agent.Plugin == nil || agent.Plugin.ManualOnly {
-		return &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
+	if agent.Plugin == nil {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonNoPlugin}
 	}
 	bin, err := resolveAgentBinary(agent)
 	if err != nil {
@@ -254,8 +255,8 @@ func UpdatePluginForAgent(ctx context.Context, agent *agents.Agent) error {
 // gone, so the record is cleared, and the leftover marketplace registration is
 // harmless and can be removed manually.
 func UninstallPluginForAgent(ctx context.Context, agent *agents.Agent, rec PluginRecord, keepMarketplace bool) error {
-	if agent.Plugin == nil || agent.Plugin.ManualOnly {
-		return &BlockedError{Agent: agent.Name, Reason: ReasonManualOnly}
+	if agent.Plugin == nil {
+		return &BlockedError{Agent: agent.Name, Reason: ReasonNoPlugin}
 	}
 	bin, err := resolveAgentBinary(agent)
 	if err != nil {

--- a/libs/aitools/installer/plugin.go
+++ b/libs/aitools/installer/plugin.go
@@ -194,9 +194,16 @@ func InstallPluginForAgent(ctx context.Context, agent *agents.Agent, nativeScope
 	// our add succeeded, so we never remove a marketplace another plugin shares.
 	// On any uncertainty marketplaceRegistered returns true, keeping us off the
 	// de-register path.
-	alreadyPresent := marketplaceRegistered(ctx, bin, agent.Plugin.Marketplace)
-	_, addErr := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceAddArgs(agent.Plugin)))
-	installedMarketplace := addErr == nil && !alreadyPresent
+	//
+	// An empty Source marks a built-in marketplace (e.g. Claude's
+	// claude-plugins-official): it is already registered, so we never add or
+	// de-register it.
+	installedMarketplace := false
+	if agent.Plugin.Source != "" {
+		alreadyPresent := marketplaceRegistered(ctx, bin, agent.Plugin.Marketplace)
+		_, addErr := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceAddArgs(agent.Plugin)))
+		installedMarketplace = addErr == nil && !alreadyPresent
+	}
 
 	if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, pluginInstallArgs(agent, nativeScope))); err != nil {
 		// Roll back a marketplace we just added so a failed install doesn't
@@ -257,7 +264,9 @@ func UninstallPluginForAgent(ctx context.Context, agent *agents.Agent, rec Plugi
 	if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, pluginUninstallArgs(agent))); err != nil {
 		return &BlockedError{Agent: agent.Name, Reason: ReasonInstallFailed, Detail: stderrOf(err)}
 	}
-	if rec.InstalledMarketplace && !keepMarketplace {
+	// Never de-register a built-in marketplace (empty Source, e.g. Claude's
+	// claude-plugins-official): it is shared infrastructure we did not add.
+	if rec.InstalledMarketplace && !keepMarketplace && agent.Plugin.Source != "" {
 		if _, err := runAgentCmd(ctx, pluginCmdTimeout, prepend(bin, marketplaceRemoveArgs(agent.Plugin))); err != nil {
 			log.Warnf(ctx, "Removed the %s plugin but could not de-register its marketplace (remove it manually if needed): %v", agent.DisplayName, stderrOf(err))
 		}

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -41,13 +41,8 @@ func pluginAgent(name, display, binary string) *agents.Agent {
 func claudeAgent() *agents.Agent { return pluginAgent(agents.NameClaudeCode, "Claude Code", "claude") }
 func codexAgent() *agents.Agent  { return pluginAgent(agents.NameCodex, "Codex CLI", "codex") }
 
-func cursorAgent() *agents.Agent {
-	return &agents.Agent{
-		Name:        agents.NameCursor,
-		DisplayName: "Cursor",
-		Binary:      "cursor-agent",
-		Plugin:      &agents.PluginSpec{ManualOnly: true, ManualInstructions: "run /add-plugin databricks in Cursor"},
-	}
+func noPluginAgent() *agents.Agent {
+	return &agents.Agent{Name: agents.NameOpenCode, DisplayName: "OpenCode", Binary: "opencode"}
 }
 
 func TestInstallPluginForAgentClaudeSuccess(t *testing.T) {
@@ -110,11 +105,11 @@ func TestInstallPluginForAgentCodexUsesAddNoScope(t *testing.T) {
 	}
 }
 
-func TestInstallPluginForAgentManualOnly(t *testing.T) {
-	_, err := InstallPluginForAgent(t.Context(), cursorAgent(), "user", "v0.2.6")
+func TestInstallPluginForAgentNoPlugin(t *testing.T) {
+	_, err := InstallPluginForAgent(t.Context(), noPluginAgent(), "user", "v0.2.6")
 	var be *BlockedError
 	require.ErrorAs(t, err, &be)
-	assert.Equal(t, ReasonManualOnly, be.Reason)
+	assert.Equal(t, ReasonNoPlugin, be.Reason)
 }
 
 func TestInstallPluginForAgentCLINotOnPath(t *testing.T) {

--- a/libs/aitools/installer/plugin_test.go
+++ b/libs/aitools/installer/plugin_test.go
@@ -69,6 +69,32 @@ func TestInstallPluginForAgentClaudeSuccess(t *testing.T) {
 	assert.Contains(t, cmds, "claude plugin install databricks@databricks-agent-skills --scope user")
 }
 
+func TestInstallPluginForAgentBuiltinMarketplace(t *testing.T) {
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+
+	// An agent whose plugin lives in a built-in marketplace (empty Source) like
+	// Claude's claude-plugins-official: install from it, never register it.
+	agent := &agents.Agent{
+		Name:        agents.NameClaudeCode,
+		DisplayName: "Claude Code",
+		Binary:      "claude",
+		Plugin:      &agents.PluginSpec{Marketplace: "claude-plugins-official", ID: "databricks", Source: ""},
+	}
+
+	rec, err := InstallPluginForAgent(ctx, agent, "user", "main")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-plugins-official", rec.Marketplace)
+	assert.False(t, rec.InstalledMarketplace, "a built-in marketplace is never registered by us")
+
+	cmds := stub.Commands()
+	for _, c := range cmds {
+		assert.NotContains(t, c, "marketplace add", "must not register a built-in marketplace")
+	}
+	assert.Contains(t, cmds, "claude plugin install databricks@claude-plugins-official --scope user")
+}
+
 func TestInstallPluginForAgentCodexUsesAddNoScope(t *testing.T) {
 	stubAgentLookPath(t, true)
 	ctx, stub := process.WithStub(t.Context())
@@ -204,21 +230,48 @@ func TestUninstallSkillsOptsTearsDownPlugin(t *testing.T) {
 		SchemaVersion: schemaVersionV2,
 		Release:       "v0.2.6",
 		Plugins: map[string]PluginRecord{
-			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", Scope: "user", InstalledMarketplace: true},
+			agents.NameCopilot: {Marketplace: "databricks-agent-skills", Plugin: "databricks", Scope: "user", InstalledMarketplace: true},
 		},
 	}))
 
 	require.NoError(t, UninstallSkillsOpts(ctx, UninstallOptions{Scope: ScopeGlobal}))
 
 	cmds := stub.Commands()
-	assert.Contains(t, cmds, "claude plugin uninstall databricks@databricks-agent-skills")
-	assert.Contains(t, cmds, "claude plugin marketplace remove databricks-agent-skills")
+	assert.Contains(t, cmds, "copilot plugin uninstall databricks@databricks-agent-skills")
+	assert.Contains(t, cmds, "copilot plugin marketplace remove databricks-agent-skills")
 	assert.Contains(t, stderr.String(), "Uninstalled the plugin from 1 agent.")
 
 	// State file removed since nothing remains.
 	state, err := LoadState(dir)
 	require.NoError(t, err)
 	assert.Nil(t, state)
+}
+
+func TestUninstallNeverDeregistersBuiltinMarketplace(t *testing.T) {
+	setupTestHome(t)
+	stubAgentLookPath(t, true)
+	ctx, stub := process.WithStub(t.Context())
+	stub.WithCallback(func(*exec.Cmd) error { return nil })
+	ctx = cmdio.MockDiscard(ctx)
+
+	dir, err := GlobalSkillsDir(ctx)
+	require.NoError(t, err)
+	// Claude installs from its built-in claude-plugins-official marketplace; even a
+	// stale InstalledMarketplace=true must never trigger a de-register.
+	require.NoError(t, SaveState(dir, &InstallState{
+		SchemaVersion: schemaVersionV2,
+		Plugins: map[string]PluginRecord{
+			agents.NameClaudeCode: {Marketplace: "claude-plugins-official", Plugin: "databricks", InstalledMarketplace: true},
+		},
+	}))
+
+	require.NoError(t, UninstallSkillsOpts(ctx, UninstallOptions{Scope: ScopeGlobal}))
+
+	cmds := stub.Commands()
+	assert.Contains(t, cmds, "claude plugin uninstall databricks@claude-plugins-official")
+	for _, c := range cmds {
+		assert.NotContains(t, c, "marketplace remove")
+	}
 }
 
 func TestUninstallKeepMarketplace(t *testing.T) {
@@ -233,7 +286,7 @@ func TestUninstallKeepMarketplace(t *testing.T) {
 	require.NoError(t, SaveState(dir, &InstallState{
 		SchemaVersion: schemaVersionV2,
 		Plugins: map[string]PluginRecord{
-			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true},
+			agents.NameCopilot: {Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true},
 		},
 	}))
 
@@ -281,7 +334,7 @@ func TestUninstallClearsRecordWhenMarketplaceRemoveFails(t *testing.T) {
 	require.NoError(t, SaveState(dir, &InstallState{
 		SchemaVersion: schemaVersionV2,
 		Plugins: map[string]PluginRecord{
-			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true},
+			agents.NameCopilot: {Marketplace: "databricks-agent-skills", Plugin: "databricks", InstalledMarketplace: true},
 		},
 	}))
 
@@ -306,20 +359,20 @@ func TestUpdateInstalledPlugins(t *testing.T) {
 		SchemaVersion: schemaVersionV2,
 		Release:       "v0.2.6",
 		Plugins: map[string]PluginRecord{
-			agents.NameClaudeCode: {Marketplace: "databricks-agent-skills", Plugin: "databricks", Scope: "user", Version: "0.2.6"},
+			agents.NameCopilot: {Marketplace: "databricks-agent-skills", Plugin: "databricks", Scope: "user", Version: "0.2.6"},
 		},
 	}))
 
 	updated, err := UpdateInstalledPlugins(ctx, ScopeGlobal, "v0.2.7")
 	require.NoError(t, err)
 	require.Len(t, updated, 1)
-	assert.Equal(t, "Claude Code", updated[0].Agent)
+	assert.Equal(t, "GitHub Copilot", updated[0].Agent)
 	assert.Equal(t, "0.2.7", updated[0].Version)
-	assert.Contains(t, stub.Commands(), "claude plugin update databricks@databricks-agent-skills")
+	assert.Contains(t, stub.Commands(), "copilot plugin update databricks@databricks-agent-skills")
 
 	state, err := LoadState(dir)
 	require.NoError(t, err)
-	assert.Equal(t, "0.2.7", state.Plugins[agents.NameClaudeCode].Version)
+	assert.Equal(t, "0.2.7", state.Plugins[agents.NameCopilot].Version)
 }
 
 func TestUninstallPluginKeepMarketplaceFlag(t *testing.T) {


### PR DESCRIPTION
<!-- aitools-stack -->
### Stack

Part of the `aitools` plugin-first redesign. Open PRs, merge bottom to top:

- #5740 Uninstall teardown + legacy skills cleanup
- #5741 list + version plugin state
- #5745 Bug bash (wording, latest-by-default skills, project-scope plan, version reporting)
- **#5746 Bug bash round 2 (uninstall confirm, picker, Cursor, official marketplace, version scope)  ← this PR**

Merged: #5734, #5736, #5737, #5738, #5739.
<!-- /aitools-stack -->

## Why

A second round of testing the plugin-first `databricks aitools` CLI. Findings are
tracked in `documents/proposals/aitools-bugbash-findings.md`.

## Changes

- **uninstall confirms in interactive mode.** It removed skills and de-registered
  plugins immediately; now (on a TTY) it summarizes what will be removed and asks
  "Proceed?". Non-interactive runs are unaffected.
- **version labels the scope.** Skills and plugins are now always labeled
  global/project (e.g. `Plugin (Claude Code, global): latest`).
- **Claude installs from the official marketplace.** The databricks plugin is in
  Claude's built-in `claude-plugins-official` marketplace, so Claude installs
  `databricks@claude-plugins-official`. A built-in marketplace (empty
  PluginSpec.Source) is never added or de-registered. Codex/Copilot keep our own
  marketplace.
- **Picker only offers actionable agents.** Every detected agent still shows in the
  detection list with its state/reason, but only agents that will do something
  (plugin or skills) are selectable; agents skipped in the scope are no longer
  checkboxes.
- **Cursor is a plain skills agent.** Cursor was a confusing "manual, run
  /add-plugin" option that did nothing. Since the Cursor plugin can't be installed
  or interacted with headlessly, all references to it are removed: Cursor now
  installs raw skills like OpenCode/Antigravity, labeled simply "skills". This
  removed the whole manual-only concept (PluginSpec.ManualOnly/ManualInstructions,
  StateManualOnly, ReasonManualOnly, the manual_add_plugin list status, and the
  deliveryManualCursor path).
- **Help links the source repo.** `databricks aitools` help points at
  https://github.com/databricks/databricks-agent-skills so users know where skills
  and plugins come from.

## Test plan

- [x] Unit: uninstall confirm; version scope labels; built-in marketplace install
  (no `marketplace add`) and uninstall (no de-register); picker offers only
  actionable agents; Cursor plan = skills; no-plugin install guard.
- [x] `go test ./libs/aitools/... ./cmd/aitools/...` and acceptance `experimental/aitools` pass.
- [x] `./task fmt-q`, `./task lint-q` (0 issues), `./task checks` (no dead code) clean.

This pull request and its description were written by Isaac.

