### PR TITLE
[VPEX][7/8] Add local-env acceptance tests

### DIFF
--- a/acceptance/localenv/constraints-only/out.test.toml
+++ b/acceptance/localenv/constraints-only/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/constraints-only/output.txt
+++ b/acceptance/localenv/constraints-only/output.txt
@@ -1,0 +1,53 @@
+
+>>> [CLI] local-env python sync --serverless v4 --constraints-only --check --output json
+{
+  "schemaVersion": 1,
+  "command": "local-env python sync",
+  "ok": true,
+  "mode": "constraints-only",
+  "dryRun": true,
+  "target": {
+    "source": "serverless",
+    "serverlessVersion": "v4",
+    "envKey": "serverless/serverless-v4"
+  },
+  "resolved": {
+    "pythonVersion": "3.12",
+    "artifactSource": "network"
+  },
+  "greenfield": true,
+  "plan": {
+    "wouldWrite": "[TEST_TMP_DIR]/pyproject.toml",
+    "wouldInstallPython": "3.12",
+    "diff": "--- pyproject.toml\n+++ pyproject.toml\n@@ -1 +1,15 @@\n+[project]\n+name = \"001\"\n+version = \"0.0.0\"\n+requires-python = \"\u003e=3.12\"\n+\n+[dependency-groups]\n+dev = []\n+\n+# managed by databricks local-env python sync — do not edit\n+[tool.uv]\n+constraint-dependencies = [\n+    \"pyarrow\u003c19\",\n+    \"pandas\u003c3\",\n+]\n+# end managed by databricks local-env python sync\n"
+  },
+  "phases": [
+    {
+      "phase": "preflight",
+      "status": "ok"
+    },
+    {
+      "phase": "resolve",
+      "status": "ok"
+    },
+    {
+      "phase": "fetch",
+      "status": "ok"
+    },
+    {
+      "phase": "merge",
+      "status": "ok"
+    },
+    {
+      "phase": "provision",
+      "status": "ok"
+    },
+    {
+      "phase": "validate",
+      "status": "ok"
+    }
+  ],
+  "warnings": [],
+  "error": null,
+  "durationMs": 0
+}

--- a/acceptance/localenv/constraints-only/script
+++ b/acceptance/localenv/constraints-only/script
@@ -1,0 +1,1 @@
+trace $CLI local-env python sync --serverless v4 --constraints-only --check --output json

--- a/acceptance/localenv/constraints-only/test.toml
+++ b/acceptance/localenv/constraints-only/test.toml
@@ -1,0 +1,21 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+[[Server]]
+Pattern = "GET /serverless/serverless-v4/pyproject.toml"
+Response.Body = '''
+[project]
+requires-python = ">=3.12"
+
+[dependency-groups]
+dev = ["databricks-connect~=17.2.0"]
+
+[tool.uv]
+constraint-dependencies = ["pyarrow<19", "pandas<3"]
+'''
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/env-unsupported/out.test.toml
+++ b/acceptance/localenv/env-unsupported/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/env-unsupported/output.txt
+++ b/acceptance/localenv/env-unsupported/output.txt
@@ -5,4 +5,3 @@ merge      pending
 provision  pending
 validate   pending
 For more detail, re-run with --debug, or --output json to share a structured report.
-Error: no published environment for "dbr/15.4.x-scala2.12". If this is a new runtime, try the latest LTS target (e.g. --serverless v4 or a supported --cluster DBR): GET [DATABRICKS_URL]/dbr/15.4.x-scala2.12/pyproject.toml: environment key not found

--- a/acceptance/localenv/env-unsupported/output.txt
+++ b/acceptance/localenv/env-unsupported/output.txt
@@ -1,0 +1,8 @@
+preflight  ok  check
+resolve    ok  source=cluster envKey=dbr/15.4.x-scala2.12
+fetch      error  no published environment for "dbr/15.4.x-scala2.12". If this is a new runtime, try the latest LTS target (e.g. --serverless v4 or a supported --cluster DBR): GET [DATABRICKS_URL]/dbr/15.4.x-scala2.12/pyproject.toml: environment key not found
+merge      pending
+provision  pending
+validate   pending
+For more detail, re-run with --debug, or --output json to share a structured report.
+Error: no published environment for "dbr/15.4.x-scala2.12". If this is a new runtime, try the latest LTS target (e.g. --serverless v4 or a supported --cluster DBR): GET [DATABRICKS_URL]/dbr/15.4.x-scala2.12/pyproject.toml: environment key not found

--- a/acceptance/localenv/env-unsupported/script
+++ b/acceptance/localenv/env-unsupported/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --cluster test-cluster-id --check

--- a/acceptance/localenv/env-unsupported/test.toml
+++ b/acceptance/localenv/env-unsupported/test.toml
@@ -1,0 +1,22 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+[[Server]]
+Pattern = "GET /api/2.1/clusters/get"
+Response.Body = '''
+{
+  "cluster_id": "test-cluster-id",
+  "spark_version": "15.4.x-scala2.12"
+}
+'''
+
+[[Server]]
+Pattern = "GET /dbr/15.4.x-scala2.12/pyproject.toml"
+Response.StatusCode = 404
+Response.Body = '{"message": "Not found"}'
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/flag-conflict/out.test.toml
+++ b/acceptance/localenv/flag-conflict/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/flag-conflict/output.txt
+++ b/acceptance/localenv/flag-conflict/output.txt
@@ -1,0 +1,1 @@
+Error: if any flags in the group [cluster serverless job] are set none of the others can be; [cluster serverless] were all set

--- a/acceptance/localenv/flag-conflict/script
+++ b/acceptance/localenv/flag-conflict/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --cluster abc --serverless v4

--- a/acceptance/localenv/flag-conflict/test.toml
+++ b/acceptance/localenv/flag-conflict/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/help/out.test.toml
+++ b/acceptance/localenv/help/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/help/output.txt
+++ b/acceptance/localenv/help/output.txt
@@ -1,0 +1,43 @@
+Manage the local Python environment matched to a Databricks compute target.
+
+Usage:
+  databricks local-env python [flags]
+  databricks local-env python [command]
+
+Available Commands:
+  sync        Provision a local Python environment matched to a Databricks compute target
+
+Flags:
+  -h, --help   help for python
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)
+
+Use "databricks local-env python [command] --help" for more information about a command.
+Provision (or update) a local Python environment matched to a Databricks compute target.
+
+Resolves the target to an environment key, fetches the pinned Python version,
+databricks-connect version, and dependency constraints published for that key,
+then provisions a matched .venv with uv. A project with no pyproject.toml is
+initialized from scratch; an existing pyproject.toml is merged in place (its
+env-owned sections are refreshed, user-owned content is preserved).
+
+Usage:
+  databricks local-env python sync [flags]
+
+Flags:
+      --check               compute the plan without writing files or provisioning
+      --cluster string      cluster ID to use as the compute target
+      --constraints-only    apply the Python version and constraints without adding the databricks-connect dependency
+  -h, --help                help for sync
+      --job string          job ID to use as the compute target
+      --serverless string   serverless version to use as the compute target (e.g. v4)
+
+Global Flags:
+      --debug            enable debug logging
+  -o, --output type      output type: text or json (default text)
+  -p, --profile string   ~/.databrickscfg profile
+  -t, --target string    bundle target to use (if applicable)

--- a/acceptance/localenv/help/script
+++ b/acceptance/localenv/help/script
@@ -1,0 +1,2 @@
+$CLI local-env python --help
+$CLI local-env python sync --help

--- a/acceptance/localenv/help/test.toml
+++ b/acceptance/localenv/help/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/job-ambiguous-compute/out.test.toml
+++ b/acceptance/localenv/job-ambiguous-compute/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/job-ambiguous-compute/output.txt
+++ b/acceptance/localenv/job-ambiguous-compute/output.txt
@@ -1,0 +1,8 @@
+preflight  ok  check
+resolve    error  resolving job 12345: job 12345 has both serverless environments and job clusters; pass --cluster or --serverless explicitly to disambiguate
+fetch      pending
+merge      pending
+provision  pending
+validate   pending
+For more detail, re-run with --debug, or --output json to share a structured report.
+Error: resolving job 12345: job 12345 has both serverless environments and job clusters; pass --cluster or --serverless explicitly to disambiguate

--- a/acceptance/localenv/job-ambiguous-compute/output.txt
+++ b/acceptance/localenv/job-ambiguous-compute/output.txt
@@ -5,4 +5,3 @@ merge      pending
 provision  pending
 validate   pending
 For more detail, re-run with --debug, or --output json to share a structured report.
-Error: resolving job 12345: job 12345 has both serverless environments and job clusters; pass --cluster or --serverless explicitly to disambiguate

--- a/acceptance/localenv/job-ambiguous-compute/script
+++ b/acceptance/localenv/job-ambiguous-compute/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --job 12345 --check

--- a/acceptance/localenv/job-ambiguous-compute/test.toml
+++ b/acceptance/localenv/job-ambiguous-compute/test.toml
@@ -1,0 +1,24 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+# A job that declares both serverless environments and classic job clusters is
+# ambiguous: its tasks can run on different compute, so resolution must refuse
+# rather than guess serverless.
+[[Server]]
+Pattern = "GET /api/2.2/jobs/get"
+Response.Body = '''
+{
+  "job_id": 12345,
+  "settings": {
+    "name": "mixed-compute-job",
+    "environments": [
+      {"environment_key": "default", "spec": {"client": "3"}}
+    ],
+    "job_clusters": [
+      {"job_cluster_key": "main", "new_cluster": {"spark_version": "15.4.x-scala2.12", "num_workers": 1}}
+    ]
+  }
+}
+'''

--- a/acceptance/localenv/job-classic-check/out.test.toml
+++ b/acceptance/localenv/job-classic-check/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/job-classic-check/output.txt
+++ b/acceptance/localenv/job-classic-check/output.txt
@@ -1,0 +1,13 @@
+
+>>> [CLI] local-env python sync --job 12345 --check
+preflight  ok  check
+resolve    ok  source=job envKey=dbr/15.4.x-scala2.12
+fetch      ok  source=[DATABRICKS_URL]/dbr/15.4.x-scala2.12/pyproject.toml fromCache=false
+merge      ok
+provision  ok
+validate   ok
+Plan: [TEST_TMP_DIR]/pyproject.toml
+  changed region: requires-python
+  changed region: tool.uv.constraint-dependencies
+  changed region: databricks-connect
+Check complete. No files were modified.

--- a/acceptance/localenv/job-classic-check/script
+++ b/acceptance/localenv/job-classic-check/script
@@ -1,0 +1,1 @@
+trace $CLI local-env python sync --job 12345 --check

--- a/acceptance/localenv/job-classic-check/test.toml
+++ b/acceptance/localenv/job-classic-check/test.toml
@@ -1,0 +1,37 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+# A classic-compute job (a single job cluster, no serverless environments)
+# resolves to that cluster's DBR-derived environment key.
+[[Server]]
+Pattern = "GET /api/2.2/jobs/get"
+Response.Body = '''
+{
+  "job_id": 12345,
+  "settings": {
+    "name": "classic-job",
+    "job_clusters": [
+      {"job_cluster_key": "main", "new_cluster": {"spark_version": "15.4.x-scala2.12", "num_workers": 1}}
+    ]
+  }
+}
+'''
+
+[[Server]]
+Pattern = "GET /dbr/15.4.x-scala2.12/pyproject.toml"
+Response.Body = '''
+[project]
+requires-python = ">=3.11"
+
+[dependency-groups]
+dev = ["databricks-connect~=15.4.0"]
+
+[tool.uv]
+constraint-dependencies = ["pyarrow<19"]
+'''
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/job-multicluster-mismatch/out.test.toml
+++ b/acceptance/localenv/job-multicluster-mismatch/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/job-multicluster-mismatch/output.txt
+++ b/acceptance/localenv/job-multicluster-mismatch/output.txt
@@ -5,4 +5,3 @@ merge      pending
 provision  pending
 validate   pending
 For more detail, re-run with --debug, or --output json to share a structured report.
-Error: resolving job 12345: job 12345 has job clusters with differing spark_version; pass --cluster or --serverless explicitly to disambiguate

--- a/acceptance/localenv/job-multicluster-mismatch/output.txt
+++ b/acceptance/localenv/job-multicluster-mismatch/output.txt
@@ -1,0 +1,8 @@
+preflight  ok  check
+resolve    error  resolving job 12345: job 12345 has job clusters with differing spark_version; pass --cluster or --serverless explicitly to disambiguate
+fetch      pending
+merge      pending
+provision  pending
+validate   pending
+For more detail, re-run with --debug, or --output json to share a structured report.
+Error: resolving job 12345: job 12345 has job clusters with differing spark_version; pass --cluster or --serverless explicitly to disambiguate

--- a/acceptance/localenv/job-multicluster-mismatch/script
+++ b/acceptance/localenv/job-multicluster-mismatch/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --job 12345 --check

--- a/acceptance/localenv/job-multicluster-mismatch/test.toml
+++ b/acceptance/localenv/job-multicluster-mismatch/test.toml
@@ -1,0 +1,22 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+# A job whose job clusters declare differing spark_version is ambiguous: tasks
+# can reference any job_cluster_key, so resolution must refuse rather than
+# silently provision for the first cluster's runtime.
+[[Server]]
+Pattern = "GET /api/2.2/jobs/get"
+Response.Body = '''
+{
+  "job_id": 12345,
+  "settings": {
+    "name": "multi-cluster-job",
+    "job_clusters": [
+      {"job_cluster_key": "a", "new_cluster": {"spark_version": "15.4.x-scala2.12", "num_workers": 1}},
+      {"job_cluster_key": "b", "new_cluster": {"spark_version": "14.3.x-scala2.12", "num_workers": 1}}
+    ]
+  }
+}
+'''

--- a/acceptance/localenv/job-serverless-check/out.test.toml
+++ b/acceptance/localenv/job-serverless-check/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/job-serverless-check/output.txt
+++ b/acceptance/localenv/job-serverless-check/output.txt
@@ -1,0 +1,13 @@
+
+>>> [CLI] local-env python sync --job 12345 --check
+preflight  ok  check
+resolve    ok  source=job envKey=serverless/serverless-v3
+fetch      ok  source=[DATABRICKS_URL]/serverless/serverless-v3/pyproject.toml fromCache=false
+merge      ok
+provision  ok
+validate   ok
+Plan: [TEST_TMP_DIR]/pyproject.toml
+  changed region: requires-python
+  changed region: tool.uv.constraint-dependencies
+  changed region: databricks-connect
+Check complete. No files were modified.

--- a/acceptance/localenv/job-serverless-check/script
+++ b/acceptance/localenv/job-serverless-check/script
@@ -1,0 +1,1 @@
+trace $CLI local-env python sync --job 12345 --check

--- a/acceptance/localenv/job-serverless-check/test.toml
+++ b/acceptance/localenv/job-serverless-check/test.toml
@@ -1,0 +1,37 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+# A serverless job pins its environment_version on the environment spec, so the
+# target resolves to that serverless-vN (here v3) rather than defaulting to v4.
+[[Server]]
+Pattern = "GET /api/2.2/jobs/get"
+Response.Body = '''
+{
+  "job_id": 12345,
+  "settings": {
+    "name": "serverless-job",
+    "environments": [
+      {"environment_key": "default", "spec": {"environment_version": "3"}}
+    ]
+  }
+}
+'''
+
+[[Server]]
+Pattern = "GET /serverless/serverless-v3/pyproject.toml"
+Response.Body = '''
+[project]
+requires-python = ">=3.11"
+
+[dependency-groups]
+dev = ["databricks-connect~=15.4.0"]
+
+[tool.uv]
+constraint-dependencies = ["pyarrow<19"]
+'''
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/job-serverless-version-mismatch/out.test.toml
+++ b/acceptance/localenv/job-serverless-version-mismatch/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/job-serverless-version-mismatch/output.txt
+++ b/acceptance/localenv/job-serverless-version-mismatch/output.txt
@@ -1,0 +1,7 @@
+preflight  ok  check
+resolve    error  resolving job 12345: job 12345 has serverless environments with differing versions; pass --serverless explicitly to disambiguate
+fetch      pending
+merge      pending
+provision  pending
+validate   pending
+For more detail, re-run with --debug, or --output json to share a structured report.

--- a/acceptance/localenv/job-serverless-version-mismatch/script
+++ b/acceptance/localenv/job-serverless-version-mismatch/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --job 12345 --check

--- a/acceptance/localenv/job-serverless-version-mismatch/test.toml
+++ b/acceptance/localenv/job-serverless-version-mismatch/test.toml
@@ -1,0 +1,22 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+# Tasks can reference any environment_key, so a job whose serverless environments
+# declare differing versions is ambiguous: resolution must refuse rather than
+# guess from the first environment.
+[[Server]]
+Pattern = "GET /api/2.2/jobs/get"
+Response.Body = '''
+{
+  "job_id": 12345,
+  "settings": {
+    "name": "serverless-mismatch-job",
+    "environments": [
+      {"environment_key": "a", "spec": {"environment_version": "3"}},
+      {"environment_key": "b", "spec": {"environment_version": "4"}}
+    ]
+  }
+}
+'''

--- a/acceptance/localenv/json-error/out.test.toml
+++ b/acceptance/localenv/json-error/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/json-error/output.txt
+++ b/acceptance/localenv/json-error/output.txt
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": 1,
+  "command": "local-env python sync",
+  "ok": false,
+  "mode": "default",
+  "dryRun": false,
+  "greenfield": false,
+  "phases": [
+    {
+      "phase": "preflight",
+      "status": "ok"
+    },
+    {
+      "phase": "resolve",
+      "status": "error"
+    },
+    {
+      "phase": "fetch",
+      "status": "pending"
+    },
+    {
+      "phase": "merge",
+      "status": "pending"
+    },
+    {
+      "phase": "provision",
+      "status": "pending"
+    },
+    {
+      "phase": "validate",
+      "status": "pending"
+    }
+  ],
+  "warnings": [],
+  "error": {
+    "code": "E_NO_TARGET",
+    "failurePhase": "resolve",
+    "message": "No compute target is selected. Select a cluster or serverless target, or pass --cluster / --serverless / --job",
+    "diskMutated": false
+  },
+  "durationMs": 0
+}

--- a/acceptance/localenv/json-error/script
+++ b/acceptance/localenv/json-error/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --output json

--- a/acceptance/localenv/json-error/test.toml
+++ b/acceptance/localenv/json-error/test.toml
@@ -1,0 +1,5 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/manager-unsupported/environment.yml
+++ b/acceptance/localenv/manager-unsupported/environment.yml
@@ -1,0 +1,3 @@
+name: demo
+dependencies:
+  - python=3.10

--- a/acceptance/localenv/manager-unsupported/out.test.toml
+++ b/acceptance/localenv/manager-unsupported/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/manager-unsupported/output.txt
+++ b/acceptance/localenv/manager-unsupported/output.txt
@@ -1,0 +1,8 @@
+preflight  error  detected a conda project; automated setup for conda is not yet available (P1). Use a uv project (add a pyproject.toml with a [tool.uv] table, or run `uv init`) to provision automatically
+resolve    pending
+fetch      pending
+merge      pending
+provision  pending
+validate   pending
+For more detail, re-run with --debug, or --output json to share a structured report.
+Error: detected a conda project; automated setup for conda is not yet available (P1). Use a uv project (add a pyproject.toml with a [tool.uv] table, or run `uv init`) to provision automatically

--- a/acceptance/localenv/manager-unsupported/output.txt
+++ b/acceptance/localenv/manager-unsupported/output.txt
@@ -5,4 +5,3 @@ merge      pending
 provision  pending
 validate   pending
 For more detail, re-run with --debug, or --output json to share a structured report.
-Error: detected a conda project; automated setup for conda is not yet available (P1). Use a uv project (add a pyproject.toml with a [tool.uv] table, or run `uv init`) to provision automatically

--- a/acceptance/localenv/manager-unsupported/script
+++ b/acceptance/localenv/manager-unsupported/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync --serverless v4 --check

--- a/acceptance/localenv/manager-unsupported/test.toml
+++ b/acceptance/localenv/manager-unsupported/test.toml
@@ -1,0 +1,5 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/no-target/out.test.toml
+++ b/acceptance/localenv/no-target/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/no-target/output.txt
+++ b/acceptance/localenv/no-target/output.txt
@@ -5,4 +5,3 @@ merge      pending
 provision  pending
 validate   pending
 For more detail, re-run with --debug, or --output json to share a structured report.
-Error: No compute target is selected. Select a cluster or serverless target, or pass --cluster / --serverless / --job

--- a/acceptance/localenv/no-target/output.txt
+++ b/acceptance/localenv/no-target/output.txt
@@ -1,0 +1,8 @@
+preflight  ok  uv [UV_VERSION]
+resolve    error  No compute target is selected. Select a cluster or serverless target, or pass --cluster / --serverless / --job
+fetch      pending
+merge      pending
+provision  pending
+validate   pending
+For more detail, re-run with --debug, or --output json to share a structured report.
+Error: No compute target is selected. Select a cluster or serverless target, or pass --cluster / --serverless / --job

--- a/acceptance/localenv/no-target/script
+++ b/acceptance/localenv/no-target/script
@@ -1,0 +1,1 @@
+musterr $CLI local-env python sync

--- a/acceptance/localenv/no-target/test.toml
+++ b/acceptance/localenv/no-target/test.toml
@@ -1,0 +1,5 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/serverless-check/out.test.toml
+++ b/acceptance/localenv/serverless-check/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/serverless-check/output.txt
+++ b/acceptance/localenv/serverless-check/output.txt
@@ -1,0 +1,13 @@
+
+>>> [CLI] local-env python sync --serverless v4 --check
+preflight  ok  check
+resolve    ok  source=serverless envKey=serverless/serverless-v4
+fetch      ok  source=[DATABRICKS_URL]/serverless/serverless-v4/pyproject.toml fromCache=false
+merge      ok
+provision  ok
+validate   ok
+Plan: [TEST_TMP_DIR]/pyproject.toml
+  changed region: requires-python
+  changed region: tool.uv.constraint-dependencies
+  changed region: databricks-connect
+Check complete. No files were modified.

--- a/acceptance/localenv/serverless-check/script
+++ b/acceptance/localenv/serverless-check/script
@@ -1,0 +1,1 @@
+trace $CLI local-env python sync --serverless v4 --check

--- a/acceptance/localenv/serverless-check/test.toml
+++ b/acceptance/localenv/serverless-check/test.toml
@@ -1,0 +1,21 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+[[Server]]
+Pattern = "GET /serverless/serverless-v4/pyproject.toml"
+Response.Body = '''
+[project]
+requires-python = ">=3.12"
+
+[dependency-groups]
+dev = ["databricks-connect~=17.2.0"]
+
+[tool.uv]
+constraint-dependencies = ["pyarrow<19", "pandas<3"]
+'''
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'

--- a/acceptance/localenv/serverless-json/out.test.toml
+++ b/acceptance/localenv/serverless-json/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/localenv/serverless-json/output.txt
+++ b/acceptance/localenv/serverless-json/output.txt
@@ -1,0 +1,54 @@
+
+>>> [CLI] local-env python sync --serverless v4 --check --output json
+{
+  "schemaVersion": 1,
+  "command": "local-env python sync",
+  "ok": true,
+  "mode": "default",
+  "dryRun": true,
+  "target": {
+    "source": "serverless",
+    "serverlessVersion": "v4",
+    "envKey": "serverless/serverless-v4"
+  },
+  "resolved": {
+    "pythonVersion": "3.12",
+    "dbconnectVersion": "17.2.0",
+    "artifactSource": "network"
+  },
+  "greenfield": true,
+  "plan": {
+    "wouldWrite": "[TEST_TMP_DIR]/pyproject.toml",
+    "wouldInstallPython": "3.12",
+    "diff": "--- pyproject.toml\n+++ pyproject.toml\n@@ -1 +1,17 @@\n+[project]\n+name = \"001\"\n+version = \"0.0.0\"\n+requires-python = \"\u003e=3.12\"\n+\n+[dependency-groups]\n+dev = [\n+    \"databricks-connect~=17.2.0\",\n+]\n+\n+# managed by databricks local-env python sync — do not edit\n+[tool.uv]\n+constraint-dependencies = [\n+    \"pyarrow\u003c19\",\n+    \"pandas\u003c3\",\n+]\n+# end managed by databricks local-env python sync\n"
+  },
+  "phases": [
+    {
+      "phase": "preflight",
+      "status": "ok"
+    },
+    {
+      "phase": "resolve",
+      "status": "ok"
+    },
+    {
+      "phase": "fetch",
+      "status": "ok"
+    },
+    {
+      "phase": "merge",
+      "status": "ok"
+    },
+    {
+      "phase": "provision",
+      "status": "ok"
+    },
+    {
+      "phase": "validate",
+      "status": "ok"
+    }
+  ],
+  "warnings": [],
+  "error": null,
+  "durationMs": 0
+}

--- a/acceptance/localenv/serverless-json/script
+++ b/acceptance/localenv/serverless-json/script
@@ -1,0 +1,1 @@
+trace $CLI local-env python sync --serverless v4 --check --output json

--- a/acceptance/localenv/serverless-json/test.toml
+++ b/acceptance/localenv/serverless-json/test.toml
@@ -1,0 +1,21 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+[Env]
+DATABRICKS_LOCALENV_CONSTRAINT_SOURCE = "$DATABRICKS_HOST"
+
+[[Server]]
+Pattern = "GET /serverless/serverless-v4/pyproject.toml"
+Response.Body = '''
+[project]
+requires-python = ">=3.12"
+
+[dependency-groups]
+dev = ["databricks-connect~=17.2.0"]
+
+[tool.uv]
+constraint-dependencies = ["pyarrow<19", "pandas<3"]
+'''
+
+[[Repls]]
+Old = 'uv uv \S+(?: \([^)]+\))?'
+New = 'uv [UV_VERSION]'


### PR DESCRIPTION
## Why

- The command's user-visible behavior — text and `--json` output, and every error path — needs end-to-end coverage against the real CLI.
- `cmd/localenv/` carries no unit tests by design, so acceptance tests are where that surface is verified (repo convention: user-visible CLI output is covered by acceptance tests).

## What

- **`acceptance/localenv/`** — 9 scenarios driven through the (hidden) command against the in-process fake server: `help` (three-level tree), `no-target` (`E_NO_TARGET`), `flag-conflict` (Cobra mutual-exclusion), `manager-unsupported` (conda project → clean P1 exit), `env-unsupported` (404 → `E_ENV_UNSUPPORTED` at fetch), `json-error` (`--output json` error object), `serverless-check` (dry-run plan), `serverless-json` (`--json` plan), and `constraints-only`.
- Scripts use `local-env python sync` and the `DATABRICKS_LOCALENV_CONSTRAINT_SOURCE` override; goldens show the `local-env python sync` command field and managed marker. No source changes.

## Testing strategy

- Goldens generated with `-update` and verified **stable on a clean re-run** (no `-update`); all 9 subtests pass.
- `musterr` guards the five expected-failure scenarios; `trace` shows the three output-producing ones.
- Full acceptance suite run to confirm no regressions elsewhere (only pre-existing, environment-specific failures unrelated to this change).
- Diff confined to `acceptance/localenv/`.
- Independently verified by a review subagent (PASS — goldens, scripts, stubs, stale-refs, hygiene) and by codex (no issues).

---

## About this stack

This is one of a series of small, stacked PRs that together add the `databricks local-env python sync` command — it provisions a local Python environment (Python version, `databricks-connect` pin, and dependency constraints) matched to a selected Databricks compute target. The work was split from one large branch into single-concern layers so each is independently reviewable; the command is kept hidden until the final PR so nothing is user-visible mid-stack.

**Review bottom-up.** Layers 1–5 have merged (the original layer-5 PR #5828 was split into 5a/5b/5c during review).

| # | PR | What | Status |
|---|----|------|--------|
| 1 | #5823 | foundation: result types + env-key mapping | merged |
| 2 | #5824 | compute-target resolution | merged |
| 3 | #5826 | constraint fetch + offline cache | merged |
| 4 | #5827 | formatting-preserving pyproject.toml merge | merged |
| 5a | #5850 | package-manager interface + detection | merged |
| 5b | #5851 | six-phase pipeline orchestrator | merged |
| 5c | #5854 | --check cache purity, greenfield name, dbc insertion | merged |
| 6 | #5832 | uv backend + CLI command (registered hidden) | |
| 7 | **#5833 ← you are here** | acceptance tests | |
| 8 | #5835 | unveil (unhide + help + changelog) | |

This pull request and its description were written by Isaac.