### PR TITLE
[WIP] Smartly select what tests to run on PR iterations

### DIFF
--- a/tools/fingerprint/fingerprint.go
+++ b/tools/fingerprint/fingerprint.go
@@ -1,0 +1,73 @@
+// Command fingerprint computes a content hash over a set of tracked files at a
+// git commit. Two commits with the same fingerprint for a given input set have
+// byte-identical inputs, so a test target that passed at one can be safely
+// skipped at the other.
+//
+// This is the primitive behind result-reuse across PR iterations: unlike
+// testmask, which diffs the cumulative PR range and so re-runs a target whenever
+// the PR *ever* touched it, a content fingerprint is identical across PR
+// iterations that leave a target's inputs unchanged — and it is force-push /
+// rebase immune because it addresses content, not history. A target that passed
+// at a fingerprint can be skipped at any later commit with the same fingerprint.
+package main
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// TreeEntry is one tracked file: its path and git blob object id (content hash).
+type TreeEntry struct {
+	Path string
+	Blob string
+}
+
+// Fingerprint returns a deterministic hash over the given tree entries.
+//
+// It is order-independent (entries are sorted by path first) so it does not
+// depend on git's listing order, and it binds each path to its blob id so both
+// a content change (blob changes) and a rename (path changes) alter the result.
+// The path is length-prefixed to make the encoding unambiguous, so no two
+// distinct entry sets can collide by concatenation.
+func Fingerprint(entries []TreeEntry) string {
+	sorted := slices.Clone(entries)
+	slices.SortFunc(sorted, func(a, b TreeEntry) int {
+		return cmp.Compare(a.Path, b.Path)
+	})
+
+	h := sha256.New()
+	for _, e := range sorted {
+		// Length-prefix the path so "ab"+"c" and "a"+"bc" cannot hash alike.
+		fmt.Fprintf(h, "%d\x00%s\x00%s\x00", len(e.Path), e.Path, e.Blob)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ParseLsTree parses the output of
+//
+//	git ls-tree -r --format='%(objectname) %(path)' <commit> [-- <paths>...]
+//
+// into tree entries. It is split from the git invocation so the parsing is
+// unit-testable with literal strings, without a git repo (the same split
+// testmask uses for GetChangedFiles vs GetTargets).
+//
+// Each line is "<blob-sha> <path>". A blank trailing line is ignored. Paths with
+// spaces are preserved because only the first field is the blob id.
+func ParseLsTree(out string) []TreeEntry {
+	var entries []TreeEntry
+	for line := range strings.SplitSeq(out, "\n") {
+		if line == "" {
+			continue
+		}
+		blob, path, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		entries = append(entries, TreeEntry{Path: path, Blob: blob})
+	}
+	return entries
+}

--- a/tools/fingerprint/fingerprint_test.go
+++ b/tools/fingerprint/fingerprint_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFingerprintDeterministic(t *testing.T) {
+	// Two independently constructed but equal inputs must hash identically, so
+	// the fingerprint depends only on content, not on slice identity or run.
+	first := []TreeEntry{
+		{Path: "a.go", Blob: "aaa"},
+		{Path: "b.go", Blob: "bbb"},
+	}
+	second := []TreeEntry{
+		{Path: "a.go", Blob: "aaa"},
+		{Path: "b.go", Blob: "bbb"},
+	}
+	assert.Equal(t, Fingerprint(first), Fingerprint(second))
+}
+
+func TestFingerprintOrderIndependent(t *testing.T) {
+	forward := []TreeEntry{
+		{Path: "a.go", Blob: "aaa"},
+		{Path: "b.go", Blob: "bbb"},
+	}
+	reversed := []TreeEntry{
+		{Path: "b.go", Blob: "bbb"},
+		{Path: "a.go", Blob: "aaa"},
+	}
+	assert.Equal(t, Fingerprint(forward), Fingerprint(reversed),
+		"listing order must not change the fingerprint")
+}
+
+func TestFingerprintContentSensitive(t *testing.T) {
+	before := []TreeEntry{{Path: "a.go", Blob: "aaa"}}
+	after := []TreeEntry{{Path: "a.go", Blob: "aab"}}
+	assert.NotEqual(t, Fingerprint(before), Fingerprint(after),
+		"a blob change must change the fingerprint")
+}
+
+func TestFingerprintRenameSensitive(t *testing.T) {
+	before := []TreeEntry{{Path: "a.go", Blob: "aaa"}}
+	after := []TreeEntry{{Path: "renamed.go", Blob: "aaa"}}
+	assert.NotEqual(t, Fingerprint(before), Fingerprint(after),
+		"a rename (same content, new path) must change the fingerprint")
+}
+
+func TestFingerprintAddedFileSensitive(t *testing.T) {
+	before := []TreeEntry{{Path: "a.go", Blob: "aaa"}}
+	after := []TreeEntry{
+		{Path: "a.go", Blob: "aaa"},
+		{Path: "b.go", Blob: "bbb"},
+	}
+	assert.NotEqual(t, Fingerprint(before), Fingerprint(after),
+		"adding a file must change the fingerprint")
+}
+
+// TestFingerprintNoConcatenationCollision guards the length-prefixed encoding:
+// path/blob boundaries must be unambiguous so no two distinct entry sets whose
+// naive concatenation matches can collide.
+func TestFingerprintNoConcatenationCollision(t *testing.T) {
+	a := []TreeEntry{{Path: "ab", Blob: "c"}}
+	b := []TreeEntry{{Path: "a", Blob: "bc"}}
+	assert.NotEqual(t, Fingerprint(a), Fingerprint(b))
+}
+
+func TestFingerprintEmptyStable(t *testing.T) {
+	// The empty set has a well-defined hash; callers (not this function) decide
+	// whether "nothing matched" is meaningful. Just assert it is stable.
+	assert.Equal(t, Fingerprint(nil), Fingerprint([]TreeEntry{}))
+}
+
+func TestParseLsTree(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []TreeEntry
+	}{
+		{
+			name: "basic",
+			out:  "aaa a.go\nbbb dir/b.go\n",
+			want: []TreeEntry{
+				{Path: "a.go", Blob: "aaa"},
+				{Path: "dir/b.go", Blob: "bbb"},
+			},
+		},
+		{
+			name: "path_with_spaces",
+			out:  "aaa dir/file with spaces.txt\n",
+			want: []TreeEntry{
+				{Path: "dir/file with spaces.txt", Blob: "aaa"},
+			},
+		},
+		{
+			name: "trailing_and_blank_lines_ignored",
+			out:  "aaa a.go\n\nbbb b.go\n\n",
+			want: []TreeEntry{
+				{Path: "a.go", Blob: "aaa"},
+				{Path: "b.go", Blob: "bbb"},
+			},
+		},
+		{
+			name: "empty",
+			out:  "",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ParseLsTree(tt.out))
+		})
+	}
+}
+
+// TestParseThenFingerprintMatchesDirect ties the two halves together: parsing
+// ls-tree output and fingerprinting it yields the same hash as fingerprinting
+// the entries directly.
+func TestParseThenFingerprintMatchesDirect(t *testing.T) {
+	entries := []TreeEntry{
+		{Path: "a.go", Blob: "aaa"},
+		{Path: "b.go", Blob: "bbb"},
+	}
+	parsed := ParseLsTree("aaa a.go\nbbb b.go\n")
+	assert.Equal(t, Fingerprint(entries), Fingerprint(parsed))
+}

--- a/tools/fingerprint/git.go
+++ b/tools/fingerprint/git.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// TreeEntriesAt lists the tracked files matching pathspecs at the given commit,
+// with their blob ids, via `git ls-tree`.
+//
+// It uses ls-tree (a snapshot of one commit) rather than a diff so the
+// fingerprint is absolute: it depends only on the content at `commit`, not on
+// any base ref. Blob ids come straight from git's index, so no file is read.
+func TreeEntriesAt(commit string, pathspecs []string) ([]TreeEntry, error) {
+	args := []string{"ls-tree", "-r", "--format=%(objectname) %(path)", commit}
+	if len(pathspecs) > 0 {
+		args = append(args, "--")
+		args = append(args, pathspecs...)
+	}
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-tree at %s failed: %w", commit, err)
+	}
+	return ParseLsTree(string(out)), nil
+}

--- a/tools/fingerprint/main.go
+++ b/tools/fingerprint/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <commit> [pathspec...]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Prints a content fingerprint over the tracked files matching pathspec at commit.\n")
+		os.Exit(1)
+	}
+
+	commit := os.Args[1]
+	pathspecs := os.Args[2:]
+
+	entries, err := TreeEntriesAt(commit, pathspecs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error listing tree: %v\n", err)
+		os.Exit(1)
+	}
+	if len(entries) == 0 {
+		// No file matched the pathspecs. Emitting a hash of the empty set would
+		// let an unrelated later commit collide with it; a caller must decide
+		// what "nothing to fingerprint" means, so make it an explicit error
+		// rather than silently returning a reusable hash.
+		fmt.Fprintf(os.Stderr, "Error: no tracked files matched at %s\n", commit)
+		os.Exit(1)
+	}
+
+	fmt.Println(Fingerprint(entries))
+}

--- a/tools/testmask/targets.go
+++ b/tools/testmask/targets.go
@@ -29,6 +29,52 @@ var commonTriggerPatterns = []string{
 	"tools/task/",
 }
 
+// inertFiles are repo-relative paths whose contents cannot affect any test
+// outcome, so a change touching only these (plus inertPrefixes) runs no tests.
+//
+// This list is deliberately narrow and must never include a file that a test
+// reads: NOTICE is verified by internal/build/notice_test.go, and the many
+// README.md files under acceptance/ and libs/template/ are test fixtures.
+// None of those are inert. TestInertPathsExcludeTestInputs guards this.
+var inertFiles = map[string]bool{
+	"README.md":                        true,
+	"SECURITY.md":                      true,
+	"CHANGELOG.md":                     true,
+	"CLAUDE.md":                        true,
+	"AGENTS.md":                        true,
+	"LICENSE":                          true,
+	".github/PULL_REQUEST_TEMPLATE.md": true,
+}
+
+// inertPrefixes are repo-relative directory prefixes that hold only
+// documentation or contributor metadata, never code or test inputs.
+//
+// .nextchanges/ holds per-PR changelog fragments. Their placement is validated
+// by `task check-changelog` in the `check` workflow, which runs on every PR
+// independently of testmask, so skipping the test suite for a fragment-only
+// change is safe.
+var inertPrefixes = []string{
+	"docs/",
+	".github/ISSUE_TEMPLATE/",
+	".nextchanges/",
+}
+
+// isInertPath reports whether a changed file is documentation or metadata that
+// cannot influence a test outcome. Matching is on exact repo-relative paths (or
+// the inertPrefixes directories), never bare basenames, so fixture files such
+// as acceptance/.../README.md are not misclassified as inert.
+func isInertPath(file string) bool {
+	if inertFiles[file] {
+		return true
+	}
+	for _, prefix := range inertPrefixes {
+		if strings.HasPrefix(file, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 type targetMapping struct {
 	prefixes []string
 	target   string
@@ -103,10 +149,22 @@ func sourceToPrefix(src string) string {
 
 // GetTargets matches files to targets based on patterns and returns the matched targets.
 func GetTargets(files []string, mappings []targetMapping) []string {
+	// No changed files were determined; fall back to the full test suite. The
+	// all-inert skip below requires at least one changed file, all inert.
+	if len(files) == 0 {
+		return []string{"test"}
+	}
+
 	targetSet := make(map[string]bool)
 	unmatchedFiles := []string{}
 
 	for _, file := range files {
+		if isInertPath(file) {
+			// Documentation/metadata: cannot affect any test outcome, so it
+			// neither selects a target nor counts as an unmatched file that
+			// would otherwise trigger the catch-all `test` target.
+			continue
+		}
 		matched := false
 		for _, mapping := range mappings {
 			for _, prefix := range mapping.prefixes {
@@ -126,8 +184,10 @@ func GetTargets(files []string, mappings []targetMapping) []string {
 		targetSet["test"] = true
 	}
 
+	// Every changed file was inert, so no test target is affected. Return an
+	// empty list; CI treats it as "skip all", including the integration tests.
 	if len(targetSet) == 0 {
-		return []string{"test"}
+		return []string{}
 	}
 
 	return slices.Sorted(maps.Keys(targetSet))

--- a/tools/testmask/targets_test.go
+++ b/tools/testmask/targets_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +58,63 @@ func TestGetTargets(t *testing.T) {
 			targets: []string{"test"},
 		},
 		{
+			name: "readme_only",
+			files: []string{
+				"README.md",
+			},
+			targets: []string{},
+		},
+		{
+			name: "docs_dir_only",
+			files: []string{
+				"docs/output.md",
+				"docs/sync.md",
+			},
+			targets: []string{},
+		},
+		{
+			name: "nextchanges_fragment_only",
+			files: []string{
+				".nextchanges/cli/my-feature.md",
+			},
+			targets: []string{},
+		},
+		{
+			name: "multiple_inert_files",
+			files: []string{
+				"README.md",
+				".nextchanges/bundles/fix.md",
+				"LICENSE",
+				".github/PULL_REQUEST_TEMPLATE.md",
+			},
+			targets: []string{},
+		},
+		{
+			name: "inert_plus_code_still_runs",
+			files: []string{
+				"README.md",
+				"bundle/config.go",
+			},
+			targets: []string{"test"},
+		},
+		{
+			name: "inert_plus_scoped_target_runs_only_that_target",
+			files: []string{
+				"README.md",
+				"experimental/ssh/main.go",
+			},
+			targets: []string{"test-exp-ssh"},
+		},
+		{
+			// NOTICE is verified by internal/build/notice_test.go, so it is not
+			// inert; a change to it must run the test suite.
+			name: "notice_is_not_inert",
+			files: []string{
+				"NOTICE",
+			},
+			targets: []string{"test"},
+		},
+		{
 			name: "go_mod_triggers_all",
 			files: []string{
 				"go.mod",
@@ -101,4 +161,56 @@ func TestGetTargets(t *testing.T) {
 func TestLoadTargetMappingsMissingFile(t *testing.T) {
 	_, err := LoadTargetMappings("nonexistent.yml")
 	assert.Error(t, err)
+}
+
+// TestAllInertEncodesAsEmptyArray locks in the wire format the CI skip relies
+// on: main.go JSON-encodes the result, and push.yml gates jobs on
+// `contains(fromJSON(targets), 'test')`. An all-inert diff must encode as `[]`
+// (a valid empty array), not `null`, which fromJSON rejects. This is why
+// GetTargets returns a non-nil empty slice rather than nil.
+func TestAllInertEncodesAsEmptyArray(t *testing.T) {
+	mappings, err := LoadTargetMappings("../../Taskfile.yml")
+	require.NoError(t, err)
+
+	targets := GetTargets([]string{"README.md"}, mappings)
+
+	var buf bytes.Buffer
+	require.NoError(t, json.NewEncoder(&buf).Encode(targets))
+	assert.JSONEq(t, "[]", buf.String())
+}
+
+// TestInertPathsExcludeTestInputs guards the correctness invariant of the inert
+// list: a file a test actually reads must never be classified as inert, or a
+// change to it would wrongly skip the suite. NOTICE is verified by
+// internal/build/notice_test.go, and README.md files under acceptance/ and
+// libs/template/ are checked-in test fixtures.
+func TestInertPathsExcludeTestInputs(t *testing.T) {
+	mustRunTests := []string{
+		"NOTICE",
+		"acceptance/README.md",
+		"acceptance/bundle/templates/default-python/classic/output/my_default_python/README.md",
+		"libs/template/templates/default-sql/README.md",
+		"bundle/config.go",
+	}
+	for _, file := range mustRunTests {
+		assert.False(t, isInertPath(file), "%s must not be inert: a change to it must run tests", file)
+	}
+}
+
+// TestInertPathsExist guards against typos in the inert list: an entry that does
+// not exist in the repository silently stops matching, disabling the skip
+// optimization for that file without any test failing. Paths are repo-relative;
+// the package runs from tools/testmask, so the repo root is ../../.
+func TestInertPathsExist(t *testing.T) {
+	const repoRoot = "../../"
+	for file := range inertFiles {
+		_, err := os.Stat(repoRoot + file)
+		assert.NoError(t, err, "inert file %q does not exist in the repo", file)
+	}
+	for _, prefix := range inertPrefixes {
+		info, err := os.Stat(repoRoot + prefix)
+		if assert.NoError(t, err, "inert prefix %q does not exist in the repo", prefix) {
+			assert.True(t, info.IsDir(), "inert prefix %q is not a directory", prefix)
+		}
+	}
 }


### PR DESCRIPTION
# Content-fingerprint result reuse for PR iterations

**Status:** design, for review before implementation
**Depends on:** Stage 1 (`92d509b924`, testmask docs-inert skip) — shipped
**Author:** drafted by Isaac for Jan

## Problem

A PR is not one CI run — it's many. During review a branch gets pushed
repeatedly: address a comment, fix lint, add a changelog fragment, merge
`origin/main`. Each `synchronize` event re-runs the full test matrix **and**
re-dispatches the expensive cross-org integration suite
(`push.yml` → `trigger-tests` → `cli-isolated-pr.yml`), even when the new
iteration didn't touch anything the integration tests exercise.

That per-iteration re-run is the waste this stage removes. It is invisible in
`main`'s history because the repo squash-merges (0 merge commits in the last
100 on `main`), so it can't be measured from `main` — but every reviewed PR
lives it.

## Why Stage 1 does not already cover this

Stage 1 (testmask) diffs the **cumulative** merge-base range
`base...head`, so it answers "did this PR *ever* touch target T?" — not "did
*this iteration* touch T?". Concretely:

- iteration 1 edits `experimental/ssh/foo.go` → integration runs (correct)
- iteration 2 only tweaks a doc in response to review

On iteration 2, the cumulative diff **still shows the ssh change**, so testmask
still emits `test-exp-ssh` and integration re-runs — despite iteration 2 adding
nothing that ssh tests cover. Stage 1 cannot skip it; it has no memory of what
already passed.

Measured over the last 80 real commits on `main`: ~90% select `test` (and thus
integration). The trigger set is broad, so "this iteration changed *nothing*
integration-relevant" is common during a review cycle — exactly the gap.

## Approach: content-address the test inputs

Instead of diffing commit-to-commit, hash the **content** of a target's
inputs and reuse a prior green result when the hash matches.

For target `T`:

```
fingerprint(T) = SHA256 over the sorted list of "(path, blob_sha)"
                 for every tracked file matching T's input set,
                 at the current commit.
```

`git ls-tree -r --format='%(objectname) %(path)' <commit> -- <paths...>` yields
path+blob-sha directly (verified on git 2.50). Blob shas are already computed by
git, so this is cheap and needs no file reads.

Protocol:

1. When target `T` **passes** at fingerprint `F`, record a marker keyed by `F`.
2. On any later run, compute `F`. If a pass marker for `F` exists → **skip `T`
   and reuse the green result**.

Why this shape is right:

- **Covers iterations** — iteration 2 that leaves T's inputs byte-identical has
  the same `F` ⇒ skip. This is the case Stage 1 structurally cannot handle.
- **Force-push / rebase immune, for free** — it's content-addressed, not
  history-addressed. This is the "snapshot" robustness the original ask hoped
  for, without depending on `pull_request.synchronize`'s fragile `before`/`after`
  SHAs (which dangle under force-push).
- **Subsumes the docs case** — a docs-only iteration doesn't change any `F`.

## Force-pushes (rebase / amend / squash / reset)

Force-pushes are covered by design — content-addressing is the reason we chose
this shape over a diff-from-last-iteration scheme. There are two layers:

**Layer 1 — computation.** `F` hashes `(path, blob-sha)` from `git ls-tree` at a
single commit. It reads no parent, commit SHA, author, or diff, so rewriting
history cannot change it. Verified: re-committing a commit's exact tree onto a
different parent (a simulated force-push) produces a new commit SHA but a
byte-identical `F`. This is why we do **not** key off
`pull_request.synchronize`'s `before`/`after` SHAs — the `before` SHA dangles
after a force-push, breaking any history-relative scheme.

**Layer 2 — cache readback.** The marker key is `pass-<T>-<F>` (no SHA in it),
and GitHub Actions cache is scoped by git *ref*, not commit. A force-push keeps
the same ref, so iteration N+1 still reads the namespace iteration N wrote.

Edge cases, all correct:

| Force-push kind | Effect on `F` | Outcome |
| --- | --- | --- |
| Pure history rewrite (amend msg, reorder, squash; tree unchanged) | unchanged | reuse — correct, and the win |
| Rebase onto a moved `main` / conflict resolution (tree changes) | changes | miss → run — correct |
| Rebase that pulls in new tooling (Go bump, `go.sum`) | changes *iff tooling is in the input set* | run — **only correct because the design mandates tooling ∈ `F`** |
| Reset/rewrite back to earlier content | equals an earlier `F` | reuse of the older marker — correct bonus (a diff scheme would re-run) |

The one real hazard is the third row: a rebase can silently change the
environment with no product-code diff. It is covered **only** because `F`
includes Go version, `go.sum`, and the harness/tool version (see safety point 3
below). Without that, a force-push-rebase could wrongly reuse.

Non-hazard: cache eviction (10 GB LRU / 7-day idle) only ever causes a miss →
safe re-run, force-push or not. Markers are written **only** by a genuinely
green run on the ref, never seeded speculatively, so nothing stale can be
resurrected by a rewrite-then-restore.

## The safety asymmetry (the crux)

testmask is a **trigger**: over-running wastes CI, under-running is safe because
a catch-all backstops it. A result-reuse **cache is the opposite**:
under-covering the fingerprint means skipping a run that *would have caught a
regression*. **A missed input is a correctness bug, not a cost bug.**

Consequences for the design:

1. **The fingerprint must hash the true input set, not testmask's trigger
   globs.** Those globs are deliberately conservative *triggers*; e.g. `test-acc`
   runs `--packages ./acceptance/...` with no `-run` filter, so the real
   acceptance coverage is broader than any single target's `sources:`. The
   fingerprint's input set must be a **superset** of what actually affects the
   outcome. When unsure, hash more (a superfluous input only causes a false
   cache-miss = a safe re-run).

2. **Default to miss.** Any error computing `F` (git failure, unknown path,
   tooling change) ⇒ run the tests. Never skip on uncertainty.

3. **Include the tooling in `F`.** Go version, `go.sum`, the test harness, the
   fingerprint tool's own version. A test-runner change can flip a result with
   zero product-code change; if it's not in `F`, reuse is unsound.

4. **Bound blast radius on rollout** — see below.

## Scaling: fingerprint compute and cache size

A large PR does **not** stress this design, because nothing here scales with the
diff. Three distinct "sizes", only the first has any cost, and it answers to
*repo* size, not *PR* size:

| Quantity | Scales with | Worst case (this repo) | Measured cost |
| --- | --- | --- | --- |
| Fingerprint compute | files in the target's input **tree** (not the diff) | whole tree, 9,663 files | ~20 ms warm CPU (0.6 s cold `ls-tree` wall) |
| Fingerprint output | nothing — constant | always | 65 bytes (sha256 hex + `\n`) |
| Cache marker | nothing — a presence key | always | empty value; all info in the key `pass-<T>-<F>` |

Verified: the largest PR in the last 200 commits (375 files changed)
fingerprinted in the same ~20 ms as a one-file PR. `ls-tree` reads the target's
input tree at HEAD and never looks at the diff, so diff size is irrelevant to
compute.

**Cache footprint** is bounded by *fingerprint churn*, not files-per-PR:
cardinality is `targets × distinct-fingerprints-ever-seen`. A 375-file PR still
mints exactly **one** fingerprint per target per iteration, same as a one-file
PR. With ~5 targets and one new fingerprint per meaningful iteration, even a busy
week is single-digit MB against GitHub's 10 GB/repo budget — and GitHub already
GCs it (10 GB LRU + 7-day idle). An evicted or stale marker only ever causes a
safe cache **miss** (→ re-run), never a wrong skip.

**The one repo-scale caveat:** cold `git ls-tree` over the whole tree was ~0.6 s
wall (60 ms warm) at 9.6k files; it is O(files-in-input-set), so a
million-file monorepo would grow it. Non-issue at current scale. If it ever
mattered: fingerprint scoped targets (ssh's input tree is 5 KB of ls-tree vs
954 KB whole-repo) rather than the whole tree, and memoize `ls-tree` per
commit SHA.

## Prior art: `internal.ChangedTests` (#5880)

PR #5880 (pietern, `extract-changed-tests`, open) extracts the
`DATABRICKS_TEST_SKIPLOCAL=withchanged` detection into a reusable
`acceptance/internal.ChangedTests`. It is **orthogonal** (it selects *which
acceptance tests inside a run* execute; testmask/this stage select *whether the
job runs at all*) and lives in the **root** module, so `tools/testmask` cannot
import it (dependency would invert). But its **dependency model is exactly the
cross-directory correctness problem this stage shares, and should be mirrored:**

- a shared parent `script.prepare` / `script.cleanup` / `test.toml` affects its
  whole subtree → those files must be in the fingerprint input set of every
  descendant target;
- a change under `acceptance/bin/**` affects every test → in the common input
  set;
- an unowned shared file (a sourced `_script`, a fixture read via `$TESTDIR/..`)
  affects its subtree.

If this stage ever moves detection into the root module, `ChangedTests` becomes
directly reusable. For now, mirror the rules and cite #5880.

## Storage

GitHub Actions cache (already the substrate for the Go build cache in
`setup-build-environment/action.yml`):

- key `pass-<T>-<F>`; presence = "T passed at F".
- **Scope works in our favour:** a PR's iterations all push the *same* branch,
  and a branch reads caches it wrote plus the base branch's — so iteration N+1
  reads iteration N's marker, and any branch reads markers seeded by `main`.
  Sibling PR branches can't read each other's, which is correct (no
  cross-contamination).
- No new secrets/infra for the unit/acceptance `test-*` jobs.

## The integration-test wrinkle (cross-org)

Unit/acceptance jobs run in `databricks/cli` and can record their own markers
inline. **Integration is different:** it's dispatched to
`databricks-eng/eng-dev-ecosystem` and the result comes back **asynchronously**
as the `Integration Tests` check written onto the head SHA. So the CLI repo
doesn't directly observe the pass.

Options (pick during review):

- **(A) eng-dev records the marker.** The integration workflow computes `F` for
  the SHA it tested and saves `pass-integration-<F>` to the CLI repo's cache on
  success. Most direct; needs a change in the other repo + cache-write scope.
- **(B) CLI-side listener.** A `check_run.completed` workflow in `databricks/cli`
  fires when `Integration Tests` concludes success, recomputes `F` for that SHA,
  and saves the marker. Keeps the fingerprint definition authoritative in this
  repo; no eng-dev change. Slightly more moving parts (one listener workflow).

Either way the **skip decision** stays in `databricks/cli`: `trigger-tests`
computes `F` and, on a marker hit, posts the synthetic green `Integration Tests`
check (reusing the exact path `integration-trigger` already uses for the
docs-skip) instead of dispatching. **Recommendation: (B)** — keeps the
fingerprint contract in one repo.

## Rollout / guardrails

- **Shadow mode first.** Compute `F`, log hit/miss and what *would* have been
  skipped, but still run everything. Validate hit-rate and zero false-hits over
  a week before enforcing.
- **Enforce unit/acceptance before integration.** The inline `test-*` jobs are
  lower-stakes and self-contained; prove the mechanism there first, then extend
  to the cross-org integration path.
- **`log()` every skip** with `T` and `F`, and count skips — silent truncation
  reads as "covered" when it didn't (the #5880 `maxChangedLocalTests` "log what
  was dropped" discipline).
- **Kill switch.** A repo variable / label forces full run (e.g.
  `full-ci`), for when a maintainer distrusts a reuse.
- **Never skip on `main` / merge_group.** Seed markers there, but always run, so
  the authoritative branch is never reused-into.

## Verified end-to-end (fingerprint primitive)

`tools/fingerprint/` implements the primitive: `Fingerprint(entries)` (pure,
order-independent, content- and rename-sensitive, collision-safe via
length-prefixed encoding) + `TreeEntriesAt(commit, pathspecs)` over
`git ls-tree`. Demonstrated on real `main` history:

| Iteration | ssh input fingerprint | Decision |
| --- | --- | --- |
| across an ssh commit (`d6636f4d51`) | **changes** | ssh integration runs ✓ |
| across a README-only commit (`9e81da898`) | **stable** | ssh integration skipped ✓ |
| across a postgres/bundle commit (`681f8b098e`) | **stable** | ssh integration skipped ✓ |

The stable cases are exactly what Stage 1 (cumulative diff) cannot skip once the
PR has touched ssh at all — the concrete Stage-2 win.

**Design coupling this surfaced:** a naive whole-tree fingerprint for the broad
`test` target flips on a README change (README is in the tree), which would
defeat the docs skip. So the **`test` target's fingerprint input set must
exclude Stage 1's inert paths** — Stage 1's `inertFiles`/`inertPrefixes` becomes
shared input to Stage 2. This answers open-question #2: per-target input sets,
with the broad target computed as "whole tree minus inert".

## Open questions for review

1. Integration marker: **(A) eng-dev writes** vs **(B) CLI-side listener**?
   (Recommend B.)
2. Fingerprint granularity: per-target (5 markers) — confirmed sufficient, or do
   we want per-acceptance-dir (finer, closer to #5880, but only helps if we also
   split the jobs)?
3. Enforce set: start with just `integration` (biggest cost), or all `test-*`?
4. Do we fold this on top of #5880 landing, or keep fully independent?

## Non-goals

- Changing *which* tests run inside a job (that's #5880's layer).
- Caching test *artifacts/outputs* — we cache only the boolean "passed at F".
- Any change to `main` / merge_group behaviour beyond seeding markers.