### PR TITLE
acc: deflake bundle generate tests by isolating workspace paths per run

### DIFF
--- a/acceptance/bundle/generate/pipeline_and_deploy/output.txt
+++ b/acceptance/bundle/generate/pipeline_and_deploy/output.txt
@@ -1,13 +1,13 @@
 
 === Upload files to workspace
->>> [CLI] workspace import /Workspace/Users/[USERNAME]/notebook.py --file notebook.py --format AUTO --overwrite
+>>> [CLI] workspace import /Workspace/Users/[USERNAME]/notebook-[UNIQUE_NAME].py --file notebook.py --format AUTO --overwrite
 
->>> [CLI] workspace import /Workspace/Users/[USERNAME]/test.py --file test.py --format AUTO --overwrite
+>>> [CLI] workspace import /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME].py --file test.py --format AUTO --overwrite
 
 === Create a pipeline that references the filesCreated pipeline
 
-=== Generate bundle config from the pipelineFile successfully saved to src/notebook.py
-File successfully saved to src/test.py
+=== Generate bundle config from the pipelineFile successfully saved to src/notebook-[UNIQUE_NAME].py
+File successfully saved to src/test-[UNIQUE_NAME].py
 Pipeline configuration successfully saved to resources/out.pipeline.yml
 
 === Verify generated yaml has expected fields
@@ -27,6 +27,6 @@ Destroy complete!
 === Cleanup: delete the original pipeline and files
 >>> errcode [CLI] pipelines delete [PIPELINE_ID]
 
->>> errcode [CLI] workspace delete /Workspace/Users/[USERNAME]/notebook
+>>> errcode [CLI] workspace delete /Workspace/Users/[USERNAME]/notebook-[UNIQUE_NAME]
 
->>> errcode [CLI] workspace delete /Workspace/Users/[USERNAME]/test.py
+>>> errcode [CLI] workspace delete /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME].py

--- a/acceptance/bundle/generate/pipeline_and_deploy/script
+++ b/acceptance/bundle/generate/pipeline_and_deploy/script
@@ -1,8 +1,11 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 title "Upload files to workspace"
-trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/notebook.py" --file notebook.py --format AUTO --overwrite
-trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test.py" --file test.py --format AUTO --overwrite
+# The terraform and direct engine variants run concurrently against the same workspace user,
+# so embed $UNIQUE_NAME in the remote paths: otherwise one variant's cleanup deletes the shared
+# files out from under the other variant's bundle generate read.
+trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/notebook-${UNIQUE_NAME}.py" --file notebook.py --format AUTO --overwrite
+trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test-${UNIQUE_NAME}.py" --file test.py --format AUTO --overwrite
 
 title "Create a pipeline that references the files"
 PIPELINE_ID=$($CLI pipelines create --json '{
@@ -10,12 +13,12 @@ PIPELINE_ID=$($CLI pipelines create --json '{
   "libraries": [
     {
       "notebook": {
-        "path": "/Workspace/Users/'${CURRENT_USER_NAME}'/notebook"
+        "path": "/Workspace/Users/'${CURRENT_USER_NAME}'/notebook-'${UNIQUE_NAME}'"
       }
     },
     {
       "file": {
-        "path": "/Workspace/Users/'${CURRENT_USER_NAME}'/test.py"
+        "path": "/Workspace/Users/'${CURRENT_USER_NAME}'/test-'${UNIQUE_NAME}'.py"
       }
     }
   ]
@@ -26,8 +29,8 @@ env -u MSYS_NO_PATHCONV add_repl.py "$PIPELINE_ID" PIPELINE_ID
 cleanup() {
     title "Cleanup: delete the original pipeline and files"
     trace errcode $CLI pipelines delete "$PIPELINE_ID"
-    trace errcode $CLI workspace delete "/Workspace/Users/${CURRENT_USER_NAME}/notebook"
-    trace errcode $CLI workspace delete "/Workspace/Users/${CURRENT_USER_NAME}/test.py"
+    trace errcode $CLI workspace delete "/Workspace/Users/${CURRENT_USER_NAME}/notebook-${UNIQUE_NAME}"
+    trace errcode $CLI workspace delete "/Workspace/Users/${CURRENT_USER_NAME}/test-${UNIQUE_NAME}.py"
 }
 trap cleanup EXIT
 
@@ -35,7 +38,7 @@ title "Generate bundle config from the pipeline"
 $CLI bundle generate pipeline --existing-pipeline-id "$PIPELINE_ID" --key out --config-dir resources --source-dir src --force 2>&1 | sort
 
 title "Verify generated yaml has expected fields"
-cat resources/out.pipeline.yml | env -u MSYS_NO_PATHCONV contains.py "libraries:" "- notebook:" "path: ../src/notebook.py" "- file:" "path: ../src/test.py" > /dev/null
+cat resources/out.pipeline.yml | env -u MSYS_NO_PATHCONV contains.py "libraries:" "- notebook:" "path: ../src/notebook-${UNIQUE_NAME}.py" "- file:" "path: ../src/test-${UNIQUE_NAME}.py" > /dev/null
 
 title "Deploy the generated bundle"
 trace $CLI bundle deploy

--- a/acceptance/bundle/generate/python_job_and_deploy/output.txt
+++ b/acceptance/bundle/generate/python_job_and_deploy/output.txt
@@ -1,12 +1,12 @@
 
 === Upload notebook to a workspace path
->>> [CLI] workspace import /Workspace/Users/[USERNAME]/test_notebook.py --file test_notebook.py --format AUTO --overwrite
+>>> [CLI] workspace import /Workspace/Users/[USERNAME]/test_notebook-[UNIQUE_NAME].py --file test_notebook.py --format AUTO --overwrite
 
 === Create a job that references the notebookCreated job
 
 === Generate bundle config from the job
 >>> [CLI] bundle generate job --existing-job-id [JOB_ID] --key out --config-dir resources --source-dir src --force
-File successfully saved to src/test_notebook.py
+File successfully saved to src/test_notebook-[UNIQUE_NAME].py
 Job configuration successfully saved to resources/out.job.yml
 
 === Verify generated yaml has expected fields
@@ -26,4 +26,4 @@ Destroy complete!
 === Cleanup: delete the original job and notebook
 >>> errcode [CLI] jobs delete [JOB_ID]
 
->>> errcode [CLI] workspace delete /Workspace/Users/[USERNAME]/test_notebook
+>>> errcode [CLI] workspace delete /Workspace/Users/[USERNAME]/test_notebook-[UNIQUE_NAME]

--- a/acceptance/bundle/generate/python_job_and_deploy/script
+++ b/acceptance/bundle/generate/python_job_and_deploy/script
@@ -1,7 +1,10 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 title "Upload notebook to a workspace path"
-trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test_notebook.py" --file test_notebook.py --format AUTO --overwrite
+# The terraform and direct engine variants run concurrently against the same workspace user,
+# so embed $UNIQUE_NAME in the remote path: otherwise one variant's cleanup deletes the shared
+# notebook out from under the other variant's bundle generate read.
+trace $CLI workspace import "/Workspace/Users/${CURRENT_USER_NAME}/test_notebook-${UNIQUE_NAME}.py" --file test_notebook.py --format AUTO --overwrite
 
 title "Create a job that references the notebook"
 JOB_ID=$($CLI jobs create --json '{
@@ -12,7 +15,7 @@ JOB_ID=$($CLI jobs create --json '{
     {
       "task_key": "test_task",
       "notebook_task": {
-        "notebook_path": "/Workspace/Users/'${CURRENT_USER_NAME}'/test_notebook"
+        "notebook_path": "/Workspace/Users/'${CURRENT_USER_NAME}'/test_notebook-'${UNIQUE_NAME}'"
       },
       "new_cluster": {
         "spark_version": "'${DEFAULT_SPARK_VERSION}'",
@@ -30,7 +33,7 @@ env -u MSYS_NO_PATHCONV add_repl.py "$JOB_ID" JOB_ID
 cleanup() {
     title "Cleanup: delete the original job and notebook"
     trace errcode $CLI jobs delete "$JOB_ID"
-    trace errcode $CLI workspace delete "/Workspace/Users/${CURRENT_USER_NAME}/test_notebook"
+    trace errcode $CLI workspace delete "/Workspace/Users/${CURRENT_USER_NAME}/test_notebook-${UNIQUE_NAME}"
 }
 trap cleanup EXIT
 
@@ -38,7 +41,7 @@ title "Generate bundle config from the job"
 trace $CLI bundle generate job --existing-job-id "$JOB_ID" --key out --config-dir resources --source-dir src --force
 
 title "Verify generated yaml has expected fields"
-cat resources/out.job.yml | env -u MSYS_NO_PATHCONV contains.py "task_key: test_task" "notebook_task:" "notebook_path: ../src/test_notebook.py" > /dev/null
+cat resources/out.job.yml | env -u MSYS_NO_PATHCONV contains.py "task_key: test_task" "notebook_task:" "notebook_path: ../src/test_notebook-${UNIQUE_NAME}.py" > /dev/null
 
 title "Deploy the generated bundle"
 trace $CLI bundle deploy


### PR DESCRIPTION
The generate/pipeline_and_deploy and generate/python_job_and_deploy cloud tests run their terraform and direct variants concurrently against the same workspace user. Both used fixed remote paths and deleted them on exit, so one variant's cleanup could delete files mid-`bundle generate` in the other. Embed `$UNIQUE_NAME` in the paths so each variant is isolated. Acceptance-fixture-only change.

This pull request and its description were written by Isaac.