### PR TITLE
Unveil environments setup-local: make the command visible

### DIFF
--- a/.nextchanges/cli/environments-setup-local.md
+++ b/.nextchanges/cli/environments-setup-local.md
@@ -1,0 +1,1 @@
+Added the `databricks environments setup-local` command, which provisions (or updates) a local Python environment matched to a Databricks compute target. It resolves the target to an environment key, fetches the pinned Python version, databricks-connect version, and dependency constraints published for that key, then provisions a matched `.venv` with uv.

--- a/acceptance/localenv/group-help/out.test.toml
+++ b/acceptance/localenv/group-help/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/group-help/out.test.toml
+++ b/acceptance/localenv/group-help/out.test.toml
@@ -1,0 +1,2 @@
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/localenv/group-help/output.txt
+++ b/acceptance/localenv/group-help/output.txt
@@ -1,0 +1,3 @@
+
+>>> [CLI] environments --help
+  setup-local                               Provision a local Python environment matched to a Databricks compute target

--- a/acceptance/localenv/group-help/output.txt
+++ b/acceptance/localenv/group-help/output.txt
@@ -1,0 +1,3 @@
+
+>>> [CLI] environments --help
+  setup-local                               Set up a local Python environment that matches your Databricks compute

--- a/acceptance/localenv/group-help/script
+++ b/acceptance/localenv/group-help/script
@@ -1,0 +1,5 @@
+# Assert setup-local is now listed under the generated environments group (the
+# visibility this PR unveils). Grep a single line rather than snapshotting the
+# whole group help, which also lists generated API subcommands that churn on
+# SDK regen.
+trace $CLI environments --help | grep setup-local

--- a/acceptance/localenv/group-help/test.toml
+++ b/acceptance/localenv/group-help/test.toml
@@ -1,0 +1,1 @@
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/cmd/environments/sync.go
+++ b/cmd/environments/sync.go
@@ -21,10 +21,6 @@ databricks-connect version, and dependency constraints published for that key,
 then provisions a matched .venv with uv. A project with no pyproject.toml is
 initialized from scratch; an existing pyproject.toml is merged in place (its
 env-owned sections are refreshed, user-owned content is preserved).`,
-		// Hidden until the environment constraints repository is publicly
-		// available: the command is runnable for dogfooding but stays out of
-		// help and completion until it is unveiled.
-		Hidden: true,
 	}
 	// The target is selected via flags; reject stray positional args rather than
 	// silently ignoring them.

--- a/cmd/environments/sync.go
+++ b/cmd/environments/sync.go
@@ -31,10 +31,6 @@ Use this when you want to develop or debug a Databricks project locally: it inst
 
   # See what would change without writing anything
   databricks environments setup-local --serverless-version 5 --dry-run`,
-		// Hidden until the environment constraints repository is publicly
-		// available: the command is runnable for dogfooding but stays out of
-		// help and completion until it is unveiled.
-		Hidden: true,
 	}
 	// The target is selected via flags; reject stray positional args rather than
 	// silently ignoring them.


### PR DESCRIPTION
## Changes
Unveils the `databricks environments setup-local` command: removes `Hidden: true` from `cmd/environments/sync.go` so it appears in `environments --help` and shell completion, and adds a changelog fragment announcing it.

## Why
The command was kept hidden while the feature landed across the VPEX stack and while its constraint-artifact repo was private. `databricks/environments` is now public and the command's source is hardcoded to it (#6136), so the command works end-to-end for users and is ready to expose.

## Tests
- `go build` + `golangci-lint` clean on `cmd/environments`.
- `./task check-changelog` passes.
- `localenv` + `help` acceptance suites pass with no golden changes (`-update` produces no diff): the top-level help lists command *groups* — `environments` is a generated API group and is always shown — and the command's own `--help` golden (`acceptance/localenv/help`) was already captured while hidden.
- Manually verified `databricks environments --help` now lists `setup-local`, and end-to-end provisioning against the public repo works (serverless dry-run + real provision, merge into an existing / `bundle init` project).

> Note: this branch was rebuilt on current `main`. The original 5 commits predated the `target`→`compute` rename (#6100), the `cmd/localenv`→`cmd/environments` rename, and the hardcoded-source change (#6136); four of them only added acceptance tests that already exist on `main`, and the fifth edited a since-renamed file. The unveil now collapses to this single focused commit.

_This PR was written by Claude Code._
