### PR TITLE
testserver: echo postgres spec on GET to match backend; recapture goldens

### DIFF
--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.no_change.direct.json
@@ -9,7 +9,9 @@
   "remote_state": {
     "branch_id": "dev-branch",
     "create_time": "[TIMESTAMP]",
+    "is_protected": false,
     "name": "[DEV_BRANCH_ID]",
+    "no_expiry": true,
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
     "status": {
       "branch_id": "dev-branch",
@@ -23,19 +25,5 @@
     },
     "uid": "[BRANCH_UID]",
     "update_time": "[TIMESTAMP]"
-  },
-  "changes": {
-    "is_protected": {
-      "action": "skip",
-      "reason": "empty",
-      "old": false,
-      "new": false
-    },
-    "no_expiry": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": true,
-      "new": true
-    }
   }
 }

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.restore.direct.json
@@ -17,7 +17,9 @@
   "remote_state": {
     "branch_id": "dev-branch",
     "create_time": "[TIMESTAMP]",
+    "is_protected": true,
     "name": "[DEV_BRANCH_ID]",
+    "no_expiry": true,
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
     "status": {
       "branch_id": "dev-branch",
@@ -36,13 +38,8 @@
     "is_protected": {
       "action": "update",
       "old": true,
-      "new": false
-    },
-    "no_expiry": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": true,
-      "new": true
+      "new": false,
+      "remote": true
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.plan.update.direct.json
@@ -17,7 +17,9 @@
   "remote_state": {
     "branch_id": "dev-branch",
     "create_time": "[TIMESTAMP]",
+    "is_protected": false,
     "name": "[DEV_BRANCH_ID]",
+    "no_expiry": true,
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]",
     "status": {
       "branch_id": "dev-branch",
@@ -36,13 +38,8 @@
     "is_protected": {
       "action": "update",
       "old": false,
-      "new": true
-    },
-    "no_expiry": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": true,
-      "new": true
+      "new": true,
+      "remote": false
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_databases/update/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_databases/update/out.plan.no_change.direct.json
@@ -15,25 +15,13 @@
     "database_id": "my-database",
     "name": "[MY_DATABASE_ID]",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+    "postgres_database": "initial_db_name",
+    "role": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner",
     "status": {
       "database_id": "my-database",
       "postgres_database": "initial_db_name",
       "role": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner"
     },
     "update_time": "[TIMESTAMP]"
-  },
-  "changes": {
-    "postgres_database": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "initial_db_name",
-      "new": "initial_db_name"
-    },
-    "role": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner",
-      "new": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner"
-    }
   }
 }

--- a/acceptance/bundle/resources/postgres_databases/update/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_databases/update/out.plan.restore.direct.json
@@ -23,6 +23,8 @@
     "database_id": "my-database",
     "name": "[MY_DATABASE_ID]",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+    "postgres_database": "renamed_db_name",
+    "role": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner",
     "status": {
       "database_id": "my-database",
       "postgres_database": "renamed_db_name",
@@ -34,13 +36,8 @@
     "postgres_database": {
       "action": "update",
       "old": "renamed_db_name",
-      "new": "initial_db_name"
-    },
-    "role": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner",
-      "new": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner"
+      "new": "initial_db_name",
+      "remote": "renamed_db_name"
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_databases/update/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_databases/update/out.plan.update.direct.json
@@ -23,6 +23,8 @@
     "database_id": "my-database",
     "name": "[MY_DATABASE_ID]",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+    "postgres_database": "initial_db_name",
+    "role": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner",
     "status": {
       "database_id": "my-database",
       "postgres_database": "initial_db_name",
@@ -34,13 +36,8 @@
     "postgres_database": {
       "action": "update",
       "old": "initial_db_name",
-      "new": "renamed_db_name"
-    },
-    "role": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner",
-      "new": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/app-owner"
+      "new": "renamed_db_name",
+      "remote": "initial_db_name"
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.no_change.direct.json
@@ -5,32 +5,5 @@
       "label": "${resources.postgres_branches.main.id}"
     }
   ],
-  "action": "skip",
-  "changes": {
-    "autoscaling_limit_max_cu": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 8,
-      "new": 8
-    },
-    "autoscaling_limit_min_cu": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 0.5,
-      "new": 0.5
-    },
-    "endpoint_type": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "ENDPOINT_TYPE_READ_ONLY",
-      "new": "ENDPOINT_TYPE_READ_ONLY",
-      "remote": ""
-    },
-    "suspend_timeout_duration": {
-      "action": "skip",
-      "reason": "empty",
-      "old": "300s",
-      "new": "300s"
-    }
-  }
+  "action": "skip"
 }

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.restore.direct.json
@@ -20,26 +20,8 @@
     "autoscaling_limit_max_cu": {
       "action": "update",
       "old": 4,
-      "new": 8
-    },
-    "autoscaling_limit_min_cu": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 0.5,
-      "new": 0.5
-    },
-    "endpoint_type": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "ENDPOINT_TYPE_READ_ONLY",
-      "new": "ENDPOINT_TYPE_READ_ONLY",
-      "remote": ""
-    },
-    "suspend_timeout_duration": {
-      "action": "skip",
-      "reason": "empty",
-      "old": "300s",
-      "new": "300s"
+      "new": 8,
+      "remote": 4
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.plan.update.direct.json
@@ -20,26 +20,8 @@
     "autoscaling_limit_max_cu": {
       "action": "update",
       "old": 8,
-      "new": 4
-    },
-    "autoscaling_limit_min_cu": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 0.5,
-      "new": 0.5
-    },
-    "endpoint_type": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "ENDPOINT_TYPE_READ_ONLY",
-      "new": "ENDPOINT_TYPE_READ_ONLY",
-      "remote": ""
-    },
-    "suspend_timeout_duration": {
-      "action": "skip",
-      "reason": "empty",
-      "old": "300s",
-      "new": "300s"
+      "new": 4,
+      "remote": 8
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.no_change.direct.json
@@ -2,7 +2,15 @@
   "action": "skip",
   "remote_state": {
     "create_time": "[TIMESTAMP]",
+    "default_endpoint_settings": {
+      "autoscaling_limit_max_cu": 4,
+      "autoscaling_limit_min_cu": 0.5,
+      "suspend_timeout_duration": "300s"
+    },
+    "display_name": "Original Name",
+    "history_retention_duration": "604800s",
     "name": "[MY_PROJECT_ID]",
+    "pg_version": 16,
     "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "status": {
       "branch_logical_size_limit_bytes": [NUMID],
@@ -22,39 +30,5 @@
     },
     "uid": "[UUID]",
     "update_time": "[TIMESTAMP]"
-  },
-  "changes": {
-    "default_endpoint_settings": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": {
-        "autoscaling_limit_max_cu": 4,
-        "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "300s"
-      },
-      "new": {
-        "autoscaling_limit_max_cu": 4,
-        "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "300s"
-      }
-    },
-    "display_name": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "Original Name",
-      "new": "Original Name"
-    },
-    "history_retention_duration": {
-      "action": "skip",
-      "reason": "empty",
-      "old": "604800s",
-      "new": "604800s"
-    },
-    "pg_version": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 16,
-      "new": 16
-    }
   }
 }

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.restore.direct.json
@@ -15,7 +15,15 @@
   },
   "remote_state": {
     "create_time": "[TIMESTAMP]",
+    "default_endpoint_settings": {
+      "autoscaling_limit_max_cu": 4,
+      "autoscaling_limit_min_cu": 0.5,
+      "suspend_timeout_duration": "300s"
+    },
+    "display_name": "Updated Name",
+    "history_retention_duration": "604800s",
     "name": "[MY_PROJECT_ID]",
+    "pg_version": 16,
     "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "status": {
       "branch_logical_size_limit_bytes": [NUMID],
@@ -37,36 +45,11 @@
     "update_time": "[TIMESTAMP]"
   },
   "changes": {
-    "default_endpoint_settings": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": {
-        "autoscaling_limit_max_cu": 4,
-        "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "300s"
-      },
-      "new": {
-        "autoscaling_limit_max_cu": 4,
-        "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "300s"
-      }
-    },
     "display_name": {
       "action": "update",
       "old": "Updated Name",
-      "new": "Original Name"
-    },
-    "history_retention_duration": {
-      "action": "skip",
-      "reason": "empty",
-      "old": "604800s",
-      "new": "604800s"
-    },
-    "pg_version": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 16,
-      "new": 16
+      "new": "Original Name",
+      "remote": "Updated Name"
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.plan.update.direct.json
@@ -15,7 +15,15 @@
   },
   "remote_state": {
     "create_time": "[TIMESTAMP]",
+    "default_endpoint_settings": {
+      "autoscaling_limit_max_cu": 4,
+      "autoscaling_limit_min_cu": 0.5,
+      "suspend_timeout_duration": "300s"
+    },
+    "display_name": "Original Name",
+    "history_retention_duration": "604800s",
     "name": "[MY_PROJECT_ID]",
+    "pg_version": 16,
     "project_id": "test-pg-proj-[UNIQUE_NAME]",
     "status": {
       "branch_logical_size_limit_bytes": [NUMID],
@@ -37,36 +45,11 @@
     "update_time": "[TIMESTAMP]"
   },
   "changes": {
-    "default_endpoint_settings": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": {
-        "autoscaling_limit_max_cu": 4,
-        "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "300s"
-      },
-      "new": {
-        "autoscaling_limit_max_cu": 4,
-        "autoscaling_limit_min_cu": 0.5,
-        "suspend_timeout_duration": "300s"
-      }
-    },
     "display_name": {
       "action": "update",
       "old": "Original Name",
-      "new": "Updated Name"
-    },
-    "history_retention_duration": {
-      "action": "skip",
-      "reason": "empty",
-      "old": "604800s",
-      "new": "604800s"
-    },
-    "pg_version": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": 16,
-      "new": 16
+      "new": "Updated Name",
+      "remote": "Original Name"
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_roles/update/out.plan.no_change.direct.json
+++ b/acceptance/bundle/resources/postgres_roles/update/out.plan.no_change.direct.json
@@ -7,9 +7,13 @@
   ],
   "action": "skip",
   "remote_state": {
+    "attributes": {
+      "createdb": false
+    },
     "create_time": "[TIMESTAMP]",
     "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+    "postgres_role": "app_role",
     "role_id": "test-role",
     "status": {
       "attributes": {
@@ -23,23 +27,5 @@
       "role_id": "test-role"
     },
     "update_time": "[TIMESTAMP]"
-  },
-  "changes": {
-    "attributes": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": {
-        "createdb": false
-      },
-      "new": {
-        "createdb": false
-      }
-    },
-    "postgres_role": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "app_role",
-      "new": "app_role"
-    }
   }
 }

--- a/acceptance/bundle/resources/postgres_roles/update/out.plan.restore.direct.json
+++ b/acceptance/bundle/resources/postgres_roles/update/out.plan.restore.direct.json
@@ -17,9 +17,13 @@
     }
   },
   "remote_state": {
+    "attributes": {
+      "createdb": true
+    },
     "create_time": "[TIMESTAMP]",
     "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+    "postgres_role": "app_role",
     "role_id": "test-role",
     "status": {
       "attributes": {
@@ -35,25 +39,11 @@
     "update_time": "[TIMESTAMP]"
   },
   "changes": {
-    "attributes": {
-      "action": "update",
-      "old": {
-        "createdb": true
-      },
-      "new": {
-        "createdb": false
-      }
-    },
     "attributes.createdb": {
       "action": "update",
       "old": true,
-      "new": false
-    },
-    "postgres_role": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "app_role",
-      "new": "app_role"
+      "new": false,
+      "remote": true
     }
   }
 }

--- a/acceptance/bundle/resources/postgres_roles/update/out.plan.update.direct.json
+++ b/acceptance/bundle/resources/postgres_roles/update/out.plan.update.direct.json
@@ -17,9 +17,13 @@
     }
   },
   "remote_state": {
+    "attributes": {
+      "createdb": false
+    },
     "create_time": "[TIMESTAMP]",
     "name": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main/roles/test-role",
     "parent": "projects/test-pg-proj-[UNIQUE_NAME]/branches/main",
+    "postgres_role": "app_role",
     "role_id": "test-role",
     "status": {
       "attributes": {
@@ -35,25 +39,11 @@
     "update_time": "[TIMESTAMP]"
   },
   "changes": {
-    "attributes": {
-      "action": "update",
-      "old": {
-        "createdb": false
-      },
-      "new": {
-        "createdb": true
-      }
-    },
     "attributes.createdb": {
       "action": "update",
       "old": false,
-      "new": true
-    },
-    "postgres_role": {
-      "action": "skip",
-      "reason": "spec:input_only",
-      "old": "app_role",
-      "new": "app_role"
+      "new": true,
+      "remote": false
     }
   }
 }

--- a/libs/testserver/postgres.go
+++ b/libs/testserver/postgres.go
@@ -150,8 +150,6 @@ func (s *FakeWorkspace) PostgresProjectCreate(req Request, projectID string) Res
 				project.Status.DefaultEndpointSettings.SuspendTimeoutDuration = project.Spec.DefaultEndpointSettings.SuspendTimeoutDuration
 			}
 		}
-		// Clear spec so it's not returned in response (API only returns status)
-		project.Spec = nil
 	}
 
 	s.PostgresProjects[name] = project
@@ -213,22 +211,32 @@ func (s *FakeWorkspace) PostgresProjectUpdate(req Request, name string) Response
 		}
 	}
 
-	// Apply updates from spec to status
+	// Apply updates to both spec and status. GET echoes the spec verbatim, so
+	// the stored spec must track updates alongside the materialized status.
 	if updateProject.Spec != nil {
+		if project.Spec == nil {
+			project.Spec = &postgres.ProjectSpec{}
+		}
 		if project.Status == nil {
 			project.Status = &postgres.ProjectStatus{}
 		}
 		if updateProject.Spec.DisplayName != "" {
+			project.Spec.DisplayName = updateProject.Spec.DisplayName
 			project.Status.DisplayName = updateProject.Spec.DisplayName
 		}
 		if updateProject.Spec.DefaultEndpointSettings != nil {
+			if project.Spec.DefaultEndpointSettings == nil {
+				project.Spec.DefaultEndpointSettings = &postgres.ProjectDefaultEndpointSettings{}
+			}
 			if project.Status.DefaultEndpointSettings == nil {
 				project.Status.DefaultEndpointSettings = &postgres.ProjectDefaultEndpointSettings{}
 			}
 			if updateProject.Spec.DefaultEndpointSettings.AutoscalingLimitMinCu != 0 {
+				project.Spec.DefaultEndpointSettings.AutoscalingLimitMinCu = updateProject.Spec.DefaultEndpointSettings.AutoscalingLimitMinCu
 				project.Status.DefaultEndpointSettings.AutoscalingLimitMinCu = updateProject.Spec.DefaultEndpointSettings.AutoscalingLimitMinCu
 			}
 			if updateProject.Spec.DefaultEndpointSettings.AutoscalingLimitMaxCu != 0 {
+				project.Spec.DefaultEndpointSettings.AutoscalingLimitMaxCu = updateProject.Spec.DefaultEndpointSettings.AutoscalingLimitMaxCu
 				project.Status.DefaultEndpointSettings.AutoscalingLimitMaxCu = updateProject.Spec.DefaultEndpointSettings.AutoscalingLimitMaxCu
 			}
 		}
@@ -350,12 +358,10 @@ func (s *FakeWorkspace) PostgresBranchCreate(req Request, parent, branchID strin
 	}
 
 	// Apply user-provided spec fields to status (where input fields are surfaced).
+	// The spec itself is preserved and echoed verbatim on GET.
 	if branch.Spec != nil {
 		branch.Status.IsProtected = branch.Spec.IsProtected
 	}
-
-	// Clear spec - API only returns status
-	branch.Spec = nil
 
 	s.PostgresBranches[name] = branch
 
@@ -436,11 +442,16 @@ func (s *FakeWorkspace) PostgresBranchUpdate(req Request, name string) Response 
 		}
 	}
 
-	// Apply updates from spec to status
+	// Apply updates to both spec and status. GET echoes the spec verbatim, so
+	// the stored spec must track updates alongside the materialized status.
 	if updateBranch.Spec != nil {
+		if branch.Spec == nil {
+			branch.Spec = &postgres.BranchSpec{}
+		}
 		if branch.Status == nil {
 			branch.Status = &postgres.BranchStatus{}
 		}
+		branch.Spec.IsProtected = updateBranch.Spec.IsProtected
 		branch.Status.IsProtected = updateBranch.Spec.IsProtected
 	}
 
@@ -587,9 +598,6 @@ func (s *FakeWorkspace) PostgresEndpointCreate(req Request, parent, endpointID s
 		endpoint.Status.Disabled = endpoint.Spec.Disabled
 	}
 
-	// Clear spec - API only returns status
-	endpoint.Spec = nil
-
 	s.PostgresEndpoints[name] = endpoint
 
 	return Response{
@@ -672,20 +680,28 @@ func (s *FakeWorkspace) PostgresEndpointUpdate(req Request, name string) Respons
 		}
 	}
 
-	// Apply updates from spec to status
+	// Apply updates to both spec and status. GET echoes the spec verbatim, so
+	// the stored spec must track updates alongside the materialized status.
 	if updateEndpoint.Spec != nil {
+		if endpoint.Spec == nil {
+			endpoint.Spec = &postgres.EndpointSpec{}
+		}
 		if endpoint.Status == nil {
 			endpoint.Status = &postgres.EndpointStatus{}
 		}
 		if updateEndpoint.Spec.AutoscalingLimitMinCu != 0 {
+			endpoint.Spec.AutoscalingLimitMinCu = updateEndpoint.Spec.AutoscalingLimitMinCu
 			endpoint.Status.AutoscalingLimitMinCu = updateEndpoint.Spec.AutoscalingLimitMinCu
 		}
 		if updateEndpoint.Spec.AutoscalingLimitMaxCu != 0 {
+			endpoint.Spec.AutoscalingLimitMaxCu = updateEndpoint.Spec.AutoscalingLimitMaxCu
 			endpoint.Status.AutoscalingLimitMaxCu = updateEndpoint.Spec.AutoscalingLimitMaxCu
 		}
 		if updateEndpoint.Spec.SuspendTimeoutDuration != nil {
+			endpoint.Spec.SuspendTimeoutDuration = updateEndpoint.Spec.SuspendTimeoutDuration
 			endpoint.Status.SuspendTimeoutDuration = updateEndpoint.Spec.SuspendTimeoutDuration
 		}
+		endpoint.Spec.Disabled = updateEndpoint.Spec.Disabled
 		endpoint.Status.Disabled = updateEndpoint.Spec.Disabled
 	}
 
@@ -775,7 +791,7 @@ func (s *FakeWorkspace) PostgresDatabaseCreate(req Request, parent, databaseID s
 		}
 		existing.UpdateTime = now
 		existing.Status = status
-		existing.Spec = nil
+		existing.Spec = database.Spec
 		s.PostgresDatabases[name] = existing
 
 		return Response{
@@ -789,14 +805,13 @@ func (s *FakeWorkspace) PostgresDatabaseCreate(req Request, parent, databaseID s
 	database.CreateTime = now
 	database.UpdateTime = now
 
-	// Mirror spec onto status; the real API only echoes Status on GET.
+	// Mirror spec onto status; GET echoes both the spec (verbatim) and status.
 	status := &postgres.DatabaseDatabaseStatus{
 		DatabaseId:       databaseID,
 		PostgresDatabase: database.Spec.PostgresDatabase,
 		Role:             database.Spec.Role,
 	}
 	database.Status = status
-	database.Spec = nil
 
 	s.PostgresDatabases[name] = database
 
@@ -890,6 +905,13 @@ func (s *FakeWorkspace) PostgresDatabaseUpdate(req Request, name string) Respons
 		}
 		database.Status = applyDatabaseSpecMask(database.Status, databaseStatusFromSpec(updateDatabase.Spec), paths)
 		database.Status.DatabaseId = databaseID
+
+		// GET echoes the spec verbatim, so keep the stored spec in sync with the
+		// masked status update.
+		database.Spec = &postgres.DatabaseDatabaseSpec{
+			PostgresDatabase: database.Status.PostgresDatabase,
+			Role:             database.Status.Role,
+		}
 	}
 
 	database.UpdateTime = nowTime()
@@ -1120,7 +1142,7 @@ func (s *FakeWorkspace) PostgresRoleCreate(req Request, parent, roleID string, r
 		existing.UpdateTime = now
 		existing.Status = roleStatusFromSpec(role.Spec)
 		existing.Status.RoleId = roleID
-		existing.Spec = nil
+		existing.Spec = role.Spec
 		s.PostgresRoles[name] = existing
 
 		return Response{
@@ -1136,7 +1158,6 @@ func (s *FakeWorkspace) PostgresRoleCreate(req Request, parent, roleID string, r
 
 	role.Status = roleStatusFromSpec(role.Spec)
 	role.Status.RoleId = roleID
-	role.Spec = nil
 
 	s.PostgresRoles[name] = role
 
@@ -1233,6 +1254,11 @@ func (s *FakeWorkspace) PostgresRoleUpdate(req Request, name string) Response {
 		}
 		role.Status = applyRoleSpecMask(role.Status, roleStatusFromSpec(updateRole.Spec), paths)
 		role.Status.RoleId = roleID
+
+		// GET echoes the spec verbatim, so keep the stored spec in sync while
+		// respecting the update_mask: only masked fields are taken from the
+		// request, so out-of-mask body values don't leak into the echoed spec.
+		role.Spec = applyRoleSpecMaskToSpec(role.Spec, updateRole.Spec, paths)
 	}
 
 	role.UpdateTime = nowTime()
@@ -1255,6 +1281,36 @@ func (s *FakeWorkspace) PostgresRoleUpdate(req Request, name string) Response {
 // attributes untouched), but the direct engine always sends the full spec in the
 // request body, so the collapsed result is identical for the requests it makes.
 func applyRoleSpecMask(existing, desired *postgres.RoleRoleStatus, paths []string) *postgres.RoleRoleStatus {
+	if len(paths) == 0 || existing == nil {
+		return desired
+	}
+	result := *existing
+	for _, p := range paths {
+		field, _, _ := strings.Cut(strings.TrimPrefix(p, "spec."), ".")
+		switch field {
+		case "spec":
+			result = *desired
+		case "postgres_role":
+			result.PostgresRole = desired.PostgresRole
+		case "auth_method":
+			result.AuthMethod = desired.AuthMethod
+		case "identity_type":
+			result.IdentityType = desired.IdentityType
+		case "membership_roles":
+			result.MembershipRoles = desired.MembershipRoles
+		case "attributes":
+			result.Attributes = desired.Attributes
+		}
+	}
+	return &result
+}
+
+// applyRoleSpecMaskToSpec applies the masked fields from desired onto existing at
+// the spec level, so the spec echoed on GET tracks exactly the fields the
+// update_mask named (out-of-mask body values are ignored). It mirrors
+// [applyRoleSpecMask] but preserves the verbatim spec shape rather than the
+// materialized status. An empty paths slice replaces everything.
+func applyRoleSpecMaskToSpec(existing, desired *postgres.RoleRoleSpec, paths []string) *postgres.RoleRoleSpec {
 	if len(paths) == 0 || existing == nil {
 		return desired
 	}

--- a/libs/testserver/postgres_test.go
+++ b/libs/testserver/postgres_test.go
@@ -19,8 +19,9 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	client := &http.Client{}
 	baseURL := server.URL
 
-	// Create project
-	createReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=test-project", nil)
+	// Create project with a spec so the GET below can assert the spec is echoed.
+	createBody := `{"spec":{"display_name":"Test Project","pg_version":16}}`
+	createReq, _ := http.NewRequest(http.MethodPost, baseURL+"/api/2.0/postgres/projects?project_id=test-project", strings.NewReader(createBody))
 	createReq.Header.Set("Authorization", "Bearer test-token")
 	createReq.Header.Set("Content-Type", "application/json")
 	createResp, err := client.Do(createReq)
@@ -42,6 +43,10 @@ func TestPostgresProjectCRUD(t *testing.T) {
 	var project postgres.Project
 	require.NoError(t, json.NewDecoder(getResp.Body).Decode(&project))
 	assert.Equal(t, "projects/test-project", project.Name)
+	// The backend echoes the spec verbatim on GET (only the fields the user set).
+	require.NotNil(t, project.Spec)
+	assert.Equal(t, "Test Project", project.Spec.DisplayName)
+	assert.Equal(t, 16, project.Spec.PgVersion)
 	getResp.Body.Close()
 
 	// List projects
@@ -407,6 +412,11 @@ func TestPostgresDatabaseUpdateMaskPreservesUnmaskedFields(t *testing.T) {
 	require.NotNil(t, database.Status)
 	assert.Equal(t, "renamed_db", database.Status.PostgresDatabase, "masked field should be updated")
 	assert.Equal(t, "projects/mask-db-project/branches/main/roles/owner", database.Status.Role, "field absent from update_mask should be preserved")
+
+	// GET echoes the spec verbatim; it must track the masked update alongside status.
+	require.NotNil(t, database.Spec)
+	assert.Equal(t, "renamed_db", database.Spec.PostgresDatabase, "spec must reflect the masked update")
+	assert.Equal(t, "projects/mask-db-project/branches/main/roles/owner", database.Spec.Role, "spec must preserve the field absent from update_mask")
 }
 
 func TestPostgresDatabaseCreateDuplicateReturns400(t *testing.T) {
@@ -596,6 +606,14 @@ func TestPostgresRoleUpdateMaskPreservesUnmaskedFields(t *testing.T) {
 	require.NotNil(t, role.Status.Attributes)
 	assert.True(t, role.Status.Attributes.Createdb, "masked field should be updated")
 	assert.Equal(t, "app_role", role.Status.PostgresRole, "field absent from update_mask should be preserved")
+
+	// GET echoes the spec verbatim; it must track the update alongside status,
+	// and honor the update_mask — the out-of-mask postgres_role in the body must
+	// not leak into the echoed spec.
+	require.NotNil(t, role.Spec)
+	require.NotNil(t, role.Spec.Attributes)
+	assert.True(t, role.Spec.Attributes.Createdb, "spec must reflect the updated attribute")
+	assert.Equal(t, "app_role", role.Spec.PostgresRole, "spec must not apply the field absent from update_mask")
 }
 
 func TestPostgresRoleNotFoundWhenBranchNotExists(t *testing.T) {


### PR DESCRIPTION
## Why

The Lakebase (postgres) backend now echoes the submitted `spec` on GET; before it returned only `status`. This broke the nightly cloud run: direct-engine plans for postgres resources started showing spec fields in `remote_state` and dropping the phantom `spec:input_only` skip-changes. The `*Remote` structs already anticipate this, so only the fake server and goldens were stale.

Verified on a real workspace: a created project's GET returns `spec` with the fields the user set. Recaptured goldens against a real cloud workspace and the full postgres acceptance suite passes locally and on cloud.

## Notes

No `resources.yml` change needed: the `spec:input_only` annotations are now redundant but benign (they only suppress phantom drift when config is unchanged) and self-heal once the OpenAPI schema drops `INPUT_ONLY`.

This pull request and its description were written by Isaac.