### PR TITLE
Add acceptance test for `ssh connect` to serverless CPU compute

### DIFF
--- a/acceptance/ssh/connect-serverless-cpu/out.stdout.txt
+++ b/acceptance/ssh/connect-serverless-cpu/out.stdout.txt
@@ -1,0 +1,1 @@
+Connection successful

--- a/acceptance/ssh/connect-serverless-cpu/out.test.toml
+++ b/acceptance/ssh/connect-serverless-cpu/out.test.toml
@@ -1,0 +1,4 @@
+Local = false
+Cloud = true
+RequiresUnityCatalog = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/ssh/connect-serverless-cpu/script
+++ b/acceptance/ssh/connect-serverless-cpu/script
@@ -1,0 +1,6 @@
+errcode $CLI ssh connect --releases-dir=$CLI_RELEASES_DIR -- "echo 'Connection successful'" >out.stdout.txt 2>LOG.stderr
+
+if ! grep -q "Connection successful" out.stdout.txt; then
+  run_id=$(cat LOG.stderr | grep -o "Job submitted successfully with run ID: [0-9]*" | grep -o "[0-9]*$")
+  trace $CLI jobs get-run "$run_id" > LOG.job
+fi

--- a/acceptance/ssh/connect-serverless-cpu/test.toml
+++ b/acceptance/ssh/connect-serverless-cpu/test.toml
@@ -1,0 +1,8 @@
+Local = false
+Cloud = true
+
+# Serverless requires Unity Catalog
+RequiresUnityCatalog = true
+
+[EnvMatrix]
+  DATABRICKS_BUNDLE_ENGINE = ["direct"]


### PR DESCRIPTION
## Summary

Adds `acceptance/ssh/connect-serverless-cpu/`, an acceptance test for the bare `databricks ssh connect` invocation, which targets **serverless CPU** compute (no `--cluster`, no `--accelerator`).

This complements the existing `acceptance/ssh/connect-serverless-gpu/` test. Compared to it:

- Drops `--accelerator` → serverless **CPU** instead of GPU; the connection name is auto-generated (`databricks-cpu-<hash>`), so no `--name` is needed.
- Drops the `CloudEnvs.gcp = false` exclusion — that exclusion exists only because serverless GPU is unavailable on GCP. Serverless CPU is available there.
- Keeps `RequiresUnityCatalog = true` — serverless requires Unity Catalog.

Like both existing ssh tests, it passes `--releases-dir=$CLI_RELEASES_DIR` so the tunnel binaries come from the artifacts the harness builds on cloud runs rather than a GitHub download, and it keeps the on-failure `jobs get-run` diagnostic so any CI failure is actionable.

## Test plan

- Local run correctly **skips** (`Local = false`).
- Verified **end-to-end against a real workspace** (`aws-prod-ucws`): the command provisions serverless CPU, uploads the CLI binaries, opens the tunnel, and runs the remote command — `out.stdout.txt` matches `Connection successful`.

```
--- PASS: TestAccept/ssh/connect-serverless-cpu/DATABRICKS_BUNDLE_ENGINE=direct
```

This pull request and its description were written by Isaac.

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._