### PR TITLE
changelog: link env-scripts entry to PR #5299 instead of issue #4179

### DIFF
--- a/.nextchanges/bundles/env-scripts.md
+++ b/.nextchanges/bundles/env-scripts.md
@@ -1,1 +1,1 @@
-Added an `env:` section to `scripts.<name>` for declaring environment variables that may reference `${bundle.*}`, `${workspace.*}`, and `${var.*}` ([#4179](https://github.com/databricks/cli/issues/4179)).
+Added an `env:` section to `scripts.<name>` for declaring environment variables that may reference `${bundle.*}`, `${workspace.*}`, and `${var.*}` ([#5299](https://github.com/databricks/cli/pull/5299)).

--- a/.nextchanges/bundles/env-scripts.md
+++ b/.nextchanges/bundles/env-scripts.md
@@ -1,1 +1,1 @@
-Added an `env:` section to `scripts.<name>` for declaring environment variables that may reference `${bundle.*}`, `${workspace.*}`, and `${var.*}` ([#5299](https://github.com/databricks/cli/pull/5299)).
+Added an `env:` section to `scripts.<name>` for declaring environment variables that may reference `${bundle.*}`, `${workspace.*}`, and `${var.*}` ([#4179](https://github.com/databricks/cli/issues/4179), [#5299](https://github.com/databricks/cli/pull/5299)).


### PR DESCRIPTION
The fragment added by #5831 linked the `env:` section changelog entry to the original issue (#4179) rather than the PR that implemented the feature (#5299). This includes both links.