### PR TITLE
acc: support DATABRICKS_TEST_SKIPLOCAL=withchanged

### DIFF
--- a/.agent/rules/style-guide-go.md
+++ b/.agent/rules/style-guide-go.md
@@ -24,6 +24,8 @@ func SomeFunc() {
 
 **RULE: Focus on making implementations as small and elegant as possible.** Avoid unnecessary loops and allocations. If dropping or relaxing a requirement would simplify things, ask the user about the trade-off.
 
+**RULE: Do not declare inline function closures just to name a repeated operation.** Extract it as a regular named function instead. Closures that capture local variables hide their dependencies, complicate reading, and can't be tested in isolation.
+
 ### Modern Go (1.24+) idioms
 
 **RULE: Use `for i := range X` for integer iteration, not `for i := 0; i < X; i++`.**

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -573,7 +573,7 @@ tasks:
     sources: *ACC_SOURCES_UPDATE
     generates: *ACC_GENERATES_UPDATE
     cmds:
-      - "deco env run -i -n aws-prod-ucws -- env DATABRICKS_TEST_SKIPLOCAL=1 go test ./acceptance -run ^TestAccept$ -update -timeout=1h -v"
+      - "deco env run -i -n aws-prod-ucws -- env DATABRICKS_TEST_SKIPLOCAL=true go test ./acceptance -run ^TestAccept$ -update -timeout=1h -v"
 
   test-update-all:
     desc: Update all acceptance test outputs
@@ -748,7 +748,7 @@ tasks:
     deps: [install-pythons]
     cmds:
       - |
-        DATABRICKS_TEST_SKIPLOCAL=1 VERBOSE_TEST=1 \
+        DATABRICKS_TEST_SKIPLOCAL=withchanged VERBOSE_TEST=1 \
         go run -modfile=tools/go.mod ./tools/testrunner/main.go \
           {{.GO_TOOL}} gotestsum \
           --format github-actions \

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -409,12 +409,13 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	testDirs := getTests(t)
 	require.NotEmpty(t, testDirs)
 
+	var changedTests map[string]bool
 	if os.Getenv(SkipLocalEnvVar) == SkipLocalWithChanged {
 		testDirsSet := make(map[string]bool, len(testDirs))
 		for _, d := range testDirs {
 			testDirsSet[d] = true
 		}
-		changedLocalTests = selectChangedLocalTests(testDirsSet)
+		changedTests = selectChangedLocalTests(testDirsSet)
 	}
 
 	if singleTest != "" {
@@ -471,7 +472,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 				t.Skip("Skipping test execution (only regenerating out.test.toml)")
 			}
 
-			skipReason := getSkipReason(&config, configPath, dir)
+			skipReason := getSkipReason(&config, configPath, dir, changedTests)
 			if skipReason != "" {
 				skippedDirs += 1
 				t.Skip(skipReason)
@@ -594,14 +595,15 @@ func validateTestPhase(phase int) error {
 }
 
 // Return a reason to skip the test. Empty string means "don't skip".
-func getSkipReason(config *internal.TestConfig, configPath string, dir string) string {
+// changedTests is the set of test dirs re-enabled under SkipLocalWithChanged; nil otherwise.
+func getSkipReason(config *internal.TestConfig, configPath string, dir string, changedTests map[string]bool) string {
 	switch os.Getenv(SkipLocalEnvVar) {
 	case SkipLocalAll:
 		if isTruePtr(config.Local) {
 			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalAll + " in " + configPath
 		}
 	case SkipLocalWithChanged:
-		if isTruePtr(config.Local) && !changedLocalTests[dir] {
+		if isTruePtr(config.Local) && !changedTests[dir] {
 			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalWithChanged + " in " + configPath
 		}
 	}

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -257,8 +257,6 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 		os.Unsetenv(v) //nolint:usetesting // t.Setenv cannot unset
 	}
 
-	validateSkipLocal(t)
-
 	if !requirePrerequisites(t) {
 		// Don't run the suite against a stale toolchain; the failed subtest
 		// has already marked the parent test as failed.
@@ -410,12 +408,16 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	require.NotEmpty(t, testDirs)
 
 	var changedTests map[string]bool
-	if os.Getenv(SkipLocalEnvVar) == SkipLocalWithChanged {
+	switch os.Getenv(SkipLocalEnvVar) {
+	case "", SkipLocalAll:
+	case SkipLocalWithChanged:
 		testDirsSet := make(map[string]bool, len(testDirs))
 		for _, d := range testDirs {
 			testDirsSet[d] = true
 		}
 		changedTests = selectChangedLocalTests(testDirsSet)
+	default:
+		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, os.Getenv(SkipLocalEnvVar), SkipLocalAll, SkipLocalWithChanged)
 	}
 
 	if singleTest != "" {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -257,6 +257,8 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 		os.Unsetenv(v) //nolint:usetesting // t.Setenv cannot unset
 	}
 
+	validateSkipLocal(t)
+
 	if !requirePrerequisites(t) {
 		// Don't run the suite against a stale toolchain; the failed subtest
 		// has already marked the parent test as failed.
@@ -407,6 +409,14 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	testDirs := getTests(t)
 	require.NotEmpty(t, testDirs)
 
+	if os.Getenv(SkipLocalEnvVar) == SkipLocalWithChanged {
+		testDirsSet := make(map[string]bool, len(testDirs))
+		for _, d := range testDirs {
+			testDirsSet[d] = true
+		}
+		changedLocalTests = selectChangedLocalTests(testDirsSet)
+	}
+
 	if singleTest != "" {
 		testDirs = slices.DeleteFunc(testDirs, func(n string) bool {
 			return n != singleTest
@@ -461,7 +471,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 				t.Skip("Skipping test execution (only regenerating out.test.toml)")
 			}
 
-			skipReason := getSkipReason(&config, configPath)
+			skipReason := getSkipReason(&config, configPath, dir)
 			if skipReason != "" {
 				skippedDirs += 1
 				t.Skip(skipReason)
@@ -584,9 +594,16 @@ func validateTestPhase(phase int) error {
 }
 
 // Return a reason to skip the test. Empty string means "don't skip".
-func getSkipReason(config *internal.TestConfig, configPath string) string {
-	if os.Getenv("DATABRICKS_TEST_SKIPLOCAL") != "" && isTruePtr(config.Local) {
-		return "Disabled via DATABRICKS_TEST_SKIPLOCAL environment variable in " + configPath
+func getSkipReason(config *internal.TestConfig, configPath string, dir string) string {
+	switch os.Getenv(SkipLocalEnvVar) {
+	case SkipLocalAll:
+		if isTruePtr(config.Local) {
+			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalAll + " in " + configPath
+		}
+	case SkipLocalWithChanged:
+		if isTruePtr(config.Local) && !changedLocalTests[dir] {
+			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalWithChanged + " in " + configPath
+		}
 	}
 
 	if Forcerun {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -408,7 +408,9 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	require.NotEmpty(t, testDirs)
 
 	skipLocalMode := os.Getenv(SkipLocalEnvVar)
-	var changedTests map[string]bool
+	// changedTests maps test dir to extra env filters to apply for that dir.
+	// nil value means all variants run; a non-nil slice restricts to matching variants.
+	var changedTests map[string][]string
 	switch skipLocalMode {
 	case "", SkipLocalAll:
 	case SkipLocalWithChanged:
@@ -526,6 +528,11 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 						if runParallel {
 							t.Parallel()
 						}
+						// For invariant dirs re-enabled by a specific config change,
+						// skip variants not matching that config.
+						if variantFilters := changedTests[dir]; variantFilters != nil {
+							checkEnvFilters(t, envset, variantFilters)
+						}
 						runTest(t, dir, ind, coverDir, repls.Clone(), config, envset, envFilters, sandboxProxyURL)
 					})
 				}
@@ -599,16 +606,18 @@ func validateTestPhase(phase int) error {
 
 // Return a reason to skip the test. Empty string means "don't skip".
 // skipLocalMode is the value of DATABRICKS_TEST_SKIPLOCAL read once at startup.
-// changedTests is the set of test dirs re-enabled under SkipLocalWithChanged; nil otherwise.
-func getSkipReason(config *internal.TestConfig, configPath string, dir string, skipLocalMode string, changedTests map[string]bool) string {
+// changedTests maps test dirs to extra env filters; nil map means feature is off.
+func getSkipReason(config *internal.TestConfig, configPath string, dir string, skipLocalMode string, changedTests map[string][]string) string {
 	switch skipLocalMode {
 	case SkipLocalAll:
 		if isTruePtr(config.Local) {
 			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalAll + " in " + configPath
 		}
 	case SkipLocalWithChanged:
-		if isTruePtr(config.Local) && !changedTests[dir] {
-			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalWithChanged + " in " + configPath
+		if isTruePtr(config.Local) {
+			if _, ok := changedTests[dir]; !ok {
+				return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalWithChanged + " in " + configPath
+			}
 		}
 	}
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -407,8 +407,9 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	testDirs := getTests(t)
 	require.NotEmpty(t, testDirs)
 
+	skipLocalMode := os.Getenv(SkipLocalEnvVar)
 	var changedTests map[string]bool
-	switch os.Getenv(SkipLocalEnvVar) {
+	switch skipLocalMode {
 	case "", SkipLocalAll:
 	case SkipLocalWithChanged:
 		testDirsSet := make(map[string]bool, len(testDirs))
@@ -417,7 +418,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 		}
 		changedTests = selectChangedLocalTests(testDirsSet)
 	default:
-		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, os.Getenv(SkipLocalEnvVar), SkipLocalAll, SkipLocalWithChanged)
+		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, skipLocalMode, SkipLocalAll, SkipLocalWithChanged)
 	}
 
 	if singleTest != "" {
@@ -474,7 +475,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 				t.Skip("Skipping test execution (only regenerating out.test.toml)")
 			}
 
-			skipReason := getSkipReason(&config, configPath, dir, changedTests)
+			skipReason := getSkipReason(&config, configPath, dir, skipLocalMode, changedTests)
 			if skipReason != "" {
 				skippedDirs += 1
 				t.Skip(skipReason)
@@ -597,9 +598,10 @@ func validateTestPhase(phase int) error {
 }
 
 // Return a reason to skip the test. Empty string means "don't skip".
+// skipLocalMode is the value of DATABRICKS_TEST_SKIPLOCAL read once at startup.
 // changedTests is the set of test dirs re-enabled under SkipLocalWithChanged; nil otherwise.
-func getSkipReason(config *internal.TestConfig, configPath string, dir string, changedTests map[string]bool) string {
-	switch os.Getenv(SkipLocalEnvVar) {
+func getSkipReason(config *internal.TestConfig, configPath string, dir string, skipLocalMode string, changedTests map[string]bool) string {
+	switch skipLocalMode {
 	case SkipLocalAll:
 		if isTruePtr(config.Local) {
 			return "Disabled via DATABRICKS_TEST_SKIPLOCAL=" + SkipLocalAll + " in " + configPath

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -607,7 +607,7 @@ func validateTestPhase(phase int) error {
 // Return a reason to skip the test. Empty string means "don't skip".
 // skipLocalMode is the value of DATABRICKS_TEST_SKIPLOCAL read once at startup.
 // changedTests maps test dirs to extra env filters; nil map means feature is off.
-func getSkipReason(config *internal.TestConfig, configPath string, dir string, skipLocalMode string, changedTests map[string][]string) string {
+func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode string, changedTests map[string][]string) string {
 	switch skipLocalMode {
 	case SkipLocalAll:
 		if isTruePtr(config.Local) {

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -76,20 +76,15 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 // SkipLocalWithChanged: those added or changed on this branch vs the merge base,
 // added-first and capped at maxChangedLocalTests.
 //
-// A renamed test dir is treated as modified, not added (git -M detects renames
-// as a single R entry rather than add+delete).
+// A test dir is "added" when its script file has status A in the diff (didn't
+// exist at the merge base). Renames (R) are treated as modified, not added.
+// --merge-base folds the merge-base computation into the diff itself, matching
+// tools/lintdiff.py — one git call total.
 func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 	base := resolveBaseRef()
+	diff := git("diff", "--name-status", "--merge-base", "-M", base)
 
-	// Compute the merge base once; use it for both the diff and the ls-tree.
-	mergeBase := git("merge-base", "HEAD", base)
-	if mergeBase == "" {
-		mergeBase = base
-	}
-
-	diff := git("diff", "--name-status", "-M", mergeBase)
-
-	renamedInto := map[string]bool{}
+	added := map[string]bool{}
 	changed := map[string]bool{}
 	for _, line := range strings.Split(diff, "\n") {
 		fields := strings.Split(line, "\t")
@@ -103,40 +98,25 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 			continue
 		}
 		changed[dir] = true
-		if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
-			renamedInto[dir] = true
+		// A script file with status A means the test dir is brand new.
+		// Renames (R) land here as the destination path but are not "added".
+		if status == "A" && strings.HasSuffix(path, "/script") {
+			added[dir] = true
 		}
 	}
 
-	// Batch all script-existence checks into one ls-tree call.
-	var scriptPaths []string
+	var addedDirs, modifiedDirs []string
 	for dir := range changed {
-		scriptPaths = append(scriptPaths, "acceptance/"+dir+"/script")
-	}
-	slices.Sort(scriptPaths)
-	existsAtBase := map[string]bool{}
-	if len(scriptPaths) > 0 {
-		args := append([]string{"ls-tree", "--name-only", mergeBase}, scriptPaths...)
-		for _, line := range strings.Split(git(args...), "\n") {
-			if line != "" {
-				existsAtBase[line] = true
-			}
-		}
-	}
-
-	var added, modified []string
-	for dir := range changed {
-		isNew := !renamedInto[dir] && !existsAtBase["acceptance/"+dir+"/script"]
-		if isNew {
-			added = append(added, dir)
+		if added[dir] {
+			addedDirs = append(addedDirs, dir)
 		} else {
-			modified = append(modified, dir)
+			modifiedDirs = append(modifiedDirs, dir)
 		}
 	}
-	slices.Sort(added)
-	slices.Sort(modified)
+	slices.Sort(addedDirs)
+	slices.Sort(modifiedDirs)
 
-	selected := append(added, modified...)
+	selected := append(addedDirs, modifiedDirs...)
 	if len(selected) > maxChangedLocalTests {
 		selected = selected[:maxChangedLocalTests]
 	}

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -56,10 +56,11 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 //
 // --merge-base diffs the working tree against the merge base of HEAD and
 // origin/main. This covers committed, staged, and unstaged changes alike —
-// the working tree reflects all three. The three-dot form origin/main...HEAD
-// only covers committed changes and misses files touched but not yet committed,
-// which breaks the "touch a config, run the test" local dev workflow
-// (same reason lintdiff.py uses --merge-base).
+// the working tree reflects all three. Untracked files (not yet git-added)
+// are not visible to git diff and will not be re-enabled until staged or
+// committed. The three-dot form origin/main...HEAD only covers committed
+// changes and misses unstaged edits, which breaks the "touch a config, run
+// the test" local dev workflow (same reason lintdiff.py uses --merge-base).
 func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 	out, _ := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
 	diff := strings.TrimSpace(string(out))

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -68,7 +68,7 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 	result := map[string][]string{}
 	added := map[string]bool{}
 
-	addDir := func(dir string, filter string) {
+	addDir := func(dir, filter string) {
 		if filter == "" {
 			result[dir] = nil // non-config change → run all variants
 			return
@@ -80,7 +80,7 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 		}
 	}
 
-	for _, line := range strings.Split(diff, "\n") {
+	for line := range strings.SplitSeq(diff, "\n") {
 		fields := strings.Split(line, "\t")
 		if len(fields) < 2 {
 			continue

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -21,6 +21,9 @@ const (
 	// maxChangedLocalTests caps how many changed tests SkipLocalWithChanged re-enables,
 	// keeping the cloud run bounded. Added tests are preferred over modified ones.
 	maxChangedLocalTests = 50
+
+	invariantConfigsPrefix = "acceptance/bundle/invariant/configs/"
+	invariantDirPrefix     = "bundle/invariant/"
 )
 
 // testDirForFile maps a repo-relative changed file (e.g. acceptance/bundle/foo/script)
@@ -41,24 +44,42 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 	return ""
 }
 
-// selectChangedLocalTests returns the set of test dirs to re-enable under
-// SkipLocalWithChanged: those added or changed on this branch vs the merge base,
-// added-first and capped at maxChangedLocalTests.
+// selectChangedLocalTests returns a map of test dir → extra env filters for
+// re-enabling under SkipLocalWithChanged. A nil filter slice means all variants
+// of that dir run; a non-nil slice restricts to variants matching those filters.
+// Added dirs come before modified ones; the total is capped at maxChangedLocalTests.
 //
-// A test dir is "added" when its script file has status A in the diff (didn't
-// exist at the merge base). Renames (R) are treated as modified, not added.
+// Invariant configs (acceptance/bundle/invariant/configs/*.yml.tmpl) each feed
+// every invariant subdir. A changed config re-enables all invariant subdirs but
+// only for variants where INPUT_CONFIG matches the changed file — so touching
+// job.yml.tmpl runs only the job.yml.tmpl variants, not all ~40 configs.
 //
 // --merge-base diffs the working tree against the merge base of HEAD and
 // origin/main, so uncommitted edits are included. The three-dot form
 // origin/main...HEAD would only cover committed changes and would miss a file
 // touched but not yet committed, which breaks the "touch a config, run the
 // test" local dev workflow (same reason lintdiff.py uses --merge-base).
-func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
+func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 	out, _ := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
 	diff := strings.TrimSpace(string(out))
 
+	// result accumulates dirs with their filters; added tracks brand-new dirs.
+	// nil filter slice = all variants run; non-nil = restricted to those filters.
+	result := map[string][]string{}
 	added := map[string]bool{}
-	changed := map[string]bool{}
+
+	addDir := func(dir string, filter string) {
+		if filter == "" {
+			result[dir] = nil // non-config change → run all variants
+			return
+		}
+		// Config-specific change: restrict to this INPUT_CONFIG, unless the dir
+		// was already unlocked for all variants by a non-config change.
+		if existing, ok := result[dir]; !ok || existing != nil {
+			result[dir] = append(result[dir], "INPUT_CONFIG="+filter)
+		}
+	}
+
 	for _, line := range strings.Split(diff, "\n") {
 		fields := strings.Split(line, "\t")
 		if len(fields) < 2 {
@@ -67,12 +88,19 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 		status := fields[0]
 		path := fields[len(fields)-1]
 
-		// A changed invariant config re-enables all invariant subdirs, since
-		// every config feeds every subdir (no_drift, migrate, continue_293, ...).
-		if strings.HasPrefix(path, "acceptance/bundle/invariant/configs/") {
-			for dir := range testDirs {
-				if strings.HasPrefix(dir, "bundle/invariant/") {
-					changed[dir] = true
+		// A changed invariant config re-enables all invariant subdirs, restricted
+		// to only the INPUT_CONFIG variant matching the changed config file.
+		if strings.HasPrefix(path, invariantConfigsPrefix) {
+			configName := path[len(invariantConfigsPrefix):]
+			// Strip -init.sh / -cleanup.sh suffixes to get the base config name.
+			if i := strings.Index(configName, "-"); i > 0 && strings.HasSuffix(configName, ".sh") {
+				configName = configName[:i]
+			}
+			if strings.HasSuffix(configName, ".yml.tmpl") {
+				for dir := range testDirs {
+					if strings.HasPrefix(dir, invariantDirPrefix) {
+						addDir(dir, configName)
+					}
 				}
 			}
 			continue
@@ -82,7 +110,7 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 		if dir == "" {
 			continue
 		}
-		changed[dir] = true
+		addDir(dir, "")
 		// A script file with status A means the test dir is brand new.
 		// Renames (R) land here as the destination path but are not "added".
 		if status == "A" && strings.HasSuffix(path, "/script") {
@@ -91,7 +119,7 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 	}
 
 	var addedDirs, modifiedDirs []string
-	for dir := range changed {
+	for dir := range result {
 		if added[dir] {
 			addedDirs = append(addedDirs, dir)
 		} else {
@@ -106,9 +134,9 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 		selected = selected[:maxChangedLocalTests]
 	}
 
-	result := make(map[string]bool, len(selected))
+	out2 := make(map[string][]string, len(selected))
 	for _, dir := range selected {
-		result[dir] = true
+		out2[dir] = result[dir]
 	}
-	return result
+	return out2
 }

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -62,6 +62,18 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 		}
 		status := fields[0]
 		path := fields[len(fields)-1]
+
+		// A changed invariant config re-enables all invariant subdirs, since
+		// every config feeds every subdir (no_drift, migrate, continue_293, ...).
+		if strings.HasPrefix(path, "acceptance/bundle/invariant/configs/") {
+			for dir := range testDirs {
+				if strings.HasPrefix(dir, "bundle/invariant/") {
+					changed[dir] = true
+				}
+			}
+			continue
+		}
+
 		dir := testDirForFile(path, testDirs)
 		if dir == "" {
 			continue

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -46,14 +46,6 @@ func git(args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// resolveBaseRef returns the ref to diff against: origin/main when present, else main.
-func resolveBaseRef() string {
-	if git("rev-parse", "--verify", "origin/main") != "" {
-		return "origin/main"
-	}
-	return "main"
-}
-
 // testDirForFile maps a repo-relative changed file (e.g. acceptance/bundle/foo/script)
 // to its owning test dir relative to acceptance/ (e.g. bundle/foo), or "" if the file
 // is outside acceptance/ or not under any known test dir.
@@ -78,11 +70,10 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 //
 // A test dir is "added" when its script file has status A in the diff (didn't
 // exist at the merge base). Renames (R) are treated as modified, not added.
-// --merge-base folds the merge-base computation into the diff itself, matching
-// tools/lintdiff.py — one git call total.
+// The three-dot form origin/main...HEAD diffs HEAD against the merge base of
+// the two refs in one call (see tools/testmask/git.go for the rationale).
 func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
-	base := resolveBaseRef()
-	diff := git("diff", "--name-status", "--merge-base", "-M", base)
+	diff := git("diff", "--name-status", "-M", "origin/main...HEAD")
 
 	added := map[string]bool{}
 	changed := map[string]bool{}

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -47,10 +47,14 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 //
 // A test dir is "added" when its script file has status A in the diff (didn't
 // exist at the merge base). Renames (R) are treated as modified, not added.
-// The three-dot form origin/main...HEAD diffs HEAD against the merge base of
-// the two refs in one call (see tools/testmask/git.go for the rationale).
+//
+// --merge-base diffs the working tree against the merge base of HEAD and
+// origin/main, so uncommitted edits are included. The three-dot form
+// origin/main...HEAD would only cover committed changes and would miss a file
+// touched but not yet committed, which breaks the "touch a config, run the
+// test" local dev workflow (same reason lintdiff.py uses --merge-base).
 func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
-	out, _ := exec.Command("git", "diff", "--name-status", "-M", "origin/main...HEAD").Output()
+	out, _ := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
 	diff := strings.TrimSpace(string(out))
 
 	added := map[string]bool{}

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -1,0 +1,163 @@
+package acceptance_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// DATABRICKS_TEST_SKIPLOCAL controls skipping of Local acceptance tests.
+const (
+	SkipLocalEnvVar = "DATABRICKS_TEST_SKIPLOCAL"
+
+	// SkipLocalAll skips every test with Local = true.
+	SkipLocalAll = "true"
+	// SkipLocalWithChanged skips Local tests except those added or changed on this
+	// branch (relative to the merge base with origin/main), so a cloud run still
+	// exercises the tests this branch touches.
+	SkipLocalWithChanged = "withchanged"
+
+	// maxChangedLocalTests caps how many changed tests SkipLocalWithChanged re-enables,
+	// keeping the cloud run bounded. Added tests are preferred over modified ones.
+	maxChangedLocalTests = 50
+)
+
+// validateSkipLocal fails fast on an unsupported DATABRICKS_TEST_SKIPLOCAL value.
+// Empty or absent means the feature is off; anything other than the known modes
+// is rejected rather than silently ignored.
+func validateSkipLocal(t *testing.T) {
+	switch os.Getenv(SkipLocalEnvVar) {
+	case "", SkipLocalAll, SkipLocalWithChanged:
+	default:
+		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, os.Getenv(SkipLocalEnvVar), SkipLocalAll, SkipLocalWithChanged)
+	}
+}
+
+// changedLocalTests is the set of test dirs (relative to acceptance/, forward slash)
+// added or changed on this branch, populated by testAccept when running in
+// SkipLocalWithChanged mode. nil in every other mode.
+var changedLocalTests map[string]bool
+
+// git runs a git command and returns trimmed stdout.
+// A non-zero exit yields an empty string.
+func git(args ...string) string {
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// resolveBaseRef returns the ref to diff against: origin/main when present, else main.
+func resolveBaseRef() string {
+	if git("rev-parse", "--verify", "origin/main") != "" {
+		return "origin/main"
+	}
+	return "main"
+}
+
+// testDirForFile maps a repo-relative changed file (e.g. acceptance/bundle/foo/script)
+// to its owning test dir relative to acceptance/ (e.g. bundle/foo), or "" if the file
+// is outside acceptance/ or not under any known test dir. testDirs is the set of dirs
+// containing a 'script' file, relative to acceptance/ with forward slashes.
+func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
+	parts := strings.Split(filepath.ToSlash(repoRelPath), "/")
+	if len(parts) < 2 || parts[0] != "acceptance" {
+		return ""
+	}
+	// Longest ancestor first so nested tests map to the innermost test dir.
+	for depth := len(parts); depth > 1; depth-- {
+		candidate := strings.Join(parts[1:depth], "/")
+		if testDirs[candidate] {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// selectChangedLocalTests returns the set of test dirs to re-enable under
+// SkipLocalWithChanged: those added or changed on this branch vs the merge base,
+// added-first and capped at maxChangedLocalTests. testDirs is the set of known test
+// dirs (relative to acceptance/, forward slash).
+//
+// A renamed test dir is treated as modified, not added, so a pure rename does not
+// consume the "added" budget (git detects it as an R entry via -M).
+//
+// --merge-base folds the merge-base computation into the diff command itself,
+// matching the approach in tools/lintdiff.py.
+func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
+	base := resolveBaseRef()
+
+	// --merge-base diffs HEAD against the merge base of HEAD and base in one call.
+	// -M detects renames so they appear as a single R entry rather than add+delete.
+	diff := git("diff", "--name-status", "--merge-base", "-M", base)
+
+	renamedInto := map[string]bool{}
+	changed := map[string]bool{}
+	for _, line := range strings.Split(diff, "\n") {
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+		status := fields[0]
+		path := fields[len(fields)-1]
+		dir := testDirForFile(path, testDirs)
+		if dir == "" {
+			continue
+		}
+		changed[dir] = true
+		if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
+			renamedInto[dir] = true
+		}
+	}
+
+	// A test dir is "added" if its script wasn't present at the merge base and it
+	// didn't arrive via a rename. ls-tree returns nothing for paths absent in the
+	// tree, so a non-empty output means the path exists.
+	//
+	// We still need the merge-base SHA for ls-tree; --merge-base above folded it
+	// into the diff but doesn't expose the SHA directly.
+	mergeBase := git("merge-base", "HEAD", base)
+
+	// Batch all existence checks into one ls-tree call.
+	var scriptPaths []string
+	for dir := range changed {
+		scriptPaths = append(scriptPaths, "acceptance/"+dir+"/script")
+	}
+	slices.Sort(scriptPaths)
+	existsAtBase := map[string]bool{}
+	if mergeBase != "" && len(scriptPaths) > 0 {
+		args := append([]string{"ls-tree", "--name-only", mergeBase}, scriptPaths...)
+		for _, line := range strings.Split(git(args...), "\n") {
+			if line != "" {
+				existsAtBase[line] = true
+			}
+		}
+	}
+
+	var added, modified []string
+	for dir := range changed {
+		isNew := !renamedInto[dir] && !existsAtBase["acceptance/"+dir+"/script"]
+		if isNew {
+			added = append(added, dir)
+		} else {
+			modified = append(modified, dir)
+		}
+	}
+	slices.Sort(added)
+	slices.Sort(modified)
+
+	selected := append(added, modified...)
+	if len(selected) > maxChangedLocalTests {
+		selected = selected[:maxChangedLocalTests]
+	}
+
+	result := make(map[string]bool, len(selected))
+	for _, dir := range selected {
+		result[dir] = true
+	}
+	return result
+}

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -1,12 +1,10 @@
 package acceptance_test
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
-	"testing"
 )
 
 // DATABRICKS_TEST_SKIPLOCAL controls skipping of Local acceptance tests.
@@ -24,17 +22,6 @@ const (
 	// keeping the cloud run bounded. Added tests are preferred over modified ones.
 	maxChangedLocalTests = 50
 )
-
-// validateSkipLocal fails the test immediately on an unsupported
-// DATABRICKS_TEST_SKIPLOCAL value. Empty or absent means disabled.
-func validateSkipLocal(t *testing.T) {
-	t.Helper()
-	switch os.Getenv(SkipLocalEnvVar) {
-	case "", SkipLocalAll, SkipLocalWithChanged:
-	default:
-		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, os.Getenv(SkipLocalEnvVar), SkipLocalAll, SkipLocalWithChanged)
-	}
-}
 
 // testDirForFile maps a repo-relative changed file (e.g. acceptance/bundle/foo/script)
 // to its owning test dir relative to acceptance/ (e.g. bundle/foo), or "" if the file

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -77,12 +77,17 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 // added-first and capped at maxChangedLocalTests.
 //
 // A renamed test dir is treated as modified, not added (git -M detects renames
-// as a single R entry rather than add+delete). --merge-base folds the merge-base
-// computation into the diff call itself, matching tools/lintdiff.py.
+// as a single R entry rather than add+delete).
 func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 	base := resolveBaseRef()
 
-	diff := git("diff", "--name-status", "--merge-base", "-M", base)
+	// Compute the merge base once; use it for both the diff and the ls-tree.
+	mergeBase := git("merge-base", "HEAD", base)
+	if mergeBase == "" {
+		mergeBase = base
+	}
+
+	diff := git("diff", "--name-status", "-M", mergeBase)
 
 	renamedInto := map[string]bool{}
 	changed := map[string]bool{}
@@ -103,9 +108,6 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 		}
 	}
 
-	// Resolve the merge-base SHA for the batched ls-tree call below.
-	mergeBase := git("merge-base", "HEAD", base)
-
 	// Batch all script-existence checks into one ls-tree call.
 	var scriptPaths []string
 	for dir := range changed {
@@ -113,7 +115,7 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 	}
 	slices.Sort(scriptPaths)
 	existsAtBase := map[string]bool{}
-	if mergeBase != "" && len(scriptPaths) > 0 {
+	if len(scriptPaths) > 0 {
 		args := append([]string{"ls-tree", "--name-only", mergeBase}, scriptPaths...)
 		for _, line := range strings.Split(git(args...), "\n") {
 			if line != "" {

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -46,13 +46,13 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 
 // selectChangedLocalTests returns a map of test dir → extra env filters for
 // re-enabling under SkipLocalWithChanged. A nil filter slice means all variants
-// of that dir run; a non-nil slice restricts to variants matching those filters.
+// of that dir run; a non-nil slice restricts to variants matching those filters
+// (applied by the caller via checkEnvFilters in the variant loop).
 // Added dirs come before modified ones; the total is capped at maxChangedLocalTests.
 //
-// Invariant configs (acceptance/bundle/invariant/configs/*.yml.tmpl) each feed
-// every invariant subdir. A changed config re-enables all invariant subdirs but
-// only for variants where INPUT_CONFIG matches the changed file — so touching
-// job.yml.tmpl runs only the job.yml.tmpl variants, not all ~40 configs.
+// A changed invariant config (acceptance/bundle/invariant/configs/*.yml.tmpl)
+// maps to all invariant subdirs with an INPUT_CONFIG= filter, so touching
+// job.yml.tmpl re-enables all subdirs but only for their job.yml.tmpl variants.
 //
 // --merge-base diffs the working tree against the merge base of HEAD and
 // origin/main, so uncommitted edits are included. The three-dot form
@@ -68,18 +68,6 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 	result := map[string][]string{}
 	added := map[string]bool{}
 
-	addDir := func(dir, filter string) {
-		if filter == "" {
-			result[dir] = nil // non-config change → run all variants
-			return
-		}
-		// Config-specific change: restrict to this INPUT_CONFIG, unless the dir
-		// was already unlocked for all variants by a non-config change.
-		if existing, ok := result[dir]; !ok || existing != nil {
-			result[dir] = append(result[dir], "INPUT_CONFIG="+filter)
-		}
-	}
-
 	for line := range strings.SplitSeq(diff, "\n") {
 		fields := strings.Split(line, "\t")
 		if len(fields) < 2 {
@@ -88,8 +76,8 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 		status := fields[0]
 		path := fields[len(fields)-1]
 
-		// A changed invariant config re-enables all invariant subdirs, restricted
-		// to only the INPUT_CONFIG variant matching the changed config file.
+		// A changed invariant config re-enables all invariant subdirs with an
+		// INPUT_CONFIG filter, unless a subdir was already unlocked by a non-config change.
 		if strings.HasPrefix(path, invariantConfigsPrefix) {
 			configName := path[len(invariantConfigsPrefix):]
 			// Strip -init.sh / -cleanup.sh suffixes to get the base config name.
@@ -99,7 +87,9 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 			if strings.HasSuffix(configName, ".yml.tmpl") {
 				for dir := range testDirs {
 					if strings.HasPrefix(dir, invariantDirPrefix) {
-						addDir(dir, configName)
+						if existing, ok := result[dir]; !ok || existing != nil {
+							result[dir] = append(result[dir], "INPUT_CONFIG="+configName)
+						}
 					}
 				}
 			}
@@ -110,7 +100,7 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 		if dir == "" {
 			continue
 		}
-		addDir(dir, "")
+		result[dir] = nil // nil = all variants; overrides any prior config-scoped filter
 		// A script file with status A means the test dir is brand new.
 		// Renames (R) land here as the destination path but are not "added".
 		if status == "A" && strings.HasSuffix(path, "/script") {

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -36,16 +36,6 @@ func validateSkipLocal(t *testing.T) {
 	}
 }
 
-// git runs a git command and returns trimmed stdout.
-// A non-zero exit yields an empty string.
-func git(args ...string) string {
-	out, err := exec.Command("git", args...).Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
-}
-
 // testDirForFile maps a repo-relative changed file (e.g. acceptance/bundle/foo/script)
 // to its owning test dir relative to acceptance/ (e.g. bundle/foo), or "" if the file
 // is outside acceptance/ or not under any known test dir.
@@ -73,7 +63,8 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 // The three-dot form origin/main...HEAD diffs HEAD against the merge base of
 // the two refs in one call (see tools/testmask/git.go for the rationale).
 func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
-	diff := git("diff", "--name-status", "-M", "origin/main...HEAD")
+	out, _ := exec.Command("git", "diff", "--name-status", "-M", "origin/main...HEAD").Output()
+	diff := strings.TrimSpace(string(out))
 
 	added := map[string]bool{}
 	changed := map[string]bool{}

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -25,21 +25,16 @@ const (
 	maxChangedLocalTests = 50
 )
 
-// validateSkipLocal fails fast on an unsupported DATABRICKS_TEST_SKIPLOCAL value.
-// Empty or absent means the feature is off; anything other than the known modes
-// is rejected rather than silently ignored.
+// validateSkipLocal fails the test immediately on an unsupported
+// DATABRICKS_TEST_SKIPLOCAL value. Empty or absent means disabled.
 func validateSkipLocal(t *testing.T) {
+	t.Helper()
 	switch os.Getenv(SkipLocalEnvVar) {
 	case "", SkipLocalAll, SkipLocalWithChanged:
 	default:
 		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, os.Getenv(SkipLocalEnvVar), SkipLocalAll, SkipLocalWithChanged)
 	}
 }
-
-// changedLocalTests is the set of test dirs (relative to acceptance/, forward slash)
-// added or changed on this branch, populated by testAccept when running in
-// SkipLocalWithChanged mode. nil in every other mode.
-var changedLocalTests map[string]bool
 
 // git runs a git command and returns trimmed stdout.
 // A non-zero exit yields an empty string.
@@ -61,8 +56,7 @@ func resolveBaseRef() string {
 
 // testDirForFile maps a repo-relative changed file (e.g. acceptance/bundle/foo/script)
 // to its owning test dir relative to acceptance/ (e.g. bundle/foo), or "" if the file
-// is outside acceptance/ or not under any known test dir. testDirs is the set of dirs
-// containing a 'script' file, relative to acceptance/ with forward slashes.
+// is outside acceptance/ or not under any known test dir.
 func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 	parts := strings.Split(filepath.ToSlash(repoRelPath), "/")
 	if len(parts) < 2 || parts[0] != "acceptance" {
@@ -80,19 +74,14 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 
 // selectChangedLocalTests returns the set of test dirs to re-enable under
 // SkipLocalWithChanged: those added or changed on this branch vs the merge base,
-// added-first and capped at maxChangedLocalTests. testDirs is the set of known test
-// dirs (relative to acceptance/, forward slash).
+// added-first and capped at maxChangedLocalTests.
 //
-// A renamed test dir is treated as modified, not added, so a pure rename does not
-// consume the "added" budget (git detects it as an R entry via -M).
-//
-// --merge-base folds the merge-base computation into the diff command itself,
-// matching the approach in tools/lintdiff.py.
+// A renamed test dir is treated as modified, not added (git -M detects renames
+// as a single R entry rather than add+delete). --merge-base folds the merge-base
+// computation into the diff call itself, matching tools/lintdiff.py.
 func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 	base := resolveBaseRef()
 
-	// --merge-base diffs HEAD against the merge base of HEAD and base in one call.
-	// -M detects renames so they appear as a single R entry rather than add+delete.
 	diff := git("diff", "--name-status", "--merge-base", "-M", base)
 
 	renamedInto := map[string]bool{}
@@ -114,15 +103,10 @@ func selectChangedLocalTests(testDirs map[string]bool) map[string]bool {
 		}
 	}
 
-	// A test dir is "added" if its script wasn't present at the merge base and it
-	// didn't arrive via a rename. ls-tree returns nothing for paths absent in the
-	// tree, so a non-empty output means the path exists.
-	//
-	// We still need the merge-base SHA for ls-tree; --merge-base above folded it
-	// into the diff but doesn't expose the SHA directly.
+	// Resolve the merge-base SHA for the batched ls-tree call below.
 	mergeBase := git("merge-base", "HEAD", base)
 
-	// Batch all existence checks into one ls-tree call.
+	// Batch all script-existence checks into one ls-tree call.
 	var scriptPaths []string
 	for dir := range changed {
 		scriptPaths = append(scriptPaths, "acceptance/"+dir+"/script")

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -55,10 +55,11 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 // job.yml.tmpl re-enables all subdirs but only for their job.yml.tmpl variants.
 //
 // --merge-base diffs the working tree against the merge base of HEAD and
-// origin/main, so uncommitted edits are included. The three-dot form
-// origin/main...HEAD would only cover committed changes and would miss a file
-// touched but not yet committed, which breaks the "touch a config, run the
-// test" local dev workflow (same reason lintdiff.py uses --merge-base).
+// origin/main. This covers committed, staged, and unstaged changes alike —
+// the working tree reflects all three. The three-dot form origin/main...HEAD
+// only covers committed changes and misses files touched but not yet committed,
+// which breaks the "touch a config, run the test" local dev workflow
+// (same reason lintdiff.py uses --merge-base).
 func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
 	out, _ := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
 	diff := strings.TrimSpace(string(out))


### PR DESCRIPTION
## Changes

Add `withchanged` mode: skips `Local=true` tests like `true` does, but re-enables any test added or changed on this branch.

Wire into `integration-short-skiplocal` so PR cloud runs exercise the tests they touch.

## Why
We should run relevant tests on cloud on PRs. The tests that were added by PR are highly relevant. The tests that were modified by PR are probably relevant as well.