### PR TITLE
acc: stop bundle-generate tests leaking cloud workspace dirs

### DIFF
--- a/acceptance/bundle/generate/alert/alert.json.tmpl
+++ b/acceptance/bundle/generate/alert/alert.json.tmpl
@@ -1,6 +1,6 @@
 {
   "display_name": "test alert",
-  "parent_path": "/Workspace/test-$UNIQUE_NAME",
+  "parent_path": "/Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME",
   "query_text": "SELECT 1\n as value",
   "warehouse_id": "$TEST_DEFAULT_WAREHOUSE_ID",
   "evaluation": {

--- a/acceptance/bundle/generate/alert/output.txt
+++ b/acceptance/bundle/generate/alert/output.txt
@@ -1,5 +1,5 @@
 
->>> [CLI] workspace mkdirs /Workspace/test-[UNIQUE_NAME]
+>>> [CLI] workspace mkdirs /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME]
 
 >>> [CLI] bundle generate alert --existing-id [ALERT_ID] --source-dir out/alert --config-dir out/resource
 Alert configuration successfully saved to [TEST_TMP_DIR]/out/resource/test_alert.alert.yml

--- a/acceptance/bundle/generate/alert/output.txt
+++ b/acceptance/bundle/generate/alert/output.txt
@@ -12,3 +12,5 @@ so it will not be deployed. Add a matching entry to the 'include' section, for e
 include:
   - out/resource/*.yml
 
+
+>>> [CLI] workspace delete /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME] --recursive

--- a/acceptance/bundle/generate/alert/script
+++ b/acceptance/bundle/generate/alert/script
@@ -1,4 +1,4 @@
-trace $CLI workspace mkdirs /Workspace/test-$UNIQUE_NAME
+trace $CLI workspace mkdirs /Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME
 
 # create an alert to import
 envsubst < alert.json.tmpl > alert.json

--- a/acceptance/bundle/generate/alert/script.cleanup
+++ b/acceptance/bundle/generate/alert/script.cleanup
@@ -1,0 +1,1 @@
+trace $CLI workspace delete /Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME --recursive

--- a/acceptance/bundle/generate/auto-bind/databricks.yml.tmpl
+++ b/acceptance/bundle/generate/auto-bind/databricks.yml.tmpl
@@ -2,7 +2,7 @@ bundle:
   name: auto-bind-test
 
 workspace:
-  root_path: /tmp/${UNIQUE_NAME}
+  root_path: ~/.bundle/auto-bind-test-${UNIQUE_NAME}
 
 include:
   - resources/*.yml

--- a/acceptance/bundle/generate/auto-bind/output.txt
+++ b/acceptance/bundle/generate/auto-bind/output.txt
@@ -21,7 +21,7 @@ test.py
 
 === Deploy the bound job:
 >>> [CLI] bundle deploy
-Uploading bundle files to /Workspace/tmp/[UNIQUE_NAME]/files...
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/auto-bind-test-[UNIQUE_NAME]/files...
 Deploying resources...
 Updating deployment state...
 Deployment complete!
@@ -31,7 +31,7 @@ Deployment complete!
 The following resources will be deleted:
   delete resources.jobs.test_job
 
-All files and directories at the following location will be deleted: /Workspace/tmp/[UNIQUE_NAME]
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/auto-bind-test-[UNIQUE_NAME]
 
 Deleting files...
 Destroy complete!

--- a/acceptance/bundle/generate/dashboard/dashboard.json.tmpl
+++ b/acceptance/bundle/generate/dashboard/dashboard.json.tmpl
@@ -1,5 +1,5 @@
 {
     "display_name": "test dashboard",
-    "parent_path": "/Workspace/test-$UNIQUE_NAME",
+    "parent_path": "/Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME",
     "serialized_dashboard": "{\"pages\":[{\"displayName\":\"New Page\",\"layout\":[],\"name\":\"12345678\"}]}"
 }

--- a/acceptance/bundle/generate/dashboard/output.txt
+++ b/acceptance/bundle/generate/dashboard/output.txt
@@ -12,3 +12,5 @@ so it will not be deployed. Add a matching entry to the 'include' section, for e
 include:
   - out/resource/*.yml
 
+
+>>> [CLI] workspace delete /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME] --recursive

--- a/acceptance/bundle/generate/dashboard/output.txt
+++ b/acceptance/bundle/generate/dashboard/output.txt
@@ -1,5 +1,5 @@
 
->>> [CLI] workspace mkdirs /Workspace/test-[UNIQUE_NAME]
+>>> [CLI] workspace mkdirs /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME]
 
 >>> [CLI] bundle generate dashboard --existing-id [DASHBOARD_ID] --dashboard-dir out/dashboard --resource-dir out/resource
 Writing dashboard to out/dashboard/test_dashboard.lvdash.json

--- a/acceptance/bundle/generate/dashboard/script
+++ b/acceptance/bundle/generate/dashboard/script
@@ -1,4 +1,4 @@
-trace $CLI workspace mkdirs /Workspace/test-$UNIQUE_NAME
+trace $CLI workspace mkdirs /Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME
 
 # create a dashboard to import
 envsubst < dashboard.json.tmpl > dashboard.json

--- a/acceptance/bundle/generate/dashboard/script.cleanup
+++ b/acceptance/bundle/generate/dashboard/script.cleanup
@@ -1,0 +1,1 @@
+trace $CLI workspace delete /Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME --recursive

--- a/acceptance/bundle/generate/genie_space/genie_space.json.tmpl
+++ b/acceptance/bundle/generate/genie_space/genie_space.json.tmpl
@@ -1,7 +1,7 @@
 {
     "title": "test genie space",
     "description": "test description",
-    "parent_path": "/Workspace/test-$UNIQUE_NAME",
+    "parent_path": "/Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME",
     "warehouse_id": "test-warehouse-id",
     "serialized_space": "{\"tables\":[],\"questions\":[]}"
 }

--- a/acceptance/bundle/generate/genie_space/out/resource/test_genie_space.genie_space.yml
+++ b/acceptance/bundle/generate/genie_space/out/resource/test_genie_space.genie_space.yml
@@ -5,4 +5,4 @@ resources:
       warehouse_id: test-warehouse-id
       file_path: ../genie_space/test_genie_space.geniespace.json
       description: test description
-      parent_path: /Workspace/test-[UNIQUE_NAME]
+      parent_path: /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME]

--- a/acceptance/bundle/generate/genie_space/output.txt
+++ b/acceptance/bundle/generate/genie_space/output.txt
@@ -1,5 +1,5 @@
 
->>> [CLI] workspace mkdirs /Workspace/test-[UNIQUE_NAME]
+>>> [CLI] workspace mkdirs /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME]
 
 >>> [CLI] bundle generate genie-space --existing-id [GENIE_SPACE_ID] --genie-space-dir out/genie_space --resource-dir out/resource
 Writing genie space to out/genie_space/test_genie_space.geniespace.json

--- a/acceptance/bundle/generate/genie_space/output.txt
+++ b/acceptance/bundle/generate/genie_space/output.txt
@@ -12,3 +12,5 @@ so it will not be deployed. Add a matching entry to the 'include' section, for e
 include:
   - out/resource/*.yml
 
+
+>>> [CLI] workspace delete /Workspace/Users/[USERNAME]/test-[UNIQUE_NAME] --recursive

--- a/acceptance/bundle/generate/genie_space/script
+++ b/acceptance/bundle/generate/genie_space/script
@@ -1,4 +1,4 @@
-trace $CLI workspace mkdirs /Workspace/test-$UNIQUE_NAME
+trace $CLI workspace mkdirs /Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME
 
 # create a genie space to import
 envsubst < genie_space.json.tmpl > genie_space.json

--- a/acceptance/bundle/generate/genie_space/script.cleanup
+++ b/acceptance/bundle/generate/genie_space/script.cleanup
@@ -1,0 +1,1 @@
+trace $CLI workspace delete /Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME --recursive


### PR DESCRIPTION
## Why

Several `bundle/generate` acceptance tests create directories on the **real workspace** (they have `Cloud = true`) and never reliably remove them, so leftovers accumulate on shared test workspaces (e.g. `azure-prod-ucws-is`), bloating `workspace list /`. This was observed contributing to a workspace-listing integration test hanging.

Two distinct leaks:

1. **`genie_space`, `dashboard`, `alert`** each ran `workspace mkdirs /Workspace/test-$UNIQUE_NAME` at the **workspace root** and used it as the `parent_path` for the resource they create. Nothing deleted it: no `script.cleanup`, and the `eng-dev-ecosystem` env cleaner only sweeps `/Users`, never the root. The alert test also frequently times out (`TimeoutCloud = "5m"`, #4221).
2. **`auto-bind`** deployed its bundle to `/Workspace/tmp/$UNIQUE_NAME`. Its `bundle destroy` removes that on the happy path, but the inline `trap` only cleaned the `/Users/.../python-*` notebook dirs — so a failure before `destroy` leaked the root into the shared, unswept `/Workspace/tmp` namespace.

## What

Every generate test that creates workspace state now cleans up after itself, in the swept user tree:

- Relocated the three root dirs to `/Workspace/Users/$CURRENT_USER_NAME/test-$UNIQUE_NAME`, and added a `script.cleanup` to each that recursively deletes it (removing the genie space / dashboard / alert created inside).
- Moved `auto-bind`'s bundle root to `~/.bundle/auto-bind-test-$UNIQUE_NAME`, matching the `~/.bundle` convention every other bundle acceptance test uses.

Output goldens regenerated with `-update`; the full `bundle/generate` suite passes locally.

This pull request and its description were written by Isaac, an AI coding agent.