### PR TITLE
[DO NOT MERGE] CI timing experiment: parallel vs serial test legs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -377,22 +377,24 @@ tasks:
 
   test:
     desc: Run unit and acceptance tests
-    deps:
-      - task: test-unit
-      - task: test-acc
-        vars:
-          ACCEPTANCE_TEST_FILTER: "{{.ACCEPTANCE_TEST_FILTER}}"
+    # Run the legs sequentially via cmds (not deps) so the `defer: cat` below
+    # runs even when a leg fails. As deps they run in parallel but the cat in
+    # cmds is skipped on failure, so test-output.json is never produced for a
+    # failed run and CI has nothing to upload.
     sources:
       - test-output-unit.json
       - test-output-acc.json
     generates:
       - test-output.json
     cmds:
-      - cat test-output-unit.json test-output-acc.json > test-output.json
+      - defer: cat test-output-unit.json test-output-acc.json > test-output.json
+      - task: test-unit
+      - task: test-acc
+        vars:
+          ACCEPTANCE_TEST_FILTER: "{{.ACCEPTANCE_TEST_FILTER}}"
 
   test-unit:
     desc: Run unit tests across all Go modules (root, tools, codegen)
-    deps: ['test-unit-root', 'test-unit-tools', 'test-unit-codegen']
     sources:
       - test-output-unit-root.json
       - tools/test-output-unit-tools.json
@@ -400,7 +402,10 @@ tasks:
     generates:
       - test-output-unit.json
     cmds:
-      - cat test-output-unit-root.json tools/test-output-unit-tools.json bundle/internal/tf/codegen/test-output-unit-codegen.json > test-output-unit.json
+      - defer: cat test-output-unit-root.json tools/test-output-unit-tools.json bundle/internal/tf/codegen/test-output-unit-codegen.json > test-output-unit.json
+      - task: test-unit-root
+      - task: test-unit-tools
+      - task: test-unit-codegen
 
   test-unit-root:
     desc: Run unit tests in root module


### PR DESCRIPTION
Measurement-only PR. Not for merge.

Compares CI wall-clock of the `test` job under two configurations of the `test-unit` / `test-acc` legs:

- Commit 1 (baseline): current parallel `deps:` configuration, empty commit.
- Commit 2: sequential `cmds:` + `defer: cat` so the concatenated `test-output.json` is produced even when a leg fails.

Local benchmarking (16-core) showed parallel at 294s vs serial at 329s (~11%), because both legs already saturate cores. This PR measures the real CI delta before deciding whether to fix the failed-upload issue in the Taskfile (serial) or in the workflow (artifact glob).

This pull request and its description were written by Isaac.
