### PR TITLE
Run OS-independent bundle acceptance tests on Linux only for PRs

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -111,6 +111,12 @@ const (
 
 var ApplyCITimeoutMultipler = os.Getenv("GITHUB_WORKFLOW") != ""
 
+// IsPullRequest is true when the test run was triggered by a GitHub pull_request
+// event. GitHub Actions sets GITHUB_EVENT_NAME automatically. On pull requests we
+// additionally apply each test's GOOSOnPR filter, so OS-independent tests can be
+// skipped on windows/macOS for PRs while still running on every OS on push to main.
+var IsPullRequest = os.Getenv("GITHUB_EVENT_NAME") == "pull_request"
+
 var exeSuffix = func() string {
 	if runtime.GOOS == "windows" {
 		return ".exe"
@@ -653,6 +659,13 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 	isEnabled, isPresent := config.GOOS[runtime.GOOS]
 	if isPresent && !isEnabled {
 		return fmt.Sprintf("Disabled via GOOS.%s setting in %s", runtime.GOOS, configPath)
+	}
+
+	if IsPullRequest {
+		isEnabled, isPresent := config.GOOSOnPR[runtime.GOOS]
+		if isPresent && !isEnabled {
+			return fmt.Sprintf("Disabled via GOOSOnPR.%s setting in %s", runtime.GOOS, configPath)
+		}
 	}
 
 	cloudEnv := os.Getenv("CLOUD_ENV")

--- a/acceptance/bundle/bundle_tag/id/out.test.toml
+++ b/acceptance/bundle/bundle_tag/id/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/test.toml
+++ b/acceptance/bundle/bundle_tag/test.toml
@@ -1,1 +1,7 @@
 Badness = "configs with id and url should be rejected"
+
+# These tests exercise platform-independent bundle logic (tag validation) and behave
+# identically on every OS, so on pull requests they run on Linux only to keep the
+# windows/macOS CI jobs fast. They still run on every OS on push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/bundle_tag/url/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url_ref/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/migrate/out.test.toml
+++ b/acceptance/bundle/invariant/migrate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/no_drift/out.test.toml
+++ b/acceptance/bundle/invariant/no_drift/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -3,6 +3,13 @@ Cloud = true
 RequiresUnityCatalog = true
 Timeout = '10m'
 
+# These tests drive platform-independent bundle logic (config normalization,
+# no-drift checks, state migration) and behave identically on every OS, so on pull
+# requests they run on Linux only to keep the windows/macOS CI jobs fast. They still
+# run on every OS on push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false
+
 Ignore = [
     ".databricks",
     ".venv",

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/lifecycle/started-validation/out.test.toml
+++ b/acceptance/bundle/lifecycle/started-validation/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/lifecycle/started/out.test.toml
+++ b/acceptance/bundle/lifecycle/started/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/lifecycle/test.toml
+++ b/acceptance/bundle/lifecycle/test.toml
@@ -1,2 +1,8 @@
 Local = true
 Cloud = false
+
+# These tests exercise platform-independent bundle logic (deploy/destroy lifecycle)
+# and behave identically on every OS, so on pull requests they run on Linux only to
+# keep the windows/macOS CI jobs fast. They still run on every OS on push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/migrate/added/out.test.toml
+++ b/acceptance/bundle/migrate/added/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/basic/out.test.toml
+++ b/acceptance/bundle/migrate/basic/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/dashboards/out.test.toml
+++ b/acceptance/bundle/migrate/dashboards/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/default-python/out.test.toml
+++ b/acceptance/bundle/migrate/default-python/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/engine-config-direct/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-direct/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/grants/out.test.toml
+++ b/acceptance/bundle/migrate/grants/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/permissions/out.test.toml
+++ b/acceptance/bundle/migrate/permissions/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/profile_arg/out.test.toml
+++ b/acceptance/bundle/migrate/profile_arg/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/removed/out.test.toml
+++ b/acceptance/bundle/migrate/removed/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/runas/out.test.toml
+++ b/acceptance/bundle/migrate/runas/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/migrate/test.toml
+++ b/acceptance/bundle/migrate/test.toml
@@ -5,3 +5,10 @@ Ignore = [".databricks"]
 
 # All tests explicitly set DATABRICKS_BUNDLE_ENGINE, so there is no need for matrix testing
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+# These tests exercise platform-independent bundle logic (state and config
+# migration) and behave identically on every OS, so on pull requests they run on
+# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
+# push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/migrate/var_arg/out.test.toml
+++ b/acceptance/bundle/migrate/var_arg/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/computed_volume_path/out.test.toml
+++ b/acceptance/bundle/resource_deps/computed_volume_path/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/create_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/create_error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/duplicate_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/duplicate_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/grant_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/grant_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/id_chain/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_chain/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_star/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_star/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_self/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_self/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/model_id_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/model_id_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/permission_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/permission_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/test.toml
+++ b/acceptance/bundle/resource_deps/test.toml
@@ -4,3 +4,10 @@ Ignore = [
     ".databricks",
     ".gitignore",
 ]
+
+# These tests exercise platform-independent bundle logic (resource dependency
+# ordering and reference resolution) and behave identically on every OS, so on pull
+# requests they run on Linux only to keep the windows/macOS CI jobs fast. They still
+# run on every OS on push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/resource_deps/tf_path_only_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/tf_path_only_error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/tf_path_renames/out.test.toml
+++ b/acceptance/bundle/resource_deps/tf_path_renames/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/unicode_reference/out.test.toml
+++ b/acceptance/bundle/resource_deps/unicode_reference/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/volume_path_contains_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/volume_path_contains_id/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/volume_path_job_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/volume_path_job_ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/alerts/basic/out.test.toml
+++ b/acceptance/bundle/resources/alerts/basic/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_run_from_subdir/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_run_from_subdir/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/config-drift/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/default_description/out.test.toml
+++ b/acceptance/bundle/resources/apps/default_description/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/immutable/out.test.toml
+++ b/acceptance/bundle/resources/apps/immutable/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/apps/readplan-lifecycle/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/apps/resource-refs/out.test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/update/out.test.toml
+++ b/acceptance/bundle/resources/apps/update/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/drift/managed_properties/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/drift/managed_properties/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.aws = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = true

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
+++ b/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-name/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-name/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/destroy/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/dashboards/simple/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
@@ -3,5 +3,7 @@ Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/recreate/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/recreate/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/database_instances/recreate/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/recreate/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
@@ -2,5 +2,7 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/experiments/basic/out.test.toml
+++ b/acceptance/bundle/resources/experiments/basic/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/external_locations/out.test.toml
+++ b/acceptance/bundle/resources/external_locations/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/delete_warning/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/delete_warning/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/inline/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/inline/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/parent_path_update/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/parent_path_update/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/serialized_space/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/serialized_space/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/simple/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/simple/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/version_migration/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/version_migration/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/catalogs/out.test.toml
+++ b/acceptance/bundle/resources/grants/catalogs/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/registered_models/out.test.toml
+++ b/acceptance/bundle/resources/grants/registered_models/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/volumes/out.test.toml
+++ b/acceptance/bundle/resources/grants/volumes/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/independent/out.test.toml
+++ b/acceptance/bundle/resources/independent/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/job_runs/basic/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/basic/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/job_parameters/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/job_parameters/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/redeploy/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/redeploy/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/alert-task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/alert-task/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/big_id/out.test.toml
+++ b/acceptance/bundle/resources/jobs/big_id/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/create-error/out.test.toml
+++ b/acceptance/bundle/resources/jobs/create-error/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/delete_job/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_job/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/delete_task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_task/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/num_workers/out.test.toml
+++ b/acceptance/bundle/resources/jobs/num_workers/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
+++ b/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/removed_from_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/removed_from_config/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/unknown-terraform-field/out.test.toml
+++ b/acceptance/bundle/resources/jobs/unknown-terraform-field/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/basic/out.test.toml
+++ b/acceptance/bundle/resources/models/basic/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/readplan-permissions/out.test.toml
+++ b/acceptance/bundle/resources/models/readplan-permissions/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -2,5 +2,7 @@ Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/out.test.toml
+++ b/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 Phase = 1
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/504/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/create/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/504/plan/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/plan/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/504/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/update/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete_transitions/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete_transitions/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/replace_existing/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_catalogs/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_databases/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/replace_existing/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/update/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/update/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete_transitions/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete_transitions/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-bind/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-bind/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_roles/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/replace_existing/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/update/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/update/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_synced_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/basic/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_synced_tables/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/recreate/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/quality_monitors/create/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/create/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/basic/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/drift/browse_only/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/drift/browse_only/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/drift/managed_properties/out.test.toml
+++ b/acceptance/bundle/resources/schemas/drift/managed_properties/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/recreate/out.test.toml
+++ b/acceptance/bundle/resources/schemas/recreate/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/update/out.test.toml
+++ b/acceptance/bundle/resources/schemas/update/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 CloudSlow = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 CloudSlow = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 CloudSlow = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 CloudSlow = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
@@ -2,5 +2,7 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/recreate/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/recreate/out.test.toml
@@ -1,5 +1,7 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/test.toml
+++ b/acceptance/bundle/resources/test.toml
@@ -1,1 +1,8 @@
 RecordRequests = true
+
+# These tests exercise platform-independent bundle logic (resource CRUD, diffing,
+# permissions) and behave identically on every OS, so on pull requests they run on
+# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
+# push to main. Individual OS-sensitive tests below re-enable themselves.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/create-fails/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/create-fails/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/basic/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/grants/select/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/grants/select/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
+++ b/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/change-comment/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-comment/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-name/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -2,4 +2,6 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
@@ -1,6 +1,8 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-volume-path/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-volume-path/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/uppercase-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/uppercase-name/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/dashboard_embed/out.test.toml
+++ b/acceptance/bundle/run_as/dashboard_embed/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_override/out.test.toml
+++ b/acceptance/bundle/run_as/empty_override/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_sp/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
+++ b/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = true
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/model_serving_different/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_different/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/model_serving_matching/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_matching/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/out.test.toml
+++ b/acceptance/bundle/run_as/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/test.toml
+++ b/acceptance/bundle/run_as/test.toml
@@ -1,0 +1,6 @@
+# These tests exercise platform-independent bundle logic (run_as identity
+# resolution) and behave identically on every OS, so on pull requests they run on
+# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
+# push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/state/bad_env/out.test.toml
+++ b/acceptance/bundle/state/bad_env/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/bad_json_local/out.test.toml
+++ b/acceptance/bundle/state/bad_json_local/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/basic/out.test.toml
+++ b/acceptance/bundle/state/basic/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/engine_default/out.test.toml
+++ b/acceptance/bundle/state/engine_default/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/engine_mismatch/out.test.toml
+++ b/acceptance/bundle/state/engine_mismatch/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/force_pull_commands/out.test.toml
+++ b/acceptance/bundle/state/force_pull_commands/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/future_version/out.test.toml
+++ b/acceptance/bundle/state/future_version/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/lineage_different/out.test.toml
+++ b/acceptance/bundle/state/lineage_different/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/permission_level_migration/out.test.toml
+++ b/acceptance/bundle/state/permission_level_migration/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/same_serial/out.test.toml
+++ b/acceptance/bundle/state/same_serial/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/state_present/out.test.toml
+++ b/acceptance/bundle/state/state_present/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/test.toml
+++ b/acceptance/bundle/state/test.toml
@@ -1,0 +1,6 @@
+# These tests exercise platform-independent bundle logic (deployment state
+# tracking and lineage) and behave identically on every OS, so on pull requests they
+# run on Linux only to keep the windows/macOS CI jobs fast. They still run on every
+# OS on push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
+++ b/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
@@ -1,3 +1,5 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/summary/modified_status/out.test.toml
+++ b/acceptance/bundle/summary/modified_status/out.test.toml
@@ -1,4 +1,6 @@
 Local = true
 Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.VARIANT = ["empty_resources.yml", "no_resources.yml"]

--- a/acceptance/bundle/summary/test.toml
+++ b/acceptance/bundle/summary/test.toml
@@ -1,0 +1,5 @@
+# These tests exercise platform-independent bundle logic (summary rendering) and
+# behave identically on every OS, so on pull requests they run on Linux only to keep
+# the windows/macOS CI jobs fast. They still run on every OS on push to main.
+GOOSOnPR.windows = false
+GOOSOnPR.darwin = false

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -37,6 +37,12 @@ type TestConfig struct {
 	// If absent, default to true.
 	GOOS map[string]bool
 
+	// Like GOOS, but only consulted when the test run is triggered by a GitHub
+	// pull_request event. Each string is compared against runtime.GOOS; if absent,
+	// default to true. This lets an OS-independent test run on Linux only for pull
+	// requests while still running on every OS on push to main.
+	GOOSOnPR map[string]bool
+
 	// Which Clouds the test is enabled on. Allowed values: "aws", "azure", "gcp".
 	// If absent, default to true.
 	// Only checked if CLOUD_ENV is not empty.

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -54,6 +54,9 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	for _, k := range slices.Sorted(maps.Keys(config.GOOS)) {
 		fmt.Fprintf(&buf, "GOOS.%s = %v\n", k, config.GOOS[k])
 	}
+	for _, k := range slices.Sorted(maps.Keys(config.GOOSOnPR)) {
+		fmt.Fprintf(&buf, "GOOSOnPR.%s = %v\n", k, config.GOOSOnPR[k])
+	}
 	for _, k := range slices.Sorted(maps.Keys(config.CloudEnvs)) {
 		fmt.Fprintf(&buf, "CloudEnvs.%s = %v\n", k, config.CloudEnvs[k])
 	}


### PR DESCRIPTION
Most Windows/macOS acceptance time re-runs platform-independent bundle logic that Linux already covers. This adds a mechanism to skip such tests on the Windows/macOS PR cells, while still running the full matrix on every OS on push to `main`.

New `GOOSOnPR` field in `test.toml`, mirroring the existing `GOOS` filter but consulted only on GitHub `pull_request` events. It ANDs with `GOOS`, inherits down the directory tree, is opt-out (absent = runs everywhere), and surfaces in `out.test.toml`. No workflow changes — the event name comes from `GITHUB_EVENT_NAME`.

- `acceptance/internal/config.go` — `GOOSOnPR map[string]bool`
- `acceptance/internal/materialized_config.go` — serialize into `out.test.toml`
- `acceptance/acceptance_test.go` — `IsPullRequest` + skip branch beside the `GOOS` check

Paths no longer run on Windows/macOS for PRs (each verified to have no OS-specific behavior; all still run on Linux for PRs and on every OS on push to `main`):

- `bundle/invariant` — config normalization, no-drift checks, state migration
- `bundle/resources` — resource CRUD, diffing, permissions
- `bundle/resource_deps` — dependency ordering and reference resolution
- `bundle/run_as` — run_as identity resolution
- `bundle/migrate` — state and config migration
- `bundle/state` — deployment state tracking and lineage
- `bundle/bundle_tag` — tag validation
- `bundle/lifecycle` — deploy/destroy lifecycle
- `bundle/summary` — summary rendering

This pull request and its description were written by Isaac.
