### PR TITLE
config-remote-sync: skip permissions/grants sub-resources instead of failing

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Bundles
 
-* Fix `bundle config-remote-sync` failing with "failed to resolve field changes" on resources that have permissions or grants; these sub-resources are not synced back to configuration and are now skipped instead of erroring the whole sync ([#XXXX](https://github.com/databricks/cli/pull/XXXX)).
 * direct: add basic version of job_runs resource (experimental) ([#5603](https://github.com/databricks/cli/pull/5603)).
 * Fix permissions added to a job or pipeline by a Python (PyDABs) mutator failing to deploy with "must have exactly one owner"; the deploying identity is now set as owner, matching resources whose permissions are declared in YAML ([#5821](https://github.com/databricks/cli/pull/5821)).
 * Remove duplicate enum values for jsonschema.json ([#5839](https://github.com/databricks/cli/pull/5839)).

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bundles
 
+* Fix `bundle config-remote-sync` failing with "failed to resolve field changes" on resources that have permissions or grants; these sub-resources are not synced back to configuration and are now skipped instead of erroring the whole sync ([#XXXX](https://github.com/databricks/cli/pull/XXXX)).
 * direct: add basic version of job_runs resource (experimental) ([#5603](https://github.com/databricks/cli/pull/5603)).
 * Fix permissions added to a job or pipeline by a Python (PyDABs) mutator failing to deploy with "must have exactly one owner"; the deploying identity is now set as owner, matching resources whose permissions are declared in YAML ([#5821](https://github.com/databricks/cli/pull/5821)).
 * Remove duplicate enum values for jsonschema.json ([#5839](https://github.com/databricks/cli/pull/5839)).

--- a/acceptance/bundle/config-remote-sync/skip_permissions/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/databricks.yml.tmpl
@@ -1,0 +1,26 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# Bundle-level permissions are applied to every resource on deploy but have no
+# per-resource YAML node. config-remote-sync must skip the resulting
+# permissions sub-resource instead of failing to resolve it.
+permissions:
+  - level: CAN_MANAGE
+    user_name: alice@example.com
+
+resources:
+  jobs:
+    my_job:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/main
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+
+targets:
+  default:
+    mode: development

--- a/acceptance/bundle/config-remote-sync/skip_permissions/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/databricks.yml.tmpl
@@ -6,7 +6,7 @@ bundle:
 # permissions sub-resource instead of failing to resolve it.
 permissions:
   - level: CAN_MANAGE
-    user_name: alice@example.com
+    user_name: ${workspace.current_user.userName}
 
 resources:
   jobs:

--- a/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = true
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
@@ -1,4 +1,4 @@
 Local = true
-Cloud = true
+Cloud = false
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/out.test.toml
@@ -1,4 +1,4 @@
 Local = true
-Cloud = false
+Cloud = true
 GOOS.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/output.txt
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/output.txt
@@ -1,0 +1,74 @@
+Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
+If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
+
+Consider using a adding a top-level permissions section such as the following:
+
+  permissions:
+    - user_name: [USERNAME]
+      level: CAN_MANAGE
+
+See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
+  in databricks.yml:8:3
+
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Add a permission remotely (a change on the permissions sub-resource)
+
+=== Modify a regular job field remotely
+
+=== Sync: permissions are skipped, the regular field change is written
+Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
+If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
+
+Consider using a adding a top-level permissions section such as the following:
+
+  permissions:
+    - user_name: [USERNAME]
+      level: CAN_MANAGE
+
+See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
+  in databricks.yml:8:3
+
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.my_job
+  max_concurrent_runs: replace
+
+
+
+=== Configuration changes
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -12,5 +12,5 @@
+   jobs:
+     my_job:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 5
+       tasks:
+         - task_key: main
+
+>>> [CLI] bundle destroy --auto-approve
+Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
+If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
+
+Consider using a adding a top-level permissions section such as the following:
+
+  permissions:
+    - user_name: [USERNAME]
+      level: CAN_MANAGE
+
+See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
+  in databricks.yml:8:3
+
+The following resources will be deleted:
+  delete resources.jobs.my_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/skip_permissions/output.txt
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/output.txt
@@ -1,15 +1,3 @@
-Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
-If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
-
-Consider using a adding a top-level permissions section such as the following:
-
-  permissions:
-    - user_name: [USERNAME]
-      level: CAN_MANAGE
-
-See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
-  in databricks.yml:8:3
-
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
 Deploying resources...
 Updating deployment state...
@@ -20,18 +8,6 @@ Deployment complete!
 === Modify a regular job field remotely
 
 === Sync: permissions are skipped, the regular field change is written
-Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
-If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
-
-Consider using a adding a top-level permissions section such as the following:
-
-  permissions:
-    - user_name: [USERNAME]
-      level: CAN_MANAGE
-
-See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
-  in databricks.yml:8:3
-
 Detected changes in 1 resource(s):
 
 Resource: resources.jobs.my_job
@@ -53,18 +29,6 @@ Resource: resources.jobs.my_job
          - task_key: main
 
 >>> [CLI] bundle destroy --auto-approve
-Recommendation: permissions section should explicitly include the current deployment identity '[USERNAME]' or one of its groups
-If it is not included, CAN_MANAGE permissions are only applied if the present identity is used to deploy.
-
-Consider using a adding a top-level permissions section such as the following:
-
-  permissions:
-    - user_name: [USERNAME]
-      level: CAN_MANAGE
-
-See https://docs.databricks.com/dev-tools/bundles/permissions.html to learn more about permission configuration.
-  in databricks.yml:8:3
-
 The following resources will be deleted:
   delete resources.jobs.my_job
 

--- a/acceptance/bundle/config-remote-sync/skip_permissions/script
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/script
@@ -13,9 +13,9 @@ job_id="$(read_id.py my_job)"
 title "Add a permission remotely (a change on the permissions sub-resource)"
 echo
 # permissions set replaces the whole ACL, so keep the deploy identity as owner
-# and add a new grantee: this makes the permissions sub-resource show a change
-# on the next sync.
-$CLI permissions set jobs $job_id --json '{"access_control_list":[{"permission_level":"IS_OWNER","user_name":"'"$CURRENT_USER_NAME"'"},{"permission_level":"CAN_MANAGE","user_name":"alice@example.com"},{"permission_level":"CAN_VIEW","user_name":"viewer@example.com"}]}' > /dev/null
+# and add a grantee (the built-in "users" group) that is not in config: this
+# makes the permissions sub-resource show a change on the next sync.
+$CLI permissions set jobs $job_id --json '{"access_control_list":[{"permission_level":"IS_OWNER","user_name":"'"$CURRENT_USER_NAME"'"},{"permission_level":"CAN_VIEW","group_name":"users"}]}' > /dev/null
 
 title "Modify a regular job field remotely"
 echo

--- a/acceptance/bundle/config-remote-sync/skip_permissions/script
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/script
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+job_id="$(read_id.py my_job)"
+
+title "Add a permission remotely (a change on the permissions sub-resource)"
+echo
+# permissions set replaces the whole ACL, so keep the deploy identity as owner
+# and add a new grantee: this makes the permissions sub-resource show a change
+# on the next sync.
+$CLI permissions set jobs $job_id --json '{"access_control_list":[{"permission_level":"IS_OWNER","user_name":"'"$CURRENT_USER_NAME"'"},{"permission_level":"CAN_MANAGE","user_name":"alice@example.com"},{"permission_level":"CAN_VIEW","user_name":"viewer@example.com"}]}' > /dev/null
+
+title "Modify a regular job field remotely"
+echo
+edit_resource.py jobs $job_id <<EOF
+r["max_concurrent_runs"] = 5
+EOF
+
+title "Sync: permissions are skipped, the regular field change is written"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --save
+
+title "Configuration changes"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
@@ -1,0 +1,10 @@
+Cloud = true
+
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
@@ -3,8 +3,7 @@ Cloud = true
 RecordRequests = false
 Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
 
-[Env]
-DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+Env.DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
 
 [EnvMatrix]
 DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
@@ -1,6 +1,5 @@
-# Local-only (no Cloud): the scenario uses synthetic grantees (alice@, viewer@)
-# that need not be valid workspace principals, and the testserver reproduces the
-# permissions sub-resource + object_id faithfully.
+Cloud = true
+
 RecordRequests = false
 Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
 

--- a/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
+++ b/acceptance/bundle/config-remote-sync/skip_permissions/test.toml
@@ -1,5 +1,6 @@
-Cloud = true
-
+# Local-only (no Cloud): the scenario uses synthetic grantees (alice@, viewer@)
+# that need not be valid workspace principals, and the testserver reproduces the
+# permissions sub-resource + object_id faithfully.
 RecordRequests = false
 Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
 

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
 	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/deploy"
 	"github.com/databricks/cli/bundle/deployplan"
@@ -154,6 +155,20 @@ func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.En
 	return deployBundle, nil
 }
 
+// isPermissionsOrGrantsSubResource reports whether a plan resource key is a
+// permissions or grants sub-resource ("resources.<type>.<name>.permissions" /
+// ".grants"). It classifies the key structurally via config.GetNodeAndType,
+// which keys on the path component (index 3), so a resource literally named
+// "permissions" ("resources.jobs.permissions") is not misclassified.
+func isPermissionsOrGrantsSubResource(resourceKey string) bool {
+	path, err := dyn.NewPathFromString(resourceKey)
+	if err != nil {
+		return false
+	}
+	_, nodeType := config.GetNodeAndType(path)
+	return strings.HasSuffix(nodeType, ".permissions") || strings.HasSuffix(nodeType, ".grants")
+}
+
 // ExtractChanges extracts the map of remote-vs-config changes from a deploy
 // plan. engine selects the LocalEdit comparison below.
 func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
@@ -166,7 +181,7 @@ func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan
 		// to YAML: their fields (e.g. object_id) are server-populated with no source
 		// location, and bundle-level permissions have no per-resource YAML node at all,
 		// so resolving them would fail the whole sync. Skip them instead.
-		if strings.HasSuffix(resourceKey, ".permissions") || strings.HasSuffix(resourceKey, ".grants") {
+		if isPermissionsOrGrantsSubResource(resourceKey) {
 			continue
 		}
 

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/engine"
@@ -153,12 +154,31 @@ func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.En
 	return deployBundle, nil
 }
 
+// isUnsupportedSubResource reports whether a plan resource key refers to a
+// permissions or grants sub-resource (e.g. "resources.jobs.foo.permissions").
+// The direct and terraform engines both emit these as their own plan keys; see
+// splitResourcePath in bundle/direct/bundle_plan.go.
+func isUnsupportedSubResource(resourceKey string) bool {
+	return strings.HasSuffix(resourceKey, ".permissions") || strings.HasSuffix(resourceKey, ".grants")
+}
+
 // ExtractChanges extracts the map of remote-vs-config changes from a deploy
 // plan. engine selects the LocalEdit comparison below.
 func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
 	changes := make(Changes)
 
 	for resourceKey, entry := range plan.Plan {
+		// permissions and grants are separate plan sub-resources keyed
+		// "resources.<type>.<name>.permissions" / ".grants". config-remote-sync
+		// cannot write them back to YAML: their fields (e.g. object_id) are
+		// server-populated and have no source location, and permissions injected
+		// at the bundle level have no per-resource YAML node at all, so resolving
+		// them fails the whole sync. Syncing permissions back is unsupported, so
+		// skip these sub-resources instead of hard-failing.
+		if isUnsupportedSubResource(resourceKey) {
+			continue
+		}
+
 		resourceChanges := make(ResourceChanges)
 
 		if entry.Changes != nil {

--- a/bundle/configsync/diff.go
+++ b/bundle/configsync/diff.go
@@ -154,28 +154,19 @@ func OpenDeploymentState(ctx context.Context, b *bundle.Bundle, engine engine.En
 	return deployBundle, nil
 }
 
-// isUnsupportedSubResource reports whether a plan resource key refers to a
-// permissions or grants sub-resource (e.g. "resources.jobs.foo.permissions").
-// The direct and terraform engines both emit these as their own plan keys; see
-// splitResourcePath in bundle/direct/bundle_plan.go.
-func isUnsupportedSubResource(resourceKey string) bool {
-	return strings.HasSuffix(resourceKey, ".permissions") || strings.HasSuffix(resourceKey, ".grants")
-}
-
 // ExtractChanges extracts the map of remote-vs-config changes from a deploy
 // plan. engine selects the LocalEdit comparison below.
 func ExtractChanges(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, engine engine.EngineType) (Changes, error) {
 	changes := make(Changes)
 
 	for resourceKey, entry := range plan.Plan {
-		// permissions and grants are separate plan sub-resources keyed
-		// "resources.<type>.<name>.permissions" / ".grants". config-remote-sync
-		// cannot write them back to YAML: their fields (e.g. object_id) are
-		// server-populated and have no source location, and permissions injected
-		// at the bundle level have no per-resource YAML node at all, so resolving
-		// them fails the whole sync. Syncing permissions back is unsupported, so
-		// skip these sub-resources instead of hard-failing.
-		if isUnsupportedSubResource(resourceKey) {
+		// permissions and grants are emitted as their own plan keys
+		// ("resources.<type>.<name>.permissions" / ".grants"; see splitResourcePath
+		// in bundle/direct/bundle_plan.go). config-remote-sync cannot write them back
+		// to YAML: their fields (e.g. object_id) are server-populated with no source
+		// location, and bundle-level permissions have no per-resource YAML node at all,
+		// so resolving them would fail the whole sync. Skip them instead.
+		if strings.HasSuffix(resourceKey, ".permissions") || strings.HasSuffix(resourceKey, ".grants") {
 			continue
 		}
 

--- a/bundle/configsync/diff_test.go
+++ b/bundle/configsync/diff_test.go
@@ -273,6 +273,14 @@ func TestExtractChangesSkipsPermissionsAndGrants(t *testing.T) {
 				"[0].privileges": {Action: deployplan.Update, New: nil, Remote: []any{"SELECT"}},
 			},
 		},
+		// A resource literally named "permissions" is a regular resource, not a
+		// permissions sub-resource, so its changes must be kept (structural
+		// classification via config.GetNodeAndType, not a suffix match).
+		"resources.jobs.permissions": {
+			Changes: deployplan.Changes{
+				"description": {Action: deployplan.Update, New: nil, Remote: "kept"},
+			},
+		},
 	}}
 
 	for _, eng := range []engine.EngineType{engine.EngineDirect, engine.EngineTerraform} {
@@ -288,6 +296,10 @@ func TestExtractChangesSkipsPermissionsAndGrants(t *testing.T) {
 			job, hasJob := changes["resources.jobs.my_job"]
 			require.True(t, hasJob, "regular resource changes must be kept")
 			assert.Contains(t, job, "description")
+
+			namedPerms, hasNamedPerms := changes["resources.jobs.permissions"]
+			require.True(t, hasNamedPerms, "a resource named permissions must not be skipped")
+			assert.Contains(t, namedPerms, "description")
 		})
 	}
 }

--- a/bundle/configsync/diff_test.go
+++ b/bundle/configsync/diff_test.go
@@ -3,6 +3,8 @@ package configsync
 import (
 	"testing"
 
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/deployplan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -244,6 +246,48 @@ func TestMatchPattern(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := matchPattern(tt.pattern, tt.path)
 			assert.Equal(t, tt.want, got, "matchPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ExtractChanges must skip permissions/grants sub-resources: they are emitted as
+// their own plan keys but cannot be written back to YAML, and resolving them
+// (e.g. the server-populated object_id field, or a bundle-level permissions entry
+// with no per-resource YAML node) otherwise fails the whole sync.
+func TestExtractChangesSkipsPermissionsAndGrants(t *testing.T) {
+	ctx := t.Context()
+
+	plan := &deployplan.Plan{Plan: map[string]*deployplan.PlanEntry{
+		"resources.jobs.my_job": {
+			Changes: deployplan.Changes{
+				"description": {Action: deployplan.Update, New: nil, Remote: "remote-desc"},
+			},
+		},
+		"resources.jobs.my_job.permissions": {
+			Changes: deployplan.Changes{
+				"object_id": {Action: deployplan.Update, New: nil, Remote: "/jobs/123"},
+			},
+		},
+		"resources.schemas.my_schema.grants": {
+			Changes: deployplan.Changes{
+				"[0].privileges": {Action: deployplan.Update, New: nil, Remote: []any{"SELECT"}},
+			},
+		},
+	}}
+
+	for _, eng := range []engine.EngineType{engine.EngineDirect, engine.EngineTerraform} {
+		t.Run(string(eng), func(t *testing.T) {
+			changes, err := ExtractChanges(ctx, &bundle.Bundle{}, plan, eng)
+			require.NoError(t, err)
+
+			_, hasPerms := changes["resources.jobs.my_job.permissions"]
+			assert.False(t, hasPerms, "permissions sub-resource must be skipped")
+			_, hasGrants := changes["resources.schemas.my_schema.grants"]
+			assert.False(t, hasGrants, "grants sub-resource must be skipped")
+
+			job, hasJob := changes["resources.jobs.my_job"]
+			require.True(t, hasJob, "regular resource changes must be kept")
+			assert.Contains(t, job, "description")
 		})
 	}
 }


### PR DESCRIPTION
## Changes

Syncing permissions back is not yet supported, so these sub-resources are now skipped in `ExtractChanges` instead of failing the whole run.

`bundle config-remote-sync` (used by DABs in the Workspace to write remote resource changes back to YAML) failed the entire sync when a job/pipeline had permissions or grants. These are emitted by the plan as their own sub-resources (`resources.<type>.<name>.permissions` / `.grants`), which config-remote-sync cannot write back — the server-populated `object_id` field has no YAML source location, and bundle-level permissions have no per-resource YAML node at all. This surfaced as either `failed to find location for resource ...permissions for a field object_id` or a selector-parse crash on `permissions.[user_name='...']`.


## Why
One malformed sub-resource change was aborting the sync for the whole bundle, so users with permissions on any resource could never sync any UI edit back to config.

## Tests
Unit test for the skip in `ExtractChanges` (both engines) and an acceptance test that reproduces the exact failure without the fix.
