### PR TITLE
[VPEX] localenv: report venvPath relative to the project root

### DIFF
--- a/libs/localenv/pipeline.go
+++ b/libs/localenv/pipeline.go
@@ -411,7 +411,11 @@ func (p *Pipeline) validate(ctx context.Context, expectedPyMinor, dbcPin string)
 	}
 	p.markOK(PhaseValidate, detail)
 
-	p.res.VenvPath = filepath.ToSlash(filepath.Join(p.ProjectDir, venvDir))
+	// venvPath is reported relative to the project root (spec §6.1), not as an
+	// absolute path: the value names the ".venv" the command provisions inside
+	// ProjectDir, and the VS Code consumer already knows the project root (it
+	// sets the working directory when it shells out). venvDir is already ".venv".
+	p.res.VenvPath = venvDir
 	if p.res.Resolved != nil {
 		if defaultMode {
 			p.res.Resolved.DBConnectVersion = dbcVer

--- a/libs/localenv/pipeline_test.go
+++ b/libs/localenv/pipeline_test.go
@@ -224,7 +224,10 @@ func TestPipelineProvisionsAndValidatesExisting(t *testing.T) {
 	require.NotNil(t, res.Resolved)
 	assert.Equal(t, "3.12", res.Resolved.PythonVersion)
 	assert.Equal(t, "17.2.0", res.Resolved.DBConnectVersion)
-	assert.Equal(t, ".venv", filepath.Base(res.VenvPath))
+	// venvPath is reported relative to the project root (spec §6.1), so it is
+	// exactly ".venv" — not an absolute path under the temp ProjectDir. Asserting
+	// the full value (not just filepath.Base) is what pins the relative contract.
+	assert.Equal(t, ".venv", res.VenvPath)
 	merged, _ := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
 	assert.Contains(t, string(merged), `"databricks-connect~=17.2.0"`)
 	assert.FileExists(t, filepath.Join(dir, "pyproject.toml.bak"))


### PR DESCRIPTION
## What

The `--output json` result reports `venvPath` as an **absolute** path (`filepath.Join(ProjectDir, ".venv")`), but the spec documents it as project-root-**relative**:

- `cli-spec-internal.md` §6.1: `"venvPath": ".venv", // relative to project root`

This change emits the relative `.venv` (the existing `venvDir` constant) directly.

## Why relative

- It's the documented machine contract — `venvPath` is a JSON field a consumer parses, and the CLI is the interface the VS Code extension wraps.
- `ProjectDir` is just `os.Getwd()`; the consumer already knows the project root (it sets the working directory when it shells out), so an absolute path is redundant and machine-specific, while a relative `.venv` is portable and directly usable (`.venv/bin/python`).
- I confirmed the VS Code extension does not currently parse `venvPath` at all (only the ERD docs reference it), so no consumer relies on the absolute form.

## Test

The existing assertion used `filepath.Base(res.VenvPath)`, which returns `.venv` for **both** the absolute and relative forms — so it never actually pinned the contract (this is why an audit flagged the field as untested). Tightened it to assert the full `.venv`.

- Build, unit (`libs/localenv`, `cmd/environments`), acceptance (`localenv`/`help`), lint, and deadcode all pass.
- No changelog fragment: the `environments setup-local` command is still hidden/experimental (consistent with the rest of the VPEX stack).

This pull request and its description were written by Isaac.
