### PR TITLE
experimental/ssh: resolve bare python/pip to the environment interpreter

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### CLI
 
+* experimental `ssh connect`: bare `python`/`pip` in an interactive session now resolve to the environment interpreter (`$DATABRICKS_VIRTUAL_ENV`) instead of the system or cluster-libraries interpreter, so packages installed in the environment are importable without extra setup. The interactive shell is now non-login (`bash -i`) and the server seeds a `~/.bashrc` snippet that re-prepends the environment's bin directory to `PATH`.
+
 ### Bundles
 
 ### Dependency updates

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### CLI
 
-* experimental `ssh connect`: bare `python`/`pip` in an interactive session now resolve to the environment interpreter (`$DATABRICKS_VIRTUAL_ENV`) instead of the system or cluster-libraries interpreter, so packages installed in the environment are importable without extra setup. The interactive shell is now non-login (`bash -i`) and the server seeds a `~/.bashrc` snippet that re-prepends the environment's bin directory to `PATH`.
+* experimental `ssh connect`: bare `python`/`pip` in an interactive session now resolve to the environment interpreter (`$DATABRICKS_VIRTUAL_ENV`) instead of the system or cluster-libraries interpreter, so packages installed in the environment are importable without extra setup. The interactive shell is now non-login (`bash -i`) and the server seeds a `~/.bashrc` snippet that re-prepends the environment's bin directory to `PATH` ([#5888](https://github.com/databricks/cli/pull/5888)).
 
 ### Bundles
 

--- a/experimental/ssh/CLAUDE.md
+++ b/experimental/ssh/CLAUDE.md
@@ -1,0 +1,57 @@
+# Working on `experimental/ssh`
+
+This file provides guidance to AI assistants working on the SSH tunnel. See the
+repository root `CLAUDE.md` for project-wide rules.
+
+## Testing an `ssh connect` change against real compute
+
+The binary uploaded to the cluster **is** the server: `ssh connect` uploads the
+local `databricks` CLI and runs it in server mode on the compute. So a fix only
+takes effect if the binary you upload actually contains it. Several ways to
+silently test stale code — verify each before trusting a result:
+
+**RULE: Confirm the binary you run is built from your current checkout.** When a
+fix lives on a branch (or a git worktree), building or running `./cli` from a
+different directory compiles unrelated code. The connection still succeeds and
+looks correct, but the server runs the wrong binary. Before connecting:
+
+```sh
+go build -o ./cli . && ./cli version
+git rev-parse --short HEAD   # the 0.0.0-dev+<sha> suffix must match this
+```
+
+If the version suffix doesn't match `HEAD`, you are running old code — stop and
+rebuild from the right directory.
+
+**RULE: For `--releases-dir`, build with `./task snapshot-release`, not `./task build`.**
+`./task build` produces only `./cli`; it does not populate `./dist`. The tunnel's
+`--releases-dir` loader expects `dist/databricks_cli_linux_{amd64,arm64}.zip`
+(see `getLocalRelease` in `internal/client/releases.go`). With a stale or empty
+`./dist`, the upload finds nothing new and the cluster reuses an older binary.
+Confirm the archive carries your change before uploading, e.g.:
+
+```sh
+unzip -p ./dist/databricks_cli_linux_amd64.zip databricks | strings | grep <a-string-your-change-adds>
+```
+
+**RULE: Dev/snapshot uploads are skipped when the versioned workspace directory already exists.**
+`uploadReleases` (`internal/client/releases.go`) skips the upload when the binary
+is already present at the versioned workspace path. Dev builds keep the same
+version string (`0.0.0-dev+<commit>`) across rebuilds, so a rebuilt server binary
+is silently **not** re-uploaded and the cluster runs the stale one. Before
+re-verifying a rebuilt binary, delete the versioned directory and connect with a
+fresh `--name`:
+
+```sh
+VER=$(./cli version | grep -o '0.0.0-dev+[a-f0-9]*')
+databricks workspace delete --recursive \
+  "/Workspace/Users/<you>/.databricks/ssh-tunnel/$VER"
+```
+
+## Server vs. session
+
+The server process and the interactive login session run as the same OS user with
+the same `$HOME` on serverless compute (CPU and GPU alike). When a session-level
+symptom (wrong `PATH`, a file not seeded, etc.) appears only on one compute type,
+check the binary version first — it is far more often a stale upload than a
+genuine per-compute difference.

--- a/experimental/ssh/internal/client/client.go
+++ b/experimental/ssh/internal/client/client.go
@@ -711,11 +711,17 @@ func shellSingleQuote(s string) string {
 // buildRemoteShellArgs returns the ssh arguments that follow the hostname.
 //
 // For the interactive case (no remote command given), it forces PTY allocation
-// and launches a login bash, because the default login shell on Databricks
-// compute images is /bin/sh. If bash is unavailable it falls back to $SHELL or
-// /bin/sh so the connection never breaks. When wsHome is set, the shell first
-// changes into the user's workspace home folder; if that directory is missing
-// the cd is ignored and the shell still launches from $HOME.
+// and launches an interactive, non-login bash. bash is invoked explicitly because
+// the default shell on Databricks compute images is /bin/sh; if bash is unavailable
+// it falls back to $SHELL or /bin/sh so the connection never breaks. A login shell
+// (-l) would re-source /etc/profile, which rebuilds PATH from scratch and drops the
+// environment's bin directory that sshd forwards via SetEnv, so bare `python`/`pip`
+// would resolve to the system interpreter instead of $DATABRICKS_VIRTUAL_ENV. Using
+// -i avoids that reset; the server's ~/.bashrc snippet (see seedEnvActivation) then
+// re-prepends the environment bin after /etc/bash.bashrc runs, so bare `python`/`pip`
+// resolve to the environment interpreter. When wsHome is set, the shell first changes
+// into the user's workspace home folder; if that directory is missing the cd is
+// ignored and the shell still launches from $HOME.
 //
 // For the non-interactive case (e.g. `databricks ssh connect ... -- ls -la`),
 // the user's command is returned verbatim so behavior is unchanged.
@@ -727,7 +733,7 @@ func buildRemoteShellArgs(opts ClientOptions, wsHome string) []string {
 	if len(opts.AdditionalArgs) > 0 {
 		return opts.AdditionalArgs
 	}
-	cmd := `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`
+	cmd := `command -v bash >/dev/null 2>&1 && exec bash -i || exec "${SHELL:-/bin/sh}" -i`
 	if wsHome != "" {
 		cmd = "cd " + shellSingleQuote(wsHome) + " 2>/dev/null; " + cmd
 	}

--- a/experimental/ssh/internal/client/client_internal_test.go
+++ b/experimental/ssh/internal/client/client_internal_test.go
@@ -348,9 +348,9 @@ func TestHostKeyChangedHint(t *testing.T) {
 }
 
 func TestBuildRemoteShellArgs(t *testing.T) {
-	const bashCmd = `command -v bash >/dev/null 2>&1 && exec bash -l || exec "${SHELL:-/bin/sh}" -l`
+	const bashCmd = `command -v bash >/dev/null 2>&1 && exec bash -i || exec "${SHELL:-/bin/sh}" -i`
 
-	t.Run("interactive returns login bash command", func(t *testing.T) {
+	t.Run("interactive returns non-login bash command", func(t *testing.T) {
 		args := buildRemoteShellArgs(ClientOptions{}, "")
 		require.Len(t, args, 1)
 		assert.Equal(t, bashCmd, args[0])
@@ -388,7 +388,7 @@ func TestBuildSSHArgsPTYPlacement(t *testing.T) {
 		assert.Less(t, ptyIdx, hostIdx, "-t must precede the destination host")
 		// The remote command is the final arg, after the host.
 		assert.Greater(t, len(args)-1, hostIdx)
-		assert.Contains(t, args[len(args)-1], "exec bash -l")
+		assert.Contains(t, args[len(args)-1], "exec bash -i")
 	})
 
 	t.Run("non-interactive does not force a PTY", func(t *testing.T) {

--- a/experimental/ssh/internal/server/server.go
+++ b/experimental/ssh/internal/server/server.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -16,6 +19,7 @@ import (
 
 	"github.com/databricks/cli/experimental/ssh/internal/proxy"
 	"github.com/databricks/cli/experimental/ssh/internal/workspace"
+	"github.com/databricks/cli/libs/env"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/databricks-sdk-go"
 )
@@ -82,6 +86,14 @@ func Run(ctx context.Context, client *databricks.WorkspaceClient, opts ServerOpt
 	err = saveJupyterInitScript(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to save Jupyter init script: %w", err)
+	}
+
+	// Best-effort: this only fixes bare python/pip resolution in interactive
+	// sessions. The tunnel works without it (the non-interactive `-- <cmd>` path
+	// is unaffected), so a write failure on a locked-down home must not abort the
+	// server. Mirrors the /run/sshd handling in prepareSSHDConfig.
+	if err := seedEnvActivation(ctx); err != nil {
+		log.Warnf(ctx, "Failed to seed environment activation, bare python/pip may resolve to the wrong interpreter in interactive sessions: %v", err)
 	}
 
 	createServerCommand := func(ctx context.Context) *exec.Cmd {
@@ -152,5 +164,59 @@ func saveJupyterInitScript(ctx context.Context) error {
 	}
 
 	log.Info(ctx, "Saved Jupyter init script to: "+initScriptPath)
+	return nil
+}
+
+// envActivationMarker identifies the block seedEnvActivation appends to ~/.bashrc,
+// so a server restart within the same home directory doesn't append it twice.
+const envActivationMarker = "# added by databricks ssh tunnel (DECO-27499)"
+
+// envActivationSnippet re-prepends the environment interpreter's bin directory to
+// PATH for interactive SSH sessions. The client runs an interactive, non-login
+// shell (bash -i), which sources /etc/bash.bashrc; on serverless that file runs
+// activate_root_python_environment.sh, which prepends the cluster-libraries python
+// ahead of the environment interpreter that sshd forwards via SetEnv. bash sources
+// ~/.bashrc after /etc/bash.bashrc, so re-prepending here wins and bare python/pip
+// resolve to $DATABRICKS_VIRTUAL_ENV. The guard makes it a no-op when the variable
+// is unset. /etc/bash.bashrc and /etc/profile.d are root-owned and not writable by
+// the non-root serverless user, so ~/.bashrc is the only usable hook.
+//
+// The bootstrap sets DATABRICKS_VIRTUAL_ENV to sys.executable, always an absolute
+// path, so dirname yields the interpreter's bin directory (not "." for a bare name).
+const envActivationSnippet = envActivationMarker + `
+if [ -n "$DATABRICKS_VIRTUAL_ENV" ]; then
+	export PATH="$(dirname "$DATABRICKS_VIRTUAL_ENV"):$PATH"
+fi
+`
+
+func seedEnvActivation(ctx context.Context) error {
+	homeDir, err := env.UserHomeDir(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+	bashrcPath := filepath.Join(homeDir, ".bashrc")
+
+	existing, err := os.ReadFile(bashrcPath)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("failed to read %s: %w", bashrcPath, err)
+	}
+	if bytes.Contains(existing, []byte(envActivationMarker)) {
+		log.Info(ctx, "Environment activation already present in "+bashrcPath)
+		return nil
+	}
+
+	// Append so the snippet runs after /etc/bash.bashrc and any existing ~/.bashrc
+	// content; the newline guards against a file that doesn't end in one.
+	separator := ""
+	if len(existing) > 0 && !bytes.HasSuffix(existing, []byte("\n")) {
+		separator = "\n"
+	}
+	content := string(existing) + separator + envActivationSnippet
+	err = os.WriteFile(bashrcPath, []byte(content), 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write %s: %w", bashrcPath, err)
+	}
+
+	log.Info(ctx, "Seeded environment activation in "+bashrcPath)
 	return nil
 }

--- a/experimental/ssh/internal/server/server_test.go
+++ b/experimental/ssh/internal/server/server_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedEnvActivation(t *testing.T) {
+	t.Run("creates bashrc when absent", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		require.NoError(t, seedEnvActivation(t.Context()))
+
+		content, err := os.ReadFile(filepath.Join(home, ".bashrc"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), envActivationMarker)
+		assert.Contains(t, string(content), `export PATH="$(dirname "$DATABRICKS_VIRTUAL_ENV"):$PATH"`)
+	})
+
+	t.Run("seeds the runtime guard so the snippet is a no-op when the var is unset", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		require.NoError(t, seedEnvActivation(t.Context()))
+
+		content, err := os.ReadFile(filepath.Join(home, ".bashrc"))
+		require.NoError(t, err)
+		assert.Contains(t, string(content), `if [ -n "$DATABRICKS_VIRTUAL_ENV" ]; then`)
+	})
+
+	t.Run("appends after existing content with separating newline", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		bashrc := filepath.Join(home, ".bashrc")
+		// No trailing newline, to exercise the separator.
+		require.NoError(t, os.WriteFile(bashrc, []byte("export FOO=bar"), 0o644))
+
+		require.NoError(t, seedEnvActivation(t.Context()))
+
+		content, err := os.ReadFile(bashrc)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "export FOO=bar\n"+envActivationMarker)
+	})
+
+	t.Run("does not insert a blank line when content already ends in a newline", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		bashrc := filepath.Join(home, ".bashrc")
+		require.NoError(t, os.WriteFile(bashrc, []byte("export FOO=bar\n"), 0o644))
+
+		require.NoError(t, seedEnvActivation(t.Context()))
+
+		content, err := os.ReadFile(bashrc)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "export FOO=bar\n"+envActivationMarker)
+		assert.NotContains(t, string(content), "export FOO=bar\n\n"+envActivationMarker)
+	})
+
+	t.Run("idempotent across restarts and preserves existing content", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		bashrc := filepath.Join(home, ".bashrc")
+		require.NoError(t, os.WriteFile(bashrc, []byte("export FOO=bar\n"), 0o644))
+
+		require.NoError(t, seedEnvActivation(t.Context()))
+		after, err := os.ReadFile(bashrc)
+		require.NoError(t, err)
+
+		// The second call must find the marker and leave the file byte-for-byte unchanged.
+		require.NoError(t, seedEnvActivation(t.Context()))
+		again, err := os.ReadFile(bashrc)
+		require.NoError(t, err)
+
+		assert.Equal(t, string(after), string(again))
+		assert.Equal(t, 1, strings.Count(string(again), envActivationMarker))
+		assert.Contains(t, string(again), "export FOO=bar")
+	})
+}

--- a/experimental/ssh/internal/server/server_test.go
+++ b/experimental/ssh/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/databricks/cli/libs/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -13,7 +14,7 @@ import (
 func TestSeedEnvActivation(t *testing.T) {
 	t.Run("creates bashrc when absent", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		t.Setenv(env.HomeEnvVar(), home)
 
 		require.NoError(t, seedEnvActivation(t.Context()))
 
@@ -25,7 +26,7 @@ func TestSeedEnvActivation(t *testing.T) {
 
 	t.Run("seeds the runtime guard so the snippet is a no-op when the var is unset", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		t.Setenv(env.HomeEnvVar(), home)
 
 		require.NoError(t, seedEnvActivation(t.Context()))
 
@@ -36,7 +37,7 @@ func TestSeedEnvActivation(t *testing.T) {
 
 	t.Run("appends after existing content with separating newline", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		t.Setenv(env.HomeEnvVar(), home)
 		bashrc := filepath.Join(home, ".bashrc")
 		// No trailing newline, to exercise the separator.
 		require.NoError(t, os.WriteFile(bashrc, []byte("export FOO=bar"), 0o644))
@@ -50,7 +51,7 @@ func TestSeedEnvActivation(t *testing.T) {
 
 	t.Run("does not insert a blank line when content already ends in a newline", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		t.Setenv(env.HomeEnvVar(), home)
 		bashrc := filepath.Join(home, ".bashrc")
 		require.NoError(t, os.WriteFile(bashrc, []byte("export FOO=bar\n"), 0o644))
 
@@ -64,7 +65,7 @@ func TestSeedEnvActivation(t *testing.T) {
 
 	t.Run("idempotent across restarts and preserves existing content", func(t *testing.T) {
 		home := t.TempDir()
-		t.Setenv("HOME", home)
+		t.Setenv(env.HomeEnvVar(), home)
 		bashrc := filepath.Join(home, ".bashrc")
 		require.NoError(t, os.WriteFile(bashrc, []byte("export FOO=bar\n"), 0o644))
 


### PR DESCRIPTION
## Summary

In an interactive `databricks ssh connect` session, bare `python`/`pip` resolved to the **wrong** interpreter (system or cluster-libraries python) instead of the environment interpreter at `$DATABRICKS_VIRTUAL_ENV`, so packages installed in the environment (including with `--base-environment`) could not be imported without extra setup. `import <env-package>` failed with `ModuleNotFoundError`. (DECO-27499)

## Root cause (two layers)

sshd forwards a snapshot of the environment-first `PATH` into each session via a `SetEnv` line, but two things clobbered it in an interactive shell:

1. **Login shell** — the client ran `exec bash -l`; `-l` re-sources `/etc/profile`, which rebuilds `PATH` from scratch, dropping the environment bin dir → bare `python` = **system** python.
2. **Interactive rc** — *any* interactive bash (`-i` or `-l`) sources `/etc/bash.bashrc`, which on serverless runs `activate_root_python_environment.sh` and prepends `.../cluster_libraries/python/bin` **ahead of** the environment interpreter → bare `python` = **cluster-libraries** python.

The non-interactive `-- <cmd>` path was already correct (sshd runs it via `$SHELL -c`, sourcing neither file).

## Fix (two coordinated changes)

- **Client** (`client.go`): launch an interactive **non-login** shell (`bash -i`) so `/etc/profile` is no longer re-sourced.
- **Server** (`server.go`): seed a guarded, idempotent `~/.bashrc` snippet that re-prepends the environment interpreter's bin directory. `~/.bashrc` is sourced *after* `/etc/bash.bashrc`, so it wins; `/etc/bash.bashrc` and `/etc/profile.d` are root-owned and not writable by the non-root serverless user, so `~/.bashrc` is the only usable hook. The seed is **best-effort** — a write failure logs a warning and does not abort the tunnel (mirrors the existing `/run/sshd` handling).

### Why server-side and not client-side
Each `--name` gets a fresh ephemeral `$HOME`, so a client-side edit wouldn't persist. A pure client-side re-prepend via `bash --rcfile <(...)` was rejected because the remote command is parsed by the login shell (`/bin/sh`/dash on some images), where process substitution is a syntax error and would break `connect`.

### Scope
Applied on all compute, guarded by `$DATABRICKS_VIRTUAL_ENV` being set. The bootstrap sets that variable to `sys.executable` (an absolute path) on every compute type, so `dirname` always yields the correct interpreter's bin directory.

## Testing

- `go test ./experimental/ssh/...` green, including new `TestSeedEnvActivation` (create / append / trailing-newline / idempotent-preserves-content / guard-present).
- `bash -i` assertions updated in `client_internal_test.go`.

### Manually verified against real compute

Confirmed end-to-end across all three compute types — in each interactive session, `which python` resolved to the environment interpreter (`dirname($DATABRICKS_VIRTUAL_ENV)`) rather than the system or cluster-libraries python, and importing an environment-only package succeeded:

- **Serverless CPU** — with a custom `--base-environment` (`cowsay`); `import cowsay` worked.
- **Serverless GPU** (`GPU_1xA10`) — with the same custom `--base-environment`; `import cowsay` worked.
- **Dedicated cluster** (single-node) — bare `which python` resolved to the environment interpreter.

This pull request and its description were written by Isaac.
