### PR TITLE
libs/upload: add the chunked large-file upload engine

### DIFF
--- a/libs/upload/api.go
+++ b/libs/upload/api.go
@@ -1,0 +1,71 @@
+package upload
+
+// Upload-side glue between the orchestration and the two transports: the
+// single-shot delegation to the authenticated files.Client, and the best-effort
+// aborts (mint a presigned abort URL on the control plane, then issue the
+// unauthenticated cloud DELETE).
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/upload/files"
+)
+
+// singleShotUpload sends the whole body in one PUT through the files.Client.
+// Used for small files and as the multipart/resumable fallback. Progress is
+// reported as the body streams; the files.Client itself is progress-agnostic.
+func (c *Client) singleShotUpload(ctx context.Context, uc *uploadContext, body io.Reader) error {
+	if uc.progress != nil {
+		body = &progressReader{r: body, p: uc.progress}
+	}
+	// A single-shot upload is one transfer; hold one slot for its duration so it
+	// draws from the same concurrency budget as multipart parts.
+	if err := uc.limiter.Acquire(ctx); err != nil {
+		return err
+	}
+	defer uc.limiter.Release()
+	return c.files.Upload(ctx, uc.targetPath, uc.overwrite, body)
+}
+
+// abortMultipartUpload mints a presigned abort URL on the control plane and
+// issues the unauthenticated cloud DELETE against it. Both halves run on the
+// caller's context, which abortMultipartBestEffort detaches and bounds.
+func (c *Client) abortMultipartUpload(ctx context.Context, uc *uploadContext, token string) error {
+	purl, err := c.files.CreateAbortURL(ctx, uc.targetPath, token)
+	if err != nil {
+		return err
+	}
+	headers := octetStreamHeaders(purl.Headers)
+	_, err = uc.cloud.Send(ctx, http.MethodDelete, purl.URL, headers, nil)
+	return err
+}
+
+func (c *Client) abortMultipartBestEffort(ctx context.Context, uc *uploadContext, token string) {
+	ctx, cancel := cleanupContext(ctx)
+	defer cancel()
+	if err := c.abortMultipartUpload(ctx, uc, token); err != nil {
+		// Best-effort cleanup; its failure is not user-actionable (e.g. some clouds
+		// do not support abort presigned URLs), so it stays at debug rather than
+		// surfacing as a warning on an otherwise-normal outcome like a skip.
+		log.Debugf(ctx, "failed to abort multipart upload: %v", err)
+	}
+}
+
+// cleanupContext returns a context for a best-effort cleanup (aborting a partial
+// upload) that is detached from the caller's cancellation and deadline but
+// bounded by its own timeout. Cleanup most needs to run exactly when the upload
+// context has already been cancelled or has expired; reusing it would make the
+// abort fail instantly and leak the partial upload on the storage provider.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cloudCleanupTimeout)
+}
+
+func (c *Client) abortResumableUpload(ctx context.Context, uc *uploadContext, purl files.PresignedURL) error {
+	ctx, cancel := cleanupContext(ctx)
+	defer cancel()
+	_, err := uc.cloud.Send(ctx, http.MethodDelete, purl.URL, purl.Headers, nil)
+	return err
+}

--- a/libs/upload/limiter.go
+++ b/libs/upload/limiter.go
@@ -1,0 +1,55 @@
+package upload
+
+import "context"
+
+// Limiter bounds the number of concurrent cloud-leg transfers an upload may run.
+// The engine acquires one unit before each transfer (every multipart part PUT,
+// the single-shot PUT, and every resumable chunk) and releases it when that
+// transfer returns. Pass the same Limiter to multiple Upload calls — for example
+// when copying many files at once — to cap their combined concurrency.
+// Implementations must be safe for concurrent use.
+type Limiter interface {
+	// Acquire blocks until a slot is free or ctx is cancelled; on cancellation it
+	// returns ctx.Err() and the caller must not Release.
+	Acquire(ctx context.Context) error
+	// Release returns a slot taken by a successful Acquire.
+	Release()
+}
+
+// NewLimiter returns a Limiter permitting at most n concurrent transfers. A value
+// of n <= 0 yields an unlimited limiter whose Acquire never blocks.
+func NewLimiter(n int) Limiter {
+	if n <= 0 {
+		return unlimitedLimiter{}
+	}
+	return make(chanLimiter, n)
+}
+
+// unlimitedLimiter imposes no bound. It is the default when no limiter is set, so
+// the transfer sites can call the limiter unconditionally.
+type unlimitedLimiter struct{}
+
+func (unlimitedLimiter) Acquire(context.Context) error { return nil }
+func (unlimitedLimiter) Release()                      {}
+
+// chanLimiter is a counting semaphore backed by a buffered channel: a send takes a
+// slot, a receive returns one.
+type chanLimiter chan struct{}
+
+func (c chanLimiter) Acquire(ctx context.Context) error {
+	select {
+	case c <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c chanLimiter) Release() { <-c }
+
+// WithLimiter bounds concurrent transfers via l, shared across Upload calls that
+// pass the same Limiter. When unset, an upload's own parallelism governs its
+// concurrency and there is no cross-upload bound.
+func WithLimiter(l Limiter) UploadOption {
+	return func(c *uploadConfig) { c.limiter = l }
+}

--- a/libs/upload/limiter_test.go
+++ b/libs/upload/limiter_test.go
@@ -1,0 +1,191 @@
+package upload
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLimiterCapacityAndCancel(t *testing.T) {
+	lim := NewLimiter(1)
+	ctx := t.Context()
+	if err := lim.Acquire(ctx); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	// A second acquire blocks at capacity; cancelling its context unblocks it with
+	// the context error, and the caller must not Release.
+	cctx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	go func() { done <- lim.Acquire(cctx) }()
+	select {
+	case err := <-done:
+		t.Fatalf("acquire should block at capacity, returned %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("blocked acquire = %v, want context.Canceled", err)
+	}
+
+	// Releasing the first slot lets a fresh acquire succeed.
+	lim.Release()
+	if err := lim.Acquire(ctx); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	lim.Release()
+}
+
+func TestUnlimitedLimiter(t *testing.T) {
+	lim := NewLimiter(0) // <= 0 means unlimited
+	for range 5 {
+		if err := lim.Acquire(t.Context()); err != nil {
+			t.Fatalf("unlimited acquire: %v", err)
+		}
+	}
+	for range 5 {
+		lim.Release()
+	}
+}
+
+// countingLimiter enforces a real bound (via an inner Limiter) and records the
+// peak concurrency and the acquire/release counts so tests can assert the engine
+// holds exactly one slot per transfer and never exceeds the bound.
+type countingLimiter struct {
+	inner Limiter
+
+	mu       sync.Mutex
+	cur, max int
+	acquires int
+	releases int
+}
+
+func newCountingLimiter(n int) *countingLimiter {
+	return &countingLimiter{inner: NewLimiter(n)}
+}
+
+func (l *countingLimiter) Acquire(ctx context.Context) error {
+	if err := l.inner.Acquire(ctx); err != nil {
+		return err
+	}
+	l.mu.Lock()
+	l.cur++
+	l.acquires++
+	l.max = max(l.max, l.cur)
+	l.mu.Unlock()
+	return nil
+}
+
+func (l *countingLimiter) Release() {
+	l.mu.Lock()
+	l.cur--
+	l.releases++
+	l.mu.Unlock()
+	l.inner.Release()
+}
+
+// slowParts makes every cloud part/chunk PUT take d so concurrent transfers
+// overlap and the peak-concurrency assertion is meaningful.
+func slowParts(f *fakeServer, d time.Duration) {
+	f.partHook = func(n, attempt int) (int, string, []byte) {
+		time.Sleep(d)
+		return 0, "", nil
+	}
+}
+
+func TestMultipartLimiterBoundsConcurrency(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	slowParts(f, 15*time.Millisecond)
+	c := newTestClient(t, f)
+
+	const limit = 2
+	lim := newCountingLimiter(limit)
+	in := data(8 * 1024) // 8 parts at the 1024 part size
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/m.bin", bytes.NewReader(in),
+		WithParallelism(8), WithLimiter(lim))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+
+	if lim.max > limit {
+		t.Errorf("peak concurrency %d exceeded limit %d", lim.max, limit)
+	}
+	if lim.max != limit {
+		t.Errorf("peak concurrency %d, want it to reach the limit %d (8 parts, 8 workers)", lim.max, limit)
+	}
+	if lim.acquires != 8 {
+		t.Errorf("acquires = %d, want 8 (one per part)", lim.acquires)
+	}
+	if lim.acquires != lim.releases {
+		t.Errorf("unbalanced: %d acquires, %d releases", lim.acquires, lim.releases)
+	}
+}
+
+func TestSingleShotAcquiresOneSlot(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	lim := newCountingLimiter(4)
+	in := data(500) // below the 1024 single-shot threshold
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/s.bin", bytes.NewReader(in), WithLimiter(lim))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+
+	if lim.acquires != 1 || lim.releases != 1 {
+		t.Errorf("single-shot: acquires=%d releases=%d, want 1/1", lim.acquires, lim.releases)
+	}
+	if lim.max != 1 {
+		t.Errorf("single-shot peak concurrency = %d, want 1", lim.max)
+	}
+}
+
+func TestResumableAcquiresPerChunk(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "resumable")
+	c := newTestClient(t, f)
+
+	lim := newCountingLimiter(4)
+	in := data(4 * 1024) // several resumable chunks
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/r.bin", bytes.NewReader(in), WithLimiter(lim))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+
+	if lim.acquires < 2 {
+		t.Errorf("resumable acquires = %d, want >= 2 (one per chunk)", lim.acquires)
+	}
+	if lim.acquires != lim.releases {
+		t.Errorf("unbalanced: %d acquires, %d releases", lim.acquires, lim.releases)
+	}
+	if lim.max != 1 {
+		t.Errorf("resumable is sequential; peak concurrency = %d, want 1", lim.max)
+	}
+}
+
+func TestLimiterCancelNoLeak(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	slowParts(f, 50*time.Millisecond)
+	c := newTestClient(t, f)
+
+	lim := newCountingLimiter(2)
+	ctx, cancel := context.WithCancel(t.Context())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := c.Upload(ctx, "/Volumes/c/s/v/c.bin", bytes.NewReader(data(16*1024)),
+			WithParallelism(8), WithLimiter(lim))
+		errc <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-errc // upload returns (with a context error)
+
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	if lim.acquires != lim.releases {
+		t.Errorf("cancellation leaked slots: %d acquires, %d releases", lim.acquires, lim.releases)
+	}
+}

--- a/libs/upload/multipart.go
+++ b/libs/upload/multipart.go
@@ -1,0 +1,451 @@
+package upload
+
+// Multipart upload for AWS and Azure: the part-based protocol and its
+// single-threaded and parallel (producer/worker) drivers. The control-plane
+// calls it relies on live in api.go; the part transfers go through uc.cloud.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/upload/cloudstorage"
+	"github.com/databricks/sdk-go/core/apierr"
+)
+
+// uploadPart is the unit of work handed to an upload worker: a part number, the
+// source of its bytes (an in-memory buffer for a streamed part, a section of the
+// open file for a file part), and an optionally pre-minted presigned URL. When
+// url is empty the worker mints one on demand; the file path pre-mints URLs in
+// batches so workers go straight to the cloud PUT.
+type uploadPart struct {
+	partNumber int
+	body       cloudstorage.Body
+	url        string            // pre-minted presigned URL; "" => mint on demand
+	headers    map[string]string // PUT headers accompanying url
+}
+
+// isCloudStatus reports whether err is a cloud-storage HTTP status error (an
+// *apierr.APIError returned by Send) rather than a transport failure. A status
+// rejection before any part has landed triggers the single-shot fallback; a
+// transport failure does not.
+func isCloudStatus(err error) bool {
+	_, ok := errors.AsType[*apierr.APIError](err)
+	return ok
+}
+
+// performMultipartUpload uploads a stream in parts on a single goroutine using
+// presigned URLs (AWS/Azure).
+func (c *Client) performMultipartUpload(ctx context.Context, uc *uploadContext, token string, r io.Reader, preRead []byte) error {
+	currentPart := 1
+	etags := map[int]string{}
+	chunkOffset := int64(0)
+	// AWS and Azure require each part size up front, so we buffer a part before
+	// uploading it; this also lets us replay a part on retry. The buffer starts
+	// with the bytes already read while deciding single-shot vs multipart.
+	buffer := preRead
+	retryCount := 0
+	eof := false
+
+	for !eof {
+		var err error
+		if buffer, err = fillBuffer(buffer, uc.partSize, r); err != nil {
+			return err
+		}
+		if len(buffer) == 0 {
+			break
+		}
+
+		urls, err := c.files.CreatePartURLs(ctx, uc.targetPath, token, currentPart, uc.batchSize)
+		if err != nil {
+			if chunkOffset == 0 {
+				return &fallbackToFilesAPI{buffer: buffer, reason: fmt.Sprintf("failed to obtain upload URLs: %v", err)}
+			}
+			return err
+		}
+
+		for _, purl := range urls {
+			if buffer, err = fillBuffer(buffer, uc.partSize, r); err != nil {
+				return err
+			}
+			if len(buffer) == 0 {
+				eof = true
+				break
+			}
+			chunkLen := min(int64(len(buffer)), uc.partSize)
+			headers := octetStreamHeaders(purl.Headers)
+
+			partStart := time.Now()
+			if err := uc.limiter.Acquire(ctx); err != nil {
+				return err
+			}
+			resp, rerr := uc.cloud.Send(ctx, http.MethodPut, purl.URL, headers, cloudstorage.BytesBody(buffer[:chunkLen]))
+			uc.limiter.Release()
+			switch {
+			case rerr == nil:
+				chunkOffset += chunkLen
+				etags[currentPart] = resp.Header.Get("ETag")
+				buffer = buffer[chunkLen:]
+				retryCount = 0
+				uc.progress.add(chunkLen)
+				log.Debugf(ctx, "chunk uploaded: part=%d bytes=%d offset=%d duration_ms=%d",
+					currentPart, chunkLen, chunkOffset-chunkLen, time.Since(partStart).Milliseconds())
+			case cloudstorage.IsURLExpired(rerr):
+				if retryCount >= multipartMaxRetries {
+					return errUploadURLExpired
+				}
+				retryCount++
+				// Preserve the buffer: the same bytes are uploaded under the next
+				// part number using a fresh URL.
+			case chunkOffset == 0 && isCloudStatus(rerr):
+				// The cloud rejected the first chunk (e.g. a firewall 403); fall back
+				// to a single-shot upload through the Files API.
+				return &fallbackToFilesAPI{buffer: buffer, reason: fmt.Sprintf("first chunk upload failed: %v", rerr)}
+			default:
+				return rerr
+			}
+			currentPart++
+		}
+	}
+
+	return c.files.CompleteMultipart(ctx, uc.targetPath, token, etags)
+}
+
+// doUploadOnePart uploads a single part. It uses part.url when the caller
+// pre-minted one (the file path mints in batches); otherwise, and whenever a URL
+// expires or a slow attempt is re-issued, it mints a fresh one (count=1). While no
+// part has completed yet, it converts a cloud rejection or URL-mint failure into a
+// fallback signal so the caller can retry the whole upload through a single-shot
+// Files API PUT (the firewall/auth case); once any part has landed, the storage
+// endpoint is known good and such a failure is returned as a real error.
+//
+// isFirstPart marks the stream path's synchronous, uncontended first part, which
+// gets its own tight soft deadline; it does not affect the fallback gating above.
+func (c *Client) doUploadOnePart(ctx context.Context, uc *uploadContext, part uploadPart, token string, isFirstPart bool) (string, error) {
+	start := time.Now()
+	urlRetries, slowRetries := 0, 0
+	url, headers := part.url, part.headers
+	for {
+		if url == "" {
+			urls, err := c.files.CreatePartURLs(ctx, uc.targetPath, token, part.partNumber, 1)
+			if err != nil {
+				if !uc.completed.Load() {
+					return "", &fallbackToFilesAPI{reason: fmt.Sprintf("failed to obtain upload URL for part %d: %v", part.partNumber, err)}
+				}
+				return "", err
+			}
+			url, headers = urls[0].URL, octetStreamHeaders(urls[0].Headers)
+		}
+
+		attemptStart := time.Now()
+		resp, slow, rerr := c.sendPart(ctx, uc, url, headers, part.body, func() time.Duration {
+			return uc.attemptDeadline(isFirstPart, slowRetries)
+		})
+		switch {
+		case rerr == nil:
+			uc.completed.Store(true)
+			uc.slowGuard.record(time.Since(attemptStart))
+			uc.progress.add(part.body.Size())
+			log.Debugf(ctx, "part uploaded: part=%d bytes=%d first=%t duration_ms=%d",
+				part.partNumber, part.body.Size(), isFirstPart, time.Since(start).Milliseconds())
+			return resp.Header.Get("ETag"), nil
+		case slow:
+			// A wedged connection: re-mint and re-issue on a fresh URL and connection.
+			// attemptDeadline disarms after slowAttemptMax tries, so a part that keeps
+			// drawing slow connections rides out the normal timeouts rather than failing.
+			slowRetries++
+			url = ""
+			log.Debugf(ctx, "part %d slow, re-issuing on a fresh connection (attempt %d)",
+				part.partNumber, slowRetries+1)
+		case cloudstorage.IsURLExpired(rerr):
+			if urlRetries >= multipartMaxRetries {
+				return "", errUploadURLExpired
+			}
+			urlRetries++
+			url = "" // re-mint the expired URL
+		case isCloudStatus(rerr) && !uc.completed.Load():
+			// The cloud rejected this part before any part has landed (e.g. a firewall
+			// 403 on the storage host); fall back to a single-shot upload through the
+			// Files API.
+			return "", &fallbackToFilesAPI{reason: fmt.Sprintf("part %d upload failed before any part completed: %v", part.partNumber, rerr)}
+		default:
+			return "", rerr
+		}
+	}
+}
+
+// sendPart performs one part PUT, cancelling it (slow=true) if it outlives the
+// soft deadline so the caller can re-issue on a fresh connection (a wedged
+// connection trickles bytes, escaping the idle and response timeouts). deadline
+// is re-evaluated while the attempt is in flight, so a part that started under
+// the cold-start deadline is caught at the tighter p95 deadline as soon as the
+// guard warms up rather than waiting out the floor; deadline returning <= 0
+// leaves the attempt unbounded. A ctx cancellation from the caller is reported
+// as not-slow so it propagates instead of looping.
+func (c *Client) sendPart(ctx context.Context, uc *uploadContext, url string, headers map[string]string, body cloudstorage.Body, deadline func() time.Duration) (resp *cloudstorage.Response, slow bool, err error) {
+	// Hold one transfer slot for the duration of this attempt. A re-issued attempt
+	// (slow/expiry) acquires a fresh slot, so a part never holds more than one.
+	if err := uc.limiter.Acquire(ctx); err != nil {
+		return nil, false, err
+	}
+	defer uc.limiter.Release()
+
+	attemptCtx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
+
+	// The deferred cancel above fires on every return path, so attemptCtx.Done()
+	// is the goroutine's stop signal once Send returns.
+	start := time.Now()
+	go func() {
+		ticker := time.NewTicker(slowAttemptCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-attemptCtx.Done():
+				return
+			case <-ticker.C:
+				if d := deadline(); d > 0 && time.Since(start) >= d {
+					cancel(errSlowAttempt)
+					return
+				}
+			}
+		}
+	}()
+
+	resp, err = uc.cloud.Send(attemptCtx, http.MethodPut, url, headers, body)
+	slow = ctx.Err() == nil && errors.Is(context.Cause(attemptCtx), errSlowAttempt)
+	return resp, slow, err
+}
+
+// startPartWorkers spawns parallelism workers that drain tasks, upload each part
+// from its source, and record the ETag into seed (which the caller may
+// pre-populate with parts it already uploaded, e.g. the stream path's synchronous
+// first part). The first failure records the error and cancels
+// the rest via cancel, which a stream producer also observes to stop feeding.
+// The returned wait blocks for all workers and returns the collected ETags or
+// the first error. The caller owns producing and closing tasks.
+func (c *Client) startPartWorkers(pctx context.Context, cancel context.CancelFunc, uc *uploadContext, token string, parallelism int, seed map[int]string, tasks <-chan uploadPart) func() (map[int]string, error) {
+	results := &uploadResults{etags: seed}
+	var wg sync.WaitGroup
+	for range parallelism {
+		wg.Go(func() {
+			for part := range tasks {
+				if pctx.Err() != nil {
+					return
+				}
+				etag, e := c.doUploadOnePart(pctx, uc, part, token, false)
+				if e != nil {
+					results.setErr(e)
+					cancel()
+					return
+				}
+				results.put(part.partNumber, etag)
+			}
+		})
+	}
+	return func() (map[int]string, error) {
+		wg.Wait()
+		if err := results.err(); err != nil {
+			return nil, err
+		}
+		return results.snapshot(), nil
+	}
+}
+
+// parallelMultipartFromStream uploads a non-seekable stream in parts using a
+// bounded producer/consumer. The first part is uploaded synchronously so an
+// auth/firewall rejection surfaces before workers spin up and can fall back.
+func (c *Client) parallelMultipartFromStream(ctx context.Context, uc *uploadContext, token string, r io.Reader) error {
+	first, err := readUpTo(r, uc.partSize)
+	if err != nil {
+		return err
+	}
+	if len(first) == 0 {
+		return &fallbackToFilesAPI{buffer: nil, reason: "empty input stream"}
+	}
+	etag1, err := c.doUploadOnePart(ctx, uc, uploadPart{partNumber: 1, body: cloudstorage.BytesBody(first)}, token, true)
+	if err != nil {
+		if fb, ok := errors.AsType[*fallbackToFilesAPI](err); ok {
+			fb.buffer = first
+			return fb
+		}
+		return err
+	}
+	if int64(len(first)) < uc.partSize {
+		return c.files.CompleteMultipart(ctx, uc.targetPath, token, map[int]string{1: etag1})
+	}
+
+	pctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Hand parts straight to workers over an unbuffered channel so the bytes held
+	// in memory stay bounded to the in-flight set: at most parallelism workers each
+	// holding one partSize buffer, plus the one the producer is handing off. The
+	// stream size is unknown, so the worker count cannot be capped by the part
+	// count (as the file path does); workers beyond the number of parts observe the
+	// closed channel and exit.
+	tasks := make(chan uploadPart)
+	wait := c.startPartWorkers(pctx, cancel, uc, token, uc.parallelism, map[int]string{1: etag1}, tasks)
+
+	// The calling goroutine is the single producer. It reads sequential parts
+	// and stops on EOF, an error, or cancellation.
+	var producerErr error
+	func() {
+		defer close(tasks)
+		partNumber := 2
+		for {
+			if pctx.Err() != nil {
+				return
+			}
+			buf, rerr := readUpTo(r, uc.partSize)
+			if rerr != nil {
+				producerErr = rerr
+				cancel()
+				return
+			}
+			if len(buf) == 0 {
+				return
+			}
+			select {
+			case tasks <- uploadPart{partNumber: partNumber, body: cloudstorage.BytesBody(buf)}:
+			case <-pctx.Done():
+				return
+			}
+			partNumber++
+			if int64(len(buf)) < uc.partSize {
+				return // short read => end of stream
+			}
+		}
+	}()
+
+	etags, err := wait()
+	if producerErr != nil {
+		return producerErr
+	}
+	if err != nil {
+		return err
+	}
+	return c.files.CompleteMultipart(ctx, uc.targetPath, token, etags)
+}
+
+// parallelMultipartFromReaderAt uploads a known-size, randomly-readable source in
+// parts. Each part streams its own section of the shared io.ReaderAt on demand,
+// so the resident bytes stay bounded to the transport's per-connection write
+// buffers rather than parallelism*partSize. The caller owns the reader's
+// lifetime; it must stay readable until this returns (wait() joins all workers
+// first).
+//
+// Unlike the stream path, the first part is not uploaded synchronously: a
+// randomly-readable source lets the single-shot fallback re-read from the start,
+// so part 1 is just another worker task rather than a canary that blocks the
+// whole upload at 0%. The fallback is instead gated on no part having completed
+// (see doUploadOnePart).
+func (c *Client) parallelMultipartFromReaderAt(ctx context.Context, uc *uploadContext, token string, ra io.ReaderAt) error {
+	fileSize := uc.contentLength
+	partSize := uc.partSize
+	numParts := max(int((fileSize+partSize-1)/partSize), 1)
+
+	pctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// A bounded channel lets the minting producer (this goroutine) run about a
+	// batch ahead of the workers without holding many presigned URLs outstanding
+	// at once, and gives backpressure on the slowest leg.
+	tasks := make(chan uploadPart, uc.batchSize)
+	wait := c.startPartWorkers(pctx, cancel, uc, token, min(uc.parallelism, numParts), map[int]string{}, tasks)
+
+	// Mint presigned URLs in batches and hand each part to the workers pre-minted,
+	// so a worker goes straight to the cloud PUT instead of minting its own URL:
+	// one control-plane call per batch rather than per part, and no parallelism-wide
+	// mint burst at startup. doUploadOnePart still re-mints on its own when a URL
+	// expires or a slow attempt is re-issued.
+	var producerErr error
+	func() {
+		defer close(tasks)
+		for next := 1; next <= numParts; {
+			if pctx.Err() != nil {
+				return
+			}
+			count := min(uc.batchSize, numParts-next+1)
+			urls, err := c.files.CreatePartURLs(pctx, uc.targetPath, token, next, count)
+			if err != nil {
+				if pctx.Err() != nil {
+					return // cancelled by a worker failure; that error wins
+				}
+				if uc.completed.Load() {
+					producerErr = err
+				} else {
+					producerErr = &fallbackToFilesAPI{reason: fmt.Sprintf("failed to obtain upload URLs at part %d: %v", next, err)}
+				}
+				cancel()
+				return
+			}
+			for _, u := range urls {
+				offset := int64(u.PartNumber-1) * partSize
+				body := cloudstorage.SectionBody(ra, offset, min(partSize, fileSize-offset))
+				select {
+				case tasks <- uploadPart{partNumber: u.PartNumber, body: body, url: u.URL, headers: octetStreamHeaders(u.Headers)}:
+				case <-pctx.Done():
+					return
+				}
+			}
+			next += len(urls)
+		}
+	}()
+
+	etags, err := wait()
+	if producerErr != nil {
+		if fb, ok := errors.AsType[*fallbackToFilesAPI](producerErr); ok {
+			return fb // the fallback re-reads the source, so no buffer is needed
+		}
+		return producerErr
+	}
+	if err != nil {
+		if fb, ok := errors.AsType[*fallbackToFilesAPI](err); ok {
+			return fb // the fallback re-reads the source, so no buffer is needed
+		}
+		return err
+	}
+	return c.files.CompleteMultipart(ctx, uc.targetPath, token, etags)
+}
+
+// uploadResults collects part ETags from workers and records the first error.
+type uploadResults struct {
+	mu       sync.Mutex
+	etags    map[int]string
+	firstErr error
+}
+
+func (r *uploadResults) put(partNumber int, etag string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.etags[partNumber] = etag
+}
+
+// setErr records the first error reported by any worker; later errors are
+// dropped so the original cause survives.
+func (r *uploadResults) setErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.firstErr == nil {
+		r.firstErr = err
+	}
+}
+
+func (r *uploadResults) err() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.firstErr
+}
+
+func (r *uploadResults) snapshot() map[int]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return maps.Clone(r.etags)
+}

--- a/libs/upload/resumable.go
+++ b/libs/upload/resumable.go
@@ -1,0 +1,185 @@
+package upload
+
+// Resumable upload for GCP: the single-stream, offset-resuming protocol used
+// when the server hands back a resumable session instead of multipart. Chunk
+// transfers go through uc.cloud.Attempt (raw responses, since 308 is the normal
+// "continue" signal); the loop runs its own resume-aware retry.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"slices"
+	"strconv"
+
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/upload/cloudstorage"
+	"github.com/databricks/cli/libs/upload/files"
+	"github.com/databricks/sdk-go/core/apierr"
+)
+
+var resumableRangeRe = regexp.MustCompile(`bytes=0-(\d+)`)
+
+// performResumableUpload uploads a stream using the GCP resumable protocol,
+// aborting the session if any chunk fails.
+func (c *Client) performResumableUpload(ctx context.Context, uc *uploadContext, token string, r io.Reader, preRead []byte) error {
+	purl, err := c.files.CreateResumableURL(ctx, uc.targetPath, token)
+	if err != nil {
+		return &fallbackToFilesAPI{buffer: preRead, reason: fmt.Sprintf("failed to obtain resumable upload URL: %v", err)}
+	}
+	if err := c.resumableUploadLoop(ctx, uc, purl, r, preRead); err != nil {
+		if aerr := c.abortResumableUpload(ctx, uc, purl); aerr != nil {
+			log.Warnf(ctx, "failed to abort resumable upload: %v", aerr)
+		}
+		return err
+	}
+	return nil
+}
+
+func (c *Client) resumableUploadLoop(ctx context.Context, uc *uploadContext, purl files.PresignedURL, r io.Reader, preRead []byte) error {
+	// Buffer one part plus a read-ahead byte: a resumable chunk cannot be empty,
+	// so reading one byte past the part tells us whether this is the last chunk
+	// (which must be sent with the real total size, not "*").
+	minBuffer := uc.partSize + multipartReadAheadBytes
+	buffer := slices.Clone(preRead)
+	chunkOffset := int64(0)
+	retryCount := 0
+	noProgress := 0
+
+	for {
+		lastChunk := false
+		if need := minBuffer - int64(len(buffer)); need > 0 {
+			tmp := make([]byte, need)
+			n, rerr := io.ReadFull(r, tmp)
+			if rerr != nil && rerr != io.EOF && rerr != io.ErrUnexpectedEOF {
+				return rerr
+			}
+			buffer = append(buffer, tmp[:n]...)
+			if int64(n) < need {
+				lastChunk = true
+			}
+		}
+
+		var chunkLen int64
+		var totalSize string
+		if lastChunk {
+			chunkLen = int64(len(buffer))
+			totalSize = strconv.FormatInt(chunkOffset+chunkLen, 10)
+		} else {
+			chunkLen = uc.partSize
+			totalSize = "*"
+		}
+		// An empty stream cannot be sent as a resumable upload: a chunk must carry
+		// at least one byte, and the range would be the malformed "bytes 0--1/0".
+		// Fall back to a single-shot PUT, which creates the empty object. Only
+		// reachable at offset 0, since the read-ahead byte folds a non-empty
+		// stream's tail into the preceding chunk.
+		if chunkLen == 0 {
+			return &fallbackToFilesAPI{reason: "empty input stream"}
+		}
+		chunkLastByte := chunkOffset + chunkLen - 1
+
+		headers := octetStreamHeaders(purl.Headers)
+		headers["Content-Range"] = fmt.Sprintf("bytes %d-%d/%s", chunkOffset, chunkLastByte, totalSize)
+
+		if err := uc.limiter.Acquire(ctx); err != nil {
+			return err
+		}
+		resp, rerr := uc.cloud.Attempt(ctx, http.MethodPut, purl.URL, headers, cloudstorage.BytesBody(buffer[:chunkLen]))
+		uc.limiter.Release()
+		switch {
+		case rerr != nil:
+			// On a transient transport error, query the server for the confirmed
+			// offset and continue from there; otherwise surface the error.
+			if retryCount >= multipartMaxRetries || !cloudstorage.IsRetriable(rerr) {
+				return rerr
+			}
+			retryCount++
+			status, qerr := c.resumableStatusQuery(ctx, uc, purl)
+			if qerr != nil || status == nil {
+				return rerr
+			}
+			resp = status
+		case cloudstorage.IsRetryableStatus(resp.StatusCode):
+			if retryCount < multipartMaxRetries {
+				retryCount++
+				if status, qerr := c.resumableStatusQuery(ctx, uc, purl); qerr == nil && status != nil {
+					resp = status
+				}
+			}
+		default:
+			retryCount = 0
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated:
+			if totalSize == "*" {
+				return fmt.Errorf("resumable upload reported complete with status %d before end of stream", resp.StatusCode)
+			}
+			uc.progress.add(chunkLen)
+			return nil
+		case resp.StatusCode == http.StatusPermanentRedirect: // 308: chunk accepted, more to come
+			confirmed, ok, perr := extractRangeOffset(resp.Header.Get("Range"))
+			if perr != nil {
+				return perr
+			}
+			var nextOffset int64
+			if ok {
+				if confirmed < chunkOffset-1 || confirmed > chunkLastByte {
+					return fmt.Errorf("resumable upload confirmed offset %d outside chunk [%d, %d]", confirmed, chunkOffset, chunkLastByte)
+				}
+				nextOffset = confirmed + 1
+			} else {
+				if chunkOffset > 0 {
+					return fmt.Errorf("resumable upload returned no confirmed offset at chunk offset %d", chunkOffset)
+				}
+				nextOffset = chunkOffset
+			}
+			// A 308 confirming no new bytes (nextOffset == chunkOffset) leaves the
+			// chunk unsent, and the first switch's default arm resets retryCount, so a
+			// server stuck at a fixed offset would loop forever (fs cp sets no context
+			// deadline). Bound it with a counter that survives that reset.
+			if nextOffset == chunkOffset {
+				noProgress++
+				if noProgress > multipartMaxRetries {
+					return fmt.Errorf("resumable upload made no progress at offset %d after %d attempts", chunkOffset, noProgress)
+				}
+			} else {
+				noProgress = 0
+			}
+			buffer = buffer[nextOffset-chunkOffset:]
+			uc.progress.add(nextOffset - chunkOffset)
+			chunkOffset = nextOffset
+		case resp.StatusCode == http.StatusPreconditionFailed && (uc.overwrite == nil || !*uc.overwrite):
+			return files.ErrAlreadyExists
+		default:
+			if apiErr := apierr.FromHTTPError(resp.StatusCode, resp.Header, resp.Body); apiErr != nil {
+				return apiErr
+			}
+			return fmt.Errorf("resumable chunk upload failed with status %d", resp.StatusCode)
+		}
+	}
+}
+
+func (c *Client) resumableStatusQuery(ctx context.Context, uc *uploadContext, purl files.PresignedURL) (*cloudstorage.Response, error) {
+	return uc.cloud.Attempt(ctx, http.MethodPut, purl.URL, map[string]string{"Content-Range": "bytes */*"}, nil)
+}
+
+// extractRangeOffset parses a resumable upload "Range: bytes=0-N" response
+// header and returns N. An empty header means the server has confirmed nothing.
+func extractRangeOffset(rangeHeader string) (offset int64, ok bool, err error) {
+	if rangeHeader == "" {
+		return 0, false, nil
+	}
+	m := resumableRangeRe.FindStringSubmatch(rangeHeader)
+	if m == nil {
+		return 0, false, fmt.Errorf("cannot parse Range header %q", rangeHeader)
+	}
+	n, perr := strconv.ParseInt(m[1], 10, 64)
+	if perr != nil {
+		return 0, false, fmt.Errorf("cannot parse Range header %q: %w", rangeHeader, perr)
+	}
+	return n, true, nil
+}

--- a/libs/upload/resumable_test.go
+++ b/libs/upload/resumable_test.go
@@ -1,0 +1,21 @@
+package upload
+
+import "testing"
+
+func TestExtractRangeOffset(t *testing.T) {
+	n, ok, err := extractRangeOffset("bytes=0-99")
+	noErr(t, err)
+	if !ok || n != 99 {
+		t.Errorf("extractRangeOffset(bytes=0-99) = (%d, %v), want (99, true)", n, ok)
+	}
+
+	_, ok, err = extractRangeOffset("")
+	noErr(t, err)
+	if ok {
+		t.Error("empty header should report nothing confirmed")
+	}
+
+	if _, _, err := extractRangeOffset("garbage"); err == nil {
+		t.Error("malformed header should error")
+	}
+}

--- a/libs/upload/straggler.go
+++ b/libs/upload/straggler.go
@@ -1,0 +1,126 @@
+package upload
+
+// Straggler control for multipart part uploads. A wedged cloud connection
+// trickles bytes for minutes while its peers stay fast; it trips neither the
+// idle timeout (bytes keep moving) nor the response timeout (the response phase
+// is fine), so a single slow part gates the whole upload (CompleteMultipart
+// needs every ETag). doUploadOnePart cancels an attempt that runs far longer
+// than the recent part-duration tail and re-issues it on a fresh connection.
+//
+// The trigger keys off the recent p95, not the median: at high concurrency the
+// opening burst of connections makes many parts legitimately slow (tens of
+// seconds) even though the median stays low, so a median-relative trigger would
+// both miss the real outliers and falsely cancel healthy burst parts. A p95
+// multiple tracks that legitimate tail and fires only well above it, while still
+// adapting to a uniformly slow network (where p95 rises with everything else).
+
+import (
+	"errors"
+	"slices"
+	"sync"
+	"time"
+)
+
+// Straggler tunables. Package variables (not constants) so tests can shrink
+// them; production code never mutates them.
+var (
+	// slowAttemptFactor cancels an attempt that exceeds this multiple of the
+	// recent p95 part duration. It is the main knob: lower catches stragglers
+	// sooner but re-issues more healthy parts.
+	slowAttemptFactor = 3
+
+	// slowAttemptWarmup is the number of completed parts required before the guard
+	// switches from the cold-start deadline to the p95-relative one.
+	slowAttemptWarmup = 32
+
+	// slowAttemptWindow bounds the rolling sample set so the p95 tracks recent
+	// conditions rather than the whole upload.
+	slowAttemptWindow = 128
+
+	// slowAttemptMinDeadline floors the soft deadline so a fast network (tiny p95)
+	// cannot produce a deadline that clips normal variance.
+	slowAttemptMinDeadline = 5 * time.Second
+
+	// slowAttemptColdDeadline is the absolute soft deadline for a part in the
+	// opening wave, before slowAttemptWarmup parts have completed and the
+	// p95-relative deadline is armed. Because the deadline is re-evaluated in
+	// flight (see sendPart), this only bites in the first seconds of an upload or
+	// for a file too small to warm the guard; once warmed, an in-flight early part
+	// is caught at the tighter p95 deadline instead. It is set above the legitimate
+	// opening-burst latency (tens of seconds at high concurrency).
+	slowAttemptColdDeadline = 30 * time.Second
+
+	// slowAttemptFirstPart is the soft deadline for the synchronous first part,
+	// which runs alone before any worker (so it has no samples and, unlike the
+	// opening wave, no burst contention). A healthy first PUT is a few seconds, so
+	// a tight deadline re-issues a wedged first connection quickly without blocking
+	// the whole upload at 0% on the cold-start floor.
+	slowAttemptFirstPart = 10 * time.Second
+
+	// slowAttemptCheckInterval is how often an in-flight attempt is re-checked
+	// against the current deadline, so warmup and a falling p95 take effect while
+	// the attempt is still running.
+	slowAttemptCheckInterval = 1 * time.Second
+
+	// slowAttemptMax caps soft re-issues per part; afterward the part rides out the
+	// normal timeouts rather than being cancelled again, so it is never failed
+	// solely for staying slow.
+	slowAttemptMax = 2
+)
+
+// errSlowAttempt is the cancel cause for a part attempt that outlived its soft
+// deadline. It never escapes doUploadOnePart; it only distinguishes the guard's
+// own cancellation from the caller cancelling ctx.
+var errSlowAttempt = errors.New("part attempt exceeded soft deadline")
+
+// slowAttemptGuard tracks the duration of recently completed part attempts so an
+// attempt that far exceeds the recent tail can be cancelled and re-issued. Safe
+// for concurrent use by the upload workers.
+type slowAttemptGuard struct {
+	mu      sync.Mutex
+	samples []time.Duration
+}
+
+// record adds a completed attempt's duration to the rolling window.
+func (g *slowAttemptGuard) record(d time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.samples = append(g.samples, d)
+	if len(g.samples) > slowAttemptWindow {
+		g.samples = g.samples[len(g.samples)-slowAttemptWindow:]
+	}
+}
+
+// deadline returns the soft deadline for the next attempt: the cold-start
+// deadline until enough attempts have completed for the p95 to be meaningful,
+// then slowAttemptFactor x the recent p95 (floored at slowAttemptMinDeadline).
+// The p95 ignores the rare wedged attempts in the window (they sit above it), so
+// the deadline does not drift up toward the stragglers it is meant to catch.
+func (g *slowAttemptGuard) deadline() time.Duration {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.samples) < slowAttemptWarmup {
+		return slowAttemptColdDeadline
+	}
+	s := slices.Clone(g.samples)
+	slices.Sort(s)
+	p95 := s[min(len(s)*95/100, len(s)-1)]
+	return max(time.Duration(slowAttemptFactor)*p95, slowAttemptMinDeadline)
+}
+
+// attemptDeadline returns the current soft deadline for a part attempt. It is
+// called repeatedly while an attempt is in flight (see sendPart), so the value
+// tracks the warming-up guard. The synchronous first part gets its own tight,
+// contention-free deadline; once a part has been re-issued slowAttemptMax times
+// the guard disarms (0) so the part rides out the normal timeouts instead of
+// being cancelled again.
+func (uc *uploadContext) attemptDeadline(isFirstPart bool, slowRetries int) time.Duration {
+	switch {
+	case slowRetries >= slowAttemptMax:
+		return 0
+	case isFirstPart:
+		return slowAttemptFirstPart
+	default:
+		return uc.slowGuard.deadline()
+	}
+}

--- a/libs/upload/straggler_test.go
+++ b/libs/upload/straggler_test.go
@@ -1,0 +1,104 @@
+package upload
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/databricks/cli/libs/upload/cloudstorage"
+)
+
+func TestSlowAttemptGuardDeadline(t *testing.T) {
+	saveWarmup, saveWindow, saveFactor, saveFloor := slowAttemptWarmup, slowAttemptWindow, slowAttemptFactor, slowAttemptMinDeadline
+	t.Cleanup(func() {
+		slowAttemptWarmup, slowAttemptWindow, slowAttemptFactor, slowAttemptMinDeadline = saveWarmup, saveWindow, saveFactor, saveFloor
+	})
+	slowAttemptWarmup = 10
+	slowAttemptWindow = 200
+	slowAttemptFactor = 3
+	slowAttemptMinDeadline = 1 * time.Second
+
+	g := &slowAttemptGuard{}
+	if d := g.deadline(); d != slowAttemptColdDeadline {
+		t.Fatalf("before warmup: deadline = %v, want cold-start %v", d, slowAttemptColdDeadline)
+	}
+
+	// 90 fast parts and 10 slow ones: p95 falls in the slow tail (20s), so the
+	// deadline is 3*20s = 60s, well above the fast bulk but below a real straggler.
+	for range 90 {
+		g.record(1 * time.Second)
+	}
+	for range 10 {
+		g.record(20 * time.Second)
+	}
+	if d := g.deadline(); d != 60*time.Second {
+		t.Fatalf("deadline = %v, want 60s (3 x p95 of 20s)", d)
+	}
+
+	// A fast network (tiny p95) is floored so the deadline never clips variance.
+	g2 := &slowAttemptGuard{}
+	for range 20 {
+		g2.record(100 * time.Millisecond)
+	}
+	if d := g2.deadline(); d != slowAttemptMinDeadline {
+		t.Fatalf("floored deadline = %v, want %v", d, slowAttemptMinDeadline)
+	}
+}
+
+// TestSendPartSoftDeadlineCancels verifies a wedged attempt (the server never
+// responds) is cancelled at the soft deadline and reported as slow, promptly.
+func TestSendPartSoftDeadlineCancels(t *testing.T) {
+	saved := slowAttemptCheckInterval
+	slowAttemptCheckInterval = 5 * time.Millisecond
+	t.Cleanup(func() { slowAttemptCheckInterval = saved })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done(): // the client cancelled at the soft deadline
+		case <-time.After(3 * time.Second):
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	uc := &uploadContext{cloud: cloudstorage.New(srv.Client()), limiter: NewLimiter(0)}
+	c := &Client{}
+
+	start := time.Now()
+	_, slow, err := c.sendPart(t.Context(), uc, srv.URL, nil, cloudstorage.BytesBody([]byte("payload")),
+		func() time.Duration { return 50 * time.Millisecond })
+	elapsed := time.Since(start)
+
+	if !slow {
+		t.Fatalf("slow = false, want true (err=%v, elapsed=%v)", err, elapsed)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("sendPart returned after %v, want prompt cancel near the 50ms deadline", elapsed)
+	}
+}
+
+// TestSendPartFastNotSlow verifies a fast attempt under a generous deadline is
+// not flagged slow and returns the response.
+func TestSendPartFastNotSlow(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", "etag-1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	uc := &uploadContext{cloud: cloudstorage.New(srv.Client()), limiter: NewLimiter(0)}
+	c := &Client{}
+
+	resp, slow, err := c.sendPart(t.Context(), uc, srv.URL, nil, cloudstorage.BytesBody([]byte("payload")),
+		func() time.Duration { return 5 * time.Second })
+	if err != nil {
+		t.Fatalf("sendPart: %v", err)
+	}
+	if slow {
+		t.Fatal("slow = true, want false for a fast attempt")
+	}
+	if resp.Header.Get("ETag") != "etag-1" {
+		t.Errorf("ETag = %q, want etag-1", resp.Header.Get("ETag"))
+	}
+}

--- a/libs/upload/types.go
+++ b/libs/upload/types.go
@@ -1,0 +1,56 @@
+package upload
+
+// Shared buffering and cloud-leg header helpers. The Files API wire types and
+// the control-plane header conversion live in the files package; the
+// cloud-transport pieces (part bodies, retry classification, presigned-URL-expiry
+// detection) live in the cloudstorage package.
+
+import (
+	"io"
+	"maps"
+)
+
+// --- Buffer helpers ---
+
+// fillBuffer reads from r until buf holds at least minSize bytes or the stream
+// ends. A short read at end-of-stream is not an error.
+func fillBuffer(buf []byte, minSize int64, r io.Reader) ([]byte, error) {
+	need := minSize - int64(len(buf))
+	if need <= 0 {
+		return buf, nil
+	}
+	tmp := make([]byte, need)
+	n, err := io.ReadFull(r, tmp)
+	buf = append(buf, tmp[:n]...)
+	if err == nil || err == io.EOF || err == io.ErrUnexpectedEOF {
+		return buf, nil
+	}
+	return buf, err
+}
+
+// readUpTo reads up to n bytes from r, returning fewer only at end-of-stream.
+func readUpTo(r io.Reader, n int64) ([]byte, error) {
+	buf := make([]byte, n)
+	read, err := io.ReadFull(r, buf)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return nil, err
+	}
+	return buf[:read], nil
+}
+
+// --- Header helpers ---
+
+func mergeHeaders(base, override map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(override))
+	maps.Copy(out, base)
+	maps.Copy(out, override)
+	return out
+}
+
+// octetStreamHeaders returns the headers for a cloud-storage request: the binary
+// content type plus the presigned URL's own headers (which win on conflict). The
+// returned map is freshly allocated, so callers may add request-specific headers
+// such as Content-Range.
+func octetStreamHeaders(presigned map[string]string) map[string]string {
+	return mergeHeaders(map[string]string{"Content-Type": "application/octet-stream"}, presigned)
+}

--- a/libs/upload/upload.go
+++ b/libs/upload/upload.go
@@ -1,0 +1,669 @@
+// Package upload uploads large files to Databricks Unity Catalog Volumes,
+// choosing a single-shot, multipart (AWS/Azure), or resumable (GCP) protocol
+// based on the stream size and the protocol the workspace's Files API selects.
+//
+// It is a CLI-agnostic port of the Databricks Go SDK files/v2 ext_upload mixin.
+// The package is pure orchestration over two transports: the authenticated
+// Databricks Files API client (the files package), which handles the single-shot
+// upload and the multipart/resumable control plane, and the unauthenticated
+// cloud-storage client (the cloudstorage package), which transfers parts and chunks
+// directly to object storage. Callers pass a [*databricks.WorkspaceClient]; see
+// [NewClient].
+package upload
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/databricks/cli/libs/auth"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/upload/cloudstorage"
+	"github.com/databricks/cli/libs/upload/files"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config/credentials"
+)
+
+// Tunables that mirror the SDK defaults. They are package variables (not
+// constants) so tests can shrink them to keep boundary cases fast; production
+// code never mutates them.
+var (
+	// multipartMinStreamSize is the threshold below which a known-size upload
+	// is sent in a single PUT instead of being split into parts.
+	multipartMinStreamSize int64 = 50 * 1024 * 1024
+
+	// multipartDefaultPartSize is the part size used when no part size is
+	// requested. A fixed, modestly sized part (rather than one scaled to keep the
+	// part count low) bounds the memory a buffering upload holds (about
+	// parallelism*partSize for a non-seekable stream) and spreads stragglers
+	// across more parts. It is only grown when a file is large enough to exceed
+	// maxUploadParts.
+	multipartDefaultPartSize int64 = 16 << 20 // 16 MiB
+
+	// multipartMaxPartSize is the largest part size a cloud provider accepts.
+	multipartMaxPartSize int64 = 4 << 30
+
+	// multipartBatchURLCount is the number of presigned URLs requested per batch
+	// when the content length is unknown.
+	multipartBatchURLCount = 1
+
+	// multipartFileParallelism is the default worker count when no parallelism is
+	// requested and the source is randomly readable (a local file or other
+	// io.ReaderAt). Each part streams from a positioned read, so resident memory
+	// stays bounded to the transport's per-connection buffers regardless of the
+	// worker count (not parallelism*partSize); a high default saturates a fast
+	// uplink, and the driver caps the workers at the part count for small files.
+	multipartFileParallelism = 128
+
+	// multipartStreamMemoryBudget bounds the bytes a buffered upload (a
+	// non-seekable stream) holds in memory, where each worker keeps one partSize
+	// buffer for its in-flight part. The default stream worker count is this budget
+	// divided by the part size, so a larger part size lowers the worker count
+	// instead of growing memory. At the 16 MiB default part size this is 16 workers.
+	multipartStreamMemoryBudget int64 = 256 << 20
+
+	// multipartReadAheadBytes is how far past a chunk the resumable upload reads
+	// to detect end-of-stream (a resumable chunk cannot be empty, so the last
+	// chunk must be marked with the real total size).
+	multipartReadAheadBytes int64 = 1
+
+	// multipartMaxRetries caps how many times a single part is retried after a
+	// presigned URL expires (multipart) or a chunk must be resumed (resumable).
+	multipartMaxRetries = 3
+
+	// maxUploadParts is the provider's maximum number of parts per multipart
+	// upload (S3's 10,000 is the common floor). The default part size is grown
+	// for files large enough to otherwise exceed it.
+	maxUploadParts int64 = 10_000
+)
+
+// Cloud-transport tunables for the unauthenticated part/chunk transfers.
+var (
+	// cloudResponseHeaderTimeout bounds the response phase of a cloud transfer so
+	// a connection that accepts the upload but never replies cannot hang a
+	// goroutine forever. It is applied to the transfer client built in
+	// resolveCloudClient.
+	cloudResponseHeaderTimeout = 60 * time.Second
+
+	// cloudCleanupTimeout bounds a best-effort abort, which runs on a context
+	// detached from the upload's (see cleanupContext).
+	cloudCleanupTimeout = 30 * time.Second
+)
+
+// errUploadURLExpired is returned when a part's presigned URL keeps expiring
+// across re-mint retries. The unexpected-response and already-exists conditions
+// are owned by the files package ([files.ErrUnexpectedServerResponse],
+// [files.ErrAlreadyExists]).
+var errUploadURLExpired = errors.New("upload URL expired after retries")
+
+// fallbackToFilesAPI signals that a multipart or resumable upload failed in a
+// way that warrants retrying through a single-shot Files API PUT (for example,
+// a cloud firewall rejecting the first part). It carries the bytes already
+// buffered but not yet uploaded so they can be replayed.
+type fallbackToFilesAPI struct {
+	buffer []byte
+	reason string
+}
+
+func (e *fallbackToFilesAPI) Error() string {
+	return "falling back to single-shot upload: " + e.reason
+}
+
+// Client uploads files to Unity Catalog Volumes. It is pure orchestration: the
+// single-shot upload and the multipart/resumable control plane run through the
+// authenticated [files.Client]; the part/chunk transfers run over an
+// unauthenticated cloud client built per upload (see resolveCloudClient).
+type Client struct {
+	files *files.Client
+}
+
+// NewClient returns a Client that uploads through w's Files API.
+func NewClient(w *databricks.WorkspaceClient) (*Client, error) {
+	if w == nil {
+		return nil, errors.New("workspace client must not be nil")
+	}
+	fc, err := files.New(filesClientOptions(w))
+	if err != nil {
+		return nil, err
+	}
+	return &Client{files: fc}, nil
+}
+
+// filesClientOptions extracts the Files API client options from a workspace
+// client: the SDK Files client for single-shot uploads, the control-plane host,
+// per-request credentials (workspace routing headers plus auth), and an HTTP
+// client whose transport honors the workspace config.
+func filesClientOptions(w *databricks.WorkspaceClient) files.ClientOptions {
+	// The control-plane requests are authenticated and routed via the workspace
+	// config; the cloud part transfers are unauthenticated and never see these.
+	creds := credentials.CredentialsProviderFn(func(r *http.Request) error {
+		for k, v := range auth.WorkspaceIDHeaders(w.Config) {
+			r.Header.Set(k, v)
+		}
+		return w.Config.Authenticate(r)
+	})
+	return files.ClientOptions{
+		FilesClient:         w.Files,
+		Host:                w.Config.Host,
+		CredentialsProvider: creds,
+		HTTPClient:          controlPlaneHTTPClient(w.Config.HTTPTransport, w.Config.InsecureSkipVerify),
+	}
+}
+
+// controlPlaneHTTPClient builds the HTTP client for the Files API control plane.
+// It mirrors the SDK's transport selection (httpclient.ClientConfig.httpTransport)
+// so a custom CA, proxy, or InsecureSkipVerify configured on the workspace is
+// honored exactly as the single-shot path (w.Files) honors it. Credentials are
+// applied per request, so the client carries no auth of its own.
+func controlPlaneHTTPClient(custom http.RoundTripper, insecureSkipVerify bool) *http.Client {
+	switch {
+	case custom != nil:
+		return &http.Client{Transport: custom}
+	case insecureSkipVerify:
+		t := http.DefaultTransport.(*http.Transport).Clone()
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		return &http.Client{Transport: t}
+	default:
+		return &http.Client{Transport: http.DefaultTransport.(*http.Transport).Clone()}
+	}
+}
+
+// UploadResult holds the result of an upload. It is currently empty and exists
+// for forward compatibility.
+type UploadResult struct{}
+
+// UploadOption configures an Upload or UploadFrom call.
+type UploadOption func(*uploadConfig)
+
+type uploadConfig struct {
+	overwrite      *bool
+	partSize       int64
+	parallelism    *int
+	progress       ProgressFunc
+	transferClient *http.Client
+	limiter        Limiter
+}
+
+// Progress reports the state of an in-flight upload. Fields may be added in
+// future releases, so callers must not depend on the struct being comparable or
+// on its exact size; always refer to fields by name.
+type Progress struct {
+	// Transferred is the cumulative number of bytes confirmed uploaded so far.
+	Transferred int64
+	// Total is the total size in bytes, or -1 if it is not known in advance (a
+	// non-seekable stream).
+	Total int64
+}
+
+// ProgressFunc is invoked as an upload makes progress. It is called from
+// internal goroutines but never concurrently with itself, so it needs no
+// locking of its own; it must return promptly.
+type ProgressFunc func(Progress)
+
+// WithOverwrite controls whether an existing file is overwritten. When this
+// option is not supplied the parameter is omitted and the server applies its
+// default.
+func WithOverwrite(overwrite bool) UploadOption {
+	return func(c *uploadConfig) { c.overwrite = &overwrite }
+}
+
+// WithPartSize sets the multipart part size in bytes. It must not exceed the
+// cloud provider maximum. When not supplied an appropriate size is chosen from
+// the content length.
+//
+//deadcode:allow exported engine option with no in-tree caller yet
+func WithPartSize(partSize int64) UploadOption {
+	return func(c *uploadConfig) { c.partSize = partSize }
+}
+
+// WithParallelism sets the number of concurrent upload workers used for a large
+// file. A value of 1 uploads the parts sequentially on a single goroutine;
+// higher values upload that many parts at once. It must be at least 1. When not
+// set, a default is used.
+func WithParallelism(n int) UploadOption {
+	return func(c *uploadConfig) { c.parallelism = &n }
+}
+
+// WithProgress registers a callback invoked as the upload progresses, reporting
+// the cumulative bytes uploaded and the total size (-1 if unknown). It is useful
+// for rendering an upload progress bar.
+//
+//deadcode:allow exported engine option with no in-tree caller yet
+func WithProgress(fn ProgressFunc) UploadOption {
+	return func(c *uploadConfig) { c.progress = fn }
+}
+
+// WithTransferClient overrides the HTTP client used to transfer file contents
+// during a large-file upload, replacing the one the call would otherwise create
+// internally. Use it to route the transfer through a custom transport, proxy, or
+// CA.
+//
+// Because these transfers use self-authenticating presigned URLs, the client must
+// not attach Databricks credentials; the storage provider rejects extra
+// authentication. Do not set http.Client.Timeout, a whole-request deadline that
+// would abort a legitimately long part transfer; bound the upload with the context
+// passed to Upload instead.
+func WithTransferClient(client *http.Client) UploadOption {
+	return func(c *uploadConfig) { c.transferClient = client }
+}
+
+func resolveUploadConfig(opts []UploadOption) (*uploadConfig, error) {
+	cfg := &uploadConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.parallelism != nil && *cfg.parallelism < 1 {
+		return nil, fmt.Errorf("parallelism must be at least 1, got %d", *cfg.parallelism)
+	}
+	if cfg.partSize < 0 {
+		return nil, fmt.Errorf("part size must be non-negative, got %d", cfg.partSize)
+	}
+	if cfg.partSize > multipartMaxPartSize {
+		return nil, fmt.Errorf("part size %d exceeds maximum %d", cfg.partSize, multipartMaxPartSize)
+	}
+	return cfg, nil
+}
+
+// resolvedParallelism returns the worker count: the caller's explicit value when
+// set, otherwise a default that depends on whether the source is buffered. A
+// randomly-readable source streams parts from positioned reads and uses a high,
+// bandwidth-oriented default; a buffered (non-seekable) source holds
+// parallelism*partSize in memory, so its default is sized to a memory budget,
+// capped at the file default so a tiny part size cannot translate the budget into
+// an unbounded number of goroutines and sockets.
+func (cfg *uploadConfig) resolvedParallelism(buffered bool, partSize int64) int {
+	if cfg.parallelism != nil {
+		return *cfg.parallelism
+	}
+	if !buffered {
+		return multipartFileParallelism
+	}
+	workers := int(multipartStreamMemoryBudget / partSize)
+	return min(max(workers, 1), multipartFileParallelism)
+}
+
+// NewTransferClient returns an HTTP client suitable for WithTransferClient, sized
+// for n concurrent transfers: it keeps up to n idle connections to the storage
+// host so they are reused rather than re-dialed (Go's default of 2 per host would
+// otherwise force re-dialing). Share one across uploads that also share a Limiter
+// so their connection pool is shared and reused. It attaches no Databricks
+// credentials (presigned URLs are self-authenticating) and sets no whole-request
+// timeout, which would abort a legitimately long transfer; bound the upload with
+// the context instead.
+func NewTransferClient(n int) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = cloudResponseHeaderTimeout
+	transport.MaxIdleConnsPerHost = n
+	transport.MaxIdleConns = max(transport.MaxIdleConns, n)
+	return &http.Client{Transport: transport}
+}
+
+// resolveCloudClient returns the caller-supplied transfer client when set, and
+// otherwise a fresh one sized to the upload parallelism.
+func (cfg *uploadConfig) resolveCloudClient(parallelism int) *http.Client {
+	if cfg.transferClient != nil {
+		return cfg.transferClient
+	}
+	return NewTransferClient(parallelism)
+}
+
+// uploadContext is the resolved per-upload state. Its fields are set once at
+// construction; the slowGuard and completed flag hold the only mutable state,
+// both safe for concurrent use by the upload workers.
+type uploadContext struct {
+	targetPath    string
+	overwrite     *bool
+	partSize      int64
+	batchSize     int
+	contentLength int64 // -1 when unknown (non-seekable stream)
+	sourcePath    string
+	parallel      bool
+	parallelism   int
+	cloud         *cloudstorage.Client
+	progress      *progressReporter
+	slowGuard     *slowAttemptGuard
+	limiter       Limiter // bounds concurrent transfers; never nil (unlimited by default)
+
+	// completed records whether any part has finished uploading. The single-shot
+	// fallback is taken only while no part has landed; once a part succeeds, a
+	// later cloud rejection is a real error rather than a blanket-block signal.
+	completed atomic.Bool
+}
+
+// newUploadContext resolves the per-upload state shared by Upload and UploadFrom.
+// contentLength is -1 for a non-seekable stream; sourcePath is "" unless the
+// source is a local file (UploadFrom). buffered reports whether the upload path
+// holds parts in memory (a non-seekable stream) rather than streaming them from
+// positioned reads, which sets the default worker count.
+func newUploadContext(cfg *uploadConfig, targetPath, sourcePath string, contentLength int64, buffered bool) *uploadContext {
+	partSize, batchSize := optimizeParams(contentLength, cfg.partSize)
+	parallelism := cfg.resolvedParallelism(buffered, partSize)
+	limiter := cfg.limiter
+	if limiter == nil {
+		limiter = unlimitedLimiter{}
+	}
+	return &uploadContext{
+		targetPath:    targetPath,
+		overwrite:     cfg.overwrite,
+		partSize:      partSize,
+		batchSize:     batchSize,
+		contentLength: contentLength,
+		sourcePath:    sourcePath,
+		parallel:      parallelism > 1,
+		parallelism:   parallelism,
+		cloud:         cloudstorage.New(cfg.resolveCloudClient(parallelism)),
+		progress:      newProgressReporter(cfg.progress, contentLength),
+		slowGuard:     &slowAttemptGuard{},
+		limiter:       limiter,
+	}
+}
+
+// progressReporter accumulates confirmed-uploaded bytes and forwards the running
+// total to a ProgressFunc. Its methods are safe for concurrent use (parallel
+// uploads report from many goroutines) and serialize callbacks so the
+// ProgressFunc never runs concurrently with itself.
+type progressReporter struct {
+	fn    ProgressFunc
+	total int64
+
+	mu          sync.Mutex
+	transferred int64
+}
+
+// newProgressReporter returns nil when fn is nil so that reporter calls are
+// no-ops without the callers having to check.
+func newProgressReporter(fn ProgressFunc, total int64) *progressReporter {
+	if fn == nil {
+		return nil
+	}
+	return &progressReporter{fn: fn, total: total}
+}
+
+// add records n newly uploaded bytes and reports the new cumulative total. It is
+// a no-op on a nil reporter, so callers need not check.
+func (p *progressReporter) add(n int64) {
+	if p == nil || n <= 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.transferred += n
+	p.fn(Progress{Transferred: p.transferred, Total: p.total})
+}
+
+// progressReader reports bytes as they are read. It tracks single-shot uploads,
+// where the whole body streams through one request rather than discrete parts.
+type progressReader struct {
+	r io.Reader
+	p *progressReporter
+}
+
+func (pr *progressReader) Read(b []byte) (int, error) {
+	n, err := pr.r.Read(b)
+	pr.p.add(int64(n))
+	return n, err
+}
+
+// Upload uploads contents to the remote file at filePath, which must be an
+// absolute path such as "/Volumes/catalog/schema/volume/file". It chooses a
+// single-shot, multipart, or resumable upload based on the stream size (when
+// the reader is seekable) and the protocol the workspace's Files API selects.
+//
+// When contents implements io.ReaderAt (for example an *os.File or a
+// *bytes.Reader), parts are read from it with concurrent positioned reads rather
+// than buffered in memory. A reader without random access has each in-flight part
+// buffered as it is read.
+//
+// ctx bounds the entire operation, including all retries; pass a context with a
+// deadline to cap the total upload time.
+func (c *Client) Upload(ctx context.Context, filePath string, contents io.Reader, opts ...UploadOption) (*UploadResult, error) {
+	cfg, err := resolveUploadConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// A seekable reader lets us learn the size up front; otherwise it is unknown.
+	// Seeking to the end moves the reader, so a failed rewind afterward is
+	// unrecoverable: the reader is left at EOF and a later read would send zero
+	// bytes. Fail loud in that case rather than silently truncating the object.
+	contentLength := int64(-1)
+	if seeker, ok := contents.(io.Seeker); ok {
+		if end, serr := seeker.Seek(0, io.SeekEnd); serr == nil {
+			if _, serr := seeker.Seek(0, io.SeekStart); serr != nil {
+				return nil, fmt.Errorf("cannot rewind reader after sizing: %w", serr)
+			}
+			contentLength = end
+		}
+	}
+
+	// A randomly-readable source large enough for the parallel path streams its
+	// parts from positioned reads; any other source buffers each in-flight part.
+	_, isReaderAt := contents.(io.ReaderAt)
+	buffered := !isReaderAt || contentLength < multipartMinStreamSize
+	uc := newUploadContext(cfg, filePath, "", contentLength, buffered)
+
+	switch {
+	case uc.parallel && contentLength < 0:
+		// Non-seekable stream of unknown size: parts are buffered as they are read.
+		return &UploadResult{}, c.parallelUploadFromStream(ctx, uc, contents)
+	case uc.parallel && contentLength >= multipartMinStreamSize:
+		// Known-size large upload. A reader supporting concurrent positioned reads
+		// (io.ReaderAt) is streamed in sections without buffering; anything else
+		// buffers parts.
+		if ra, ok := contents.(io.ReaderAt); ok {
+			return &UploadResult{}, c.parallelUploadFromReaderAt(ctx, uc, ra)
+		}
+		return &UploadResult{}, c.parallelUploadFromStream(ctx, uc, contents)
+	case contentLength >= 0:
+		return &UploadResult{}, c.uploadSingleThreadKnownSize(ctx, uc, contents)
+	default:
+		return &UploadResult{}, c.singleThreadMultipart(ctx, uc, contents)
+	}
+}
+
+// UploadFrom uploads the local file at sourcePath to the remote file at
+// filePath. The local file is opened as needed; its size is always known, so it
+// never takes the non-seekable path.
+//
+// Parts are read from the file on demand rather than buffered, so the upload
+// covers the file as of its size when the call begins: bytes appended afterward
+// are not included, and truncating the file mid-upload fails the upload (it does
+// not produce a partial object). Do not modify the file while an upload is in
+// progress.
+//
+// ctx bounds the entire operation, including all retries; pass a context with a
+// deadline to cap the total upload time.
+func (c *Client) UploadFrom(ctx context.Context, filePath, sourcePath string, opts ...UploadOption) (*UploadResult, error) {
+	cfg, err := resolveUploadConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+
+	// A local file is randomly readable, so the parallel path streams parts from
+	// positioned reads and never buffers them: buffered is false.
+	uc := newUploadContext(cfg, filePath, sourcePath, size, false)
+
+	if uc.parallel && size >= multipartMinStreamSize {
+		return &UploadResult{}, c.parallelUploadFromFile(ctx, uc)
+	}
+	f, err := os.Open(sourcePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return &UploadResult{}, c.uploadSingleThreadKnownSize(ctx, uc, f)
+}
+
+// optimizeParams picks a part size and a presigned-URL batch size. contentLength
+// is -1 when unknown; override is 0 when no part size was requested. The override
+// is already range-checked in resolveUploadConfig.
+func optimizeParams(contentLength, override int64) (partSize int64, batchSize int) {
+	switch {
+	case override > 0:
+		partSize = override
+	default:
+		partSize = multipartDefaultPartSize
+		// Grow the part size only if the fixed default would exceed the
+		// provider's maximum part count for this (known) content length.
+		if contentLength >= 0 {
+			if minPart := (contentLength + maxUploadParts - 1) / maxUploadParts; minPart > partSize {
+				partSize = min(minPart, multipartMaxPartSize)
+			}
+		}
+	}
+
+	batchSize = multipartBatchURLCount
+	if contentLength >= 0 && partSize > 0 {
+		numParts := (contentLength + partSize - 1) / partSize
+		// The square root of the part count is a heuristic that balances the
+		// number of URL-minting round trips against batch size.
+		batchSize = max(int(math.Ceil(math.Sqrt(float64(numParts)))), 1)
+	}
+	return partSize, batchSize
+}
+
+func (c *Client) uploadSingleThreadKnownSize(ctx context.Context, uc *uploadContext, r io.Reader) error {
+	if uc.contentLength < multipartMinStreamSize {
+		return c.singleShotUpload(ctx, uc, r)
+	}
+	return c.singleThreadMultipart(ctx, uc, r)
+}
+
+// singleThreadMultipart pre-reads up to the single-shot threshold to handle
+// small (or non-seekable but actually small) streams without a multipart
+// round trip, then initiates the upload.
+func (c *Client) singleThreadMultipart(ctx context.Context, uc *uploadContext, r io.Reader) error {
+	preRead, err := readUpTo(r, multipartMinStreamSize)
+	if err != nil {
+		return err
+	}
+	if int64(len(preRead)) < multipartMinStreamSize {
+		return c.singleShotUpload(ctx, uc, bytes.NewReader(preRead))
+	}
+	return c.initiateAndUpload(ctx, uc, false,
+		func(token string) error { return c.performMultipartUpload(ctx, uc, token, r, preRead) },
+		func(token string) error { return c.performResumableUpload(ctx, uc, token, r, preRead) },
+		func(buffered []byte) error {
+			return c.singleShotUpload(ctx, uc, io.MultiReader(bytes.NewReader(buffered), r))
+		},
+	)
+}
+
+func (c *Client) parallelUploadFromStream(ctx context.Context, uc *uploadContext, r io.Reader) error {
+	return c.initiateAndUpload(ctx, uc, true,
+		func(token string) error { return c.parallelMultipartFromStream(ctx, uc, token, r) },
+		func(token string) error { return c.performResumableUpload(ctx, uc, token, r, nil) },
+		func(buffered []byte) error {
+			return c.singleShotUpload(ctx, uc, io.MultiReader(bytes.NewReader(buffered), r))
+		},
+	)
+}
+
+func (c *Client) parallelUploadFromFile(ctx context.Context, uc *uploadContext) error {
+	// Each branch opens its own handle: only one runs per upload, and the multipart
+	// driver keeps its handle open until all its workers finish (wait()).
+	withFile := func(use func(*os.File) error) error {
+		f, err := os.Open(uc.sourcePath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return use(f)
+	}
+	return c.initiateAndUpload(ctx, uc, true,
+		func(token string) error {
+			return withFile(func(f *os.File) error { return c.parallelMultipartFromReaderAt(ctx, uc, token, f) })
+		},
+		func(token string) error {
+			return withFile(func(f *os.File) error { return c.performResumableUpload(ctx, uc, token, f, nil) })
+		},
+		func(buffered []byte) error {
+			return withFile(func(f *os.File) error { return c.singleShotUpload(ctx, uc, f) })
+		},
+	)
+}
+
+// parallelUploadFromReaderAt uploads a known-size, randomly-readable source
+// (an *os.File or *bytes.Reader passed to Upload) by streaming sections of it
+// concurrently, without buffering whole parts. The resumable and fallback paths
+// re-read it through fresh section readers.
+func (c *Client) parallelUploadFromReaderAt(ctx context.Context, uc *uploadContext, ra io.ReaderAt) error {
+	return c.initiateAndUpload(ctx, uc, true,
+		func(token string) error { return c.parallelMultipartFromReaderAt(ctx, uc, token, ra) },
+		func(token string) error {
+			return c.performResumableUpload(ctx, uc, token, io.NewSectionReader(ra, 0, uc.contentLength), nil)
+		},
+		func(buffered []byte) error {
+			return c.singleShotUpload(ctx, uc, io.NewSectionReader(ra, 0, uc.contentLength))
+		},
+	)
+}
+
+// initiateAndUpload initiates the server-coordinated upload, dispatches to the
+// multipart or resumable path the server selected (multipart on AWS/Azure,
+// resumable on GCP), and applies the shared abort-and-fallback handling.
+func (c *Client) initiateAndUpload(
+	ctx context.Context,
+	uc *uploadContext,
+	parallel bool,
+	performMultipart func(token string) error,
+	performResumable func(token string) error,
+	fallbackSingleShot func(buffered []byte) error,
+) error {
+	resp, err := c.files.Initiate(ctx, uc.targetPath, uc.overwrite)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case resp.MultipartUpload != nil:
+		token := resp.MultipartUpload.SessionToken
+		if token == "" {
+			return fmt.Errorf("%w: missing multipart session token", files.ErrUnexpectedServerResponse)
+		}
+		uerr := performMultipart(token)
+		if uerr == nil {
+			return nil
+		}
+		// Abort is best-effort in both the fallback and the hard-error case.
+		c.abortMultipartBestEffort(ctx, uc, token)
+		if fb, ok := errors.AsType[*fallbackToFilesAPI](uerr); ok {
+			log.Infof(ctx, "using single-shot fallback: %s", fb.reason)
+			return fallbackSingleShot(fb.buffer)
+		}
+		return uerr
+
+	case resp.ResumableUpload != nil:
+		token := resp.ResumableUpload.SessionToken
+		if token == "" {
+			return fmt.Errorf("%w: missing resumable session token", files.ErrUnexpectedServerResponse)
+		}
+		if parallel {
+			log.Warnf(ctx, "GCP does not support parallel resumable uploads; using single-threaded upload")
+		}
+		// The resumable path aborts itself on error, so no abort here.
+		uerr := performResumable(token)
+		if fb, ok := errors.AsType[*fallbackToFilesAPI](uerr); ok {
+			log.Infof(ctx, "using single-shot fallback: %s", fb.reason)
+			return fallbackSingleShot(fb.buffer)
+		}
+		return uerr
+
+	default:
+		return fmt.Errorf("%w: neither multipart nor resumable upload offered", files.ErrUnexpectedServerResponse)
+	}
+}

--- a/libs/upload/upload_test.go
+++ b/libs/upload/upload_test.go
@@ -1,0 +1,697 @@
+package upload
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/databricks/cli/libs/upload/files"
+	"github.com/databricks/databricks-sdk-go"
+)
+
+// Wire types the fake server speaks. They mirror the Files API JSON contract;
+// the production copies are unexported in the files package, so the test owns
+// its own copy of the shapes it fabricates and decodes.
+type nameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type createPartURLsRequest struct {
+	StartPartNumber int `json:"start_part_number"`
+	Count           int `json:"count"`
+}
+
+type createPartURLsResponse struct {
+	UploadPartURLs []struct {
+		URL        string      `json:"url"`
+		PartNumber int         `json:"part_number"`
+		Headers    []nameValue `json:"headers"`
+	} `json:"upload_part_urls"`
+}
+
+type urlWithHeaders struct {
+	URL     string      `json:"url"`
+	Headers []nameValue `json:"headers"`
+}
+
+type resumableURLResponse struct {
+	ResumableUploadURL *urlWithHeaders `json:"resumable_upload_url"`
+}
+
+type abortURLResponse struct {
+	AbortUploadURL *urlWithHeaders `json:"abort_upload_url"`
+}
+
+type uploadSession struct {
+	SessionToken string `json:"session_token"`
+}
+
+type initiateResponse struct {
+	MultipartUpload *uploadSession `json:"multipart_upload"`
+	ResumableUpload *uploadSession `json:"resumable_upload"`
+}
+
+type completePart struct {
+	PartNumber int    `json:"part_number"`
+	ETag       string `json:"etag"`
+}
+
+type completeRequest struct {
+	Parts []completePart `json:"parts"`
+}
+
+// fakeServer emulates both the Files API control plane and the cloud storage
+// provider: the presigned URLs it mints point back at itself, so a single
+// httptest server backs the whole upload. It reassembles the uploaded object so
+// tests can assert byte-for-byte equality with the input.
+type fakeServer struct {
+	srv *httptest.Server
+
+	mu          sync.Mutex
+	mode        string // "multipart" or "resumable"
+	parts       map[int][]byte
+	completed   []completePart
+	singleBody  []byte
+	resumable   []byte
+	overwriteQ  []string      // overwrite query values seen on initiate + single-shot
+	partHeaders []http.Header // headers seen on cloud part PUTs
+	partURLReqs []int         // Count of each create-upload-part-urls request
+
+	// partHook injects faults. It returns (statusCode, etag, body); a zero
+	// statusCode means "use the default 200 + store".
+	partHook func(n, attempt int) (int, string, []byte)
+	partTry  map[int]int
+
+	// singleShotStatus, when non-zero, is returned by the single-shot PUT.
+	singleShotStatus int
+	singleShotBody   string
+
+	// stuckResumable makes a resumable chunk PUT confirm no new bytes, modeling a
+	// server/proxy wedged at a fixed offset.
+	stuckResumable bool
+}
+
+func newFakeServer(t *testing.T, mode string) *fakeServer {
+	f := &fakeServer{
+		mode:    mode,
+		parts:   map[int][]byte{},
+		partTry: map[int]int{},
+	}
+	f.srv = httptest.NewServer(f)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeServer) base() string { return f.srv.URL }
+
+func (f *fakeServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	switch {
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/create-upload-part-urls"):
+		f.handleCreatePartURLs(w, r)
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/create-resumable-upload-url"):
+		writeJSON(w, resumableURLResponse{ResumableUploadURL: &urlWithHeaders{URL: f.base() + "/cloud/resumable"}})
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/create-abort-upload-url"):
+		writeJSON(w, abortURLResponse{AbortUploadURL: &urlWithHeaders{URL: f.base() + "/cloud/abort"}})
+	case r.Method == http.MethodPut && strings.HasPrefix(path, "/cloud/part/"):
+		f.handlePartPut(w, r)
+	case r.Method == http.MethodPut && path == "/cloud/resumable":
+		f.handleResumablePut(w, r)
+	case r.Method == http.MethodDelete && (path == "/cloud/abort" || path == "/cloud/resumable"):
+		w.WriteHeader(http.StatusOK)
+	case strings.Contains(path, "/api/2.0/fs/files/"):
+		f.handleFiles(w, r)
+	default:
+		http.Error(w, "unexpected request: "+r.Method+" "+path, http.StatusInternalServerError)
+	}
+}
+
+func (f *fakeServer) handleFiles(w http.ResponseWriter, r *http.Request) {
+	action := r.URL.Query().Get("action")
+	switch {
+	case r.Method == http.MethodPost && action == "initiate-upload":
+		f.mu.Lock()
+		f.overwriteQ = append(f.overwriteQ, r.URL.Query().Get("overwrite"))
+		f.mu.Unlock()
+		if f.mode == "resumable" {
+			writeJSON(w, initiateResponse{ResumableUpload: &uploadSession{SessionToken: "tok"}})
+		} else {
+			writeJSON(w, initiateResponse{MultipartUpload: &uploadSession{SessionToken: "tok"}})
+		}
+	case r.Method == http.MethodPost && action == "complete-upload":
+		var req completeRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		f.mu.Lock()
+		f.completed = req.Parts
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	case r.Method == http.MethodPut: // single-shot
+		body, _ := io.ReadAll(r.Body)
+		f.mu.Lock()
+		f.singleBody = body
+		f.overwriteQ = append(f.overwriteQ, r.URL.Query().Get("overwrite"))
+		status, respBody := f.singleShotStatus, f.singleShotBody
+		f.mu.Unlock()
+		if status != 0 {
+			w.WriteHeader(status)
+			_, _ = io.WriteString(w, respBody)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	default:
+		http.Error(w, "unexpected files request", http.StatusInternalServerError)
+	}
+}
+
+func (f *fakeServer) handleCreatePartURLs(w http.ResponseWriter, r *http.Request) {
+	var req createPartURLsRequest
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	f.mu.Lock()
+	f.partURLReqs = append(f.partURLReqs, req.Count)
+	f.mu.Unlock()
+	var out createPartURLsResponse
+	for i := range req.Count {
+		n := req.StartPartNumber + i
+		out.UploadPartURLs = append(out.UploadPartURLs, struct {
+			URL        string      `json:"url"`
+			PartNumber int         `json:"part_number"`
+			Headers    []nameValue `json:"headers"`
+		}{URL: f.base() + "/cloud/part/" + strconv.Itoa(n), PartNumber: n})
+	}
+	writeJSON(w, out)
+}
+
+func (f *fakeServer) handlePartPut(w http.ResponseWriter, r *http.Request) {
+	n, _ := strconv.Atoi(strings.TrimPrefix(r.URL.Path, "/cloud/part/"))
+	body, _ := io.ReadAll(r.Body)
+
+	f.mu.Lock()
+	f.partHeaders = append(f.partHeaders, r.Header.Clone())
+	f.partTry[n]++
+	attempt := f.partTry[n]
+	hook := f.partHook
+	f.mu.Unlock()
+
+	if hook != nil {
+		if status, etag, respBody := hook(n, attempt); status != 0 {
+			if etag != "" {
+				w.Header().Set("ETag", etag)
+			}
+			w.WriteHeader(status)
+			_, _ = w.Write(respBody)
+			return
+		}
+	}
+
+	f.mu.Lock()
+	f.parts[n] = body
+	f.mu.Unlock()
+	w.Header().Set("ETag", fmt.Sprintf("etag-%d", n))
+	w.WriteHeader(http.StatusOK)
+}
+
+func (f *fakeServer) handleResumablePut(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	cr := r.Header.Get("Content-Range")
+	// Status query: "bytes */*" -> report current confirmed offset.
+	if cr == "bytes */*" {
+		f.mu.Lock()
+		n := len(f.resumable)
+		f.mu.Unlock()
+		if n == 0 {
+			w.WriteHeader(http.StatusPermanentRedirect)
+			return
+		}
+		w.Header().Set("Range", fmt.Sprintf("bytes=0-%d", n-1))
+		w.WriteHeader(http.StatusPermanentRedirect)
+		return
+	}
+
+	// A wedged server: accept a non-final chunk but confirm no new bytes (no Range
+	// header), so the client sees a zero-progress 308 and must bound its retries.
+	if f.stuckResumable && strings.HasSuffix(cr, "/*") {
+		w.WriteHeader(http.StatusPermanentRedirect)
+		return
+	}
+
+	f.mu.Lock()
+	f.resumable = append(f.resumable, body...)
+	total := len(f.resumable)
+	f.mu.Unlock()
+
+	// Content-Range: bytes {start}-{end}/{total|*}
+	final := !strings.HasSuffix(cr, "/*")
+	if final {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.Header().Set("Range", fmt.Sprintf("bytes=0-%d", total-1))
+	w.WriteHeader(http.StatusPermanentRedirect)
+}
+
+// assembled returns the bytes the server reconstructed for the upload.
+func (f *fakeServer) assembled() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.singleBody != nil {
+		return f.singleBody
+	}
+	if f.mode == "resumable" {
+		return f.resumable
+	}
+	var out []byte
+	for _, p := range f.completed {
+		out = append(out, f.parts[p.PartNumber]...)
+	}
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newTestClient(t *testing.T, f *fakeServer) *Client {
+	t.Helper()
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:     f.base(),
+		Token:    "dummy-token",
+		AuthType: "pat",
+	})
+	noErr(t, err)
+	c, err := NewClient(w)
+	noErr(t, err)
+	return c
+}
+
+func TestControlPlaneHTTPClient(t *testing.T) {
+	// A configured transport is used as-is, so the control plane honors a custom
+	// CA/proxy exactly as the single-shot SDK path does, and wins over
+	// InsecureSkipVerify (matching the SDK's selection order).
+	custom := http.DefaultTransport.(*http.Transport).Clone()
+	if c := controlPlaneHTTPClient(custom, false); c.Transport != custom {
+		t.Error("a configured transport should be used as-is")
+	}
+	if c := controlPlaneHTTPClient(custom, true); c.Transport != custom {
+		t.Error("a configured transport should win over InsecureSkipVerify")
+	}
+
+	// InsecureSkipVerify alone yields a transport that skips TLS verification.
+	insecure, ok := controlPlaneHTTPClient(nil, true).Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("InsecureSkipVerify should produce an *http.Transport")
+	}
+	if insecure.TLSClientConfig == nil || !insecure.TLSClientConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should set TLSClientConfig.InsecureSkipVerify")
+	}
+
+	// The plain default is a non-nil transport that verifies TLS.
+	def, ok := controlPlaneHTTPClient(nil, false).Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("the default should produce an *http.Transport")
+	}
+	if def.TLSClientConfig != nil && def.TLSClientConfig.InsecureSkipVerify {
+		t.Error("the default transport must verify TLS")
+	}
+}
+
+func TestFilesClientOptions(t *testing.T) {
+	// A reachable host so workspace-client construction's metadata probe does not
+	// stall; the response body is unused here.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "{}")
+	}))
+	t.Cleanup(srv.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        srv.URL,
+		Token:       "dummy-token",
+		AuthType:    "pat",
+		WorkspaceID: "1234",
+	})
+	noErr(t, err)
+
+	opts := filesClientOptions(w)
+	if opts.Host != srv.URL {
+		t.Errorf("Host = %q, want %q", opts.Host, srv.URL)
+	}
+	if opts.FilesClient == nil {
+		t.Error("FilesClient must be set")
+	}
+	if opts.HTTPClient == nil {
+		t.Error("HTTPClient must be set")
+	}
+
+	// The credentials provider carries the workspace routing header and the auth
+	// derived from the workspace config, which every control-plane request relies on.
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL+"/api/2.0/fs/files/x", nil)
+	noErr(t, err)
+	noErr(t, opts.CredentialsProvider.SetHeaders(req))
+	if got := req.Header.Get("X-Databricks-Workspace-Id"); got != "1234" {
+		t.Errorf("X-Databricks-Workspace-Id = %q, want 1234", got)
+	}
+	if req.Header.Get("Authorization") == "" {
+		t.Error("Authorization header was not set")
+	}
+}
+
+// failingSeeker reports a size (Seek to the end succeeds) but cannot rewind
+// (Seek to the start fails), modeling the unrecoverable probe case.
+type failingSeeker struct{ io.ReadSeeker }
+
+func (f failingSeeker) Seek(offset int64, whence int) (int64, error) {
+	if whence == io.SeekStart {
+		return 0, errors.New("seek start failed")
+	}
+	return f.ReadSeeker.Seek(offset, whence)
+}
+
+func TestUploadRewindFailureIsLoud(t *testing.T) {
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+	// A reader the engine can size but not rewind must fail the upload rather
+	// than send a truncated object from the EOF position.
+	r := failingSeeker{bytes.NewReader(make([]byte, 1024))}
+	if _, err := c.Upload(t.Context(), "/Volumes/c/s/v/f.bin", r); err == nil {
+		t.Fatal("expected an error when the reader cannot be rewound after sizing")
+	}
+}
+
+// shrinkTunables makes the size thresholds tiny so multipart boundaries are hit
+// with small inputs, and restores them after the test.
+func shrinkTunables(t *testing.T, partSize int64) {
+	t.Helper()
+	origMin, origPart := multipartMinStreamSize, multipartDefaultPartSize
+	multipartMinStreamSize = partSize
+	multipartDefaultPartSize = partSize
+	t.Cleanup(func() {
+		multipartMinStreamSize = origMin
+		multipartDefaultPartSize = origPart
+	})
+}
+
+// --- assertion helpers (standard library testing; no third-party framework) ---
+
+func noErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func eqBytes(t *testing.T, got, want []byte) {
+	t.Helper()
+	if !bytes.Equal(got, want) {
+		t.Errorf("uploaded bytes differ: got %d bytes, want %d bytes", len(got), len(want))
+	}
+}
+
+func data(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+func writeTemp(t *testing.T, b []byte) string {
+	t.Helper()
+	p := t.TempDir() + "/src.bin"
+	noErr(t, os.WriteFile(p, b, 0o600))
+	return p
+}
+
+func TestUploadSingleShot(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	in := data(500) // below the 1024 single-shot threshold
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/small.bin", bytes.NewReader(in))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+}
+
+func TestUploadMultipartParallelMatchesSequential(t *testing.T) {
+	in := data(20 * 1024)
+
+	run := func(parallelism int) []byte {
+		shrinkTunables(t, 1024)
+		f := newFakeServer(t, "multipart")
+		c := newTestClient(t, f)
+		_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/big.bin", writeTemp(t, in),
+			WithParallelism(parallelism))
+		noErr(t, err)
+		// Parts must be completed in sorted order with non-empty ETags.
+		if len(f.completed) == 0 {
+			t.Fatal("expected completed parts")
+		}
+		for i, p := range f.completed {
+			if p.PartNumber != i+1 {
+				t.Errorf("part %d: got part number %d, want %d", i, p.PartNumber, i+1)
+			}
+			if p.ETag == "" {
+				t.Errorf("part %d: empty ETag", p.PartNumber)
+			}
+		}
+		return f.assembled()
+	}
+
+	eqBytes(t, run(1), in)
+	eqBytes(t, run(8), in)
+}
+
+func TestUploadFromReaderAtKnownSize(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	in := data(5000)
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/r.bin", bytes.NewReader(in), WithParallelism(4))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+}
+
+func TestUploadNonSeekableStream(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	in := data(5000)
+	// io.Reader wrapper that is neither Seeker nor ReaderAt.
+	r := io.MultiReader(bytes.NewReader(in))
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/stream.bin", r, WithParallelism(4))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+}
+
+func TestCloudPartsCarryNoDatabricksCredentials(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/big.bin", writeTemp(t, data(5000)), WithParallelism(4))
+	noErr(t, err)
+
+	if len(f.partHeaders) == 0 {
+		t.Fatal("expected cloud part requests")
+	}
+	for _, h := range f.partHeaders {
+		if got := h.Get("Authorization"); got != "" {
+			t.Errorf("cloud part PUT must not carry Databricks auth, got Authorization=%q", got)
+		}
+		if got := h.Get("X-Databricks-Workspace-Id"); got != "" {
+			t.Errorf("cloud part PUT must not carry workspace routing, got X-Databricks-Workspace-Id=%q", got)
+		}
+	}
+}
+
+func TestUploadOverwrite(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []UploadOption
+		want string
+	}{
+		{"unset", nil, ""},
+		{"true", []UploadOption{WithOverwrite(true)}, "true"},
+		{"false", []UploadOption{WithOverwrite(false)}, "false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			shrinkTunables(t, 1024)
+			f := newFakeServer(t, "multipart")
+			c := newTestClient(t, f)
+			_, err := c.Upload(t.Context(), "/Volumes/c/s/v/x.bin", bytes.NewReader(data(100)), tc.opts...)
+			noErr(t, err)
+			if len(f.overwriteQ) == 0 {
+				t.Fatal("expected an overwrite query value")
+			}
+			if f.overwriteQ[0] != tc.want {
+				t.Errorf("overwrite query = %q, want %q", f.overwriteQ[0], tc.want)
+			}
+		})
+	}
+}
+
+func TestFileUploadMintsURLsInBatches(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	in := data(16 * 1024) // 16 parts at the 1024 part size
+	_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/batch.bin", writeTemp(t, in), WithParallelism(8))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+
+	// The file path pre-mints in batches, so at least one create-upload-part-urls
+	// call requests more than one URL; per-part minting would never exceed 1.
+	maxCount := 0
+	for _, cnt := range f.partURLReqs {
+		maxCount = max(maxCount, cnt)
+	}
+	if maxCount <= 1 {
+		t.Errorf("expected batched URL minting (a request with count > 1), got max count %d across %d calls", maxCount, len(f.partURLReqs))
+	}
+}
+
+func TestCloudRejectsAllPartsFallsBackToSingleShot(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	// A cloud firewall forbids every part PUT on every attempt (a blanket block of
+	// the storage host). Parts upload concurrently, so no single part is the canary;
+	// because none lands, the upload falls back to single-shot.
+	f.partHook = func(n, attempt int) (int, string, []byte) {
+		return http.StatusForbidden, "", []byte("forbidden")
+	}
+	c := newTestClient(t, f)
+
+	in := data(5000)
+	_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/fb.bin", writeTemp(t, in), WithParallelism(4))
+	noErr(t, err)
+	// The fallback single-shot PUT carries the whole object.
+	eqBytes(t, f.assembled(), in)
+}
+
+func TestUploadAlreadyExists(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	f.singleShotStatus = http.StatusConflict
+	f.singleShotBody = `{"error_code":"ALREADY_EXISTS","message":"file already exists"}`
+	c := newTestClient(t, f)
+
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/exists.bin", bytes.NewReader(data(100)), WithOverwrite(false))
+	if !errors.Is(err, files.ErrAlreadyExists) {
+		t.Fatalf("got error %v, want files.ErrAlreadyExists", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestUploadWithTransferClient(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	c := newTestClient(t, f)
+
+	var used atomic.Int32
+	custom := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		used.Add(1)
+		return http.DefaultTransport.RoundTrip(r)
+	})}
+
+	in := data(5000)
+	_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/tc.bin", writeTemp(t, in),
+		WithParallelism(2), WithTransferClient(custom))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+	if used.Load() == 0 {
+		t.Error("the cloud transfer must go through the supplied client")
+	}
+}
+
+func TestUploadResumableHappyPath(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "resumable")
+	c := newTestClient(t, f)
+
+	in := data(5000)
+	// Parallelism > 1 still uses single-threaded resumable; bytes must match.
+	_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/gcp.bin", writeTemp(t, in), WithParallelism(4))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+}
+
+func TestUploadResumableNoProgressBounded(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "resumable")
+	f.stuckResumable = true
+	c := newTestClient(t, f)
+
+	// The server confirms no new bytes on every chunk; the resumable loop must
+	// error rather than spin forever (fs cp sets no context deadline).
+	_, err := c.Upload(t.Context(), "/Volumes/c/s/v/gcp.bin", bytes.NewReader(data(5000)))
+	if err == nil {
+		t.Fatal("expected an error when the resumable server makes no progress")
+	}
+}
+
+func TestUploadPresignedURLExpiryRetried(t *testing.T) {
+	shrinkTunables(t, 1024)
+	f := newFakeServer(t, "multipart")
+	// Every part's first presigned URL is reported expired; the second succeeds.
+	azure := `<Error><Code>AuthenticationFailed</Code><AuthenticationErrorDetail>Signature not valid in the specified time frame</AuthenticationErrorDetail></Error>`
+	f.partHook = func(n, attempt int) (int, string, []byte) {
+		if attempt == 1 {
+			return http.StatusForbidden, "", []byte(azure)
+		}
+		return 0, "", nil
+	}
+	c := newTestClient(t, f)
+
+	in := data(5000)
+	_, err := c.UploadFrom(t.Context(), "/Volumes/c/s/v/exp.bin", writeTemp(t, in), WithParallelism(4))
+	noErr(t, err)
+	eqBytes(t, f.assembled(), in)
+}
+
+// Retry-timing coverage (retryable-status retried/exhausted, with shrunk backoff)
+// lives in the cloudstorage package, where Send's retry policy is defined.
+
+func TestResolvedParallelism(t *testing.T) {
+	n := func(v int) *int { return &v }
+	const mib int64 = 1 << 20
+	tests := []struct {
+		name     string
+		cfg      uploadConfig
+		buffered bool
+		partSize int64
+		want     int
+	}{
+		{"explicit override wins for a file", uploadConfig{parallelism: n(7)}, false, 16 * mib, 7},
+		{"explicit override wins for a stream", uploadConfig{parallelism: n(3)}, true, 16 * mib, 3},
+		{"file default is bandwidth-oriented", uploadConfig{}, false, 16 * mib, multipartFileParallelism},
+		{"stream default fits the memory budget", uploadConfig{}, true, 16 * mib, int(multipartStreamMemoryBudget / (16 * mib))},
+		{"larger stream part size lowers the worker count", uploadConfig{}, true, 64 * mib, int(multipartStreamMemoryBudget / (64 * mib))},
+		{"tiny stream part size is capped at the file default", uploadConfig{}, true, 1, multipartFileParallelism},
+		{"huge stream part size floors at one worker", uploadConfig{}, true, multipartStreamMemoryBudget * 2, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.resolvedParallelism(tc.buffered, tc.partSize); got != tc.want {
+				t.Errorf("resolvedParallelism(%v, %d) = %d, want %d", tc.buffered, tc.partSize, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

`databricks fs cp` and bundle library uploads to Unity Catalog Volumes go through a single `PUT /api/2.0/fs/files`, which caps a file at the single-request size limit and pushes it over one connection. This stack adds chunked upload (multipart on AWS/Azure, resumable on GCP) so large files upload reliably and in parallel. The whole feature is gated behind the `DATABRICKS_EXPERIMENTAL_MULTIPART_UPLOAD` environment variable and is off by default, so merging the stack changes no behavior until the flag is set.

## Stack

1. #5753 cloud-storage data-plane client
2. #5754 Files API control-plane client
3. #5755 chunked upload engine (this PR)
4. #5756 route large Volumes writes through the engine
5. #5757 `fs cp` shared transfer budget
6. #5758 `fs cp` progress bar

## This PR

Adds `libs/upload`, the engine that orchestrates a chunked upload. Once the Files API initiates a session it follows the protocol the server selected: multipart on AWS/Azure, resumable on GCP. For multipart it uploads parts in parallel through the cloud-storage client under a shared concurrency limiter, mitigates stragglers by cancelling and re-issuing a part that runs far longer than the recent part-duration tail on a fresh connection, prefetches presigned URLs in batches, and overlaps the first part with session setup. For resumable it streams chunks sequentially (GCP does not allow parallel resumable uploads), resumes from the server-confirmed offset on a transient failure, and bounds a server wedged at a fixed offset so the upload fails rather than hanging. It builds the Files API client from a workspace client, deriving per-request credentials (workspace routing headers plus auth) and an HTTP client whose transport honors the workspace config (custom CA, proxy, `InsecureSkipVerify`). No production caller yet; the filer routes through it in the next PR.

## Testing

Unit tests run against a fake Files API and cloud server covering the single-shot, multipart (parallel and sequential), and resumable paths; straggler cancel-and-reissue; presigned-URL-expiry retries; the size-probe rewind failure; the resumable no-progress bound; and the workspace-config transport selection. The full stack is also exercised with a live `fs cp` of a multi-GB file to a Volume.

This pull request and its description were written by Isaac.
