### PR TITLE
acc: Fix mlops-stacks deploy test for upstream stacks_version 0.5

### DIFF
--- a/acceptance/bundle/deploy/mlops-stacks/config.json.tmpl
+++ b/acceptance/bundle/deploy/mlops-stacks/config.json.tmpl
@@ -1,6 +1,5 @@
 {
   "input_project_name": "project_name_$UNIQUE_NAME",
   "input_root_dir": "test_repo_mlops_stacks",
-  "input_include_models_in_unity_catalog": "no",
   "input_cloud": "$CLOUD_ENV_BASE"
 }

--- a/acceptance/bundle/deploy/mlops-stacks/out.test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/out.test.toml
@@ -1,3 +1,4 @@
 Local = false
 Cloud = true
+RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy/mlops-stacks/output.txt
+++ b/acceptance/bundle/deploy/mlops-stacks/output.txt
@@ -3,8 +3,12 @@
 {
   "input_project_name": "project_name_[UNIQUE_NAME]",
   "input_root_dir": "test_repo_mlops_stacks",
-  "input_include_models_in_unity_catalog": "no",
   "input_cloud": "[CLOUD_ENV_BASE]"
+}
+
+>>> [CLI] schemas create project_name_[UNIQUE_NAME] main
+{
+  "full_name": "main.project_name_[UNIQUE_NAME]"
 }
 
 >>> [CLI] bundle init mlops-stacks --config-file config.json
@@ -20,14 +24,14 @@ Please refer to the README.md for further instructions on getting started.
 This directory contains an ML project based on the default
 [Databricks MLOps Stacks](https://github.com/databricks/mlops-stacks),
 
->>> [CLI] bundle summary
+>>> [CLI] bundle summary --var catalog_name=main
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 Name: project_name_[UNIQUE_NAME]
 Target: dev
@@ -46,19 +50,19 @@ Resources:
     model_training_job:
       Name: [dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model-training-job
       URL:  (not deployed)
-  Models:
+  Registered Models:
     model:
-      Name: [dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model
+      Name: dev_[USERNAME]_project_name_[UNIQUE_NAME]-model
       URL:  (not deployed)
 
->>> [CLI] bundle validate
+>>> [CLI] bundle validate --var catalog_name=main
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 Name: project_name_[UNIQUE_NAME]
 Target: dev
@@ -68,32 +72,32 @@ Workspace:
 
 Found 2 warnings
 
->>> [CLI] bundle deploy
+>>> [CLI] bundle deploy --var catalog_name=main
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
 
->>> [CLI] bundle summary -o json
+>>> [CLI] bundle summary --var catalog_name=main -o json
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 {
   "experiment_id": "[NUMID]",
-  "model_id": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-model",
+  "model_id": "main.project_name_[UNIQUE_NAME].dev_[USERNAME]_project_name_[UNIQUE_NAME]-model",
   "inference_job_id": "[NUMID]",
   "training_job_id": "[NUMID]"
 }
@@ -101,40 +105,50 @@ Warning: unknown field: description
 === Assert the batch inference job actually exists
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 {
   "name": "[dev [USERNAME]] dev-project_name_[UNIQUE_NAME]-batch-inference-job"
 }
 
->>> [CLI] bundle destroy --auto-approve
+>>> [CLI] bundle destroy --var catalog_name=main --auto-approve
 Warning: expected a string value, found null
   at targets.dev.workspace.host
-  in databricks.yml:34:12
+  in databricks.yml:37:12
 
 Warning: unknown field: description
   at resources.experiments.experiment
-  in resources/ml-artifacts-resource.yml:21:7
+  in resources/ml-artifacts-resource.yml:28:7
 
 The following resources will be deleted:
   delete resources.experiments.experiment
   delete resources.jobs.batch_inference_job
   delete resources.jobs.model_training_job
-  delete resources.models.model
+  delete resources.registered_models.model
 
 All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/project_name_[UNIQUE_NAME]/dev
 
 Deleting files...
 Destroy complete!
+
+>>> [CLI] schemas delete main.project_name_[UNIQUE_NAME]
+Warning: expected a string value, found null
+  at targets.dev.workspace.host
+  in databricks.yml:37:12
+
+Warning: unknown field: description
+  at resources.experiments.experiment
+  in resources/ml-artifacts-resource.yml:28:7
+

--- a/acceptance/bundle/deploy/mlops-stacks/script
+++ b/acceptance/bundle/deploy/mlops-stacks/script
@@ -13,24 +13,33 @@
 envsubst < config.json.tmpl > config.json
 trace cat config.json
 
+# The template hard-codes the model's schema name to the project name and always
+# registers the model in Unity Catalog, so the schema must already exist in the
+# target catalog. Create it in the shared "main" catalog (the convention used by
+# other cloud UC acceptance tests) and override catalog_name to match.
+SCHEMA_NAME="project_name_${UNIQUE_NAME}"
+
 cleanup() {
-  trace $CLI bundle destroy --auto-approve
+  trace $CLI bundle destroy --var catalog_name=main --auto-approve
+  trace $CLI schemas delete "main.${SCHEMA_NAME}"
   cd ../..
   rm -rf test_repo_mlops_stacks
 }
 trap cleanup EXIT
+
+trace $CLI schemas create "${SCHEMA_NAME}" main | jq '{full_name}'
 
 trace $CLI bundle init mlops-stacks --config-file config.json
 trace cat test_repo_mlops_stacks/README.md | head -n 4
 
 cd "test_repo_mlops_stacks/project_name_${UNIQUE_NAME}" || exit 1
 
-trace $CLI bundle summary
-trace $CLI bundle validate
-trace $CLI bundle deploy
+trace $CLI bundle summary --var catalog_name=main
+trace $CLI bundle validate --var catalog_name=main
+trace $CLI bundle deploy --var catalog_name=main
 
-trace $CLI bundle summary -o json | jq -r '{experiment_id: .resources.experiments.experiment.id, model_id: .resources.models.model.id, inference_job_id: .resources.jobs.batch_inference_job.id, training_job_id: .resources.jobs.model_training_job.id}'
+trace $CLI bundle summary --var catalog_name=main -o json | jq -r '{experiment_id: .resources.experiments.experiment.id, model_id: .resources.registered_models.model.id, inference_job_id: .resources.jobs.batch_inference_job.id, training_job_id: .resources.jobs.model_training_job.id}'
 
 title "Assert the batch inference job actually exists\n"
-JOB_ID=$($CLI bundle summary -o json | jq -r '.resources.jobs.batch_inference_job.id')
+JOB_ID=$($CLI bundle summary --var catalog_name=main -o json | jq -r '.resources.jobs.batch_inference_job.id')
 $CLI jobs get "${JOB_ID}" | jq '{name: .settings.name}'

--- a/acceptance/bundle/deploy/mlops-stacks/test.toml
+++ b/acceptance/bundle/deploy/mlops-stacks/test.toml
@@ -1,6 +1,12 @@
 Cloud=true
 Local=false
 
+# The MLOps Stacks template registers the model in Unity Catalog and runs its
+# jobs on serverless compute, so this test only works on a UC-enabled workspace
+# (which also has serverless jobs). Gate on UC so it skips on the non-UC cloud
+# envs instead of failing with METASTORE_DOES_NOT_EXIST.
+RequiresUnityCatalog = true
+
 Badness = "the newly initialized bundle from the 'mlops-stacks' template contains two validation warnings in the configuration"
 
 Ignore = [


### PR DESCRIPTION
## Why

The `bundle/deploy/mlops-stacks` acceptance test deploys the upstream [MLOps Stacks](https://github.com/databricks/mlops-stacks) template end-to-end, so upstream template changes can break it. Upstream bumped to `stacks_version 0.5`, which reworked the scaffold:

- The `input_include_models_in_unity_catalog` toggle was **removed** — the model is now always registered in Unity Catalog (`resources.registered_models` instead of the legacy `resources.models`).
- Jobs now run on **serverless compute by default**.

The old test failed in every nightly env: the golden still expected the legacy `models` resource (and stale warning line numbers), and `bundle deploy` could no longer create the UC model or serverless jobs on the test workspaces.

## What

Fix the test forward to match the new template:

- Drop the removed `input_include_models_in_unity_catalog` option from the init config.
- The template hard-codes the model's schema name to the project name, so the schema must exist before deploy. Create it in the shared `main` catalog and deploy with `--var catalog_name=main` — mirroring the `main`-catalog + `schema-$UNIQUE_NAME` convention already used by other cloud UC acceptance tests. Drop the schema in cleanup.
- Read the model id from `resources.registered_models.model` in the summary assertion.
- Gate the test with `RequiresUnityCatalog = true` so it skips on the non-UC cloud envs (which have no metastore) instead of failing with `METASTORE_DOES_NOT_EXIST`.

## Tests

Verified end-to-end on the real nightly UC + serverless env `aws-prod-ucws` — both engine variants pass and produce identical output:

```
--- PASS: TestAccept/bundle/deploy/mlops-stacks/DATABRICKS_BUNDLE_ENGINE=direct (28.93s)
--- PASS: TestAccept/bundle/deploy/mlops-stacks/DATABRICKS_BUNDLE_ENGINE=terraform (41.75s)
```

The full deploy → assert batch-inference job → destroy → drop-schema cycle completes cleanly with no leaked resources. Test-only change, so no changelog fragment (per pr-checklist).

This pull request and its description were written by Isaac.