### PR TITLE
acc: use valid PEP 440 placeholder for masked databricks-bundles version

### DIFF
--- a/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/pyproject.toml
+++ b/acceptance/bundle/templates/pydabs/init-classic/output/my_pydabs/pyproject.toml
@@ -18,7 +18,7 @@ dev = [
     "databricks-dlt",
     "databricks-connect>=15.4,<15.5",
     "ipykernel",
-    "databricks-bundles==x.y.z",
+    "databricks-bundles==0.0.0",
 ]
 
 [project.scripts]

--- a/acceptance/bundle/templates/pydabs/test.toml
+++ b/acceptance/bundle/templates/pydabs/test.toml
@@ -4,6 +4,10 @@ TimeoutWindows = '120s'
 Local = true
 Cloud = false
 
+# Mask the real databricks-bundles version so the golden pyproject.toml does not
+# churn on every release. The placeholder must stay valid PEP 440: Dependabot's
+# dependency-graph submission scans this generated manifest and aborts the whole
+# pip/uv graph job on an unparseable version (the old "x.y.z" did exactly that).
 [[Repls]]
 Old = '"databricks-bundles==\d+\.\d+\.\d+"'
-New = '"databricks-bundles==x.y.z"'
+New = '"databricks-bundles==0.0.0"'


### PR DESCRIPTION
## TL;DR

#5866 added dependabot.yml with the goal of fixing dependabot graph generation errors. This did not work because `exclude-paths` only impacts the automatic PRs, not the graph generation. This PR fixes the underlying issue (PEP 440 incompliant placeholder version in test fixtures).

## Changes

The pydabs template test (`acceptance/bundle/templates/pydabs`) masks the real `databricks-bundles` version to `x.y.z` via a `[[Repls]]` rule, so the golden `pyproject.toml` doesn't churn on every release.

The problem: `x.y.z` is not a valid [PEP 440](https://peps.python.org/pep-0440/) version. Dependabot's **dependency-graph submission** jobs (the `update-pip-graph` / `update-uv-graph` jobs, distinct from the version-update PRs) scan this generated fixture manifest and abort the *entire* pip/uv graph submission with:

```
InvalidRequirement('Expected semicolon (after name with no version specifier) or end
    databricks-bundles==x.y.z
                      ^')
```

This is why those graph jobs keep failing ([example run](https://github.com/databricks/cli/actions/runs/29593157047/job/87927006614)) even after `exclude-paths` was added to `.github/dependabot.yml` — the graph-submission code path does **not** honor `exclude-paths` (the job definition is dispatched with `"exclude-paths":[]`), so the `acceptance/**` fixtures are scanned regardless.

This PR changes the placeholder to `0.0.0`: still an obvious masked value, but valid PEP 440, so the graph submission parses it cleanly instead of crashing. A comment on the `[[Repls]]` rule records why the placeholder must stay parseable.

## Tests

Regenerated the golden with `./task test-update-templates`; `go test ./acceptance -run '^TestAccept/bundle/templates/pydabs'` passes.

This pull request and its description were written by Isaac, an AI coding agent.