### PR TITLE
localenv: pin uv sync to the target Python minor

### DIFF
--- a/libs/localenv/pipeline.go
+++ b/libs/localenv/pipeline.go
@@ -356,7 +356,7 @@ func (p *Pipeline) provision(ctx context.Context, pyMinor string) error {
 	if err := p.PM.EnsurePython(ctx, pyMinor); err != nil {
 		return p.fail(PhaseProvision, true, asPipelineError(err, ErrPythonInstall, "ensure python %s failed", pyMinor))
 	}
-	if err := p.PM.Provision(ctx, p.ProjectDir); err != nil {
+	if err := p.PM.Provision(ctx, p.ProjectDir, pyMinor); err != nil {
 		return p.fail(PhaseProvision, true, asPipelineError(err, ErrProvision, "provision failed"))
 	}
 	if err := p.PM.PostProvision(ctx, p.ProjectDir); err != nil {

--- a/libs/localenv/pipeline_test.go
+++ b/libs/localenv/pipeline_test.go
@@ -19,7 +19,7 @@ type fakePM struct{ py, dbc string }
 func (fakePM) Name() string                                    { return "fake" }
 func (fakePM) EnsureAvailable(context.Context) (string, error) { return "fake 1.0", nil }
 func (fakePM) EnsurePython(context.Context, string) error      { return nil }
-func (fakePM) Provision(context.Context, string) error         { return nil }
+func (fakePM) Provision(context.Context, string, string) error { return nil }
 func (fakePM) PostProvision(context.Context, string) error     { return nil }
 func (f fakePM) Validate(context.Context, string) (string, string, error) {
 	return f.py, f.dbc, nil
@@ -39,7 +39,7 @@ func (noProvisionPM) EnsurePython(context.Context, string) error {
 	return errors.New("EnsurePython must not be called under --dry-run")
 }
 
-func (noProvisionPM) Provision(context.Context, string) error {
+func (noProvisionPM) Provision(context.Context, string, string) error {
 	return errors.New("Provision must not be called under --dry-run")
 }
 

--- a/libs/localenv/pkgmanager.go
+++ b/libs/localenv/pkgmanager.go
@@ -15,8 +15,10 @@ type PackageManager interface {
 	// available via the package manager.
 	EnsurePython(ctx context.Context, minor string) error
 
-	// Provision installs the project dependencies inside projectDir.
-	Provision(ctx context.Context, projectDir string) error
+	// Provision installs the project dependencies inside projectDir, pinning the
+	// environment to the given Python minor (e.g. "3.12") so it matches the target
+	// rather than whatever newer interpreter the manager might otherwise pick.
+	Provision(ctx context.Context, projectDir, pyMinor string) error
 
 	// PostProvision seeds pip into the virtual environment inside projectDir.
 	// This step is required because VS Code's ms-python.vscode-python-envs

--- a/libs/localenv/uv.go
+++ b/libs/localenv/uv.go
@@ -93,9 +93,13 @@ func (m *uvManager) EnsurePython(ctx context.Context, minor string) error {
 	return nil
 }
 
-// Provision runs `uv sync` inside projectDir to install project dependencies.
-func (m *uvManager) Provision(ctx context.Context, projectDir string) error {
-	args := append([]string{m.bin}, m.syncArgs()...)
+// Provision runs `uv sync` inside projectDir to install project dependencies,
+// pinning the interpreter to pyMinor. Without --python, `uv sync` selects the
+// newest installed interpreter satisfying requires-python (e.g. 3.13 for a
+// ">=3.12" floor), which then fails validation against the 3.12 target; pinning
+// the minor we just installed keeps the venv on the intended version.
+func (m *uvManager) Provision(ctx context.Context, projectDir, pyMinor string) error {
+	args := append([]string{m.bin}, m.syncArgs(pyMinor)...)
 	if err := m.runUv(ctx, args, projectDir); err != nil {
 		return uvFailure(ErrProvision, err, "uv sync")
 	}
@@ -180,9 +184,10 @@ func lineWithPrefix(out, prefix string) (string, bool) {
 	return "", false
 }
 
-// syncArgs returns the argument slice for `uv sync` (without the binary).
-func (m *uvManager) syncArgs() []string {
-	return []string{"sync"}
+// syncArgs returns the argument slice for `uv sync` (without the binary),
+// pinning the interpreter to pyMinor via --python.
+func (m *uvManager) syncArgs(pyMinor string) []string {
+	return []string{"sync", "--python", pyMinor}
 }
 
 // pythonInstallArgs returns the argument slice for `uv python install <minor>`.

--- a/libs/localenv/uv_test.go
+++ b/libs/localenv/uv_test.go
@@ -37,7 +37,7 @@ func writePipConf(t *testing.T, conf string) context.Context {
 
 func TestUvArgs(t *testing.T) {
 	m := &uvManager{bin: "uv"}
-	assert.Equal(t, []string{"sync"}, m.syncArgs())
+	assert.Equal(t, []string{"sync", "--python", "3.12"}, m.syncArgs("3.12"))
 	assert.Equal(t, []string{"python", "install", "3.12"}, m.pythonInstallArgs("3.12"))
 	assert.Equal(t, []string{"pip", "install", "pip", "--python", "/p/.venv/bin/python"}, m.pipSeedArgs("/p/.venv/bin/python"))
 }


### PR DESCRIPTION
## What

`Provision` ran a bare `uv sync`, which selects the **newest** installed interpreter satisfying `requires-python`. With a floor of `">=3.12"` and a newer Python (e.g. 3.13) present on the machine, uv builds the `.venv` on 3.13, and the `validate` phase then fails with `E_VALIDATE` — `"python version mismatch: want 3.12, got 3.13"`.

This breaks `setup-local` for **any user who already has a Python newer than the target minor** — a common case (3.13/3.14 are current). It is a launch-blocking bug independent of the constraints-repo gating.

## Fix

Thread the resolved minor into `Provision` and pass `uv sync --python <minor>`, so the environment is pinned to the version we just installed and validate against. The `PackageManager.Provision` signature gains the minor argument; `uvManager` and the test fakes are updated to match.

## Verification

Reproduced and fixed against real uv 0.11.22 with a 3.13 present:
- **Before:** bare `uv sync` on `">=3.12"` → `.venv` on 3.13 → `E_VALIDATE`.
- **After:** `uv sync --python 3.12` → `.venv` on 3.12 → `validate ok python=3.12 databricks-connect=17.2.10`.

Unit + acceptance suites pass (dry-run goldens unchanged, since dry-run never provisions). A live regression guard is added in the stacked integration-test PR.

Part of the pre-unhide hardening of `environments setup-local` (still `Hidden`).

This pull request and its description were written by Isaac.
