### PR TITLE
Translate `command_path` and `code_source_path` for AI runtime task to remote paths

### DIFF
--- a/acceptance/bundle/artifacts/ai_runtime_code_source/command.sh
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/command.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "hello from AI Runtime"

--- a/acceptance/bundle/artifacts/ai_runtime_code_source/databricks.yml
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/databricks.yml
@@ -1,0 +1,40 @@
+bundle:
+  name: test-bundle
+
+workspace:
+  artifact_path: /foo/bar/artifacts
+
+# The tarball is delivered as an artifact; don't also sync it as a bundle file.
+sync:
+  exclude:
+    - build/**
+    - dist/**
+    - code.tgz
+
+# The AI Runtime task ships user code as a tarball built locally by an artifact.
+artifacts:
+  code_source:
+    build: touch code.tgz
+    files:
+      - source: code.tgz
+
+resources:
+  jobs:
+    job:
+      name: "[${bundle.target}] AI Runtime Job"
+      environments:
+        - environment_key: default
+          spec:
+            environment_version: "4"
+      tasks:
+        - task_key: train
+          environment_key: default
+          ai_runtime_task:
+            experiment: my-experiment
+            # Local path to the built tarball; rewritten to the uploaded remote path.
+            code_source_path: code.tgz
+            deployments:
+              - command_path: command.sh
+                compute:
+                  accelerator_type: GPU_1xA10
+                  accelerator_count: 1

--- a/acceptance/bundle/artifacts/ai_runtime_code_source/out.test.toml
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/artifacts/ai_runtime_code_source/output.txt
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/output.txt
@@ -1,0 +1,28 @@
+
+>>> [CLI] bundle deploy
+Building code_source...
+Uploading code.tgz...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Expecting code_source_path rewritten to the uploaded artifact remote path
+>>> jq -s .[] | select(.path=="/api/2.2/jobs/create") | .body.tasks[].ai_runtime_task out.requests.txt
+{
+  "code_source_path": "/Workspace/foo/bar/artifacts/.internal/code.tgz",
+  "deployments": [
+    {
+      "command_path": "/Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files/command.sh",
+      "compute": {
+        "accelerator_count": 1,
+        "accelerator_type": "GPU_1xA10"
+      }
+    }
+  ],
+  "experiment": "my-experiment"
+}
+
+=== Expecting the code_source tarball to be uploaded
+>>> jq .path
+"/api/2.0/workspace-files/import-file/Workspace/foo/bar/artifacts/.internal/code.tgz"

--- a/acceptance/bundle/artifacts/ai_runtime_code_source/script
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/script
@@ -1,0 +1,9 @@
+trace $CLI bundle deploy
+
+title "Expecting code_source_path rewritten to the uploaded artifact remote path"
+trace jq -s '.[] | select(.path=="/api/2.2/jobs/create") | .body.tasks[].ai_runtime_task' out.requests.txt
+
+title "Expecting the code_source tarball to be uploaded"
+trace jq .path < out.requests.txt | grep import | grep code.tgz | sort
+
+rm out.requests.txt

--- a/acceptance/bundle/artifacts/ai_runtime_code_source/test.toml
+++ b/acceptance/bundle/artifacts/ai_runtime_code_source/test.toml
@@ -1,0 +1,5 @@
+RecordRequests = true
+Ignore = [
+    'code.tgz',
+    '.databricks',
+]

--- a/acceptance/bundle/validate/immutable_workspace_paths/databricks.yml
+++ b/acceptance/bundle/validate/immutable_workspace_paths/databricks.yml
@@ -21,3 +21,11 @@ resources:
           existing_cluster_id: "0101-120000-aaaaaaaa"
           spark_python_task:
             python_file: ./src/main.py
+        - task_key: my_ai_runtime_task
+          ai_runtime_task:
+            experiment: my-experiment
+            deployments:
+              - command_path: ./src/main.py
+                compute:
+                  accelerator_type: GPU_1xA10
+                  accelerator_count: 1

--- a/acceptance/bundle/validate/immutable_workspace_paths/output.txt
+++ b/acceptance/bundle/validate/immutable_workspace_paths/output.txt
@@ -20,6 +20,21 @@ Warning: Pattern user_repls.json does not match any files
   },
   "tasks": [
     {
+      "ai_runtime_task": {
+        "deployments": [
+          {
+            "command_path": "${workspace.snapshot_path}/src/files/src/main.py",
+            "compute": {
+              "accelerator_count": 1,
+              "accelerator_type": "GPU_1xA10"
+            }
+          }
+        ],
+        "experiment": "my-experiment"
+      },
+      "task_key": "my_ai_runtime_task"
+    },
+    {
       "existing_cluster_id": "0101-120000-aaaaaaaa",
       "spark_python_task": {
         "python_file": "${workspace.snapshot_path}/src/files/src/main.py"

--- a/bundle/config/mutator/paths/job_paths_visitor.go
+++ b/bundle/config/mutator/paths/job_paths_visitor.go
@@ -46,6 +46,14 @@ func jobTaskRewritePatterns(base dyn.Pattern) []jobRewritePattern {
 			TranslateModeFile,
 			noSkipRewrite,
 		},
+		{
+			// The AI Runtime task runs this bash script on each node; the backend
+			// reads it as a workspace file, so translate the local path to its
+			// remote (or immutable-snapshot) location like any other file.
+			base.Append(dyn.Key("ai_runtime_task"), dyn.Key("deployments"), dyn.AnyIndex(), dyn.Key("command_path")),
+			TranslateModeFile,
+			noSkipRewrite,
+		},
 	}
 }
 

--- a/bundle/config/mutator/paths/job_paths_visitor_test.go
+++ b/bundle/config/mutator/paths/job_paths_visitor_test.go
@@ -54,6 +54,13 @@ func TestVisitJobPaths(t *testing.T) {
 			WorkspacePath: "abc",
 		},
 	}
+	task8 := jobs.Task{
+		AiRuntimeTask: &jobs.AiRuntimeTask{
+			Deployments: []jobs.DeploymentSpec{
+				{CommandPath: "abc"},
+			},
+		},
+	}
 
 	job0 := &resources.Job{
 		JobSettings: jobs.JobSettings{
@@ -66,6 +73,7 @@ func TestVisitJobPaths(t *testing.T) {
 				task5,
 				task6,
 				task7,
+				task8,
 			},
 		},
 	}
@@ -86,6 +94,7 @@ func TestVisitJobPaths(t *testing.T) {
 		dyn.MustPathFromString("resources.jobs.job0.tasks[3].sql_task.file.path"),
 		dyn.MustPathFromString("resources.jobs.job0.tasks[6].libraries[0].requirements"),
 		dyn.MustPathFromString("resources.jobs.job0.tasks[7].alert_task.workspace_path"),
+		dyn.MustPathFromString("resources.jobs.job0.tasks[8].ai_runtime_task.deployments[0].command_path"),
 	}
 
 	assert.ElementsMatch(t, expected, actual)

--- a/bundle/libraries/expand_glob_references.go
+++ b/bundle/libraries/expand_glob_references.go
@@ -155,6 +155,28 @@ var forEachTaskLibrariesPattern = dyn.NewPattern(
 	dyn.Key("libraries"),
 )
 
+var aiRuntimeCodeSourcePattern = dyn.NewPattern(
+	dyn.Key("resources"),
+	dyn.Key("jobs"),
+	dyn.AnyKey(),
+	dyn.Key("tasks"),
+	dyn.AnyIndex(),
+	dyn.Key("ai_runtime_task"),
+	dyn.Key("code_source_path"),
+)
+
+var forEachAiRuntimeCodeSourcePattern = dyn.NewPattern(
+	dyn.Key("resources"),
+	dyn.Key("jobs"),
+	dyn.AnyKey(),
+	dyn.Key("tasks"),
+	dyn.AnyIndex(),
+	dyn.Key("for_each_task"),
+	dyn.Key("task"),
+	dyn.Key("ai_runtime_task"),
+	dyn.Key("code_source_path"),
+)
+
 var envDepsPattern = dyn.NewPattern(
 	dyn.Key("resources"),
 	dyn.Key("jobs"),

--- a/bundle/libraries/remote_path.go
+++ b/bundle/libraries/remote_path.go
@@ -67,6 +67,11 @@ func collectLocalLibraries(b *bundle.Bundle) (map[string][]LocationToUpdate, err
 		forEachTaskLibrariesPattern.Append(dyn.AnyIndex(), dyn.Key("jar")),
 		envDepsPattern.Append(dyn.AnyIndex()),
 		pipelineEnvDepsPattern.Append(dyn.AnyIndex()),
+		// The AI Runtime task's code_source_path is a local archive (typically an
+		// artifact-built .tar.gz) that must be uploaded and referenced by its remote
+		// path, exactly like a wheel or jar library.
+		aiRuntimeCodeSourcePattern,
+		forEachAiRuntimeCodeSourcePattern,
 	}
 
 	for _, pattern := range patterns {


### PR DESCRIPTION
DABs now rewrites the two local path fields on an `ai_runtime_task` job task to their uploaded remote locations:

- **`command_path`**: translated like `spark_python_task.python_file`.
- **`code_source_path`**: uploaded and rewritten like other artifacts. Here the artifact is a gzipped tarball (a `.tgz`), which can be produced by an `artifacts` build block. Works with both UC-Volume and workspace `artifact_path` destinations.

No new artifact type needed. A typeless artifact builds and uploads generically.

This pull request and its description were written by Isaac.