### PR TITLE
Document `+` modifier syntax in `bundle run --only` help

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bundles
 
  * `bundle generate job` now downloads workspace files referenced by `spark_python_task`, rewriting them to a relative path like it already does for notebooks. Git-sourced files and cloud URIs are left untouched ([#5799](https://github.com/databricks/cli/pull/5799)).
+ * `bundle run --only` help now documents the `+` modifier syntax: prefix a task key with `+` to also run its upstream tasks, or suffix it with `+` for downstream tasks ([#5760](https://github.com/databricks/cli/pull/5760)).
 
 ### Dependency updates
 

--- a/acceptance/bundle/help/bundle-run/output.txt
+++ b/acceptance/bundle/help/bundle-run/output.txt
@@ -38,7 +38,7 @@ Usage:
   databricks bundle run [flags] [KEY]
 
 Job Flags:
-      --only strings            comma separated list of task keys to run
+      --only strings            comma separated list of task keys to run. Prefix a key with + to also run its upstream tasks. Suffix with + to also run its downstream tasks
       --params stringToString   comma separated k=v pairs for job parameters (default [])
 
 Job Task Flags:

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -118,3 +118,31 @@ Hello from notebook2!
     ]
   }
 }
+
+>>> [CLI] bundle run my_job --only +task_1,task_2+
+Run URL: [DATABRICKS_URL]/jobs/[NUMID]/runs/[NUMID]?o=[NUMID]
+
+[TIMESTAMP] "my_job" RUNNING
+[TIMESTAMP] "my_job" TERMINATED SUCCESS
+Output:
+=======
+Task task_1:
+Hello from notebook1!
+
+=======
+Task task_2:
+Hello from notebook2!
+
+
+>>> print_requests.py //jobs/run-now
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [NUMID],
+    "only": [
+      "+task_1",
+      "task_2+"
+    ]
+  }
+}

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -18,3 +18,7 @@ trace musterr $CLI bundle run my_job --only non_existent_task,task_1
 # We expect these values to be send through
 trace $CLI bundle run my_job --only "task1.table1,task2>,task3>table3"
 trace print_requests.py //jobs/run-now
+
+# + modifiers (run upstream/downstream tasks) are forwarded unchanged
+trace $CLI bundle run my_job --only "+task_1,task_2+"
+trace print_requests.py //jobs/run-now

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -34,7 +34,7 @@ type JobOptions struct {
 
 func (o *JobOptions) DefineJobOptions(fs *flag.FlagSet) {
 	fs.StringToStringVar(&o.jobParams, "params", nil, "comma separated k=v pairs for job parameters")
-	fs.StringSliceVar(&o.only, "only", nil, "comma separated list of task keys to run")
+	fs.StringSliceVar(&o.only, "only", nil, "comma separated list of task keys to run. Prefix a key with + to also run its upstream tasks. Suffix with + to also run its downstream tasks")
 }
 
 func (o *JobOptions) DefineTaskOptions(fs *flag.FlagSet) {


### PR DESCRIPTION
## Changes

`bundle run --only` takes a comma-separated list of task keys to run a subset of a job's tasks. Its help text did not mention that a task key can be prefixed or suffixed with `+` to also pull in upstream/downstream tasks (the value is forwarded to the `run-now` `only` API field, which interprets the modifiers). This documents that syntax in the flag's help:

- `+my_task`: run `my_task` and everything upstream of it
- `my_task+`: run `my_task` and everything downstream of it
- `+my_task+`: both

Adresses #4244
## Tests

- New `acceptance/bundle/run/jobs/partial_run` case asserts `--only +task_1,task_2+` is forwarded unchanged to the run-now request body (`"only": ["+task_1", "task_2+"]`), proving the documented `+` syntax is not mangled or rejected client-side.
- Regenerated the `bundle run --help` golden for the updated `--only` description.

This pull request and its description were written by Isaac.
