### PR TITLE
AIR CLI: drop max_retries from the ai_runtime_task payload

### DIFF
--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -66,6 +66,13 @@ type jobEnvironment struct {
 }
 
 // submitTask is the single task air submits: a native ai_runtime_task.
+//
+// max_retries is always sent (including 0) so the user's YAML value is honored:
+// setting it to 0 explicitly disables retries rather than falling back to the
+// server default. retry_on_timeout is sent only when retries are allowed, and is
+// omitempty so the wire form matches the Python CLI (which never emits a bare
+// "false"). Jobs performs the retries — each attempt is a fresh AI Runtime
+// workload.
 type submitTask struct {
 	TaskKey        string        `json:"task_key"`
 	RunIf          string        `json:"run_if"`
@@ -125,8 +132,9 @@ func buildSubmitPayload(cfg *runConfig, commandPath, dlImage string) jobsSubmitR
 		EnvironmentKey: aiRuntimeEnvironmentKey,
 		MaxRetries:     cfg.maxRetries(),
 	}
-	// max_retries 0 (no retries) is sent explicitly; retry_on_timeout only
-	// applies when retries are allowed.
+	// retry_on_timeout only makes sense when retries are allowed; otherwise omit
+	// it (matches Python's native path, which sets retry_on_timeout only under
+	// the same > 0 gate).
 	st.RetryOnTimeout = st.MaxRetries > 0
 
 	return jobsSubmitRun{

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -61,22 +61,37 @@ func TestBuildSubmitPayload(t *testing.T) {
 	assert.Equal(t, aiRuntimeCompute{AcceleratorType: "GPU_8xH100", AcceleratorCount: 16}, at.Deployments[0].Compute)
 }
 
-func TestBuildSubmitPayload_NoRetries(t *testing.T) {
+func TestBuildSubmitPayloadDefaultRetries(t *testing.T) {
+	// max_retries unset defaults to 3 (matching the Python native path), so both
+	// retry fields are sent.
+	cfg := &runConfig{
+		ExperimentName: "exp",
+		Command:        new("x"),
+		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
+	}
+	task := buildSubmitPayload(cfg, "/d/command.sh", "4").Tasks[0]
+	assert.Equal(t, defaultMaxRetries, task.MaxRetries)
+	assert.True(t, task.RetryOnTimeout)
+}
+
+func TestBuildSubmitPayloadNoRetries(t *testing.T) {
+	// max_retries: 0 must be sent explicitly so Jobs honors "no retries" instead
+	// of applying the server default. retry_on_timeout is omitted when retries
+	// aren't allowed.
 	cfg := &runConfig{
 		ExperimentName: "exp",
 		Command:        new("x"),
 		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
 		MaxRetries:     new(0),
 	}
-
 	task := buildSubmitPayload(cfg, "/d/command.sh", "4").Tasks[0]
 	assert.Equal(t, 0, task.MaxRetries)
 	assert.False(t, task.RetryOnTimeout)
 
-	// max_retries: 0 must be sent, not omitted, so the server honors "no retries".
 	b, err := json.Marshal(task)
 	require.NoError(t, err)
 	assert.Contains(t, string(b), `"max_retries":0`)
+	assert.NotContains(t, string(b), "retry_on_timeout")
 }
 
 func TestSubmitToken(t *testing.T) {


### PR DESCRIPTION
## Changes
Send max_retries on the ai_runtime_task submit payload whenever it is set, so the user's YAML value is honored end-to-end:

- max_retries unset defaults to 3 and is sent (matches the Python CLI default, sdk/config.py Field(default=3)).
- max_retries: N (N > 0) gets sent, with retry_on_timeout: true.
- max_retries: 0 ussent explicitly ("max_retries":0); retry_on_timeout is omitted.

max_retries is always marshaled (no omitempty) so an explicit 0 reaches the server. retry_on_timeout keeps omitempty and is set only when max_retries > 0, so the wire form matches the Python CLI (which never emits a bare retry_on_timeout: false). The YAML field and its >= 0 validation are unchanged.


## Why
On the ai_runtime_task path, retries are honored via the Jobs task max_retries field: Jobs performs the retry, and each attempt is created as its own AIR workload. 

The bug was that max_retries was previously sent unconditionally including 0, but 0 was being dropped/ignored so that setting max_retries: 0 to disable retries silently fell back to the server default and the workload still retried. Sending 0 explicitly makes "no retries" actually take effect.

This intentionally diverges from the Python CLI's native branch by one case: Python only adds the field under if max_retries > 0, so Python's max_retries: 0 silently reverts to the server default. We send 0 so the user's intent is honored.

## Tests
- TestBuildSubmitPayload: max_retries: 2 means task has MaxRetries == 2, RetryOnTimeout == true.
- TestBuildSubmitPayloadDefaultRetries: unset var means MaxRetries == 3 (defaultMaxRetries), RetryOnTimeout == true
- TestBuildSubmitPayloadNoRetries: max_retries: 0 should result in marshaled JSON contains "max_retries":0 and no retry_on_timeout.
- go test ./experimental/air/... and ./task lint-q pass
- manual verification passes