### PR TITLE
libs/cmdio: centralize lipgloss renderer initialization

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -155,6 +155,10 @@ mattn/go-isatty - https://github.com/mattn/go-isatty
 Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 License - https://github.com/mattn/go-isatty/blob/master/LICENSE
 
+muesli/termenv - https://github.com/muesli/termenv
+Copyright (c) 2019 Christian Muehlhaeuser
+License - https://github.com/muesli/termenv/blob/master/LICENSE
+
 sabhiram/go-gitignore - https://github.com/sabhiram/go-gitignore
 Copyright (c) 2015 Shaba Abhiram
 License - https://github.com/sabhiram/go-gitignore/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // BSD-3-Clause
 	github.com/jackc/pgx/v5 v5.10.0 // MIT
 	github.com/mattn/go-isatty v0.0.22 // MIT
+	github.com/muesli/termenv v0.16.0 // MIT
 	github.com/palantir/pkg/yamlpatch v1.5.0 // BSD-3-Clause
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // BSD-2-Clause
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22 // BSD-3-Clause
@@ -85,7 +86,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/libs/cmdio/color.go
+++ b/libs/cmdio/color.go
@@ -3,10 +3,12 @@ package cmdio
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"text/template"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 // SGR (Select Graphic Rendition) escapes; see
@@ -137,4 +139,18 @@ func PadLeft(s string, n int) string {
 		return strings.Repeat(" ", pad) + s
 	}
 	return s
+}
+
+// NewRenderer returns a lipgloss renderer targeting w, along with whether w
+// supports color. When it does not (NO_COLOR, TERM=dumb, or w is piped or
+// redirected) the renderer is forced to the Ascii profile so every Style it
+// mints emits no SGR escapes. Callers still write rendered strings to w
+// themselves; the renderer only carries the color profile.
+func NewRenderer(ctx context.Context, w io.Writer) (*lipgloss.Renderer, bool) {
+	color := SupportsColor(ctx, w)
+	r := lipgloss.NewRenderer(w)
+	if !color {
+		r.SetColorProfile(termenv.Ascii)
+	}
+	return r, color
 }

--- a/libs/cmdio/color_test.go
+++ b/libs/cmdio/color_test.go
@@ -1,10 +1,12 @@
 package cmdio_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/databricks/cli/libs/cmdio"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,6 +126,17 @@ func TestPadLeft(t *testing.T) {
 			assert.Equal(t, c.want, cmdio.PadLeft(c.in, c.n))
 		})
 	}
+}
+
+func TestNewRendererForcesAsciiWhenNoColor(t *testing.T) {
+	ctx := noColorContext(t)
+
+	// A bytes.Buffer is never a TTY, so the renderer must fall back to Ascii and
+	// its styles must render without SGR escapes.
+	r, color := cmdio.NewRenderer(ctx, &bytes.Buffer{})
+	assert.False(t, color)
+	assert.Equal(t, termenv.Ascii, r.ColorProfile())
+	assert.Equal(t, "hi", r.NewStyle().Bold(true).Render("hi"))
 }
 
 func TestRenderFuncMap(t *testing.T) {


### PR DESCRIPTION
Add `cmdio.NewRenderer(ctx, w)`, which builds a `lipgloss.Renderer` and forces the Ascii profile when the writer has no color, returning the renderer plus the resolved `colorOn` bool. Callers stop repeating the `NewRenderer` + `SetColorProfile(termenv.Ascii)` dance.

This makes `cmdio` the sole importer of `muesli/termenv`, so it's promoted from indirect to a direct dependency (with `NOTICE` entry).

This pull request and its description were written by Isaac.
