### PR TITLE
Rename remaining "Databricks Asset Bundles" references to "Declarative Automation Bundles"

### DIFF
--- a/.nextchanges/cli/dab-rename-stragglers.md
+++ b/.nextchanges/cli/dab-rename-stragglers.md
@@ -1,0 +1,1 @@
+Renamed remaining "Databricks Asset Bundles" references to "Declarative Automation Bundles" in CLI help text, quickstart docs, and project templates.

--- a/.nextchanges/cli/dab-rename-stragglers.md
+++ b/.nextchanges/cli/dab-rename-stragglers.md
@@ -1,1 +1,0 @@
-Renamed remaining "Databricks Asset Bundles" references to "Declarative Automation Bundles" in CLI help text, quickstart docs, and project templates.

--- a/acceptance/bundle/help/bundle-schema/output.txt
+++ b/acceptance/bundle/help/bundle-schema/output.txt
@@ -3,7 +3,7 @@
 Generate JSON Schema for bundle configuration to enable validation and autocomplete.
 
 This command outputs the JSON Schema that describes the structure and validation
-rules for Databricks Asset Bundle configuration files.
+rules for Declarative Automation Bundle configuration files.
 
 Common use cases:
 - Configure IDE/editor validation for databricks.yml files

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_project.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/dbt_project.yml
@@ -6,7 +6,7 @@ config-version: 2
 profile: 'my_dbt_sql'
 
 # These configurations specify where dbt should look for different types of files.
-# For Databricks asset bundles, we put everything in src, as you may have
+# For Declarative Automation Bundles, we put everything in src, as you may have
 # non-dbt resources in your project.
 model-paths: ["src/models"]
 analysis-paths: ["src/analyses"]

--- a/acceptance/bundle/templates/default-minimal/output.txt
+++ b/acceptance/bundle/templates/default-minimal/output.txt
@@ -1,6 +1,6 @@
 
 >>> [CLI] bundle init default-minimal --config-file ./input.json --output-dir output
-Welcome to the minimal Databricks Asset Bundle template!
+Welcome to the minimal Declarative Automation Bundle template!
 
 This template creates a minimal project structure without sample code, ideal for advanced users.
 (For getting started with Python or SQL code, use the default-python or default-sql templates instead.)

--- a/acceptance/bundle/templates/default-minimal/output/my_default_minimal/databricks.yml
+++ b/acceptance/bundle/templates/default-minimal/output/my_default_minimal/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_minimal.
+# This is a Declarative Automation Bundle definition for my_default_minimal.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_minimal

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/databricks.yml
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_python.
+# This is a Declarative Automation Bundle definition for my_default_python.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_python

--- a/acceptance/bundle/templates/default-python/serverless/output/my_default_python/databricks.yml
+++ b/acceptance/bundle/templates/default-python/serverless/output/my_default_python/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_python.
+# This is a Declarative Automation Bundle definition for my_default_python.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_python

--- a/acceptance/bundle/templates/default-scala/output/my_default_scala/databricks.yml
+++ b/acceptance/bundle/templates/default-scala/output/my_default_scala/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_scala.
+# This is a Declarative Automation Bundle definition for my_default_scala.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_scala

--- a/acceptance/bundle/templates/default-sql/output/my_default_sql/databricks.yml
+++ b/acceptance/bundle/templates/default-sql/output/my_default_sql/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_sql.
+# This is a Declarative Automation Bundle definition for my_default_sql.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_sql

--- a/acceptance/bundle/templates/lakeflow-integrations/output/my_lakeflow_integrations/databricks.yml
+++ b/acceptance/bundle/templates/lakeflow-integrations/output/my_lakeflow_integrations/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_lakeflow_integrations.
+# This is a Declarative Automation Bundle definition for my_lakeflow_integrations.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_lakeflow_integrations

--- a/acceptance/bundle/templates/lakeflow-pipelines/python/output/my_lakeflow_pipelines/databricks.yml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/python/output/my_lakeflow_pipelines/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_lakeflow_pipelines.
+# This is a Declarative Automation Bundle definition for my_lakeflow_pipelines.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_lakeflow_pipelines

--- a/acceptance/bundle/templates/lakeflow-pipelines/sql/output/my_lakeflow_pipelines/databricks.yml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/sql/output/my_lakeflow_pipelines/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_lakeflow_pipelines.
+# This is a Declarative Automation Bundle definition for my_lakeflow_pipelines.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_lakeflow_pipelines

--- a/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/databricks.yml
+++ b/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_pydabs.
+# This is a Declarative Automation Bundle definition for my_pydabs.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_pydabs

--- a/acceptance/bundle/templates/telemetry/default-python/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/default-python/out.databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_python.
+# This is a Declarative Automation Bundle definition for my_default_python.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_python

--- a/acceptance/bundle/templates/telemetry/default-sql/out.databricks.yml
+++ b/acceptance/bundle/templates/telemetry/default-sql/out.databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_default_sql.
+# This is a Declarative Automation Bundle definition for my_default_sql.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_default_sql

--- a/acceptance/bundle/variables/prepend-workspace-var/databricks.yml
+++ b/acceptance/bundle/variables/prepend-workspace-var/databricks.yml
@@ -7,7 +7,7 @@ workspace:
 
 variables:
   workspace_root:
-    description: "root directory in the Databricks workspace to store the asset bundle and associated artifacts"
+    description: "root directory in the Databricks workspace to store the Declarative Automation Bundle and associated artifacts"
     default: /Users/${workspace.current_user.userName}
 
 targets:

--- a/acceptance/bundle/variables/prepend-workspace-var/output.txt
+++ b/acceptance/bundle/variables/prepend-workspace-var/output.txt
@@ -52,7 +52,7 @@ Warning: required field "package_name" is not set
   "variables": {
     "workspace_root": {
       "default": "/Users/[USERNAME]",
-      "description": "root directory in the Databricks workspace to store the asset bundle and associated artifacts",
+      "description": "root directory in the Databricks workspace to store the Declarative Automation Bundle and associated artifacts",
       "value": "/Users/[USERNAME]"
     }
   },

--- a/acceptance/pipelines/e2e/output/lakeflow_project/databricks.yml
+++ b/acceptance/pipelines/e2e/output/lakeflow_project/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for lakeflow_project.
+# This is a Declarative Automation Bundle definition for lakeflow_project.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: lakeflow_project

--- a/acceptance/pipelines/init/python/output/my_python_project/databricks.yml
+++ b/acceptance/pipelines/init/python/output/my_python_project/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_python_project.
+# This is a Declarative Automation Bundle definition for my_python_project.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_python_project

--- a/acceptance/pipelines/init/sql/output/my_sql_project/databricks.yml
+++ b/acceptance/pipelines/init/sql/output/my_sql_project/databricks.yml
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for my_sql_project.
+# This is a Declarative Automation Bundle definition for my_sql_project.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: my_sql_project

--- a/acceptance/quickstart/output.txt
+++ b/acceptance/quickstart/output.txt
@@ -1,11 +1,11 @@
 # Databricks Quickstart
 
-The `databricks` CLI wraps the public Databricks REST API — there's a command for essentially every API endpoint, so almost any Databricks task can be driven from here. If something looks unsupported, it's almost always a command you haven't found yet, not a real gap. The headline workflow: build durable resources as code with **Databricks Asset Bundles (DABs)** and ship them with `databricks bundle deploy` (see Build and deploy below).
+The `databricks` CLI wraps the public Databricks REST API — there's a command for essentially every API endpoint, so almost any Databricks task can be driven from here. If something looks unsupported, it's almost always a command you haven't found yet, not a real gap. The headline workflow: build durable resources as code with **Declarative Automation Bundles (DABs)** and ship them with `databricks bundle deploy` (see Build and deploy below).
 
 ## Golden rules
 
 - **Reason, don't refuse.** Before telling the user something can't be done, run `databricks <group> --help` and install the matching skill (below). Almost everything is reachable through the CLI.
-- **Build with bundles.** For anything durable — jobs, pipelines, dashboards, apps — define it as code in a Databricks Asset Bundle (DABs) and ship with `databricks bundle deploy`, not one-off API calls.
+- **Build with bundles.** For anything durable — jobs, pipelines, dashboards, apps — define it as code in a Declarative Automation Bundle (DABs) and ship with `databricks bundle deploy`, not one-off API calls.
 - **Pick the profile deliberately.** Run `databricks auth profiles`. If only one profile exists, use it. If one is already set as the default (via `databricks auth switch`), assume that one — you can confirm if unsure. Otherwise, show the user the profiles with their workspace URLs and let them choose. Don't invent profile names.
 - **Always pass `--profile <name>`.** Each Bash command runs in its own shell, so a separate `export DATABRICKS_CONFIG_PROFILE=...` line does NOT persist. Use the flag, or chain with `&&`.
 - **OAuth, never PAT.** Authenticate with `databricks auth login`, not personal access tokens.
@@ -25,7 +25,7 @@ No host needed: without `--host`, login opens login.databricks.com and the user 
 databricks current-user me --profile <name>
 ```
 
-## Build and deploy with Asset Bundles (DABs)
+## Build and deploy with Declarative Automation Bundles (DABs)
 
 **DABs are the standard, recommended way to build on Databricks.** A bundle is a project with a `databricks.yml` that declares your resources (jobs, pipelines, dashboards, apps) and its targets (e.g. dev, prod) — one project, one deploy, every resource type:
 

--- a/cmd/bundle/schema.go
+++ b/cmd/bundle/schema.go
@@ -13,7 +13,7 @@ func newSchemaCommand() *cobra.Command {
 		Long: `Generate JSON Schema for bundle configuration to enable validation and autocomplete.
 
 This command outputs the JSON Schema that describes the structure and validation
-rules for Databricks Asset Bundle configuration files.
+rules for Declarative Automation Bundle configuration files.
 
 Common use cases:
 - Configure IDE/editor validation for databricks.yml files

--- a/cmd/labs/project/entrypoint.go
+++ b/cmd/labs/project/entrypoint.go
@@ -204,7 +204,7 @@ func (e *Entrypoint) getLoginConfig(cmd *cobra.Command) (*loginConfig, *config.C
 		ctx := cmd.Context()
 		b := root.TryConfigureBundle(cmd)
 		if b != nil {
-			log.Infof(ctx, "Using login configuration from Databricks Asset Bundle")
+			log.Infof(ctx, "Using login configuration from Declarative Automation Bundle")
 			return &loginConfig{}, b.WorkspaceClient(ctx).Config, nil
 		}
 	}

--- a/cmd/quickstart/quickstart-agent.md
+++ b/cmd/quickstart/quickstart-agent.md
@@ -5,12 +5,12 @@ description: First-contact orientation for the Databricks CLI when no Databricks
 
 # Databricks Quickstart
 
-The `databricks` CLI wraps the public Databricks REST API — there's a command for essentially every API endpoint, so almost any Databricks task can be driven from here. If something looks unsupported, it's almost always a command you haven't found yet, not a real gap. The headline workflow: build durable resources as code with **Databricks Asset Bundles (DABs)** and ship them with `databricks bundle deploy` (see Build and deploy below).
+The `databricks` CLI wraps the public Databricks REST API — there's a command for essentially every API endpoint, so almost any Databricks task can be driven from here. If something looks unsupported, it's almost always a command you haven't found yet, not a real gap. The headline workflow: build durable resources as code with **Declarative Automation Bundles (DABs)** and ship them with `databricks bundle deploy` (see Build and deploy below).
 
 ## Golden rules
 
 - **Reason, don't refuse.** Before telling the user something can't be done, run `databricks <group> --help` and install the matching skill (below). Almost everything is reachable through the CLI.
-- **Build with bundles.** For anything durable — jobs, pipelines, dashboards, apps — define it as code in a Databricks Asset Bundle (DABs) and ship with `databricks bundle deploy`, not one-off API calls.
+- **Build with bundles.** For anything durable — jobs, pipelines, dashboards, apps — define it as code in a Declarative Automation Bundle (DABs) and ship with `databricks bundle deploy`, not one-off API calls.
 - **Pick the profile deliberately.** Run `databricks auth profiles`. If only one profile exists, use it. If one is already set as the default (via `databricks auth switch`), assume that one — you can confirm if unsure. Otherwise, show the user the profiles with their workspace URLs and let them choose. Don't invent profile names.
 - **Always pass `--profile <name>`.** Each Bash command runs in its own shell, so a separate `export DATABRICKS_CONFIG_PROFILE=...` line does NOT persist. Use the flag, or chain with `&&`.
 - **OAuth, never PAT.** Authenticate with `databricks auth login`, not personal access tokens.
@@ -30,7 +30,7 @@ No host needed: without `--host`, login opens login.databricks.com and the user 
 databricks current-user me --profile <name>
 ```
 
-## Build and deploy with Asset Bundles (DABs)
+## Build and deploy with Declarative Automation Bundles (DABs)
 
 **DABs are the standard, recommended way to build on Databricks.** A bundle is a project with a `databricks.yml` that declares your resources (jobs, pipelines, dashboards, apps) and its targets (e.g. dev, prod) — one project, one deploy, every resource type:
 

--- a/cmd/quickstart/quickstart-human.md
+++ b/cmd/quickstart/quickstart-human.md
@@ -39,7 +39,7 @@ Got more than one workspace? Name each at login (`databricks auth login --profil
 
 ## Step 3 — Build something
 
-The standard way to build on Databricks is **Databricks Asset Bundles (DABs)** — your jobs, pipelines, dashboards, and apps defined as code in one project, shipped with one command:
+The standard way to build on Databricks is **Declarative Automation Bundles (DABs)** — your jobs, pipelines, dashboards, and apps defined as code in one project, shipped with one command:
 
 ```bash
 databricks bundle init                 # start from a template

--- a/cmd/quickstart/quickstart.go
+++ b/cmd/quickstart/quickstart.go
@@ -28,7 +28,7 @@ func New() *cobra.Command {
 		Args:  root.NoArgs,
 		Short: "Print an introduction to the Databricks CLI",
 		Long: `Print a short introduction to the Databricks CLI: authentication, profiles,
-building with Databricks Asset Bundles, and where to go next.
+building with Declarative Automation Bundles, and where to go next.
 
 Prints a human-friendly guide by default. When stdout is not an interactive
 terminal (for example, when a coding agent runs the command), it prints a

--- a/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_project.yml.tmpl
+++ b/libs/template/templates/dbt-sql/template/{{.project_name}}/dbt_project.yml.tmpl
@@ -6,7 +6,7 @@ config-version: 2
 profile: '{{.project_name}}'
 
 # These configurations specify where dbt should look for different types of files.
-# For Databricks asset bundles, we put everything in src, as you may have
+# For Declarative Automation Bundles, we put everything in src, as you may have
 # non-dbt resources in your project.
 model-paths: ["src/models"]
 analysis-paths: ["src/analyses"]

--- a/libs/template/templates/default-minimal/databricks_template_schema.json
+++ b/libs/template/templates/default-minimal/databricks_template_schema.json
@@ -1,6 +1,6 @@
 {
     "template_dir": "../default",
-    "welcome_message": "Welcome to the minimal Databricks Asset Bundle template!\n\nThis template creates a minimal project structure without sample code, ideal for advanced users.\n(For getting started with Python or SQL code, use the default-python or default-sql templates instead.)\n\nYour workspace at {{workspace_host}} is used for initialization.\n(See https://docs.databricks.com/dev-tools/cli/profiles.html for how to change your profile.)",
+    "welcome_message": "Welcome to the minimal Declarative Automation Bundle template!\n\nThis template creates a minimal project structure without sample code, ideal for advanced users.\n(For getting started with Python or SQL code, use the default-python or default-sql templates instead.)\n\nYour workspace at {{workspace_host}} is used for initialization.\n(See https://docs.databricks.com/dev-tools/cli/profiles.html for how to change your profile.)",
     "properties": {
         "template_name": {
             "//": "This property is always set to 'default-minimal'",

--- a/libs/template/templates/default-scala/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-scala/template/{{.project_name}}/databricks.yml.tmpl
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for {{.project_name}}.
+# This is a Declarative Automation Bundle definition for {{.project_name}}.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}

--- a/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default-sql/template/{{.project_name}}/databricks.yml.tmpl
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for {{.project_name}}.
+# This is a Declarative Automation Bundle definition for {{.project_name}}.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}

--- a/libs/template/templates/default/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/default/template/{{.project_name}}/databricks.yml.tmpl
@@ -1,7 +1,7 @@
 {{$with_classic := (ne .serverless "yes") -}}
 {{$with_python := (eq .include_python "yes") -}}
 {{$with_pydabs := (eq .enable_pydabs "yes") -}}
-# This is a Databricks asset bundle definition for {{.project_name}}.
+# This is a Declarative Automation Bundle definition for {{.project_name}}.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}

--- a/libs/template/templates/lakeflow-integrations/template/{{.project_name}}/databricks.yml.tmpl
+++ b/libs/template/templates/lakeflow-integrations/template/{{.project_name}}/databricks.yml.tmpl
@@ -1,4 +1,4 @@
-# This is a Databricks asset bundle definition for {{.project_name}}.
+# This is a Declarative Automation Bundle definition for {{.project_name}}.
 # See https://docs.databricks.com/dev-tools/bundles/index.html for documentation.
 bundle:
   name: {{.project_name}}


### PR DESCRIPTION
## Summary

The rename from "Databricks Asset Bundles" to "Declarative Automation Bundles" left some stragglers in the codebase. This PR finds and renames the remaining hand-written references:

- **CLI help text**: `bundle schema` long description, `quickstart` command description, and the labs login-config info log.
- **Quickstart docs**: `quickstart-human.md` and `quickstart-agent.md` (keeping the `(DABs)` abbreviation, matching `AGENTS.md`).
- **Project template sources** under `libs/template/templates/`: the `databricks.yml.tmpl` header comments (default, default-sql, default-scala, lakeflow-integrations), the dbt-sql `dbt_project.yml.tmpl` comment, and the default-minimal welcome message.
- **Acceptance fixture** `prepend-workspace-var/databricks.yml` variable description.

Regenerated acceptance outputs and materialized templates accordingly (`test-update-templates` + targeted `-update` runs).

## Left untouched (intentional)

- `CHANGELOG.md` — generated + historical record of past release names.
- `AGENTS.md` — the "formerly known as Databricks Asset Bundles" line is deliberate context.
- `.codegen/cli.json` and `bundle/schema/jsonschema.json` — the `DeploymentKind` enum descriptions come from the upstream OpenAPI spec; editing them would diverge and be overwritten on regeneration.

## Testing

- `./task build`, `./task fmt`, `./task lint-q` — clean.
- Affected acceptance tests pass (quickstart, pipelines/init, bundle/help/bundle-schema, prepend-workspace-var, bundle/templates).

This pull request and its description were written by Isaac, an AI coding agent.