### PR TITLE
Isolate golangci-lint cache per worktree to stop cross-worktree contamination

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,10 +28,21 @@ env:
   # first's absolute paths; the //nolint processor then re-opens those paths to
   # apply suppressions and, when the other worktree was deleted, can't — so
   # suppressed issues leak through as phantom failures pointing at a gone path.
-  # The default shared cache (~/Library/Caches/golangci-lint) is machine-global;
-  # rooting it under the gitignored per-worktree .task/ makes contamination
-  # impossible. CI is unaffected: it runs a single checkout and never persists
-  # this directory (setup-go caches only the Go build cache).
+  # See golangci/golangci-lint#6656 (closed as an accepted trade-off of the
+  # shared-cache work in #6445). The default shared cache
+  # (~/Library/Caches/golangci-lint) is machine-global; rooting it under the
+  # gitignored per-worktree .task/ makes contamination impossible.
+  #
+  # CI is unaffected: it runs a single checkout and never persists this directory
+  # (setup-go caches only the Go build cache).
+  #
+  # Trade-off: a fresh worktree's FIRST full `task lint` can't reuse another
+  # worktree's issue cache, so it runs cold (~2min on the root module vs ~20s
+  # warm; the incremental `task lint-q` used by the default dev loop is
+  # unaffected, <1s either way). Task's `env:` yields to an inherited value, so
+  # this is opt-out: export GOLANGCI_LINT_CACHE (e.g. to the shared
+  # ~/Library/Caches/golangci-lint) to trade isolation back for cross-worktree
+  # reuse, or run `task seed-lint-cache` to warm a new worktree from main.
   GOLANGCI_LINT_CACHE: '{{.ROOT_DIR}}/.task/golangci-lint'
 
 # pydabs-* tasks live in python/Taskfile.yml so `task pydabs-foo` works when
@@ -188,6 +199,27 @@ tasks:
       - "**/testdata/**"
     cmds:
       - "./tools/lintdiff.py {{.GO_TOOL}} golangci-lint run --allow-parallel-runners -j=4 --fix"
+
+  seed-lint-cache:
+    desc: >-
+      Warm this worktree's golangci-lint cache by copying the main worktree's,
+      so the first full `task lint` runs warm instead of cold. Safe because the
+      main worktree is permanent, so its cached issue paths always resolve.
+    # Skip when GOLANGCI_LINT_CACHE has been overridden away from the per-worktree
+    # default (the shared-cache opt-out already gets cross-worktree reuse for free).
+    status:
+      - test "$GOLANGCI_LINT_CACHE" != "{{.ROOT_DIR}}/.task/golangci-lint"
+    cmds:
+      - |
+        main_wt=$(git worktree list --porcelain | grep -m1 '^worktree ' | cut -d' ' -f2-)
+        src="$main_wt/.task/golangci-lint"
+        dst="{{.ROOT_DIR}}/.task/golangci-lint"
+        if [ "$src" = "$dst" ]; then echo "Already in the main worktree; nothing to seed."; exit 0; fi
+        if [ ! -d "$src" ]; then echo "No cache at $src; run 'task lint' in the main worktree first." >&2; exit 1; fi
+        mkdir -p "{{.ROOT_DIR}}/.task"
+        rm -rf "$dst"
+        cp -R "$src" "$dst"
+        echo "Seeded $dst from $src"
 
   # --- Formatting ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,6 +20,20 @@ vars:
   EMBED_SOURCES:
     sh: 'uv run -p ">=3.11" --no-project python tools/list_embeds.py'
 
+env:
+  # Isolate golangci-lint's results cache per worktree. Its cache key is a hash
+  # of file *contents*, but each cached issue stores the file's *absolute* path.
+  # Two worktrees with byte-identical packages (the near-static tools/ module is
+  # the usual culprit) get a cross-worktree cache hit, so the second inherits the
+  # first's absolute paths; the //nolint processor then re-opens those paths to
+  # apply suppressions and, when the other worktree was deleted, can't — so
+  # suppressed issues leak through as phantom failures pointing at a gone path.
+  # The default shared cache (~/Library/Caches/golangci-lint) is machine-global;
+  # rooting it under the gitignored per-worktree .task/ makes contamination
+  # impossible. CI is unaffected: it runs a single checkout and never persists
+  # this directory (setup-go caches only the Go build cache).
+  GOLANGCI_LINT_CACHE: '{{.ROOT_DIR}}/.task/golangci-lint'
+
 # pydabs-* tasks live in python/Taskfile.yml so `task pydabs-foo` works when
 # run from python/. Flattened so they keep their `pydabs-` names at the root.
 includes:
@@ -113,8 +127,10 @@ tasks:
   #   -j=4 — cap analyzer concurrency; higher values use more CPU without
   #     reducing wall time on this codebase.
   #
-  # Cross-worktree concurrency relies on content-addressable cache keys added
-  # in golangci-lint v2.12.0; keep the binary at v2.12.0+ in tools/go.mod.
+  # Concurrent cross-worktree runs rely on content-addressable cache keys added
+  # in golangci-lint v2.12.0; keep the binary at v2.12.0+ in tools/go.mod. Those
+  # keys don't cover the deleted-worktree case (stale absolute paths in cached
+  # issues) — the per-worktree GOLANGCI_LINT_CACHE in the top-level `env:` does.
   lint-go:
     desc: Lint Go files across all modules (root, tools, codegen)
     deps: ['lint-go-root', 'lint-go-tools', 'lint-go-codegen']


### PR DESCRIPTION
## Problem

Running lint from a worktree under `~/pub/cli.worktrees/*` intermittently fails with **phantom lint issues pointing at file paths in *other* worktrees** — including deleted ones (`failed to parse file … no such file or directory`).

golangci-lint keys its results cache on file **contents** but stores each cached issue's **absolute path**. Two worktrees with byte-identical packages (the near-static `tools/` module is the usual culprit) get a cross-worktree cache hit in the machine-global `~/Library/Caches/golangci-lint`, so the second worktree inherits the first's absolute paths. The `//nolint` post-processor then re-opens those paths to apply suppressions; when the other worktree has been deleted the open fails, so suppressed issues (e.g. `dupword`) **leak through as phantom failures**.

**Upstream:** this is [golangci/golangci-lint#6656](https://github.com/golangci/golangci-lint/issues/6656), closed as an **accepted trade-off** (won't-fix, no opt-out flag shipped) of the shared-cache work in [#6445](https://github.com/golangci/golangci-lint/pull/6445) ("decrease cache entropy", which dropped the path from the cache key in v2.12.0). The maintainer's position: *"the core of linters is required absolute paths."* A commenter reproduced the exact `//nolint`-leak variant. #6445 also notes concurrent cross-worktree runs on the shared cache are unsafe (file races).

## Fix

Set `GOLANGCI_LINT_CACHE` to a per-worktree path (`{{.ROOT_DIR}}/.task/golangci-lint`) in a top-level `env:` block, so the cache lives under each worktree's already-gitignored `.task/`. No two worktrees can share it → contamination is structurally impossible.

Verified with disposable worktrees (create A → lint → delete A → lint identical B): 3 phantom `dupword` failures before, `0 issues` after. **CI is unaffected**: the `lint` job runs a single clean checkout and never persists this directory (`setup-go` caches only the Go build cache).

## Performance trade-off (measured)

Isolation removes cross-worktree cache reuse, so a fresh worktree's **first full lint** runs cold. Measured on the root module with the shared `go-build` cache kept warm (only golangci-lint's own issues cache is affected):

| Scenario | Time |
|---|---|
| `task lint` warm (steady state) | ~20s |
| `task lint` **cold** golangci, warm go-build (fresh worktree, our change) | ~100–146s |
| `task lint` fresh worktree reusing shared cache (today's default) | ~14s |
| **`task lint-q`** (incremental, the default `./task` dev loop) cold **or** warm | **<0.5s** |

So the penalty **only** hits full `task lint` / `full` / `all`. The everyday `./task` loop (`lint-q`, changed files only) is unaffected.

Two mitigations for developers with many worktrees:

- **Opt-out:** Task's `env:` yields to an inherited value, so `export GOLANGCI_LINT_CACHE=~/Library/Caches/golangci-lint` restores cross-worktree reuse with no Taskfile edit.
- **`task seed-lint-cache`:** copies the main worktree's cache into the current one so the first full lint runs warm (~4s in testing). Safe because the main worktree is permanent, so its cached issue paths always resolve; no-ops when `GOLANGCI_LINT_CACHE` is overridden.

## Testing

Reproduced the failure and confirmed the fix, the opt-out precedence, and the seed task end-to-end using disposable detached worktrees. `yamlfmt -lint` clean.

This pull request and its description were written by Isaac.