### PR TITLE
acc: assert SP identity by userName in destroy_without_mgmtperms

### DIFF
--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.destroy.direct.txt
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.destroy.direct.txt
@@ -1,12 +1,12 @@
 
 >>> errcode as-test-sp [CLI] bundle destroy --auto-approve
-Warn: planning resources.jobs.foo.permissions: reading resources.jobs.foo.permissions id="/jobs/[NUMID]": [UUID] does not have Manage permissions on Job with ID: ElasticJobId([NUMID]). Please contact the owner or an administrator for access.
-Warn: planning resources.jobs.foo: reading resources.jobs.foo id="[NUMID]": User [UUID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
+Warn: planning resources.jobs.foo.permissions: reading resources.jobs.foo.permissions id="/jobs/[NUMID]": [TEST_SP_APPLICATION_ID] does not have Manage permissions on Job with ID: ElasticJobId([NUMID]). Please contact the owner or an administrator for access.
+Warn: planning resources.jobs.foo: reading resources.jobs.foo id="[NUMID]": User [TEST_SP_APPLICATION_ID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
 The following resources will be deleted:
   delete resources.jobs.foo
 
-All files and directories at the following location will be deleted: /Workspace/Users/[UUID]/.bundle/test-bundle-[UNIQUE_NAME]/default
+All files and directories at the following location will be deleted: /Workspace/Users/[TEST_SP_APPLICATION_ID]/.bundle/test-bundle-[UNIQUE_NAME]/default
 
-Warn: destroying resources.jobs.foo: Ignoring permission error when deleting resources.jobs.foo id=[NUMID]: User [UUID] does not have Admin or Owner permissions on job [NUMID]
+Warn: destroying resources.jobs.foo: Ignoring permission error when deleting resources.jobs.foo id=[NUMID]: User [TEST_SP_APPLICATION_ID] does not have Admin or Owner permissions on job [NUMID]
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.destroy.terraform.txt
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.destroy.terraform.txt
@@ -2,7 +2,7 @@
 >>> errcode as-test-sp [CLI] bundle destroy --auto-approve
 Error: exit status 1
 
-Error: cannot read job: User [UUID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
+Error: cannot read job: User [TEST_SP_APPLICATION_ID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
 
   with databricks_job.foo,
   on bundle.tf.json line 27, in resource.databricks_job.foo:

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/output.txt
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/output.txt
@@ -5,13 +5,13 @@
 }
 
 >>> as-test-sp [CLI] current-user me
-"deco-test-spn"
+"[TEST_SP_APPLICATION_ID]"
 
 >>> [CLI] bundle destroy --auto-approve
 No active deployment found to destroy!
 
 >>> as-test-sp [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[UUID]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Uploading bundle files to /Workspace/Users/[TEST_SP_APPLICATION_ID]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/script
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/script
@@ -1,10 +1,19 @@
+if [ -z "${TEST_SP_APPLICATION_ID:-}" ]; then
+    # Falls back to the fixed userName the testserver reports for the as-test-sp
+    # guest, used whenever the env does not provide a real application_id (locally).
+    export TEST_SP_APPLICATION_ID="aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee"
+fi
+# Mask the test SP's application_id (its userName) to a dedicated placeholder so
+# the assertion is env-independent instead of collapsing into the generic [UUID].
+echo "$TEST_SP_APPLICATION_ID:TEST_SP_APPLICATION_ID" >> ACC_REPLS
+
 envsubst < databricks.yml.tmpl > databricks.yml
 # Locally DATABRICKS_CLIENT_ID is unset; fall back to the current identity so the
 # owner matches cloud. Scoped to this command so CLI auth is unaffected.
 DATABRICKS_CLIENT_ID="${DATABRICKS_CLIENT_ID:-$CURRENT_USER_NAME}" envsubst < take_ownership.json.tmpl > take_ownership.json
 trace cat take_ownership.json
 
-trace as-test-sp $CLI current-user me | jq .displayName
+trace as-test-sp $CLI current-user me | jq .userName
 
 cleanup() {
     trace $CLI bundle destroy --auto-approve

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.destroy.direct.txt
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.destroy.direct.txt
@@ -1,11 +1,11 @@
 
 >>> errcode as-test-sp [CLI] bundle destroy --auto-approve
-Warn: planning resources.jobs.foo: reading resources.jobs.foo id="[NUMID]": User [UUID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
+Warn: planning resources.jobs.foo: reading resources.jobs.foo id="[NUMID]": User [TEST_SP_APPLICATION_ID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
 The following resources will be deleted:
   delete resources.jobs.foo
 
-All files and directories at the following location will be deleted: /Workspace/Users/[UUID]/.bundle/test-bundle-[UNIQUE_NAME]/default
+All files and directories at the following location will be deleted: /Workspace/Users/[TEST_SP_APPLICATION_ID]/.bundle/test-bundle-[UNIQUE_NAME]/default
 
-Warn: destroying resources.jobs.foo: Ignoring permission error when deleting resources.jobs.foo id=[NUMID]: User [UUID] does not have Admin or Owner permissions on job [NUMID]
+Warn: destroying resources.jobs.foo: Ignoring permission error when deleting resources.jobs.foo id=[NUMID]: User [TEST_SP_APPLICATION_ID] does not have Admin or Owner permissions on job [NUMID]
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.destroy.terraform.txt
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.destroy.terraform.txt
@@ -2,7 +2,7 @@
 >>> errcode as-test-sp [CLI] bundle destroy --auto-approve
 Error: exit status 1
 
-Error: cannot read job: User [UUID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
+Error: cannot read job: User [TEST_SP_APPLICATION_ID] does not have View or Admin or Manage Run or Owner permissions on job [NUMID]
 
   with databricks_job.foo,
   on bundle.tf.json line 27, in resource.databricks_job.foo:

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/output.txt
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/output.txt
@@ -5,13 +5,13 @@
 }
 
 >>> as-test-sp [CLI] current-user me
-"deco-test-spn"
+"[TEST_SP_APPLICATION_ID]"
 
 >>> [CLI] bundle destroy --auto-approve
 No active deployment found to destroy!
 
 >>> as-test-sp [CLI] bundle deploy
-Uploading bundle files to /Workspace/Users/[UUID]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Uploading bundle files to /Workspace/Users/[TEST_SP_APPLICATION_ID]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/script
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/script
@@ -1,10 +1,19 @@
+if [ -z "${TEST_SP_APPLICATION_ID:-}" ]; then
+    # Falls back to the fixed userName the testserver reports for the as-test-sp
+    # guest, used whenever the env does not provide a real application_id (locally).
+    export TEST_SP_APPLICATION_ID="aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee"
+fi
+# Mask the test SP's application_id (its userName) to a dedicated placeholder so
+# the assertion is env-independent instead of collapsing into the generic [UUID].
+echo "$TEST_SP_APPLICATION_ID:TEST_SP_APPLICATION_ID" >> ACC_REPLS
+
 envsubst < databricks.yml.tmpl > databricks.yml
 # Locally DATABRICKS_CLIENT_ID is unset; fall back to the current identity so the
 # owner matches cloud. Scoped to this command so CLI auth is unaffected.
 DATABRICKS_CLIENT_ID="${DATABRICKS_CLIENT_ID:-$CURRENT_USER_NAME}" envsubst < take_ownership.json.tmpl > take_ownership.json
 trace cat take_ownership.json
 
-trace as-test-sp $CLI current-user me | jq .displayName
+trace as-test-sp $CLI current-user me | jq .userName
 
 cleanup() {
     trace $CLI bundle destroy --auto-approve


### PR DESCRIPTION
These tests asserted `current-user me | jq .displayName` equals `deco-test-spn`, which fails in any environment whose SP has a different display name.

Assert `.userName` instead. For a service principal that's its `application_id` UUID, which still proves we're acting as the test SP without depending on the display name. Register it as a dedicated `[TEST_SP_APPLICATION_ID]` replacement (from the env var, with a testserver fallback) rather than the generic `[UUID]`, mirroring `secret_scopes/permissions`.

This pull request and its description were written by Isaac.