### PR TITLE
experimental/ssh: retry tunnel binary upload on transient errors

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 * An explicitly selected profile (`--profile` or a bundle's `workspace.profile`) now takes precedence over auth environment variables (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`, etc.) instead of being silently shadowed by them; env vars still fill auth fields the profile leaves empty ([#5096](https://github.com/databricks/cli/issues/5096)).
+* `databricks ssh connect` now retries the SSH tunnel binary upload on transient workspace-files errors (a cold `get-status` request timeout or a 5xx), instead of aborting the whole connect on a single blip ([#5836](https://github.com/databricks/cli/pull/5836)).
 
 ### Bundles
 

--- a/experimental/ssh/internal/client/releases.go
+++ b/experimental/ssh/internal/client/releases.go
@@ -10,13 +10,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/databricks/cli/experimental/ssh/internal/workspace"
 	"github.com/databricks/cli/libs/filer"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
+	"github.com/databricks/databricks-sdk-go/retries"
 	"golang.org/x/net/http2"
 )
+
+// uploadRetryTimeout bounds how long the transient-error retries for a single
+// workspace-files operation (stat or upload) may run before giving up.
+const uploadRetryTimeout = 5 * time.Minute
 
 type releaseProvider func(ctx context.Context, architecture, version, releasesDir string) (io.ReadCloser, error)
 
@@ -47,39 +54,95 @@ func uploadReleases(ctx context.Context, workspaceFiler filer.Filer, getRelease 
 		remoteBinaryPath := filepath.ToSlash(filepath.Join(remoteSubFolder, "databricks"))
 		remoteArchivePath := filepath.ToSlash(filepath.Join(remoteSubFolder, "databricks.zip"))
 
-		_, err := workspaceFiler.Stat(ctx, remoteBinaryPath)
-		if err == nil {
-			log.Infof(ctx, "File %s already exists in the workspace, skipping upload", remoteBinaryPath)
-			continue
-		} else if !errors.Is(err, fs.ErrNotExist) {
+		exists, err := binaryExists(ctx, workspaceFiler, remoteBinaryPath)
+		if err != nil {
 			return fmt.Errorf("failed to check if file %s exists in workspace: %w", remoteBinaryPath, err)
 		}
-
-		releaseReader, err := getRelease(ctx, arch, version, releasesDir)
-		if err != nil {
-			return fmt.Errorf("failed to get archive for architecture %s: %w", arch, err)
+		if exists {
+			log.Infof(ctx, "File %s already exists in the workspace, skipping upload", remoteBinaryPath)
+			continue
 		}
-		defer releaseReader.Close()
 
 		log.Infof(ctx, "Uploading %s to the workspace", fileName)
-		// workspace-files/import-file API will automatically unzip the payload,
-		// producing the filerRoot/remoteSubFolder/*archive-contents* structure, with 'databricks' binary inside.
-		err = workspaceFiler.Write(ctx, remoteArchivePath, releaseReader, filer.OverwriteIfExists, filer.CreateParentDirectories)
-		if err != nil {
-			if isStreamResetError(err) {
-				return fmt.Errorf("failed to upload file %s to workspace: %w\n\n"+
-					"The connection was closed before the upload finished. "+
-					"This is usually caused by a network intermediary (corporate egress proxy, VPN, or firewall/WAF) "+
-					"enforcing a request-body size limit on POSTs to *.cloud.databricks.com. "+
-					"Try running this command from a network without such restrictions",
-					remoteArchivePath, err)
-			}
-			return fmt.Errorf("failed to upload file %s to workspace: %w", remoteArchivePath, err)
+		if err := uploadRelease(ctx, workspaceFiler, getRelease, arch, version, releasesDir, remoteArchivePath); err != nil {
+			return err
 		}
 		log.Infof(ctx, "Successfully uploaded %s to workspace", remoteBinaryPath)
 	}
 
 	return nil
+}
+
+// binaryExists reports whether the tunnel binary is already present in the workspace,
+// retrying the stat on transient errors. The workspace-files get-status endpoint can
+// stall (a cold request routinely takes ~60s, right at the SDK's per-request timeout)
+// or return a transient 5xx, and a single such failure otherwise aborts the whole connect.
+func binaryExists(ctx context.Context, workspaceFiler filer.Filer, remoteBinaryPath string) (bool, error) {
+	var exists bool
+	err := retries.Wait(ctx, uploadRetryTimeout, func() *retries.Err {
+		_, statErr := workspaceFiler.Stat(ctx, remoteBinaryPath)
+		switch {
+		case statErr == nil:
+			exists = true
+			return nil
+		case errors.Is(statErr, fs.ErrNotExist):
+			exists = false
+			return nil
+		case isRetriableUploadError(ctx, statErr):
+			return retries.Continue(statErr)
+		default:
+			return retries.Halt(statErr)
+		}
+	})
+	return exists, err
+}
+
+// uploadRelease uploads a single architecture's release archive, retrying transient
+// failures. The reader is re-fetched on each attempt because Write drains it.
+func uploadRelease(ctx context.Context, workspaceFiler filer.Filer, getRelease releaseProvider, arch, version, releasesDir, remoteArchivePath string) error {
+	return retries.Wait(ctx, uploadRetryTimeout, func() *retries.Err {
+		releaseReader, err := getRelease(ctx, arch, version, releasesDir)
+		if err != nil {
+			return retries.Halt(fmt.Errorf("failed to get archive for architecture %s: %w", arch, err))
+		}
+		defer releaseReader.Close()
+
+		// workspace-files/import-file API will automatically unzip the payload,
+		// producing the filerRoot/remoteSubFolder/*archive-contents* structure, with 'databricks' binary inside.
+		err = workspaceFiler.Write(ctx, remoteArchivePath, releaseReader, filer.OverwriteIfExists, filer.CreateParentDirectories)
+		switch {
+		case err == nil:
+			return nil
+		case isStreamResetError(err):
+			// A stream reset is a proxy body-size rejection, not a transient blip: retrying
+			// won't help, so fail with the actionable hint instead of exhausting the budget.
+			return retries.Halt(fmt.Errorf("failed to upload file %s to workspace: %w\n\n"+
+				"The connection was closed before the upload finished. "+
+				"This is usually caused by a network intermediary (corporate egress proxy, VPN, or firewall/WAF) "+
+				"enforcing a request-body size limit on POSTs to *.cloud.databricks.com. "+
+				"Try running this command from a network without such restrictions",
+				remoteArchivePath, err))
+		case isRetriableUploadError(ctx, err):
+			return retries.Continue(fmt.Errorf("failed to upload file %s to workspace: %w", remoteArchivePath, err))
+		default:
+			return retries.Halt(fmt.Errorf("failed to upload file %s to workspace: %w", remoteArchivePath, err))
+		}
+	})
+}
+
+// isRetriableUploadError reports whether a workspace-files stat/upload error is worth
+// retrying: a transient API error (per the SDK's own classification, e.g. 429/503) or a
+// timeout/deadline, which the workspace-files get-status endpoint produces on a cold request.
+func isRetriableUploadError(ctx context.Context, err error) bool {
+	if apiErr, ok := errors.AsType[*apierr.APIError](err); ok && apiErr.IsRetriable(ctx) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	// The SDK surfaces a per-request inactivity timeout as a plain error whose message
+	// ends with "request timed out after ...", losing any typed deadline value.
+	return strings.Contains(err.Error(), "request timed out after")
 }
 
 // isStreamResetError reports whether err looks like an HTTP/2 stream reset from

--- a/experimental/ssh/internal/client/releases_test.go
+++ b/experimental/ssh/internal/client/releases_test.go
@@ -1,13 +1,53 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/databricks/cli/libs/filer"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
+
+// stubFiler is a filer.Filer whose Stat and Write return scripted results per call,
+// so tests can drive the retry loops in binaryExists/uploadRelease deterministically.
+type stubFiler struct {
+	filer.Filer
+	statErrs  []error
+	writeErrs []error
+	statCalls int
+	writes    int
+}
+
+func (s *stubFiler) Stat(ctx context.Context, name string) (fs.FileInfo, error) {
+	err := s.statErrs[s.statCalls]
+	s.statCalls++
+	return nil, err
+}
+
+func (s *stubFiler) Write(ctx context.Context, path string, reader io.Reader, mode ...filer.WriteMode) error {
+	// Drain the reader as the real filer would, so a retry must supply a fresh one.
+	_, _ = io.Copy(io.Discard, reader)
+	err := s.writeErrs[s.writes]
+	s.writes++
+	return err
+}
+
+func fakeRelease(ctx context.Context, arch, version, releasesDir string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("archive")), nil
+}
+
+func timeoutErr() error {
+	return errors.New(`Get "https://example.test/api/2.0/workspace/get-status": request timed out after 1m0s of inactivity`)
+}
 
 func TestIsStreamResetError(t *testing.T) {
 	tests := []struct {
@@ -42,4 +82,77 @@ func TestIsStreamResetError(t *testing.T) {
 			assert.Equal(t, tt.want, isStreamResetError(tt.err))
 		})
 	}
+}
+
+func TestIsRetriableUploadError(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"inactivity timeout string", timeoutErr(), true},
+		{"context deadline", context.DeadlineExceeded, true},
+		{"retriable API 503", &apierr.APIError{StatusCode: http.StatusServiceUnavailable}, true},
+		{"retriable API 429", &apierr.APIError{StatusCode: http.StatusTooManyRequests}, true},
+		{"non-retriable API 404", &apierr.APIError{StatusCode: http.StatusNotFound}, false},
+		{"plain error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetriableUploadError(ctx, tt.err))
+		})
+	}
+}
+
+func TestBinaryExistsRetriesTransientStat(t *testing.T) {
+	ctx := context.Background()
+
+	// A transient timeout on the first stat, then a clean "exists" on the retry.
+	f := &stubFiler{statErrs: []error{timeoutErr(), nil}}
+	exists, err := binaryExists(ctx, f, "amd64/databricks")
+	require.NoError(t, err)
+	assert.True(t, exists)
+	assert.Equal(t, 2, f.statCalls)
+}
+
+func TestBinaryExistsNotFoundNoRetry(t *testing.T) {
+	ctx := context.Background()
+
+	// A definitive "not found" must resolve immediately (it's the signal to upload), not retry.
+	f := &stubFiler{statErrs: []error{fs.ErrNotExist}}
+	exists, err := binaryExists(ctx, f, "amd64/databricks")
+	require.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, 1, f.statCalls)
+}
+
+func TestBinaryExistsHaltsOnNonRetriable(t *testing.T) {
+	ctx := context.Background()
+
+	f := &stubFiler{statErrs: []error{&apierr.APIError{StatusCode: http.StatusForbidden, Message: "denied"}}}
+	_, err := binaryExists(ctx, f, "amd64/databricks")
+	require.Error(t, err)
+	assert.Equal(t, 1, f.statCalls)
+}
+
+func TestUploadReleaseRetriesTransientWrite(t *testing.T) {
+	ctx := context.Background()
+
+	// First write fails transiently; the retry must re-fetch a fresh reader and succeed.
+	f := &stubFiler{writeErrs: []error{&apierr.APIError{StatusCode: http.StatusServiceUnavailable}, nil}}
+	err := uploadRelease(ctx, f, fakeRelease, "amd64", "1.0.0", "", "amd64/databricks.zip")
+	require.NoError(t, err)
+	assert.Equal(t, 2, f.writes)
+}
+
+func TestUploadReleaseStreamResetNoRetry(t *testing.T) {
+	ctx := context.Background()
+
+	// A stream reset is a proxy body-size rejection: fail fast with the hint, don't retry.
+	f := &stubFiler{writeErrs: []error{http2.StreamError{StreamID: 1, Code: http2.ErrCodeNo}}}
+	err := uploadRelease(ctx, f, fakeRelease, "amd64", "1.0.0", "", "amd64/databricks.zip")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request-body size limit")
+	assert.Equal(t, 1, f.writes)
 }


### PR DESCRIPTION
## Changes

The binary-upload phase of `databricks ssh connect` (`UploadTunnelReleases`) did a single `Stat` followed by a single `Write` against the workspace-files API per architecture. A single transient failure on either call aborted the whole connect.

In practice this fires often on a busy workspace:
- A **cold `get-status` request routinely takes ~60s** — right at the SDK's per-request inactivity timeout — so the existence check trips `request timed out after 1m0s of inactivity` and aborts. Repeating the same stat immediately after is sub-second (the endpoint is warm).
- The import (`Write`) endpoint intermittently returns a 5xx `Internal error`.

This wraps both operations in a bounded retry (5 min) that re-runs only on **transient** errors:
- SDK-classified retriable API errors (`apierr.APIError.IsRetriable` — 429, 503, etc.), and
- request timeouts (`context.DeadlineExceeded` / `os.ErrDeadlineExceeded`, plus the SDK's stringified `"request timed out after ..."`).

Not retried:
- `fs.ErrNotExist` from `Stat` — that's the signal that the binary isn't there yet and must be uploaded; it resolves immediately.
- **Stream resets** — a proxy body-size rejection where retrying won't help; these still fail fast with the existing actionable hint about egress proxies.

The upload retry re-fetches the release reader on each attempt, since `Write` drains it.

## Why

Transient workspace-files blips (cold get-status latency, intermittent 5xx) were the most common real-world failure when connecting: a single 60s stat timeout or one 5xx would kill an otherwise-healthy connect, and the fix was always just "run it again." A bounded retry absorbs these transparently.

## Tests

New unit tests in `releases_test.go` using a scripted stub filer:
- `TestIsRetriableUploadError` — timeout string, `context.DeadlineExceeded`, retriable 503/429, non-retriable 404, plain error.
- `TestBinaryExistsRetriesTransientStat` — transient stat timeout then success.
- `TestBinaryExistsNotFoundNoRetry` — `fs.ErrNotExist` resolves in one call (no retry).
- `TestBinaryExistsHaltsOnNonRetriable` — a 403 halts immediately.
- `TestUploadReleaseRetriesTransientWrite` — transient 503 then success, re-fetching a fresh reader.
- `TestUploadReleaseStreamResetNoRetry` — stream reset fails fast with the proxy hint, no retry.

`go test ./experimental/ssh/...` passes; `gofmt` and `go vet` clean.

## Notes

This is an independent robustness fix, separate from the `--base-environment` env-version work. It targets only the tunnel binary-upload path; the server-side `metadata.json` write (which can hit the same transient 5xx) is a candidate for the same treatment in a follow-up.

_This pull request and its description were written by Isaac._
