### PR TITLE
Report an actionable error for unsupported bundle init template URLs

### DIFF
--- a/.nextchanges/bundles/bundle-init-unsupported-protocol.md
+++ b/.nextchanges/bundles/bundle-init-unsupported-protocol.md
@@ -1,0 +1,1 @@
+`databricks bundle init` now reports an actionable error when given a template URL with an unsupported protocol (`http://`, `git://`, `ftp://`, `ftps://`) instead of failing with a confusing "not a bundle template" message ([#5902](https://github.com/databricks/cli/pull/5902)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### CLI
 
 * experimental `ssh connect`: bare `python`/`pip` in an interactive session now resolve to the environment interpreter (`$DATABRICKS_VIRTUAL_ENV`) instead of the system or cluster-libraries interpreter, so packages installed in the environment are importable without extra setup. The interactive shell is now non-login (`bash -i`) and the server seeds a `~/.bashrc` snippet that re-prepends the environment's bin directory to `PATH` ([#5888](https://github.com/databricks/cli/pull/5888)).
+* `databricks bundle init` now reports an actionable error when given a template URL with an unsupported protocol (`http://`, `git://`, `ftp://`, `ftps://`) instead of failing with a confusing "not a bundle template" message.
 
 ### Bundles
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,7 +7,6 @@
 ### CLI
 
 * experimental `ssh connect`: bare `python`/`pip` in an interactive session now resolve to the environment interpreter (`$DATABRICKS_VIRTUAL_ENV`) instead of the system or cluster-libraries interpreter, so packages installed in the environment are importable without extra setup. The interactive shell is now non-login (`bash -i`) and the server seeds a `~/.bashrc` snippet that re-prepends the environment's bin directory to `PATH` ([#5888](https://github.com/databricks/cli/pull/5888)).
-* `databricks bundle init` now reports an actionable error when given a template URL with an unsupported protocol (`http://`, `git://`, `ftp://`, `ftps://`) instead of failing with a confusing "not a bundle template" message.
 
 ### Bundles
 

--- a/acceptance/bundle/templates-machinery/supported-url/out.test.toml
+++ b/acceptance/bundle/templates-machinery/supported-url/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/supported-url/output.txt
+++ b/acceptance/bundle/templates-machinery/supported-url/output.txt
@@ -1,3 +1,4 @@
 
+=== https:// URL is recognized as a Git URL
 === ssh:// URL is recognized as a Git URL
 === git@ URL is recognized as a Git URL

--- a/acceptance/bundle/templates-machinery/supported-url/output.txt
+++ b/acceptance/bundle/templates-machinery/supported-url/output.txt
@@ -1,0 +1,3 @@
+
+=== ssh:// URL is recognized as a Git URL
+=== git@ URL is recognized as a Git URL

--- a/acceptance/bundle/templates-machinery/supported-url/script
+++ b/acceptance/bundle/templates-machinery/supported-url/script
@@ -1,0 +1,15 @@
+export NO_COLOR=1
+
+# These hosts do not resolve (.invalid is reserved by RFC 6761), so the clone
+# fails fast without network access. The point of the test is that ssh:// and
+# git@ URLs are recognized as Git URLs and a clone is attempted, rather than
+# being misread as local template paths (which would report a "not a bundle
+# template" error instead). The git error text varies by platform, so we route
+# it to LOG (excluded from the diff) and assert the invariant with contains.py.
+title "ssh:// URL is recognized as a Git URL"
+errcode $CLI bundle init ssh://git@nonexistent.databricks.invalid/databricks/cli &> LOG.ssh
+contains.py "git clone ssh://git@nonexistent.databricks.invalid/databricks/cli" "!not a bundle template" < LOG.ssh > /dev/null
+
+title "git@ URL is recognized as a Git URL"
+errcode $CLI bundle init git@nonexistent.databricks.invalid:databricks/cli.git &> LOG.git
+contains.py "git clone git@nonexistent.databricks.invalid:databricks/cli.git" "!not a bundle template" < LOG.git > /dev/null

--- a/acceptance/bundle/templates-machinery/supported-url/script
+++ b/acceptance/bundle/templates-machinery/supported-url/script
@@ -1,11 +1,15 @@
 export NO_COLOR=1
 
 # These hosts do not resolve (.invalid is reserved by RFC 6761), so the clone
-# fails fast without network access. The point of the test is that ssh:// and
-# git@ URLs are recognized as Git URLs and a clone is attempted, rather than
-# being misread as local template paths (which would report a "not a bundle
-# template" error instead). The git error text varies by platform, so we route
-# it to LOG (excluded from the diff) and assert the invariant with contains.py.
+# fails fast without network access. The point of the test is that these URLs
+# are recognized as Git URLs and a clone is attempted, rather than being misread
+# as local template paths (which would report a "not a bundle template" error
+# instead). The git error text varies by platform, so we route it to LOG
+# (excluded from the diff) and assert the invariant with contains.py.
+title "https:// URL is recognized as a Git URL"
+errcode $CLI bundle init https://nonexistent.databricks.invalid/databricks/cli &> LOG.https
+contains.py "git clone https://nonexistent.databricks.invalid/databricks/cli" "!not a bundle template" < LOG.https > /dev/null
+
 title "ssh:// URL is recognized as a Git URL"
 errcode $CLI bundle init ssh://git@nonexistent.databricks.invalid/databricks/cli &> LOG.ssh
 contains.py "git clone ssh://git@nonexistent.databricks.invalid/databricks/cli" "!not a bundle template" < LOG.ssh > /dev/null

--- a/acceptance/bundle/templates-machinery/supported-url/script
+++ b/acceptance/bundle/templates-machinery/supported-url/script
@@ -1,5 +1,3 @@
-export NO_COLOR=1
-
 # These hosts do not resolve (.invalid is reserved by RFC 6761), so the clone
 # fails fast without network access. The point of the test is that these URLs
 # are recognized as Git URLs and a clone is attempted, rather than being misread

--- a/acceptance/bundle/templates-machinery/unsupported-url/out.test.toml
+++ b/acceptance/bundle/templates-machinery/unsupported-url/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/templates-machinery/unsupported-url/output.txt
+++ b/acceptance/bundle/templates-machinery/unsupported-url/output.txt
@@ -1,0 +1,3 @@
+Error: unsupported protocol in Git URL "http://github.com/databricks/cli": only https://, ssh://, and git@ URLs are supported
+
+Exit code: 1

--- a/acceptance/bundle/templates-machinery/unsupported-url/output.txt
+++ b/acceptance/bundle/templates-machinery/unsupported-url/output.txt
@@ -1,3 +1,12 @@
-Error: unsupported protocol in Git URL "http://github.com/databricks/cli": only https://, ssh://, and git@ URLs are supported
 
-Exit code: 1
+>>> musterr [CLI] bundle init http://github.com/databricks/cli
+Error: unsupported protocol in Git URL "http://github.com/databricks/cli": only https://, ssh://, git@ URLs are supported
+
+>>> musterr [CLI] bundle init git://github.com/databricks/cli
+Error: unsupported protocol in Git URL "git://github.com/databricks/cli": only https://, ssh://, git@ URLs are supported
+
+>>> musterr [CLI] bundle init ftp://github.com/databricks/cli
+Error: unsupported protocol in Git URL "ftp://github.com/databricks/cli": only https://, ssh://, git@ URLs are supported
+
+>>> musterr [CLI] bundle init ftps://github.com/databricks/cli
+Error: unsupported protocol in Git URL "ftps://github.com/databricks/cli": only https://, ssh://, git@ URLs are supported

--- a/acceptance/bundle/templates-machinery/unsupported-url/script
+++ b/acceptance/bundle/templates-machinery/unsupported-url/script
@@ -1,5 +1,3 @@
-export NO_COLOR=1
-
 trace musterr $CLI bundle init http://github.com/databricks/cli
 trace musterr $CLI bundle init git://github.com/databricks/cli
 trace musterr $CLI bundle init ftp://github.com/databricks/cli

--- a/acceptance/bundle/templates-machinery/unsupported-url/script
+++ b/acceptance/bundle/templates-machinery/unsupported-url/script
@@ -1,2 +1,6 @@
 export NO_COLOR=1
-errcode $CLI bundle init http://github.com/databricks/cli
+
+trace musterr $CLI bundle init http://github.com/databricks/cli
+trace musterr $CLI bundle init git://github.com/databricks/cli
+trace musterr $CLI bundle init ftp://github.com/databricks/cli
+trace musterr $CLI bundle init ftps://github.com/databricks/cli

--- a/acceptance/bundle/templates-machinery/unsupported-url/script
+++ b/acceptance/bundle/templates-machinery/unsupported-url/script
@@ -1,0 +1,2 @@
+export NO_COLOR=1
+errcode $CLI bundle init http://github.com/databricks/cli

--- a/cmd/bundle/debug/render_template_schema.go
+++ b/cmd/bundle/debug/render_template_schema.go
@@ -44,7 +44,10 @@ func NewRenderTemplateSchemaCommand() *cobra.Command {
 		}
 
 		// Resolve the template reader
-		reader, isGitReader := template.ResolveReader(templatePathOrUrl, templateDir, ref)
+		reader, isGitReader, err := template.ResolveReader(templatePathOrUrl, templateDir, ref)
+		if err != nil {
+			return err
+		}
 		defer reader.Cleanup(ctx)
 
 		// For git reader, load schema first to initialize the temp directory

--- a/libs/template/resolver.go
+++ b/libs/template/resolver.go
@@ -55,12 +55,23 @@ func ResolveReader(templatePathOrUrl, templateDir, ref string) (Reader, bool, er
 
 	if p := matchGitUrlPrefix(templatePathOrUrl); p != nil {
 		if p.invalid {
-			return nil, false, fmt.Errorf("unsupported protocol in Git URL %q: only https://, ssh://, and git@ URLs are supported", templatePathOrUrl)
+			return nil, false, fmt.Errorf("unsupported protocol in Git URL %q: only %s URLs are supported", templatePathOrUrl, strings.Join(supportedGitUrlPrefixes(), ", "))
 		}
 		return NewGitReader(templatePathOrUrl, ref, templateDir, git.Clone), true, nil
 	}
 
 	return NewLocalReader(templatePathOrUrl), false, nil
+}
+
+// supportedGitUrlPrefixes returns the valid (non-rejected) Git URL prefixes.
+func supportedGitUrlPrefixes() []string {
+	var prefixes []string
+	for i := range gitUrlPrefixes {
+		if !gitUrlPrefixes[i].invalid {
+			prefixes = append(prefixes, gitUrlPrefixes[i].prefix)
+		}
+	}
+	return prefixes
 }
 
 type Resolver struct {

--- a/libs/template/resolver.go
+++ b/libs/template/resolver.go
@@ -3,40 +3,64 @@ package template
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/databricks/cli/libs/git"
 )
 
-// See https://git-scm.com/docs/git-clone#_git_urls for the set of supported
-// Git URL forms. We deliberately exclude deprecated/insecure protocols (git, http, ftp[s]).
-var gitUrlPrefixes = []string{
-	"https://",
-	"ssh://",
+type gitUrlPrefix struct {
+	prefix string
+
+	// invalid marks a prefix that git recognizes as a URL but that we refuse to
+	// clone from, so we can report an actionable error instead of falling through
+	// to the local-path reader.
+	invalid bool
+}
+
+// See https://git-scm.com/docs/git-clone#_git_urls for the set of Git URL forms.
+// We deliberately reject the deprecated/insecure transports (git, http, ftp[s]).
+var gitUrlPrefixes = []gitUrlPrefix{
+	{prefix: "https://"},
+	{prefix: "ssh://"},
 	// recognize git@ without ssh:// protocol because this is very common
-	"git@",
+	{prefix: "git@"},
+	{prefix: "http://", invalid: true},
+	{prefix: "git://", invalid: true},
+	{prefix: "ftp://", invalid: true},
+	{prefix: "ftps://", invalid: true},
+}
+
+// matchGitUrlPrefix returns the matching prefix entry, or nil if the input does
+// not look like a Git URL.
+func matchGitUrlPrefix(url string) *gitUrlPrefix {
+	for i := range gitUrlPrefixes {
+		if strings.HasPrefix(url, gitUrlPrefixes[i].prefix) {
+			return &gitUrlPrefixes[i]
+		}
+	}
+	return nil
 }
 
 func IsGitRepoUrl(url string) bool {
-	for _, prefix := range gitUrlPrefixes {
-		if strings.HasPrefix(url, prefix) {
-			return true
-		}
-	}
-	return false
+	p := matchGitUrlPrefix(url)
+	return p != nil && !p.invalid
 }
 
 // ResolveReader resolves a template path/URL to a Reader (built-in, git or local)
-func ResolveReader(templatePathOrUrl, templateDir, ref string) (Reader, bool) {
+func ResolveReader(templatePathOrUrl, templateDir, ref string) (Reader, bool, error) {
 	if tmpl := GetDatabricksTemplate(TemplateName(templatePathOrUrl)); tmpl != nil {
-		return tmpl.Reader, false
+		return tmpl.Reader, false, nil
 	}
 
-	if IsGitRepoUrl(templatePathOrUrl) {
-		return NewGitReader(templatePathOrUrl, ref, templateDir, git.Clone), true
+	if p := matchGitUrlPrefix(templatePathOrUrl); p != nil {
+		if p.invalid {
+			return nil, false, fmt.Errorf("unsupported protocol in Git URL %q: only https://, ssh://, and git@ URLs are supported", templatePathOrUrl)
+		}
+		return NewGitReader(templatePathOrUrl, ref, templateDir, git.Clone), true, nil
 	}
 
-	return NewLocalReader(templatePathOrUrl), false
+	return NewLocalReader(templatePathOrUrl), false, nil
 }
 
 type Resolver struct {
@@ -107,7 +131,10 @@ func (r Resolver) Resolve(ctx context.Context) (*Template, error) {
 	//
 	// We resolve the appropriate reader according to the reference provided by the user.
 	if tmpl == nil {
-		reader, _ := ResolveReader(r.TemplatePathOrUrl, r.TemplateDir, ref)
+		reader, _, err := ResolveReader(r.TemplatePathOrUrl, r.TemplateDir, ref)
+		if err != nil {
+			return nil, err
+		}
 		tmpl = &Template{
 			name:   Custom,
 			Reader: reader,

--- a/libs/template/resolver_test.go
+++ b/libs/template/resolver_test.go
@@ -120,13 +120,15 @@ func TestBundleInitIsGitRepoUrl(t *testing.T) {
 
 func TestResolveReader(t *testing.T) {
 	t.Run("builtin template", func(t *testing.T) {
-		reader, isGit := ResolveReader("default-python", "", "")
+		reader, isGit, err := ResolveReader("default-python", "", "")
+		require.NoError(t, err)
 		assert.False(t, isGit)
 		assert.Equal(t, &builtinReader{name: "default-python"}, reader)
 	})
 
 	t.Run("git URL", func(t *testing.T) {
-		reader, isGit := ResolveReader("https://github.com/example/repo", "/template", "v1.0")
+		reader, isGit, err := ResolveReader("https://github.com/example/repo", "/template", "v1.0")
+		require.NoError(t, err)
 		assert.True(t, isGit)
 		gitReader := reader.(*gitReader)
 		assert.Equal(t, "https://github.com/example/repo", gitReader.gitUrl)
@@ -134,8 +136,14 @@ func TestResolveReader(t *testing.T) {
 		assert.Equal(t, "v1.0", gitReader.ref)
 	})
 
+	t.Run("unsupported protocol", func(t *testing.T) {
+		_, _, err := ResolveReader("http://github.com/example/repo", "", "")
+		assert.ErrorContains(t, err, "unsupported protocol")
+	})
+
 	t.Run("local path", func(t *testing.T) {
-		reader, isGit := ResolveReader("/local/path", "", "")
+		reader, isGit, err := ResolveReader("/local/path", "", "")
+		require.NoError(t, err)
 		assert.False(t, isGit)
 		assert.Equal(t, "/local/path", reader.(*localReader).path)
 	})

--- a/libs/template/resolver_test.go
+++ b/libs/template/resolver_test.go
@@ -126,20 +126,33 @@ func TestResolveReader(t *testing.T) {
 		assert.Equal(t, &builtinReader{name: "default-python"}, reader)
 	})
 
-	t.Run("git URL", func(t *testing.T) {
-		reader, isGit, err := ResolveReader("https://github.com/example/repo", "/template", "v1.0")
-		require.NoError(t, err)
-		assert.True(t, isGit)
-		gitReader := reader.(*gitReader)
-		assert.Equal(t, "https://github.com/example/repo", gitReader.gitUrl)
-		assert.Equal(t, "/template", gitReader.templateDir)
-		assert.Equal(t, "v1.0", gitReader.ref)
-	})
+	for _, url := range []string{
+		"https://github.com/example/repo",
+		"ssh://git@github.com/example/repo",
+		"git@github.com:example/repo",
+	} {
+		t.Run("git URL "+url, func(t *testing.T) {
+			reader, isGit, err := ResolveReader(url, "/template", "v1.0")
+			require.NoError(t, err)
+			assert.True(t, isGit)
+			gitReader := reader.(*gitReader)
+			assert.Equal(t, url, gitReader.gitUrl)
+			assert.Equal(t, "/template", gitReader.templateDir)
+			assert.Equal(t, "v1.0", gitReader.ref)
+		})
+	}
 
-	t.Run("unsupported protocol", func(t *testing.T) {
-		_, _, err := ResolveReader("http://github.com/example/repo", "", "")
-		assert.ErrorContains(t, err, "unsupported protocol")
-	})
+	for _, url := range []string{
+		"http://github.com/example/repo",
+		"git://github.com/example/repo",
+		"ftp://github.com/example/repo",
+		"ftps://github.com/example/repo",
+	} {
+		t.Run("unsupported protocol "+url, func(t *testing.T) {
+			_, _, err := ResolveReader(url, "", "")
+			assert.ErrorContains(t, err, "unsupported protocol")
+		})
+	}
 
 	t.Run("local path", func(t *testing.T) {
 		reader, isGit, err := ResolveReader("/local/path", "", "")


### PR DESCRIPTION
## Changes
`databricks bundle init <url>` with an unsupported protocol previously fell through to the local-path reader and failed with a confusing error:

```
$ databricks bundle init http://github.com/databricks/cli.git
Error: not a bundle template: expected to find a template schema file at databricks_template_schema.json
```

Now the deprecated/insecure transports (`http://`, `git://`, `ftp://`, `ftps://`) are recognized as Git URLs but flagged invalid, so `ResolveReader` returns an actionable error naming the supported protocols:

```
Error: unsupported protocol in Git URL "http://github.com/databricks/cli.git": only https://, ssh://, and git@ URLs are supported
```

`ResolveReader` now returns an `error`; both callers (`Resolver.Resolve` and the `render-template-schema` debug command) propagate it.

## Why
Follow-up to #5891. The fall-through behavior gave no hint that the protocol was the problem.

## Tests
- Unit tests in `resolver_test.go` cover the invalid-protocol path in `ResolveReader`.
- New acceptance test `bundle/templates-machinery/unsupported-url` asserts the CLI error. The error is raised at resolve time, before any network access, so no request mocking is needed.

_This PR was written by Claude Code._
