### PR TITLE
Add lennartkats-db to maintainers and team:bundle

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,11 +1,11 @@
 # Maintainers (can approve any PR)
-*                           @andrewnester @anton-107 @denik @pietern @shreyas-goenka @simonfaltum @renaudhartert-db @janniklasrose
+*                           @andrewnester @anton-107 @denik @pietern @shreyas-goenka @simonfaltum @renaudhartert-db @janniklasrose @lennartkats-db
 
 # Bundles
-/bundle/                    team:bundle @lennartkats-db
-/cmd/bundle/                team:bundle @lennartkats-db
-/acceptance/bundle/         team:bundle @lennartkats-db
-/libs/template/             team:bundle @lennartkats-db
+/bundle/                    team:bundle
+/cmd/bundle/                team:bundle
+/acceptance/bundle/         team:bundle
+/libs/template/             team:bundle
 
 # Pipelines
 /cmd/pipelines/             @jefferycheng1 @kanterov @lennartkats-db

--- a/.github/OWNERTEAMS
+++ b/.github/OWNERTEAMS
@@ -12,7 +12,7 @@
 #   eng-apps-devex:  https://github.com/orgs/databricks/teams/eng-apps-devex
 #   eng-sandbox:     https://github.com/orgs/databricks/teams/eng-sandbox
 
-team:bundle     @andrewnester @anton-107 @denik @janniklasrose @pietern @shreyas-goenka
+team:bundle     @andrewnester @anton-107 @denik @janniklasrose @lennartkats-db @pietern @shreyas-goenka
 team:platform   @simonfaltum @renaudhartert-db @hectorcast-db @parthban-db @tanmay-db @Divyansh-db @tejaskochar-db @mihaimitrea-db @chrisst @rauchy
 team:eng-apps-devex @fjakobs @Shridhad @atilafassina @keugenek @igrekun @pkosiec @MarioCadenas @pffigueiredo @ditadi @calvarjorge
 team:eng-sandbox @pietern @shuochen0311 @akshaysingla-db @anwell-db @samhuan-db


### PR DESCRIPTION
## Changes

Add `@lennartkats-db` to the maintainers (`*`) rule and to `team:bundle`, and drop the now-redundant standalone entry from the bundle path rules. Previously signed off by Pieter.

## Tests

`owners.js validate` + owners/maintainer-approval unit tests pass.
