### PR TITLE
ssh setup: handle duplicate cluster names in the interactive cluster picker

### DIFF
--- a/experimental/ssh/internal/setup/setup.go
+++ b/experimental/ssh/internal/setup/setup.go
@@ -57,10 +57,35 @@ func generateHostConfig(ctx context.Context, opts SetupOptions, proxyCommand str
 // clusterSelectionPrompt is a package-level var so tests can replace it with a mock.
 var clusterSelectionPrompt = defaultClusterSelectionPrompt
 
+// buildClusterItems converts a list of cluster details into a slice of
+// display tuples suitable for an ordered picker. When two or more clusters
+// share the same name, the cluster ID is appended in parentheses to each
+// duplicate entry so the user can tell them apart.
+func buildClusterItems(clusters []compute.ClusterDetails) []cmdio.Tuple {
+	seen := make(map[string]bool, len(clusters))
+	items := make([]cmdio.Tuple, 0, len(clusters))
+	for _, c := range clusters {
+		label := c.ClusterName
+		if seen[label] {
+			// A previous cluster already used this name; go back and append
+			// the ID to that earlier entry too, so the list is unambiguous.
+			for i, item := range items {
+				if item.Name == label {
+					items[i].Name = label + " (" + item.Id + ")"
+				}
+			}
+			label = label + " (" + c.ClusterId + ")"
+		}
+		seen[c.ClusterName] = true
+		items = append(items, cmdio.Tuple{Name: label, Id: c.ClusterId})
+	}
+	return items
+}
+
 func defaultClusterSelectionPrompt(ctx context.Context, client *databricks.WorkspaceClient) (string, error) {
 	sp := cmdio.NewSpinner(ctx)
 	sp.Update("Loading clusters.")
-	clusters, err := client.Clusters.ClusterDetailsClusterNameToClusterIdMap(ctx, compute.ListClustersRequest{
+	all, err := client.Clusters.ListAll(ctx, compute.ListClustersRequest{
 		FilterBy: &compute.ListClustersFilterBy{
 			ClusterSources: []compute.ClusterSource{compute.ClusterSourceApi, compute.ClusterSourceUi},
 		},
@@ -69,7 +94,12 @@ func defaultClusterSelectionPrompt(ctx context.Context, client *databricks.Works
 	if err != nil {
 		return "", fmt.Errorf("failed to load names for Clusters drop-down. Please manually specify cluster argument. Original error: %w", err)
 	}
-	id, err := cmdio.Select(ctx, clusters, "The cluster to connect to")
+
+	// Databricks allows clusters to share names; use buildClusterItems to
+	// disambiguate duplicates before passing them to the interactive picker.
+	items := buildClusterItems(all)
+
+	id, err := cmdio.SelectOrdered(ctx, items, "The cluster to connect to")
 	if err != nil {
 		return "", err
 	}

--- a/experimental/ssh/internal/setup/setup_test.go
+++ b/experimental/ssh/internal/setup/setup_test.go
@@ -18,6 +18,66 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBuildClusterItems_UniqueNames verifies that clusters with distinct names
+// are shown with their original name.
+func TestBuildClusterItems_UniqueNames(t *testing.T) {
+	clusters := []compute.ClusterDetails{
+		{ClusterId: "id-1", ClusterName: "alpha"},
+		{ClusterId: "id-2", ClusterName: "beta"},
+	}
+	items := buildClusterItems(clusters)
+	require.Len(t, items, 2)
+	assert.Equal(t, "alpha", items[0].Name)
+	assert.Equal(t, "id-1", items[0].Id)
+	assert.Equal(t, "beta", items[1].Name)
+	assert.Equal(t, "id-2", items[1].Id)
+}
+
+// TestBuildClusterItems_DuplicateNames verifies that when two clusters share a
+// name, both entries are disambiguated by appending their cluster ID.
+func TestBuildClusterItems_DuplicateNames(t *testing.T) {
+	clusters := []compute.ClusterDetails{
+		{ClusterId: "id-1", ClusterName: "shared"},
+		{ClusterId: "id-2", ClusterName: "shared"},
+	}
+	items := buildClusterItems(clusters)
+	require.Len(t, items, 2)
+	assert.Equal(t, "shared (id-1)", items[0].Name)
+	assert.Equal(t, "id-1", items[0].Id)
+	assert.Equal(t, "shared (id-2)", items[1].Name)
+	assert.Equal(t, "id-2", items[1].Id)
+}
+
+// TestBuildClusterItems_ThreeDuplicateNames verifies disambiguation when three
+// clusters share the same name.
+func TestBuildClusterItems_ThreeDuplicateNames(t *testing.T) {
+	clusters := []compute.ClusterDetails{
+		{ClusterId: "id-a", ClusterName: "dup"},
+		{ClusterId: "id-b", ClusterName: "dup"},
+		{ClusterId: "id-c", ClusterName: "dup"},
+	}
+	items := buildClusterItems(clusters)
+	require.Len(t, items, 3)
+	assert.Equal(t, "dup (id-a)", items[0].Name)
+	assert.Equal(t, "dup (id-b)", items[1].Name)
+	assert.Equal(t, "dup (id-c)", items[2].Name)
+}
+
+// TestBuildClusterItems_MixedDuplicates verifies that only the duplicate names
+// get a suffix while unique names stay unchanged.
+func TestBuildClusterItems_MixedDuplicates(t *testing.T) {
+	clusters := []compute.ClusterDetails{
+		{ClusterId: "id-1", ClusterName: "unique"},
+		{ClusterId: "id-2", ClusterName: "dup"},
+		{ClusterId: "id-3", ClusterName: "dup"},
+	}
+	items := buildClusterItems(clusters)
+	require.Len(t, items, 3)
+	assert.Equal(t, "unique", items[0].Name)
+	assert.Equal(t, "dup (id-2)", items[1].Name)
+	assert.Equal(t, "dup (id-3)", items[2].Name)
+}
+
 func TestValidateClusterAccess_SingleUser(t *testing.T) {
 	ctx := cmdio.MockDiscard(t.Context())
 	m := mocks.NewMockWorkspaceClient(t)


### PR DESCRIPTION
## Problem

The SSH `setup` command's interactive cluster picker called the SDK's
`ClusterDetailsClusterNameToClusterIdMap`, which builds a `map[string]string`
keyed by cluster display name. Databricks allows multiple clusters to share the
same name, so this call fails with:

```
Error: failed to load names for Clusters drop-down. Please manually specify
cluster argument. Original error: duplicate .ClusterName: <name>
```

The same underlying issue was originally reported against `auth login
--configure-cluster` (#974) — the `auth login` path was fixed by switching to
`AskForCluster` (which uses `ListAll` directly), but the SSH setup path was
left using the broken SDK helper.

## Fix

In `experimental/ssh/internal/setup/setup.go`, replaced the
`ClusterDetailsClusterNameToClusterIdMap` call with `ListAll` plus a new
`buildClusterItems` helper. The helper builds the picker list without any
name-based keying. When two or more clusters share a name, each entry gets
` (<cluster-id>)` appended so the user can distinguish them. Clusters with
unique names are displayed without modification.

## Tests

Added four unit tests for `buildClusterItems` covering:
- Two clusters with unique names — no suffix added
- Two clusters with the same name — both get `(id)` appended
- Three clusters with the same name — all three disambiguated
- Mixed case: one unique name and two duplicates — only the duplicates get a suffix

Fixes #974