### PR TITLE
direct: Recognize UC-managed property defaults on catalogs and add delta.feature.catalogManaged

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -16,7 +16,7 @@
 * direct: volumes: support `volume_path` property ([#5550](https://github.com/databricks/cli/pull/5550)).
 * direct: Fix deploy bug when a `postgres_projects`, `postgres_branches`, or `postgres_endpoints` field is set to its zero value (e.g. `enable_pg_native_login: false`, `replace_existing: false`) ([#5782](https://github.com/databricks/cli/pull/5782)).
 * `bundle run --only` help now documents the `+` modifier syntax: prefix a task key with `+` to also run its upstream tasks, or suffix it with `+` for downstream tasks ([#5760](https://github.com/databricks/cli/pull/5760)).
-* direct: Recognize more UC-managed schema property defaults to avoid unnecessary drift ([#5865](https://github.com/databricks/cli/pull/5865)).
+* direct: Recognize UC-managed catalog and schema property defaults to avoid unnecessary drift ([#5865](https://github.com/databricks/cli/pull/5865) & [#5870](https://github.com/databricks/cli/pull/5870)).
 
 ### Dependency updates
 

--- a/acceptance/bundle/resources/catalogs/drift/managed_properties/output.txt
+++ b/acceptance/bundle/resources/catalogs/drift/managed_properties/output.txt
@@ -17,7 +17,12 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
     "action": "skip",
     "reason": "backend_default",
     "remote": {
+      "unity.catalog.managed.delta.defaults.defaultClusterByAuto": "true",
+      "unity.catalog.managed.delta.defaults.delta.checkpointPolicy": "v2",
       "unity.catalog.managed.delta.defaults.delta.enableRowTracking": "true",
+      "unity.catalog.managed.delta.defaults.delta.feature.catalogManaged": "supported",
+      "unity.catalog.managed.delta.defaults.delta.parquet.format.version": "2.12.0",
+      "unity.catalog.managed.delta.defaults.delta.parquet.format.version.afe.internal": "2.12.0",
       "unity.catalog.managed.iceberg.defaults.delta.feature.catalogManaged": "true"
     }
   }

--- a/acceptance/bundle/resources/schemas/drift/managed_properties/output.txt
+++ b/acceptance/bundle/resources/schemas/drift/managed_properties/output.txt
@@ -20,6 +20,7 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
       "unity.catalog.managed.delta.defaults.defaultClusterByAuto": "true",
       "unity.catalog.managed.delta.defaults.delta.checkpointPolicy": "v2",
       "unity.catalog.managed.delta.defaults.delta.enableRowTracking": "true",
+      "unity.catalog.managed.delta.defaults.delta.feature.catalogManaged": "supported",
       "unity.catalog.managed.delta.defaults.delta.parquet.format.version": "2.12.0",
       "unity.catalog.managed.delta.defaults.delta.parquet.format.version.afe.internal": "2.12.0",
       "unity.catalog.managed.iceberg.defaults.delta.feature.catalogManaged": "true"

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -392,6 +392,11 @@ resources:
       # UC auto-populates these system-managed keys after create (same as schemas).
       - field: properties['unity.catalog.managed.delta.defaults.delta.enableRowTracking']
       - field: properties['unity.catalog.managed.iceberg.defaults.delta.feature.catalogManaged']
+      - field: properties['unity.catalog.managed.delta.defaults.defaultClusterByAuto']
+      - field: properties['unity.catalog.managed.delta.defaults.delta.checkpointPolicy']
+      - field: properties['unity.catalog.managed.delta.defaults.delta.parquet.format.version']
+      - field: properties['unity.catalog.managed.delta.defaults.delta.parquet.format.version.afe.internal']
+      - field: properties['unity.catalog.managed.delta.defaults.delta.feature.catalogManaged']
 
   schemas:
     provided_id_fields:
@@ -416,6 +421,7 @@ resources:
       - field: properties['unity.catalog.managed.delta.defaults.delta.checkpointPolicy']
       - field: properties['unity.catalog.managed.delta.defaults.delta.parquet.format.version']
       - field: properties['unity.catalog.managed.delta.defaults.delta.parquet.format.version.afe.internal']
+      - field: properties['unity.catalog.managed.delta.defaults.delta.feature.catalogManaged']
 
   external_locations:
     recreate_on_changes:

--- a/libs/testserver/catalogs.go
+++ b/libs/testserver/catalogs.go
@@ -44,8 +44,13 @@ func (s *FakeWorkspace) CatalogsCreate(req Request) Response {
 	if catalogInfo.Properties == nil && createRequest.Name == catalogNameManagedDefaults {
 		// Mirror UC: managed system defaults are populated when the user sets none.
 		catalogInfo.Properties = map[string]string{
-			"unity.catalog.managed.delta.defaults.delta.enableRowTracking":        "true",
-			"unity.catalog.managed.iceberg.defaults.delta.feature.catalogManaged": "true",
+			"unity.catalog.managed.delta.defaults.delta.enableRowTracking":                   "true",
+			"unity.catalog.managed.iceberg.defaults.delta.feature.catalogManaged":            "true",
+			"unity.catalog.managed.delta.defaults.defaultClusterByAuto":                      "true",
+			"unity.catalog.managed.delta.defaults.delta.checkpointPolicy":                    "v2",
+			"unity.catalog.managed.delta.defaults.delta.parquet.format.version":              "2.12.0",
+			"unity.catalog.managed.delta.defaults.delta.parquet.format.version.afe.internal": "2.12.0",
+			"unity.catalog.managed.delta.defaults.delta.feature.catalogManaged":              "supported",
 		}
 	}
 

--- a/libs/testserver/schemas.go
+++ b/libs/testserver/schemas.go
@@ -60,6 +60,7 @@ func (s *FakeWorkspace) SchemasCreate(req Request) Response {
 			"unity.catalog.managed.delta.defaults.delta.checkpointPolicy":                    "v2",
 			"unity.catalog.managed.delta.defaults.delta.parquet.format.version":              "2.12.0",
 			"unity.catalog.managed.delta.defaults.delta.parquet.format.version.afe.internal": "2.12.0",
+			"unity.catalog.managed.delta.defaults.delta.feature.catalogManaged":              "supported",
 		}
 	}
 	s.Schemas[schema.FullName] = schema


### PR DESCRIPTION
Follow-up to #5865, which added the schema keys but did not cover catalogs or the `delta.feature.catalogManaged` key.

This pull request and its description were written by Isaac, an AI coding agent.
