### PR TITLE
Run "Changelog Preview" on pushes to main

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,12 +1,14 @@
 name: Changelog Preview
 
-# Renders the CHANGELOG.md section the next release would generate from this
-# PR's .nextchanges/ fragments into this check's job summary, so reviewers see
-# the rendered changelog without cutting a release. Fails the check if a
-# fragment is misplaced (so it can't be silently skipped by the renderer).
+# Renders the CHANGELOG.md section the next release would generate from the
+# .nextchanges/ fragments into this check's job summary, so reviewers see the
+# rendered changelog without cutting a release. Fails the check if a fragment
+# is misplaced (so it can't be silently skipped by the renderer).
 #
-# Uses `pull_request` with a read-only token: it renders the PR's own
-# .nextchanges/ content and never needs write credentials.
+# Runs on pull requests (rendering the PR's own .nextchanges/ content) and on
+# pushes to main (so anyone can view the preview for any commit on main). Uses
+# a read-only token: it only reads .nextchanges/ and never needs write
+# credentials.
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -15,6 +17,9 @@ on:
       - "internal/genkit/**"
       - "tools/validate_nextchanges.py"
       - "tools/update_github_links.py"
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Changes
Run the Changelog Preview workflow on every push to main

## Why
To allow preview at any state after we fragmented changelog entries into .nextchanges/
