### PR TITLE
Add localenv/environments path owners

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -14,6 +14,11 @@
 # Labs
 /cmd/labs/                  @alexott @asnare
 
+# Local environments / DB Connect
+/libs/localenv/             @rugpanov @rclarey @anton-107 @misha-db
+/cmd/environments/          @rugpanov @rclarey @anton-107 @misha-db
+/acceptance/localenv/       @rugpanov @rclarey @anton-107 @misha-db
+
 # Apps
 /cmd/apps/                  team:eng-apps-devex
 /cmd/workspace/apps/        team:eng-apps-devex


### PR DESCRIPTION
## Why

PRs touching `libs/localenv/`, `cmd/environments/`, and `acceptance/localenv/` currently fall through to the `*` rule in `.github/OWNERS` and therefore require a global maintainer's approval, even though these areas have dedicated owners. This adds review-turnaround friction on DB Connect / local-environment work (e.g. #5963).

## What

Adds an OWNERS section granting per-path ownership of those three directories to `@rugpanov`, `@rclarey`, `@anton-107`, and `@misha-db`, so any of them can satisfy the `maintainer-approval` gate for changes in those areas — matching the existing per-path pattern used for Labs and Pipelines.

## Verification

- `node .github/scripts/owners.js validate` passes (all three paths exist in the tree; each rule resolves to 4 owners; only the pre-existing `team:ai-training` warning remains).
- `node --test .github/scripts/owners.test.js .github/workflows/maintainer-approval.test.js` passes (64/64).

> Note: because this edits `.github/OWNERS` (a `*`-owned file), this PR itself still requires one existing global maintainer's approval to merge.

This pull request and its description were written by Isaac.