### PR TITLE
Remove `src` folder from immutable folder paths

### DIFF
--- a/acceptance/bundle/deploy/immutable-no-artifacts/output.txt
+++ b/acceptance/bundle/deploy/immutable-no-artifacts/output.txt
@@ -15,13 +15,13 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] jobs get [NUMID]
-"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/src/files/src/main.py"
+"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/files/src/main.py"
 
 >>> [CLI] jobs get [NUMID]
-"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/src/files/src/notebook"
+"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/files/src/notebook"
 
 >>> [CLI] jobs get [NUMID]
-"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/src/files/some_path"
+"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/files/some_path"
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:

--- a/acceptance/bundle/deploy/immutable/output.txt
+++ b/acceptance/bundle/deploy/immutable/output.txt
@@ -13,7 +13,7 @@ Building python_artifact...
 [
   {
     "notebook_task": {
-      "notebook_path": "${workspace.snapshot_path}/src/files/src/notebook"
+      "notebook_path": "${workspace.snapshot_path}/files/src/notebook"
     },
     "task_key": "notebook_task"
   },
@@ -28,7 +28,7 @@ Building python_artifact...
   {
     "environment_key": "env",
     "spark_python_task": {
-      "python_file": "${workspace.snapshot_path}/src/files/src/main.py"
+      "python_file": "${workspace.snapshot_path}/files/src/main.py"
     },
     "task_key": "spark_python_task"
   }
@@ -42,14 +42,14 @@ Updating deployment state...
 Deployment complete!
 
 >>> [CLI] jobs get [NUMID]
-"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/src/files/src/main.py"
+"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/files/src/main.py"
 
 >>> [CLI] jobs get [NUMID]
-"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/src/files/src/notebook"
+"/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/files/src/notebook"
 
 >>> [CLI] jobs get [NUMID]
 [
-  "/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/src/artifacts/.internal/immutable-0.0.1-py3-none-any.whl"
+  "/Workspace/Users/[UUID]/.snapshots/[UUID]/[SNAPSHOT_HASH]/artifacts/.internal/immutable-0.0.1-py3-none-any.whl"
 ]
 
 >>> [CLI] bundle destroy --auto-approve

--- a/acceptance/bundle/resources/apps/immutable/output.txt
+++ b/acceptance/bundle/resources/apps/immutable/output.txt
@@ -37,6 +37,6 @@ You can access the app at my-immutable-app-123.cloud.databricksapps.com
   "path": "/api/2.0/apps/my-immutable-app/deployments",
   "body": {
     "mode": "SNAPSHOT",
-    "source_code_path": "${workspace.snapshot_path}/src/files/app"
+    "source_code_path": "${workspace.snapshot_path}/files/app"
   }
 }

--- a/acceptance/bundle/validate/immutable_workspace_paths/output.txt
+++ b/acceptance/bundle/validate/immutable_workspace_paths/output.txt
@@ -23,7 +23,7 @@ Warning: Pattern user_repls.json does not match any files
       "ai_runtime_task": {
         "deployments": [
           {
-            "command_path": "${workspace.snapshot_path}/src/files/src/main.py",
+            "command_path": "${workspace.snapshot_path}/files/src/main.py",
             "compute": {
               "accelerator_count": 1,
               "accelerator_type": "GPU_1xA10"
@@ -37,7 +37,7 @@ Warning: Pattern user_repls.json does not match any files
     {
       "existing_cluster_id": "0101-120000-aaaaaaaa",
       "spark_python_task": {
-        "python_file": "${workspace.snapshot_path}/src/files/src/main.py"
+        "python_file": "${workspace.snapshot_path}/files/src/main.py"
       },
       "task_key": "my_task"
     }

--- a/bundle/config/mutator/translate_paths.go
+++ b/bundle/config/mutator/translate_paths.go
@@ -333,10 +333,10 @@ func applyTranslations(ctx context.Context, b *bundle.Bundle, t *translateContex
 			}}
 		}
 		// Use a placeholder referencing workspace.snapshot_path so that paths are stored
-		// as ${workspace.snapshot_path}/src/files/<rel> during validate. After
+		// as ${workspace.snapshot_path}/files/<rel> during validate. After
 		// snapshot.Upload() sets workspace.snapshot_path, a variable-resolution pass
 		// expands these references to the actual content-addressed paths.
-		t.remoteRoot = "${workspace.snapshot_path}/src/files"
+		t.remoteRoot = "${workspace.snapshot_path}/files"
 	case config.IsExplicitlyEnabled(t.b.Config.Presets.SourceLinkedDeployment):
 		t.remoteRoot = t.b.SyncRootPath
 	default:

--- a/bundle/deploy/snapshot/upload.go
+++ b/bundle/deploy/snapshot/upload.go
@@ -68,13 +68,12 @@ func (m *snapshotUpload) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagn
 
 	log.Infof(ctx, "Snapshot uploaded to %s", info.Path)
 
-	// The API unpacks the zip under a "src" subdirectory.
 	b.Config.Workspace.SnapshotPath = info.Path
-	b.Config.Workspace.FilePath = path.Join(info.Path, "src", "files")
+	b.Config.Workspace.FilePath = path.Join(info.Path, "files")
 	// Only set artifact_path when artifacts are present; with no artifacts the
-	// zip has no "src/artifacts" directory and a get-status on it would 404.
+	// zip has no "artifacts" directory and a get-status on it would 404.
 	if len(b.Config.Artifacts) > 0 {
-		b.Config.Workspace.ArtifactPath = path.Join(info.Path, "src", "artifacts")
+		b.Config.Workspace.ArtifactPath = path.Join(info.Path, "artifacts")
 	}
 
 	return diags


### PR DESCRIPTION
## Changes
Remove `src` folder from immutable folder paths

## Why
API won't unpack the snapshot into `src` folder and instead will unpack in the root of snapshot path.

## Tests
Covered by acceptance tests

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
