### PR TITLE
Fix missing_role golden: backend error has trailing (not "")!

### DIFF
--- a/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/output.txt
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/missing_role/output.txt
@@ -1,11 +1,11 @@
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/missing-role-[UNIQUE_NAME]/default/files...
 Deploying resources...
-Error: cannot create resources.postgres_databases.my_database: Field 'database.spec.role' is required, expected non-default value (400 INVALID_PARAMETER_VALUE)
+Error: cannot create resources.postgres_databases.my_database: Field 'database.spec.role' is required, expected non-default value (not "")! (400 INVALID_PARAMETER_VALUE)
 
 Endpoint: POST [DATABRICKS_URL]/api/2.0/postgres/projects/test-pg-proj-[UNIQUE_NAME]/branches/main/databases?database_id=my-database
 HTTP Status: 400 Bad Request
 API error_code: INVALID_PARAMETER_VALUE
-API message: Field 'database.spec.role' is required, expected non-default value
+API message: Field 'database.spec.role' is required, expected non-default value (not "")!
 
 Updating deployment state...
 

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -752,7 +752,7 @@ func (s *FakeWorkspace) PostgresDatabaseCreate(req Request, parent, databaseID s
 	// one with this exact error (verified on aws-ucws 2026-07-13). The fake does
 	// not synthesize a default, matching that behavior.
 	if database.Spec == nil || database.Spec.Role == "" {
-		return postgresErrorResponse(400, "INVALID_PARAMETER_VALUE", "Field 'database.spec.role' is required, expected non-default value")
+		return postgresErrorResponse(400, "INVALID_PARAMETER_VALUE", `Field 'database.spec.role' is required, expected non-default value (not "")!`)
 	}
 
 	name := fmt.Sprintf("%s/databases/%s", parent, databaseID)


### PR DESCRIPTION
Fix the `postgres_databases/live_errors/missing_role` acceptance test, which fails on aws-ucws because the real Lakebase backend returns `Field 'database.spec.role' is required, expected non-default value (not "")!` but the testserver fake and the golden omit the trailing `(not "")!` suffix.

Every other postgres field error in `libs/testserver/postgres.go` already carries that suffix (project_id, branch_id, endpoint_id, database_id, catalog_id, synced_table_id) — the role error was the odd one out. This aligns the fake's error string with the real backend and regenerates the golden. The `contains.py` assertion stays on the stable prefix so it doesn't have to chase future suffix changes.

Co-authored-by: Isaac
