### PR TITLE
Acc local generate alert

### DIFF
--- a/acceptance/bundle/generate/alert/out.test.toml
+++ b/acceptance/bundle/generate/alert/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/generate/alert/output.txt
+++ b/acceptance/bundle/generate/alert/output.txt
@@ -1,6 +1,6 @@
 
 >>> [CLI] workspace mkdirs /Workspace/test-[UNIQUE_NAME]
 
->>> [CLI] bundle generate alert --existing-id [NUMID] --source-dir out/alert --config-dir out/resource
+>>> [CLI] bundle generate alert --existing-id [ALERT_ID] --source-dir out/alert --config-dir out/resource
 Alert configuration successfully saved to [TEST_TMP_DIR]/out/resource/test_alert.alert.yml
 Serialized alert definition to [TEST_TMP_DIR]/out/alert/test_alert.dbalert.json

--- a/acceptance/bundle/generate/alert/script
+++ b/acceptance/bundle/generate/alert/script
@@ -3,6 +3,7 @@ trace $CLI workspace mkdirs /Workspace/test-$UNIQUE_NAME
 # create an alert to import
 envsubst < alert.json.tmpl > alert.json
 alert_id=$($CLI alerts-v2 create-alert --json @alert.json | jq -r '.id')
+echo "$alert_id:ALERT_ID" >> ACC_REPLS
 rm alert.json
 
 trace $CLI bundle generate alert --existing-id $alert_id --source-dir out/alert --config-dir out/resource

--- a/acceptance/bundle/generate/alert/test.toml
+++ b/acceptance/bundle/generate/alert/test.toml
@@ -1,5 +1,5 @@
 Cloud = true
-Local = false
+Local = true
 
 # Alert tests timeout during bundle deploy (hang at file upload for 50+ minutes).
 # Use aggressive 5-minute timeout until the issue is resolved.

--- a/libs/testserver/alerts.go
+++ b/libs/testserver/alerts.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/databricks/databricks-sdk-go/service/sql"
@@ -16,11 +18,69 @@ import (
 // warehouse_id) are dropped and the joined query_text/custom_description are
 // split back into lines. The field order matches what the backend materializes.
 type alertFile struct {
-	CustomSummary          string                 `json:"custom_summary,omitempty"`
-	Evaluation             *sql.AlertV2Evaluation `json:"evaluation,omitempty"`
-	Schedule               *sql.CronSchedule      `json:"schedule,omitempty"`
-	QueryLines             []string               `json:"query_lines,omitempty"`
-	CustomDescriptionLines []string               `json:"custom_description_lines,omitempty"`
+	CustomSummary          string                  `json:"custom_summary,omitempty"`
+	Evaluation             *materializedEvaluation `json:"evaluation,omitempty"`
+	Schedule               *sql.CronSchedule       `json:"schedule,omitempty"`
+	QueryLines             []string                `json:"query_lines,omitempty"`
+	CustomDescriptionLines []string                `json:"custom_description_lines,omitempty"`
+}
+
+// materializedEvaluation mirrors the field order the alerts backend uses when it
+// writes the .dbalert.json file, which differs from sql.AlertV2Evaluation: the
+// backend emits source before comparison_operator and always writes a
+// notification object (an empty {} when none is configured).
+type materializedEvaluation struct {
+	Source             sql.AlertV2OperandColumn `json:"source"`
+	ComparisonOperator sql.ComparisonOperator   `json:"comparison_operator"`
+	Threshold          *materializedOperand     `json:"threshold,omitempty"`
+	Notification       *sql.AlertV2Notification `json:"notification"`
+}
+
+// materializedOperand and materializedOperandValue mirror sql.AlertV2Operand but
+// format double_value via jsonFloat so it keeps its decimal point in the file.
+type materializedOperand struct {
+	Column *sql.AlertV2OperandColumn `json:"column,omitempty"`
+	Value  *materializedOperandValue `json:"value,omitempty"`
+}
+
+type materializedOperandValue struct {
+	BoolValue   bool       `json:"bool_value,omitempty"`
+	DoubleValue *jsonFloat `json:"double_value,omitempty"`
+	StringValue string     `json:"string_value,omitempty"`
+}
+
+// jsonFloat marshals a float64 the way the alerts backend serializes numeric
+// thresholds in .dbalert.json: always with a decimal point (0 -> "0.0"). Go's
+// encoding/json drops the fractional part for integer-valued floats.
+type jsonFloat float64
+
+func (f jsonFloat) MarshalJSON() ([]byte, error) {
+	s := strconv.FormatFloat(float64(f), 'f', -1, 64)
+	if !strings.ContainsRune(s, '.') {
+		s += ".0"
+	}
+	return []byte(s), nil
+}
+
+// materializeThreshold converts the SDK threshold into the file representation.
+// double_value is emitted whenever the source request set it explicitly (tracked
+// via ForceSendFields), even when it is the zero value.
+func materializeThreshold(t *sql.AlertV2Operand) *materializedOperand {
+	if t == nil {
+		return nil
+	}
+	out := &materializedOperand{Column: t.Column}
+	if v := t.Value; v != nil {
+		out.Value = &materializedOperandValue{
+			BoolValue:   v.BoolValue,
+			StringValue: v.StringValue,
+		}
+		if v.DoubleValue != 0 || slices.Contains(v.ForceSendFields, "DoubleValue") {
+			d := jsonFloat(v.DoubleValue)
+			out.Value.DoubleValue = &d
+		}
+	}
+	return out
 }
 
 // alertFilePath returns the workspace path of the .dbalert.json file the backend
@@ -46,18 +106,27 @@ func (s *FakeWorkspace) writeAlertFile(alert sql.AlertV2) error {
 		return nil
 	}
 
-	evaluation := alert.Evaluation
-	if evaluation.Notification != nil {
+	notification := alert.Evaluation.Notification
+	if notification != nil {
 		// The backend always serializes notify_on_ok in the file, even when
 		// false; the SDK marshaler would otherwise drop the zero value.
-		notification := *evaluation.Notification
-		notification.ForceSendFields = append(notification.ForceSendFields, "NotifyOnOk")
-		evaluation.Notification = &notification
+		n := *notification
+		n.ForceSendFields = append(n.ForceSendFields, "NotifyOnOk")
+		notification = &n
+	} else {
+		// The backend always writes a notification object, materializing an
+		// empty {} when the alert has no notification configured.
+		notification = &sql.AlertV2Notification{}
 	}
 
 	af := alertFile{
-		CustomSummary:          alert.CustomSummary,
-		Evaluation:             &evaluation,
+		CustomSummary: alert.CustomSummary,
+		Evaluation: &materializedEvaluation{
+			Source:             alert.Evaluation.Source,
+			ComparisonOperator: alert.Evaluation.ComparisonOperator,
+			Threshold:          materializeThreshold(alert.Evaluation.Threshold),
+			Notification:       notification,
+		},
 		Schedule:               &alert.Schedule,
 		QueryLines:             splitLines(alert.QueryText),
 		CustomDescriptionLines: splitLines(alert.CustomDescription),


### PR DESCRIPTION
## Why
Convert `bundle/generate/alert` from cloud-only to `Local = true` so it also runs against the local testserver — fast and free in CI/dev, and covers local + aws/azure/gcp instead of cloud-only.

## Changes
- Flip `bundle/generate/alert` to `Local = true`.
- `libs/testserver`: materialize the `.dbalert.json` file the way the alerts backend does — `source` before `comparison_operator`, an always-present `notification` (empty `{}` when unset), and `double_value` with a trailing decimal (`0` → `0.0`) via a `jsonFloat` type. The golden is unchanged; the local output now matches the existing cloud recording.
- Capture the created alert id into `ACC_REPLS` (as `deployment/bind/alert` does), since the testserver assigns a UUID while cloud uses a numeric id.

## Tests
- No additional tests.