### PR TITLE
acc: fix flaky grants-remove-principal plan golden

### DIFF
--- a/acceptance/bundle/deploy/readplan/grants-remove-principal/out.plan.grants.json
+++ b/acceptance/bundle/deploy/readplan/grants-remove-principal/out.plan.grants.json
@@ -25,15 +25,15 @@
     "full_name": "main.myschema",
     "__embed__": [
       {
-        "principal": "[USERNAME]",
-        "privileges": [
-          "USE_SCHEMA"
-        ]
-      },
-      {
         "principal": "extra@example.test",
         "privileges": [
           "CREATE_TABLE"
+        ]
+      },
+      {
+        "principal": "[USERNAME]",
+        "privileges": [
+          "USE_SCHEMA"
         ]
       }
     ]

--- a/acceptance/bundle/deploy/readplan/grants-remove-principal/script
+++ b/acceptance/bundle/deploy/readplan/grants-remove-principal/script
@@ -12,8 +12,10 @@ trace print_requests.py //unity-catalog/permissions --sort
 grep -v 'TO_REMOVE' databricks.yml > updated.yml && mv updated.yml databricks.yml
 
 # Generate update plan: entry.RemoteState captures both principals as GrantsState.
+# remote_state.__embed__ principal order is non-deterministic (the backend, and the
+# testserver mirroring it, iterate a map), so sort it by principal for a stable golden.
 trace $CLI bundle plan -o json > tmp.plan.json
-jq '.plan["resources.schemas.myschema.grants"]' tmp.plan.json > out.plan.grants.json
+jq '.plan["resources.schemas.myschema.grants"] | .remote_state.__embed__ |= sort_by(.principal)' tmp.plan.json > out.plan.grants.json
 trace print_requests.py --get //unity-catalog/permissions --sort
 
 # Deploy from serialized plan (READPLAN=1) or without (READPLAN="").


### PR DESCRIPTION
## What

`acceptance/bundle/deploy/readplan/grants-remove-principal` was failing intermittently on `main` (seen on the `linux, direct` job of the post-merge `build` run for dce783d66). The diff was a pure reordering of the two entries in `remote_state.__embed__`:

```
-        "principal": "[USERNAME]",
+        "principal": "extra@example.test",
         ...
-        "principal": "extra@example.test",
+        "principal": "[USERNAME]",
```

## Why

The testserver deliberately randomizes grant-assignment order — it builds the list by iterating a Go map (`libs/testserver/grants.go`), with a comment noting this is intentional because the Azure backend behaves the same way. The test wrote `remote_state.__embed__` straight into the golden without normalizing that order, so the golden matched only when map iteration happened to emit the principals in the checked-in order.

This is a flaky test, not a product regression: `macos, direct` passed on the same commit, and the test passes locally on repeated runs.

## Fix

Sort `__embed__` by principal in the `jq` step, matching how the sibling `acceptance/bundle/resources/grants/schemas/out_of_band_principal` test handles the same non-deterministic array. Verified with 40 consecutive local runs of both `EnvMatrix` variants.

This pull request and its description were written by Isaac.