### PR TITLE
AIR CLI Integration: implement the `air cancel` command

### DIFF
--- a/acceptance/experimental/air/cancel/out.test.toml
+++ b/acceptance/experimental/air/cancel/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/experimental/air/cancel/output.txt
+++ b/acceptance/experimental/air/cancel/output.txt
@@ -1,0 +1,29 @@
+
+=== cancel by id (text)
+>>> [CLI] experimental air cancel 123
+Successfully requested cancellation for run 123
+
+=== cancel by id (json)
+>>> [CLI] experimental air cancel 123 -o json
+{
+  "v": 1,
+  "ts": "[TIMESTAMP]",
+  "data": {
+    "cancelled": [
+      "123"
+    ]
+  }
+}
+
+=== cancel multiple ids
+>>> [CLI] experimental air cancel 123 456
+Successfully requested cancellation for run 123
+Successfully requested cancellation for run 456
+Successfully requested cancellation for 2 run(s).
+
+=== cancel --all
+>>> [CLI] experimental air cancel --all -y
+Searching active runs for [USERNAME] in [DATABRICKS_URL]...
+Successfully requested cancellation for run [NUMID]
+Successfully requested cancellation for run [NUMID]
+Successfully requested cancellation for 2 run(s).

--- a/acceptance/experimental/air/cancel/script
+++ b/acceptance/experimental/air/cancel/script
@@ -1,0 +1,11 @@
+title "cancel by id (text)"
+trace $CLI experimental air cancel 123
+
+title "cancel by id (json)"
+trace $CLI experimental air cancel 123 -o json
+
+title "cancel multiple ids"
+trace $CLI experimental air cancel 123 456
+
+title "cancel --all"
+trace $CLI experimental air cancel --all -y

--- a/acceptance/experimental/air/cancel/test.toml
+++ b/acceptance/experimental/air/cancel/test.toml
@@ -13,33 +13,40 @@ Response.Body = ''
 Pattern = "POST /api/2.2/jobs/runs/cancel"
 Response.Body = '{}'
 
-# ListTrainingWorkflows backs `cancel --all`: two active runs for the current user.
+# Jobs runs/list backs `cancel --all`: two active AIR runs for the current user
+# (tester@databricks.com, from the built-in scim/v2/Me handler).
 [[Server]]
-Pattern = "GET /api/2.0/ai-training/workflows"
+Pattern = "GET /api/2.2/jobs/runs/list"
 Response.Body = '''
 {
-  "training_workflows": [
+  "runs": [
     {
-      "job_run_id": "334747067049496",
-      "metadata": {"creator_name": "tester@databricks.com"},
-      "spec": {"compute": {"hardware_accelerator_type": "GPU_1xA10", "accelerator_count": 1}},
-      "status": {
-        "state": "TRAINING_WORKFLOW_STATE_RUNNING",
-        "start_time": "2026-06-05T17:32:39.000Z",
-        "job": {"name": "qwen-train"},
-        "mlflow": {"experiment": "/Users/tester@databricks.com/qwen-train"}
-      }
+      "run_id": 334747067049496,
+      "run_name": "qwen-train",
+      "creator_user_name": "tester@databricks.com",
+      "start_time": 1717608759000,
+      "state": {"life_cycle_state": "RUNNING"},
+      "tasks": [{
+        "run_id": 334747067049497,
+        "ai_runtime_task": {
+          "experiment": "/Users/tester@databricks.com/qwen-train",
+          "deployments": [{"compute": {"accelerator_type": "GPU_1xA10", "accelerator_count": 1}}]
+        }
+      }]
     },
     {
-      "job_run_id": "566001814929041",
-      "metadata": {"creator_name": "tester@databricks.com"},
-      "spec": {"compute": {"hardware_accelerator_type": "GPU_1xA10", "accelerator_count": 1}},
-      "status": {
-        "state": "TRAINING_WORKFLOW_STATE_RUNNING",
-        "start_time": "2026-06-05T18:43:24.000Z",
-        "job": {"name": "llama-train"},
-        "mlflow": {"experiment": "/Users/tester@databricks.com/llama-train"}
-      }
+      "run_id": 566001814929041,
+      "run_name": "llama-train",
+      "creator_user_name": "tester@databricks.com",
+      "start_time": 1717612404000,
+      "state": {"life_cycle_state": "RUNNING"},
+      "tasks": [{
+        "run_id": 566001814929042,
+        "ai_runtime_task": {
+          "experiment": "/Users/tester@databricks.com/llama-train",
+          "deployments": [{"compute": {"accelerator_type": "GPU_1xA10", "accelerator_count": 1}}]
+        }
+      }]
     }
   ]
 }

--- a/acceptance/experimental/air/cancel/test.toml
+++ b/acceptance/experimental/air/cancel/test.toml
@@ -1,0 +1,46 @@
+# This command does not deploy a bundle, so no engine matrix is needed.
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = []
+
+# The SDK occasionally probes host reachability with a HEAD request; stub it so
+# the test is deterministic.
+[[Server]]
+Pattern = "HEAD /"
+Response.Body = ''
+
+# CancelRun accepts the request and returns an empty body.
+[[Server]]
+Pattern = "POST /api/2.2/jobs/runs/cancel"
+Response.Body = '{}'
+
+# ListTrainingWorkflows backs `cancel --all`: two active runs for the current user.
+[[Server]]
+Pattern = "GET /api/2.0/ai-training/workflows"
+Response.Body = '''
+{
+  "training_workflows": [
+    {
+      "job_run_id": "334747067049496",
+      "metadata": {"creator_name": "tester@databricks.com"},
+      "spec": {"compute": {"hardware_accelerator_type": "GPU_1xA10", "accelerator_count": 1}},
+      "status": {
+        "state": "TRAINING_WORKFLOW_STATE_RUNNING",
+        "start_time": "2026-06-05T17:32:39.000Z",
+        "job": {"name": "qwen-train"},
+        "mlflow": {"experiment": "/Users/tester@databricks.com/qwen-train"}
+      }
+    },
+    {
+      "job_run_id": "566001814929041",
+      "metadata": {"creator_name": "tester@databricks.com"},
+      "spec": {"compute": {"hardware_accelerator_type": "GPU_1xA10", "accelerator_count": 1}},
+      "status": {
+        "state": "TRAINING_WORKFLOW_STATE_RUNNING",
+        "start_time": "2026-06-05T18:43:24.000Z",
+        "job": {"name": "llama-train"},
+        "mlflow": {"experiment": "/Users/tester@databricks.com/llama-train"}
+      }
+    }
+  ]
+}
+'''

--- a/acceptance/experimental/air/unimplemented/output.txt
+++ b/acceptance/experimental/air/unimplemented/output.txt
@@ -5,12 +5,6 @@ Error: `air logs` is not implemented yet
 
 Exit code: 1
 
-=== cancel
->>> [CLI] experimental air cancel 123
-Error: `air cancel` is not implemented yet
-
-Exit code: 1
-
 === register-image
 >>> [CLI] experimental air register-image my-image:latest
 Error: `air register-image` is not implemented yet

--- a/acceptance/experimental/air/unimplemented/script
+++ b/acceptance/experimental/air/unimplemented/script
@@ -3,8 +3,5 @@
 title "logs"
 errcode trace $CLI experimental air logs 123
 
-title "cancel"
-errcode trace $CLI experimental air cancel 123
-
 title "register-image"
 errcode trace $CLI experimental air register-image my-image:latest

--- a/experimental/air/cmd/cancel.go
+++ b/experimental/air/cmd/cancel.go
@@ -94,7 +94,10 @@ func newCancelCommand() *cobra.Command {
 				cmdio.LogString(ctx, fmt.Sprintf("Searching active runs for %s in %s...", me.UserName, host))
 			}
 
-			rows, err := listAirRuns(ctx, w, listQuery{activeOnly: true, userFilter: me.UserName})
+			// Fetch every active run (up to the scan bound) so --all cancels all
+			// of them, not just the first page.
+			fetcher := newRunFetcher(ctx, w, listQuery{activeOnly: true, userFilter: me.UserName})
+			rows, err := fetcher.next(maxListScan)
 			if err != nil {
 				return renderError(ctx, cmd, "INTERNAL_ERROR", "TRANSIENT", true,
 					fmt.Errorf("failed to list active runs: %w", err))
@@ -144,7 +147,7 @@ func newCancelCommand() *cobra.Command {
 			}
 			data.Cancelled = append(data.Cancelled, rid)
 			if !jsonOut {
-				cmdio.LogString(ctx, fmt.Sprintf("Successfully requested cancellation for run %s", rid))
+				cmdio.LogString(ctx, "Successfully requested cancellation for run "+rid)
 			}
 		}
 

--- a/experimental/air/cmd/cancel.go
+++ b/experimental/air/cmd/cancel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -133,8 +134,7 @@ func newCancelCommand() *cobra.Command {
 			if err != nil {
 				data.Failed = append(data.Failed, cancelFailure{RunID: rid, Error: err.Error()})
 				if !jsonOut {
-					// Returned when the run ID is unknown to the user.
-					if errors.Is(err, apierr.ErrResourceDoesNotExist) {
+					if runNotFound(err) {
 						cmdio.LogString(ctx, fmt.Sprintf("Run %s not found. Please check the run ID and ensure you're using a Job Run ID.", rid))
 					} else {
 						cmdio.LogString(ctx, fmt.Sprintf("Failed to cancel run %s: %s", rid, err))
@@ -170,6 +170,20 @@ func newCancelCommand() *cobra.Command {
 	}
 
 	return cmd
+}
+
+// runNotFound reports whether err means the run does not exist. The cancel
+// endpoint returns 400 INVALID_PARAMETER_VALUE ("Run <id> does not exist") for
+// an unknown run, and the SDK only remaps that to ErrResourceDoesNotExist for
+// the runs/get path, not cancel — so we also detect the raw code here.
+func runNotFound(err error) bool {
+	if errors.Is(err, apierr.ErrResourceDoesNotExist) {
+		return true
+	}
+	if apiErr, ok := errors.AsType[*apierr.APIError](err); ok {
+		return apiErr.StatusCode == http.StatusBadRequest && apiErr.ErrorCode == "INVALID_PARAMETER_VALUE"
+	}
+	return false
 }
 
 // cancelRun requests cancellation of a single job run. The cancel is async, so

--- a/experimental/air/cmd/cancel.go
+++ b/experimental/air/cmd/cancel.go
@@ -1,9 +1,38 @@
 package aircmd
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/spf13/cobra"
 )
+
+// cancelData is the JSON payload printed by `air cancel`. `all` is set only for
+// --all, `workspace` only when --all finds no active runs, and `failed` only
+// when a run could not be cancelled.
+type cancelData struct {
+	Cancelled []string        `json:"cancelled"`
+	All       bool            `json:"all,omitempty"`
+	Workspace string          `json:"workspace,omitempty"`
+	Failed    []cancelFailure `json:"failed,omitempty"`
+}
+
+type cancelFailure struct {
+	RunID string `json:"run_id"`
+	Error string `json:"error"`
+}
 
 func newCancelCommand() *cobra.Command {
 	var (
@@ -15,9 +44,6 @@ func newCancelCommand() *cobra.Command {
 		Use:   "cancel [JOB_RUN_ID...]",
 		Short: "Cancel one or more runs",
 		Long:  `Cancel one or more runs by ID, or cancel all of your active runs with --all.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return notImplemented("cancel")
-		},
 	}
 
 	cmd.Flags().BoolVar(&all, "all", false, "Cancel all of your active runs")
@@ -35,5 +61,145 @@ func newCancelCommand() *cobra.Command {
 		return nil
 	}
 
+	// In -o json mode an auth failure should be a JSON error envelope, not a bare
+	// error. ErrAlreadyPrinted passes through (already handled upstream).
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		err := root.MustWorkspaceClient(cmd, args)
+		if err == nil || errors.Is(err, root.ErrAlreadyPrinted) {
+			return err
+		}
+		return renderError(cmd.Context(), cmd, "INTERNAL_ERROR", "TRANSIENT", true, err)
+	}
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		w := cmdctx.WorkspaceClient(ctx)
+		jsonOut := root.OutputType(cmd) == flags.OutputJSON
+
+		runIDs := args
+		data := cancelData{Cancelled: []string{}}
+
+		if all {
+			data.All = true
+
+			me, err := w.CurrentUser.Me(ctx, iam.MeRequest{})
+			if err != nil {
+				return renderError(ctx, cmd, "INTERNAL_ERROR", "TRANSIENT", true,
+					fmt.Errorf("failed to resolve current user: %w", err))
+			}
+			host := strings.TrimRight(w.Config.Host, "/")
+
+			if !jsonOut {
+				cmdio.LogString(ctx, fmt.Sprintf("Searching active runs for %s in %s...", me.UserName, host))
+			}
+
+			rows, err := listAirRuns(ctx, w, listQuery{activeOnly: true, userFilter: me.UserName})
+			if err != nil {
+				return renderError(ctx, cmd, "INTERNAL_ERROR", "TRANSIENT", true,
+					fmt.Errorf("failed to list active runs: %w", err))
+			}
+
+			runIDs = make([]string, 0, len(rows))
+			for i := range rows {
+				if rows[i].RunID != "" {
+					runIDs = append(runIDs, rows[i].RunID)
+				}
+			}
+
+			if len(runIDs) == 0 {
+				if jsonOut {
+					data.Workspace = host
+					return renderEnvelope(ctx, data)
+				}
+				cmdio.LogString(ctx, "No active runs found.")
+				return nil
+			}
+
+			if !yes {
+				displayCancelPreview(ctx, rows, host)
+				confirmed, err := cmdio.AskYesOrNo(ctx, fmt.Sprintf("\nCancel %d run(s) in %s?", len(runIDs), host))
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					cmdio.LogString(ctx, "Cancellation aborted.")
+					return root.ErrAlreadyPrinted
+				}
+			}
+		}
+
+		for _, rid := range runIDs {
+			err := cancelRun(ctx, w, rid)
+			if err != nil {
+				data.Failed = append(data.Failed, cancelFailure{RunID: rid, Error: err.Error()})
+				if !jsonOut {
+					// Returned when the run ID is unknown to the user.
+					if errors.Is(err, apierr.ErrResourceDoesNotExist) {
+						cmdio.LogString(ctx, fmt.Sprintf("Run %s not found. Please check the run ID and ensure you're using a Job Run ID.", rid))
+					} else {
+						cmdio.LogString(ctx, fmt.Sprintf("Failed to cancel run %s: %s", rid, err))
+					}
+				}
+				continue
+			}
+			data.Cancelled = append(data.Cancelled, rid)
+			if !jsonOut {
+				cmdio.LogString(ctx, fmt.Sprintf("Successfully requested cancellation for run %s", rid))
+			}
+		}
+
+		if jsonOut {
+			if err := renderEnvelope(ctx, data); err != nil {
+				return err
+			}
+			// Print the envelope, but still exit non-zero on any failure.
+			if len(data.Failed) > 0 {
+				return root.ErrAlreadyPrinted
+			}
+			return nil
+		}
+
+		if len(data.Failed) > 0 {
+			cmdio.LogString(ctx, fmt.Sprintf("%d run(s) failed to cancel.", len(data.Failed)))
+			return root.ErrAlreadyPrinted
+		}
+		if all || len(data.Cancelled) > 1 {
+			cmdio.LogString(ctx, fmt.Sprintf("Successfully requested cancellation for %d run(s).", len(data.Cancelled)))
+		}
+		return nil
+	}
+
 	return cmd
+}
+
+// cancelRun requests cancellation of a single job run. The cancel is async, so
+// the returned waiter is ignored.
+func cancelRun(ctx context.Context, w *databricks.WorkspaceClient, rid string) error {
+	runID, err := strconv.ParseInt(rid, 10, 64)
+	if err != nil || runID <= 0 {
+		return fmt.Errorf("invalid run ID %q: must be a positive integer", rid)
+	}
+	_, err = w.Jobs.CancelRun(ctx, jobs.CancelRun{RunId: runID})
+	return err
+}
+
+// displayCancelPreview shows the runs that `cancel --all` is about to terminate.
+func displayCancelPreview(ctx context.Context, rows []listRow, host string) {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "\nWorkspace: %s\n", host)
+	fmt.Fprintf(&sb, "Found %d active run(s) to cancel:\n\n", len(rows))
+
+	tw := tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "Run ID\tExperiment\tStarted")
+	for i := range rows {
+		experiment := orNA(rows[i].Experiment)
+		started := na
+		if rows[i].StartedAt != nil {
+			started = *rows[i].StartedAt
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", rows[i].RunID, experiment, started)
+	}
+	tw.Flush()
+
+	cmdio.LogString(ctx, strings.TrimRight(sb.String(), "\n"))
 }

--- a/experimental/air/cmd/cancel_test.go
+++ b/experimental/air/cmd/cancel_test.go
@@ -3,8 +3,13 @@ package aircmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/databricks/cli/cmd/root"
 	"github.com/databricks/cli/libs/cmdctx"
@@ -13,12 +18,24 @@ import (
 	"github.com/databricks/databricks-sdk-go"
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// runCancelAll runs `cancel --all` against w with the given output mode and
+// stdin, capturing output into buf.
+func runCancelAll(t *testing.T, w *databricks.WorkspaceClient, out flags.Output, in io.Reader, buf *bytes.Buffer) error {
+	t.Helper()
+	cmd := withOutput(newCancelCommand(), out)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), out, in, buf, buf, "", ""))
+	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
+	return cmd.RunE(cmd, nil)
+}
 
 // cancelEnvelope decodes the air JSON envelope with the cancel payload.
 type cancelEnvelope struct {
@@ -138,18 +155,35 @@ func TestCancelByIDSuccessJSON(t *testing.T) {
 	assert.Empty(t, got.Data.Failed)
 }
 
+func TestCancelByIDGenericFailure(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 7}).Return(nil, errors.New("boom"))
+
+	var buf bytes.Buffer
+	_, err := runCancel(t, m.WorkspaceClient, flags.OutputText, "", &buf, "7")
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+	assert.Contains(t, buf.String(), "Failed to cancel run 7: boom")
+}
+
 func TestCancelAllNoActiveRuns(t *testing.T) {
+	w := newTestWorkspaceClient(t, workflowsServer(t, workflowsBody(t, "")).URL)
+	var buf bytes.Buffer
+	require.NoError(t, runCancelAll(t, w, flags.OutputText, nil, &buf))
+	assert.Contains(t, buf.String(), "No active runs found.")
+}
+
+func TestCancelAllNoActiveRunsJSON(t *testing.T) {
 	srv := workflowsServer(t, workflowsBody(t, ""))
 	w := newTestWorkspaceClient(t, srv.URL)
 
 	var buf bytes.Buffer
-	cmd := withOutput(newCancelCommand(), flags.OutputText)
-	require.NoError(t, cmd.Flags().Set("all", "true"))
-	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, nil, &buf, &buf, "", ""))
-	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
+	require.NoError(t, runCancelAll(t, w, flags.OutputJSON, nil, &buf))
 
-	require.NoError(t, cmd.RunE(cmd, nil))
-	assert.Contains(t, buf.String(), "No active runs found.")
+	var got cancelEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Empty(t, got.Data.Cancelled)
+	assert.True(t, got.Data.All)
+	assert.Equal(t, srv.URL, got.Data.Workspace)
 }
 
 func TestCancelAllConfirmYes(t *testing.T) {
@@ -160,12 +194,7 @@ func TestCancelAllConfirmYes(t *testing.T) {
 	w := newTestWorkspaceClient(t, srv.URL)
 
 	var buf bytes.Buffer
-	cmd := withOutput(newCancelCommand(), flags.OutputText)
-	require.NoError(t, cmd.Flags().Set("all", "true"))
-	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, strings.NewReader("y\n"), &buf, &buf, "", ""))
-	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
-
-	require.NoError(t, cmd.RunE(cmd, nil))
+	require.NoError(t, runCancelAll(t, w, flags.OutputText, strings.NewReader("y\n"), &buf))
 	out := buf.String()
 	assert.Contains(t, out, "active run(s) to cancel")
 	assert.Contains(t, out, "Successfully requested cancellation for run 111")
@@ -179,14 +208,50 @@ func TestCancelAllAbort(t *testing.T) {
 	w := newTestWorkspaceClient(t, srv.URL)
 
 	var buf bytes.Buffer
-	cmd := withOutput(newCancelCommand(), flags.OutputText)
-	require.NoError(t, cmd.Flags().Set("all", "true"))
-	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, strings.NewReader("n\n"), &buf, &buf, "", ""))
-	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
-
-	err := cmd.RunE(cmd, nil)
+	err := runCancelAll(t, w, flags.OutputText, strings.NewReader("n\n"), &buf)
 	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
 	assert.Contains(t, buf.String(), "Cancellation aborted.")
+}
+
+func TestCancelAllConfirmReadError(t *testing.T) {
+	srv := workflowsServer(t, workflowsBody(t, "",
+		testWorkflow(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
+	))
+	w := newTestWorkspaceClient(t, srv.URL)
+
+	var buf bytes.Buffer
+	err := runCancelAll(t, w, flags.OutputText, iotest.ErrReader(errors.New("read failed")), &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read failed")
+}
+
+func TestCancelAllMeError(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockCurrentUserAPI().EXPECT().Me(mock.Anything, iam.MeRequest{}).Return(nil, errors.New("nope"))
+
+	var buf bytes.Buffer
+	err := runCancelAll(t, m.WorkspaceClient, flags.OutputText, nil, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve current user")
+}
+
+func TestCancelAllListError(t *testing.T) {
+	// Me succeeds (default empty user), but listing active runs fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == listWorkflowsPath {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error_code":"INTERNAL","message":"boom"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	w := newTestWorkspaceClient(t, srv.URL)
+
+	var buf bytes.Buffer
+	err := runCancelAll(t, w, flags.OutputText, nil, &buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list active runs")
 }
 
 func TestDisplayCancelPreview(t *testing.T) {

--- a/experimental/air/cmd/cancel_test.go
+++ b/experimental/air/cmd/cancel_test.go
@@ -179,14 +179,14 @@ func TestCancelByIDGenericFailure(t *testing.T) {
 }
 
 func TestCancelAllNoActiveRuns(t *testing.T) {
-	w := newTestWorkspaceClient(t, workflowsServer(t, workflowsBody(t, "")).URL)
+	w := newTestWorkspaceClient(t, runsServer(t, runsListBody(t, "")).URL)
 	var buf bytes.Buffer
 	require.NoError(t, runCancelAll(t, w, flags.OutputText, nil, &buf))
 	assert.Contains(t, buf.String(), "No active runs found.")
 }
 
 func TestCancelAllNoActiveRunsJSON(t *testing.T) {
-	srv := workflowsServer(t, workflowsBody(t, ""))
+	srv := runsServer(t, runsListBody(t, ""))
 	w := newTestWorkspaceClient(t, srv.URL)
 
 	var buf bytes.Buffer
@@ -200,9 +200,9 @@ func TestCancelAllNoActiveRunsJSON(t *testing.T) {
 }
 
 func TestCancelAllConfirmYes(t *testing.T) {
-	srv := workflowsServer(t, workflowsBody(t, "",
-		testWorkflow(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
-		testWorkflow(222, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-b"),
+	srv := runsServer(t, runsListBody(t, "",
+		airJobRun(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
+		airJobRun(222, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-b"),
 	))
 	w := newTestWorkspaceClient(t, srv.URL)
 
@@ -215,8 +215,8 @@ func TestCancelAllConfirmYes(t *testing.T) {
 }
 
 func TestCancelAllAbort(t *testing.T) {
-	srv := workflowsServer(t, workflowsBody(t, "",
-		testWorkflow(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
+	srv := runsServer(t, runsListBody(t, "",
+		airJobRun(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
 	))
 	w := newTestWorkspaceClient(t, srv.URL)
 
@@ -227,8 +227,8 @@ func TestCancelAllAbort(t *testing.T) {
 }
 
 func TestCancelAllConfirmReadError(t *testing.T) {
-	srv := workflowsServer(t, workflowsBody(t, "",
-		testWorkflow(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
+	srv := runsServer(t, runsListBody(t, "",
+		airJobRun(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
 	))
 	w := newTestWorkspaceClient(t, srv.URL)
 
@@ -251,7 +251,7 @@ func TestCancelAllMeError(t *testing.T) {
 func TestCancelAllListError(t *testing.T) {
 	// Me succeeds (default empty user), but listing active runs fails.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == listWorkflowsPath {
+		if r.URL.Path == jobsRunsListPath {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"error_code":"INTERNAL","message":"boom"}`))
 			return

--- a/experimental/air/cmd/cancel_test.go
+++ b/experimental/air/cmd/cancel_test.go
@@ -123,6 +123,19 @@ func TestCancelByIDNotFound(t *testing.T) {
 	assert.Contains(t, out, "1 run(s) failed to cancel.")
 }
 
+func TestCancelByIDNotFoundInvalidParam(t *testing.T) {
+	// The cancel endpoint reports an unknown run as 400 INVALID_PARAMETER_VALUE,
+	// which the SDK does not remap to ErrResourceDoesNotExist for this path.
+	m := mocks.NewMockWorkspaceClient(t)
+	apiErr := &apierr.APIError{StatusCode: http.StatusBadRequest, ErrorCode: "INVALID_PARAMETER_VALUE", Message: "Run 5 does not exist."}
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 5}).Return(nil, apiErr)
+
+	var buf bytes.Buffer
+	_, err := runCancel(t, m.WorkspaceClient, flags.OutputText, "", &buf, "5")
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+	assert.Contains(t, buf.String(), "Run 5 not found")
+}
+
 func TestCancelPartialFailureJSON(t *testing.T) {
 	m := mocks.NewMockWorkspaceClient(t)
 	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 123}).Return(nil, nil)

--- a/experimental/air/cmd/cancel_test.go
+++ b/experimental/air/cmd/cancel_test.go
@@ -1,0 +1,211 @@
+package aircmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/databricks/cli/cmd/root"
+	"github.com/databricks/cli/libs/cmdctx"
+	"github.com/databricks/cli/libs/cmdio"
+	"github.com/databricks/cli/libs/flags"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/experimental/mocks"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// cancelEnvelope decodes the air JSON envelope with the cancel payload.
+type cancelEnvelope struct {
+	V    int        `json:"v"`
+	Data cancelData `json:"data"`
+}
+
+// runCancel runs the cancel command against w with the given output mode and
+// stdin, capturing stdout/stderr into buf.
+func runCancel(t *testing.T, w *databricks.WorkspaceClient, out flags.Output, in string, buf *bytes.Buffer, args ...string) (*cobra.Command, error) {
+	t.Helper()
+	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), out, strings.NewReader(in), buf, buf, "", ""))
+	ctx = cmdctx.SetWorkspaceClient(ctx, w)
+	cmd := withOutput(newCancelCommand(), out)
+	cmd.SetContext(ctx)
+	return cmd, cmd.RunE(cmd, args)
+}
+
+func TestCancelArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		all     bool
+		args    []string
+		wantErr string
+	}{
+		{name: "one id", args: []string{"123"}},
+		{name: "many ids", args: []string{"123", "456"}},
+		{name: "all", all: true},
+		{name: "no input", wantErr: "provide at least one JOB_RUN_ID, or use --all"},
+		{name: "ids with all", all: true, args: []string{"123"}, wantErr: "cannot combine JOB_RUN_ID arguments with --all"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newCancelCommand()
+			if tc.all {
+				require.NoError(t, cmd.Flags().Set("all", "true"))
+			}
+			err := cmd.Args(cmd, tc.args)
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestCancelRunInvalidID(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	for _, id := range []string{"abc", "0", "-1"} {
+		err := cancelRun(t.Context(), m.WorkspaceClient, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid run ID")
+	}
+}
+
+func TestCancelByIDSuccess(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 123}).Return(nil, nil)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 456}).Return(nil, nil)
+
+	var buf bytes.Buffer
+	_, err := runCancel(t, m.WorkspaceClient, flags.OutputText, "", &buf, "123", "456")
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "Successfully requested cancellation for run 123")
+	assert.Contains(t, out, "Successfully requested cancellation for run 456")
+	// More than one run cancelled prints the count summary.
+	assert.Contains(t, out, "Successfully requested cancellation for 2 run(s).")
+}
+
+func TestCancelByIDNotFound(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 5}).Return(nil, apierr.ErrResourceDoesNotExist)
+
+	var buf bytes.Buffer
+	_, err := runCancel(t, m.WorkspaceClient, flags.OutputText, "", &buf, "5")
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+
+	out := buf.String()
+	assert.Contains(t, out, "Run 5 not found")
+	assert.Contains(t, out, "1 run(s) failed to cancel.")
+}
+
+func TestCancelPartialFailureJSON(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 123}).Return(nil, nil)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 5}).Return(nil, apierr.ErrResourceDoesNotExist)
+
+	var buf bytes.Buffer
+	_, err := runCancel(t, m.WorkspaceClient, flags.OutputJSON, "", &buf, "123", "5")
+	// The envelope is printed, but a failure still exits non-zero.
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+
+	var got cancelEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, []string{"123"}, got.Data.Cancelled)
+	require.Len(t, got.Data.Failed, 1)
+	assert.Equal(t, "5", got.Data.Failed[0].RunID)
+	assert.False(t, got.Data.All)
+}
+
+func TestCancelByIDSuccessJSON(t *testing.T) {
+	m := mocks.NewMockWorkspaceClient(t)
+	m.GetMockJobsAPI().EXPECT().CancelRun(mock.Anything, jobs.CancelRun{RunId: 123}).Return(nil, nil)
+
+	var buf bytes.Buffer
+	_, err := runCancel(t, m.WorkspaceClient, flags.OutputJSON, "", &buf, "123")
+	require.NoError(t, err)
+
+	var got cancelEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.Equal(t, []string{"123"}, got.Data.Cancelled)
+	assert.Empty(t, got.Data.Failed)
+}
+
+func TestCancelAllNoActiveRuns(t *testing.T) {
+	srv := workflowsServer(t, workflowsBody(t, ""))
+	w := newTestWorkspaceClient(t, srv.URL)
+
+	var buf bytes.Buffer
+	cmd := withOutput(newCancelCommand(), flags.OutputText)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, nil, &buf, &buf, "", ""))
+	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
+
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Contains(t, buf.String(), "No active runs found.")
+}
+
+func TestCancelAllConfirmYes(t *testing.T) {
+	srv := workflowsServer(t, workflowsBody(t, "",
+		testWorkflow(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
+		testWorkflow(222, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-b"),
+	))
+	w := newTestWorkspaceClient(t, srv.URL)
+
+	var buf bytes.Buffer
+	cmd := withOutput(newCancelCommand(), flags.OutputText)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, strings.NewReader("y\n"), &buf, &buf, "", ""))
+	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
+
+	require.NoError(t, cmd.RunE(cmd, nil))
+	out := buf.String()
+	assert.Contains(t, out, "active run(s) to cancel")
+	assert.Contains(t, out, "Successfully requested cancellation for run 111")
+	assert.Contains(t, out, "Successfully requested cancellation for run 222")
+}
+
+func TestCancelAllAbort(t *testing.T) {
+	srv := workflowsServer(t, workflowsBody(t, "",
+		testWorkflow(111, "me@example.com", "GPU_1xA10", 1, "/Users/me@example.com/exp-a"),
+	))
+	w := newTestWorkspaceClient(t, srv.URL)
+
+	var buf bytes.Buffer
+	cmd := withOutput(newCancelCommand(), flags.OutputText)
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, strings.NewReader("n\n"), &buf, &buf, "", ""))
+	cmd.SetContext(cmdctx.SetWorkspaceClient(ctx, w))
+
+	err := cmd.RunE(cmd, nil)
+	require.ErrorIs(t, err, root.ErrAlreadyPrinted)
+	assert.Contains(t, buf.String(), "Cancellation aborted.")
+}
+
+func TestDisplayCancelPreview(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := cmdio.InContext(t.Context(), cmdio.NewIO(t.Context(), flags.OutputText, nil, &buf, &buf, "", ""))
+
+	started := "2026-06-05 17:32 UTC"
+	rows := []listRow{
+		{RunID: "111", Experiment: "exp-a", StartedAt: &started},
+		{RunID: "222"}, // no experiment or start time -> N/A
+	}
+	displayCancelPreview(ctx, rows, "https://my-workspace.cloud.databricks.test")
+
+	out := buf.String()
+	assert.Contains(t, out, "Workspace: https://my-workspace.cloud.databricks.test")
+	assert.Contains(t, out, "Found 2 active run(s) to cancel:")
+	assert.Contains(t, out, "Run ID")
+	assert.Contains(t, out, "111")
+	assert.Contains(t, out, "exp-a")
+	assert.Contains(t, out, "222")
+	assert.Contains(t, out, na)
+}

--- a/experimental/air/cmd/stubs_test.go
+++ b/experimental/air/cmd/stubs_test.go
@@ -14,7 +14,6 @@ import (
 func TestStubCommandsReturnNotImplemented(t *testing.T) {
 	stubs := map[string]*cobra.Command{
 		"logs":           newLogsCommand(),
-		"cancel":         newCancelCommand(),
 		"register-image": newRegisterImageCommand(),
 	}
 


### PR DESCRIPTION
## Summary

Ports the Python `air` CLI's `handle_cancel` to the Go `air cancel` command (stacked on `air-integration-m1-2`).

- Cancel one or more runs by ID, or all of the current user's active runs with `--all`.
- `--all` resolves the current user, lists their active runs via the Jobs-API run fetcher, shows a preview table, and prompts for confirmation unless `-y` is set (fetches up to `maxListScan` so every active run is cancelled).
- Cancellation goes through the typed SDK `w.Jobs.CancelRun`.
- Not-found is detected via `errors.Is(apierr.ErrResourceDoesNotExist)` and, for the cancel endpoint's `400 INVALID_PARAMETER_VALUE` shape, a typed `errors.As` check — restoring the Python CLI's friendly "Run X not found" guidance.
- Text and JSON (air envelope) output; exits non-zero on any failure.

## Tests

- Unit (`cancel_test.go`): arg validation, by-ID success/not-found (both error shapes), partial-failure JSON exit code, `--all` (no runs / confirm / abort / read error), current-user + list errors, and the preview table.
- Acceptance (`acceptance/experimental/air/cancel`): by-ID text+JSON, multiple IDs, and `--all -y`.
- Drops the now-implemented `cancel` case from the stub unit test and the `unimplemented` acceptance test.

This pull request and its description were written by Isaac.
