### PR TITLE
Document +modifier syntax inbundle run --only help

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,6 +14,7 @@
 * Remove duplicate enum values for jsonschema.json ([#5839](https://github.com/databricks/cli/pull/5839)).
 * direct: volumes: support `volume_path` property ([#5550](https://github.com/databricks/cli/pull/5550)).
 * direct: Fix deploy bug when a `postgres_projects`, `postgres_branches`, or `postgres_endpoints` field is set to its zero value (e.g. `enable_pg_native_login: false`, `replace_existing: false`) ([#5782](https://github.com/databricks/cli/pull/5782)).
+* `bundle run --only` help now documents the `+` modifier syntax: prefix a task key with `+` to also run its upstream tasks, or suffix it with `+` for downstream tasks ([#5760](https://github.com/databricks/cli/pull/5760)).
 
 ### Dependency updates
 

--- a/acceptance/bundle/help/bundle-run/output.txt
+++ b/acceptance/bundle/help/bundle-run/output.txt
@@ -38,7 +38,7 @@ Usage:
   databricks bundle run [flags] [KEY]
 
 Job Flags:
-      --only strings            comma separated list of task keys to run
+      --only strings            comma separated list of task keys to run. Prefix a key with + to also run its upstream tasks. Suffix with + to also run its downstream tasks
       --params stringToString   comma separated k=v pairs for job parameters (default [])
 
 Job Task Flags:

--- a/acceptance/bundle/run/jobs/partial_run/output.txt
+++ b/acceptance/bundle/run/jobs/partial_run/output.txt
@@ -118,3 +118,31 @@ Hello from notebook2!
     ]
   }
 }
+
+>>> [CLI] bundle run my_job --only +task_1,task_2+
+Run URL: [DATABRICKS_URL]/jobs/[NUMID]/runs/[NUMID]?o=[NUMID]
+
+[TIMESTAMP] "my_job" RUNNING
+[TIMESTAMP] "my_job" TERMINATED SUCCESS
+Output:
+=======
+Task task_1:
+Hello from notebook1!
+
+=======
+Task task_2:
+Hello from notebook2!
+
+
+>>> print_requests.py //jobs/run-now
+{
+  "method": "POST",
+  "path": "/api/2.2/jobs/run-now",
+  "body": {
+    "job_id": [NUMID],
+    "only": [
+      "+task_1",
+      "task_2+"
+    ]
+  }
+}

--- a/acceptance/bundle/run/jobs/partial_run/script
+++ b/acceptance/bundle/run/jobs/partial_run/script
@@ -18,3 +18,7 @@ trace musterr $CLI bundle run my_job --only non_existent_task,task_1
 # We expect these values to be send through
 trace $CLI bundle run my_job --only "task1.table1,task2>,task3>table3"
 trace print_requests.py //jobs/run-now
+
+# + modifiers (run upstream/downstream tasks) are forwarded unchanged
+trace $CLI bundle run my_job --only "+task_1,task_2+"
+trace print_requests.py //jobs/run-now

--- a/bundle/run/job_options.go
+++ b/bundle/run/job_options.go
@@ -34,7 +34,7 @@ type JobOptions struct {
 
 func (o *JobOptions) DefineJobOptions(fs *flag.FlagSet) {
 	fs.StringToStringVar(&o.jobParams, "params", nil, "comma separated k=v pairs for job parameters")
-	fs.StringSliceVar(&o.only, "only", nil, "comma separated list of task keys to run")
+	fs.StringSliceVar(&o.only, "only", nil, "comma separated list of task keys to run. Prefix a key with + to also run its upstream tasks. Suffix with + to also run its downstream tasks")
 }
 
 func (o *JobOptions) DefineTaskOptions(fs *flag.FlagSet) {


### PR DESCRIPTION
## Changes
The `bundle run --only` command takes a comma-separated list of task keys to run a subset of a job's tasks. Its help text did not mention that a task key can be prefixed or suffixed with `+` to also pull in upstream/downstream tasks (the value is forwarded to the run-now only API field, which interprets the modifiers). This documents that syntax in the flag's help:

* `+my_task`: run `my_task` and everything upstream of it
* `my_task+`: run `my_task` and everything downstream of it
* `+my_task+`: both

Supercedes #5760, addresses #4244

## Why
Documentation was out of date so agents & users were not able to use the new functionality

## Tests
Yes, new tests assert that the data is passed through unchanged