### PR TITLE
Update build badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Databricks CLI
 
-[![build](https://github.com/databricks/cli/workflows/build/badge.svg?branch=main)](https://github.com/databricks/cli/actions?query=workflow%3Abuild+branch%3Amain)
+[![build](https://github.com/databricks/cli/actions/workflows/push.yml/badge.svg?branch=main)](https://github.com/databricks/cli/actions?query=workflow%3Abuild+branch%3Amain)
 
 Documentation is available at https://docs.databricks.com/dev-tools/cli/databricks-cli.html.
 


### PR DESCRIPTION
Badge currently shows `no status`.

Workflow file is push.yml with name `build`: https://github.com/databricks/cli/blob/main/.github/workflows/push.yml#L1

Documentation for badge link: https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge
