### PR TITLE
acc: disable Lakebase v2 invariant tests on cloud

### DIFF
--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -97,6 +97,12 @@ no_postgres_synced_table_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=postgres
 no_postgres_role_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=postgres_role.yml.tmpl"]
 no_postgres_database_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=postgres_database.yml.tmpl"]
 
+# Lakebase v2 (database instances/catalogs/synced tables) is not available on GCP,
+# so exclude these from all cloud runs (same as the postgres resources above).
+no_database_instance_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=database_instance.yml.tmpl"]
+no_database_catalog_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=database_catalog.yml.tmpl"]
+no_synced_database_table_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=synced_database_table.yml.tmpl"]
+
 # External locations require actual storage credentials with cloud IAM setup
 # which are environment-specific, so we only test locally with the mock server
 no_external_location_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=external_location.yml.tmpl"]

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -97,7 +97,7 @@ no_postgres_synced_table_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=postgres
 no_postgres_role_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=postgres_role.yml.tmpl"]
 no_postgres_database_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=postgres_database.yml.tmpl"]
 
-# Lakebase v2 (database instances/catalogs/synced tables) is not available on GCP,
+# Lakebase v1 (database instances/catalogs/synced tables) is not available on GCP,
 # so exclude these from all cloud runs (same as the postgres resources above).
 no_database_instance_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=database_instance.yml.tmpl"]
 no_database_catalog_on_cloud = ["CONFIG_Cloud=true", "INPUT_CONFIG=database_catalog.yml.tmpl"]


### PR DESCRIPTION
Prep for new test envs that are all UC-enabled. The UC-gated `bundle/invariant` test was skipped on GCP only because the old GCP env had no metastore; once every env is UC-enabled it would run there and its Lakebase v1 templates fail with "Lakebase is not enabled" (400), since Lakebase v1 isn't on GCP.

Exclude `database_instance`/`database_catalog`/`synced_database_table` (Lakebase v1) from all cloud runs via `CONFIG_Cloud=true`, matching the `postgres_*` block (Lakebase v2). Follow-up will add per-cloud (AWS+Azure) enablement across all Lakebase v1/v2 resources.

This pull request and its description were written by Isaac.