### PR TITLE
libs/upload/files: add Files API control-plane client

### DIFF
--- a/libs/upload/files/files.go
+++ b/libs/upload/files/files.go
@@ -1,0 +1,324 @@
+// Package files is the authenticated Databricks Files API client used by the
+// large-file uploader. It owns everything that talks to /api/2.0/fs.
+//
+// It is implemented as a wrapper on top of the SDK Files client to add support
+// for methods that have not been added to the SDK yet.
+//
+// TODO: This client should ultimately be entirely replaced by the SDK Files
+// client once it has reached feature parity.
+package files
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	sdkapierr "github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/httpclient"
+	sdkfiles "github.com/databricks/databricks-sdk-go/service/files"
+	"github.com/databricks/sdk-go/core/apierr"
+	"github.com/databricks/sdk-go/core/apierr/codes"
+	"github.com/databricks/sdk-go/core/apiretry"
+	"github.com/databricks/sdk-go/core/ops"
+
+	"github.com/databricks/databricks-sdk-go/config/credentials"
+)
+
+// controlPlaneRetryStatusCodes are the HTTP statuses retried for an
+// authenticated control-plane call.
+var controlPlaneRetryStatusCodes = []int{
+	http.StatusRequestTimeout,     // 408
+	http.StatusTooManyRequests,    // 429
+	http.StatusBadGateway,         // 502
+	http.StatusServiceUnavailable, // 503
+	http.StatusGatewayTimeout,     // 504
+}
+
+// controlPlaneBackoff is the exponential-backoff-with-jitter policy for
+// control-plane retries.
+var controlPlaneBackoff = ops.BackoffPolicy{}
+
+// controlPlaneRetryTimeout bounds the total time spent retrying a single
+// control-plane call. Without it, a persistently failing endpoint would be
+// retried until the caller's context expires (and forever if it has no
+// deadline).
+var controlPlaneRetryTimeout = 5 * time.Minute
+
+// FilesClient is the subset of the SDK Files API used for the standard
+// single-shot upload.
+//
+// A *databricks.WorkspaceClient's Files field satisfies it directly,
+// while staying an in-package interface this package owns and tests
+// can fake.
+type FilesClient interface {
+	Upload(ctx context.Context, request sdkfiles.UploadRequest) error
+}
+
+// Client coordinates large uploads with the Databricks Files API. The standard
+// single-shot upload goes through the SDK FilesClient; the large-file multipart
+// and resumable coordination runs over a custom authenticated HTTP client, and
+// the parts/chunks transfer directly to cloud storage (in the cloudstorage package)
+// over the URLs this client mints.
+type Client struct {
+	files FilesClient
+	host  string
+	creds credentials.CredentialsProvider
+	http  *http.Client
+}
+
+// ClientOptions configures a [Client].
+type ClientOptions struct {
+	// HTTPClient is the HTTP client to use for control-plane requests.
+	HTTPClient *http.Client
+
+	// CredentialsProvider is the credentials provider to use for control-plane
+	// requests.
+	//
+	// IMPORTANT: that provider must apply the workspace routing headers to the
+	// request by setting the X-Databricks-Workspace-Id header.
+	CredentialsProvider credentials.CredentialsProvider
+
+	// Host is the host to use for control-plane requests.
+	Host string
+
+	// FilesClient is the FilesClient to use for single-shot uploads.
+	FilesClient FilesClient
+}
+
+// New returns a Client from options. options.FilesClient performs the standard
+// single-shot upload; options.Host and options.CredentialsProvider address and
+// authenticate the custom multipart/resumable control-plane requests (a
+// WorkspaceClient's Config.Authenticate satisfies the provider via
+// credentials.CredentialsProviderFn). options.HTTPClient carries the
+// control-plane transport and defaults to http.DefaultClient; the cloud part
+// transfers are unauthenticated and never see the credentials.
+func New(options ClientOptions) (*Client, error) {
+	if options.HTTPClient == nil {
+		options.HTTPClient = http.DefaultClient
+	}
+	if options.FilesClient == nil {
+		return nil, errors.New("SDK Files client must not be nil")
+	}
+	if options.Host == "" {
+		return nil, errors.New("host must not be empty")
+	}
+	if options.CredentialsProvider == nil {
+		return nil, errors.New("credentials provider must not be nil")
+	}
+	return &Client{
+		files: options.FilesClient,
+		host:  options.Host,
+		creds: options.CredentialsProvider,
+		http:  options.HTTPClient,
+	}, nil
+}
+
+// Upload sends the whole body in one PUT through the SDK Files client. Used for
+// small files and as the multipart/resumable fallback. overwrite is tri-state:
+// a non-nil value is sent explicitly; nil lets the server apply its default. A
+// 409 ALREADY_EXISTS is mapped to ErrAlreadyExists.
+func (c *Client) Upload(ctx context.Context, path string, overwrite *bool, body io.Reader) error {
+	req := sdkfiles.UploadRequest{
+		FilePath: path,
+		Contents: io.NopCloser(body),
+	}
+	// ForceSendFields makes the SDK send overwrite=false explicitly; omitting
+	// both lets the server apply its default.
+	if overwrite != nil {
+		req.Overwrite = *overwrite
+		req.ForceSendFields = []string{"Overwrite"}
+	}
+	return asAlreadyExists(c.files.Upload(ctx, req))
+}
+
+// Initiate opens a server-coordinated upload session for path. The result
+// reports which protocol the workspace selected (multipart on AWS/Azure,
+// resumable on GCP).
+func (c *Client) Initiate(ctx context.Context, path string, overwrite *bool) (*InitiateResult, error) {
+	query := url.Values{"action": {"initiate-upload"}}
+	if overwrite != nil {
+		query.Set("overwrite", strconv.FormatBool(*overwrite))
+	}
+	var out InitiateResult
+	if err := c.controlPlaneJSON(ctx, http.MethodPost, filesAPIPath(path), query, nil, &out); err != nil {
+		return nil, asAlreadyExists(err)
+	}
+	return &out, nil
+}
+
+// asAlreadyExists maps an "already exists" API error to the ErrAlreadyExists
+// sentinel, so callers detect it with errors.Is regardless of which path
+// surfaced it. The Files API returns HTTP 409 with error_code ALREADY_EXISTS
+// when an upload targets an existing path with overwrite=false; for multipart
+// this surfaces from complete-upload (after the parts are sent).
+//
+// Two error types are checked: the control plane runs over core/apierr, while
+// single-shot Upload goes through the SDK Files client, whose older
+// databricks-sdk-go apierr type core/apierr.Code does not classify. Other errors
+// pass through unchanged.
+func asAlreadyExists(err error) error {
+	if apierr.Code(err) == codes.AlreadyExists {
+		return ErrAlreadyExists
+	}
+	if aerr, ok := errors.AsType[*sdkapierr.APIError](err); ok &&
+		aerr.StatusCode == http.StatusConflict && aerr.ErrorCode == "ALREADY_EXISTS" {
+		return ErrAlreadyExists
+	}
+	return err
+}
+
+// CreatePartURLs mints count presigned URLs for multipart parts starting at
+// startPart.
+func (c *Client) CreatePartURLs(ctx context.Context, path, token string, startPart, count int) ([]PresignedURL, error) {
+	body := createPartURLsRequest{
+		Path:            path,
+		SessionToken:    token,
+		StartPartNumber: startPart,
+		Count:           count,
+		ExpireTime:      expireTime(),
+	}
+	var out createPartURLsResponse
+	if err := c.controlPlaneJSON(ctx, http.MethodPost, "/api/2.0/fs/create-upload-part-urls", nil, body, &out); err != nil {
+		return nil, err
+	}
+	if len(out.UploadPartURLs) == 0 {
+		return nil, fmt.Errorf("%w: no upload part URLs returned", ErrUnexpectedServerResponse)
+	}
+	result := make([]PresignedURL, 0, len(out.UploadPartURLs))
+	for _, p := range out.UploadPartURLs {
+		result = append(result, PresignedURL{URL: p.URL, PartNumber: p.PartNumber, Headers: headerMap(p.Headers)})
+	}
+	return result, nil
+}
+
+// CreateResumableURL mints the single presigned URL for a GCP resumable session.
+func (c *Client) CreateResumableURL(ctx context.Context, path, token string) (PresignedURL, error) {
+	body := resumableURLRequest{Path: path, SessionToken: token}
+	var out resumableURLResponse
+	if err := c.controlPlaneJSON(ctx, http.MethodPost, "/api/2.0/fs/create-resumable-upload-url", nil, body, &out); err != nil {
+		return PresignedURL{}, err
+	}
+	if out.ResumableUploadURL == nil || out.ResumableUploadURL.URL == "" {
+		return PresignedURL{}, fmt.Errorf("%w: no resumable upload URL returned", ErrUnexpectedServerResponse)
+	}
+	return PresignedURL{URL: out.ResumableUploadURL.URL, Headers: headerMap(out.ResumableUploadURL.Headers)}, nil
+}
+
+// CompleteMultipart finalizes a multipart upload with the part ETags, which it
+// sorts by part number before sending.
+func (c *Client) CompleteMultipart(ctx context.Context, path, token string, etags map[int]string) error {
+	nums := make([]int, 0, len(etags))
+	for n := range etags {
+		nums = append(nums, n)
+	}
+	slices.Sort(nums)
+	parts := make([]completePart, 0, len(nums))
+	for _, n := range nums {
+		parts = append(parts, completePart{PartNumber: n, ETag: etags[n]})
+	}
+	query := url.Values{"action": {"complete-upload"}, "upload_type": {"multipart"}, "session_token": {token}}
+	return asAlreadyExists(c.controlPlaneJSON(ctx, http.MethodPost, filesAPIPath(path), query, completeRequest{Parts: parts}, nil))
+}
+
+// CreateAbortURL mints a presigned URL for aborting an upload session. The
+// caller issues the (unauthenticated) cloud DELETE against it.
+func (c *Client) CreateAbortURL(ctx context.Context, path, token string) (PresignedURL, error) {
+	body := abortURLRequest{Path: path, SessionToken: token, ExpireTime: expireTime()}
+	var out abortURLResponse
+	if err := c.controlPlaneJSON(ctx, http.MethodPost, "/api/2.0/fs/create-abort-upload-url", nil, body, &out); err != nil {
+		return PresignedURL{}, err
+	}
+	if out.AbortUploadURL == nil || out.AbortUploadURL.URL == "" {
+		return PresignedURL{}, fmt.Errorf("%w: no abort upload URL returned", ErrUnexpectedServerResponse)
+	}
+	return PresignedURL{URL: out.AbortUploadURL.URL, Headers: headerMap(out.AbortUploadURL.Headers)}, nil
+}
+
+// controlPlaneJSON performs an authenticated JSON request against the Files API
+// control plane, retrying transient failures via core/ops. reqBody and out may
+// be nil. A fresh request is built on each attempt so retries re-apply
+// credentials (handling token refresh) and rewind the body.
+func (c *Client) controlPlaneJSON(ctx context.Context, method, path string, query url.Values, reqBody, out any) error {
+	urlStr := strings.TrimRight(c.host, "/") + path
+	if len(query) > 0 {
+		urlStr += "?" + query.Encode()
+	}
+	var bodyBytes []byte
+	if reqBody != nil {
+		var err error
+		if bodyBytes, err = json.Marshal(reqBody); err != nil {
+			return err
+		}
+	}
+
+	call := func(ctx context.Context) error {
+		var rdr io.Reader
+		if bodyBytes != nil {
+			rdr = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, urlStr, rdr)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if err := c.creds.SetHeaders(req); err != nil {
+			return err
+		}
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if apiErr := apierr.FromHTTPError(resp.StatusCode, resp.Header, respBody); apiErr != nil {
+			return apiErr
+		}
+		if out != nil && len(respBody) > 0 {
+			return json.Unmarshal(respBody, out)
+		}
+		return nil
+	}
+	return ops.Execute(ctx, call, ops.WithRetrier(newControlPlaneRetrier), ops.WithTimeout(controlPlaneRetryTimeout))
+}
+
+func newControlPlaneRetrier() ops.Retrier {
+	return apiretry.NewRetrier(controlPlaneBackoff, apiretry.RetrierConfig{StatusCodes: controlPlaneRetryStatusCodes})
+}
+
+// nowFunc defaults to real time; overridable in tests for deterministic
+// presigned-URL expiry timestamps.
+var nowFunc = time.Now
+
+// uploadURLExpiry is how long requested presigned URLs are valid.
+var uploadURLExpiry = time.Hour
+
+// filesAPIPath builds the Files API URL path for an absolute volume path. It
+// uses the SDK's segment encoder so the control-plane initiate/complete calls
+// escape the path identically to the single-shot FilesClient.Upload.
+func filesAPIPath(absPath string) string {
+	return "/api/2.0/fs/files" + httpclient.EncodeMultiSegmentPathParameter(absPath)
+}
+
+func expireTime() string {
+	return nowFunc().UTC().Add(uploadURLExpiry).Format("2006-01-02T15:04:05Z")
+}
+
+func headerMap(headers []nameValue) map[string]string {
+	out := make(map[string]string, len(headers))
+	for _, h := range headers {
+		out[h.Name] = h.Value
+	}
+	return out
+}

--- a/libs/upload/files/files_test.go
+++ b/libs/upload/files/files_test.go
@@ -1,0 +1,253 @@
+package files
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/config/credentials"
+	sdkfiles "github.com/databricks/databricks-sdk-go/service/files"
+)
+
+func noAuth() credentials.CredentialsProvider {
+	return credentials.CredentialsProviderFn(func(r *http.Request) error { return nil })
+}
+
+// fakeFiles is a fake SDK Files client that records the single-shot request and
+// returns a canned error.
+type fakeFiles struct {
+	req sdkfiles.UploadRequest
+	err error
+}
+
+func (f *fakeFiles) Upload(ctx context.Context, req sdkfiles.UploadRequest) error {
+	f.req = req
+	return f.err
+}
+
+// newClient builds a Client whose control plane points at an httptest server
+// running h, and returns the fake SDK Files client backing single-shot.
+func newClient(t *testing.T, h http.HandlerFunc) (*Client, *fakeFiles) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	ff := &fakeFiles{}
+	c, err := New(ClientOptions{FilesClient: ff, Host: srv.URL, CredentialsProvider: noAuth()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c, ff
+}
+
+func TestNewValidation(t *testing.T) {
+	if _, err := New(ClientOptions{Host: "https://h.test", CredentialsProvider: noAuth()}); err == nil {
+		t.Error("nil SDK client should error")
+	}
+	if _, err := New(ClientOptions{FilesClient: &fakeFiles{}, CredentialsProvider: noAuth()}); err == nil {
+		t.Error("empty host should error")
+	}
+	if _, err := New(ClientOptions{FilesClient: &fakeFiles{}, Host: "https://h.test"}); err == nil {
+		t.Error("nil creds should error")
+	}
+}
+
+func TestInitiate(t *testing.T) {
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/2.0/fs/files/") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("action"); got != "initiate-upload" {
+			t.Errorf("action = %q", got)
+		}
+		if got := r.URL.Query().Get("overwrite"); got != "true" {
+			t.Errorf("overwrite = %q, want true", got)
+		}
+		_, _ = io.WriteString(w, `{"multipart_upload":{"session_token":"tok"}}`)
+	})
+
+	ow := true
+	res, err := c.Initiate(t.Context(), "/Volumes/c/s/v/f.bin", &ow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.MultipartUpload == nil || res.MultipartUpload.SessionToken != "tok" {
+		t.Errorf("multipart = %+v", res.MultipartUpload)
+	}
+	if res.ResumableUpload != nil {
+		t.Error("resumable should be nil")
+	}
+}
+
+func TestCreatePartURLs(t *testing.T) {
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"upload_part_urls":[{"url":"https://cloud.test/part/1","part_number":1,"headers":[{"name":"x-h","value":"v"}]}]}`)
+	})
+
+	urls, err := c.CreatePartURLs(t.Context(), "/Volumes/c/s/v/f.bin", "tok", 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(urls) != 1 {
+		t.Fatalf("got %d URLs, want 1", len(urls))
+	}
+	if urls[0].URL != "https://cloud.test/part/1" || urls[0].PartNumber != 1 || urls[0].Headers["x-h"] != "v" {
+		t.Errorf("url = %+v", urls[0])
+	}
+}
+
+func TestCreatePartURLsEmpty(t *testing.T) {
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"upload_part_urls":[]}`)
+	})
+	if _, err := c.CreatePartURLs(t.Context(), "/Volumes/c/s/v/f.bin", "tok", 1, 1); !errors.Is(err, ErrUnexpectedServerResponse) {
+		t.Fatalf("err = %v, want ErrUnexpectedServerResponse", err)
+	}
+}
+
+func TestCreateResumableURL(t *testing.T) {
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"resumable_upload_url":{"url":"https://cloud.test/resumable","headers":[{"name":"x-h","value":"v"}]}}`)
+	})
+
+	purl, err := c.CreateResumableURL(t.Context(), "/Volumes/c/s/v/f.bin", "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if purl.URL != "https://cloud.test/resumable" || purl.Headers["x-h"] != "v" {
+		t.Errorf("url = %+v", purl)
+	}
+}
+
+func TestCreateResumableURLMissing(t *testing.T) {
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{}`)
+	})
+	if _, err := c.CreateResumableURL(t.Context(), "/Volumes/c/s/v/f.bin", "tok"); !errors.Is(err, ErrUnexpectedServerResponse) {
+		t.Fatalf("err = %v, want ErrUnexpectedServerResponse", err)
+	}
+}
+
+func TestCreateAbortURL(t *testing.T) {
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"abort_upload_url":{"url":"https://cloud.test/abort"}}`)
+	})
+
+	purl, err := c.CreateAbortURL(t.Context(), "/Volumes/c/s/v/f.bin", "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if purl.URL != "https://cloud.test/abort" {
+		t.Errorf("url = %q", purl.URL)
+	}
+}
+
+func TestCompleteMultipartSortsParts(t *testing.T) {
+	var got []int
+	c, _ := newClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("action"); got != "complete-upload" {
+			t.Errorf("action = %q", got)
+		}
+		var body struct {
+			Parts []struct {
+				PartNumber int    `json:"part_number"`
+				ETag       string `json:"etag"`
+			} `json:"parts"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		for _, p := range body.Parts {
+			got = append(got, p.PartNumber)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := c.CompleteMultipart(t.Context(), "/Volumes/c/s/v/f.bin", "tok", map[int]string{3: "e3", 1: "e1", 2: "e2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Errorf("parts = %v, want sorted [1 2 3]", got)
+	}
+}
+
+func TestControlPlaneAlreadyExists(t *testing.T) {
+	conflict := func(errorCode string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = io.WriteString(w, `{"error_code":"`+errorCode+`","message":"the file being created already exists"}`)
+		}
+	}
+
+	// complete-upload (the multipart finish) returning 409 ALREADY_EXISTS maps to
+	// the sentinel so callers can skip-if-exists, matching single-shot/resumable.
+	c, _ := newClient(t, conflict("ALREADY_EXISTS"))
+	if err := c.CompleteMultipart(t.Context(), "/Volumes/c/s/v/f.bin", "tok", map[int]string{1: "e1"}); !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("CompleteMultipart err = %v, want ErrAlreadyExists", err)
+	}
+
+	// initiate-upload maps the same way.
+	c2, _ := newClient(t, conflict("ALREADY_EXISTS"))
+	if _, err := c2.Initiate(t.Context(), "/Volumes/c/s/v/f.bin", nil); !errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("Initiate err = %v, want ErrAlreadyExists", err)
+	}
+
+	// A different 409 is not mistaken for the already-exists sentinel.
+	c3, _ := newClient(t, conflict("RESOURCE_CONFLICT"))
+	if _, err := c3.Initiate(t.Context(), "/Volumes/c/s/v/f.bin", nil); errors.Is(err, ErrAlreadyExists) {
+		t.Errorf("a non-ALREADY_EXISTS 409 mapped to ErrAlreadyExists: %v", err)
+	}
+}
+
+func TestUploadBuildsRequest(t *testing.T) {
+	c, ff := newClient(t, func(w http.ResponseWriter, r *http.Request) {})
+	ow := false
+	err := c.Upload(t.Context(), "/Volumes/c/s/v/f.bin", &ow, strings.NewReader("hi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ff.req.FilePath != "/Volumes/c/s/v/f.bin" {
+		t.Errorf("FilePath = %q", ff.req.FilePath)
+	}
+	// overwrite=false is sent explicitly via ForceSendFields.
+	if ff.req.Overwrite != false || len(ff.req.ForceSendFields) != 1 || ff.req.ForceSendFields[0] != "Overwrite" {
+		t.Errorf("overwrite not forced: %+v", ff.req.ForceSendFields)
+	}
+}
+
+func TestUploadOverwriteUnset(t *testing.T) {
+	c, ff := newClient(t, func(w http.ResponseWriter, r *http.Request) {})
+	if err := c.Upload(t.Context(), "/Volumes/c/s/v/f.bin", nil, strings.NewReader("hi")); err != nil {
+		t.Fatal(err)
+	}
+	if len(ff.req.ForceSendFields) != 0 {
+		t.Errorf("ForceSendFields = %v, want empty when overwrite is unset", ff.req.ForceSendFields)
+	}
+}
+
+func TestUploadAlreadyExists(t *testing.T) {
+	c, ff := newClient(t, func(w http.ResponseWriter, r *http.Request) {})
+	ff.err = &apierr.APIError{StatusCode: http.StatusConflict, ErrorCode: "ALREADY_EXISTS", Message: "exists"}
+
+	err := c.Upload(t.Context(), "/Volumes/c/s/v/f.bin", nil, strings.NewReader("hi"))
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("err = %v, want ErrAlreadyExists", err)
+	}
+}
+
+func TestUploadOtherErrorPassThrough(t *testing.T) {
+	c, ff := newClient(t, func(w http.ResponseWriter, r *http.Request) {})
+	ff.err = &apierr.APIError{StatusCode: http.StatusForbidden, ErrorCode: "PERMISSION_DENIED"}
+
+	err := c.Upload(t.Context(), "/Volumes/c/s/v/f.bin", nil, strings.NewReader("hi"))
+	if errors.Is(err, ErrAlreadyExists) {
+		t.Fatal("a 403 must not map to ErrAlreadyExists")
+	}
+	if err == nil {
+		t.Fatal("expected the underlying error to pass through")
+	}
+}

--- a/libs/upload/files/types.go
+++ b/libs/upload/files/types.go
@@ -1,0 +1,90 @@
+package files
+
+import "errors"
+
+// Sentinel errors surfaced by the Files API client.
+var (
+	ErrUnexpectedServerResponse = errors.New("unexpected server response")
+	ErrAlreadyExists            = errors.New("the file being created already exists")
+)
+
+// --- Exported result types ---
+
+// InitiateResult reports which large-file protocol the server selected. Exactly
+// one of MultipartUpload (AWS/Azure) and ResumableUpload (GCP) is non-nil on a
+// well-formed response; the pointers distinguish "not offered" from "offered
+// with an empty token".
+type InitiateResult struct {
+	MultipartUpload *UploadSession `json:"multipart_upload"`
+	ResumableUpload *UploadSession `json:"resumable_upload"`
+}
+
+type UploadSession struct {
+	SessionToken string `json:"session_token"`
+}
+
+// PresignedURL is a resolved cloud-storage URL with its associated request
+// headers, as minted by the control plane and transferred over by the caller.
+type PresignedURL struct {
+	URL        string
+	PartNumber int
+	Headers    map[string]string
+}
+
+// --- Wire types for the Files API multipart/resumable coordination ---
+
+type nameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type createPartURLsRequest struct {
+	Path            string `json:"path"`
+	SessionToken    string `json:"session_token"`
+	StartPartNumber int    `json:"start_part_number"`
+	Count           int    `json:"count"`
+	ExpireTime      string `json:"expire_time"`
+}
+
+type createPartURLsResponse struct {
+	UploadPartURLs []struct {
+		URL        string      `json:"url"`
+		PartNumber int         `json:"part_number"`
+		Headers    []nameValue `json:"headers"`
+	} `json:"upload_part_urls"`
+}
+
+type resumableURLRequest struct {
+	Path         string `json:"path"`
+	SessionToken string `json:"session_token"`
+}
+
+// urlWithHeaders is a presigned cloud-storage URL and its required request
+// headers, as returned by the resumable and abort URL endpoints.
+type urlWithHeaders struct {
+	URL     string      `json:"url"`
+	Headers []nameValue `json:"headers"`
+}
+
+type resumableURLResponse struct {
+	ResumableUploadURL *urlWithHeaders `json:"resumable_upload_url"`
+}
+
+type abortURLRequest struct {
+	Path         string `json:"path"`
+	SessionToken string `json:"session_token"`
+	ExpireTime   string `json:"expire_time"`
+}
+
+type abortURLResponse struct {
+	AbortUploadURL *urlWithHeaders `json:"abort_upload_url"`
+}
+
+type completePart struct {
+	PartNumber int    `json:"part_number"`
+	ETag       string `json:"etag"`
+}
+
+type completeRequest struct {
+	Parts []completePart `json:"parts"`
+}


### PR DESCRIPTION
## Context

`databricks fs cp` and bundle library uploads to Unity Catalog Volumes go through a single `PUT /api/2.0/fs/files`, which caps a file at the single-request size limit and pushes it over one connection. This stack adds chunked upload (multipart on AWS/Azure, resumable on GCP) so large files upload reliably and in parallel. The whole feature is gated behind the `DATABRICKS_EXPERIMENTAL_MULTIPART_UPLOAD` environment variable and is off by default, so merging the stack changes no behavior until the flag is set.

## Stack

1. #5753 cloud-storage data-plane client
2. #5754 Files API control-plane client (this PR)
3. #5755 chunked upload engine
4. #5756 route large Volumes writes through the engine
5. #5757 `fs cp` shared transfer budget
6. #5758 `fs cp` progress bar

## This PR

Adds `libs/upload/files`, the authenticated client for the Databricks Files API control plane that coordinates a chunked upload: it initiates a server-coordinated upload session, mints the presigned URLs for parts (multipart) and the resumable session (GCP), completes a multipart upload, and mints abort URLs for cleanup, over a hand-rolled JSON layer on `sdk-go/core`. The standard single-shot upload delegates to the SDK Files client. A 409 `ALREADY_EXISTS` from either path is surfaced as a typed sentinel so callers detect "already exists" with `errors.Is` regardless of which protocol produced it. The client is constructed from explicit options (HTTP client, host, credentials, SDK Files client), keeping it independent of the workspace client. No production caller yet; the engine in the next PR drives it.

## Testing

Unit tests run against an httptest server modeling the Files API control plane: initiate, part-URL minting, resumable-URL minting, complete, and abort, plus the single-shot upload path and the already-exists mapping.

This pull request and its description were written by Isaac.
