### PR TITLE
localenv: validate the provisioned venv interpreter directly

### DIFF
--- a/libs/localenv/uv.go
+++ b/libs/localenv/uv.go
@@ -143,14 +143,17 @@ try:
     print("` + validateDBCPrefix + `" + importlib.metadata.version("databricks-connect"))
 except importlib.metadata.PackageNotFoundError:
     print("` + validateDBCPrefix + `")`
-	// --no-project runs the interpreter from the created .venv without re-resolving/syncing
-	// the project's declared dependencies, so validation observes exactly what was installed.
+	// Invoke the venv interpreter directly rather than `uv run`: `uv run` resolves
+	// the interpreter from an active VIRTUAL_ENV / CONDA_PREFIX when one is set
+	// (even with --no-project), which would validate whatever env the caller has
+	// active instead of the .venv we just provisioned. The direct path is exactly
+	// what was installed, so validation observes the real target.
 	out, err := process.Background(ctx,
-		[]string{m.bin, "run", "--no-project", "python", "-c", pyCode},
+		[]string{venvPython(projectDir), "-c", pyCode},
 		process.WithDir(projectDir),
 	)
 	if err != nil {
-		return "", "", uvFailure(ErrValidate, err, "uv run python validation")
+		return "", "", uvFailure(ErrValidate, err, "venv python validation")
 	}
 	pyVer, ok := lineWithPrefix(out, validatePyPrefix)
 	if !ok || pyVer == "" {

--- a/libs/localenv/uv_test.go
+++ b/libs/localenv/uv_test.go
@@ -42,6 +42,19 @@ func TestUvArgs(t *testing.T) {
 	assert.Equal(t, []string{"pip", "install", "pip", "--python", "/p/.venv/bin/python"}, m.pipSeedArgs("/p/.venv/bin/python"))
 }
 
+func TestVenvPythonPath(t *testing.T) {
+	// Validate invokes this interpreter directly (not via `uv run`) so it observes
+	// exactly the .venv that was provisioned, ignoring any active VIRTUAL_ENV.
+	got := venvPython(filepath.Join("p", "proj"))
+	var want string
+	if runtime.GOOS == "windows" {
+		want = filepath.Join("p", "proj", ".venv", "Scripts", "python.exe")
+	} else {
+		want = filepath.Join("p", "proj", ".venv", "bin", "python")
+	}
+	assert.Equal(t, want, got)
+}
+
 func TestDiscoverUvFindsBinOnPath(t *testing.T) {
 	dir := t.TempDir()
 	// exec.LookPath only resolves a bare "uv" to a file with a PATHEXT extension


### PR DESCRIPTION
## What

`uvManager.Validate` ran `uv run --no-project python`, but `uv run` resolves the interpreter from an active `VIRTUAL_ENV` / `CONDA_PREFIX` when one is set (even with `--no-project`). With an unrelated environment active, validation inspected that interpreter instead of the `.venv` just provisioned — so a venv whose Python or databricks-connect version did not match the target could still pass validation.

## Fix

Invoke the venv interpreter directly (`venvPython(projectDir)`), which is exactly what `uv sync` created, so validation observes the real installed environment regardless of the caller's active environment.

## Verification

Reproduced against real uv 0.11.22: with `VIRTUAL_ENV` pointing at a 3.13 venv and a 3.12 project venv, `uv run --no-project python` reported 3.13 (wrong) while the direct interpreter reported 3.12 (correct). Unit tests pass; a live regression guard is added in the stacked integration-test PR.

Part of the pre-unhide hardening of `environments setup-local` (still `Hidden`).

This pull request and its description were written by Isaac.
