### PR TITLE
Skip app drift on deploy-only fields when there is no active deployment

### DIFF
--- a/acceptance/bundle/resources/apps/config-drift-stopped/app/app.py
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/app/app.py
@@ -1,0 +1,5 @@
+import http.server, os
+
+http.server.HTTPServer(
+    ("", int(os.environ["DATABRICKS_APP_PORT"])), http.server.SimpleHTTPRequestHandler
+).serve_forever()

--- a/acceptance/bundle/resources/apps/config-drift-stopped/databricks.yml.tmpl
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/databricks.yml.tmpl
@@ -1,0 +1,18 @@
+bundle:
+  name: config-drift-stopped-$UNIQUE_NAME
+
+resources:
+  apps:
+    myapp:
+      name: $UNIQUE_NAME
+      description: my_app
+      source_code_path: ./app
+      config:
+        command:
+          - python
+          - app.py
+        env:
+          - name: MY_VAR
+            value: original_value
+      lifecycle:
+        started: true

--- a/acceptance/bundle/resources/apps/config-drift-stopped/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-drift-stopped/output.txt
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/output.txt
@@ -1,0 +1,73 @@
+
+=== Deploy with started=true so the app has an active deployment
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/config-drift-stopped-[UNIQUE_NAME]/default/files...
+Deploying resources...
+✓ Deployment succeeded
+Updating deployment state...
+Deployment complete!
+
+=== Change config while running: drift is detected (active deployment present)
+>>> update_file.py databricks.yml original_value changed_value
+
+>>> [CLI] bundle plan -o json
+{
+  "config.env[0].value": {
+    "action": "update",
+    "old": "original_value",
+    "new": "changed_value",
+    "remote": "original_value"
+  }
+}
+
+=== Stop the app: the backend clears the active deployment
+>>> [CLI] apps stop [UNIQUE_NAME]
+"STOPPED"
+
+=== Same config change is now skipped: no active deployment to compare against
+>>> [CLI] bundle plan -o json
+{
+  "config": {
+    "action": "skip",
+    "reason": "no active deployment",
+    "old": {
+      "command": [
+        "python",
+        "app.py"
+      ],
+      "env": [
+        {
+          "name": "MY_VAR",
+          "value": "original_value"
+        }
+      ]
+    },
+    "new": {
+      "command": [
+        "python",
+        "app.py"
+      ],
+      "env": [
+        {
+          "name": "MY_VAR",
+          "value": "changed_value"
+        }
+      ]
+    }
+  },
+  "config.env[0].value": {
+    "action": "skip",
+    "reason": "no active deployment",
+    "old": "original_value",
+    "new": "changed_value"
+  }
+}
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.apps.myapp
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/config-drift-stopped-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/resources/apps/config-drift-stopped/script
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/script
@@ -1,0 +1,19 @@
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+    trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+title "Deploy with started=true so the app has an active deployment"
+trace $CLI bundle deploy
+
+title "Change config while running: drift is detected (active deployment present)"
+trace update_file.py databricks.yml original_value changed_value
+trace $CLI bundle plan -o json | jq '.plan[].changes | with_entries(select(.key | startswith("config")))'
+
+title "Stop the app: the backend clears the active deployment"
+trace $CLI apps stop $UNIQUE_NAME | jq '.compute_status.state'
+
+title "Same config change is now skipped: no active deployment to compare against"
+trace $CLI bundle plan -o json | jq '.plan[].changes | with_entries(select(.key | startswith("config")))'

--- a/acceptance/bundle/resources/apps/config-drift-stopped/test.toml
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/test.toml
@@ -1,0 +1,11 @@
+Local = true
+Cloud = false
+
+# Asserts plan classification, not requests; drop the inherited RecordRequests.
+RecordRequests = false
+
+Ignore = [".databricks", "databricks.yml"]
+
+# Direct engine only: the skip logic lives in OverrideChangeDesc. Mirrors
+# config-no-deployment.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-no-deployment/app/app.py
+++ b/acceptance/bundle/resources/apps/config-no-deployment/app/app.py
@@ -1,0 +1,10 @@
+import os
+
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def home():
+    return "Hello from config-no-deployment app!"

--- a/acceptance/bundle/resources/apps/config-no-deployment/app/app.yaml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/app/app.yaml
@@ -1,0 +1,3 @@
+command:
+  - python
+  - app.py

--- a/acceptance/bundle/resources/apps/config-no-deployment/databricks.yml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/databricks.yml
@@ -1,0 +1,14 @@
+bundle:
+  name: app-config-no-deployment
+
+resources:
+  apps:
+    myapp:
+      name: test-app-config-no-deployment
+      description: my_app_description
+      source_code_path: ./app
+      config:
+        command: ["python", "app.py"]
+        env:
+          - name: MY_ENV_VAR
+            value: test_value

--- a/acceptance/bundle/resources/apps/config-no-deployment/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-no-deployment/output.txt
+++ b/acceptance/bundle/resources/apps/config-no-deployment/output.txt
@@ -1,0 +1,50 @@
+
+=== Deploy: app created with no_compute; config is not deployed until the app starts
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/app-config-no-deployment/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Plan is a no-op: config/source_code_path drift is skipped while the app has no deployment
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
+
+=== Both deploy-only fields are skipped with reason "no deployment"
+>>> [CLI] bundle plan -o json
+{
+  "config": {
+    "action": "skip",
+    "reason": "no deployment",
+    "old": {
+      "command": [
+        "python",
+        "app.py"
+      ],
+      "env": [
+        {
+          "name": "MY_ENV_VAR",
+          "value": "test_value"
+        }
+      ]
+    },
+    "new": {
+      "command": [
+        "python",
+        "app.py"
+      ],
+      "env": [
+        {
+          "name": "MY_ENV_VAR",
+          "value": "test_value"
+        }
+      ]
+    }
+  },
+  "source_code_path": {
+    "action": "skip",
+    "reason": "no deployment",
+    "old": "/Workspace/Users/[USERNAME]/.bundle/app-config-no-deployment/default/files/app",
+    "new": "/Workspace/Users/[USERNAME]/.bundle/app-config-no-deployment/default/files/app"
+  }
+}

--- a/acceptance/bundle/resources/apps/config-no-deployment/output.txt
+++ b/acceptance/bundle/resources/apps/config-no-deployment/output.txt
@@ -6,16 +6,16 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
-=== Plan is a no-op: config/source_code_path drift is skipped while the app has no deployment
+=== Plan is a no-op: config/source_code_path drift is skipped while the app has no active deployment
 >>> [CLI] bundle plan
 Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
 
-=== Both deploy-only fields are skipped with reason "no deployment"
+=== Both deploy-only fields are skipped with reason "no active deployment"
 >>> [CLI] bundle plan -o json
 {
   "config": {
     "action": "skip",
-    "reason": "no deployment",
+    "reason": "no active deployment",
     "old": {
       "command": [
         "python",
@@ -43,7 +43,7 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
   },
   "source_code_path": {
     "action": "skip",
-    "reason": "no deployment",
+    "reason": "no active deployment",
     "old": "/Workspace/Users/[USERNAME]/.bundle/app-config-no-deployment/default/files/app",
     "new": "/Workspace/Users/[USERNAME]/.bundle/app-config-no-deployment/default/files/app"
   }

--- a/acceptance/bundle/resources/apps/config-no-deployment/script
+++ b/acceptance/bundle/resources/apps/config-no-deployment/script
@@ -1,0 +1,10 @@
+echo "*" > .gitignore
+
+title "Deploy: app created with no_compute; config is not deployed until the app starts"
+trace $CLI bundle deploy
+
+title "Plan is a no-op: config/source_code_path drift is skipped while the app has no deployment"
+trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
+
+title "Both deploy-only fields are skipped with reason \"no deployment\""
+trace $CLI bundle plan -o json | jq '.plan[].changes | {config, source_code_path}'

--- a/acceptance/bundle/resources/apps/config-no-deployment/script
+++ b/acceptance/bundle/resources/apps/config-no-deployment/script
@@ -3,8 +3,8 @@ echo "*" > .gitignore
 title "Deploy: app created with no_compute; config is not deployed until the app starts"
 trace $CLI bundle deploy
 
-title "Plan is a no-op: config/source_code_path drift is skipped while the app has no deployment"
+title "Plan is a no-op: config/source_code_path drift is skipped while the app has no active deployment"
 trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
 
-title "Both deploy-only fields are skipped with reason \"no deployment\""
+title "Both deploy-only fields are skipped with reason \"no active deployment\""
 trace $CLI bundle plan -o json | jq '.plan[].changes | {config, source_code_path}'

--- a/acceptance/bundle/resources/apps/config-no-deployment/test.toml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/test.toml
@@ -1,0 +1,11 @@
+Local = true
+Cloud = false
+
+# Asserts plan classification, not requests; drop the inherited RecordRequests.
+RecordRequests = false
+
+Ignore = [".databricks"]
+
+# Direct engine only: the skip logic lives in OverrideChangeDesc. Mirrors
+# lifecycle-started-omitted.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/databricks.yml
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/databricks.yml
@@ -1,0 +1,10 @@
+bundle:
+  name: app-git-source-no-deployment
+
+resources:
+  apps:
+    myapp:
+      name: test-app-git-source-no-deployment
+      description: my_app_description
+      git_source:
+        branch: main

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/out.test.toml
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/output.txt
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/output.txt
@@ -6,16 +6,16 @@ Deploying resources...
 Updating deployment state...
 Deployment complete!
 
-=== Plan is a no-op: git_source drift is skipped while the app has no deployment
+=== Plan is a no-op: git_source drift is skipped while the app has no active deployment
 >>> [CLI] bundle plan
 Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
 
-=== git_source is skipped with reason "no deployment"
+=== git_source is skipped with reason "no active deployment"
 >>> [CLI] bundle plan -o json
 {
   "git_source": {
     "action": "skip",
-    "reason": "no deployment",
+    "reason": "no active deployment",
     "old": {
       "branch": "main"
     },

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/output.txt
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/output.txt
@@ -1,0 +1,26 @@
+
+=== Deploy: app created with no_compute; git_source is not deployed until the app starts
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/app-git-source-no-deployment/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Plan is a no-op: git_source drift is skipped while the app has no deployment
+>>> [CLI] bundle plan
+Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
+
+=== git_source is skipped with reason "no deployment"
+>>> [CLI] bundle plan -o json
+{
+  "git_source": {
+    "action": "skip",
+    "reason": "no deployment",
+    "old": {
+      "branch": "main"
+    },
+    "new": {
+      "branch": "main"
+    }
+  }
+}

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/script
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/script
@@ -1,0 +1,10 @@
+echo "*" > .gitignore
+
+title "Deploy: app created with no_compute; git_source is not deployed until the app starts"
+trace $CLI bundle deploy
+
+title "Plan is a no-op: git_source drift is skipped while the app has no deployment"
+trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
+
+title "git_source is skipped with reason \"no deployment\""
+trace $CLI bundle plan -o json | jq '.plan[].changes | {git_source}'

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/script
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/script
@@ -3,8 +3,8 @@ echo "*" > .gitignore
 title "Deploy: app created with no_compute; git_source is not deployed until the app starts"
 trace $CLI bundle deploy
 
-title "Plan is a no-op: git_source drift is skipped while the app has no deployment"
+title "Plan is a no-op: git_source drift is skipped while the app has no active deployment"
 trace $CLI bundle plan | contains.py "Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged"
 
-title "git_source is skipped with reason \"no deployment\""
+title "git_source is skipped with reason \"no active deployment\""
 trace $CLI bundle plan -o json | jq '.plan[].changes | {git_source}'

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/test.toml
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/test.toml
@@ -1,0 +1,11 @@
+Local = true
+Cloud = false
+
+# Asserts plan classification, not requests; drop the inherited RecordRequests.
+RecordRequests = false
+
+Ignore = [".databricks"]
+
+# Direct engine only: the skip logic lives in OverrideChangeDesc. Mirrors
+# config-no-deployment.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -247,12 +247,11 @@ func hasAppChanges(entry *PlanEntry) bool {
 }
 
 // OverrideChangeDesc suppresses drift on the deploy-only fields (source_code_path,
-// config, git_source) whenever the app has no active deployment. DoRead can only
-// read these back from the active deployment, and the backend clears it whenever the
-// app is stopped, not just before the first deploy. Without an active deployment the
-// remote side is empty, so any diff against the configured value is spurious. Such a
-// change is applied on the next start (see manageLifecycle), not lost; once a
-// deployment exists, real out-of-band drift is reported normally.
+// config, git_source) when the app has no active deployment. DoRead reads these only
+// from the active deployment, which is absent before the first deploy and, for
+// non-scalable apps, cleared on stop. Without it the remote side is empty, so any
+// diff is spurious; the change applies on the next start (see manageLifecycle). Real
+// drift is still reported once a deployment exists.
 func (*ResourceApp) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *AppRemote) error {
 	// Prefix(1) so a nested diff (e.g. config.command) matches its top-level field.
 	switch path.Prefix(1).String() {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -246,22 +246,20 @@ func hasAppChanges(entry *PlanEntry) bool {
 	return entry.Changes.HasChangeExcept("source_code_path", "config", "git_source", "lifecycle", "lifecycle.started")
 }
 
-// OverrideChangeDesc skips drift on deploy-only fields (source_code_path, config,
-// git_source) until the app has a deployment: they're applied via an app deployment
-// (see manageLifecycle), so DoRead leaves them nil until then and any diff is
-// spurious. Real out-of-band drift is reported again once a deployment exists.
+// OverrideChangeDesc suppresses drift on the deploy-only fields (source_code_path,
+// config, git_source) whenever the app has no active deployment. DoRead can only
+// read these back from the active deployment, and the backend clears it whenever the
+// app is stopped, not just before the first deploy. Without an active deployment the
+// remote side is empty, so any diff against the configured value is spurious. Such a
+// change is applied on the next start (see manageLifecycle), not lost; once a
+// deployment exists, real out-of-band drift is reported normally.
 func (*ResourceApp) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *AppRemote) error {
 	// Prefix(1) so a nested diff (e.g. config.command) matches its top-level field.
 	switch path.Prefix(1).String() {
-	case "source_code_path":
-		if remote.SourceCodePath == "" || remote.SourceCodePath == "null" {
-			change.Action = deployplan.Skip
-			change.Reason = "no deployment"
-		}
-	case "config", "git_source":
+	case "source_code_path", "config", "git_source":
 		if remote.ActiveDeployment == nil {
 			change.Action = deployplan.Skip
-			change.Reason = "no deployment"
+			change.Reason = "no active deployment"
 		}
 	}
 	return nil

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -246,12 +246,10 @@ func hasAppChanges(entry *PlanEntry) bool {
 	return entry.Changes.HasChangeExcept("source_code_path", "config", "git_source", "lifecycle", "lifecycle.started")
 }
 
-// OverrideChangeDesc suppresses drift on the deploy-only fields (source_code_path,
-// config, git_source) when the app has no active deployment. DoRead reads these only
-// from the active deployment, which is absent before the first deploy and, for
-// non-scalable apps, cleared on stop. Without it the remote side is empty, so any
-// diff is spurious; the change applies on the next start (see manageLifecycle). Real
-// drift is still reported once a deployment exists.
+// OverrideChangeDesc skips drift on the deploy-only fields (source_code_path, config,
+// git_source) while the app has no active deployment. DoRead reads them only from the
+// active deployment, so before the first deploy (or once a stop clears it) the remote
+// side is empty and the diff is spurious; it applies on the next start (manageLifecycle).
 func (*ResourceApp) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *AppRemote) error {
 	// Prefix(1) so a nested diff (e.g. config.command) matches its top-level field.
 	switch path.Prefix(1).String() {

--- a/bundle/direct/dresources/app.go
+++ b/bundle/direct/dresources/app.go
@@ -246,12 +246,23 @@ func hasAppChanges(entry *PlanEntry) bool {
 	return entry.Changes.HasChangeExcept("source_code_path", "config", "git_source", "lifecycle", "lifecycle.started")
 }
 
-// OverrideChangeDesc skips source_code_path drift when the remote value is empty.
-// This happens when an app has no deployment yet (DefaultSourceCodePath is unset).
+// OverrideChangeDesc skips drift on deploy-only fields (source_code_path, config,
+// git_source) until the app has a deployment: they're applied via an app deployment
+// (see manageLifecycle), so DoRead leaves them nil until then and any diff is
+// spurious. Real out-of-band drift is reported again once a deployment exists.
 func (*ResourceApp) OverrideChangeDesc(_ context.Context, path *structpath.PathNode, change *ChangeDesc, remote *AppRemote) error {
-	if path.String() == "source_code_path" && (remote.SourceCodePath == "" || remote.SourceCodePath == "null") {
-		change.Action = deployplan.Skip
-		change.Reason = "no deployment"
+	// Prefix(1) so a nested diff (e.g. config.command) matches its top-level field.
+	switch path.Prefix(1).String() {
+	case "source_code_path":
+		if remote.SourceCodePath == "" || remote.SourceCodePath == "null" {
+			change.Action = deployplan.Skip
+			change.Reason = "no deployment"
+		}
+	case "config", "git_source":
+		if remote.ActiveDeployment == nil {
+			change.Action = deployplan.Skip
+			change.Reason = "no deployment"
+		}
 	}
 	return nil
 }

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -186,6 +186,11 @@ func (s *FakeWorkspace) AppsStop(_ Request, name string) Response {
 		State:   "UNAVAILABLE",
 		Message: appStatusUnavailableMessage,
 	}
+	// The backend clears the active/pending deployment when compute stops; only
+	// default_source_code_path is retained. Mirror that so drift detection against a
+	// stopped app matches cloud behavior.
+	app.ActiveDeployment = nil
+	app.PendingDeployment = nil
 	s.Apps[name] = app
 
 	return Response{Body: app}

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -186,9 +186,10 @@ func (s *FakeWorkspace) AppsStop(_ Request, name string) Response {
 		State:   "UNAVAILABLE",
 		Message: appStatusUnavailableMessage,
 	}
-	// The backend clears the active/pending deployment when compute stops; only
-	// default_source_code_path is retained. Mirror that so drift detection against a
-	// stopped app matches cloud behavior.
+	// Non-scalable apps clear the active deployment on stop (pending is always
+	// cleared); only default_source_code_path is retained. The fixtures are all
+	// non-scalable, so clear unconditionally. Scalable apps retain it on stop, which
+	// this fake does not model.
 	app.ActiveDeployment = nil
 	app.PendingDeployment = nil
 	s.Apps[name] = app

--- a/libs/testserver/apps.go
+++ b/libs/testserver/apps.go
@@ -186,10 +186,8 @@ func (s *FakeWorkspace) AppsStop(_ Request, name string) Response {
 		State:   "UNAVAILABLE",
 		Message: appStatusUnavailableMessage,
 	}
-	// Non-scalable apps clear the active deployment on stop (pending is always
-	// cleared); only default_source_code_path is retained. The fixtures are all
-	// non-scalable, so clear unconditionally. Scalable apps retain it on stop, which
-	// this fake does not model.
+	// The backend clears both deployments on stop for the apps these fixtures use,
+	// so the deploy-only fields read back empty. Match that so drift tests are realistic.
 	app.ActiveDeployment = nil
 	app.PendingDeployment = nil
 	s.Apps[name] = app


### PR DESCRIPTION
## Changes
Skip drift reporting on the deploy-only app fields `source_code_path`, `config`, and `git_source` whenever the app has no active deployment, unifying all three under a single `ActiveDeployment == nil` check (reason: `no active deployment`). Also fix the test server's `stop` handler to clear the active deployment, matching the real backend, and add a test covering the stopped-app case.

## Why
`DoRead` can only read these fields back from the app's active deployment. An app created without `lifecycle.started` (the default `no_compute` case) has none, so the fields read back empty while the bundle sets them — producing a phantom `update` in `bundle plan` that can never converge (these fields are excluded from the App Update call and only deploy on start). A stop can also clear the `active_deployment` for some apps (`pending_deployment` is always cleared), so the same spurious diff applies to a stopped app that has none; the previous `source_code_path`-only check and the "no deployment" wording didn't capture that. Verified against a real workspace: a never-started app and a stopped app that cleared its deployment both return `active_deployment: null`, while a running app returns it, so real out-of-band drift is still reported once a deployment exists. This is a plan-idempotency fix. A `config`/`git_source` change made while the app has no active deployment is applied on the next start (see `manageLifecycle`), not silently lost — it is deferred, not applied while stopped, because the API neither exposes nor accepts deployed config for a non-running app.

## Tests
- `config-no-deployment` / `git-source-no-deployment`: no-op plan on a never-started app.
- `config-drift-stopped`: drift is detected while running, then skipped after stop.

This gap was found by fuzz testing.