### PR TITLE
Add uv & pip to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,30 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
+  # acceptance/ holds generated template output and test fixtures, not real
+  # project dependencies. Some pin a placeholder version (e.g.
+  # databricks-bundles==x.y.z, produced by a test.toml Repls rule) that is not
+  # valid PEP 440 and aborts the whole dependency-graph submission for the
+  # ecosystem. cmd/labs/project/testdata/ is vendored test data. The pip and uv
+  # graph jobs both scan pyproject.toml, so both need the exclusion.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14
+    exclude-paths:
+      - "acceptance/**"
+      - "cmd/labs/project/testdata/**"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14
+    exclude-paths:
+      - "acceptance/**"
+      - "cmd/labs/project/testdata/**"
   # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories
   - package-ecosystem: "github-actions"
     directories:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
     exclude-paths:
       - "acceptance/**"
       - "cmd/labs/project/testdata/**"
+      - "python/codegen/**"
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
@@ -39,6 +40,7 @@ updates:
     exclude-paths:
       - "acceptance/**"
       - "cmd/labs/project/testdata/**"
+      - "python/codegen/**"
   # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories
   - package-ecosystem: "github-actions"
     directories:


### PR DESCRIPTION
## Changes

Add uv and pip blocks to dependabot.yml, encoding the defaults of pip, but excluding auto-generated paths

## Why

Dependabot on python keeps failing on test fixture pyproject.toml files that have `==x.y.z` causing errors in updating the [dependency graph](https://github.com/databricks/cli/network/dependencies)

```
ERROR <job_1387978654> InvalidRequirement('Expected semicolon (after name with no version specifier) or end\n    databricks-bundles==x.y.z\n                      ^')
```
from failed runs [pip](https://github.com/databricks/cli/actions/runs/28801862650) and [uv](https://github.com/databricks/cli/actions/runs/26564645466)

## Tests
<!-- How have you tested the changes? -->

<!-- If your PR needs to be included in the release notes for next release,
add a separate entry in NEXT_CHANGELOG.md as part of your PR. -->
