### PR TITLE
libs/upload/cloudstorage: add cloud-storage transfer client

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -34,6 +34,7 @@
 /cmd/sync/                  team:platform
 /libs/filer/                team:platform
 /libs/sync/                 team:platform
+/libs/upload/               team:platform
 
 # Core CLI infrastructure
 /cmd/root/                  team:platform

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	gopkg.in/ini.v1 v1.67.2 // Apache-2.0
 )
 
+require github.com/databricks/sdk-go/core v0.0.0 // Apache-2.0
+
 require (
 	cloud.google.com/go/auth v0.18.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMF
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/databricks/databricks-sdk-go v0.147.0 h1:B6Qk0LVvazg/qdvqoINzipnl0QhXKwgdw35JH905LCg=
 github.com/databricks/databricks-sdk-go v0.147.0/go.mod h1:C5LNgGe6hGuRrTwoxFmuup3XtQQEaqtq0e+K8IFDIS4=
+github.com/databricks/sdk-go/core v0.0.0 h1:1Zg54LjihKnFTfcVwtEsbv/nm446QVOtenS8dSPjQ9U=
+github.com/databricks/sdk-go/core v0.0.0/go.mod h1:7Ckau34bOsaZhHJE6r7ORNa+/kO33jIs6DfrJL6UbsM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/build/notice_test.go
+++ b/internal/build/notice_test.go
@@ -22,6 +22,7 @@ var moduleToGitHub = map[string]string{
 // Modules excluded from NOTICE requirements (Databricks-owned).
 var noticeExclude = map[string]bool{
 	"github.com/databricks/databricks-sdk-go": true,
+	"github.com/databricks/sdk-go/core":       true,
 }
 
 // Additional entries required in the NOTICE file that are not direct go.mod

--- a/libs/upload/cloudstorage/body.go
+++ b/libs/upload/cloudstorage/body.go
@@ -1,0 +1,55 @@
+package cloudstorage
+
+import (
+	"bytes"
+	"io"
+)
+
+// Body supplies a request's bytes and can re-supply them for each retry attempt,
+// so a request is retried without the caller buffering it again.
+type Body interface {
+	// Reader returns a reader over the body positioned at the start. It is called
+	// once per attempt.
+	Reader() (io.Reader, error)
+	// Size reports the body length in bytes, for Content-Length and the
+	// short-read guard.
+	Size() int64
+}
+
+// BytesBody returns a Body backed by an in-memory buffer.
+func BytesBody(data []byte) Body {
+	return bytesBody{data}
+}
+
+type bytesBody struct {
+	data []byte
+}
+
+func (b bytesBody) Reader() (io.Reader, error) {
+	return bytes.NewReader(b.data), nil
+}
+
+func (b bytesBody) Size() int64 {
+	return int64(len(b.data))
+}
+
+// SectionBody returns a Body that reads length bytes starting at offset from ra
+// on each attempt. ra may be shared across concurrent bodies: positioned reads
+// via io.ReaderAt are safe to run in parallel.
+func SectionBody(ra io.ReaderAt, offset, length int64) Body {
+	return sectionBody{ra: ra, offset: offset, length: length}
+}
+
+type sectionBody struct {
+	ra     io.ReaderAt
+	offset int64
+	length int64
+}
+
+func (s sectionBody) Reader() (io.Reader, error) {
+	return io.NewSectionReader(s.ra, s.offset, s.length), nil
+}
+
+func (s sectionBody) Size() int64 {
+	return s.length
+}

--- a/libs/upload/cloudstorage/body_test.go
+++ b/libs/upload/cloudstorage/body_test.go
@@ -1,0 +1,57 @@
+package cloudstorage
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestBytesBody(t *testing.T) {
+	data := []byte("hello world")
+	b := BytesBody(data)
+
+	if b.Size() != int64(len(data)) {
+		t.Errorf("Size = %d, want %d", b.Size(), len(data))
+	}
+
+	// Reader is called once per attempt and must re-supply the full body from the
+	// start each time, so a retry needs no rewind.
+	for i := range 2 {
+		r, err := b.Reader()
+		if err != nil {
+			t.Fatalf("attempt %d: Reader returned error: %v", i, err)
+		}
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("attempt %d: ReadAll returned error: %v", i, err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Errorf("attempt %d: read %q, want %q", i, got, data)
+		}
+	}
+}
+
+func TestSectionBody(t *testing.T) {
+	src := strings.NewReader("0123456789")
+	b := SectionBody(src, 3, 4)
+
+	if b.Size() != 4 {
+		t.Errorf("Size = %d, want 4", b.Size())
+	}
+
+	// Each Reader reads only the [offset, offset+length) section, from the start.
+	for i := range 2 {
+		r, err := b.Reader()
+		if err != nil {
+			t.Fatalf("attempt %d: Reader returned error: %v", i, err)
+		}
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("attempt %d: ReadAll returned error: %v", i, err)
+		}
+		if string(got) != "3456" {
+			t.Errorf("attempt %d: read %q, want %q", i, got, "3456")
+		}
+	}
+}

--- a/libs/upload/cloudstorage/cloudstorage.go
+++ b/libs/upload/cloudstorage/cloudstorage.go
@@ -1,0 +1,280 @@
+// Package cloudstorage issues unauthenticated, idempotent HTTP requests to cloud
+// object storage (S3, Azure Blob, GCS) using short-lived presigned URLs. The
+// URLs are self-authenticating, so the client deliberately carries no Databricks
+// credentials. It owns the inactivity-stall and exact-length guards and a capped
+// retry-with-backoff policy; callers supply the bytes via a [Body] and interpret
+// the returned [Response].
+package cloudstorage
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/sdk-go/core/apierr"
+	"github.com/databricks/sdk-go/core/ops"
+)
+
+// defaultIdleTimeout cuts a transfer that stops making progress: if the request
+// body is not read for this long, no bytes are moving and the attempt is cancelled.
+var defaultIdleTimeout = 60 * time.Second
+
+var (
+	errStalled   = errors.New("transfer stalled (no progress within the idle timeout)")
+	errShortRead = errors.New("body produced fewer bytes than expected (was the source modified mid-transfer?)")
+)
+
+// Response is the captured result of a presigned request. Unlike a Databricks
+// API call, cloud requests expose the raw status and headers (ETag, Range, 308)
+// and are never mapped to a Databricks API error.
+type Response struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// Client issues requests to cloud object storage over presigned URLs. It holds
+// only an *http.Client: no Databricks credentials, no config.
+type Client struct {
+	http        *http.Client
+	retrier     func() ops.Retrier
+	idleTimeout time.Duration
+}
+
+// New returns a Client that sends over the given HTTP client. The caller owns
+// the client's transport, timeouts, and connection-pool sizing; it must not
+// attach Databricks credentials, and should not set a whole-request
+// http.Client.Timeout (it would abort a legitimately long transfer; bound the
+// operation with the request context instead).
+func New(httpClient *http.Client) *Client {
+	return &Client{
+		http:        httpClient,
+		retrier:     newRetrier,
+		idleTimeout: defaultIdleTimeout,
+	}
+}
+
+// Attempt performs a single request and returns the raw response. body may be
+// nil for a bodyless request (a status query or an abort).
+func (c *Client) Attempt(ctx context.Context, method, url string, headers map[string]string, body Body) (*Response, error) {
+	var rdr io.Reader
+	var bodyLen int64
+	if body != nil {
+		var err error
+		if rdr, err = body.Reader(); err != nil {
+			return nil, err
+		}
+		bodyLen = body.Size()
+	}
+
+	// Cancel the attempt on two conditions, each with a distinct cause: the
+	// transfer stalls (a dead connection that accepts no more bytes but never
+	// errors), or the source comes up short (truncated mid-transfer). Both are
+	// told apart from the caller cancelling ctx; the stall is retried, the short
+	// read is not.
+	attemptCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	req, err := http.NewRequestWithContext(attemptCtx, method, url, rdr)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if bodyLen > 0 && req.Body != nil {
+		// A non-bytes source (a file section) is not length-detected by NewRequest,
+		// so set Content-Length explicitly. Enforce the exact length and guard
+		// against a stall; the body is read as bytes move to the socket, so a gap
+		// longer than IdleTimeout means the transfer has stalled. The response phase
+		// is bounded by the transport's ResponseHeaderTimeout.
+		req.ContentLength = bodyLen
+		req.Body = stallGuardedBody(exactBody(req.Body, bodyLen, cancel), c.idleTimeout, cancel)
+	}
+
+	// Trace connection reuse so a slow request can be attributed to connection
+	// behavior (e.g. HTTP/2 multiplexing onto one connection vs a fresh one).
+	var connReused, connWasIdle bool
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			connReused, connWasIdle = info.Reused, info.WasIdle
+		},
+	}))
+
+	start := time.Now()
+	resp, err := c.http.Do(req)
+	if err != nil {
+		// Surface our own cancellations as distinct errors; a caller ctx
+		// cancellation stays as-is. errShortRead carries its detail message.
+		if ctx.Err() == nil {
+			switch cause := context.Cause(attemptCtx); {
+			case errors.Is(cause, errShortRead):
+				err = cause
+			case errors.Is(cause, errStalled):
+				err = errStalled
+			}
+		}
+		log.Debugf(ctx, "request failed: method=%s host=%s req_bytes=%d duration_ms=%d error=%v",
+			method, req.URL.Host, bodyLen, time.Since(start).Milliseconds(), err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	duration := time.Since(start)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf(ctx, "response: method=%s host=%s status=%d proto=%s conn_reused=%t conn_was_idle=%t req_bytes=%d duration_ms=%d",
+		method, req.URL.Host, resp.StatusCode, resp.Proto, connReused, connWasIdle, bodyLen, duration.Milliseconds())
+	return &Response{StatusCode: resp.StatusCode, Header: resp.Header, Body: respBody}, nil
+}
+
+// Send performs Attempt with capped retries: transient network errors, the
+// retryable statuses in retryStatusCodes (honoring Retry-After), and stalled
+// attempts are retried with exponential backoff. A fresh request and body reader
+// are built per attempt, so no explicit rewind is needed. Exhausting retries on
+// a retryable status returns that status as an error.
+func (c *Client) Send(ctx context.Context, method, url string, headers map[string]string, body Body) (*Response, error) {
+	var result *Response
+	op := func(ctx context.Context) error {
+		resp, err := c.Attempt(ctx, method, url, headers, body)
+		if err != nil {
+			return err // network error or inactivity cut; the retrier decides
+		}
+		// Surface a failure status as an APIError and let the retrier decide: it
+		// retries the retryable statuses (honoring Retry-After) and transient
+		// transport failures, and returns everything else. A non-retryable status
+		// (403 URL expired, 412 already exists, ...) therefore reaches the caller as
+		// this error, which carries the status, headers, and body for inspection.
+		// FromHTTPError returns nil for 2xx and 3xx, so both pass through as a
+		// successful response (the http.Client already follows real redirects).
+		if apiErr := apierr.FromHTTPError(resp.StatusCode, resp.Header, resp.Body); apiErr != nil {
+			return apiErr
+		}
+		result = resp
+		return nil
+	}
+	if err := ops.Execute(ctx, op, ops.WithRetrier(c.retrier)); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// IsURLExpired reports whether err (as returned by Send) is one of the known
+// cloud-provider "presigned URL expired" errors: a 403 with the AWS or Azure
+// signature-expiry body.
+func IsURLExpired(err error) bool {
+	aerr, ok := errors.AsType[*apierr.APIError](err)
+	if !ok || aerr.HTTPStatusCode() != http.StatusForbidden {
+		return false
+	}
+	var e struct {
+		XMLName    xml.Name `xml:"Error"`
+		Code       string   `xml:"Code"`
+		Message    string   `xml:"Message"`
+		AuthDetail string   `xml:"AuthenticationErrorDetail"`
+	}
+	if uerr := xml.Unmarshal(aerr.HTTPBody(), &e); uerr != nil {
+		return false
+	}
+	switch e.Code {
+	case "AuthenticationFailed": // Azure
+		return strings.Contains(e.AuthDetail, "Signature not valid in the specified time frame")
+	case "AccessDenied": // AWS
+		return e.Message == "Request has expired"
+	default:
+		return false
+	}
+}
+
+// stallReader wraps a request body so a transfer that stops making progress is
+// cancelled. The transport reads the body as it writes bytes to the socket, so a
+// gap longer than idle between reads means no bytes are moving -- a stalled or
+// dead connection. A transfer making any progress keeps resetting the timer and
+// so cannot be cut, unlike a whole-attempt or throughput-floor deadline.
+type stallReader struct {
+	r      io.Reader
+	idle   time.Duration
+	cancel context.CancelCauseFunc
+	timer  *time.Timer
+}
+
+func newStallReader(r io.Reader, idle time.Duration, cancel context.CancelCauseFunc) *stallReader {
+	return &stallReader{r: r, idle: idle, cancel: cancel}
+}
+
+func (s *stallReader) Read(p []byte) (int, error) {
+	// Arm on the first read (after the connection is established, so dial time is
+	// not charged against the idle budget) and reset on each later read.
+	if s.timer == nil {
+		s.timer = time.AfterFunc(s.idle, func() { s.cancel(errStalled) })
+	} else {
+		s.timer.Reset(s.idle)
+	}
+	n, err := s.r.Read(p)
+	if err != nil {
+		// EOF (transfer done) or a read error: stop arming so the response phase is
+		// not subject to the stall timer.
+		s.timer.Stop()
+	}
+	return n, err
+}
+
+// stallGuardedBody wraps a request body's reads with stall detection while
+// preserving its Close.
+func stallGuardedBody(body io.ReadCloser, idle time.Duration, cancel context.CancelCauseFunc) io.ReadCloser {
+	return &stallGuardedReadCloser{Closer: body, sr: newStallReader(body, idle, cancel)}
+}
+
+type stallGuardedReadCloser struct {
+	io.Closer
+	sr *stallReader
+}
+
+func (b *stallGuardedReadCloser) Read(p []byte) (int, error) {
+	return b.sr.Read(p)
+}
+
+// exactReader enforces that a body delivers exactly the declared length. If the
+// source ends early -- e.g. the file was truncated during the transfer -- it
+// cancels the attempt with errShortRead rather than letting a short body be sent
+// (silent corruption) or surfacing net/http's opaque ContentLength-mismatch
+// error (which would then be pointlessly retried).
+type exactReader struct {
+	r      io.Reader
+	left   int64
+	cancel context.CancelCauseFunc
+}
+
+func (e *exactReader) Read(p []byte) (int, error) {
+	n, err := e.r.Read(p)
+	e.left -= int64(n)
+	if err == io.EOF && e.left > 0 {
+		cause := fmt.Errorf("%w: stream ended %d bytes short of the expected length", errShortRead, e.left)
+		e.cancel(cause)
+		return n, cause
+	}
+	return n, err
+}
+
+// exactBody wraps a request body's reads with the exact-length check while
+// preserving its Close.
+func exactBody(body io.ReadCloser, n int64, cancel context.CancelCauseFunc) io.ReadCloser {
+	return &exactReadCloser{Closer: body, er: &exactReader{r: body, left: n, cancel: cancel}}
+}
+
+type exactReadCloser struct {
+	io.Closer
+	er *exactReader
+}
+
+func (b *exactReadCloser) Read(p []byte) (int, error) {
+	return b.er.Read(p)
+}

--- a/libs/upload/cloudstorage/cloudstorage_test.go
+++ b/libs/upload/cloudstorage/cloudstorage_test.go
@@ -1,0 +1,140 @@
+package cloudstorage
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/databricks/sdk-go/core/apierr"
+	"github.com/databricks/sdk-go/core/ops"
+)
+
+// fastClient returns a Client whose retrier backs off in milliseconds, so retry
+// tests do not sleep.
+func fastClient(srv *httptest.Server) *Client {
+	fast := ops.BackoffPolicy{Initial: time.Millisecond, Maximum: time.Millisecond, Factor: 1}
+	c := New(srv.Client())
+	c.retrier = func() ops.Retrier {
+		return &retrier{backoff: fast, maxRetries: 3}
+	}
+	return c
+}
+
+func TestSendRetriesRetryableStatus(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := fastClient(srv).Send(t.Context(), http.MethodPut, srv.URL, nil, BytesBody([]byte("x")))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("calls = %d, want 2 (one retry)", calls.Load())
+	}
+}
+
+func TestSendExhaustsRetryableStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := fastClient(srv).Send(t.Context(), http.MethodPut, srv.URL, nil, BytesBody([]byte("x")))
+	aerr, ok := errors.AsType[*apierr.APIError](err)
+	if !ok || aerr.HTTPStatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("err = %v, want a 503 APIError after exhausting retries", err)
+	}
+}
+
+func TestSendReturnsNonRetryableStatusAsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	resp, err := New(srv.Client()).Send(t.Context(), http.MethodPut, srv.URL, nil, BytesBody([]byte("x")))
+	if resp != nil {
+		t.Errorf("expected nil response on error, got %v", resp)
+	}
+	aerr, ok := errors.AsType[*apierr.APIError](err)
+	if !ok || aerr.HTTPStatusCode() != http.StatusForbidden {
+		t.Fatalf("err = %v, want a 403 APIError", err)
+	}
+	if string(aerr.HTTPBody()) != "nope" {
+		t.Errorf("HTTPBody = %q, want %q", aerr.HTTPBody(), "nope")
+	}
+}
+
+func TestAttemptReturnsRawResponse(t *testing.T) {
+	// Attempt never maps a status to an error: a 308 (resumable continue) and its
+	// Range header come back as a Response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Range", "bytes=0-41")
+		w.WriteHeader(http.StatusPermanentRedirect)
+	}))
+	defer srv.Close()
+
+	resp, err := New(srv.Client()).Attempt(t.Context(), http.MethodPut, srv.URL, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusPermanentRedirect {
+		t.Errorf("status = %d, want 308", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Range"); got != "bytes=0-41" {
+		t.Errorf("Range = %q, want bytes=0-41", got)
+	}
+}
+
+func TestIsURLExpired(t *testing.T) {
+	azure := `<?xml version="1.0"?><Error><Code>AuthenticationFailed</Code><AuthenticationErrorDetail>Signature not valid in the specified time frame</AuthenticationErrorDetail></Error>`
+	aws := `<?xml version="1.0"?><Error><Code>AccessDenied</Code><Message>Request has expired</Message></Error>`
+	other := `<?xml version="1.0"?><Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>`
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"azure expired", apierr.FromHTTPError(http.StatusForbidden, nil, []byte(azure)), true},
+		{"aws expired", apierr.FromHTTPError(http.StatusForbidden, nil, []byte(aws)), true},
+		{"other 403", apierr.FromHTTPError(http.StatusForbidden, nil, []byte(other)), false},
+		{"404", apierr.FromHTTPError(http.StatusNotFound, nil, []byte(azure)), false},
+		{"nil", nil, false},
+		{"non-apierr", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		if got := IsURLExpired(tc.err); got != tc.want {
+			t.Errorf("%s: IsURLExpired = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestExactReaderShortRead(t *testing.T) {
+	var caught error
+	er := &exactReader{r: bytes.NewReader(make([]byte, 10)), left: 100, cancel: func(c error) { caught = c }}
+
+	_, err := io.ReadAll(er)
+	if !errors.Is(err, errShortRead) {
+		t.Fatalf("read error = %v, want errShortRead", err)
+	}
+	if !errors.Is(caught, errShortRead) {
+		t.Errorf("attempt cancelled with %v, want errShortRead", caught)
+	}
+}

--- a/libs/upload/cloudstorage/retries.go
+++ b/libs/upload/cloudstorage/retries.go
@@ -1,0 +1,76 @@
+package cloudstorage
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/databricks/sdk-go/core/apierr"
+	"github.com/databricks/sdk-go/core/apiretry"
+	"github.com/databricks/sdk-go/core/ops"
+)
+
+// maxRetries caps how many times a single request is retried before giving up.
+var maxRetries = 4
+
+// retryStatusCodes are the HTTP statuses retried for an idempotent request.
+var retryStatusCodes = []int{
+	http.StatusRequestTimeout,     // 408
+	http.StatusTooManyRequests,    // 429
+	http.StatusBadGateway,         // 502
+	http.StatusServiceUnavailable, // 503
+	http.StatusGatewayTimeout,     // 504
+}
+
+// IsRetryableStatus reports whether an HTTP status code should be retried. It is
+// exported for callers (such as a resumable upload) that run their own
+// resume-aware retry loop over Attempt rather than using Send.
+func IsRetryableStatus(code int) bool {
+	return slices.Contains(retryStatusCodes, code)
+}
+
+func newRetrier() ops.Retrier {
+	return &retrier{maxRetries: maxRetries}
+}
+
+type retrier struct {
+	backoff    ops.BackoffPolicy
+	maxRetries int
+	attempts   int
+}
+
+func (r *retrier) IsRetriable(err error) (time.Duration, bool) {
+	r.attempts++
+	if r.attempts > r.maxRetries {
+		return 0, false
+	}
+	if !IsRetriable(err) {
+		return 0, false
+	}
+	// Honor a Retry-After hint (carried on a throttling response's APIError)
+	// when it exceeds the next backoff delay.
+	return max(r.backoff.Delay(), apiretry.RetryDurationHint(err)), true
+}
+
+// IsRetryable reports whether an error from Attempt is worth retrying: a stalled
+// attempt is, a short read (deterministic) is not, a retryable HTTP status (as
+// an APIError) is, and any other failure is retried only if it is a transient
+// network error (which excludes context cancellation and deadline). It is
+// exported for callers (such as a resumable upload) that run their own
+// resume-aware retry loop over Attempt.
+func IsRetriable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errShortRead) {
+		return false
+	}
+	if errors.Is(err, errStalled) {
+		return true
+	}
+	if apiErr, ok := errors.AsType[*apierr.APIError](err); ok {
+		return IsRetryableStatus(apiErr.HTTPStatusCode())
+	}
+	return apiretry.IsTransientNetworkError(err)
+}

--- a/libs/upload/cloudstorage/retries_test.go
+++ b/libs/upload/cloudstorage/retries_test.go
@@ -1,0 +1,43 @@
+package cloudstorage
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"syscall"
+	"testing"
+
+	"github.com/databricks/sdk-go/core/apierr"
+)
+
+func TestIsRetriable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"stall", errStalled, true},
+		{"short read", errShortRead, false},
+		{"canceled", context.Canceled, false},
+		{"deadline", context.DeadlineExceeded, false},
+		{"transient network", syscall.ECONNRESET, true},
+		{"retryable status", apierr.FromHTTPError(http.StatusServiceUnavailable, nil, nil), true},
+		{"non-retryable status", apierr.FromHTTPError(http.StatusForbidden, nil, nil), false},
+		{"generic", errors.New("connection reset"), false},
+	}
+	for _, tc := range cases {
+		if got := IsRetriable(tc.err); got != tc.want {
+			t.Errorf("%s: IsRetriable = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	if !IsRetryableStatus(http.StatusServiceUnavailable) {
+		t.Error("503 should be retryable")
+	}
+	if IsRetryableStatus(http.StatusNotFound) {
+		t.Error("404 should not be retryable")
+	}
+}


### PR DESCRIPTION
## Context

`databricks fs cp` and bundle library uploads to Unity Catalog Volumes go through a single `PUT /api/2.0/fs/files`, which caps a file at the single-request size limit and pushes it over one connection. This stack adds chunked upload (multipart on AWS/Azure, resumable on GCP) so large files upload reliably and in parallel. The whole feature is gated behind the `DATABRICKS_EXPERIMENTAL_MULTIPART_UPLOAD` environment variable and is off by default, so merging the stack changes no behavior until the flag is set.

## Stack

1. #5753 cloud-storage data-plane client (this PR)
2. #5754 Files API control-plane client
3. #5755 chunked upload engine
4. #5756 route large Volumes writes through the engine
5. #5757 `fs cp` shared transfer budget
6. #5758 `fs cp` progress bar

## This PR

Adds `libs/upload/cloudstorage`, the data-plane HTTP client that transfers file parts and chunks directly to cloud object storage (S3, Azure Blob, GCS) over short-lived presigned URLs. The URLs are self-authenticating, so the client carries no Databricks credentials. It cancels a transfer that stalls (no progress within an idle window) or comes up short (the source shrank mid-transfer), and retries transient failures with capped backoff. No code calls this package yet; the upload engine in a later PR builds on it. This PR also adds the `github.com/databricks/sdk-go/core` dependency the client is built on.

## Testing

Unit tests cover the stall and short-read guards, retry classification, presigned-URL-expiry detection, and request-body framing. The full stack is also exercised with a live `fs cp` of a multi-GB file to a Volume.

This pull request and its description were written by Isaac.