### PR TITLE
acc: run bundle/artifacts/artifact_path_with_volume locally

### DIFF
--- a/acceptance/bundle/artifacts/artifact_path_with_volume/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/test.toml
@@ -1,3 +1,6 @@
 Local = true
 Cloud = true
+RequiresUnityCatalog = true
+
+# Overrides RecordRequests = true set by the artifacts parent test.toml.
 RecordRequests = false

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 RecordRequests = false

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_doesnot_exist/test.toml
@@ -1,3 +1,0 @@
-Local = true
-Cloud = true
-RequiresUnityCatalog = true

--- a/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/test.toml
+++ b/acceptance/bundle/artifacts/artifact_path_with_volume/volume_not_deployed/test.toml
@@ -1,4 +1,1 @@
 Badness = "Requires two bundles; one for volumes, another for artifacts. Ideally it would just work but today we first upload then deploy, so it does not fit in that architecture."
-Local = true
-Cloud = true
-RequiresUnityCatalog = true


### PR DESCRIPTION
## Summary
- The two subtests (`volume_doesnot_exist`, `volume_not_deployed`) already run locally via their own `Local = true` overrides; only the group's parent `test.toml` still defaulted to `Local = false`.
- Flip the parent to `Local = true` so the default matches how the tests actually run and no stale cloud-only default remains.
- `RecordRequests = false` stays: it intentionally overrides the `RecordRequests = true` set by the artifacts parent `test.toml`.