### PR TITLE
acc: look up SP by env-provided display name in variables/lookup

### DIFF
--- a/acceptance/bundle/variables/lookup/databricks.yml.tmpl
+++ b/acceptance/bundle/variables/lookup/databricks.yml.tmpl
@@ -4,7 +4,7 @@ bundle:
 variables:
   sp:
     lookup:
-      service_principal: "deco-test-spn"
+      service_principal: "$TEST_SP_DISPLAY_NAME"
 
   result:
     default: ${var.sp}

--- a/acceptance/bundle/variables/lookup/output.txt
+++ b/acceptance/bundle/variables/lookup/output.txt
@@ -7,7 +7,7 @@
   },
   "sp": {
     "lookup": {
-      "service_principal": "deco-test-spn"
+      "service_principal": "[TEST_SP_DISPLAY_NAME]"
     },
     "value": "[UUID]"
   }

--- a/acceptance/bundle/variables/lookup/script
+++ b/acceptance/bundle/variables/lookup/script
@@ -1,1 +1,8 @@
+# The SP display name to look up differs per environment; TEST_SP_DISPLAY_NAME is
+# provisioned in the cloud env, and we fall back to the name the local testserver
+# reports so the test passes in both. Mask it to a stable placeholder either way.
+export TEST_SP_DISPLAY_NAME="${TEST_SP_DISPLAY_NAME:-deco-test-spn}"
+echo "$TEST_SP_DISPLAY_NAME:TEST_SP_DISPLAY_NAME" >> ACC_REPLS
+envsubst < databricks.yml.tmpl > databricks.yml
+
 trace $CLI bundle validate -o json | jq '.variables'

--- a/acceptance/bundle/variables/lookup/test.toml
+++ b/acceptance/bundle/variables/lookup/test.toml
@@ -1,6 +1,10 @@
 Local = true
 Cloud = true
 
+Ignore = [
+    "databricks.yml",
+]
+
 [[Server]]
 Pattern = "GET /api/2.0/preview/scim/v2/ServicePrincipals"
 Response.Body = '''{


### PR DESCRIPTION
The test hardcoded `service_principal: "deco-test-spn"` as the lookup input, so it failed on any environment without an SP by that exact display name.

Read the name from `TEST_SP_DISPLAY_NAME` (with a `deco-test-spn` fallback for local and current envs) and register it as a `[TEST_SP_DISPLAY_NAME]` replacement so the golden is env-independent.

This pull request and its description were written by Isaac.