### PR TITLE
acc: normalize GCP gs:// volume storage_location to match s3://[METASTORE_NAME] golden

### DIFF
--- a/acceptance/bundle/resources/grants/volumes/test.toml
+++ b/acceptance/bundle/resources/grants/volumes/test.toml
@@ -3,3 +3,11 @@
 Old = 'abfss://decotestprod-unity-iso@decotestprodunityiso.dfs.core.windows.net'
 New = 's3://deco-uc-prod-isolated-aws-us-east-1/metastore'
 Order = -1
+
+[[Repls]]
+# Normalize GCP storage URL to match AWS format, before METASTORE_NAME replacement.
+# Unlike Azure, the gs:// URL carries the /metastore/... suffix directly after the
+# bucket, so only the bucket prefix is rewritten and the METASTORE_NAME repl finishes.
+Old = 'gs://deco-uc-prod-gcp-us-central1-isolated'
+New = 's3://deco-uc-prod-isolated-aws-us-east-1'
+Order = -1


### PR DESCRIPTION
Adds a GCP storage-URL normalization repl to `grants/volumes/test.toml` (mirroring the existing Azure one) so the `s3://[METASTORE_NAME]` golden holds on the new GCP UC test env; without it, the raw `gs://` location fails the `Cloud = true` test. No-op for AWS/local/Azure.

This pull request and its description were written by Isaac.