### PR TITLE
libs/filer: tolerate already-vanished directory during recursive delete

### DIFF
--- a/.nextchanges/cli/filer-gcs-recursive-delete.md
+++ b/.nextchanges/cli/filer-gcs-recursive-delete.md
@@ -1,0 +1,1 @@
+Fixed `databricks fs rm -r` failing on UC Volumes backed by GCS when a directory becomes empty during recursive deletion.

--- a/.nextchanges/cli/filer-gcs-recursive-delete.md
+++ b/.nextchanges/cli/filer-gcs-recursive-delete.md
@@ -1,1 +1,1 @@
-Fixed `databricks fs rm -r` failing on UC Volumes backed by GCS when a directory becomes empty during recursive deletion.
+Fixed `databricks fs rm -r` failing on UC Volumes backed by GCS when a directory becomes empty during recursive deletion ([#5958](https://github.com/databricks/cli/pull/5958)).

--- a/libs/filer/files_client.go
+++ b/libs/filer/files_client.go
@@ -272,6 +272,14 @@ func (w *FilesClient) deleteDirectory(ctx context.Context, name string) error {
 		return directoryNotEmptyError{absPath}
 	}
 
+	// On GCS-backed storage a directory created implicitly is just a key prefix
+	// with no standalone object, so it disappears when its last child is
+	// deleted. The delete API then returns 404 for that already-vanished
+	// directory; treat it as a not-found error so recursive delete can consider
+	// its goal satisfied.
+	if apierr.IsMissing(err) {
+		return noSuchDirectoryError{absPath}
+	}
 	return err
 }
 
@@ -331,6 +339,12 @@ func (w *FilesClient) recursiveDelete(ctx context.Context, name string) error {
 	// fs.WalkDir walks the directories in lexicographical order.
 	for _, dir := range slices.Backward(dirsToDelete) {
 		err := w.deleteDirectory(ctx, dir)
+		// A directory may have already vanished after its last child was
+		// deleted (see deleteDirectory for the GCS implicit-directory quirk).
+		// The delete's goal is already satisfied, so tolerate it.
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
 		if err != nil {
 			return err
 		}

--- a/libs/filer/files_client_test.go
+++ b/libs/filer/files_client_test.go
@@ -1,0 +1,57 @@
+package filer
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func deleteDirectoryWithError(t *testing.T, statusCode int, errorCode, reason string) error {
+	t.Helper()
+
+	server := testserver.New(t)
+	server.Handle("DELETE", "/api/2.0/fs/directories/{path...}", func(req testserver.Request) any {
+		return testserver.Response{
+			StatusCode: statusCode,
+			Body: map[string]any{
+				"error_code": errorCode,
+				"message":    "test error",
+				"details": []map[string]any{
+					{
+						"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+						"reason": reason,
+					},
+				},
+			},
+		}
+	})
+	testserver.AddDefaultHandlers(server)
+
+	client, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:  server.URL,
+		Token: "testtoken",
+	})
+	require.NoError(t, err)
+
+	f, err := NewFilesClient(client, "/test")
+	require.NoError(t, err)
+
+	return f.(*FilesClient).deleteDirectory(t.Context(), "dir")
+}
+
+func TestFilesClientDeleteDirectoryNotFound(t *testing.T) {
+	// A GCS-backed implicit directory can vanish once its last child is deleted,
+	// so the delete API returns 404 FILES_API_DIRECTORY_IS_NOT_FOUND. It must
+	// map to a not-found error so recursive delete can tolerate it.
+	err := deleteDirectoryWithError(t, 404, "NOT_FOUND", "FILES_API_DIRECTORY_IS_NOT_FOUND")
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestFilesClientDeleteDirectoryNotEmpty(t *testing.T) {
+	err := deleteDirectoryWithError(t, 400, "INVALID_PARAMETER_VALUE", "FILES_API_DIRECTORY_IS_NOT_EMPTY")
+	assert.ErrorIs(t, err, fs.ErrInvalid)
+}


### PR DESCRIPTION
On GCS-backed UC Volumes, a directory created implicitly via CreateParentDirectories has no standalone object, so it disappears when its last child file is deleted. `recursiveDelete` deletes files first and directories after, so on GCS the directory-delete returns 404 and fails the whole operation even though its goal (directory and contents gone) is already met. This surfaced as `databricks fs rm -r` failing on GCS volumes.

Map that 404 to a not-found error via `apierr.IsMissing` and skip not-found directories in `recursiveDelete`. Correct on every backend: on AWS/Azure the directory-delete still returns 204, so the tolerant branch is never taken.

Cross-verified on live test environments: `TestFilerReadWrite/files` and `TestFilerRecursiveDelete/files` now pass on GCP (previously failed) and stay green on AWS.

This pull request and its description were written by Isaac.
