### PR TITLE
Fix experiment create trace location

### DIFF
--- a/libs/testserver/experiments.go
+++ b/libs/testserver/experiments.go
@@ -71,6 +71,10 @@ func (s *FakeWorkspace) ExperimentCreate(req Request) Response {
 		ArtifactLocation: experiment.ArtifactLocation,
 		Tags:             append(experiment.Tags, appendTags...),
 		LifecycleStage:   "active",
+		// TraceLocation is immutable and echoed back by the real GetExperiment.
+		// Dropping it here makes the direct-engine diff see local-present vs
+		// remote-absent and spuriously recreate the experiment.
+		TraceLocation: experiment.TraceLocation,
 	}
 
 	s.Experiments[experimentId] = ml.GetExperimentResponse{

--- a/libs/testserver/experiments.go
+++ b/libs/testserver/experiments.go
@@ -71,9 +71,7 @@ func (s *FakeWorkspace) ExperimentCreate(req Request) Response {
 		ArtifactLocation: experiment.ArtifactLocation,
 		Tags:             append(experiment.Tags, appendTags...),
 		LifecycleStage:   "active",
-		// TraceLocation is immutable and echoed back by the real GetExperiment.
-		// Dropping it here makes the direct-engine diff see local-present vs
-		// remote-absent and spuriously recreate the experiment.
+		// Echo back like the real GetExperiment; omitting this immutable field triggers a spurious recreate.
 		TraceLocation: experiment.TraceLocation,
 	}
 


### PR DESCRIPTION
The test server's fake `ExperimentCreate` rebuilt the experiment field-by-field and dropped `TraceLocation`. Since it's immutable and the real `GetExperiment` echoes it back, the direct-engine diff saw local-present vs remote-absent and spuriously recreated the experiment on every plan/deploy. Fix: pass `TraceLocation` through.

_Found by fuzz testing._