### PR TITLE
acc: keep heredoc created files checked in

### DIFF
--- a/acceptance/auth/bundle_default_profile/home/.databrickscfg.tmpl
+++ b/acceptance/auth/bundle_default_profile/home/.databrickscfg.tmpl
@@ -1,0 +1,10 @@
+[default-target]
+host  = $DATABRICKS_HOST
+token = $DATABRICKS_TOKEN
+
+[other]
+host  = https://other.test
+token = other-token
+
+[__settings__]
+default_profile = default-target

--- a/acceptance/auth/bundle_default_profile/script
+++ b/acceptance/auth/bundle_default_profile/script
@@ -3,18 +3,7 @@ sethome "./home"
 # Save the test server host so we can pin a bundle-with-host variant below.
 host_value="$DATABRICKS_HOST"
 
-cat > "./home/.databrickscfg" <<EOF
-[default-target]
-host  = $DATABRICKS_HOST
-token = $DATABRICKS_TOKEN
-
-[other]
-host  = https://other.test
-token = other-token
-
-[__settings__]
-default_profile = default-target
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 unset DATABRICKS_HOST
 unset DATABRICKS_TOKEN

--- a/acceptance/auth/host-metadata-cache/home/.databrickscfg.tmpl
+++ b/acceptance/auth/host-metadata-cache/home/.databrickscfg.tmpl
@@ -1,0 +1,3 @@
+[cached]
+host = ${DATABRICKS_HOST}
+token = test-token

--- a/acceptance/auth/host-metadata-cache/script
+++ b/acceptance/auth/host-metadata-cache/script
@@ -4,11 +4,7 @@ export DATABRICKS_CACHE_DIR="$TEST_TMP_DIR/cache"
 # Point a profile at the mock server so auth profiles triggers a host metadata
 # fetch. Validation must stay on: --skip-validate resolves offline and would
 # never fetch or populate the cache.
-cat > "./home/.databrickscfg" <<EOF
-[cached]
-host = ${DATABRICKS_HOST}
-token = test-token
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "First invocation populates the cache\n"
 $CLI auth profiles --output json

--- a/acceptance/bundle/multi_profile/auto_select/databricks.yml
+++ b/acceptance/bundle/multi_profile/auto_select/databricks.yml
@@ -1,2 +1,5 @@
 bundle:
   name: multi-profile-auto-select
+
+workspace:
+  host: $DATABRICKS_HOST

--- a/acceptance/bundle/multi_profile/auto_select/script
+++ b/acceptance/bundle/multi_profile/auto_select/script
@@ -1,15 +1,7 @@
-# Set up .databrickscfg with two profiles for the same host:
-# one workspace profile and one account profile.
+# Substitute the actual host URL into the checked-in .databrickscfg (two profiles
+# for the same host: one workspace, one account) and databricks.yml.
 envsubst < .databrickscfg > out && mv out .databrickscfg
-
-# Write databricks.yml with the actual host URL.
-cat > databricks.yml << EOF
-bundle:
-  name: multi-profile-auto-select
-
-workspace:
-  host: $DATABRICKS_HOST
-EOF
+envsubst < databricks.yml > out && mv out databricks.yml
 
 export DATABRICKS_CONFIG_FILE=.databrickscfg
 unset DATABRICKS_HOST

--- a/acceptance/bundle/multi_profile/env_auth_skip/databricks.yml
+++ b/acceptance/bundle/multi_profile/env_auth_skip/databricks.yml
@@ -1,2 +1,5 @@
 bundle:
   name: multi-profile-env-skip
+
+workspace:
+  host: $DATABRICKS_HOST

--- a/acceptance/bundle/multi_profile/env_auth_skip/script
+++ b/acceptance/bundle/multi_profile/env_auth_skip/script
@@ -1,13 +1,7 @@
-# Set up .databrickscfg with two workspace profiles for the same host.
+# Substitute the actual host URL into the checked-in .databrickscfg (two
+# workspace profiles for the same host) and databricks.yml.
 envsubst < .databrickscfg > out && mv out .databrickscfg
-
-cat > databricks.yml << EOF
-bundle:
-  name: multi-profile-env-skip
-
-workspace:
-  host: $DATABRICKS_HOST
-EOF
+envsubst < databricks.yml > out && mv out databricks.yml
 
 export DATABRICKS_CONFIG_FILE=.databrickscfg
 # Keep DATABRICKS_HOST and DATABRICKS_TOKEN set — env auth takes precedence

--- a/acceptance/bundle/multi_profile/no_workspace_profiles/databricks.yml
+++ b/acceptance/bundle/multi_profile/no_workspace_profiles/databricks.yml
@@ -1,2 +1,5 @@
 bundle:
   name: multi-profile-no-ws
+
+workspace:
+  host: $DATABRICKS_HOST

--- a/acceptance/bundle/multi_profile/no_workspace_profiles/script
+++ b/acceptance/bundle/multi_profile/no_workspace_profiles/script
@@ -1,13 +1,7 @@
-# Set up .databrickscfg with two account-only profiles for the same host.
+# Substitute the actual host URL into the checked-in .databrickscfg (two
+# account-only profiles for the same host) and databricks.yml.
 envsubst < .databrickscfg > out && mv out .databrickscfg
-
-cat > databricks.yml << EOF
-bundle:
-  name: multi-profile-no-ws
-
-workspace:
-  host: $DATABRICKS_HOST
-EOF
+envsubst < databricks.yml > out && mv out databricks.yml
 
 export DATABRICKS_CONFIG_FILE=.databrickscfg
 unset DATABRICKS_HOST

--- a/acceptance/bundle/multi_profile/non_interactive_error/databricks.yml
+++ b/acceptance/bundle/multi_profile/non_interactive_error/databricks.yml
@@ -1,2 +1,5 @@
 bundle:
   name: multi-profile-non-interactive
+
+workspace:
+  host: $DATABRICKS_HOST

--- a/acceptance/bundle/multi_profile/non_interactive_error/script
+++ b/acceptance/bundle/multi_profile/non_interactive_error/script
@@ -1,13 +1,7 @@
-# Set up .databrickscfg with two workspace profiles for the same host.
+# Substitute the actual host URL into the checked-in .databrickscfg (two
+# workspace profiles for the same host) and databricks.yml.
 envsubst < .databrickscfg > out && mv out .databrickscfg
-
-cat > databricks.yml << EOF
-bundle:
-  name: multi-profile-non-interactive
-
-workspace:
-  host: $DATABRICKS_HOST
-EOF
+envsubst < databricks.yml > out && mv out databricks.yml
 
 export DATABRICKS_CONFIG_FILE=.databrickscfg
 unset DATABRICKS_HOST

--- a/acceptance/cmd/api/default-profile-vs-env/home/.databrickscfg
+++ b/acceptance/cmd/api/default-profile-vs-env/home/.databrickscfg
@@ -1,0 +1,7 @@
+[__settings__]
+default_profile = other
+
+[other]
+host     = https://other.cloud.databricks.test
+username = user
+password = pass

--- a/acceptance/cmd/api/default-profile-vs-env/script
+++ b/acceptance/cmd/api/default-profile-vs-env/script
@@ -1,19 +1,9 @@
 sethome "./home"
 
-# A default profile with conflicting (basic) auth on a different host. The env
-# below still points a PAT at the test server. Without the #5616 guard, the
-# default profile would be pinned and merged with the env PAT, failing with
-# "more than one authorization method configured".
-cat > "./home/.databrickscfg" <<EOF
-[__settings__]
-default_profile = other
-
-[other]
-host     = https://other.cloud.databricks.test
-username = user
-password = pass
-EOF
-
+# home/.databrickscfg is a checked-in input: a default profile with conflicting
+# (basic) auth on a different host. The env below still points a PAT at the test
+# server. Without the #5616 guard, the default profile would be pinned and merged
+# with the env PAT, failing with "more than one authorization method configured".
 title "api without --profile uses env auth, ignoring default_profile (#5616)\n"
 MSYS_NO_PATHCONV=1 trace $CLI api get /api/2.0/clusters/list
 trace print_requests.py --get //api/2.0/clusters/list

--- a/acceptance/cmd/api/default-profile/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/api/default-profile/home/.databrickscfg.tmpl
@@ -1,0 +1,10 @@
+[default-target]
+host  = $DATABRICKS_HOST
+token = $DATABRICKS_TOKEN
+
+[other]
+host  = https://other.test
+token = other-token
+
+[__settings__]
+default_profile = default-target

--- a/acceptance/cmd/api/default-profile/script
+++ b/acceptance/cmd/api/default-profile/script
@@ -3,18 +3,7 @@ sethome "./home"
 # Two profiles plus an explicit default_profile pointing at the test server.
 # The 'other' profile points at an RFC 2606 reserved host so we can assert
 # that --profile overrides default_profile without making a real request.
-cat > "./home/.databrickscfg" <<EOF
-[default-target]
-host  = $DATABRICKS_HOST
-token = $DATABRICKS_TOKEN
-
-[other]
-host  = https://other.test
-token = other-token
-
-[__settings__]
-default_profile = default-target
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 unset DATABRICKS_HOST
 unset DATABRICKS_TOKEN

--- a/acceptance/cmd/api/profile-overrides-env/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/api/profile-overrides-env/home/.databrickscfg.tmpl
@@ -1,0 +1,6 @@
+[my-workspace]
+host  = $DATABRICKS_HOST
+token = $DATABRICKS_TOKEN
+
+[host-only]
+host  = $DATABRICKS_HOST

--- a/acceptance/cmd/api/profile-overrides-env/script
+++ b/acceptance/cmd/api/profile-overrides-env/script
@@ -2,14 +2,7 @@ sethome "./home"
 
 # One profile with full credentials, one host-only; both point at the test
 # server while the auth env vars below point elsewhere.
-cat > "./home/.databrickscfg" <<EOF
-[my-workspace]
-host  = $DATABRICKS_HOST
-token = $DATABRICKS_TOKEN
-
-[host-only]
-host  = $DATABRICKS_HOST
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 # direnv-style auth env vars for a different workspace; before #5096 these
 # shadowed the profile selected with --profile.

--- a/acceptance/cmd/api/workspace-id-none/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/api/workspace-id-none/home/.databrickscfg.tmpl
@@ -1,0 +1,4 @@
+[spog-account]
+host         = $DATABRICKS_HOST
+token        = $DATABRICKS_TOKEN
+workspace_id = none

--- a/acceptance/cmd/api/workspace-id-none/script
+++ b/acceptance/cmd/api/workspace-id-none/script
@@ -2,12 +2,7 @@
 # The CLI must strip the sentinel before the header decision; the recorded
 # request should not carry the routing identifier.
 sethome "./home"
-cat > "./home/.databrickscfg" <<EOF
-[spog-account]
-host         = $DATABRICKS_HOST
-token        = $DATABRICKS_TOKEN
-workspace_id = none
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 MSYS_NO_PATHCONV=1 $CLI api get /api/2.0/clusters/list --profile spog-account
 trace print_requests.py --get //api/2.0/clusters/list | contains.py "!X-Databricks-Workspace-Id"

--- a/acceptance/cmd/auth/describe/account-host-with-workspace-id/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/describe/account-host-with-workspace-id/home/.databrickscfg.tmpl
@@ -1,0 +1,5 @@
+[acct-with-ws]
+host         = $DATABRICKS_HOST
+token        = $DATABRICKS_TOKEN
+account_id   = acct-123
+workspace_id = 900800700600

--- a/acceptance/cmd/auth/describe/account-host-with-workspace-id/script
+++ b/acceptance/cmd/auth/describe/account-host-with-workspace-id/script
@@ -3,13 +3,7 @@ sethome "./home"
 # Older logins wrote account console profiles with both account_id and
 # workspace_id, which resolves to a workspace client even though the host only
 # serves account APIs (https://github.com/databricks/cli/issues/5479).
-cat > "./home/.databrickscfg" <<EOF
-[acct-with-ws]
-host         = $DATABRICKS_HOST
-token        = $DATABRICKS_TOKEN
-account_id   = acct-123
-workspace_id = 900800700600
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Describe falls back to the account endpoint when the workspace check fails\n"
 trace $CLI auth describe --profile acct-with-ws

--- a/acceptance/cmd/auth/describe/default-profile/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/describe/default-profile/home/.databrickscfg.tmpl
@@ -1,0 +1,12 @@
+[DEFAULT]
+
+[my-workspace]
+host  = $DATABRICKS_HOST
+token = $DATABRICKS_TOKEN
+
+[other-workspace]
+host  = https://other.cloud.databricks.com
+token = other-token
+
+[__settings__]
+default_profile = my-workspace

--- a/acceptance/cmd/auth/describe/default-profile/script
+++ b/acceptance/cmd/auth/describe/default-profile/script
@@ -1,20 +1,7 @@
 sethome "./home"
 
-# Create a config with two profiles and an explicit default.
-cat > "./home/.databrickscfg" <<EOF
-[DEFAULT]
-
-[my-workspace]
-host  = $DATABRICKS_HOST
-token = $DATABRICKS_TOKEN
-
-[other-workspace]
-host  = https://other.cloud.databricks.com
-token = other-token
-
-[__settings__]
-default_profile = my-workspace
-EOF
+# A config with two profiles and an explicit default.
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 # DATABRICKS_HOST is set in the environment, so authentication is fully
 # determined by the environment and the default profile is not pinned.

--- a/acceptance/cmd/auth/describe/profile-overrides-env/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/describe/profile-overrides-env/home/.databrickscfg.tmpl
@@ -1,0 +1,6 @@
+[my-workspace]
+host  = $DATABRICKS_HOST
+token = $DATABRICKS_TOKEN
+
+[host-only]
+host  = $DATABRICKS_HOST

--- a/acceptance/cmd/auth/describe/profile-overrides-env/script
+++ b/acceptance/cmd/auth/describe/profile-overrides-env/script
@@ -1,14 +1,7 @@
 sethome "./home"
 
 # A profile carries full credentials; a second profile carries only a host.
-cat > "./home/.databrickscfg" <<EOF
-[my-workspace]
-host  = $DATABRICKS_HOST
-token = $DATABRICKS_TOKEN
-
-[host-only]
-host  = $DATABRICKS_HOST
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 # direnv-style auth env vars for a different workspace; before #5096 these
 # shadowed the profile selected with --profile.

--- a/acceptance/cmd/auth/describe/u2m-json-output/home/.databrickscfg
+++ b/acceptance/cmd/auth/describe/u2m-json-output/home/.databrickscfg
@@ -1,0 +1,3 @@
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/describe/u2m-json-output/script
+++ b/acceptance/cmd/auth/describe/u2m-json-output/script
@@ -5,12 +5,6 @@ unset DATABRICKS_TOKEN
 unset DATABRICKS_CONFIG_PROFILE
 unset DATABRICKS_AUTH_STORAGE
 
-cat > "./home/.databrickscfg" <<ENDCFG
-[u2m-profile]
-host       = https://u2m-profile.databricks.test
-auth_type  = databricks-cli
-ENDCFG
-
 # Filter to just the new token_storage object so the assertion is focused
 # and doesn't churn when other fields evolve.
 trace $CLI auth describe --profile u2m-profile --output json | jq '.token_storage'

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/home/.databrickscfg
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/home/.databrickscfg
@@ -1,0 +1,6 @@
+[__settings__]
+auth_storage = plaintext
+
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/describe/u2m-plaintext-config/script
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-config/script
@@ -5,13 +5,4 @@ unset DATABRICKS_TOKEN
 unset DATABRICKS_CONFIG_PROFILE
 unset DATABRICKS_AUTH_STORAGE
 
-cat > "./home/.databrickscfg" <<ENDCFG
-[__settings__]
-auth_storage = plaintext
-
-[u2m-profile]
-host       = https://u2m-profile.databricks.test
-auth_type  = databricks-cli
-ENDCFG
-
 trace $CLI auth describe --profile u2m-profile

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/home/.databrickscfg
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/home/.databrickscfg
@@ -1,0 +1,3 @@
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/describe/u2m-plaintext-env/script
+++ b/acceptance/cmd/auth/describe/u2m-plaintext-env/script
@@ -6,10 +6,4 @@ unset DATABRICKS_CONFIG_PROFILE
 
 export DATABRICKS_AUTH_STORAGE=plaintext
 
-cat > "./home/.databrickscfg" <<ENDCFG
-[u2m-profile]
-host       = https://u2m-profile.databricks.test
-auth_type  = databricks-cli
-ENDCFG
-
 trace $CLI auth describe --profile u2m-profile

--- a/acceptance/cmd/auth/describe/u2m-secure-default/home/.databrickscfg
+++ b/acceptance/cmd/auth/describe/u2m-secure-default/home/.databrickscfg
@@ -1,0 +1,3 @@
+[u2m-profile]
+host       = https://u2m-profile.databricks.test
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/describe/u2m-secure-default/script
+++ b/acceptance/cmd/auth/describe/u2m-secure-default/script
@@ -5,10 +5,4 @@ unset DATABRICKS_TOKEN
 unset DATABRICKS_CONFIG_PROFILE
 unset DATABRICKS_AUTH_STORAGE
 
-cat > "./home/.databrickscfg" <<ENDCFG
-[u2m-profile]
-host       = https://u2m-profile.databricks.test
-auth_type  = databricks-cli
-ENDCFG
-
 trace $CLI auth describe --profile u2m-profile

--- a/acceptance/cmd/auth/login/configure-serverless/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/login/configure-serverless/home/.databrickscfg.tmpl
@@ -1,0 +1,3 @@
+[DEFAULT]
+host = $DATABRICKS_HOST
+cluster_id = existing-cluster-123

--- a/acceptance/cmd/auth/login/configure-serverless/script
+++ b/acceptance/cmd/auth/login/configure-serverless/script
@@ -1,11 +1,7 @@
 sethome "./home"
 
-# Create an initial profile with cluster_id to be cleared out.
-cat > "./home/.databrickscfg" <<EOF
-[DEFAULT]
-host = $DATABRICKS_HOST
-cluster_id = existing-cluster-123
-EOF
+# Initial profile with cluster_id to be cleared out.
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Initial profile with cluster_id\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/login/custom-config-file/home/custom.databrickscfg
+++ b/acceptance/cmd/auth/login/custom-config-file/home/custom.databrickscfg
@@ -1,0 +1,4 @@
+[custom-test]
+host = https://old-host.cloud.databricks.com
+auth_type = pat
+token = old-token-123

--- a/acceptance/cmd/auth/login/custom-config-file/script
+++ b/acceptance/cmd/auth/login/custom-config-file/script
@@ -7,15 +7,8 @@ export BROWSER="browser.py"
 # Set custom config file location via env var
 export DATABRICKS_CONFIG_FILE="./home/custom.databrickscfg"
 
-# Create an existing custom config file with a DIFFERENT host.
-# Since --profile and --host conflict, the CLI should error.
-cat > "./home/custom.databrickscfg" <<EOF
-[custom-test]
-host = https://old-host.cloud.databricks.com
-auth_type = pat
-token = old-token-123
-EOF
-
+# home/custom.databrickscfg is a checked-in input: an existing custom config file
+# with a DIFFERENT host. Since --profile and --host conflict, the CLI should error.
 title "Initial custom config file (with old host)\n"
 cat "./home/custom.databrickscfg"
 

--- a/acceptance/cmd/auth/login/host-arg-overrides-profile/home/.databrickscfg
+++ b/acceptance/cmd/auth/login/host-arg-overrides-profile/home/.databrickscfg
@@ -1,0 +1,2 @@
+[override-test]
+host = https://old-host.cloud.databricks.com

--- a/acceptance/cmd/auth/login/host-arg-overrides-profile/script
+++ b/acceptance/cmd/auth/login/host-arg-overrides-profile/script
@@ -1,11 +1,6 @@
 sethome "./home"
 
-# Create an existing profile with a DIFFERENT host
-cat > "./home/.databrickscfg" <<EOF
-[override-test]
-host = https://old-host.cloud.databricks.com
-EOF
-
+# home/.databrickscfg is a checked-in input: an existing profile with a DIFFERENT host.
 title "Initial profile with old host\n"
 cat "./home/.databrickscfg"
 

--- a/acceptance/cmd/auth/login/host-from-profile/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/login/host-from-profile/home/.databrickscfg.tmpl
@@ -1,0 +1,2 @@
+[existing-profile]
+host = $DATABRICKS_HOST

--- a/acceptance/cmd/auth/login/host-from-profile/script
+++ b/acceptance/cmd/auth/login/host-from-profile/script
@@ -1,10 +1,7 @@
 sethome "./home"
 
-# Create an existing profile with a host
-cat > "./home/.databrickscfg" <<EOF
-[existing-profile]
-host = $DATABRICKS_HOST
-EOF
+# An existing profile with a host.
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Initial profile\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/login/preserve-fields/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/login/preserve-fields/home/.databrickscfg.tmpl
@@ -1,0 +1,6 @@
+[DEFAULT]
+host = $DATABRICKS_HOST
+cluster_id = existing-cluster-123
+warehouse_id = warehouse-456
+azure_environment = USGOVERNMENT
+custom_key = my-custom-value

--- a/acceptance/cmd/auth/login/preserve-fields/script
+++ b/acceptance/cmd/auth/login/preserve-fields/script
@@ -1,15 +1,8 @@
 sethome "./home"
 
-# Create an initial profile with cluster_id, warehouse_id, azure_environment,
-# and a custom key that is not a recognized SDK config attribute.
-cat > "./home/.databrickscfg" <<EOF
-[DEFAULT]
-host = $DATABRICKS_HOST
-cluster_id = existing-cluster-123
-warehouse_id = warehouse-456
-azure_environment = USGOVERNMENT
-custom_key = my-custom-value
-EOF
+# Initial profile with cluster_id, warehouse_id, azure_environment, and a custom
+# key that is not a recognized SDK config attribute.
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Initial profile\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/default-profile/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/logout/default-profile/home/.databrickscfg.tmpl
@@ -1,0 +1,9 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+host = ${DATABRICKS_HOST}
+auth_type = databricks-cli
+
+; Dev workspace
+[dev]
+host = ${DATABRICKS_HOST}
+auth_type = databricks-cli

--- a/acceptance/cmd/auth/logout/default-profile/script
+++ b/acceptance/cmd/auth/logout/default-profile/script
@@ -1,16 +1,6 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<EOF
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-host = ${DATABRICKS_HOST}
-auth_type = databricks-cli
-
-; Dev workspace
-[dev]
-host = ${DATABRICKS_HOST}
-auth_type = databricks-cli
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Initial config\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/delete-clears-default/home/.databrickscfg
+++ b/acceptance/cmd/auth/logout/delete-clears-default/home/.databrickscfg
@@ -1,0 +1,15 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+
+[workspace-a]
+host      = https://workspace-a.cloud.databricks.com
+token     = token-a
+auth_type = pat
+
+[workspace-b]
+host      = https://workspace-b.cloud.databricks.com
+token     = token-b
+auth_type = pat
+
+[__settings__]
+default_profile = workspace-a

--- a/acceptance/cmd/auth/logout/delete-clears-default/script
+++ b/acceptance/cmd/auth/logout/delete-clears-default/script
@@ -1,23 +1,5 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<'EOF'
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-
-[workspace-a]
-host      = https://workspace-a.cloud.databricks.com
-token     = token-a
-auth_type = pat
-
-[workspace-b]
-host      = https://workspace-b.cloud.databricks.com
-token     = token-b
-auth_type = pat
-
-[__settings__]
-default_profile = workspace-a
-EOF
-
 title "Initial settings section\n"
 cat "./home/.databrickscfg" | grep -A1 __settings__
 

--- a/acceptance/cmd/auth/logout/delete-pat-token-profile/home/.databrickscfg
+++ b/acceptance/cmd/auth/logout/delete-pat-token-profile/home/.databrickscfg
@@ -1,0 +1,6 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+
+[dev]
+host = https://dev.cloud.databricks.com
+token = dev-pat-token

--- a/acceptance/cmd/auth/logout/delete-pat-token-profile/script
+++ b/acceptance/cmd/auth/logout/delete-pat-token-profile/script
@@ -1,14 +1,5 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<'EOF'
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-
-[dev]
-host = https://dev.cloud.databricks.com
-token = dev-pat-token
-EOF
-
 title "Initial config\n"
 cat "./home/.databrickscfg"
 

--- a/acceptance/cmd/auth/logout/error-cases/home/.databrickscfg
+++ b/acceptance/cmd/auth/logout/error-cases/home/.databrickscfg
@@ -1,0 +1,6 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+
+[dev]
+host = https://dev.cloud.databricks.com
+auth_type = databricks-cli

--- a/acceptance/cmd/auth/logout/error-cases/script
+++ b/acceptance/cmd/auth/logout/error-cases/script
@@ -1,14 +1,5 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<'EOF'
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-
-[dev]
-host = https://dev.cloud.databricks.com
-auth_type = databricks-cli
-EOF
-
 title "Logout of non-existent profile\n"
 musterr $CLI auth logout --profile nonexistent --auto-approve
 

--- a/acceptance/cmd/auth/logout/last-non-default/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/logout/last-non-default/home/.databrickscfg.tmpl
@@ -1,0 +1,7 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+
+; The only non-default profile
+[only-profile]
+host = ${DATABRICKS_HOST}
+auth_type = databricks-cli

--- a/acceptance/cmd/auth/logout/last-non-default/script
+++ b/acceptance/cmd/auth/logout/last-non-default/script
@@ -1,14 +1,6 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<EOF
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-
-; The only non-default profile
-[only-profile]
-host = ${DATABRICKS_HOST}
-auth_type = databricks-cli
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Initial config\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/ordering-preserved/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/logout/ordering-preserved/home/.databrickscfg.tmpl
@@ -1,0 +1,20 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+host = ${DATABRICKS_HOST}
+auth_type = databricks-cli
+
+; First workspace — alpha
+[alpha]
+host = ${DATABRICKS_HOST}
+auth_type = databricks-cli
+
+; Second workspace — beta
+[beta]
+host = ${DATABRICKS_HOST}
+auth_type = databricks-cli
+
+; Third workspace — gamma
+[gamma]
+host = https://accounts.cloud.databricks.test
+account_id = account-id
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/logout/ordering-preserved/script
+++ b/acceptance/cmd/auth/logout/ordering-preserved/script
@@ -1,27 +1,6 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<EOF
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-host = ${DATABRICKS_HOST}
-auth_type = databricks-cli
-
-; First workspace — alpha
-[alpha]
-host = ${DATABRICKS_HOST}
-auth_type = databricks-cli
-
-; Second workspace — beta
-[beta]
-host = ${DATABRICKS_HOST}
-auth_type = databricks-cli
-
-; Third workspace — gamma
-[gamma]
-host = https://accounts.cloud.databricks.test
-account_id = account-id
-auth_type  = databricks-cli
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Initial config\n"
 cat "./home/.databrickscfg"

--- a/acceptance/cmd/auth/logout/token-only/home/.databricks/token-cache.json
+++ b/acceptance/cmd/auth/logout/token-only/home/.databricks/token-cache.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "tokens": {
+    "dev": {
+      "access_token": "dev-cached-token",
+      "token_type": "Bearer"
+    },
+    "https://accounts.cloud.databricks.test/oidc/accounts/account-id": {
+      "access_token": "dev-host-token",
+      "token_type": "Bearer"
+    }
+  }
+}

--- a/acceptance/cmd/auth/logout/token-only/home/.databrickscfg
+++ b/acceptance/cmd/auth/logout/token-only/home/.databrickscfg
@@ -1,0 +1,7 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+
+[dev]
+host = https://accounts.cloud.databricks.test
+account_id = account-id
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/logout/token-only/script
+++ b/acceptance/cmd/auth/logout/token-only/script
@@ -1,32 +1,6 @@
 sethome "./home"
 
-cat > "./home/.databrickscfg" <<'EOF'
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-
-[dev]
-host = https://accounts.cloud.databricks.test
-account_id = account-id
-auth_type  = databricks-cli
-EOF
-
-mkdir -p "./home/.databricks"
-cat > "./home/.databricks/token-cache.json" <<'EOF'
-{
-  "version": 1,
-  "tokens": {
-    "dev": {
-      "access_token": "dev-cached-token",
-      "token_type": "Bearer"
-    },
-    "https://accounts.cloud.databricks.test/oidc/accounts/account-id": {
-      "access_token": "dev-host-token",
-      "token_type": "Bearer"
-    }
-  }
-}
-EOF
-
+# home/.databrickscfg and home/.databricks/token-cache.json are checked-in inputs.
 title "Token cache keys before logout\n"
 jq -S '.tokens | keys' "./home/.databricks/token-cache.json"
 

--- a/acceptance/cmd/auth/profiles/home/.databrickscfg
+++ b/acceptance/cmd/auth/profiles/home/.databrickscfg
@@ -1,0 +1,12 @@
+[workspace-profile]
+host = https://workspace.cloud.databricks.test
+
+[account-profile]
+host = https://accounts.cloud.databricks.test
+account_id = test-account-123
+
+[unified-profile]
+host = https://unified.databricks.test
+account_id = unified-account-456
+workspace_id = 987654321
+experimental_is_unified_host = true

--- a/acceptance/cmd/auth/profiles/script
+++ b/acceptance/cmd/auth/profiles/script
@@ -1,20 +1,5 @@
 sethome "./home"
 
-# Create profiles including one with workspace_id
-cat > "./home/.databrickscfg" <<EOF
-[workspace-profile]
-host = https://workspace.cloud.databricks.test
-
-[account-profile]
-host = https://accounts.cloud.databricks.test
-account_id = test-account-123
-
-[unified-profile]
-host = https://unified.databricks.test
-account_id = unified-account-456
-workspace_id = 987654321
-experimental_is_unified_host = true
-EOF
-
+# home/.databrickscfg is a checked-in input with profiles including one with workspace_id.
 title "Profiles with workspace_id (JSON output)\n"
 $CLI auth profiles --skip-validate --output json

--- a/acceptance/cmd/auth/profiles/spog-account/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/profiles/spog-account/home/.databrickscfg.tmpl
@@ -1,0 +1,5 @@
+[spog-account]
+host = ${DATABRICKS_HOST}
+account_id = spog-acct-123
+workspace_id = none
+token = test-token

--- a/acceptance/cmd/auth/profiles/spog-account/script
+++ b/acceptance/cmd/auth/profiles/spog-account/script
@@ -1,15 +1,9 @@
 sethome "./home"
 
-# Create a SPOG account profile: non-accounts.* host with account_id, no workspace_id.
+# A SPOG account profile: non-accounts.* host with account_id, no workspace_id.
 # Before the fix, this was misclassified as WorkspaceConfig and validated with
 # CurrentUser.Me, which fails on account-scoped SPOG hosts.
-cat > "./home/.databrickscfg" <<EOF
-[spog-account]
-host = ${DATABRICKS_HOST}
-account_id = spog-acct-123
-workspace_id = none
-token = test-token
-EOF
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "SPOG account profile should be valid"
 trace $CLI auth profiles --output json

--- a/acceptance/cmd/auth/storage-modes/env-overrides-config/home/.databricks/token-cache.json
+++ b/acceptance/cmd/auth/storage-modes/env-overrides-config/home/.databricks/token-cache.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "tokens": {
+    "dev": {
+      "access_token": "dev-cached-token",
+      "token_type": "Bearer"
+    }
+  }
+}

--- a/acceptance/cmd/auth/storage-modes/env-overrides-config/home/.databrickscfg
+++ b/acceptance/cmd/auth/storage-modes/env-overrides-config/home/.databrickscfg
@@ -1,0 +1,7 @@
+[__settings__]
+auth_storage = secure
+
+[dev]
+host = https://accounts.cloud.databricks.test
+account_id = account-id
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/storage-modes/env-overrides-config/script
+++ b/acceptance/cmd/auth/storage-modes/env-overrides-config/script
@@ -1,28 +1,7 @@
 export DATABRICKS_AUTH_STORAGE=plaintext
 
-cat > "./home/.databrickscfg" <<ENDCFG
-[__settings__]
-auth_storage = secure
-
-[dev]
-host = https://accounts.cloud.databricks.test
-account_id = account-id
-auth_type  = databricks-cli
-ENDCFG
-
-mkdir -p "./home/.databricks"
-cat > "./home/.databricks/token-cache.json" <<ENDCACHE
-{
-  "version": 1,
-  "tokens": {
-    "dev": {
-      "access_token": "dev-cached-token",
-      "token_type": "Bearer"
-    }
-  }
-}
-ENDCACHE
-
+# home/.databrickscfg ([__settings__] auth_storage = secure) and
+# home/.databricks/token-cache.json are checked-in inputs.
 title "Token cache keys before logout\n"
 jq -S '.tokens | keys' "./home/.databricks/token-cache.json"
 

--- a/acceptance/cmd/auth/storage-modes/invalid-config/home/.databrickscfg
+++ b/acceptance/cmd/auth/storage-modes/invalid-config/home/.databrickscfg
@@ -1,0 +1,2 @@
+[__settings__]
+auth_storage = bogus

--- a/acceptance/cmd/auth/storage-modes/invalid-config/script
+++ b/acceptance/cmd/auth/storage-modes/invalid-config/script
@@ -1,8 +1,3 @@
-cat > "./home/.databrickscfg" <<ENDCFG
-[__settings__]
-auth_storage = bogus
-ENDCFG
-
 # auth token is the smallest reproducer that resolves the storage mode
 # without performing any network I/O.
 trace $CLI auth token --profile nonexistent

--- a/acceptance/cmd/auth/storage-modes/plaintext-env-default/home/.databricks/token-cache.json
+++ b/acceptance/cmd/auth/storage-modes/plaintext-env-default/home/.databricks/token-cache.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "tokens": {
+    "dev": {
+      "access_token": "dev-cached-token",
+      "token_type": "Bearer"
+    }
+  }
+}

--- a/acceptance/cmd/auth/storage-modes/plaintext-env-default/home/.databrickscfg
+++ b/acceptance/cmd/auth/storage-modes/plaintext-env-default/home/.databrickscfg
@@ -1,0 +1,4 @@
+[dev]
+host = https://accounts.cloud.databricks.test
+account_id = account-id
+auth_type  = databricks-cli

--- a/acceptance/cmd/auth/storage-modes/plaintext-env-default/script
+++ b/acceptance/cmd/auth/storage-modes/plaintext-env-default/script
@@ -1,25 +1,6 @@
 export DATABRICKS_AUTH_STORAGE=plaintext
 
-cat > "./home/.databrickscfg" <<ENDCFG
-[dev]
-host = https://accounts.cloud.databricks.test
-account_id = account-id
-auth_type  = databricks-cli
-ENDCFG
-
-mkdir -p "./home/.databricks"
-cat > "./home/.databricks/token-cache.json" <<ENDCACHE
-{
-  "version": 1,
-  "tokens": {
-    "dev": {
-      "access_token": "dev-cached-token",
-      "token_type": "Bearer"
-    }
-  }
-}
-ENDCACHE
-
+# home/.databrickscfg and home/.databricks/token-cache.json are checked-in inputs.
 title "Token cache keys before logout\n"
 jq -S '.tokens | keys' "./home/.databricks/token-cache.json"
 

--- a/acceptance/cmd/auth/switch/nominal/home/.databrickscfg.tmpl
+++ b/acceptance/cmd/auth/switch/nominal/home/.databrickscfg.tmpl
@@ -1,0 +1,12 @@
+; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
+[DEFAULT]
+
+[profile-a]
+host      = ${DATABRICKS_HOST}
+token     = token-a
+auth_type = pat
+
+[profile-b]
+host      = ${DATABRICKS_HOST}
+token     = token-b
+auth_type = pat

--- a/acceptance/cmd/auth/switch/nominal/script
+++ b/acceptance/cmd/auth/switch/nominal/script
@@ -1,20 +1,7 @@
 sethome "./home"
 
-# Create two profiles without a [__settings__] section.
-cat > "./home/.databrickscfg" <<EOF
-; The profile defined in the DEFAULT section is to be used as a fallback when no profile is explicitly specified.
-[DEFAULT]
-
-[profile-a]
-host      = ${DATABRICKS_HOST}
-token     = token-a
-auth_type = pat
-
-[profile-b]
-host      = ${DATABRICKS_HOST}
-token     = token-b
-auth_type = pat
-EOF
+# Two profiles without a [__settings__] section.
+envsubst < "./home/.databrickscfg.tmpl" > "./home/.databrickscfg"
 
 title "Switch to profile-a\n"
 trace $CLI auth switch --profile profile-a

--- a/acceptance/cmd/auth/token/no-args-with-profiles/home/.databrickscfg
+++ b/acceptance/cmd/auth/token/no-args-with-profiles/home/.databrickscfg
@@ -1,0 +1,3 @@
+[myprofile]
+host = https://myworkspace.cloud.databricks.com
+auth_type = databricks-cli

--- a/acceptance/cmd/auth/token/no-args-with-profiles/script
+++ b/acceptance/cmd/auth/token/no-args-with-profiles/script
@@ -4,12 +4,6 @@ unset DATABRICKS_HOST
 unset DATABRICKS_TOKEN
 unset DATABRICKS_CONFIG_PROFILE
 
-# Create a .databrickscfg with a profile
-cat > "./home/.databrickscfg" <<'ENDCFG'
-[myprofile]
-host = https://myworkspace.cloud.databricks.com
-auth_type = databricks-cli
-ENDCFG
-
+# home/.databrickscfg is a checked-in input with a single profile.
 # No arguments, non-interactive: should error with profile hint
 musterr $CLI auth token

--- a/acceptance/cmd/configure/clears-oauth-on-pat/home/.databrickscfg
+++ b/acceptance/cmd/configure/clears-oauth-on-pat/home/.databrickscfg
@@ -1,0 +1,7 @@
+[DEFAULT]
+host                         = https://host
+auth_type                    = databricks-cli
+scopes                       = all-apis
+experimental_is_unified_host = true
+account_id                   = acc-123
+workspace_id                 = ws-456

--- a/acceptance/cmd/configure/clears-oauth-on-pat/script
+++ b/acceptance/cmd/configure/clears-oauth-on-pat/script
@@ -1,17 +1,7 @@
 sethome "./home"
 
-# Pre-populate a profile with OAuth metadata and unified host fields
-# (as if `auth login` was previously run against a unified host).
-cat > "./home/.databrickscfg" <<EOF
-[DEFAULT]
-host                         = https://host
-auth_type                    = databricks-cli
-scopes                       = all-apis
-experimental_is_unified_host = true
-account_id                   = acc-123
-workspace_id                 = ws-456
-EOF
-
+# home/.databrickscfg is a checked-in input: a profile with OAuth metadata and
+# unified host fields (as if `auth login` was previously run against a unified host).
 title "Initial profile (OAuth with unified host)\n"
 cat "./home/.databrickscfg"
 

--- a/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/home/.databrickscfg
+++ b/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/home/.databrickscfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+host                  = https://host
+serverless_compute_id = auto

--- a/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/script
+++ b/acceptance/cmd/configure/clears-serverless-when-cluster-from-env/script
@@ -1,12 +1,6 @@
 sethome "./home"
 
-# Pre-populate a profile with serverless_compute_id.
-cat > "./home/.databrickscfg" <<EOF
-[DEFAULT]
-host                  = https://host
-serverless_compute_id = auto
-EOF
-
+# home/.databrickscfg is a checked-in input: a profile with serverless_compute_id.
 title "Initial profile with serverless_compute_id\n"
 cat "./home/.databrickscfg"
 


### PR DESCRIPTION
## Changes
Move heredoc (`cat > file <<EOF` or similar) created files into source control.

Either direct lifts [750d8b0](https://github.com/databricks/cli/pull/5938/commits/750d8b088c5437d9f81043c0a0421f5fc9e6fed9) or simple `envsubst` replacements [79250aa](https://github.com/databricks/cli/pull/5938/commits/79250aaa678476adbd999a1354f2679d1aba1512)

## Why
Easier to review

## Tests
Existing tests