### PR TITLE
[VPEX] localenv: anchor repo-derived constraint URL at the python/ subtree

### DIFF
--- a/libs/localenv/constraints.go
+++ b/libs/localenv/constraints.go
@@ -47,7 +47,12 @@ func RepoConstraintBaseURL(ctx context.Context) string {
 	if repo == "" {
 		return ""
 	}
-	return "https://raw.githubusercontent.com/" + repo + "/main"
+	// The databricks/environments repo nests its language ecosystems under a
+	// top-level directory, so the Python artifacts live at python/<env key>/
+	// pyproject.toml (e.g. python/serverless/serverless-v5, python/dbr/<spark>),
+	// not at the repo root. Anchor the base URL at that python/ subtree so an
+	// env key of "serverless/serverless-v5" resolves to the real path.
+	return "https://raw.githubusercontent.com/" + repo + "/main/python"
 }
 
 // errEnvKeyNotFound is returned by fetchURL when the constraint artifact does

--- a/libs/localenv/constraints_test.go
+++ b/libs/localenv/constraints_test.go
@@ -18,9 +18,10 @@ func TestRepoConstraintBaseURL(t *testing.T) {
 	// can report the missing source at the fetch phase rather than aborting early.
 	assert.Empty(t, RepoConstraintBaseURL(t.Context()))
 
-	// The env var supplies the repo and is turned into a raw main-branch URL.
+	// The env var supplies the repo and is turned into a raw main-branch URL
+	// anchored at the python/ subtree where the Python artifacts live.
 	ctx := env.Set(t.Context(), EnvConstraintRepo, "databricks/environments")
-	assert.Equal(t, "https://raw.githubusercontent.com/databricks/environments/main", RepoConstraintBaseURL(ctx))
+	assert.Equal(t, "https://raw.githubusercontent.com/databricks/environments/main/python", RepoConstraintBaseURL(ctx))
 
 	// Whitespace-only is treated as unset.
 	ctx = env.Set(t.Context(), EnvConstraintRepo, "  ")


### PR DESCRIPTION
## What

`RepoConstraintBaseURL` derives the constraint-artifact base URL from the hosting GitHub repo (the `DATABRICKS_LOCALENV_CONSTRAINT_REPO` env var, and eventually the built-in `databricks/environments` default). It produced:

```
https://raw.githubusercontent.com/<repo>/main
```

then `FetchConstraints` appends `<env key>/pyproject.toml`.

## Why

The `databricks/environments` repo nests its language ecosystems under a **top-level `python/` directory** — the real published paths are:

```
python/serverless/serverless-v5/pyproject.toml
python/dbr/<spark>/pyproject.toml
```

There is no `serverless/` or `dbr/` at the repo root. So the derived URL was missing the `python/` segment and would **404 every fetch** once the built-in default (or the `CONSTRAINT_REPO` env var) is pointed at `databricks/environments`:

```
.../main/serverless/serverless-v5/pyproject.toml   ❌ 404
.../main/python/serverless/serverless-v5/pyproject.toml   ✅
```

This was surfaced by an audit of the implementation against the VPEX design docs, and confirmed against the (currently private) `databricks/environments` layout.

## Scope

- Only the **repo-derived** route (`RepoConstraintBaseURL`) is changed — it now anchors at `.../main/python`.
- The **full-URL overrides** (`--constraint-source-url` and `DATABRICKS_LOCALENV_CONSTRAINT_SOURCE`, which the acceptance tests use) are passed through unchanged, so a caller pointing at a different layout is unaffected.
- The command is still hidden/experimental and the built-in default repo is still empty; this is a correctness fix so the repo-derived path works the moment it is wired up.

## Test

- Updated `TestRepoConstraintBaseURL` to assert the `/python`-anchored URL.
- Build, unit (`libs/localenv`, `cmd/environments`), acceptance (`localenv`/`help`), lint, and deadcode all pass.

This pull request and its description were written by Isaac.