### PR TITLE
fs cp: share one multipart transfer budget across a recursive copy

### DIFF
--- a/cmd/fs/cp.go
+++ b/cmd/fs/cp.go
@@ -18,10 +18,18 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Default number of concurrent file copy operations. This is a conservative
-// default that should be sufficient to fully utilize the available bandwidth
-// in most cases.
+// defaultConcurrency is the number of files copied in parallel. Each in-flight
+// file drives Files API requests (a single-shot PUT, or the multipart
+// control-plane calls), which allow only ~10 concurrent requests, so this stays
+// conservative regardless of whether multipart upload is enabled.
 const defaultConcurrency = 8
+
+// multipartUploadConcurrency is the cloud-transfer budget for large-file
+// (multipart) writes: a shared cap on concurrent part uploads, which go to cloud
+// storage rather than the rate-limited Files API and so can fan out wider than
+// the file-level copy concurrency. It is sized independently of --concurrency and
+// applies only to the Volumes target filer.
+const multipartUploadConcurrency = 64
 
 // errInvalidConcurrency is returned when the value of the concurrency
 // flag is invalid.
@@ -229,9 +237,20 @@ func newCpCommand() *cobra.Command {
 			return err
 		}
 
-		// Get target filer and target path without scheme
+		// The cloud-transfer budget for large-file (multipart) writes is sized
+		// independently of c.concurrency (the file-level copy parallelism, which
+		// stays at the Files-API-safe default). A large file's part uploads go to
+		// cloud storage rather than the rate-limited Files API, so they can fan out
+		// wider; the budget is shared across all files in a recursive copy and
+		// applies only to the Volumes target filer.
+		uploadConcurrency := c.concurrency
+		if filer.MultipartUploadEnabled(ctx) {
+			uploadConcurrency = multipartUploadConcurrency
+		}
+
+		// Get target filer and target path without scheme.
 		fullTargetPath := args[1]
-		targetFiler, targetPath, err := filerForPath(ctx, fullTargetPath)
+		targetFiler, targetPath, err := filerForUploadTarget(ctx, fullTargetPath, uploadConcurrency)
 		if err != nil {
 			return err
 		}

--- a/cmd/fs/helpers.go
+++ b/cmd/fs/helpers.go
@@ -14,6 +14,20 @@ import (
 )
 
 func filerForPath(ctx context.Context, fullPath string) (filer.Filer, string, error) {
+	return newFilerForPath(ctx, fullPath, 0)
+}
+
+// filerForUploadTarget is filerForPath for a copy target. When the target
+// resolves to a Volumes (Files API) filer, large-file (multipart) uploads use
+// uploadConcurrency as the shared transfer budget; other schemes ignore it.
+func filerForUploadTarget(ctx context.Context, fullPath string, uploadConcurrency int) (filer.Filer, string, error) {
+	return newFilerForPath(ctx, fullPath, uploadConcurrency)
+}
+
+// newFilerForPath resolves a filer and the scheme-stripped path. uploadConcurrency
+// (when > 0) sizes a Volumes filer's large-file upload budget; it is ignored for
+// every other scheme.
+func newFilerForPath(ctx context.Context, fullPath string, uploadConcurrency int) (filer.Filer, string, error) {
 	// Split path at : to detect any file schemes
 	parts := strings.SplitN(fullPath, ":", 2)
 
@@ -40,7 +54,11 @@ func filerForPath(ctx context.Context, fullPath string) (filer.Filer, string, er
 
 	// If the specified path has the "Volumes" prefix, use the Files API.
 	if strings.HasPrefix(path, "/Volumes/") {
-		f, err := filer.NewFilesClient(w, "/")
+		var opts []filer.FilesClientOption
+		if uploadConcurrency > 0 {
+			opts = append(opts, filer.WithUploadConcurrency(uploadConcurrency))
+		}
+		f, err := filer.NewFilesClient(w, "/", opts...)
 		return f, path, err
 	}
 


### PR DESCRIPTION
## Context

`databricks fs cp` and bundle library uploads to Unity Catalog Volumes go through a single `PUT /api/2.0/fs/files`, which caps a file at the single-request size limit and pushes it over one connection. This stack adds chunked upload (multipart on AWS/Azure, resumable on GCP) so large files upload reliably and in parallel. The whole feature is gated behind the `DATABRICKS_EXPERIMENTAL_MULTIPART_UPLOAD` environment variable and is off by default, so merging the stack changes no behavior until the flag is set.

## Stack

1. #5753 cloud-storage data-plane client
2. #5754 Files API control-plane client
3. #5755 chunked upload engine
4. #5756 route large Volumes writes through the engine
5. #5757 `fs cp` shared transfer budget (this PR)
6. #5758 `fs cp` progress bar

## This PR

Decouples the two concurrency knobs in `fs cp`. `--concurrency` keeps governing how many files copy at once and stays at the Files-API-safe default; the multipart cloud-transfer budget is sized independently and, when the flag is on, set wider for part uploads, which go to cloud storage rather than the rate-limited Files API. Keeping them separate means a recursive copy of many small files does not burst the Files API, while a single large file can still fan its parts out wide. The budget is applied only to the Volumes target filer.

## Testing

Covered by the existing `cmd/fs` tests; the decoupling and Volumes-only budget are validated with a live recursive `fs cp` to a Volume.

This pull request and its description were written by Isaac.
