### PR TITLE
acc: run generate/auto-bind locally on all clouds

### DIFF
--- a/acceptance/bundle/generate/auto-bind/out.test.toml
+++ b/acceptance/bundle/generate/auto-bind/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/generate/auto-bind/test.toml
+++ b/acceptance/bundle/generate/auto-bind/test.toml
@@ -1,7 +1,4 @@
-# This test is using a workspace import API to load a notebook file.
-# This API has a logic on how to accept notebook files and distinguishes them from regular python files.
-# To succeed locally we would need to replicate this logic in the fake_workspace
-Local = false
+Local = true
 Cloud = true
 
 Ignore = [


### PR DESCRIPTION
## Changes
Flip `acceptance/bundle/generate/auto-bind` to `Local = true` so it runs against the local testserver in addition to cloud.

The test imports a notebook through the workspace import API and then generates, binds, deploys and destroys a job from it. The fake workspace already models the notebook-import behavior, so the local run produces output identical to cloud with no testserver changes. The stale comment claiming this could not run locally is removed.

## Why
Local tests are better.

## Tests
No additional tests.