### PR TITLE
Add permissions/grants coverage to invariant test configs

### DIFF
--- a/acceptance/bundle/invariant/configs/alert.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/alert.yml.tmpl
@@ -7,3 +7,6 @@ resources:
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
       display_name: test-alert-$UNIQUE_NAME
       file_path: ./alert.dbalert.json
+      permissions:
+        - level: CAN_MANAGE
+          group_name: users

--- a/acceptance/bundle/invariant/configs/app.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/app.yml.tmpl
@@ -6,3 +6,6 @@ resources:
     foo:
       name: app-$UNIQUE_NAME
       source_code_path: ./app
+      permissions:
+        - level: CAN_USE
+          group_name: users

--- a/acceptance/bundle/invariant/configs/catalog.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/catalog.yml.tmpl
@@ -6,3 +6,7 @@ resources:
     foo:
       name: test-catalog-$UNIQUE_NAME
       comment: This is a test catalog
+      grants:
+        - principal: account users
+          privileges:
+            - USE_CATALOG

--- a/acceptance/bundle/invariant/configs/cluster.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/cluster.yml.tmpl
@@ -9,3 +9,6 @@ resources:
       node_type_id: $NODE_TYPE_ID
       instance_pool_id: $TEST_INSTANCE_POOL_ID
       num_workers: 1
+      permissions:
+        - level: CAN_ATTACH_TO
+          group_name: users

--- a/acceptance/bundle/invariant/configs/dashboard.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/dashboard.yml.tmpl
@@ -7,3 +7,6 @@ resources:
       warehouse_id: $TEST_DEFAULT_WAREHOUSE_ID
       display_name: test-dashboard-$UNIQUE_NAME
       file_path: ./dashboard.lvdash.json
+      permissions:
+        - level: CAN_READ
+          group_name: users

--- a/acceptance/bundle/invariant/configs/experiment.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/experiment.yml.tmpl
@@ -5,3 +5,6 @@ resources:
   experiments:
     foo:
       name: /Users/$CURRENT_USER_NAME/test-experiment-$UNIQUE_NAME
+      permissions:
+        - level: CAN_READ
+          group_name: users

--- a/acceptance/bundle/invariant/configs/external_location.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/external_location.yml.tmpl
@@ -8,3 +8,7 @@ resources:
       url: s3://test-bucket/path
       credential_name: test_storage_credential
       comment: "Test external location from DABs"
+      grants:
+        - principal: account users
+          privileges:
+            - READ_FILES

--- a/acceptance/bundle/invariant/configs/pipeline.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/pipeline.yml.tmpl
@@ -8,3 +8,6 @@ resources:
       libraries:
         - file:
             path: pipeline.py
+      permissions:
+        - level: CAN_VIEW
+          group_name: users

--- a/acceptance/bundle/invariant/configs/postgres_project.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/postgres_project.yml.tmpl
@@ -6,3 +6,6 @@ resources:
     foo:
       project_id: test-pg-project-$UNIQUE_NAME
       display_name: Test Postgres Project
+      permissions:
+        - level: CAN_USE
+          group_name: users

--- a/acceptance/bundle/invariant/configs/registered_model.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/registered_model.yml.tmpl
@@ -7,3 +7,7 @@ resources:
       name: test-model-$UNIQUE_NAME
       catalog_name: main
       schema_name: default
+      grants:
+        - principal: account users
+          privileges:
+            - EXECUTE

--- a/acceptance/bundle/invariant/configs/sql_warehouse.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/sql_warehouse.yml.tmpl
@@ -10,3 +10,6 @@ resources:
       max_num_clusters: 1
       min_num_clusters: 1
       warehouse_type: CLASSIC
+      permissions:
+        - level: CAN_VIEW
+          group_name: users

--- a/acceptance/bundle/invariant/configs/vector_search_index.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/vector_search_index.yml.tmpl
@@ -17,3 +17,7 @@ resources:
         embedding_vector_columns:
           - name: vector
             embedding_dimension: 768
+      grants:
+        - principal: account users
+          privileges:
+            - SELECT

--- a/acceptance/bundle/invariant/configs/volume.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/volume.yml.tmpl
@@ -7,3 +7,7 @@ resources:
       name: test-volume-$UNIQUE_NAME
       catalog_name: main
       schema_name: default
+      grants:
+        - principal: account users
+          privileges:
+            - READ_VOLUME

--- a/acceptance/invariant_test.go
+++ b/acceptance/invariant_test.go
@@ -23,21 +23,6 @@ const invariantConfigsDir = "bundle/invariant/configs"
 // the test fails if an entry here is actually covered, so the list only shrinks.
 var LackingInvariantTest = map[string]bool{
 	"quality_monitors": true,
-
-	"alerts.permissions":            true,
-	"apps.permissions":              true,
-	"clusters.permissions":          true,
-	"dashboards.permissions":        true,
-	"experiments.permissions":       true,
-	"pipelines.permissions":         true,
-	"postgres_projects.permissions": true,
-	"sql_warehouses.permissions":    true,
-
-	"catalogs.grants":              true,
-	"external_locations.grants":    true,
-	"registered_models.grants":     true,
-	"vector_search_indexes.grants": true,
-	"volumes.grants":               true,
 }
 
 // TestInvariantConfigsCoverage ensures that the invariant test configs in


### PR DESCRIPTION
Extend the existing invariant test configs to exercise permissions and grants for the resource types that previously lacked coverage, and shrink `LackingInvariantTest` down to just `quality_monitors`.

Verified locally (`no_drift` + `migrate`) and on cloud (`aws-prod-ucws`, `no_drift`) that all extended configs deploy with no drift.

This pull request and its description were written by Isaac.