### PR TITLE
Fix Lakebase acceptance tests after backend response changes

### DIFF
--- a/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/output.txt
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/output.txt
@@ -1,11 +1,11 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/missing-role-[UNIQUE_NAME]/default/files...
 Deploying resources...
-Error: cannot create resources.postgres_databases.my_database: Field 'spec.role' cannot be empty (400 INVALID_PARAMETER_VALUE)
+Error: cannot create resources.postgres_databases.my_database: Field 'database.spec.role' is required, expected non-default value (not "")! (400 INVALID_PARAMETER_VALUE)
 
 Endpoint: POST [DATABRICKS_URL]/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/databases?database_id=my-database
 HTTP Status: 400 Bad Request
 API error_code: INVALID_PARAMETER_VALUE
-API message: Field 'spec.role' cannot be empty
+API message: Field 'database.spec.role' is required, expected non-default value (not "")!
 
 Updating deployment state...
 

--- a/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/script
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/script
@@ -5,4 +5,4 @@ cleanup() {
 }
 trap cleanup EXIT
 
-musterr $CLI bundle deploy 2>&1 | contains.py "Field 'spec.role' cannot be empty"
+musterr $CLI bundle deploy 2>&1 | contains.py 'Field '\''database.spec.role'\'' is required, expected non-default value (not "")!'

--- a/acceptance/bundle/resources/postgres_endpoints/basic/script
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/script
@@ -17,7 +17,10 @@ trace $CLI bundle deploy
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 endpoint_name="${branch_name}/endpoints/custom"
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time)'
+# The pooled host names and last-active timestamp are only populated by the live
+# backend (the testserver fake omits them), so filter them out to keep the local
+# and cloud output identical.
+trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .status.hosts.read_only_pooled_host, .status.hosts.read_write_pooled_host, .status.last_active_time)'
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/script
@@ -15,7 +15,11 @@ trace $CLI bundle deploy
 # The implicit primary endpoint inherits suspend_timeout_duration from the
 # project default (300s). After deploy with replace_existing=true, the
 # bundle's spec must be applied: 600s.
-trace $CLI postgres get-endpoint "projects/test-pg-proj-${UNIQUE_NAME}/branches/develop/endpoints/primary" | jq 'del(.create_time, .update_time)'
+#
+# The pooled host names and last-active timestamp are only populated by the live
+# backend (the testserver fake omits them), so filter them out to keep the local
+# and cloud output identical.
+trace $CLI postgres get-endpoint "projects/test-pg-proj-${UNIQUE_NAME}/branches/develop/endpoints/primary" | jq 'del(.create_time, .update_time, .status.hosts.read_only_pooled_host, .status.hosts.read_write_pooled_host, .status.last_active_time)'
 
 trace print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --keep --get '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json
 

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/script
@@ -15,7 +15,7 @@ print_requests() {
 title "Initial deployment"
 trace $CLI bundle validate
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.create.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '(.plan."resources.postgres_endpoints.my_endpoint" // .) | del(.remote_state.status.hosts.read_only_pooled_host, .remote_state.status.hosts.read_write_pooled_host, .remote_state.status.last_active_time)' > out.plan.create.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
@@ -25,11 +25,11 @@ project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 endpoint_name="${branch_name}/endpoints/my-endpoint"
 endpoint_id_1=`read_id.py my_endpoint`
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling, .status.hosts.read_only_pooled_host, .status.hosts.read_write_pooled_host, .status.last_active_time)'
 
 title "Verify no changes"
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.no_change.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '(.plan."resources.postgres_endpoints.my_endpoint" // .) | del(.remote_state.status.hosts.read_only_pooled_host, .remote_state.status.hosts.read_write_pooled_host, .remote_state.status.last_active_time)' > out.plan.no_change.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
@@ -40,22 +40,22 @@ trace update_file.py databricks.yml "autoscaling_limit_max_cu: 8" "autoscaling_l
 trace cat databricks.yml
 
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.update.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '(.plan."resources.postgres_endpoints.my_endpoint" // .) | del(.remote_state.status.hosts.read_only_pooled_host, .remote_state.status.hosts.read_write_pooled_host, .remote_state.status.last_active_time)' > out.plan.update.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
 print_requests update
 
 endpoint_id_2=`read_id.py my_endpoint`
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling, .status.hosts.read_only_pooled_host, .status.hosts.read_write_pooled_host, .status.last_active_time)'
 
 title "Restore endpoint autoscaling to original value"
 trace update_file.py databricks.yml "autoscaling_limit_max_cu: 4" "autoscaling_limit_max_cu: 8"
 trace $CLI bundle plan
-trace $CLI bundle plan -o json | jq '.plan."resources.postgres_endpoints.my_endpoint" // .' > out.plan.restore.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | jq '(.plan."resources.postgres_endpoints.my_endpoint" // .) | del(.remote_state.status.hosts.read_only_pooled_host, .remote_state.status.hosts.read_write_pooled_host, .remote_state.status.last_active_time)' > out.plan.restore.$DATABRICKS_BUNDLE_ENGINE.json
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
 print_requests restore
 
-trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling)'
+trace $CLI postgres get-endpoint "${endpoint_name}" | jq 'del(.create_time, .update_time, .reconciling, .status.hosts.read_only_pooled_host, .status.hosts.read_write_pooled_host, .status.last_active_time)'

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -749,10 +749,10 @@ func (s *FakeWorkspace) PostgresDatabaseCreate(req Request, parent, databaseID s
 	}
 
 	// The real Lakebase API requires the owning role on create and rejects an empty
-	// one with this exact error (verified on e2-dogfood 2026-06-16). The fake does
-	// not synthesize a default, matching that behavior.
+	// one with this exact error. The fake does not synthesize a default, matching
+	// that behavior.
 	if database.Spec == nil || database.Spec.Role == "" {
-		return postgresErrorResponse(400, "INVALID_PARAMETER_VALUE", "Field 'spec.role' cannot be empty")
+		return postgresErrorResponse(400, "INVALID_PARAMETER_VALUE", `Field 'database.spec.role' is required, expected non-default value (not "")!`)
 	}
 
 	name := fmt.Sprintf("%s/databases/%s", parent, databaseID)


### PR DESCRIPTION
## Why

Two Lakebase (postgres) acceptance tests started failing deterministically on `aws-ucws` (linux + windows) after backend changes. Both live under `acceptance/bundle/resources/postgres_*` and run `Local = true, Cloud = true` against a **single shared golden**, so any fix has to keep the testserver fake (local) and the real AWS backend (cloud) producing identical output.

## What changed

**1. Endpoint response gained new fields.** `postgres get-endpoint` (and the `remote_state` in `bundle plan -o json`) now include `read_only_pooled_host` / `read_write_pooled_host` under `status.hosts`, plus `status.last_active_time`. Only the live backend populates these; the testserver fake omits them.

Rather than add volatile hostname/timestamp placeholders to the golden — which would then force the fake to synthesize them too — I extended the `jq 'del(...)'` filters already present in the `basic`, `replace_existing`, and `update_autoscaling` scripts to drop the new fields:

```sh
# get-endpoint output
jq 'del(.create_time, .update_time, .status.hosts.read_only_pooled_host, .status.hosts.read_write_pooled_host, .status.last_active_time)'

# bundle plan output (fields nested under remote_state)
jq '(.plan."resources.postgres_endpoints.my_endpoint" // .) | del(.remote_state.status.hosts.read_only_pooled_host, .remote_state.status.hosts.read_write_pooled_host, .remote_state.status.last_active_time)'
```

This is a no-op locally (fields absent) and strips them on cloud, so both engines converge with **zero golden churn**.

**2. Missing-role validation error reworded.** The backend changed its error from `Field 'spec.role' cannot be empty` to:

```
Field 'database.spec.role' is required, expected non-default value (not "")!
```

Updated the fake's error string in `libs/testserver/postgres.go`, the `contains.py` assertion in the `missing_role` script, and regenerated the golden to match.

## Verification

Both areas pass locally and against the real backend:

```sh
deco env run -i -n aws-prod-ucws -- go test ./acceptance \
  -run 'TestAccept/bundle/resources/postgres_endpoints|TestAccept/bundle/resources/postgres_databases/live_errors/missing_role'
# ok  github.com/databricks/cli/acceptance
```

An initial cloud run caught that the real error string has a trailing `(not "")!` that the ticket description omitted; the wording here is the exact backend string.

This pull request and its description were written by Isaac.
