### PR TITLE
Remove duplicate `enum` values for jsonschema.json

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Bundles
 
 * Fix permissions added to a job or pipeline by a Python (PyDABs) mutator failing to deploy with "must have exactly one owner"; the deploying identity is now set as owner, matching resources whose permissions are declared in YAML ([#5821](https://github.com/databricks/cli/pull/5821)).
-* Fix duplicate `enum` values for `catalog.SseEncryptionDetailsAlgorithm` in the generated bundle JSON schema, which caused strict JSON Schema validators (e.g. OPA) to reject the schema ([#5839](https://github.com/databricks/cli/pull/5839)).
+* Remove duplicate enum values for jsonschema.json ([#5839](https://github.com/databricks/cli/pull/5839)).
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bundles
 
 * Fix permissions added to a job or pipeline by a Python (PyDABs) mutator failing to deploy with "must have exactly one owner"; the deploying identity is now set as owner, matching resources whose permissions are declared in YAML ([#5821](https://github.com/databricks/cli/pull/5821)).
+* Fix duplicate `enum` values for `catalog.SseEncryptionDetailsAlgorithm` in the generated bundle JSON schema, which caused strict JSON Schema validators (e.g. OPA) to reject the schema ([#5713](https://github.com/databricks/cli/issues/5713)).
 
 ### Dependency updates
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Bundles
 
 * Fix permissions added to a job or pipeline by a Python (PyDABs) mutator failing to deploy with "must have exactly one owner"; the deploying identity is now set as owner, matching resources whose permissions are declared in YAML ([#5821](https://github.com/databricks/cli/pull/5821)).
-* Fix duplicate `enum` values for `catalog.SseEncryptionDetailsAlgorithm` in the generated bundle JSON schema, which caused strict JSON Schema validators (e.g. OPA) to reject the schema ([#5713](https://github.com/databricks/cli/issues/5713)).
+* Fix duplicate `enum` values for `catalog.SseEncryptionDetailsAlgorithm` in the generated bundle JSON schema, which caused strict JSON Schema validators (e.g. OPA) to reject the schema ([#5839](https://github.com/databricks/cli/pull/5839)).
 
 ### Dependency updates
 

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -847,11 +847,6 @@ resources:
                   "$type":
                     "description": |-
                       SSE algorithm to use for encrypting S3 objects
-                    "enum":
-                      - |-
-                        AWS_SSE_KMS
-                      - |-
-                        AWS_SSE_S3
         "grants":
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.

--- a/bundle/schema/embed_test.go
+++ b/bundle/schema/embed_test.go
@@ -2,6 +2,7 @@ package schema_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/databricks/cli/bundle/schema"
@@ -63,4 +64,46 @@ func TestJsonSchema(t *testing.T) {
 	assert.Contains(t, providers.OneOf[0].Enum, "bitbucketCloud")
 	assert.Contains(t, providers.OneOf[0].Enum, "gitHubEnterprise")
 	assert.Contains(t, providers.OneOf[0].Enum, "bitbucketServer")
+}
+
+// JSON Schema requires enum values to be unique; strict validators (e.g. OPA)
+// reject the whole schema otherwise. Duplicates slip in when an enum is
+// hand-authored in annotations.yml for a field cli.json also defines, since the
+// annotation merge concatenates the two sequences. Guard the whole schema.
+func TestJsonSchemaEnumsAreUnique(t *testing.T) {
+	var s any
+	err := json.Unmarshal(schema.Bytes, &s)
+	require.NoError(t, err)
+
+	assert.Empty(t, duplicateEnumPaths(s, ""))
+}
+
+func duplicateEnumPaths(v any, path string) []string {
+	var duplicates []string
+	switch v := v.(type) {
+	case map[string]any:
+		if enum, ok := v["enum"].([]any); ok {
+			seen := map[string]struct{}{}
+			for _, item := range enum {
+				key := fmt.Sprintf("%v", item)
+				if _, ok := seen[key]; ok {
+					duplicates = append(duplicates, path)
+					break
+				}
+				seen[key] = struct{}{}
+			}
+		}
+		for key, value := range v {
+			childPath := key
+			if path != "" {
+				childPath = path + "/" + key
+			}
+			duplicates = append(duplicates, duplicateEnumPaths(value, childPath)...)
+		}
+	case []any:
+		for i, value := range v {
+			duplicates = append(duplicates, duplicateEnumPaths(value, fmt.Sprintf("%s[%d]", path, i))...)
+		}
+	}
+	return duplicates
 }

--- a/bundle/schema/embed_test.go
+++ b/bundle/schema/embed_test.go
@@ -94,11 +94,10 @@ func duplicateEnumPaths(v any, path string) []string {
 			}
 		}
 		for key, value := range v {
-			childPath := key
 			if path != "" {
-				childPath = path + "/" + key
+				key = path + "/" + key
 			}
-			duplicates = append(duplicates, duplicateEnumPaths(value, childPath)...)
+			duplicates = append(duplicates, duplicateEnumPaths(value, key)...)
 		}
 	case []any:
 		for i, value := range v {

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -4720,9 +4720,7 @@
                   "description": "SSE algorithm to use for encrypting S3 objects",
                   "enum": [
                     "AWS_SSE_S3",
-                    "AWS_SSE_KMS",
-                    "AWS_SSE_KMS",
-                    "AWS_SSE_S3"
+                    "AWS_SSE_KMS"
                   ]
                 },
                 {


### PR DESCRIPTION
## Summary

`catalog.SseEncryptionDetailsAlgorithm` published a duplicated `enum` in the generated bundle JSON schema:

```json
"enum": ["AWS_SSE_S3", "AWS_SSE_KMS", "AWS_SSE_KMS", "AWS_SSE_S3"]
```

JSON Schema requires enum values to be unique, so strict validators (e.g. OPA) reject the entire schema at compile time. The duplicate has shipped since v0.290.0 (Feb 26 2026); the issue reports it "since v0.299.1" only because that is the first release where `jsonschema.json` was published as a downloadable release asset, so it is the earliest version an external consumer could inspect.

Fixes #5713.

## Root cause

The enum was **hand-authored** for `catalog.SseEncryptionDetailsAlgorithm` in #4484 (UC external locations, Feb 18 2026), in the hand-authored override annotation file, with order `[AWS_SSE_KMS, AWS_SSE_S3]`. At that point the SDK-derived annotations did not define this type, so the generated schema had the correct **2** entries.

Two days later, #4552 (Upgrade Go SDK to v0.110.0, Feb 20 2026) regenerated the SDK-derived annotation file, which now defined the same enum with order `[AWS_SSE_S3, AWS_SSE_KMS]`. From then on **both** annotation sources supplied the enum. The annotation merge concatenates sequences, so the two pairs combined into four entries — `[S3, KMS]` (SDK, merge base) followed by `[KMS, S3]` (override), producing `[S3, KMS, KMS, S3]`.

The later consolidation of the annotation files into a single `annotations.yml` + `.codegen/cli.json` (#5484 / #5574) preserved this pre-existing duplicate rather than causing it; only the file names changed. `annotations.yml` is **not** generated from `cli.json` — `./task generate-schema` only syncs descriptions and placeholders and drops stale entries; it never rewrites hand-authored enums. So the redundant entry persisted silently across the refactor.

## Fix

- Remove the redundant hand-authored `enum` from `annotations.yml`, leaving `cli.json` (SDK-derived) as the single source of truth. The `description` override there is intentional (it differs from cli.json's text) and is kept.
- Regenerate `bundle/schema/jsonschema.json`; the enum is now `["AWS_SSE_S3", "AWS_SSE_KMS"]`.
- Add `TestJsonSchemaEnumsAreUnique`, a whole-schema guard that walks every `enum` in the embedded schema and fails on any duplicate, so this class of bug cannot return regardless of source.

## Tests

- `go test ./bundle/internal/schema ./bundle/schema -count=1`
- Verified the new guard fails on the pre-fix schema, reporting the exact path `$defs/.../catalog.SseEncryptionDetailsAlgorithm/oneOf[0]`.
- Confirmed the regenerated schema is reproducible via the schema generator.

This pull request and its description were written by Isaac, an AI coding agent.