### PR TITLE
direct: make Changes.HasChange skip-aware

### DIFF
--- a/bundle/deployplan/plan.go
+++ b/bundle/deployplan/plan.go
@@ -111,7 +111,8 @@ const (
 	ReasonDrop = "!drop"
 )
 
-// HasChange checks if there are any changes for fields with the given prefix.
+// HasChange checks if there are any actionable changes for fields with the given prefix.
+// Suppressed changes (Action == Skip) are ignored, matching HasChangeExcept.
 // This function is path-aware and correctly handles path component boundaries.
 // For example:
 //   - HasChange for path "a" matches "a" and "a.b" but not "aa"
@@ -121,7 +122,10 @@ func (c *Changes) HasChange(fieldPath *structpath.PathNode) bool {
 		return false
 	}
 
-	for field := range *c {
+	for field, change := range *c {
+		if change.Action == Skip {
+			continue
+		}
 		fieldNode, err := structpath.ParsePath(field)
 		if err != nil {
 			continue

--- a/bundle/deployplan/plan_test.go
+++ b/bundle/deployplan/plan_test.go
@@ -1,0 +1,67 @@
+package deployplan_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle/deployplan"
+	"github.com/databricks/cli/libs/structs/structpath"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasChange(t *testing.T) {
+	tests := []struct {
+		name    string
+		changes deployplan.Changes
+		path    string
+		want    bool
+	}{
+		{
+			name:    "nil changes",
+			changes: nil,
+			path:    "config",
+			want:    false,
+		},
+		{
+			name:    "actionable change matches prefix",
+			changes: deployplan.Changes{"config.name": {Action: deployplan.Update}},
+			path:    "config",
+			want:    true,
+		},
+		{
+			name:    "skip change is ignored",
+			changes: deployplan.Changes{"config.traffic_config": {Action: deployplan.Skip}},
+			path:    "config",
+			want:    false,
+		},
+		{
+			name: "skip alongside actionable change still reports",
+			changes: deployplan.Changes{
+				"config.traffic_config":  {Action: deployplan.Skip},
+				"config.served_entities": {Action: deployplan.Update},
+			},
+			path: "config",
+			want: true,
+		},
+		{
+			name:    "no match for unrelated prefix",
+			changes: deployplan.Changes{"tags.team": {Action: deployplan.Update}},
+			path:    "config",
+			want:    false,
+		},
+		{
+			name:    "prefix respects path boundaries",
+			changes: deployplan.Changes{"configuration": {Action: deployplan.Update}},
+			path:    "config",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := structpath.ParsePath(tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, tt.changes.HasChange(path))
+		})
+	}
+}


### PR DESCRIPTION
Split out of #5708 per review feedback, with a dedicated regression test.

`Changes.HasChange` counted suppressed changes (`Action == Skip`), so a section whose only change was suppressed — `backend_default`, `ignore_remote_changes`, `remote_already_set`, `empty`, `missing_in_remote`, etc. — still reported a change. In `model_serving_endpoint` and `vector_search_endpoint` `DoUpdate`, this triggered a spurious per-section update API call (e.g. a `PUT /config` for a `traffic_config` default the user never set).

`HasChange` now skips suppressed changes, matching the already skip-aware `HasChangeExcept`.

All six `HasChange` call sites gate a per-section update in `DoUpdate`:

```
bundle/direct/dresources/model_serving_endpoint.go  (tags, ai_gateway, config, email_notifications)
bundle/direct/dresources/vector_search_endpoint.go  (budget_policy_id, target_qps)
```

In every case the call exists to push a real change to that section, so ignoring suppressed changes is strictly more correct. The other call sites denik listed (`bind.go`, `app.go`, `cluster.go`, `sql_warehouse.go`) use `HasChangeExcept` or the `Action`-based `HasChanges` field, both of which already filter `Skip`.

Added `TestHasChange` covering the skip-aware behavior and path-boundary matching.

This pull request and its description were written by Isaac.
