### PR TITLE
internal: Allow absence of field to mean "all fields" in resource config

### DIFF
--- a/bundle/direct/dresources/all_test.go
+++ b/bundle/direct/dresources/all_test.go
@@ -1149,9 +1149,6 @@ func TestNoUpdateResourcesCoverAllFields(t *testing.T) {
 
 		t.Run(resourceType, func(t *testing.T) {
 			err := structwalk.WalkType(adapter.StateType(), func(path *structpath.PatternNode, typ reflect.Type, _ *reflect.StructField) bool {
-				if path.IsRoot() {
-					return true
-				}
 				if covered[path.String()] {
 					// This field (or its enclosing object) is classified; the
 					// whole subtree is covered, so stop descending.

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -494,28 +494,7 @@ resources:
     # handles the read side (input-only and output-only fields) so no-op deploys
     # stay idempotent. Same pattern as postgres_synced_tables.
     recreate_on_changes:
-      - field: database_instance_name
-        reason: immutable
-      - field: logical_database_name
-        reason: immutable
-      - field: spec.source_table_full_name
-        reason: immutable
-      - field: spec.primary_key_columns
-        reason: immutable
-      - field: spec.timeseries_key
-        reason: immutable
-      - field: spec.scheduling_policy
-        reason: immutable
-      - field: spec.create_database_objects_if_missing
-        reason: immutable
-      - field: spec.new_pipeline_spec
-        reason: immutable
-      - field: spec.existing_pipeline_id
-        reason: immutable
-      - field: spec.accelerated_sync
-        reason: immutable
-      - field: spec.type_overrides
-        reason: immutable
+      - reason: immutable
 
   apps:
     provided_id_fields:

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -476,12 +476,7 @@ resources:
     # handles the read side (create_database_if_not_exists is input-only, uid is
     # output-only) so no-op deploys stay idempotent.
     recreate_on_changes:
-      - field: database_instance_name
-        reason: immutable
-      - field: database_name
-        reason: immutable
-      - field: create_database_if_not_exists
-        reason: immutable
+      - reason: immutable
 
   synced_database_tables:
     provided_id_fields:
@@ -678,10 +673,7 @@ resources:
       # requires delete+create. The OpenAPI spec only marks postgres_database
       # as IMMUTABLE (handled by autogen); branch and create_database_if_missing
       # need explicit entries here.
-      - field: branch
-        reason: immutable
-      - field: create_database_if_missing
-        reason: immutable
+      - reason: immutable
 
   postgres_synced_tables:
     # The Postgres API has no UpdateSyncedTable endpoint, so every settable
@@ -695,28 +687,7 @@ resources:
       - field: synced_table_id
         reason: id_field
     recreate_on_changes:
-      - field: branch
-        reason: immutable
-      - field: postgres_database
-        reason: immutable
-      - field: source_table_full_name
-        reason: immutable
-      - field: primary_key_columns
-        reason: immutable
-      - field: timeseries_key
-        reason: immutable
-      - field: scheduling_policy
-        reason: immutable
-      - field: create_database_objects_if_missing
-        reason: immutable
-      - field: new_pipeline_spec
-        reason: immutable
-      - field: existing_pipeline_id
-        reason: immutable
-      - field: accelerated_sync
-        reason: immutable
-      - field: type_overrides
-        reason: immutable
+      - reason: immutable
 
   postgres_roles:
     recreate_on_changes:


### PR DESCRIPTION
This is useful for resources without update methods.

The provided_id_fields takes preference, so works as expected if field is in both.