### PR TITLE
fs cp: show an upload progress bar for a single large-file copy

### DIFF
--- a/cmd/fs/cp.go
+++ b/cmd/fs/cp.go
@@ -45,6 +45,11 @@ type copy struct {
 	sourceScheme string
 	targetScheme string
 
+	// showProgress renders an upload progress bar. It is set only for a single
+	// large-file copy to a Volume, not for recursive copies (where many files
+	// would each fight for the spinner line).
+	showProgress bool
+
 	mu sync.Mutex // protect output from concurrent writes
 }
 
@@ -131,20 +136,31 @@ func (c *copy) cpFileToFile(ctx context.Context, sourcePath, targetPath string) 
 	}
 	defer r.Close()
 
+	// For a single large-file copy, attach a progress callback to the context
+	// that the Files filer forwards to the upload engine, rendering an upload bar.
+	// The spinner is stopped before any event line is emitted so its final frame
+	// does not overwrite it.
+	closeProgress := func() {}
+	if c.showProgress {
+		fn, stop := newProgressFunc(ctx)
+		ctx = filer.WithUploadProgress(ctx, fn)
+		closeProgress = stop
+	}
+
+	var writeErr error
 	if c.overwrite {
-		err = c.targetFiler.Write(ctx, targetPath, r, filer.OverwriteIfExists)
-		if err != nil {
-			return err
-		}
+		writeErr = c.targetFiler.Write(ctx, targetPath, r, filer.OverwriteIfExists)
 	} else {
-		err = c.targetFiler.Write(ctx, targetPath, r)
-		// skip if file already exists
-		if err != nil && errors.Is(err, fs.ErrExist) {
-			return c.emitFileSkippedEvent(ctx, sourcePath, targetPath)
-		}
-		if err != nil {
-			return err
-		}
+		writeErr = c.targetFiler.Write(ctx, targetPath, r)
+	}
+	closeProgress()
+
+	// skip if file already exists
+	if !c.overwrite && writeErr != nil && errors.Is(writeErr, fs.ErrExist) {
+		return c.emitFileSkippedEvent(ctx, sourcePath, targetPath)
+	}
+	if writeErr != nil {
+		return writeErr
 	}
 	return c.emitFileCopiedEvent(ctx, sourcePath, targetPath)
 }
@@ -277,6 +293,10 @@ func newCpCommand() *cobra.Command {
 		if sourceInfo.IsDir() {
 			return c.cpDirToDir(ctx, sourcePath, targetPath)
 		}
+
+		// A single large file copied to a Volume goes through the multipart engine,
+		// which reports progress; render an upload bar for it.
+		c.showProgress = filer.MultipartUploadEnabled(ctx) && strings.HasPrefix(targetPath, "/Volumes/")
 
 		// If target path has a trailing separator, trim it and let case 2 handle it
 		if hasTrailingDirSeparator(fullTargetPath) {

--- a/cmd/fs/upload_progress.go
+++ b/cmd/fs/upload_progress.go
@@ -1,0 +1,256 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/upload"
+)
+
+// renderThrottle caps how often the interactive bar is redrawn so a fast upload
+// does not spend its time repainting the terminal; completion always renders.
+const renderThrottle = 100 * time.Millisecond
+
+// preparingFrame is how long each "Preparing upload" dot frame is shown before
+// the upload reports its first completed part.
+const preparingFrame = 400 * time.Millisecond
+
+// barWidth keeps the rendered bar narrow enough that the whole progress line
+// stays on a single terminal row, so the spinner's in-place redraw is clean.
+const barWidth = 24
+
+// rateWindow is the trailing duration over which the transfer rate is averaged.
+// A few seconds smooths the burstiness of concurrent part completions while
+// still tracking genuine changes in throughput.
+const rateWindow = 5 * time.Second
+
+// Bar styling. Green for the filled portion matches the cmdio spinner glyph;
+// the remainder is dimmed.
+var (
+	barFilledStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	barEmptyStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+)
+
+// barBlocks are partial block glyphs for sub-character precision, so the bar
+// advances smoothly rather than in whole-cell jumps. Index 0 is a full cell
+// (8/8); index i is (8-i)/8 of a cell. Matches experimental/genie/agentstream.
+var barBlocks = []string{"█", "▉", "▊", "▋", "▌", "▍", "▎", "▏"}
+
+// humanBytes formats a byte count using binary (1024-based) units.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	units := []string{"KiB", "MiB", "GiB", "TiB", "PiB"}
+	div, exp := int64(unit), 0
+	for n/div >= unit && exp < len(units)-1 {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), units[exp])
+}
+
+// formatSpeed formats a transfer rate in bytes per second.
+func formatSpeed(bytesPerSec float64) string {
+	if bytesPerSec < 0 {
+		bytesPerSec = 0
+	}
+	return humanBytes(int64(bytesPerSec)) + "/s"
+}
+
+// formatETA formats the estimated time remaining as MM:SS. It returns a
+// placeholder when the rate is unknown so the line does not show a misleading
+// estimate before any throughput has been measured.
+func formatETA(remaining int64, bytesPerSec float64) string {
+	if bytesPerSec <= 0 || remaining < 0 {
+		return "--:--"
+	}
+	secs := int(float64(remaining) / bytesPerSec)
+	return fmt.Sprintf("%02d:%02d", secs/60, secs%60)
+}
+
+// formatPlainProgress renders a single non-interactive progress line.
+func formatPlainProgress(p upload.Progress) string {
+	if p.Total <= 0 {
+		return "Uploaded " + humanBytes(p.Transferred)
+	}
+	pct := int(float64(p.Transferred) / float64(p.Total) * 100)
+	return fmt.Sprintf("Uploaded %s / %s (%d%%)", humanBytes(p.Transferred), humanBytes(p.Total), pct)
+}
+
+// renderBar returns a fixed-width progress bar for the given completion ratio.
+// The total visible width is always barWidth: full cells, an optional partial
+// cell for the fractional remainder, then the dimmed empty track.
+func renderBar(ratio float64) string {
+	ratio = min(max(ratio, 0), 1)
+	exact := ratio * barWidth
+	full := int(exact)
+
+	filled := strings.Repeat("█", full)
+	partial := int((exact - float64(full)) * 8)
+	if partial > 0 && full < barWidth {
+		filled += barBlocks[8-partial]
+		full++ // the partial glyph occupies one cell of the track
+	}
+
+	return barFilledStyle.Render(filled) +
+		barEmptyStyle.Render(strings.Repeat("░", barWidth-full))
+}
+
+// rateSample is a cumulative byte count observed at a point in time.
+type rateSample struct {
+	at    time.Time
+	bytes int64
+}
+
+// rateMeter computes the transfer rate as a rolling average over a trailing
+// time window. Averaging over elapsed wall-clock time, rather than an
+// exponential moving average over samples, keeps the reported speed and the
+// ETA derived from it stable: the engine reports progress in irregular bursts
+// as concurrent parts complete, and a per-sample EMA spikes on every burst.
+// Callers pass the current time so the meter stays deterministic and
+// unit-testable.
+type rateMeter struct {
+	samples []rateSample
+}
+
+// observe records a cumulative byte count at now and returns the average
+// bytes/sec over the trailing rateWindow. It returns 0 until two samples span
+// a positive interval (the first sample, or one taken after a stall longer
+// than the window, leaves nothing to average against).
+func (m *rateMeter) observe(now time.Time, transferred int64) float64 {
+	// Drop samples that have aged out of the window, then record this one.
+	// Filtering in place reuses the backing array; at the render cadence the
+	// window holds at most a few dozen samples, so this stays cheap.
+	cutoff := now.Add(-rateWindow)
+	kept := m.samples[:0]
+	for _, s := range m.samples {
+		if !s.at.Before(cutoff) {
+			kept = append(kept, s)
+		}
+	}
+	m.samples = append(kept, rateSample{at: now, bytes: transferred})
+
+	oldest := m.samples[0]
+	dt := now.Sub(oldest.at).Seconds()
+	if dt <= 0 {
+		return 0
+	}
+	return float64(transferred-oldest.bytes) / dt
+}
+
+// progressRenderer builds the rich single-line progress string shown as the
+// spinner suffix in an interactive terminal.
+type progressRenderer struct {
+	meter rateMeter
+}
+
+// newProgressRenderer creates a renderer.
+func newProgressRenderer() *progressRenderer {
+	return &progressRenderer{}
+}
+
+// render returns the progress line for the given progress sample at time now.
+func (r *progressRenderer) render(now time.Time, p upload.Progress) string {
+	rate := r.meter.observe(now, p.Transferred)
+	if p.Total <= 0 {
+		return fmt.Sprintf("%s  %s", humanBytes(p.Transferred), formatSpeed(rate))
+	}
+	ratio := float64(p.Transferred) / float64(p.Total)
+	return fmt.Sprintf("%s %.0f%%  %s/%s  %s  ETA %s",
+		renderBar(ratio), ratio*100,
+		humanBytes(p.Transferred), humanBytes(p.Total),
+		formatSpeed(rate), formatETA(p.Total-p.Transferred, rate))
+}
+
+// newProgressFunc returns the upload progress callback for the current terminal
+// and a function that stops it. In an interactive terminal it renders a rich
+// single-line bar via the spinner; otherwise it logs coarse progress so a long
+// upload still shows life. The returned stop function is idempotent (it is safe
+// to defer it and also call it before printing a summary line). The callback is
+// serialized by the engine, so its captured state needs no locking.
+func newProgressFunc(ctx context.Context) (upload.ProgressFunc, func()) {
+	if cmdio.GetInteractiveMode(ctx) == cmdio.InteractiveModeNone {
+		nextPct := 10
+		fn := func(p upload.Progress) {
+			// The final summary line covers completion; only log intermediate steps.
+			if p.Total <= 0 || p.Transferred >= p.Total {
+				return
+			}
+			pct := int(float64(p.Transferred) / float64(p.Total) * 100)
+			if pct < nextPct {
+				return
+			}
+			cmdio.LogString(ctx, formatPlainProgress(p))
+			for pct >= nextPct {
+				nextPct += 10
+			}
+		}
+		return fn, func() {}
+	}
+
+	sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
+	r := newProgressRenderer()
+
+	// The callback first fires only when a part completes; session initiation, URL
+	// minting, and the first PUT take a beat, during which it never runs. Animate a
+	// "Preparing upload" label with cycling dots over that window so the spinner is
+	// not bare. mu serializes the animator's suffix updates with the callback's, and
+	// preparing gates the animator off once real progress arrives, so the bar
+	// replaces the label with no flicker.
+	var (
+		mu         sync.Mutex
+		preparing  = true
+		lastRender time.Time
+	)
+	prepCtx, stopPreparing := context.WithCancel(ctx)
+	prepDone := make(chan struct{})
+	go func() {
+		defer close(prepDone)
+		ticker := time.NewTicker(preparingFrame)
+		defer ticker.Stop()
+		for dots := 1; ; dots = dots%3 + 1 {
+			mu.Lock()
+			if !preparing {
+				mu.Unlock()
+				return
+			}
+			sp.Update("Preparing upload" + strings.Repeat(".", dots))
+			mu.Unlock()
+			select {
+			case <-prepCtx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	fn := func(p upload.Progress) {
+		mu.Lock()
+		defer mu.Unlock()
+		if preparing {
+			preparing = false
+			stopPreparing() // first real progress: stop the animator, the bar takes over
+		}
+		now := time.Now()
+		if p.Total > 0 && p.Transferred < p.Total && now.Sub(lastRender) < renderThrottle {
+			return
+		}
+		lastRender = now
+		sp.Update(r.render(now, p))
+	}
+	// Stop the animator and wait for it to exit before closing the spinner, so no
+	// suffix update races the spinner shutdown.
+	return fn, func() {
+		stopPreparing()
+		<-prepDone
+		sp.Close()
+	}
+}

--- a/cmd/fs/upload_progress_test.go
+++ b/cmd/fs/upload_progress_test.go
@@ -1,0 +1,96 @@
+package fs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestRenderBarWidth(t *testing.T) {
+	// The bar must always occupy exactly barWidth cells regardless of ratio,
+	// including the partial-cell and out-of-range cases.
+	for _, ratio := range []float64{-0.5, 0, 0.0001, 0.123, 0.5, 0.52, 0.999, 1, 1.5} {
+		if w := lipgloss.Width(renderBar(ratio)); w != barWidth {
+			t.Errorf("renderBar(%v) width = %d, want %d", ratio, w, barWidth)
+		}
+	}
+}
+
+func TestRateMeter(t *testing.T) {
+	var m rateMeter
+	base := time.Unix(0, 0)
+
+	if got := m.observe(base, 0); got != 0 {
+		t.Fatalf("first observe = %v, want 0", got)
+	}
+	// A second sample at the same instant spans no interval to average over.
+	if got := m.observe(base, 1<<20); got != 0 {
+		t.Fatalf("zero-dt observe = %v, want 0 (no positive interval)", got)
+	}
+
+	// A steady 1 MiB/s stream averages to 1 MiB/s.
+	var rate float64
+	for i := 1; i <= 50; i++ {
+		rate = m.observe(base.Add(time.Duration(i)*time.Second), int64(i)<<20)
+	}
+	const want = float64(1 << 20)
+	if rate < want*0.99 || rate > want*1.01 {
+		t.Errorf("steady rate = %v, want ~%v", rate, want)
+	}
+}
+
+func TestRateMeterSmoothsBursts(t *testing.T) {
+	var m rateMeter
+	base := time.Unix(0, 0)
+
+	// Prime a steady 1 MiB/s stream over the full window.
+	for i := range 6 {
+		m.observe(base.Add(time.Duration(i)*time.Second), int64(i)<<20)
+	}
+
+	// A large part lands almost instantly: 5 MiB in 100ms. A per-sample EMA
+	// would read this as a ~50 MiB/s spike; the rolling window keeps the
+	// reported rate near the windowed throughput.
+	rate := m.observe(base.Add(5100*time.Millisecond), 10<<20)
+	if rate > 3<<20 {
+		t.Errorf("post-burst rate = %.0f B/s, want smoothed under %d B/s", rate, 3<<20)
+	}
+}
+
+func TestFormatSpeed(t *testing.T) {
+	cases := []struct {
+		bps  float64
+		want string
+	}{
+		{0, "0 B/s"},
+		{-5, "0 B/s"},
+		{512, "512 B/s"},
+		{48 << 20, "48.0 MiB/s"},
+	}
+	for _, tc := range cases {
+		if got := formatSpeed(tc.bps); got != tc.want {
+			t.Errorf("formatSpeed(%v) = %q, want %q", tc.bps, got, tc.want)
+		}
+	}
+}
+
+func TestFormatETA(t *testing.T) {
+	cases := []struct {
+		remaining int64
+		bps       float64
+		want      string
+	}{
+		{0, 0, "--:--"},
+		{1 << 20, 0, "--:--"},
+		{-1, 1 << 20, "--:--"},
+		{0, 1 << 20, "00:00"},
+		{1 << 20, 1 << 20, "00:01"},
+		{120 << 20, 1 << 20, "02:00"},
+	}
+	for _, tc := range cases {
+		if got := formatETA(tc.remaining, tc.bps); got != tc.want {
+			t.Errorf("formatETA(%d, %v) = %q, want %q", tc.remaining, tc.bps, got, tc.want)
+		}
+	}
+}

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -109,6 +109,24 @@ func MultipartUploadEnabled(ctx context.Context) bool {
 	return enabled
 }
 
+// uploadProgressKey is the context key for an optional large-file upload
+// progress callback.
+type uploadProgressKey struct{}
+
+// WithUploadProgress returns a context carrying a progress callback for
+// large-file (multipart) uploads. FilesClient.Write forwards it to the upload
+// engine; it has no effect on writes that do not go through the engine (small
+// files, non-seekable streams, non-Volumes targets, or when multipart upload is
+// disabled).
+func WithUploadProgress(ctx context.Context, fn upload.ProgressFunc) context.Context {
+	return context.WithValue(ctx, uploadProgressKey{}, fn)
+}
+
+func uploadProgressFromContext(ctx context.Context) upload.ProgressFunc {
+	fn, _ := ctx.Value(uploadProgressKey{}).(upload.ProgressFunc)
+	return fn
+}
+
 // FilesClient implements the [Filer] interface for the Files API backend.
 type FilesClient struct {
 	workspaceClient *databricks.WorkspaceClient
@@ -212,10 +230,17 @@ func (w *FilesClient) Write(ctx context.Context, name string, reader io.Reader, 
 	// reads when the source provides one (a local file).
 	if MultipartUploadEnabled(ctx) {
 		if isSeekable(reader) {
-			_, uerr := w.uploader.Upload(ctx, absPath, reader,
+			opts := []upload.UploadOption{
 				upload.WithOverwrite(overwrite),
 				upload.WithLimiter(w.limiter),
-				upload.WithTransferClient(w.transferClient))
+				upload.WithTransferClient(w.transferClient),
+			}
+			// A caller (fs cp) can attach a progress callback via the context to
+			// render an upload bar; it is absent for other writers (e.g. bundle).
+			if fn := uploadProgressFromContext(ctx); fn != nil {
+				opts = append(opts, upload.WithProgress(fn))
+			}
+			_, uerr := w.uploader.Upload(ctx, absPath, reader, opts...)
 			return mapUploadError(uerr, absPath)
 		}
 	}

--- a/libs/upload/upload.go
+++ b/libs/upload/upload.go
@@ -236,8 +236,6 @@ func WithParallelism(n int) UploadOption {
 // WithProgress registers a callback invoked as the upload progresses, reporting
 // the cumulative bytes uploaded and the total size (-1 if unknown). It is useful
 // for rendering an upload progress bar.
-//
-//deadcode:allow exported engine option with no in-tree caller yet
 func WithProgress(fn ProgressFunc) UploadOption {
 	return func(c *uploadConfig) { c.progress = fn }
 }


### PR DESCRIPTION
## Context

`databricks fs cp` and bundle library uploads to Unity Catalog Volumes go through a single `PUT /api/2.0/fs/files`, which caps a file at the single-request size limit and pushes it over one connection. This stack adds chunked upload (multipart on AWS/Azure, resumable on GCP) so large files upload reliably and in parallel. The whole feature is gated behind the `DATABRICKS_EXPERIMENTAL_MULTIPART_UPLOAD` environment variable and is off by default, so merging the stack changes no behavior until the flag is set.

## Stack

1. #5753 cloud-storage data-plane client
2. #5754 Files API control-plane client
3. #5755 chunked upload engine
4. #5756 route large Volumes writes through the engine
5. #5757 `fs cp` shared transfer budget
6. #5758 `fs cp` progress bar (this PR)

## This PR

Adds an upload progress bar to `fs cp` for a single large file copied to a Volume (when multipart is enabled). It reuses the bar from the experimental files-upload command: a spinner that animates a "Preparing upload" label during session setup, then a single-line bar with percentage, transfer rate, and ETA. The engine reports progress through a callback that the command threads down via the context (`filer.WithUploadProgress`), so the `Filer.Write` interface is unchanged. Recursive copies, non-Volumes targets, and other writers (bundle) are unaffected; a non-interactive terminal logs coarse progress instead of drawing the bar.

## Testing

Unit tests cover the fixed-width bar invariant, the rolling-window rate meter (including burst smoothing), and the speed and ETA formatters. The interactive bar is exercised with a live `fs cp` of a multi-GB file.

This pull request and its description were written by Isaac.
