### PR TITLE
Update postgres cloud test golden outputs

### DIFF
--- a/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/output.txt
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/output.txt
@@ -1,11 +1,11 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/missing-role-[UNIQUE_NAME]/default/files...
 Deploying resources...
-Error: cannot create resources.postgres_databases.my_database: Field 'spec.role' cannot be empty (400 INVALID_PARAMETER_VALUE)
+Error: cannot create resources.postgres_databases.my_database: Field 'database.spec.role' is required, expected non-default value (400 INVALID_PARAMETER_VALUE)
 
 Endpoint: POST [DATABRICKS_URL]/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/databases?database_id=my-database
 HTTP Status: 400 Bad Request
 API error_code: INVALID_PARAMETER_VALUE
-API message: Field 'spec.role' cannot be empty
+API message: Field 'database.spec.role' is required, expected non-default value
 
 Updating deployment state...
 

--- a/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/script
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/script
@@ -5,4 +5,4 @@ cleanup() {
 }
 trap cleanup EXIT
 
-musterr $CLI bundle deploy 2>&1 | contains.py "Field 'spec.role' cannot be empty"
+musterr $CLI bundle deploy 2>&1 | contains.py "Field 'database.spec.role' is required, expected non-default value"

--- a/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/output.txt
@@ -39,26 +39,14 @@ Deployment complete!
   "endpoint_id": "custom",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/endpoints/custom",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
   "status": {
-    "autoscaling_limit_max_cu": 2,
-    "autoscaling_limit_min_cu": 0.5,
-    "current_state": "ACTIVE",
-    "disabled": false,
     "endpoint_id": "custom",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-    "group": {
-      "enable_readable_secondaries": true,
-      "max": 1,
-      "min": 1
-    },
-    "hosts": {
-      "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-      "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-    },
-    "settings": {},
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 2,
     "suspend_timeout_duration": "300s"
-  },
-  "uid": "[ENDPOINT_UID]"
+  }
 }
 
 >>> [CLI] bundle summary

--- a/acceptance/bundle/resources/postgres_endpoints/basic/script
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/script
@@ -17,7 +17,7 @@ trace $CLI bundle deploy
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 endpoint_name="${branch_name}/endpoints/custom"
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/output.txt
@@ -19,25 +19,14 @@ Deployment complete!
   "endpoint_id": "primary",
   "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/develop/endpoints/primary",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/develop",
+  "uid": "[ENDPOINT_UID]",
   "status": {
-    "autoscaling_limit_max_cu": 4,
-    "autoscaling_limit_min_cu": 0.5,
-    "current_state": "ACTIVE",
-    "disabled": false,
     "endpoint_id": "primary",
     "endpoint_type": "ENDPOINT_TYPE_READ_WRITE",
-    "group": {
-      "enable_readable_secondaries": false,
-      "max": 1,
-      "min": 1
-    },
-    "hosts": {
-      "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-    },
-    "settings": {},
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 4,
     "suspend_timeout_duration": "600s"
-  },
-  "uid": "[ENDPOINT_UID]"
+  }
 }
 
 >>> print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --keep --get //postgres ^//workspace-files/ ^//workspace/ ^//telemetry-ext ^//operations/

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/script
@@ -15,7 +15,7 @@ trace $CLI bundle deploy
 # The implicit primary endpoint inherits suspend_timeout_duration from the
 # project default (300s). After deploy with replace_existing=true, the
 # bundle's spec must be applied: 600s.
-trace $CLI postgres get-endpoint "projects/test-pg-proj-${UNIQUE_NAME}/branches/develop/endpoints/primary" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-endpoint "projects/test-pg-proj-${UNIQUE_NAME}/branches/develop/endpoints/primary" | endpoint_fields
 
 trace print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --keep --get '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json
 

--- a/acceptance/bundle/resources/postgres_endpoints/script.prepare
+++ b/acceptance/bundle/resources/postgres_endpoints/script.prepare
@@ -1,0 +1,10 @@
+# endpoint_fields projects a `postgres get-endpoint` response (stdin) down to the
+# identifying fields plus the status fields the bundle spec controls. Server-
+# materialized status fields (hosts, current_state, group, settings,
+# last_active_time, ...) are deliberately dropped: they differ between the
+# testserver mock and the real backend, and the backend keeps adding new ones
+# over time. Asserting only these stable fields keeps local and cloud output
+# identical without chasing every backend field.
+endpoint_fields() {
+    jq '{endpoint_id, name, parent, uid, status: (.status | {endpoint_id, endpoint_type, autoscaling_limit_min_cu, autoscaling_limit_max_cu, suspend_timeout_duration})}'
+}

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
@@ -6,34 +6,6 @@
     }
   ],
   "action": "skip",
-  "remote_state": {
-    "create_time": "[TIMESTAMP]",
-    "endpoint_id": "my-endpoint",
-    "endpoint_type": "",
-    "name": "[MY_ENDPOINT_ID]",
-    "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
-    "status": {
-      "autoscaling_limit_max_cu": 8,
-      "autoscaling_limit_min_cu": 0.5,
-      "current_state": "ACTIVE",
-      "disabled": false,
-      "endpoint_id": "my-endpoint",
-      "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-      "group": {
-        "enable_readable_secondaries": true,
-        "max": 1,
-        "min": 1
-      },
-      "hosts": {
-        "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-        "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-      },
-      "settings": {},
-      "suspend_timeout_duration": "300s"
-    },
-    "uid": "[ENDPOINT_UID]",
-    "update_time": "[TIMESTAMP]"
-  },
   "changes": {
     "autoscaling_limit_max_cu": {
       "action": "skip",

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
@@ -16,34 +16,6 @@
       "suspend_timeout_duration": "300s"
     }
   },
-  "remote_state": {
-    "create_time": "[TIMESTAMP]",
-    "endpoint_id": "my-endpoint",
-    "endpoint_type": "",
-    "name": "[MY_ENDPOINT_ID]",
-    "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
-    "status": {
-      "autoscaling_limit_max_cu": 4,
-      "autoscaling_limit_min_cu": 0.5,
-      "current_state": "ACTIVE",
-      "disabled": false,
-      "endpoint_id": "my-endpoint",
-      "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-      "group": {
-        "enable_readable_secondaries": true,
-        "max": 1,
-        "min": 1
-      },
-      "hosts": {
-        "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-        "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-      },
-      "settings": {},
-      "suspend_timeout_duration": "300s"
-    },
-    "uid": "[ENDPOINT_UID]",
-    "update_time": "[TIMESTAMP]"
-  },
   "changes": {
     "autoscaling_limit_max_cu": {
       "action": "update",

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
@@ -16,34 +16,6 @@
       "suspend_timeout_duration": "300s"
     }
   },
-  "remote_state": {
-    "create_time": "[TIMESTAMP]",
-    "endpoint_id": "my-endpoint",
-    "endpoint_type": "",
-    "name": "[MY_ENDPOINT_ID]",
-    "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
-    "status": {
-      "autoscaling_limit_max_cu": 8,
-      "autoscaling_limit_min_cu": 0.5,
-      "current_state": "ACTIVE",
-      "disabled": false,
-      "endpoint_id": "my-endpoint",
-      "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-      "group": {
-        "enable_readable_secondaries": true,
-        "max": 1,
-        "min": 1
-      },
-      "hosts": {
-        "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-        "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-      },
-      "settings": {},
-      "suspend_timeout_duration": "300s"
-    },
-    "uid": "[ENDPOINT_UID]",
-    "update_time": "[TIMESTAMP]"
-  },
   "changes": {
     "autoscaling_limit_max_cu": {
       "action": "update",

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/output.txt
@@ -31,26 +31,14 @@ Deployment complete!
   "endpoint_id": "my-endpoint",
   "name": "[MY_ENDPOINT_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
   "status": {
-    "autoscaling_limit_max_cu": 8,
-    "autoscaling_limit_min_cu": 0.5,
-    "current_state": "ACTIVE",
-    "disabled": false,
     "endpoint_id": "my-endpoint",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-    "group": {
-      "enable_readable_secondaries": true,
-      "max": 1,
-      "min": 1
-    },
-    "hosts": {
-      "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-      "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-    },
-    "settings": {},
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 8,
     "suspend_timeout_duration": "300s"
-  },
-  "uid": "[ENDPOINT_UID]"
+  }
 }
 
 === Verify no changes
@@ -120,26 +108,14 @@ Deployment complete!
   "endpoint_id": "my-endpoint",
   "name": "[MY_ENDPOINT_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
   "status": {
-    "autoscaling_limit_max_cu": 4,
-    "autoscaling_limit_min_cu": 0.5,
-    "current_state": "ACTIVE",
-    "disabled": false,
     "endpoint_id": "my-endpoint",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-    "group": {
-      "enable_readable_secondaries": true,
-      "max": 1,
-      "min": 1
-    },
-    "hosts": {
-      "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-      "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-    },
-    "settings": {},
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 4,
     "suspend_timeout_duration": "300s"
-  },
-  "uid": "[ENDPOINT_UID]"
+  }
 }
 
 === Restore endpoint autoscaling to original value
@@ -165,26 +141,14 @@ Deployment complete!
   "endpoint_id": "my-endpoint",
   "name": "[MY_ENDPOINT_ID]",
   "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+  "uid": "[ENDPOINT_UID]",
   "status": {
-    "autoscaling_limit_max_cu": 8,
-    "autoscaling_limit_min_cu": 0.5,
-    "current_state": "ACTIVE",
-    "disabled": false,
     "endpoint_id": "my-endpoint",
     "endpoint_type": "ENDPOINT_TYPE_READ_ONLY",
-    "group": {
-      "enable_readable_secondaries": true,
-      "max": 1,
-      "min": 1
-    },
-    "hosts": {
-      "host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com",
-      "read_only_host": "[ENDPOINT_UID].database.us-east-1.cloud.databricks.com"
-    },
-    "settings": {},
+    "autoscaling_limit_min_cu": 0.5,
+    "autoscaling_limit_max_cu": 8,
     "suspend_timeout_duration": "300s"
-  },
-  "uid": "[ENDPOINT_UID]"
+  }
 }
 
 >>> [CLI] bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
@@ -15,7 +15,7 @@ print_requests() {
 title "Initial deployment"
 trace $CLI bundle validate
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.create.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // . | del(.remote_state)' > out.plan.create.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
@@ -29,7 +29,7 @@ trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields
 
 title "Verify no changes"
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.no_change.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // . | del(.remote_state)' > out.plan.no_change.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
@@ -40,7 +40,7 @@ trace update_file.py databricks.yml "autoscaling_limit_max_cu: 8" "autoscaling_l
 trace cat databricks.yml
 
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.update.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // . | del(.remote_state)' > out.plan.update.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
@@ -52,7 +52,7 @@ trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields
 title "Restore endpoint autoscaling to original value"
 trace update_file.py databricks.yml "autoscaling_limit_max_cu: 4" "autoscaling_limit_max_cu: 8"
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.restore.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // . | del(.remote_state)' > out.plan.restore.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
@@ -25,7 +25,7 @@ project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 endpoint_name="${branch_name}/endpoints/my-endpoint"
 endpoint_id_1=`read_id.py my_endpoint`
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields
 
 title "Verify no changes"
 trace $CLI bundle plan
@@ -47,7 +47,7 @@ trace $CLI bundle deploy
 print_requests update
 
 endpoint_id_2=`read_id.py my_endpoint`
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields
 
 title "Restore endpoint autoscaling to original value"
 trace update_file.py databricks.yml "autoscaling_limit_max_cu: 4" "autoscaling_limit_max_cu: 8"
@@ -58,4 +58,4 @@ trace $CLI bundle deploy
 
 print_requests restore
 
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | endpoint_fields

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -749,10 +749,10 @@ func (s *FakeWorkspace) PostgresDatabaseCreate(req Request, parent, databaseID s
 	}
 
 	// The real Lakebase API requires the owning role on create and rejects an empty
-	// one with this exact error (verified on e2-dogfood 2026-06-16). The fake does
+	// one with this exact error (verified on aws-ucws 2026-07-13). The fake does
 	// not synthesize a default, matching that behavior.
 	if database.Spec == nil || database.Spec.Role == "" {
-		return postgresErrorResponse(400, "INVALID_PARAMETER_VALUE", "Field 'spec.role' cannot be empty")
+		return postgresErrorResponse(400, "INVALID_PARAMETER_VALUE", "Field 'database.spec.role' is required, expected non-default value")
 	}
 
 	name := fmt.Sprintf("%s/databases/%s", parent, databaseID)


### PR DESCRIPTION
## Changes

Update postgres endpoint & database golden outputs

Dropping unrelated/irrelevant fields from endpoint tests to avoid churn when backend changes

## Why
Failing in cloud

## Tests
CI