### PR TITLE
acc: select asserted fields on postgres GETs instead of del-ing volatile ones

### DIFF
--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -186,6 +186,28 @@ trace print_requests
 
 **RULE: Route noisy or non-deterministic command output to `LOG.<name>` instead of `output.txt` or `/dev/null`.** `LOG.*` files are visible under `go test -v` but excluded from the diff — see `acceptance/selftest/log/`. Use `&> LOG.<name>` to capture both streams (then `contains.py` to assert invariants like `'!panic' '!internal error'`), or `2>>LOG.<name>` for cleanup-step stderr you'd otherwise drop to `/dev/null`.
 
+**RULE: When a test prints an API GET/read response into `output.txt`, project it to an allow-list of the fields the test asserts — never dump the full payload or strip a deny-list of volatile fields with `jq 'del(...)'`.** The backend keeps adding response fields, and cloud tests run against the real API, so a full payload (or a `del` that only removes today's volatile fields) breaks the golden every time the response grows — even for fields the test does not care about. Instead define a `<resource>_fields()` helper in the resource directory's `script.prepare` that `jq`-selects the fields you assert, and pipe the response through it. Precedent: `acceptance/bundle/resources/postgres_*/script.prepare`.
+
+GOOD:
+
+```bash
+# in script.prepare
+branch_fields() {
+    jq '{branch_id, name, parent, status: (.status | {branch_id, default, is_protected})}'
+}
+# in script
+trace $CLI postgres get-branch "$name" | branch_fields
+```
+
+BAD:
+
+```bash
+trace $CLI postgres get-branch "$name" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-branch "$name"   # full payload straight into output.txt
+```
+
+For a field that appears on some responses but not others (e.g. a provenance field absent on a default resource), append `| with_entries(select(.value != null))` to the projected object so the optional field is dropped rather than emitted as `null`.
+
 ### Test server
 
 Acceptance tests run against an in-process fake of the Databricks API in `libs/testserver/` (`FakeWorkspace` and the per-service handler files). The fake keeps real in-memory state and returns the same errors the backend does: 404 on a missing parent, 409 on a duplicate create, 400 on a missing required field, and so on. `test.toml` can also stub a single route with a canned response:

--- a/acceptance/bundle/resources/database_instances/script.prepare
+++ b/acceptance/bundle/resources/database_instances/script.prepare
@@ -1,0 +1,6 @@
+# database_instance_fields is the allow-list of database-instance fields the
+# acceptance tests assert on. Anything the backend returns outside this list is
+# dropped, so a new field in the API response does not break the golden.
+database_instance_fields() {
+    jq '{capacity, creation_time, creator, effective_capacity, effective_enable_pg_native_login, effective_enable_readable_secondaries, effective_node_count, effective_retention_window_in_days, effective_stopped, name, pg_version, state, uid}'
+}

--- a/acceptance/bundle/resources/database_instances/single-instance/script
+++ b/acceptance/bundle/resources/database_instances/single-instance/script
@@ -25,6 +25,6 @@ for i in {1..10}; do
 done
 
 # _dns fields are excluded since they differ between cloud envs
-trace $CLI database get-database-instance "test-db-instance-single-${UNIQUE_NAME}" | jq 'del(.read_only_dns, .read_write_dns)'
+trace $CLI database get-database-instance "test-db-instance-single-${UNIQUE_NAME}" | database_instance_fields
 
 trace $CLI bundle summary

--- a/acceptance/bundle/resources/postgres_branches/basic/script
+++ b/acceptance/bundle/resources/postgres_branches/basic/script
@@ -16,7 +16,7 @@ trace $CLI bundle deploy
 # Get branch details
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
-trace $CLI postgres get-branch "${branch_name}" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
+trace $CLI postgres get-branch "${branch_name}" | branch_fields
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete/script
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete/script
@@ -19,8 +19,8 @@ trace $CLI bundle validate
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
-trace $CLI postgres get-branch "${hard_branch}" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
-trace $CLI postgres get-branch "${soft_branch}" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
+trace $CLI postgres get-branch "${hard_branch}" | branch_fields
+trace $CLI postgres get-branch "${soft_branch}" | branch_fields
 
 # Deploy requests are split per-engine: Terraform sends "parent" in the branch
 # create body, the direct engine sends it only as a query parameter.

--- a/acceptance/bundle/resources/postgres_branches/recreate/script
+++ b/acceptance/bundle/resources/postgres_branches/recreate/script
@@ -38,7 +38,7 @@ print_requests.py --del-body parent,project_id,branch_id,endpoint_id,database_id
 title "Fetch new branch ID"
 branch_id_2=`read_id.py main`
 # Get output differs between engines (different branch IDs)
-$CLI postgres get-branch $branch_id_2 | jq 'del(.create_time, .update_time, .status.logical_size_bytes)' > out.get_branch.txt
+$CLI postgres get-branch $branch_id_2 | branch_fields > out.get_branch.txt
 
 title "Destroy and verify cleanup"
 trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_branches/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_branches/replace_existing/script
@@ -13,7 +13,7 @@ rm -f out.requests.txt
 trace $CLI bundle deploy
 
 # Confirm the implicit production branch is now under management.
-trace $CLI postgres get-branch "projects/test-pg-proj-${UNIQUE_NAME}/branches/production" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
+trace $CLI postgres get-branch "projects/test-pg-proj-${UNIQUE_NAME}/branches/production" | branch_fields
 
 trace print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --keep --get '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json
 

--- a/acceptance/bundle/resources/postgres_branches/script.prepare
+++ b/acceptance/bundle/resources/postgres_branches/script.prepare
@@ -1,0 +1,10 @@
+# branch_fields is the allow-list of branch fields the acceptance tests assert
+# on. Anything the backend returns outside this list is dropped, so a new field
+# in the API response does not break the golden.
+#
+# The source_* provenance fields are present on branches forked from another
+# branch but absent on the default branch, so the null-drop keeps the projection
+# valid for both shapes.
+branch_fields() {
+    jq '{branch_id, name, parent, status: (.status | {branch_id, current_state, default, is_protected, source_branch, source_branch_lsn, source_branch_time, state_change_time} | with_entries(select(.value != null))), uid}'
+}

--- a/acceptance/bundle/resources/postgres_branches/update_protected/script
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/script
@@ -24,7 +24,7 @@ print_requests create
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/dev-branch"
 branch_id_1=`read_id.py dev_branch`
-trace $CLI postgres get-branch "${branch_name}" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
+trace $CLI postgres get-branch "${branch_name}" | branch_fields
 
 title "Verify no_change (no changes)"
 trace $CLI bundle plan
@@ -46,7 +46,7 @@ trace $CLI bundle deploy
 print_requests update
 
 branch_id_2=`read_id.py dev_branch`
-trace $CLI postgres get-branch "${branch_name}" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
+trace $CLI postgres get-branch "${branch_name}" | branch_fields
 
 title "Restore is_protected to false"
 trace update_file.py databricks.yml "is_protected: true" "is_protected: false"
@@ -57,4 +57,4 @@ trace $CLI bundle deploy
 
 print_requests restore
 
-trace $CLI postgres get-branch "${branch_name}" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
+trace $CLI postgres get-branch "${branch_name}" | branch_fields

--- a/acceptance/bundle/resources/postgres_catalogs/basic/script
+++ b/acceptance/bundle/resources/postgres_catalogs/basic/script
@@ -15,7 +15,7 @@ trace $CLI bundle deploy
 
 # Get catalog details. Hide volatile fields so cloud and local match.
 catalog_name="catalogs/lakebase_test_${UNIQUE_NAME}"
-trace $CLI postgres get-catalog "${catalog_name}" | jq 'del(.create_time, .update_time, .uid)'
+trace $CLI postgres get-catalog "${catalog_name}" | catalog_fields
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_catalogs/script.prepare
+++ b/acceptance/bundle/resources/postgres_catalogs/script.prepare
@@ -1,0 +1,6 @@
+# catalog_fields is the allow-list of catalog fields the acceptance tests assert
+# on. Anything the backend returns outside this list is dropped, so a new field
+# in the API response does not break the golden.
+catalog_fields() {
+    jq '{catalog_id, name, status: (.status | {branch, postgres_database, project})}'
+}

--- a/acceptance/bundle/resources/postgres_databases/basic/script
+++ b/acceptance/bundle/resources/postgres_databases/basic/script
@@ -17,7 +17,7 @@ trace $CLI bundle deploy
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 database_name="${branch_name}/databases/my-database"
-trace $CLI postgres get-database "${database_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-database "${database_name}" | database_fields
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_databases/recreate/script
+++ b/acceptance/bundle/resources/postgres_databases/recreate/script
@@ -41,7 +41,7 @@ title "Fetch database and verify it exists after recreation"
 
 database_id_2=`read_id.py my_database`
 # Verify the database was recreated (DELETE/POST in requests proves recreation)
-trace $CLI postgres get-database $database_id_2 | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-database $database_id_2 | database_fields
 
 title "Destroy and verify cleanup"
 trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_databases/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_databases/replace_existing/script
@@ -22,6 +22,6 @@ rm -f out.requests.txt
 trace $CLI bundle deploy
 
 title "Confirm the database is under management again"
-trace $CLI postgres get-database "projects/test-pg-proj-${UNIQUE_NAME}/branches/main/databases/my-database" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-database "projects/test-pg-proj-${UNIQUE_NAME}/branches/main/databases/my-database" | database_fields
 
 trace print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --keep --get '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/postgres_databases/script.prepare
+++ b/acceptance/bundle/resources/postgres_databases/script.prepare
@@ -1,0 +1,6 @@
+# database_fields is the allow-list of database fields the acceptance tests
+# assert on. Anything the backend returns outside this list is dropped, so a new
+# field in the API response does not break the golden.
+database_fields() {
+    jq '{database_id, name, parent, status: (.status | {database_id, postgres_database, role})}'
+}

--- a/acceptance/bundle/resources/postgres_databases/update/script
+++ b/acceptance/bundle/resources/postgres_databases/update/script
@@ -25,7 +25,7 @@ project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 database_name="${branch_name}/databases/my-database"
 database_id_1=`read_id.py my_database`
-trace $CLI postgres get-database "${database_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-database "${database_name}" | database_fields
 
 title "Verify no changes"
 trace $CLI bundle plan
@@ -47,7 +47,7 @@ trace $CLI bundle deploy
 print_requests update
 
 database_id_2=`read_id.py my_database`
-trace $CLI postgres get-database "${database_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-database "${database_name}" | database_fields
 
 title "Restore postgres_database to original value"
 trace update_file.py databricks.yml "postgres_database: renamed_db_name" "postgres_database: initial_db_name"
@@ -58,4 +58,4 @@ trace $CLI bundle deploy
 
 print_requests restore
 
-trace $CLI postgres get-database "${database_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-database "${database_name}" | database_fields

--- a/acceptance/bundle/resources/postgres_projects/basic/script
+++ b/acceptance/bundle/resources/postgres_projects/basic/script
@@ -15,7 +15,7 @@ trace $CLI bundle deploy
 
 # Direct mode already waits for the project to be READY during deployment
 # Get project details - exclude timestamps that vary
-trace $CLI postgres get-project "projects/test-pg-proj-${UNIQUE_NAME}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-project "projects/test-pg-proj-${UNIQUE_NAME}" | project_fields
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete/script
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete/script
@@ -14,8 +14,8 @@ trace $CLI bundle validate
 rm -f out.requests.txt
 trace $CLI bundle deploy
 
-trace $CLI postgres get-project "projects/test-pg-proj-hard-${UNIQUE_NAME}" | jq 'del(.create_time, .update_time)'
-trace $CLI postgres get-project "projects/test-pg-proj-soft-${UNIQUE_NAME}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-project "projects/test-pg-proj-hard-${UNIQUE_NAME}" | project_fields
+trace $CLI postgres get-project "projects/test-pg-proj-soft-${UNIQUE_NAME}" | project_fields
 
 trace print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --sort --get '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.deploy.json
 

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.get_project.txt
@@ -1,5 +1,4 @@
 {
-  "create_time": "[TIMESTAMP]",
   "name": "[MY_PROJECT_ID_2]",
   "project_id": "test-pg-new-[UNIQUE_NAME]",
   "status": {
@@ -18,6 +17,5 @@
     "project_id": "test-pg-new-[UNIQUE_NAME]",
     "synthetic_storage_size_bytes": 0
   },
-  "uid": "[UUID]",
-  "update_time": "[TIMESTAMP]"
+  "uid": "[UUID]"
 }

--- a/acceptance/bundle/resources/postgres_projects/recreate/script
+++ b/acceptance/bundle/resources/postgres_projects/recreate/script
@@ -38,7 +38,7 @@ print_requests.py --del-body parent,project_id,branch_id,endpoint_id,database_id
 title "Fetch new project ID"
 project_id_2=`read_id.py my_project`
 # Get output differs between engines (different project IDs)
-$CLI postgres get-project $project_id_2 > out.get_project.txt
+$CLI postgres get-project $project_id_2 | project_fields > out.get_project.txt
 
 title "Destroy and verify cleanup"
 trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_projects/script.prepare
+++ b/acceptance/bundle/resources/postgres_projects/script.prepare
@@ -1,0 +1,6 @@
+# project_fields is the allow-list of project fields the acceptance tests assert
+# on. Anything the backend returns outside this list is dropped, so a new field
+# in the API response does not break the golden.
+project_fields() {
+    jq '{name, project_id, status: (.status | {branch_logical_size_limit_bytes, default_branch, default_endpoint_settings, display_name, enable_pg_native_login, history_retention_duration, owner, pg_version, project_id, synthetic_storage_size_bytes}), uid}'
+}

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/script
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/script
@@ -23,7 +23,7 @@ print_requests create
 
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 project_id_1=`read_id.py my_project`
-trace $CLI postgres get-project "${project_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-project "${project_name}" | project_fields
 
 title "Verify no changes"
 trace $CLI bundle plan
@@ -45,7 +45,7 @@ trace $CLI bundle deploy
 print_requests update
 
 project_id_2=`read_id.py my_project`
-trace $CLI postgres get-project "${project_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-project "${project_name}" | project_fields
 
 title "Restore display_name to original value"
 trace update_file.py databricks.yml "Updated Name" "Original Name"
@@ -56,4 +56,4 @@ trace $CLI bundle deploy
 
 print_requests restore
 
-trace $CLI postgres get-project "${project_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-project "${project_name}" | project_fields

--- a/acceptance/bundle/resources/postgres_roles/basic/script
+++ b/acceptance/bundle/resources/postgres_roles/basic/script
@@ -17,7 +17,7 @@ trace $CLI bundle deploy
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 role_name="${branch_name}/roles/test-role"
-trace $CLI postgres get-role "${role_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role "${role_name}" | role_fields
 
 trace $CLI bundle summary
 

--- a/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/script
+++ b/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/script
@@ -32,7 +32,7 @@ trace print_requests.py --unique --del-body parent,project_id,branch_id,endpoint
 title "Fetch role and verify the new postgres_role value is live"
 
 role_name=`read_id.py my_role`
-trace $CLI postgres get-role $role_name | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role $role_name | role_fields
 
 title "Destroy and verify cleanup"
 trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_roles/recreate/script
+++ b/acceptance/bundle/resources/postgres_roles/recreate/script
@@ -34,7 +34,7 @@ trace print_requests.py --unique --del-body parent,project_id,branch_id,endpoint
 title "Fetch role and verify it exists after recreation"
 
 role_id_2=`read_id.py my_role`
-trace $CLI postgres get-role $role_id_2 | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role $role_id_2 | role_fields
 
 title "Destroy and verify cleanup"
 trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/postgres_roles/replace_existing/script
+++ b/acceptance/bundle/resources/postgres_roles/replace_existing/script
@@ -22,6 +22,6 @@ rm -f out.requests.txt
 trace $CLI bundle deploy
 
 title "Confirm the role is under management again"
-trace $CLI postgres get-role "projects/test-pg-proj-${UNIQUE_NAME}/branches/main/roles/test-role" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role "projects/test-pg-proj-${UNIQUE_NAME}/branches/main/roles/test-role" | role_fields
 
 trace print_requests.py --del-body project_id,branch_id,endpoint_id,database_id,role_id,catalog_id,synced_table_id --keep --get '//postgres' '^//workspace-files/' '^//workspace/' '^//telemetry-ext' '^//operations/' > out.requests.deploy.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/postgres_roles/script.prepare
+++ b/acceptance/bundle/resources/postgres_roles/script.prepare
@@ -1,0 +1,6 @@
+# role_fields is the allow-list of role fields the acceptance tests assert on.
+# Anything the backend returns outside this list is dropped, so a new field in
+# the API response does not break the golden.
+role_fields() {
+    jq '{name, parent, role_id, status: (.status | {attributes, auth_method, identity_type, postgres_role, role_id})}'
+}

--- a/acceptance/bundle/resources/postgres_roles/update/script
+++ b/acceptance/bundle/resources/postgres_roles/update/script
@@ -24,7 +24,7 @@ print_requests create
 project_name="projects/test-pg-proj-${UNIQUE_NAME}"
 branch_name="${project_name}/branches/main"
 role_name="${branch_name}/roles/test-role"
-trace $CLI postgres get-role "${role_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role "${role_name}" | role_fields
 
 title "Verify no changes"
 trace $CLI bundle plan
@@ -45,7 +45,7 @@ trace $CLI bundle deploy
 
 print_requests update
 
-trace $CLI postgres get-role "${role_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role "${role_name}" | role_fields
 
 title "Restore attributes.createdb to original value"
 trace update_file.py databricks.yml "createdb: true" "createdb: false"
@@ -56,4 +56,4 @@ trace $CLI bundle deploy
 
 print_requests restore
 
-trace $CLI postgres get-role "${role_name}" | jq 'del(.create_time, .update_time)'
+trace $CLI postgres get-role "${role_name}" | role_fields


### PR DESCRIPTION
## Why

The Cloud postgres/database acceptance tests filtered each `get-<resource>` response with a **deny-list** and then asserted on everything left:

```sh
$CLI postgres get-branch "$name" | jq 'del(.create_time, .update_time, .status.logical_size_bytes)'
```

Every time the backend adds a response field the golden breaks — even though the test doesn't care about that field. That's what happened when the endpoint response gained `read_only_pooled_host` / `read_write_pooled_host` / `last_active_time`.

## What changed

Flip the deny-list to an **allow-list**: a `<resource>_fields()` helper in each resource dir's `script.prepare` that `jq`-selects exactly the fields the test was already asserting. 
