### PR TITLE
localenv: reject unusable requires-python before caching constraints

### DIFF
--- a/libs/localenv/constraints.go
+++ b/libs/localenv/constraints.go
@@ -271,6 +271,14 @@ func parseConstraints(data []byte) (requiresPython, dbconnect string, deps []str
 	if strings.TrimSpace(requiresPython) == "" {
 		return "", "", nil, errors.New("constraint artifact has no [project].requires-python")
 	}
+	// Reject a requires-python that is present but yields no installable floor
+	// (e.g. ">=3", "<3.13", "*") here, before the body is cached. This is the
+	// same check the pipeline applies later; running it in the pre-cache guard
+	// ensures an unusable 2xx body cannot overwrite a valid cached copy and
+	// break offline fallback, which is the guard's stated purpose.
+	if _, err = PythonMinorFromRequires(requiresPython); err != nil {
+		return "", "", nil, fmt.Errorf("constraint artifact has an unusable [project].requires-python: %w", err)
+	}
 
 	for _, entry := range p.DependencyGroups.Dev {
 		if isDatabricksConnectDep(entry) {

--- a/libs/localenv/constraints_test.go
+++ b/libs/localenv/constraints_test.go
@@ -220,3 +220,42 @@ func TestFetchConstraintsFallsBackToCache(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, c.FromCache)
 }
+
+func TestParseConstraintsRejectsUnusableRequiresPython(t *testing.T) {
+	// requires-python present but with no installable floor is not a usable
+	// artifact; it must be rejected before caching (not only later in the
+	// pipeline) so it cannot poison the cache.
+	for _, rp := range []string{">=3", "<3.13", "!=3.12", "*", ">3"} {
+		toml := "[project]\nrequires-python = \"" + rp + "\"\n"
+		_, _, _, err := parseConstraints([]byte(toml))
+		require.Error(t, err, "requires-python %q should be rejected", rp)
+		assert.Contains(t, err.Error(), "unusable")
+	}
+}
+
+func TestFetchConstraintsUnusableBodyDoesNotPoisonCache(t *testing.T) {
+	// A good artifact populates the cache; a later 2xx body that is valid TOML but
+	// carries an unusable requires-python must NOT overwrite the last-good copy,
+	// so an offline run still recovers via the cache. This is the guard's purpose.
+	cacheDir := t.TempDir()
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleToml))
+	}))
+	defer good.Close()
+	_, err := FetchConstraints(t.Context(), good.URL, "serverless/serverless-v4", cacheDir, true)
+	require.NoError(t, err)
+
+	// The repo now publishes a TOML-valid but unusable body (no installable floor).
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("[project]\nrequires-python = \">=3\"\n"))
+	}))
+	defer bad.Close()
+	_, err = FetchConstraints(t.Context(), bad.URL, "serverless/serverless-v4", cacheDir, true)
+	require.Error(t, err)
+
+	// The cache still holds the last-good copy: an offline fetch recovers it.
+	c, err := FetchConstraints(t.Context(), "http://127.0.0.1:0", "serverless/serverless-v4", cacheDir, true)
+	require.NoError(t, err)
+	assert.True(t, c.FromCache)
+	assert.Equal(t, "==3.12.*", c.RequiresPython)
+}


### PR DESCRIPTION
## What

`parseConstraints` accepted any non-empty `requires-python`, but the pipeline later rejects one that yields no installable floor (e.g. `">=3"`, `"<3.13"`, `"*"`) via `PythonMinorFromRequires`. Because that usability check ran only **after** the fetched body was written to the on-disk cache, a TOML-valid but unusable 2xx body overwrote the last-good cached copy and then failed one phase later.

A subsequent offline / transport-failure run re-read the poisoned cache and failed again — with the recoverable copy gone. This is exactly the failure the "parse before caching" guard is documented to prevent.

## Fix

Run the floor check inside `parseConstraints`, before the cache write, so an unusable artifact is rejected without clobbering the cache. The check now covers both the live-fetch and cached-read paths; the pipeline's later call becomes harmless defense in depth.

## Tests

- Unit: `parseConstraints` rejects `">=3"`, `"<3.13"`, `"!=3.12"`, `"*"`, `">3"`.
- End-to-end: a good artifact is cached, a later unusable 2xx body is rejected **without** overwriting the cache, and an offline fetch still recovers the last-good copy.

Part of the pre-unhide hardening of `environments setup-local` (still `Hidden`).

This pull request and its description were written by Isaac.
