### PR TITLE
acc: run jobs destroy_without_mgmtperms/with_permissions locally

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -854,6 +854,17 @@ func runTest(t *testing.T,
 	cmd.Env = append(cmd.Env, "CLOUD_ENV="+cloudEnv)
 	cmd.Env = append(cmd.Env, "CURRENT_USER_NAME="+user.UserName)
 	if !isRunningOnCloud {
+		// Expose a guest service-principal token for the as-test-sp helper. Its
+		// dedicated prefix plus the primary identity's uuid suffix make it share
+		// the same fake workspace, letting one local test exercise two
+		// identities the way cloud does. On cloud TEST_SP_TOKEN comes from the
+		// real environment.
+		suffix := cfg.Token
+		for _, prefix := range []string{testserver.UserNameTokenPrefix, testserver.ServicePrincipalTokenPrefix} {
+			suffix = strings.TrimPrefix(suffix, prefix)
+		}
+		cmd.Env = append(cmd.Env, "TEST_SP_TOKEN="+testserver.GuestServicePrincipalTokenPrefix+suffix)
+
 		proxyURL := sharedProxyURL
 		if DebugSandbox {
 			// Per-test proxy: errors are attributed to this subtest's t, making

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -854,11 +854,9 @@ func runTest(t *testing.T,
 	cmd.Env = append(cmd.Env, "CLOUD_ENV="+cloudEnv)
 	cmd.Env = append(cmd.Env, "CURRENT_USER_NAME="+user.UserName)
 	if !isRunningOnCloud {
-		// Expose a guest service-principal token for the as-test-sp helper. Its
-		// dedicated prefix plus the primary identity's uuid suffix make it share
-		// the same fake workspace, letting one local test exercise two
-		// identities the way cloud does. On cloud TEST_SP_TOKEN comes from the
-		// real environment.
+		// Expose a guest token for the as-test-sp helper: the guest prefix plus
+		// the primary identity's uuid suffix make it share the same fake
+		// workspace. On cloud TEST_SP_TOKEN comes from the real environment.
 		suffix := cfg.Token
 		for _, prefix := range []string{testserver.UserNameTokenPrefix, testserver.ServicePrincipalTokenPrefix} {
 			suffix = strings.TrimPrefix(suffix, prefix)

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RunsOnDbr = false
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/script
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/script
@@ -1,5 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
-envsubst < take_ownership.json.tmpl > take_ownership.json
+# Locally DATABRICKS_CLIENT_ID is unset; fall back to the current identity so
+# the owner principal matches cloud (where the two values are equal).
+DATABRICKS_CLIENT_ID="${DATABRICKS_CLIENT_ID:-$CURRENT_USER_NAME}" envsubst < take_ownership.json.tmpl > take_ownership.json
 trace cat take_ownership.json
 
 trace as-test-sp $CLI current-user me | jq .displayName

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/script
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/script
@@ -1,6 +1,6 @@
 envsubst < databricks.yml.tmpl > databricks.yml
-# Locally DATABRICKS_CLIENT_ID is unset; fall back to the current identity so
-# the owner principal matches cloud (where the two values are equal).
+# Locally DATABRICKS_CLIENT_ID is unset; fall back to the current identity so the
+# owner matches cloud. Scoped to this command so CLI auth is unaffected.
 DATABRICKS_CLIENT_ID="${DATABRICKS_CLIENT_ID:-$CURRENT_USER_NAME}" envsubst < take_ownership.json.tmpl > take_ownership.json
 trace cat take_ownership.json
 

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RecordRequests = false
 CloudEnvs.gcp = false

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -34,10 +34,15 @@ import (
 const (
 	UserNameTokenPrefix         = "dbapi0"
 	ServicePrincipalTokenPrefix = "dbapi1"
-	UserID                      = "1000012345"
-	TestDefaultClusterId        = "0123-456789-cluster0"
-	TestDefaultWarehouseId      = "8ec9edc1-db0c-40df-af8d-7580020fe61e"
-	TestDefaultInstancePoolId   = "0123-456789-pool0"
+	// GuestServicePrincipalTokenPrefix marks a guest service principal that
+	// shares another identity's workspace (the as-test-sp helper). A dedicated
+	// prefix identifies the guest regardless of request order and keeps it
+	// distinct from a test whose primary identity is itself a service principal.
+	GuestServicePrincipalTokenPrefix = "dbapi2"
+	UserID                           = "1000012345"
+	TestDefaultClusterId             = "0123-456789-cluster0"
+	TestDefaultWarehouseId           = "8ec9edc1-db0c-40df-af8d-7580020fe61e"
+	TestDefaultInstancePoolId        = "0123-456789-pool0"
 )
 
 var TestUser = iam.User{
@@ -48,6 +53,42 @@ var TestUser = iam.User{
 var TestUserSP = iam.User{
 	Id:       UserID,
 	UserName: "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+}
+
+// guestServicePrincipalDisplayName is the display name reported for a guest
+// service principal (the as-test-sp helper). On cloud the guest is a distinct,
+// named SP, so only the guest—not the primary SP identity—carries this name.
+const guestServicePrincipalDisplayName = "deco-test-spn"
+
+// isGuestToken reports whether a token belongs to a guest service principal
+// that shares another identity's workspace. Job permission checks apply only to
+// guests; the workspace's primary identity is treated as an admin.
+func isGuestToken(token string) bool {
+	return strings.HasPrefix(token, GuestServicePrincipalTokenPrefix)
+}
+
+// userForToken returns the identity behind a request token. Service-principal
+// tokens (primary or guest) authenticate as the SP, otherwise as the user. This
+// lets a single workspace be accessed by both the test's primary identity and a
+// guest service principal (the as-test-sp helper), mirroring cloud where one
+// workspace serves many identities.
+func userForToken(token string) iam.User {
+	if strings.HasPrefix(token, ServicePrincipalTokenPrefix) || isGuestToken(token) {
+		return TestUserSP
+	}
+	return TestUser
+}
+
+// MeUser returns the identity for a request token. A guest service principal
+// (the as-test-sp helper on a workspace shared with a primary user) reports a
+// display name, matching the named SP used on cloud; the primary SP identity
+// does not, so single-identity service-principal tests are unaffected.
+func (s *FakeWorkspace) MeUser(token string) iam.User {
+	user := userForToken(token)
+	if isGuestToken(token) {
+		user.DisplayName = guestServicePrincipalDisplayName
+	}
+	return user
 }
 
 var (

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -34,10 +34,9 @@ import (
 const (
 	UserNameTokenPrefix         = "dbapi0"
 	ServicePrincipalTokenPrefix = "dbapi1"
-	// GuestServicePrincipalTokenPrefix marks a guest service principal that
-	// shares another identity's workspace (the as-test-sp helper). A dedicated
-	// prefix identifies the guest regardless of request order and keeps it
-	// distinct from a test whose primary identity is itself a service principal.
+	// GuestServicePrincipalTokenPrefix marks an as-test-sp guest sharing another
+	// identity's workspace, kept distinct from a test whose primary identity is
+	// itself a service principal.
 	GuestServicePrincipalTokenPrefix = "dbapi2"
 	UserID                           = "1000012345"
 	TestDefaultClusterId             = "0123-456789-cluster0"
@@ -55,23 +54,18 @@ var TestUserSP = iam.User{
 	UserName: "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
 }
 
-// guestServicePrincipalDisplayName is the display name reported for a guest
-// service principal (the as-test-sp helper). On cloud the guest is a distinct,
-// named SP, so only the guest—not the primary SP identity—carries this name.
+// guestServicePrincipalDisplayName is reported on /Me for the as-test-sp guest,
+// matching the named SP used on cloud.
 const guestServicePrincipalDisplayName = "deco-test-spn"
 
-// isGuestToken reports whether a token belongs to a guest service principal
-// that shares another identity's workspace. Job permission checks apply only to
-// guests; the workspace's primary identity is treated as an admin.
+// isGuestToken reports whether a token is an as-test-sp guest. Job permission
+// checks apply only to guests; the primary identity is treated as an admin.
 func isGuestToken(token string) bool {
 	return strings.HasPrefix(token, GuestServicePrincipalTokenPrefix)
 }
 
-// userForToken returns the identity behind a request token. Service-principal
-// tokens (primary or guest) authenticate as the SP, otherwise as the user. This
-// lets a single workspace be accessed by both the test's primary identity and a
-// guest service principal (the as-test-sp helper), mirroring cloud where one
-// workspace serves many identities.
+// userForToken returns the identity behind a token: any service-principal token
+// (primary or guest) is the SP, otherwise the user.
 func userForToken(token string) iam.User {
 	if strings.HasPrefix(token, ServicePrincipalTokenPrefix) || isGuestToken(token) {
 		return TestUserSP
@@ -79,10 +73,8 @@ func userForToken(token string) iam.User {
 	return TestUser
 }
 
-// MeUser returns the identity for a request token. A guest service principal
-// (the as-test-sp helper on a workspace shared with a primary user) reports a
-// display name, matching the named SP used on cloud; the primary SP identity
-// does not, so single-identity service-principal tests are unaffected.
+// MeUser returns the /Me identity for a token. Only the guest SP carries a
+// display name, so single-identity SP tests are unaffected.
 func (s *FakeWorkspace) MeUser(token string) iam.User {
 	user := userForToken(token)
 	if isGuestToken(token) {

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -74,7 +74,7 @@ func AddDefaultHandlers(server *Server) {
 	server.Handle("GET", "/api/2.0/preview/scim/v2/Me", func(req Request) any {
 		return Response{
 			Headers: map[string][]string{"X-Databricks-Org-Id": {"900800700600"}},
-			Body:    req.Workspace.CurrentUser(),
+			Body:    req.Workspace.MeUser(req.Token),
 		}
 	})
 
@@ -259,7 +259,7 @@ func AddDefaultHandlers(server *Server) {
 				Body:       fmt.Sprintf("request parsing error: %s", err),
 			}
 		}
-		return MapDelete(req.Workspace, req.Workspace.Jobs, request.JobId)
+		return req.Workspace.JobsDelete(req, request.JobId)
 	})
 
 	server.Handle("POST", "/api/2.2/jobs/reset", func(req Request) any {

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -73,11 +73,12 @@ func (s *FakeWorkspace) JobsCreate(req Request) Response {
 
 	// CreatorUserName field is used by TF to check if the resource exists or not. CreatorUserName should be non-empty for the resource to be considered as "exists"
 	// https://github.com/databricks/terraform-provider-databricks/blob/main/permissions/permission_definitions.go#L108
+	creator := userForToken(req.Token).UserName
 	s.Jobs[jobId] = jobs.Job{
 		JobId:           jobId,
 		Settings:        &jobSettings,
-		CreatorUserName: s.CurrentUser().UserName,
-		RunAsUserName:   s.CurrentUser().UserName,
+		CreatorUserName: creator,
+		RunAsUserName:   creator,
 		CreatedTime:     nowMilli(),
 	}
 	return Response{Body: jobs.CreateResponse{JobId: jobId}}
@@ -217,6 +218,13 @@ func (s *FakeWorkspace) JobsGet(req Request) Response {
 
 	defer s.LockUnlock()()
 
+	// A guest service principal that lacks access reads as a permission error,
+	// not a 404, and it does so even after the job is deleted: the backend
+	// checks permissions before existence. This is the quirk the test asserts.
+	if isGuestToken(req.Token) && !s.guestHasJobAccess(jobIdInt, userForToken(req.Token).UserName) {
+		return jobReadPermissionDenied(userForToken(req.Token).UserName, jobIdInt)
+	}
+
 	job, ok := s.Jobs[jobIdInt]
 	if !ok {
 		// Match the real Jobs API, which echoes the job id in the error message.
@@ -264,6 +272,47 @@ func (s *FakeWorkspace) JobsGet(req Request) Response {
 	}
 
 	return Response{Body: job}
+}
+
+// JobsDelete deletes a job, enforcing permissions for guest service principals.
+// A guest without admin/owner access gets a permission error rather than a
+// delete, matching cloud (and even after the job is gone, since the permission
+// check precedes the existence check).
+func (s *FakeWorkspace) JobsDelete(req Request, jobId int64) Response {
+	defer s.LockUnlock()()
+
+	if isGuestToken(req.Token) && !s.guestHasJobAccess(jobId, userForToken(req.Token).UserName) {
+		return jobDeletePermissionDenied(userForToken(req.Token).UserName, jobId)
+	}
+
+	if _, ok := s.Jobs[jobId]; !ok {
+		return Response{StatusCode: 404}
+	}
+	delete(s.Jobs, jobId)
+	return Response{}
+}
+
+const permissionDeniedErrorCode = "PERMISSION_DENIED"
+
+func jobPermissionDenied(message string) Response {
+	return Response{
+		StatusCode: 403,
+		Body:       map[string]string{"error_code": permissionDeniedErrorCode, "message": message},
+	}
+}
+
+// jobManagePermissionDenied is returned when reading a job's permissions without
+// Manage access. ElasticJobId mirrors the identifier shape in the backend error.
+func jobManagePermissionDenied(principal string, jobId int64) Response {
+	return jobPermissionDenied(fmt.Sprintf("%s does not have Manage permissions on Job with ID: ElasticJobId(%d). Please contact the owner or an administrator for access.", principal, jobId))
+}
+
+func jobReadPermissionDenied(principal string, jobId int64) Response {
+	return jobPermissionDenied(fmt.Sprintf("User %s does not have View or Admin or Manage Run or Owner permissions on job %d", principal, jobId))
+}
+
+func jobDeletePermissionDenied(principal string, jobId int64) Response {
+	return jobPermissionDenied(fmt.Sprintf("User %s does not have Admin or Owner permissions on job %d", principal, jobId))
 }
 
 func (s *FakeWorkspace) JobsList() Response {

--- a/libs/testserver/jobs.go
+++ b/libs/testserver/jobs.go
@@ -218,9 +218,8 @@ func (s *FakeWorkspace) JobsGet(req Request) Response {
 
 	defer s.LockUnlock()()
 
-	// A guest service principal that lacks access reads as a permission error,
-	// not a 404, and it does so even after the job is deleted: the backend
-	// checks permissions before existence. This is the quirk the test asserts.
+	// The backend checks permissions before existence, so a guest without access
+	// gets a permission error rather than a 404, even after the job is deleted.
 	if isGuestToken(req.Token) && !s.guestHasJobAccess(jobIdInt, userForToken(req.Token).UserName) {
 		return jobReadPermissionDenied(userForToken(req.Token).UserName, jobIdInt)
 	}
@@ -274,10 +273,8 @@ func (s *FakeWorkspace) JobsGet(req Request) Response {
 	return Response{Body: job}
 }
 
-// JobsDelete deletes a job, enforcing permissions for guest service principals.
-// A guest without admin/owner access gets a permission error rather than a
-// delete, matching cloud (and even after the job is gone, since the permission
-// check precedes the existence check).
+// JobsDelete deletes a job. A guest without admin/owner access gets a permission
+// error, even after the job is gone (permission check precedes existence check).
 func (s *FakeWorkspace) JobsDelete(req Request, jobId int64) Response {
 	defer s.LockUnlock()()
 
@@ -302,7 +299,7 @@ func jobPermissionDenied(message string) Response {
 }
 
 // jobManagePermissionDenied is returned when reading a job's permissions without
-// Manage access. ElasticJobId mirrors the identifier shape in the backend error.
+// Manage access. ElasticJobId mirrors the backend error's identifier shape.
 func jobManagePermissionDenied(principal string, jobId int64) Response {
 	return jobPermissionDenied(fmt.Sprintf("%s does not have Manage permissions on Job with ID: ElasticJobId(%d). Please contact the owner or an administrator for access.", principal, jobId))
 }

--- a/libs/testserver/permissions.go
+++ b/libs/testserver/permissions.go
@@ -77,6 +77,42 @@ func (s *FakeWorkspace) upsertPermission(objectKey string, entry iam.AccessContr
 	s.Permissions[objectKey] = perms
 }
 
+// jobPrincipalHasAccess reports whether the named principal holds a direct ACL
+// entry on the job (hasAccess) and whether the ACL assigns an explicit owner
+// (hasOwner). The owner signal lets callers grant the creator implicit access
+// only until ownership is transferred to someone else.
+func jobPrincipalHasAccess(perms iam.ObjectPermissions, principal string) (hasAccess, hasOwner bool) {
+	for _, acl := range perms.AccessControlList {
+		for _, p := range acl.AllPermissions {
+			if p.PermissionLevel == "IS_OWNER" {
+				hasOwner = true
+			}
+		}
+		if len(acl.AllPermissions) > 0 && (acl.UserName == principal || acl.ServicePrincipalName == principal) {
+			hasAccess = true
+		}
+	}
+	return hasAccess, hasOwner
+}
+
+// guestHasJobAccess reports whether a guest service principal may read a job.
+// Access is granted by a direct ACL entry, or—when no explicit owner is set—by
+// being the job's creator (the creator is the implicit owner until ownership is
+// transferred away). Must be called with s.mu held.
+func (s *FakeWorkspace) guestHasJobAccess(jobId int64, principal string) bool {
+	perms := s.Permissions[fmt.Sprintf("/jobs/%d", jobId)]
+	hasAccess, hasOwner := jobPrincipalHasAccess(perms, principal)
+	if hasAccess {
+		return true
+	}
+	if !hasOwner {
+		if job, ok := s.Jobs[jobId]; ok && job.CreatorUserName == principal {
+			return true
+		}
+	}
+	return false
+}
+
 // GetPermissions retrieves permissions for a given object type and ID
 func (s *FakeWorkspace) GetPermissions(req Request) any {
 	defer s.LockUnlock()()
@@ -86,6 +122,14 @@ func (s *FakeWorkspace) GetPermissions(req Request) any {
 	prefix := req.Vars["prefix"]
 	if prefix != "" {
 		requestObjectType = prefix + "/" + requestObjectType
+	}
+
+	// A guest service principal without manage access on a job cannot read its
+	// permissions, mirroring the backend's pre-existence permission check.
+	if requestObjectType == "jobs" && isGuestToken(req.Token) {
+		if jobId, err := strconv.ParseInt(objectId, 10, 64); err == nil && !s.guestHasJobAccess(jobId, userForToken(req.Token).UserName) {
+			return jobManagePermissionDenied(userForToken(req.Token).UserName, jobId)
+		}
 	}
 
 	if requestObjectType == "" {

--- a/libs/testserver/permissions.go
+++ b/libs/testserver/permissions.go
@@ -77,10 +77,9 @@ func (s *FakeWorkspace) upsertPermission(objectKey string, entry iam.AccessContr
 	s.Permissions[objectKey] = perms
 }
 
-// jobPrincipalHasAccess reports whether the named principal holds a direct ACL
-// entry on the job (hasAccess) and whether the ACL assigns an explicit owner
-// (hasOwner). The owner signal lets callers grant the creator implicit access
-// only until ownership is transferred to someone else.
+// jobPrincipalHasAccess reports whether the principal has a direct ACL entry
+// (hasAccess) and whether the ACL names an explicit owner (hasOwner). hasOwner
+// lets callers grant the creator implicit access only until ownership moves.
 func jobPrincipalHasAccess(perms iam.ObjectPermissions, principal string) (hasAccess, hasOwner bool) {
 	for _, acl := range perms.AccessControlList {
 		for _, p := range acl.AllPermissions {
@@ -95,10 +94,8 @@ func jobPrincipalHasAccess(perms iam.ObjectPermissions, principal string) (hasAc
 	return hasAccess, hasOwner
 }
 
-// guestHasJobAccess reports whether a guest service principal may read a job.
-// Access is granted by a direct ACL entry, or—when no explicit owner is set—by
-// being the job's creator (the creator is the implicit owner until ownership is
-// transferred away). Must be called with s.mu held.
+// guestHasJobAccess reports whether a guest may access a job: via a direct ACL
+// entry, or as the creator while no explicit owner is set. Call with s.mu held.
 func (s *FakeWorkspace) guestHasJobAccess(jobId int64, principal string) bool {
 	perms := s.Permissions[fmt.Sprintf("/jobs/%d", jobId)]
 	hasAccess, hasOwner := jobPrincipalHasAccess(perms, principal)
@@ -124,8 +121,8 @@ func (s *FakeWorkspace) GetPermissions(req Request) any {
 		requestObjectType = prefix + "/" + requestObjectType
 	}
 
-	// A guest service principal without manage access on a job cannot read its
-	// permissions, mirroring the backend's pre-existence permission check.
+	// A guest without manage access cannot read a job's permissions, mirroring
+	// the backend's pre-existence permission check.
 	if requestObjectType == "jobs" && isGuestToken(req.Token) {
 		if jobId, err := strconv.ParseInt(objectId, 10, 64); err == nil && !s.guestHasJobAccess(jobId, userForToken(req.Token).UserName) {
 			return jobManagePermissionDenied(userForToken(req.Token).UserName, jobId)

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -326,19 +326,35 @@ Response.Body = '<response body here>'
 	return s
 }
 
+// workspaceKeyForToken maps a token to its workspace key. A test's primary
+// token and its as-test-sp guest token differ only by the dbapi0/dbapi1
+// identity prefix; stripping the prefix makes both resolve to the same
+// FakeWorkspace so they share state, the way a single cloud workspace serves
+// many identities. The per-test uuid suffix keeps distinct tests isolated.
+func workspaceKeyForToken(token string) string {
+	for _, prefix := range []string{UserNameTokenPrefix, ServicePrincipalTokenPrefix, GuestServicePrincipalTokenPrefix} {
+		if s, ok := strings.CutPrefix(token, prefix); ok {
+			return s
+		}
+	}
+	return token
+}
+
 func (s *Server) getWorkspaceForToken(token string) *FakeWorkspace {
 	if token == "" {
 		return nil
 	}
 
+	key := workspaceKeyForToken(token)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, ok := s.fakeWorkspaces[token]; !ok {
-		s.fakeWorkspaces[token] = NewFakeWorkspace(s.URL, token)
+	if _, ok := s.fakeWorkspaces[key]; !ok {
+		s.fakeWorkspaces[key] = NewFakeWorkspace(s.URL, token)
 	}
 
-	return s.fakeWorkspaces[token]
+	return s.fakeWorkspaces[key]
 }
 
 func (s *Server) serve(w http.ResponseWriter, r *http.Request, handler HandlerFunc, vars map[string]string) {

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -326,11 +326,9 @@ Response.Body = '<response body here>'
 	return s
 }
 
-// workspaceKeyForToken maps a token to its workspace key. A test's primary
-// token and its as-test-sp guest token differ only by the dbapi0/dbapi1
-// identity prefix; stripping the prefix makes both resolve to the same
-// FakeWorkspace so they share state, the way a single cloud workspace serves
-// many identities. The per-test uuid suffix keeps distinct tests isolated.
+// workspaceKeyForToken strips the identity prefix so a test's user, primary SP,
+// and guest tokens resolve to the same FakeWorkspace and share state. The uuid
+// suffix keeps distinct tests isolated.
 func workspaceKeyForToken(token string) string {
 	for _, prefix := range []string{UserNameTokenPrefix, ServicePrincipalTokenPrefix, GuestServicePrincipalTokenPrefix} {
 		if s, ok := strings.CutPrefix(token, prefix); ok {


### PR DESCRIPTION
## Changes
- Flip destroy_without_mgmtperms/with_permissions to also run locally against testserver.
- testserver: share one FakeWorkspace across a test's user/SP/guest-SP tokens by stripping the dbapi0/dbapi1/dbapi2 identity prefix, and resolve identity per request token (the guest SP reports deco-test-spn on /Me).
- testserver: enforce job read/manage/delete permissions for the guest SP with backend-matching PERMISSION_DENIED errors.
- harness: inject TEST_SP_TOKEN for local runs; script falls back DATABRICKS_CLIENT_ID to the current identity.

## Why
The test drives a guest service principal (as-test-sp) that lacks manage permissions on a job and tries to read/destroy it. Running it locally requires the fake workspace to model multiple identities sharing one workspace and to enforce job permissions the way cloud does. Golden files are unchanged, so local output now matches cloud for both engines.

## Tests
- destroy_without_mgmtperms/with_permissions now runs locally in addition to cloud; golden files are unchanged, so local output matches cloud for both engines.