### PR TITLE
bundle: add per-resource deploy_targets to scope resources to targets (draft for #2878)

### DIFF
--- a/acceptance/bundle/deploy_targets/databricks.yml
+++ b/acceptance/bundle/deploy_targets/databricks.yml
@@ -1,0 +1,23 @@
+bundle:
+  name: deploy-targets
+
+# Each job is defined once at the top level. deploy_targets restricts a job to
+# a subset of targets. A job with no deploy_targets is deployed to every target.
+resources:
+  jobs:
+    shared_job:
+      name: shared_job
+
+    dev_and_staging_job:
+      name: dev_and_staging_job
+      deploy_targets: [dev, staging]
+
+    prod_only_job:
+      name: prod_only_job
+      deploy_targets: [prod]
+
+targets:
+  dev:
+    default: true
+  staging:
+  prod:

--- a/acceptance/bundle/deploy_targets/out.test.toml
+++ b/acceptance/bundle/deploy_targets/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deploy_targets/output.txt
+++ b/acceptance/bundle/deploy_targets/output.txt
@@ -1,0 +1,18 @@
+
+>>> [CLI] bundle validate -o json -t dev
+[
+  "dev_and_staging_job",
+  "shared_job"
+]
+
+>>> [CLI] bundle validate -o json -t staging
+[
+  "dev_and_staging_job",
+  "shared_job"
+]
+
+>>> [CLI] bundle validate -o json -t prod
+[
+  "prod_only_job",
+  "shared_job"
+]

--- a/acceptance/bundle/deploy_targets/script
+++ b/acceptance/bundle/deploy_targets/script
@@ -1,0 +1,3 @@
+trace $CLI bundle validate -o json -t dev | jq '.resources.jobs | keys'
+trace $CLI bundle validate -o json -t staging | jq '.resources.jobs | keys'
+trace $CLI bundle validate -o json -t prod | jq '.resources.jobs | keys'

--- a/acceptance/bundle/deploy_targets/test.toml
+++ b/acceptance/bundle/deploy_targets/test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/bundle/config/mutator/resourcemutator/filter_deploy_targets.go
+++ b/bundle/config/mutator/resourcemutator/filter_deploy_targets.go
@@ -1,0 +1,87 @@
+package resourcemutator
+
+import (
+	"context"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/libs/diag"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/dyn/merge"
+)
+
+type filterDeployTargets struct{}
+
+// FilterDeployTargets drops resources that declare a deploy_targets list which
+// does not include the selected target. A resource with an empty (or absent)
+// deploy_targets list is left untouched and deploys to every target, matching
+// the historical behavior of a top-level resource.
+//
+// This lets a single top-level resource definition be scoped to a subset of
+// targets without nesting its body under targets.<name>.resources. It runs
+// after resources are fully materialized (after PythonMutator) so that
+// dynamically added resources are also filtered, and before validation so that
+// required-field checks only see resources that will actually be deployed.
+func FilterDeployTargets() bundle.Mutator {
+	return &filterDeployTargets{}
+}
+
+func (m *filterDeployTargets) Name() string {
+	return "FilterDeployTargets"
+}
+
+func (m *filterDeployTargets) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnostics {
+	target := b.Config.Bundle.Target
+
+	// Compute, per resource type, the names to drop for the selected target.
+	// Reading the typed structs is sufficient here because deploy_targets is a
+	// plain string slice; the actual removal happens on the dyn tree below so it
+	// deletes from the real resource maps rather than a copy.
+	dropByType := map[string][]string{}
+	for _, group := range b.Config.Resources.AllResources() {
+		typeName := group.Description.PluralName
+		for name, resource := range group.Resources {
+			deployTargets := resource.GetDeployTargets()
+			if len(deployTargets) == 0 {
+				continue
+			}
+			if !slicesContains(deployTargets, target) {
+				dropByType[typeName] = append(dropByType[typeName], name)
+			}
+		}
+	}
+
+	if len(dropByType) == 0 {
+		return nil
+	}
+
+	err := b.Config.Mutate(func(root dyn.Value) (dyn.Value, error) {
+		newRoot := root
+		for typeName, names := range dropByType {
+			typePath := dyn.NewPath(dyn.Key("resources"), dyn.Key(typeName))
+			var err error
+			newRoot, err = dyn.MapByPath(newRoot, typePath, func(_ dyn.Path, resources dyn.Value) (dyn.Value, error) {
+				return merge.AntiSelect(resources, names)
+			})
+			if err != nil {
+				return dyn.InvalidValue, err
+			}
+		}
+		return newRoot, nil
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// slicesContains reports whether target is present in list. Kept local to avoid
+// widening imports for a single call.
+func slicesContains(list []string, target string) bool {
+	for _, v := range list {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}

--- a/bundle/config/mutator/resourcemutator/filter_deploy_targets_test.go
+++ b/bundle/config/mutator/resourcemutator/filter_deploy_targets_test.go
@@ -1,0 +1,118 @@
+package resourcemutator_test
+
+import (
+	"testing"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/mutator/resourcemutator"
+	"github.com/databricks/cli/bundle/config/resources"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/stretchr/testify/assert"
+)
+
+func filterDeployTargetsBundle(target string) *bundle.Bundle {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					// No deploy_targets: deployed everywhere.
+					"everywhere": {
+						JobSettings: jobs.JobSettings{Name: "everywhere"},
+					},
+					// Restricted to dev and staging.
+					"dev_and_staging": {
+						BaseResource: resources.BaseResource{DeployTargets: []string{"dev", "staging"}},
+						JobSettings:  jobs.JobSettings{Name: "dev_and_staging"},
+					},
+					// Restricted to prod only.
+					"prod_only": {
+						BaseResource: resources.BaseResource{DeployTargets: []string{"prod"}},
+						JobSettings:  jobs.JobSettings{Name: "prod_only"},
+					},
+				},
+				Pipelines: map[string]*resources.Pipeline{
+					// A different resource type, restricted to prod, to confirm
+					// filtering is applied uniformly across resource kinds.
+					"pipeline_prod_only": {
+						BaseResource:   resources.BaseResource{DeployTargets: []string{"prod"}},
+						CreatePipeline: pipelines.CreatePipeline{Name: "pipeline_prod_only"},
+					},
+				},
+			},
+		},
+	}
+	b.Config.Bundle.Target = target
+	return b
+}
+
+func TestFilterDeployTargetsDev(t *testing.T) {
+	b := filterDeployTargetsBundle("dev")
+
+	diags := bundle.Apply(t.Context(), b, resourcemutator.FilterDeployTargets())
+	assert.NoError(t, diags.Error())
+
+	// everywhere has no list so it stays; dev_and_staging includes dev so it
+	// stays; prod_only does not include dev so it is dropped.
+	assert.Contains(t, b.Config.Resources.Jobs, "everywhere")
+	assert.Contains(t, b.Config.Resources.Jobs, "dev_and_staging")
+	assert.NotContains(t, b.Config.Resources.Jobs, "prod_only")
+	assert.Len(t, b.Config.Resources.Jobs, 2)
+
+	// The prod-only pipeline is dropped in dev as well.
+	assert.NotContains(t, b.Config.Resources.Pipelines, "pipeline_prod_only")
+	assert.Empty(t, b.Config.Resources.Pipelines)
+}
+
+func TestFilterDeployTargetsProd(t *testing.T) {
+	b := filterDeployTargetsBundle("prod")
+
+	diags := bundle.Apply(t.Context(), b, resourcemutator.FilterDeployTargets())
+	assert.NoError(t, diags.Error())
+
+	// everywhere stays; dev_and_staging does not include prod so it is dropped;
+	// prod_only includes prod so it stays.
+	assert.Contains(t, b.Config.Resources.Jobs, "everywhere")
+	assert.NotContains(t, b.Config.Resources.Jobs, "dev_and_staging")
+	assert.Contains(t, b.Config.Resources.Jobs, "prod_only")
+	assert.Len(t, b.Config.Resources.Jobs, 2)
+
+	// The prod-only pipeline is kept in prod.
+	assert.Contains(t, b.Config.Resources.Pipelines, "pipeline_prod_only")
+	assert.Len(t, b.Config.Resources.Pipelines, 1)
+}
+
+func TestFilterDeployTargetsUnlistedTarget(t *testing.T) {
+	// A target that appears in no deploy_targets list keeps only the resources
+	// that have no list at all.
+	b := filterDeployTargetsBundle("qa")
+
+	diags := bundle.Apply(t.Context(), b, resourcemutator.FilterDeployTargets())
+	assert.NoError(t, diags.Error())
+
+	assert.Contains(t, b.Config.Resources.Jobs, "everywhere")
+	assert.NotContains(t, b.Config.Resources.Jobs, "dev_and_staging")
+	assert.NotContains(t, b.Config.Resources.Jobs, "prod_only")
+	assert.Len(t, b.Config.Resources.Jobs, 1)
+	assert.Empty(t, b.Config.Resources.Pipelines)
+}
+
+func TestFilterDeployTargetsNoFieldsSet(t *testing.T) {
+	// When no resource declares deploy_targets, the mutator makes no changes.
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Resources: config.Resources{
+				Jobs: map[string]*resources.Job{
+					"a": {JobSettings: jobs.JobSettings{Name: "a"}},
+					"b": {JobSettings: jobs.JobSettings{Name: "b"}},
+				},
+			},
+		},
+	}
+	b.Config.Bundle.Target = "dev"
+
+	diags := bundle.Apply(t.Context(), b, resourcemutator.FilterDeployTargets())
+	assert.NoError(t, diags.Error())
+	assert.Len(t, b.Config.Resources.Jobs, 2)
+}

--- a/bundle/config/resources.go
+++ b/bundle/config/resources.go
@@ -64,6 +64,10 @@ type ConfigResource interface {
 
 	// GetLifecycle returns the lifecycle settings for the resource.
 	GetLifecycle() resources.LifecycleConfig
+
+	// GetDeployTargets returns the targets the resource is restricted to, or an
+	// empty slice when the resource is not target-scoped.
+	GetDeployTargets() []string
 }
 
 // ResourceGroup represents a group of resources of the same type.

--- a/bundle/config/resources/base.go
+++ b/bundle/config/resources/base.go
@@ -6,9 +6,25 @@ type BaseResource struct {
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
 	URL            string         `json:"url,omitempty" bundle:"internal"`
 	Lifecycle      Lifecycle      `json:"lifecycle,omitempty"`
+
+	// DeployTargets optionally restricts the resource to a subset of targets.
+	// When empty (the default) the resource is deployed to every target, matching
+	// the historical behavior of a top-level resource. When set, the resource is
+	// only deployed to a target whose name appears in the list; for any other
+	// target it is dropped from the configuration before deployment. This lets a
+	// single top-level definition be scoped to specific targets without nesting
+	// the body under targets.<name>.resources. It is a bundle-only field and is
+	// never emitted to the deployment engine.
+	DeployTargets []string `json:"deploy_targets,omitempty"`
 }
 
 // GetLifecycle returns the lifecycle settings for the resource.
 func (b *BaseResource) GetLifecycle() LifecycleConfig {
 	return b.Lifecycle
+}
+
+// GetDeployTargets returns the targets the resource is restricted to, or an
+// empty slice when the resource is not target-scoped.
+func (b *BaseResource) GetDeployTargets() []string {
+	return b.DeployTargets
 }

--- a/bundle/config/resources/external_location.go
+++ b/bundle/config/resources/external_location.go
@@ -17,7 +17,8 @@ type ExternalLocation struct {
 	ID             string         `json:"id,omitempty" bundle:"readonly"`
 	ModifiedStatus ModifiedStatus `json:"modified_status,omitempty" bundle:"internal"`
 	// Note: We intentionally don't include BaseResource.URL here to avoid conflict with Url field below
-	Lifecycle Lifecycle `json:"lifecycle,omitempty"`
+	Lifecycle     Lifecycle `json:"lifecycle,omitempty"`
+	DeployTargets []string  `json:"deploy_targets,omitempty"`
 
 	catalog.CreateExternalLocation
 
@@ -65,6 +66,12 @@ func (e *ExternalLocation) GetName() string {
 // GetLifecycle returns the lifecycle settings for the resource.
 func (e *ExternalLocation) GetLifecycle() LifecycleConfig {
 	return e.Lifecycle
+}
+
+// GetDeployTargets returns the targets the resource is restricted to, or an
+// empty slice when the resource is not target-scoped.
+func (e *ExternalLocation) GetDeployTargets() []string {
+	return e.DeployTargets
 }
 
 func (e *ExternalLocation) UnmarshalJSON(b []byte) error {

--- a/bundle/direct/dresources/type_test.go
+++ b/bundle/direct/dresources/type_test.go
@@ -59,6 +59,7 @@ var knownMissingInRemoteType = map[string][]string{
 // commonMissingInStateType lists fields that are commonly missing across all resource types.
 // These are bundle-specific fields that exist in InputType but not in StateType.
 var commonMissingInStateType = []string{
+	"deploy_targets",
 	"grants",
 	"lifecycle",
 	"permissions",

--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -238,6 +238,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "evaluation":
           "description": |-
             PLACEHOLDER
@@ -344,6 +347,9 @@ resources:
                 "value_from":
                   "description": |-
                     PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "effective_budget_policy_id":
           "description": |-
             PLACEHOLDER
@@ -505,6 +511,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "grants":
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
@@ -573,6 +582,9 @@ resources:
                       notebook_path: "./src/my_notebook.py"
           ```
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -648,6 +660,9 @@ resources:
         "dataset_schema":
           "description": |-
             Sets the default schema for all datasets in this dashboard. When set, this overrides the schema specified in individual dataset definitions.
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "display_name":
           "description": |-
             The display name of the dashboard.
@@ -730,6 +745,9 @@ resources:
         "create_database_if_not_exists":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -740,6 +758,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -782,6 +803,9 @@ resources:
                 description: MLflow experiment used to track runs
           ```
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -819,6 +843,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "effective_file_event_queue":
           "$fields":
             "managed_aqs":
@@ -871,6 +898,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "description":
           "description": |-
             Description of the Genie space shown alongside the title in the Databricks UI.
@@ -916,6 +946,9 @@ resources:
       "description": |-
         The job run definitions for the bundle, where each key is the name of the job run. Each job run triggers a run of an existing job as part of bundle deployment.
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -946,6 +979,9 @@ resources:
 
           For information about defining job tasks and overriding job settings, see [_](/dev-tools/bundles/job-task-types.md), [_](/dev-tools/bundles/job-task-override.md), and [_](/dev-tools/bundles/cluster-override.md).
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "environments":
           "$fields":
             "spec":
@@ -1127,6 +1163,9 @@ resources:
                     "served_entity_name":
                       "description": |-
                         PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "description":
           "description": |-
             PLACEHOLDER
@@ -1172,6 +1211,9 @@ resources:
         "markdown_description": |-
           The model resource allows you to define [legacy models](/api/workspace/modelregistry/createmodel) in bundles. Databricks recommends you use Unity Catalog [registered models](#registered-model) instead.
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -1234,6 +1276,9 @@ resources:
                       path: ./pipeline.py
           ```
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "ingestion_definition":
           "$fields":
             "objects":
@@ -1347,6 +1392,9 @@ resources:
         "branch_id":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "expire_time":
           "description": |-
             PLACEHOLDER
@@ -1393,6 +1441,9 @@ resources:
         "create_database_if_missing":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -1406,6 +1457,9 @@ resources:
         "database_id":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -1431,6 +1485,9 @@ resources:
         "autoscaling_limit_min_cu":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "disabled":
           "description": |-
             PLACEHOLDER
@@ -1477,6 +1534,9 @@ resources:
         "default_endpoint_settings":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "display_name":
           "description": |-
             PLACEHOLDER
@@ -1535,6 +1595,9 @@ resources:
         "auth_method":
           "description": |-
             How the role is authenticated when connecting to Postgres. If left unspecified, a meaningful authentication method is derived from the identity_type.
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "identity_type":
           "description": |-
             The type of the Databricks managed identity that this Role represents. Leave empty to create a regular Postgres role not associated with a Databricks identity.
@@ -1569,6 +1632,9 @@ resources:
         "create_database_objects_if_missing":
           "description": |-
             PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "existing_pipeline_id":
           "description": |-
             PLACEHOLDER
@@ -1629,6 +1695,9 @@ resources:
                   timezone_id: UTC
           ```
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "inference_log":
           "description": |-
             PLACEHOLDER
@@ -1672,6 +1741,9 @@ resources:
                       principal: account users
           ```
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "grants":
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
@@ -1744,6 +1816,9 @@ resources:
                 catalog_name: main
             ```
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "grants":
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
@@ -1773,6 +1848,9 @@ resources:
         "backend_type":
           "description": |-
             The backend type the scope will be created with. If not specified, will default to `DATABRICKS`
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "keyvault_metadata":
           "description": |-
             The metadata for the secret scope if the `backend_type` is `AZURE_KEYVAULT`
@@ -1820,6 +1898,9 @@ resources:
             "name":
               "description": |-
                 PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "enable_photon":
           "description": |-
             Configures whether the warehouse should use Photon optimized clusters.
@@ -1881,6 +1962,9 @@ resources:
                 "delta_table_sync_info":
                   "description": |-
                     PLACEHOLDER
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -1888,6 +1972,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -1912,6 +1999,9 @@ resources:
       "description": |-
         PLACEHOLDER
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "grants":
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.
@@ -1958,6 +2048,9 @@ resources:
 
           For an example bundle that runs a job that writes to a file in Unity Catalog volume, see the [bundle-examples GitHub repository](https://github.com/databricks/bundle-examples/tree/main/knowledge_base/write_from_job_to_volume).
       "$fields":
+        "deploy_targets":
+          "description": |-
+            A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.
         "grants":
           "description": |-
             The Unity Catalog privileges to grant to principals on this securable.

--- a/bundle/phases/initialize.go
+++ b/bundle/phases/initialize.go
@@ -160,6 +160,12 @@ func Initialize(ctx context.Context, b *bundle.Bundle) {
 		// filter resources; the direct engine selects against the resolved keys later.
 		mutator.ResolveSelect(),
 
+		// Drop resources whose deploy_targets list does not include the selected
+		// target. Runs after all resource mutations so that dynamically added
+		// resources are also filtered, and before validation so required-field
+		// checks only see resources that will actually be deployed.
+		resourcemutator.FilterDeployTargets(),
+
 		// Validate all required fields are set. This is run after variable interpolation and PyDABs mutators
 		// since they can also set and modify resources.
 		validate.Required(),

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -87,6 +87,10 @@
                         "description": "[Public Preview] Custom summary for the alert. support mustache template.",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "display_name": {
                         "description": "[Public Preview] The display name of the alert.",
                         "$ref": "#/$defs/string"
@@ -175,6 +179,10 @@
                       },
                       "config": {
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.AppConfig"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "description": {
                         "description": "The description of the app.",
@@ -334,6 +342,10 @@
                         "description": "[Public Preview] Custom maximum retention period in hours for the catalog",
                         "$ref": "#/$defs/int64"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
@@ -424,6 +436,10 @@
                       "data_security_mode": {
                         "description": "Data security mode decides what data governance model to use when accessing data\nfrom a cluster.\n\n* `DATA_SECURITY_MODE_AUTO`: Databricks will choose the most appropriate access mode depending on your compute configuration.\n* `DATA_SECURITY_MODE_STANDARD`: A secure cluster that can be shared by multiple users. Cluster users are fully isolated so that they cannot see each other’s data and credentials. Most data governance features are supported in this mode. But programming languages and cluster features might be limited.\n* `DATA_SECURITY_MODE_DEDICATED`: A secure cluster that can only be exclusively used by a single user specified in `single_user_name`. Most programming languages, cluster features and data governance features are available in this mode.\n\nThe following modes are legacy aliases for the above modes:\n\n* `USER_ISOLATION`: Legacy alias for `DATA_SECURITY_MODE_STANDARD`.\n* `SINGLE_USER`: Legacy alias for `DATA_SECURITY_MODE_DEDICATED`.\n\nThe following modes are deprecated starting with Databricks Runtime 15.0 and\nwill be removed for future Databricks Runtime versions:\n\n* `LEGACY_TABLE_ACL`: This mode is for users migrating from legacy Table ACL clusters.\n* `LEGACY_PASSTHROUGH`: This mode is for users migrating from legacy Passthrough on high concurrency clusters.\n* `LEGACY_SINGLE_USER`: This mode is for users migrating from legacy Passthrough on standard clusters.\n* `LEGACY_SINGLE_USER_STANDARD`: This mode provides a way that doesn’t have UC nor passthrough enabled.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/compute.DataSecurityMode"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "docker_image": {
                         "description": "Custom docker image BYOC",
@@ -598,6 +614,10 @@
                         "description": "Sets the default schema for all datasets in this dashboard. When set, this overrides the schema specified in individual dataset definitions.",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "display_name": {
                         "description": "The display name of the dashboard.",
                         "$ref": "#/$defs/string"
@@ -672,6 +692,10 @@
                         "description": "[Public Preview] The name of the database (in an instance) associated with the catalog.",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "lifecycle": {
                         "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
@@ -707,6 +731,10 @@
                       "custom_tags": {
                         "description": "[Beta] Custom tags associated with the instance. This field is only included on create and update responses.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/database.CustomTag"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "enable_pg_native_login": {
                         "description": "[Public Preview] Whether to enable PG native password login on the instance. Defaults to false.",
@@ -774,6 +802,10 @@
                         "description": "Name of the storage credential used with this location.",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "enable_file_events": {
                         "description": "Whether to enable file events on this external location. Default to `true`. Set to `false` to disable file events.\nThe actual applied value may differ due to server-side defaults; check `effective_enable_file_events` for the effective state.",
                         "$ref": "#/$defs/bool"
@@ -834,6 +866,10 @@
                   {
                     "type": "object",
                     "properties": {
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "description": {
                         "description": "Description of the Genie space shown alongside the title in the Databricks UI.",
                         "$ref": "#/$defs/string"
@@ -891,6 +927,10 @@
                       "continuous": {
                         "description": "An optional continuous property for this job. The continuous property will ensure that there is always one run executing. Only one of `schedule` and `continuous` can be used.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/jobs.Continuous"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "description": {
                         "description": "An optional description for the job. The maximum length is 27700 characters in UTF-8 encoding.",
@@ -1045,6 +1085,10 @@
                         "doNotSuggest": true,
                         "deprecated": true
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "idempotency_token": {
                         "description": "An optional token to guarantee the idempotency of job run requests. If a run with the provided token already exists,\nthe request does not create a new run but returns the ID of the existing run instead. If a run with the provided token is deleted,\nan error is returned.\n\nIf you specify the idempotency token, upon failure you can retry until the request succeeds. Databricks guarantees that exactly one run\nis launched with that idempotency token.\n\nThis token must have at most 64 characters.\n\nFor more information, see [How to ensure idempotency for jobs](https://kb.databricks.com/jobs/jobs-idempotency.html).",
                         "$ref": "#/$defs/string"
@@ -1186,6 +1230,10 @@
                         "description": "Location where all artifacts for the experiment are stored.\nIf not provided, the remote server will select an appropriate default.",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "lifecycle": {
                         "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
@@ -1254,6 +1302,10 @@
                   {
                     "type": "object",
                     "properties": {
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "description": {
                         "description": "Optional description for registered model.",
                         "$ref": "#/$defs/string"
@@ -1337,6 +1389,10 @@
                       "config": {
                         "description": "The core config of the serving endpoint.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/serving.EndpointCoreConfigInput"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "description": {
                         "$ref": "#/$defs/string"
@@ -1487,6 +1543,10 @@
                       "continuous": {
                         "description": "Whether the pipeline is continuous or triggered. This replaces `trigger`.",
                         "$ref": "#/$defs/bool"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "development": {
                         "description": "Whether the pipeline is in Development mode. Defaults to false.",
@@ -1656,6 +1716,10 @@
                       "branch_id": {
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "expire_time": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/time.Time"
                       },
@@ -1717,6 +1781,10 @@
                       "create_database_if_missing": {
                         "$ref": "#/$defs/bool"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "lifecycle": {
                         "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
@@ -1744,6 +1812,10 @@
                     "properties": {
                       "database_id": {
                         "$ref": "#/$defs/string"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "lifecycle": {
                         "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
@@ -1785,6 +1857,10 @@
                       },
                       "autoscaling_limit_min_cu": {
                         "$ref": "#/$defs/float64"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "disabled": {
                         "$ref": "#/$defs/bool"
@@ -1848,6 +1924,10 @@
                       "default_endpoint_settings": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.ProjectDefaultEndpointSettings"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "display_name": {
                         "$ref": "#/$defs/string"
                       },
@@ -1899,6 +1979,10 @@
                       "auth_method": {
                         "description": "How the role is authenticated when connecting to Postgres. If left unspecified, a meaningful authentication method is derived from the identity_type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.RoleAuthMethod"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "identity_type": {
                         "description": "The type of the Databricks managed identity that this Role represents. Leave empty to create a regular Postgres role not associated with a Databricks identity.",
@@ -1954,6 +2038,10 @@
                       },
                       "create_database_objects_if_missing": {
                         "$ref": "#/$defs/bool"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "existing_pipeline_id": {
                         "$ref": "#/$defs/string"
@@ -2020,6 +2108,10 @@
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorDataClassificationConfig",
                         "x-databricks-launch-stage": "PRIVATE_PREVIEW",
                         "doNotSuggest": true
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "inference_log": {
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/catalog.MonitorInferenceLog"
@@ -2111,6 +2203,10 @@
                         "description": "The identifier of the user who created the registered model",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "full_name": {
                         "description": "The three-level (fully qualified) name of the registered model",
                         "$ref": "#/$defs/string"
@@ -2179,6 +2275,10 @@
                         "description": "[Public Preview] Custom maximum retention period in hours for the schema.",
                         "$ref": "#/$defs/int64"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/catalog.PrivilegeAssignment",
@@ -2222,6 +2322,10 @@
                       "backend_type": {
                         "description": "The backend type the scope will be created with. If not specified, will default to `DATABRICKS`",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/workspace.ScopeBackendType"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "keyvault_metadata": {
                         "description": "The metadata for the secret scope if the `backend_type` is `AZURE_KEYVAULT`",
@@ -2322,6 +2426,10 @@
                         "description": "warehouse creator name",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "enable_photon": {
                         "description": "Configures whether the warehouse should use Photon optimized clusters.\n\nDefaults to true.",
                         "$ref": "#/$defs/bool"
@@ -2420,6 +2528,10 @@
                         "description": "[Public Preview] Name of the target database instance. This is required when creating synced database tables in standard catalogs.\nThis is optional when creating synced database tables in registered catalogs. If this field is specified\nwhen creating synced database tables in registered catalogs, the database instance name MUST\nmatch that of the registered catalog (or the request will be rejected).",
                         "$ref": "#/$defs/string"
                       },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
+                      },
                       "lifecycle": {
                         "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
@@ -2456,6 +2568,10 @@
                       "budget_policy_id": {
                         "description": "[Public Preview] The budget policy id to be applied",
                         "$ref": "#/$defs/string"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "endpoint_type": {
                         "description": "Type of endpoint",
@@ -2505,6 +2621,10 @@
                       "delta_sync_index_spec": {
                         "description": "Specification for Delta Sync Index. Required if `index_type` is `DELTA_SYNC`.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/vectorsearch.DeltaSyncVectorIndexSpecRequest"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "direct_access_index_spec": {
                         "description": "Specification for Direct Vector Access Index. Required if `index_type` is `DIRECT_ACCESS`.",
@@ -2566,6 +2686,10 @@
                       "comment": {
                         "description": "The comment attached to the volume",
                         "$ref": "#/$defs/string"
+                      },
+                      "deploy_targets": {
+                        "description": "A list of target names that this resource is deployed to. When omitted, the resource is deployed to every target. When set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for any other target.",
+                        "$ref": "#/$defs/slice/string"
                       },
                       "grants": {
                         "description": "The Unity Catalog privileges to grant to principals on this securable.",

--- a/bundle/terraform_dabs_map/generated.go
+++ b/bundle/terraform_dabs_map/generated.go
@@ -2,34 +2,54 @@
 
 package terraform_dabs_map
 
-// alerts / databricks_alert_v2: 1 dabs-only
+// alerts / databricks_alert_v2: 2 dabs-only
 // alerts / databricks_alert_v2: 3 tf-only
-// apps / databricks_app: 16 dabs-only
+// apps / databricks_app: 17 dabs-only
 // apps / databricks_app: 1 tf-only
+// clusters / databricks_cluster: 1 dabs-only
 // clusters / databricks_cluster: 25 tf-only
+// dashboards / databricks_dashboard: 1 dabs-only
 // dashboards / databricks_dashboard: 2 tf-only
+// database_catalogs / databricks_database_database_catalog: 1 dabs-only
+// database_instances / databricks_database_instance: 1 dabs-only
 // database_instances / databricks_database_instance: 1 tf-only
+// experiments / databricks_mlflow_experiment: 1 dabs-only
 // experiments / databricks_mlflow_experiment: 1 tf-only
 // jobs / databricks_job: 11 renames
-// jobs / databricks_job: 16 dabs-only
+// jobs / databricks_job: 17 dabs-only
 // jobs / databricks_job: 258 tf-only
+// model_serving_endpoints / databricks_model_serving: 1 dabs-only
 // model_serving_endpoints / databricks_model_serving: 2 tf-only
 // models / databricks_mlflow_model: 1 renames
+// models / databricks_mlflow_model: 1 dabs-only
 // pipelines / databricks_pipeline: 3 renames
-// pipelines / databricks_pipeline: 5 dabs-only
+// pipelines / databricks_pipeline: 6 dabs-only
 // pipelines / databricks_pipeline: 2 tf-only
+// postgres_branches / databricks_postgres_branch: 1 dabs-only
 // postgres_branches / databricks_postgres_branch: 1 unwraps
+// postgres_catalogs / databricks_postgres_catalog: 1 dabs-only
 // postgres_catalogs / databricks_postgres_catalog: 1 unwraps
+// postgres_databases / databricks_postgres_database: 1 dabs-only
 // postgres_databases / databricks_postgres_database: 1 unwraps
+// postgres_endpoints / databricks_postgres_endpoint: 1 dabs-only
 // postgres_endpoints / databricks_postgres_endpoint: 1 unwraps
+// postgres_projects / databricks_postgres_project: 1 dabs-only
 // postgres_projects / databricks_postgres_project: 2 tf-only
 // postgres_projects / databricks_postgres_project: 1 unwraps
+// postgres_roles / databricks_postgres_role: 1 dabs-only
 // postgres_roles / databricks_postgres_role: 1 unwraps
+// postgres_synced_tables / databricks_postgres_synced_table: 1 dabs-only
 // postgres_synced_tables / databricks_postgres_synced_table: 1 unwraps
-// schemas / databricks_schema: 1 dabs-only
+// quality_monitors / databricks_quality_monitor: 1 dabs-only
+// registered_models / databricks_registered_model: 1 dabs-only
+// schemas / databricks_schema: 2 dabs-only
 // schemas / databricks_schema: 1 tf-only
+// secret_scopes / databricks_secret_scope: 1 dabs-only
 // secret_scopes / databricks_secret_scope: 1 tf-only
+// sql_warehouses / databricks_sql_endpoint: 1 dabs-only
 // sql_warehouses / databricks_sql_endpoint: 2 tf-only
+// synced_database_tables / databricks_database_synced_database_table: 1 dabs-only
+// volumes / databricks_volume: 1 dabs-only
 
 // TerraformToDABsFieldMap maps DABs group name → nested TF segments → DABs segment name.
 // Navigate using TF field name segments; DABs is the corresponding DABs name when it differs.
@@ -88,7 +108,8 @@ var TerraformToDABsFieldMap = map[string]RenameTree{
 // DABsOnlyFields maps DABs group name → FieldSet of DABs fields with no TF equivalent.
 var DABsOnlyFields = map[string]FieldSet{
 	"alerts": {
-		"file_path": {},
+		"deploy_targets": {},
+		"file_path":      {},
 	},
 	"apps": {
 		"config": {
@@ -99,6 +120,7 @@ var DABsOnlyFields = map[string]FieldSet{
 				"value_from": {}, // apps.*.config.env.value_from
 			},
 		},
+		"deploy_targets": {},
 		"git_source": {
 			"branch": {}, // apps.*.git_source.branch
 			"commit": {}, // apps.*.git_source.commit
@@ -112,7 +134,23 @@ var DABsOnlyFields = map[string]FieldSet{
 		},
 		"source_code_path": {},
 	},
+	"clusters": {
+		"deploy_targets": {},
+	},
+	"dashboards": {
+		"deploy_targets": {},
+	},
+	"database_catalogs": {
+		"deploy_targets": {},
+	},
+	"database_instances": {
+		"deploy_targets": {},
+	},
+	"experiments": {
+		"deploy_targets": {},
+	},
 	"jobs": {
+		"deploy_targets": {},
 		"job_clusters": {
 			"new_cluster": {
 				"autotermination_minutes": {}, // jobs.*.job_clusters.new_cluster.autotermination_minutes
@@ -151,6 +189,12 @@ var DABsOnlyFields = map[string]FieldSet{
 			},
 		},
 	},
+	"model_serving_endpoints": {
+		"deploy_targets": {},
+	},
+	"models": {
+		"deploy_targets": {},
+	},
 	"pipelines": {
 		"clusters": {
 			"gcp_attributes": {
@@ -158,13 +202,54 @@ var DABsOnlyFields = map[string]FieldSet{
 				"use_preemptible_executors": {}, // pipelines.*.clusters.gcp_attributes.use_preemptible_executors
 			},
 		},
-		"dry_run": {},
+		"deploy_targets": {},
+		"dry_run":        {},
 		"parameters": {
 			"*": {}, // pipelines.*.parameters.*
 		},
 	},
+	"postgres_branches": {
+		"deploy_targets": {},
+	},
+	"postgres_catalogs": {
+		"deploy_targets": {},
+	},
+	"postgres_databases": {
+		"deploy_targets": {},
+	},
+	"postgres_endpoints": {
+		"deploy_targets": {},
+	},
+	"postgres_projects": {
+		"deploy_targets": {},
+	},
+	"postgres_roles": {
+		"deploy_targets": {},
+	},
+	"postgres_synced_tables": {
+		"deploy_targets": {},
+	},
+	"quality_monitors": {
+		"deploy_targets": {},
+	},
+	"registered_models": {
+		"deploy_targets": {},
+	},
 	"schemas": {
 		"custom_max_retention_hours": {},
+		"deploy_targets":             {},
+	},
+	"secret_scopes": {
+		"deploy_targets": {},
+	},
+	"sql_warehouses": {
+		"deploy_targets": {},
+	},
+	"synced_database_tables": {
+		"deploy_targets": {},
+	},
+	"volumes": {
+		"deploy_targets": {},
 	},
 }
 


### PR DESCRIPTION
> Draft to support the design discussion on #2878. Context and the two options considered are in [this comment](https://github.com/databricks/cli/issues/2878#issuecomment-5006656415).

## Summary

This is a draft to make the design conversation on #2878 concrete. It adds an optional `deploy_targets` field to any bundle resource. When the field is set, the resource is deployed only to the targets whose names appear in the list, and it is dropped from the configuration for every other target. When the field is omitted, the resource is deployed to every target, which is the current behavior, so this change is additive and existing bundles are unaffected.

The request in #2878 is for a way to include configuration for one target and not others. The include section is global today, so the common workaround is to nest a resource under `targets.<name>.resources`, or to define the body once under a YAML anchor and alias it under each target in a per-file `targets:` block. That works, but the target membership ends up duplicated across files and is only visible by reading each file or running `bundle validate` per target. `deploy_targets` keeps the resource defined once at the top level and puts its target membership on the resource itself, which also covers the case where a single file defines several resources and a target needs only some of them.

I am opening this as a draft rather than proposing it for merge. It is one of two shapes discussed on the issue (the other is a per-target `include` list), and I thought it would be easier to look at the code alongside the discussion so the team can decide the direction and the field name. I am glad to rework it toward the other option, adjust the naming, or set it aside, depending on what you prefer.

## Example

```yaml
resources:
  jobs:
    shared_job:
      name: shared_job
      # no deploy_targets: deployed to every target

    dev_and_staging_job:
      name: dev_and_staging_job
      deploy_targets: [dev, staging]

    prod_only_job:
      name: prod_only_job
      deploy_targets: [prod]
```

With this config, `bundle validate -t dev` resolves `shared_job` and `dev_and_staging_job`, `-t staging` resolves the same two, and `-t prod` resolves `shared_job` and `prod_only_job`.

## Implementation

- `deploy_targets` is added once to `BaseResource` (`bundle/config/resources/base.go`), so it applies to every resource type through the embedded struct. `ExternalLocation` copies the base fields by hand rather than embedding, so the field and accessor are added there too.
- A `FilterDeployTargets` mutator (`bundle/config/mutator/resourcemutator/filter_deploy_targets.go`) drops resources whose `deploy_targets` list is set and does not contain the selected target. It runs in the initialize phase after resources are materialized and after `PythonMutator`, so dynamically added resources are also filtered, and before validation, so required-field checks only see resources that will be deployed.
- The field is bundle-only and does not reach the deployment engine. Terraform generation projects each resource onto the typed schema through `convert.Normalize`, which drops the field the same way it drops `id`, `url`, and `lifecycle`. For the direct engine it is registered in the config-only field list, alongside `lifecycle`, `grants`, and `permissions`.
- The JSON schema and the generated maps are regenerated.

## Tests

- Unit tests for the mutator covering: a resource with no list is kept everywhere; a resource is kept only in its listed targets; a target that appears in no list keeps only the unrestricted resources; filtering applies across resource types (jobs and pipelines).
- An acceptance test (`acceptance/bundle/deploy_targets`) that runs `bundle validate` for three targets and checks the resolved resource set for each, under both the terraform and direct engines.

## Open questions

- Direction: this per-resource shape, a per-target `include` list, or both. They cover different cases and are discussed on #2878.
- Field name: `deploy_targets` is a placeholder if you prefer something else.
- Whether a resource listing a target that does not exist should warn.

Related: #2878.
