### PR TITLE
direct: classify schema custom_max_retention_hours as input_only

### DIFF
--- a/acceptance/bundle/resources/schemas/drift/write_only/databricks.yml
+++ b/acceptance/bundle/resources/schemas/drift/write_only/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: test-bundle
+
+resources:
+  schemas:
+    schema1:
+      name: test_schema
+      catalog_name: main
+      # custom_max_retention_hours is accepted on write but never returned on GET.
+      custom_max_retention_hours: 643

--- a/acceptance/bundle/resources/schemas/drift/write_only/out.test.toml
+++ b/acceptance/bundle/resources/schemas/drift/write_only/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/drift/write_only/output.txt
+++ b/acceptance/bundle/resources/schemas/drift/write_only/output.txt
@@ -1,0 +1,36 @@
+
+=== Initial deployment
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Plan is a no-op despite custom_max_retention_hours not round-tripping
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
+
+=== custom_max_retention_hours is skipped as input_only (confirms the matched rule)
+>>> [CLI] bundle plan --output json
+{
+  "custom_max_retention_hours": {
+    "action": "skip",
+    "reason": "input_only",
+    "old": 643,
+    "new": 643
+  }
+}
+
+=== Redeploy is a no-op (no UpdateSchema call)
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+>>> print_requests.py //unity
+json.method = "POST";
+json.path = "/api/2.1/unity-catalog/schemas";
+json.body.catalog_name = "main";
+json.body.custom_max_retention_hours = 643;
+json.body.name = "test_schema";

--- a/acceptance/bundle/resources/schemas/drift/write_only/script
+++ b/acceptance/bundle/resources/schemas/drift/write_only/script
@@ -1,0 +1,14 @@
+echo "*" > .gitignore
+
+title "Initial deployment"
+trace $CLI bundle deploy
+
+title "Plan is a no-op despite custom_max_retention_hours not round-tripping"
+trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
+
+title "custom_max_retention_hours is skipped as input_only (confirms the matched rule)"
+trace $CLI bundle plan --output json | jq '.plan[].changes'
+
+title "Redeploy is a no-op (no UpdateSchema call)"
+trace $CLI bundle deploy
+trace print_requests.py //unity | gron.py | contains.py '!json.method = "PATCH"'

--- a/acceptance/bundle/resources/schemas/drift/write_only/test.toml
+++ b/acceptance/bundle/resources/schemas/drift/write_only/test.toml
@@ -1,0 +1,5 @@
+RecordRequests = true
+
+# Scope this regression to the direct engine where the classification lives;
+# terraform models this field differently.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -405,6 +405,13 @@ resources:
     normalize_slash:
       - field: storage_root
         reason: uc_strips_trailing_slash
+    ignore_remote_changes:
+      # Accepted on write but never returned by GET: UC stores custom_max_retention_hours
+      # but the schema GET response always reports it as nil, so a config that sets it
+      # re-planned as a perpetual no-op update (old==new) that never converged, most
+      # visibly after a terraform->direct migrate.
+      - field: custom_max_retention_hours
+        reason: input_only
     backend_defaults:
       # UC auto-populates unity.catalog.managed.<format>.defaults.* keys after create.
       # Without this, every subsequent plan produces an Update whose payload is empty,

--- a/libs/testserver/schemas.go
+++ b/libs/testserver/schemas.go
@@ -30,6 +30,10 @@ func (s *FakeWorkspace) SchemasCreate(req Request) Response {
 		}
 	}
 
+	// UC accepts custom_max_retention_hours on write but never echoes it back on GET,
+	// so drop it from stored state to keep reads faithful to the real backend.
+	schema.CustomMaxRetentionHours = 0
+
 	// UC normalizes schema names to lowercase.
 	schema.Name = strings.ToLower(schema.Name)
 	schema.FullName = schema.CatalogName + "." + schema.Name


### PR DESCRIPTION
## Changes

Classify `schemas.*.custom_max_retention_hours` as `input_only` (`ignore_remote_changes`) in the direct engine, so a schema that sets it converges instead of re-planning forever. The testserver now drops the field on read to mirror the real backend.

## Why

Fuzzing the direct engine ([#5686](https://github.com/databricks/cli/pull/5686)) found that UC accepts `custom_max_retention_hours` on write but the schema **GET response never returns it** (on dogfood, `schemas get` reports `custom_max_retention_hours: null` after a deploy that set `643`). Since the field was unclassified, reconcile compared config (`643`) against remote (`nil`) on every plan, producing a **perpetual no-op `update` (old == new) that never converged** — most visibly after a `terraform` -> `direct` migrate.

## Tests

- New direct-engine drift acceptance test `acceptance/bundle/resources/schemas/drift/write_only/` asserting a no-op plan and no `UpdateSchema` call on redeploy.
- `libs/testserver/schemas.go` drops `custom_max_retention_hours` on read so the fake backend matches UC's write-only behavior.