### PR TITLE
Attribute remote SSH session WSFS activity via command origin

### DIFF
--- a/experimental/ssh/internal/client/ssh-server-bootstrap.py
+++ b/experimental/ssh/internal/client/ssh-server-bootstrap.py
@@ -127,6 +127,14 @@ def run_ssh_server():
         raise RuntimeError("Session ID is required. Please provide it using the 'sessionId' widget.")
     serverless = dbutils.widgets.get("serverless")
 
+    # Mark this process's WSFS command origin so workspace-file activity from the
+    # remote SSH session is attributable
+    try:
+        with open("/Workspace/.proc/self/metadata/command_origin", "w") as command_origin_file:
+            command_origin_file.write("RemoteSshServer")
+    except OSError as e:
+        print(f"Could not set WSFS command origin: {e}")
+
     arch = platform.machine()
     if arch == "x86_64":
         cli_arch = "linux_amd64"


### PR DESCRIPTION
Re-home of #5728 (fork PR by @sbauersfeld) onto an in-repo branch so CI can run with OIDC/JFrog access — fork `pull_request` runs can't obtain an OIDC token, so the required `test-result` and `validate-generated` checks fail at the `setup-jfrog` step and the PR can never enter the merge queue. The change and authorship are unchanged (Scott is the commit author).

## Changes
The SSH server bootstrap notebook (`experimental/ssh/internal/client/ssh-server-bootstrap.py`) writes `RemoteSshServer` to `/Workspace/.proc/self/metadata/command_origin` just before launching the SSH server.

## Why
The bootstrap runs as a notebook job on the cluster, so without this, all workspace-file (WSFS) activity from a remote SSH session is attributed to the generic `PythonDriver` command origin. WSFS resolves each request to its leaf-most registered ancestor, so the SSH server subprocess and the shells it spawns inherit this origin, making that activity attributable in WSFS logs.

## Pairs with
`WsfsOperation.CommandOrigin` enum value `COMMAND_ORIGIN_REMOTE_SSH_SERVER` added in databricks-eng/universe#2127479.

## Tests
- `experimental/ssh/...` unit tests and `TestAccept/ssh` acceptance pass locally on this change merged onto `main`.
- The `.proc/.../command_origin` write path is exercised server-side by the WSFS `TestMetadataCommandOrigin` unit test.

Closes #5728

Co-authored-by: Scott Bauersfeld <scott.bauersfeld@databricks.com>