### PR TITLE
acc: run jobs destroy_without_mgmtperms/without_permissions locally

### DIFF
--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RunsOnDbr = false
 CloudEnvs.azure = false

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/script
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/script
@@ -1,5 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
-envsubst < take_ownership.json.tmpl > take_ownership.json
+# Locally DATABRICKS_CLIENT_ID is unset; fall back to the current identity so the
+# owner matches cloud. Scoped to this command so CLI auth is unaffected.
+DATABRICKS_CLIENT_ID="${DATABRICKS_CLIENT_ID:-$CURRENT_USER_NAME}" envsubst < take_ownership.json.tmpl > take_ownership.json
 trace cat take_ownership.json
 
 trace as-test-sp $CLI current-user me | jq .displayName

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RecordRequests = false
 CloudEnvs.gcp = false


### PR DESCRIPTION
## Summary

Convert the `destroy_without_mgmtperms/without_permissions` acceptance test to run against the local testserver in addition to cloud.

The guest-SP, permission-aware testserver model this test relies on already landed with the sibling `with_permissions` test (#5769), so this change is small:

- `test.toml`: set `Local = true` so the test runs locally.
- `script`: fall back `DATABRICKS_CLIENT_ID` to the current identity locally so the owner principal matches cloud (scoped to the `envsubst` command so CLI auth is unaffected).
- `out.test.toml`: regenerated snapshot (`Local = true`).