### PR TITLE
experimental/ssh: wait full startup timeout for server health check

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### CLI
 
+* Wait for the SSH server health check to pass for the full startup timeout (10 minutes, or 45 minutes with `--accelerator`) instead of a fixed 60 seconds, so `databricks ssh connect` no longer fails with a driver-proxy 503 while a custom `--base-environment` finishes installing ([#5807](https://github.com/databricks/cli/pull/5807)).
+
 ### Bundles
 
 ### Dependency updates

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -1063,33 +1063,45 @@ func ensureSSHServerIsRunning(ctx context.Context, client *databricks.WorkspaceC
 		sp := cmdio.NewSpinner(ctx, cmdio.WithElapsedTime())
 		defer sp.Close()
 		sp.Update("Waiting for the SSH server to start...")
-		maxRetries := 30
-		for retries := range maxRetries {
-			if ctx.Err() != nil {
-				return "", 0, "", ctx.Err()
-			}
+		// After the task reaches RUNNING the driver proxy still answers /metadata with 503
+		// until the container's HTTP endpoint is reachable; with a custom base environment
+		// that install happens post-RUNNING, so warmup can outlast a short fixed window. Poll
+		// for the same budget we allowed for the task to start (accelerator-aware), backing
+		// off between attempts rather than hammering the proxy every 2s during a long wait.
+		_, pollErr := retries.Poll(ctx, opts.TaskStartupTimeout, func() (*struct{}, *retries.Err) {
 			serverPort, userName, effectiveClusterID, err = getServerMetadata(ctx, client, sessionID, clusterID, version, opts.Liteswap)
 			if err == nil {
-				cmdio.LogString(ctx, "Health check successful, starting ssh WebSocket connection...")
-				break
+				return &struct{}{}, nil
 			}
 			// The metadata never appears if the bootstrap job dies after reaching RUNNING.
 			// Surface the job's actual error instead of waiting out the full timeout with a
 			// generic "metadata.json doesn't exist" message.
 			if failure, terminated := runFailureIfTerminated(ctx, client, runID); terminated {
-				return "", 0, "", fmt.Errorf("ssh server bootstrap job failed:\n%s", failure)
+				return nil, retries.Halt(fmt.Errorf("ssh server bootstrap job failed:\n%s", failure))
 			}
-			if retries < maxRetries-1 {
-				time.Sleep(2 * time.Second)
-			} else {
-				return "", 0, "", fmt.Errorf("failed to start the ssh server: %w\n%s", err, describeRunFailure(ctx, client, runID))
-			}
+			return nil, retries.Continue(fmt.Errorf("waiting for ssh server health check: %w", err))
+		})
+		if pollErr != nil {
+			return "", 0, "", formatServerStartError(ctx, client, runID, pollErr)
 		}
+		cmdio.LogString(ctx, "Health check successful, starting ssh WebSocket connection...")
 	} else if err != nil {
 		return "", 0, "", err
 	}
 
 	return userName, serverPort, effectiveClusterID, nil
+}
+
+// formatServerStartError turns a failed health-check poll into the error returned to the user.
+// A halted poll (the bootstrap job terminated) already carries the job's failure details, so it
+// is returned as-is. A timeout carries only the last generic health-check error, so the run's
+// diagnostics are appended. Splitting on the timeout case avoids printing the failure trace twice.
+func formatServerStartError(ctx context.Context, client *databricks.WorkspaceClient, runID int64, pollErr error) error {
+	var timedOut *retries.ErrTimedOut
+	if errors.As(pollErr, &timedOut) {
+		return fmt.Errorf("failed to start the ssh server: %w\n%s", pollErr, describeRunFailure(ctx, client, runID))
+	}
+	return pollErr
 }
 
 func logSshTunnelEvent(ctx context.Context, opts ClientOptions, isSuccess, isReconnect bool, serverStartTimeMs int64) {

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -1,12 +1,14 @@
 package client
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/retries"
 	"github.com/databricks/databricks-sdk-go/service/environments"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/stretchr/testify/assert"
@@ -191,6 +193,36 @@ func TestRunFailureIfTerminated(t *testing.T) {
 		_, terminated := runFailureIfTerminated(ctx, m.WorkspaceClient, 1)
 		assert.False(t, terminated)
 	})
+}
+
+func TestFormatServerStartErrorTimeoutAppendsRunFailure(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	m := mocks.NewMockWorkspaceClient(t)
+	api := m.GetMockJobsAPI()
+	api.EXPECT().GetRun(mock.Anything, jobs.GetRunRequest{RunId: 1}).Return(
+		terminatedRun(1, 99, "Could not reach driver of cluster 0605-x.", "https://example.test/run/1"), nil)
+	api.EXPECT().GetRunOutput(mock.Anything, jobs.GetRunOutputRequest{RunId: 99}).Return(
+		&jobs.RunOutput{}, nil)
+
+	pollErr := &retries.ErrTimedOut{}
+	err := formatServerStartError(ctx, m.WorkspaceClient, 1, pollErr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to start the ssh server")
+	// The run diagnostics are fetched and appended for the timeout case.
+	assert.Contains(t, err.Error(), "Could not reach driver of cluster 0605-x.")
+}
+
+func TestFormatServerStartErrorHaltReturnedAsIs(t *testing.T) {
+	ctx := cmdio.MockDiscard(t.Context())
+	// A halted poll already carries the job failure details, so formatServerStartError must not
+	// fetch the run again (no GetRun expectation) nor re-append the trace.
+	m := mocks.NewMockWorkspaceClient(t)
+	pollErr := fmt.Errorf("ssh server bootstrap job failed:\n%s", "Could not reach driver of cluster 0605-x.")
+	err := formatServerStartError(ctx, m.WorkspaceClient, 1, pollErr)
+	require.Error(t, err)
+	assert.Equal(t, pollErr.Error(), err.Error())
+	assert.Equal(t, 1, strings.Count(err.Error(), "Could not reach driver of cluster 0605-x."))
+	assert.NotContains(t, err.Error(), "failed to start the ssh server")
 }
 
 func TestWaitForJobToStartSurfacesFailure(t *testing.T) {


### PR DESCRIPTION
## Changes

`databricks ssh connect` health-checks the bootstrap SSH server after its job task reaches `RUNNING` by polling the driver-proxy `/metadata` endpoint. That poll used a hardcoded `30 × 2s = 60s` window.

The problem: after the task reaches `RUNNING`, the driver proxy still answers `/metadata` with **503** until the container's HTTP endpoint is actually reachable. With a custom `--base-environment`, that environment install happens *after* the task is `RUNNING`, so warmup routinely outlasts 60s — and `ssh connect` fails with `server is not ok, status code 503` even though the server comes up fine moments later. The 503 originates in the serverless driver-proxy layer, not our server binary (`serveMetadata` only ever returns 200/500).

This replaces the fixed loop with `retries.Poll` bounded by the same accelerator-aware budget already used to wait for the task to start (`TaskStartupTimeout`: **10 min** CPU / **45 min** GPU). The SDK poller backs off between attempts (linear, capped ~10s, jittered) instead of hammering the proxy every 2s during a long install, and it still succeeds immediately on the first attempt when the server is already warm.

`formatServerStartError` is extracted so the two failure modes stay distinct: a **halted** poll (bootstrap job terminated) already carries the job's failure trace and is returned as-is, while a **timeout** appends `describeRunFailure` diagnostics. This preserves the prior behavior and avoids printing the failure trace twice.

## Why

Serverless SSH connections with a custom base environment (introduced in #5706) frequently fail on first connect with a driver-proxy 503, because installing the base environment pushes health-readiness past the fixed 60s window. Sizing the health-check wait to match the provisioning wait the user already opted into fixes this without a new flag.

## Tests

- New unit tests `TestFormatServerStartErrorTimeoutAppendsRunFailure` and `TestFormatServerStartErrorHaltReturnedAsIs` cover both error-routing branches (timeout appends run diagnostics; halt returns as-is with the trace exactly once).
- `go test ./experimental/ssh/...` passes.
- `TestAccept/ssh` acceptance suite passes: **`ok github.com/databricks/cli/acceptance 481.255s`**.

### Local run timing

Measured locally (Apple Silicon). Note the acceptance figure includes compiling the full CLI binary on a cold build cache:

| Stage | Time |
| --- | --- |
| `go mod download` (deps, warm module cache) | ~6.6s |
| `go test ./experimental/ssh/...` (unit, compile + run) | ~7.9s |
| `TestAccept/ssh` (acceptance, incl. full CLI compile) | **481.3s (~8m)** |

The bulk of the acceptance wall-clock is the one-time CLI/dependency compilation on a cold `go-build` cache; the ssh test execution itself is a small fraction of that.

_This pull request and its description were written by Isaac._
