### PR TITLE
invariant: use a real schema in volume_path_job_ref

### DIFF
--- a/acceptance/bundle/invariant/configs/volume_path_job_ref.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/volume_path_job_ref.yml.tmpl
@@ -1,12 +1,10 @@
 bundle:
   name: test-bundle-$UNIQUE_NAME
 
-# A job parameter references a volume's computed volume_path, and the volume's
-# schema_name/name are references to another job's id, which is only known after
-# deploy. So volume_path embeds a reference at initialize that only resolves at
-# deploy, exercising the deferred-resolution chain (foo -> data.volume_path ->
-# process) end to end with no drift afterwards. job.id is exported by Terraform
-# too, so this chain resolves on both engines (see migrate).
+# The volume name references foo.id (only known after deploy), so volume_path
+# resolves at deploy and exercises the foo -> data.volume_path -> process chain
+# on both engines. schema_name must be a real schema (create-volume validates
+# it), so it points at "default" rather than a deferred reference.
 resources:
   jobs:
     foo:
@@ -21,5 +19,5 @@ resources:
   volumes:
     data:
       catalog_name: main
-      schema_name: ${resources.jobs.foo.id}
+      schema_name: default
       name: ${resources.jobs.foo.id}


### PR DESCRIPTION
### Changes
In `acceptance/bundle/invariant/configs/volume_path_job_ref.yml.tmpl`, change the volume's `schema_name` from `${resources.jobs.foo.id}` to the real `default` schema.

### Why
The config fails deterministically on every real Unity Catalog workspace. A numeric job id is never a real UC schema, so `create-volume` returns `SCHEMA_DOES_NOT_EXIST`. The reference itself resolves correctly — this is a fixture bug, not a `direct`-engine regression.
