### PR TITLE
libs/cmdio,tableview: build lipgloss styles via NewRenderer

### DIFF
--- a/experimental/aitools/cmd/query.go
+++ b/experimental/aitools/cmd/query.go
@@ -191,7 +191,7 @@ multi-query mode, the same parameter set is applied to every statement.`,
 			case queryOutputModeStaticTable:
 				return renderStaticTable(cmd.OutOrStdout(), columns, rows)
 			default:
-				return renderInteractiveTable(cmd.OutOrStdout(), columns, rows)
+				return renderInteractiveTable(ctx, cmd.OutOrStdout(), columns, rows)
 			}
 		},
 	}

--- a/experimental/aitools/cmd/render.go
+++ b/experimental/aitools/cmd/render.go
@@ -1,6 +1,7 @@
 package aitools
 
 import (
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -113,6 +114,6 @@ func renderStaticTable(w io.Writer, columns []string, rows [][]string) error {
 }
 
 // renderInteractiveTable displays query results in the interactive table browser.
-func renderInteractiveTable(w io.Writer, columns []string, rows [][]string) error {
-	return tableview.Run(w, columns, rows)
+func renderInteractiveTable(ctx context.Context, w io.Writer, columns []string, rows [][]string) error {
+	return tableview.Run(ctx, w, columns, rows)
 }

--- a/experimental/postgres/cmd/execute.go
+++ b/experimental/postgres/cmd/execute.go
@@ -20,7 +20,7 @@ type rowSink interface {
 	// Begin and uses pgx's Go type mapping (int64, float64, time.Time, ...).
 	Row(values []any) error
 	// End is called once on successful completion.
-	End(commandTag string) error
+	End(ctx context.Context, commandTag string) error
 	// OnError is called if iteration errors after Begin returned successfully.
 	// The sink is expected to flush any in-progress output structures so
 	// stdout remains well-formed. The caller still surfaces err to its caller.
@@ -74,5 +74,5 @@ func executeOne(ctx context.Context, conn *pgx.Conn, sql string, sink rowSink) e
 		return fmt.Errorf("query failed: %w", err)
 	}
 
-	return sink.End(rows.CommandTag().String())
+	return sink.End(ctx, rows.CommandTag().String())
 }

--- a/experimental/postgres/cmd/query.go
+++ b/experimental/postgres/cmd/query.go
@@ -235,7 +235,7 @@ func runQuery(ctx context.Context, cmd *cobra.Command, args []string, f queryFla
 		if err != nil {
 			// Render the successful prefix, then surface the error with
 			// rich pgError formatting if applicable.
-			if rerr := renderPartial(out, stderr, format, results, r, err); rerr != nil {
+			if rerr := renderPartial(ctx, out, stderr, format, results, r, err); rerr != nil {
 				// Best-effort partial render failed; surface the original
 				// error to the user, the renderer error to debug logs.
 				fmt.Fprintln(stderr, "warning: failed to render partial result:", rerr)
@@ -254,9 +254,9 @@ func runQuery(ctx context.Context, cmd *cobra.Command, args []string, f queryFla
 
 	switch format {
 	case sqlcli.OutputJSON:
-		return renderJSONMulti(out, stderr, results, nil, "")
+		return renderJSONMulti(ctx, out, stderr, results, nil, "")
 	default:
-		return renderTextMulti(out, results)
+		return renderTextMulti(ctx, out, results)
 	}
 }
 
@@ -312,14 +312,14 @@ func newSinkInteractive(format sqlcli.Format, out, stderr io.Writer, interactive
 // renderPartial emits the rendered output for the prefix of units that ran
 // successfully before a unit errored. For multi-input json this also writes
 // the error envelope as the last array element.
-func renderPartial(out, stderr io.Writer, format sqlcli.Format, results []*unitResult, errored *unitResult, err error) error {
+func renderPartial(ctx context.Context, out, stderr io.Writer, format sqlcli.Format, results []*unitResult, errored *unitResult, err error) error {
 	switch format {
 	case sqlcli.OutputJSON:
-		return renderJSONMulti(out, stderr, results, errored, formatPgError(err))
+		return renderJSONMulti(ctx, out, stderr, results, errored, formatPgError(err))
 	default:
 		// Text: render whatever ran cleanly. The error message goes through
 		// cobra's default error path on stderr after we return.
-		return renderTextMulti(out, results)
+		return renderTextMulti(ctx, out, results)
 	}
 }
 

--- a/experimental/postgres/cmd/render.go
+++ b/experimental/postgres/cmd/render.go
@@ -1,6 +1,7 @@
 package postgrescmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -74,7 +75,7 @@ func escapeControlForTabwriter(s string) string {
 	return r.Replace(s)
 }
 
-func (s *textSink) End(commandTag string) error {
+func (s *textSink) End(ctx context.Context, commandTag string) error {
 	if len(s.columns) == 0 {
 		_, err := fmt.Fprintln(s.out, commandTag)
 		return err
@@ -85,7 +86,7 @@ func (s *textSink) End(commandTag string) error {
 		// resize race, etc.) fall through to the static path so the user
 		// still sees the rows their query returned. Without this fallback
 		// a successful query would surface as "viewer failed" with no data.
-		if err := tableview.Run(s.out, s.columns, s.rows); err == nil {
+		if err := tableview.Run(ctx, s.out, s.columns, s.rows); err == nil {
 			return nil
 		}
 	}

--- a/experimental/postgres/cmd/render_csv.go
+++ b/experimental/postgres/cmd/render_csv.go
@@ -1,6 +1,7 @@
 package postgrescmd
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -63,7 +64,7 @@ func (s *csvSink) Row(values []any) error {
 	return s.w.Error()
 }
 
-func (s *csvSink) End(commandTag string) error {
+func (s *csvSink) End(ctx context.Context, commandTag string) error {
 	if !s.rowsProducing {
 		_, err := fmt.Fprintln(s.stderr, commandTag)
 		return err

--- a/experimental/postgres/cmd/render_csv_test.go
+++ b/experimental/postgres/cmd/render_csv_test.go
@@ -14,7 +14,7 @@ func TestCSVSink_TwoRows(t *testing.T) {
 	require.NoError(t, s.Begin(fields("id", "name")))
 	require.NoError(t, s.Row([]any{int64(1), "alice"}))
 	require.NoError(t, s.Row([]any{int64(2), "bob"}))
-	require.NoError(t, s.End("SELECT 2"))
+	require.NoError(t, s.End(t.Context(), "SELECT 2"))
 
 	assert.Equal(t, "id,name\n1,alice\n2,bob\n", stdout.String())
 	assert.Empty(t, stderr.String())
@@ -25,7 +25,7 @@ func TestCSVSink_NULLEmptyField(t *testing.T) {
 	s := newCSVSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(fields("id", "note")))
 	require.NoError(t, s.Row([]any{int64(1), nil}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 
 	assert.Equal(t, "id,note\n1,\n", stdout.String())
 }
@@ -34,7 +34,7 @@ func TestCSVSink_CommandOnly(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	s := newCSVSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(nil))
-	require.NoError(t, s.End("CREATE DATABASE"))
+	require.NoError(t, s.End(t.Context(), "CREATE DATABASE"))
 	assert.Empty(t, stdout.String())
 	assert.Equal(t, "CREATE DATABASE\n", stderr.String())
 }
@@ -44,7 +44,7 @@ func TestCSVSink_QuotesFieldsWithCommas(t *testing.T) {
 	s := newCSVSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(fields("note")))
 	require.NoError(t, s.Row([]any{"a,b"}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 	assert.Contains(t, stdout.String(), `"a,b"`)
 }
 
@@ -53,7 +53,7 @@ func TestCSVSink_EmbeddedNewlineAndQuote(t *testing.T) {
 	s := newCSVSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(fields("note")))
 	require.NoError(t, s.Row([]any{"line1\nline2 \"quoted\""}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 	assert.Contains(t, stdout.String(), "\"line1\nline2 \"\"quoted\"\"\"")
 }
 

--- a/experimental/postgres/cmd/render_json.go
+++ b/experimental/postgres/cmd/render_json.go
@@ -2,6 +2,7 @@ package postgrescmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -145,7 +146,7 @@ func marshalJSON(v any) ([]byte, error) {
 	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
-func (s *jsonSink) End(commandTag string) error {
+func (s *jsonSink) End(ctx context.Context, commandTag string) error {
 	if s.hasOpenedArray {
 		if s.rowsWritten == 0 {
 			// Empty result: collapse to "[]\n" rather than "[\n\n]\n".

--- a/experimental/postgres/cmd/render_json_test.go
+++ b/experimental/postgres/cmd/render_json_test.go
@@ -26,7 +26,7 @@ func TestJSONSink_TwoRows(t *testing.T) {
 	require.NoError(t, s.Begin(fieldsWithOIDs([]string{"id", "name"}, []uint32{pgtype.Int8OID, pgtype.TextOID})))
 	require.NoError(t, s.Row([]any{int64(1), "alice"}))
 	require.NoError(t, s.Row([]any{int64(2), "bob"}))
-	require.NoError(t, s.End("SELECT 2"))
+	require.NoError(t, s.End(t.Context(), "SELECT 2"))
 
 	assert.Equal(t,
 		"[\n"+
@@ -42,7 +42,7 @@ func TestJSONSink_EmptyRowsProducing(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	s := newJSONSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(fieldsWithOIDs([]string{"id"}, []uint32{pgtype.Int8OID})))
-	require.NoError(t, s.End("SELECT 0"))
+	require.NoError(t, s.End(t.Context(), "SELECT 0"))
 	assert.Equal(t, "[\n]\n", stdout.String())
 }
 
@@ -51,7 +51,7 @@ func TestJSONSink_KeysInColumnOrder(t *testing.T) {
 	s := newJSONSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(fieldsWithOIDs([]string{"b", "a"}, []uint32{pgtype.Int8OID, pgtype.Int8OID})))
 	require.NoError(t, s.Row([]any{int64(1), int64(2)}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 	assert.Equal(t, "[\n"+`{"b":1,"a":2}`+"\n]\n", stdout.String())
 }
 
@@ -59,7 +59,7 @@ func TestJSONSink_CommandOnly_WithRowCount(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	s := newJSONSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(nil))
-	require.NoError(t, s.End("INSERT 0 5"))
+	require.NoError(t, s.End(t.Context(), "INSERT 0 5"))
 	// Byte-equal: pins the field order so adding a future field (e.g. last_oid)
 	// must update the test rather than silently drift.
 	assert.Equal(t, `{"command":"INSERT","rows_affected":5}`+"\n", stdout.String())
@@ -69,7 +69,7 @@ func TestJSONSink_CommandOnly_NoRowCount(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	s := newJSONSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(nil))
-	require.NoError(t, s.End("CREATE DATABASE"))
+	require.NoError(t, s.End(t.Context(), "CREATE DATABASE"))
 	assert.Equal(t, `{"command":"CREATE"}`+"\n", stdout.String())
 }
 
@@ -78,7 +78,7 @@ func TestJSONSink_DuplicateColumns(t *testing.T) {
 	s := newJSONSink(&stdout, &stderr)
 	require.NoError(t, s.Begin(fieldsWithOIDs([]string{"id", "id", "id"}, []uint32{pgtype.Int8OID, pgtype.Int8OID, pgtype.Int8OID})))
 	require.NoError(t, s.Row([]any{int64(1), int64(2), int64(3)}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 
 	assert.Contains(t, stdout.String(), `"id":1`)
 	assert.Contains(t, stdout.String(), `"id__2":2`)
@@ -149,7 +149,7 @@ func TestJSONSink_DuplicateColumns_DoesNotCollideWithExistingSuffix(t *testing.T
 		[]uint32{pgtype.Int8OID, pgtype.Int8OID, pgtype.Int8OID},
 	)))
 	require.NoError(t, s.Row([]any{int64(1), int64(2), int64(3)}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 
 	// All three keys present with no duplicates.
 	out := stdout.String()

--- a/experimental/postgres/cmd/render_multi.go
+++ b/experimental/postgres/cmd/render_multi.go
@@ -2,6 +2,7 @@ package postgrescmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 )
@@ -14,14 +15,14 @@ import (
 // errIndex/errResult identifies the unit that errored (-1 if none); we still
 // render any successful prefix. The error itself is surfaced by the caller
 // via cobra's default error rendering.
-func renderTextMulti(out io.Writer, results []*unitResult) error {
+func renderTextMulti(ctx context.Context, out io.Writer, results []*unitResult) error {
 	for i, r := range results {
 		if i > 0 {
 			if _, err := io.WriteString(out, "\n"); err != nil {
 				return err
 			}
 		}
-		if err := renderTextResult(out, r); err != nil {
+		if err := renderTextResult(ctx, out, r); err != nil {
 			return err
 		}
 	}
@@ -30,7 +31,7 @@ func renderTextMulti(out io.Writer, results []*unitResult) error {
 
 // renderTextResult renders a single buffered unitResult in the same shape as
 // textSink would for a streamed result.
-func renderTextResult(out io.Writer, r *unitResult) error {
+func renderTextResult(ctx context.Context, out io.Writer, r *unitResult) error {
 	if !r.IsRowsProducing() {
 		_, err := fmt.Fprintln(out, r.CommandTag)
 		return err
@@ -47,7 +48,7 @@ func renderTextResult(out io.Writer, r *unitResult) error {
 			return err
 		}
 	}
-	return sink.End(r.CommandTag)
+	return sink.End(ctx, r.CommandTag)
 }
 
 // renderJSONMulti emits the wrapped multi-input JSON shape: a top-level
@@ -68,7 +69,7 @@ func renderTextResult(out io.Writer, r *unitResult) error {
 //
 // elapsed_ms is present on errors too: it captures how long the failing
 // statement ran before the error fired.
-func renderJSONMulti(out, stderr io.Writer, results []*unitResult, errored *unitResult, errMessage string) error {
+func renderJSONMulti(ctx context.Context, out, stderr io.Writer, results []*unitResult, errored *unitResult, errMessage string) error {
 	if _, err := io.WriteString(out, "[\n"); err != nil {
 		return err
 	}
@@ -80,7 +81,7 @@ func renderJSONMulti(out, stderr io.Writer, results []*unitResult, errored *unit
 			}
 		}
 		var unitBuf bytes.Buffer
-		if err := renderJSONUnit(&unitBuf, stderr, r); err != nil {
+		if err := renderJSONUnit(ctx, &unitBuf, stderr, r); err != nil {
 			return err
 		}
 		if _, err := out.Write(unitBuf.Bytes()); err != nil {
@@ -107,7 +108,7 @@ func renderJSONMulti(out, stderr io.Writer, results []*unitResult, errored *unit
 // renderJSONUnit writes one buffered result object to buf, using the
 // existing single-input json rendering for the rows array so the value
 // mapping stays consistent across single- and multi-input shapes.
-func renderJSONUnit(buf *bytes.Buffer, stderr io.Writer, r *unitResult) error {
+func renderJSONUnit(ctx context.Context, buf *bytes.Buffer, stderr io.Writer, r *unitResult) error {
 	if err := writeJSONUnitHeader(buf, r); err != nil {
 		return err
 	}
@@ -143,7 +144,7 @@ func renderJSONUnit(buf *bytes.Buffer, stderr io.Writer, r *unitResult) error {
 			return err
 		}
 	}
-	if err := sink.End(""); err != nil {
+	if err := sink.End(ctx, ""); err != nil {
 		return err
 	}
 	rowsTrimmed := bytes.TrimRight(rowsBuf.Bytes(), "\n")

--- a/experimental/postgres/cmd/render_multi_test.go
+++ b/experimental/postgres/cmd/render_multi_test.go
@@ -27,7 +27,7 @@ func TestRenderTextMulti_TwoResults(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	require.NoError(t, renderTextMulti(&buf, []*unitResult{r1, r2}))
+	require.NoError(t, renderTextMulti(t.Context(), &buf, []*unitResult{r1, r2}))
 	out := buf.String()
 	assert.Contains(t, out, "INSERT 0 1\n")
 	assert.Contains(t, out, "id")
@@ -53,7 +53,7 @@ func TestRenderJSONMulti_TwoResults(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, renderJSONMulti(&stdout, &stderr, []*unitResult{r1, r2}, nil, ""))
+	require.NoError(t, renderJSONMulti(t.Context(), &stdout, &stderr, []*unitResult{r1, r2}, nil, ""))
 
 	out := stdout.String()
 	// Canonical key order: source, sql, kind, elapsed_ms, payload.
@@ -81,7 +81,7 @@ func TestRenderJSONMulti_WithErrorAtEnd(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, renderJSONMulti(&stdout, &stderr, []*unitResult{r1}, errored, "ERROR: syntax error (SQLSTATE 42601)"))
+	require.NoError(t, renderJSONMulti(t.Context(), &stdout, &stderr, []*unitResult{r1}, errored, "ERROR: syntax error (SQLSTATE 42601)"))
 
 	out := stdout.String()
 	assert.Contains(t, out, `"kind":"rows"`)
@@ -96,7 +96,7 @@ func TestRenderJSONMulti_FirstUnitFails(t *testing.T) {
 		Elapsed: 7 * time.Millisecond,
 	}
 	var stdout, stderr bytes.Buffer
-	require.NoError(t, renderJSONMulti(&stdout, &stderr, nil, errored, "ERROR: bad"))
+	require.NoError(t, renderJSONMulti(t.Context(), &stdout, &stderr, nil, errored, "ERROR: bad"))
 
 	out := stdout.String()
 	// No leading separator before the single error envelope.

--- a/experimental/postgres/cmd/render_test.go
+++ b/experimental/postgres/cmd/render_test.go
@@ -26,7 +26,7 @@ func TestTextSink_RowsProducing(t *testing.T) {
 	require.NoError(t, s.Begin(fields("id", "name")))
 	require.NoError(t, s.Row([]any{int64(1), "alice"}))
 	require.NoError(t, s.Row([]any{int64(2), "bob"}))
-	require.NoError(t, s.End("SELECT 2"))
+	require.NoError(t, s.End(t.Context(), "SELECT 2"))
 
 	assert.Equal(t,
 		"id   name\n"+
@@ -43,7 +43,7 @@ func TestTextSink_SingleRow(t *testing.T) {
 	s := newTextSink(&buf)
 	require.NoError(t, s.Begin(fields("id")))
 	require.NoError(t, s.Row([]any{int64(42)}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 	assert.Contains(t, buf.String(), "(1 row)\n")
 }
 
@@ -51,7 +51,7 @@ func TestTextSink_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	s := newTextSink(&buf)
 	require.NoError(t, s.Begin(fields("id", "name")))
-	require.NoError(t, s.End("SELECT 0"))
+	require.NoError(t, s.End(t.Context(), "SELECT 0"))
 	assert.Contains(t, buf.String(), "(0 rows)\n")
 }
 
@@ -59,7 +59,7 @@ func TestTextSink_CommandOnly(t *testing.T) {
 	var buf bytes.Buffer
 	s := newTextSink(&buf)
 	require.NoError(t, s.Begin(nil))
-	require.NoError(t, s.End("INSERT 0 5"))
+	require.NoError(t, s.End(t.Context(), "INSERT 0 5"))
 	assert.Equal(t, "INSERT 0 5\n", buf.String())
 }
 
@@ -68,7 +68,7 @@ func TestTextSink_NULLRendersAsNULL(t *testing.T) {
 	s := newTextSink(&buf)
 	require.NoError(t, s.Begin(fields("id")))
 	require.NoError(t, s.Row([]any{nil}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 	assert.Contains(t, buf.String(), "NULL")
 }
 
@@ -89,7 +89,7 @@ func TestTextSink_EscapesTabAndNewlineInCells(t *testing.T) {
 	s := newTextSink(&buf)
 	require.NoError(t, s.Begin(fields("note")))
 	require.NoError(t, s.Row([]any{"a\tb\nc\rd"}))
-	require.NoError(t, s.End("SELECT 1"))
+	require.NoError(t, s.End(t.Context(), "SELECT 1"))
 	// The escape replaces tabs/newlines/CR with their backslash-letter forms
 	// so the tabwriter doesn't treat them as column or row boundaries.
 	assert.Contains(t, buf.String(), `a\tb\nc\rd`)

--- a/experimental/postgres/cmd/result.go
+++ b/experimental/postgres/cmd/result.go
@@ -68,7 +68,7 @@ func (s *bufferSink) Row(values []any) error {
 	return nil
 }
 
-func (s *bufferSink) End(commandTag string) error {
+func (s *bufferSink) End(ctx context.Context, commandTag string) error {
 	s.result.CommandTag = commandTag
 	return nil
 }

--- a/experimental/postgres/cmd/result_test.go
+++ b/experimental/postgres/cmd/result_test.go
@@ -34,7 +34,7 @@ func TestBufferSink_RowAndEnd(t *testing.T) {
 	require.NoError(t, s.Begin([]pgconn.FieldDescription{{Name: "a"}}))
 	require.NoError(t, s.Row([]any{int64(1)}))
 	require.NoError(t, s.Row([]any{int64(2)}))
-	require.NoError(t, s.End("SELECT 2"))
+	require.NoError(t, s.End(t.Context(), "SELECT 2"))
 
 	assert.Equal(t, [][]any{{int64(1)}, {int64(2)}}, r.Rows)
 	assert.Equal(t, "SELECT 2", r.CommandTag)

--- a/libs/cmdio/paged_template.go
+++ b/libs/cmdio/paged_template.go
@@ -103,7 +103,7 @@ func renderIteratorPagedTemplateCore[T any](
 		rowT:      rowT,
 		headerStr: headerTemplate,
 	}
-	m := newPagerModel(ctx, iter, pager, pageSize, limitFromContext(ctx))
+	m := newPagerModel(ctx, out, iter, pager, pageSize, limitFromContext(ctx))
 	p := tea.NewProgram(
 		m,
 		tea.WithInput(in),

--- a/libs/cmdio/pager.go
+++ b/libs/cmdio/pager.go
@@ -2,6 +2,7 @@ package cmdio
 
 import (
 	"context"
+	"io"
 	"strings"
 	"time"
 
@@ -62,6 +63,7 @@ type pagerModel[T any] struct {
 // struct has to hold onto a context.
 func newPagerModel[T any](
 	ctx context.Context,
+	out io.Writer,
 	iter listing.Iterator[T],
 	pager *templatePager,
 	pageSize, limit int,
@@ -69,7 +71,7 @@ func newPagerModel[T any](
 	m := &pagerModel[T]{
 		iter:     iter,
 		pager:    pager,
-		spinner:  newPagerSpinner(),
+		spinner:  newPagerSpinner(ctx, out),
 		pageSize: pageSize,
 		limit:    limit,
 	}
@@ -81,13 +83,14 @@ func newPagerModel[T any](
 
 // newPagerSpinner builds a spinner matching the one the cmdio package's
 // NewSpinner uses, so interactive feedback looks the same everywhere.
-func newPagerSpinner() bubblespinner.Model {
+func newPagerSpinner(ctx context.Context, out io.Writer) bubblespinner.Model {
 	s := bubblespinner.New()
 	s.Spinner = bubblespinner.Spinner{
 		Frames: []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
 		FPS:    time.Second / 5,
 	}
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	r, _ := NewRenderer(ctx, out)
+	s.Style = r.NewStyle().Foreground(lipgloss.Color("10"))
 	return s
 }
 

--- a/libs/cmdio/pager_test.go
+++ b/libs/cmdio/pager_test.go
@@ -2,6 +2,7 @@ package cmdio
 
 import (
 	"errors"
+	"io"
 	"reflect"
 	"testing"
 	"text/template"
@@ -20,7 +21,7 @@ func newTestPager(t *testing.T, iter listing.Iterator[int], pageSize int) *pager
 	require.NoError(t, err)
 	headerT, err := template.New("header").Funcs(fm).Parse("")
 	require.NoError(t, err)
-	return newPagerModel(ctx, iter, &templatePager{
+	return newPagerModel(ctx, io.Discard, iter, &templatePager{
 		headerT: headerT,
 		rowT:    rowT,
 	}, pageSize, 0)

--- a/libs/cmdio/spinner.go
+++ b/libs/cmdio/spinner.go
@@ -3,6 +3,7 @@ package cmdio
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -35,15 +36,17 @@ func WithElapsedTime() SpinnerOption {
 	}
 }
 
-// newSpinnerModel creates a new spinner model.
-func newSpinnerModel(opts ...SpinnerOption) spinnerModel {
+// newSpinnerModel creates a new spinner model. The style is minted from a
+// renderer targeting w so color handling stays centralized in NewRenderer.
+func newSpinnerModel(ctx context.Context, w io.Writer, opts ...SpinnerOption) spinnerModel {
 	s := bubblespinner.New()
 	// Braille spinner frames with 200ms timing
 	s.Spinner = bubblespinner.Spinner{
 		Frames: []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"},
 		FPS:    time.Second / 5, // 200ms = 5 FPS
 	}
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // Green
+	r, _ := NewRenderer(ctx, w)
+	s.Style = r.NewStyle().Foreground(lipgloss.Color("10")) // Green
 
 	m := spinnerModel{
 		spinner: s,
@@ -147,7 +150,7 @@ func (c *cmdIO) NewSpinner(ctx context.Context, opts ...SpinnerOption) *spinner 
 	}
 
 	// Create model and program
-	m := newSpinnerModel(opts...)
+	m := newSpinnerModel(ctx, c.err, opts...)
 	p := tea.NewProgram(
 		m,
 		tea.WithInput(nil),

--- a/libs/cmdio/spinner_test.go
+++ b/libs/cmdio/spinner_test.go
@@ -2,6 +2,7 @@ package cmdio
 
 import (
 	"context"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -10,14 +11,14 @@ import (
 )
 
 func TestSpinnerModelInit(t *testing.T) {
-	m := newSpinnerModel()
+	m := newSpinnerModel(MockDiscard(t.Context()), io.Discard)
 	assert.False(t, m.quitting)
 	assert.Empty(t, m.suffix)
 	assert.NotNil(t, m.spinner)
 }
 
 func TestSpinnerModelUpdateSuffixMsg(t *testing.T) {
-	m := newSpinnerModel()
+	m := newSpinnerModel(MockDiscard(t.Context()), io.Discard)
 	msg := suffixMsg("processing files")
 
 	updatedModel, _ := m.Update(msg)
@@ -28,7 +29,7 @@ func TestSpinnerModelUpdateSuffixMsg(t *testing.T) {
 }
 
 func TestSpinnerModelUpdateQuitMsg(t *testing.T) {
-	m := newSpinnerModel()
+	m := newSpinnerModel(MockDiscard(t.Context()), io.Discard)
 	msg := quitMsg{}
 
 	updatedModel, cmd := m.Update(msg)
@@ -39,7 +40,7 @@ func TestSpinnerModelUpdateQuitMsg(t *testing.T) {
 }
 
 func TestSpinnerModelViewActive(t *testing.T) {
-	m := newSpinnerModel()
+	m := newSpinnerModel(MockDiscard(t.Context()), io.Discard)
 	m.suffix = "loading"
 
 	view := m.View()
@@ -49,7 +50,7 @@ func TestSpinnerModelViewActive(t *testing.T) {
 }
 
 func TestSpinnerModelViewQuitting(t *testing.T) {
-	m := newSpinnerModel()
+	m := newSpinnerModel(MockDiscard(t.Context()), io.Discard)
 	m.quitting = true
 
 	view := m.View()

--- a/libs/gorules/rule_lipgloss_renderer.go
+++ b/libs/gorules/rule_lipgloss_renderer.go
@@ -1,0 +1,13 @@
+package gorules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// NoLipglossNewRenderer steers renderer construction through cmdio.NewRenderer,
+// which forces the Ascii profile when the target writer has no color. A bare
+// lipgloss.NewRenderer bypasses that gate and reads color from process env, so
+// it is only allowed inside libs/cmdio itself (where the wrapper lives).
+func NoLipglossNewRenderer(m dsl.Matcher) {
+	m.Match(`lipgloss.NewRenderer($*_)`).
+		Where(!m.File().PkgPath.Matches(`libs/cmdio$`)).
+		Report(`Do not call lipgloss.NewRenderer directly; use cmdio.NewRenderer(ctx, w) so color handling stays centralized`)
+}

--- a/libs/tableview/tableview.go
+++ b/libs/tableview/tableview.go
@@ -2,6 +2,7 @@
 package tableview
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -10,6 +11,8 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/databricks/cli/libs/cmdio"
 )
 
 const (
@@ -21,24 +24,22 @@ const (
 	headerLines = 2
 )
 
-var (
-	searchHighlightStyle = lipgloss.NewStyle().Background(lipgloss.Color("228")).Foreground(lipgloss.Color("0"))
-	cursorStyle          = lipgloss.NewStyle().Background(lipgloss.Color("57")).Foreground(lipgloss.Color("229"))
-	footerStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	searchStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("229"))
-)
-
 // Run displays tabular data in an interactive browser.
 // Writes to w (typically stdout). Blocks until user quits.
-func Run(w io.Writer, columns []string, rows [][]string) error {
+func Run(ctx context.Context, w io.Writer, columns []string, rows [][]string) error {
 	all := renderTableLines(columns, rows)
 	header := all[:headerLines]
 	dataLines := all[headerLines:]
 
+	r, _ := cmdio.NewRenderer(ctx, w)
 	m := model{
-		header: header,
-		lines:  dataLines,
-		cursor: 0,
+		header:               header,
+		lines:                dataLines,
+		cursor:               0,
+		searchHighlightStyle: r.NewStyle().Background(lipgloss.Color("228")).Foreground(lipgloss.Color("0")),
+		cursorStyle:          r.NewStyle().Background(lipgloss.Color("57")).Foreground(lipgloss.Color("229")),
+		footerStyle:          r.NewStyle().Foreground(lipgloss.Color("241")),
+		searchStyle:          r.NewStyle().Foreground(lipgloss.Color("229")),
 	}
 
 	p := tea.NewProgram(m, tea.WithOutput(w))
@@ -109,7 +110,7 @@ func findMatches(lines []string, query string) []int {
 }
 
 // highlightSearch applies search match highlighting to a single line.
-func highlightSearch(line, query string) string {
+func (m model) highlightSearch(line, query string) string {
 	if query == "" {
 		return line
 	}
@@ -126,7 +127,7 @@ func highlightSearch(line, query string) string {
 			break
 		}
 		b.WriteString(line[pos : pos+idx])
-		b.WriteString(searchHighlightStyle.Render(line[pos+idx : pos+idx+qLen]))
+		b.WriteString(m.searchHighlightStyle.Render(line[pos+idx : pos+idx+qLen]))
 		pos += idx + qLen
 	}
 	return b.String()
@@ -137,9 +138,9 @@ func highlightSearch(line, query string) string {
 func (m model) renderContent() string {
 	result := make([]string, len(m.lines))
 	for i, line := range m.lines {
-		rendered := highlightSearch(line, m.searchQuery)
+		rendered := m.highlightSearch(line, m.searchQuery)
 		if i == m.cursor {
-			rendered = cursorStyle.Render(rendered)
+			rendered = m.cursorStyle.Render(rendered)
 		}
 		result[i] = rendered
 	}
@@ -159,6 +160,12 @@ type model struct { //nolint:recvcheck // value receivers for tea.Model interfac
 	searchQuery string
 	matchLines  []int // indices into lines
 	matchIdx    int
+
+	// Styles, minted from a writer-scoped renderer in Run.
+	searchHighlightStyle lipgloss.Style
+	cursorStyle          lipgloss.Style
+	footerStyle          lipgloss.Style
+	searchStyle          lipgloss.Style
 }
 
 func (m model) dataRowCount() int {
@@ -324,8 +331,8 @@ func (m model) View() string {
 
 func (m model) renderFooter() string {
 	if m.searching {
-		prompt := searchStyle.Render("/ " + m.searchInput + "█")
-		return footerStyle.Render(fmt.Sprintf("%d rows", m.dataRowCount())) + "\n" + prompt
+		prompt := m.searchStyle.Render("/ " + m.searchInput + "█")
+		return m.footerStyle.Render(fmt.Sprintf("%d rows", m.dataRowCount())) + "\n" + prompt
 	}
 
 	parts := []string{fmt.Sprintf("%d rows", m.dataRowCount())}
@@ -342,5 +349,5 @@ func (m model) renderFooter() string {
 	pct := int(m.viewport.ScrollPercent() * 100)
 	parts = append(parts, fmt.Sprintf("%d%%", pct))
 
-	return footerStyle.Render(strings.Join(parts, " | "))
+	return m.footerStyle.Render(strings.Join(parts, " | "))
 }

--- a/libs/tableview/tableview_test.go
+++ b/libs/tableview/tableview_test.go
@@ -58,18 +58,18 @@ func TestFindMatchesEmptyQuery(t *testing.T) {
 }
 
 func TestHighlightSearchEmptyQuery(t *testing.T) {
-	result := highlightSearch("hello alice", "")
+	result := model{}.highlightSearch("hello alice", "")
 	assert.Equal(t, "hello alice", result)
 }
 
 func TestHighlightSearchWithMatch(t *testing.T) {
-	result := highlightSearch("hello alice", "alice")
+	result := model{}.highlightSearch("hello alice", "alice")
 	assert.Contains(t, result, "alice")
 	assert.Contains(t, result, "hello")
 }
 
 func TestHighlightSearchNoMatch(t *testing.T) {
-	result := highlightSearch("hello bob", "alice")
+	result := model{}.highlightSearch("hello bob", "alice")
 	assert.Equal(t, "hello bob", result)
 }
 


### PR DESCRIPTION
Follow-up to #5903, which introduced `cmdio.NewRenderer(ctx, w)`. This adopts it at the call sites: route the hardcoded spinner and table `lipgloss.NewStyle()` sites through `cmdio.NewRenderer(ctx, w)`, so the color-profile decision flows from the target writer instead of lipgloss's package-global default renderer. Threading `ctx` to `tableview.Run` extends the postgres `rowSink.End` signature.

Also add a ruleguard lint that rejects direct `lipgloss.NewRenderer` calls outside `libs/cmdio`, keeping construction funneled through the wrapper.

This pull request and its description were written by Isaac.
