### PR TITLE
[VPEX] add real uv provision + validate integration test

### DIFF
--- a/libs/localenv/pipeline.go
+++ b/libs/localenv/pipeline.go
@@ -356,7 +356,7 @@ func (p *Pipeline) provision(ctx context.Context, pyMinor string) error {
 	if err := p.PM.EnsurePython(ctx, pyMinor); err != nil {
 		return p.fail(PhaseProvision, true, asPipelineError(err, ErrPythonInstall, "ensure python %s failed", pyMinor))
 	}
-	if err := p.PM.Provision(ctx, p.ProjectDir); err != nil {
+	if err := p.PM.Provision(ctx, p.ProjectDir, pyMinor); err != nil {
 		return p.fail(PhaseProvision, true, asPipelineError(err, ErrProvision, "provision failed"))
 	}
 	if err := p.PM.PostProvision(ctx, p.ProjectDir); err != nil {

--- a/libs/localenv/pipeline_test.go
+++ b/libs/localenv/pipeline_test.go
@@ -19,7 +19,7 @@ type fakePM struct{ py, dbc string }
 func (fakePM) Name() string                                    { return "fake" }
 func (fakePM) EnsureAvailable(context.Context) (string, error) { return "fake 1.0", nil }
 func (fakePM) EnsurePython(context.Context, string) error      { return nil }
-func (fakePM) Provision(context.Context, string) error         { return nil }
+func (fakePM) Provision(context.Context, string, string) error { return nil }
 func (fakePM) PostProvision(context.Context, string) error     { return nil }
 func (f fakePM) Validate(context.Context, string) (string, string, error) {
 	return f.py, f.dbc, nil
@@ -39,7 +39,7 @@ func (noProvisionPM) EnsurePython(context.Context, string) error {
 	return errors.New("EnsurePython must not be called under --dry-run")
 }
 
-func (noProvisionPM) Provision(context.Context, string) error {
+func (noProvisionPM) Provision(context.Context, string, string) error {
 	return errors.New("Provision must not be called under --dry-run")
 }
 

--- a/libs/localenv/pkgmanager.go
+++ b/libs/localenv/pkgmanager.go
@@ -15,8 +15,10 @@ type PackageManager interface {
 	// available via the package manager.
 	EnsurePython(ctx context.Context, minor string) error
 
-	// Provision installs the project dependencies inside projectDir.
-	Provision(ctx context.Context, projectDir string) error
+	// Provision installs the project dependencies inside projectDir, pinning the
+	// environment to the given Python minor (e.g. "3.12") so it matches the target
+	// rather than whatever newer interpreter the manager might otherwise pick.
+	Provision(ctx context.Context, projectDir, pyMinor string) error
 
 	// PostProvision seeds pip into the virtual environment inside projectDir.
 	// This step is required because VS Code's ms-python.vscode-python-envs

--- a/libs/localenv/provision_integration_test.go
+++ b/libs/localenv/provision_integration_test.go
@@ -1,0 +1,159 @@
+package localenv
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/cli/libs/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// EnvTestProvision opts a machine into the real provision/validate integration
+// tests below. They are skipped by default because they run a real `uv sync`
+// (installing an interpreter and databricks-connect from a package index), which
+// needs uv on PATH and network access to a PyPI mirror — neither is guaranteed in
+// unit-test CI. The rest of the pipeline is covered hermetically by the unit and
+// acceptance suites (all of which use --dry-run or a fake PackageManager); this
+// file is the one place the real merge -> provision -> validate path is exercised.
+const EnvTestProvision = "DATABRICKS_LOCALENV_TEST_PROVISION"
+
+// requireRealProvision skips unless the machine opted in and uv is discoverable.
+func requireRealProvision(t *testing.T) {
+	t.Helper()
+	if env.Get(t.Context(), EnvTestProvision) == "" {
+		t.Skipf("%s is not set; skipping real uv provision integration test", EnvTestProvision)
+	}
+	if _, err := discoverUv(t.Context()); err != nil {
+		t.Skipf("uv not available (%v); skipping real uv provision integration test", err)
+	}
+}
+
+// realProvisionCtx allows uv to install itself and bridges the user's pip index
+// so `uv sync` can reach databricks-connect on networks where pypi.org is blocked
+// but a corporate mirror is declared in pip.conf.
+func realProvisionCtx(t *testing.T) context.Context {
+	ctx := env.Set(t.Context(), EnvAutoInstallUv, "1")
+	if idx := pipConfIndexURL(ctx); idx != "" {
+		ctx = env.Set(ctx, "UV_INDEX_URL", idx)
+	}
+	return ctx
+}
+
+// serverlessConstraintServer serves a per-env pyproject.toml for the serverless
+// target, mirroring what databricks/environments will publish.
+func serverlessConstraintServer(t *testing.T) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[project]
+requires-python = ">=3.12"
+
+[dependency-groups]
+dev = ["databricks-connect~=17.2.0"]
+
+[tool.uv]
+constraint-dependencies = ["pyarrow<19"]
+`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestProvisionCreatesAndValidatesVenv drives the full non-dry-run pipeline
+// (merge -> provision -> validate) against a stubbed constraint fetch and asserts
+// a real .venv is created and validated with the target's versions. This is the
+// only test that exercises a real uv provision; everything else is dry-run.
+func TestProvisionCreatesAndValidatesVenv(t *testing.T) {
+	requireRealProvision(t)
+	dir := t.TempDir() // greenfield: no pre-existing pyproject.toml
+	srv := serverlessConstraintServer(t)
+
+	p := &Pipeline{
+		Mode: ModeDefault, Check: false, ProjectDir: dir,
+		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
+		Flags:   TargetFlags{Serverless: "5"},
+		Compute: stubCompute{}, PM: NewUvManager(),
+	}
+	res, err := p.Run(realProvisionCtx(t))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.OK)
+	assert.False(t, res.DryRun)
+
+	// Every phase reached ok — including the real provision and validate.
+	for _, ph := range res.Phases {
+		assert.Equalf(t, StatusOK, ph.Status, "phase %s not ok", ph.Phase)
+	}
+
+	// A real interpreter exists in the created venv.
+	assert.FileExists(t, venvPython(dir))
+
+	// pyproject.toml + uv.lock were written; the env-owned pin was applied.
+	pyproject, err := os.ReadFile(filepath.Join(dir, "pyproject.toml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(pyproject), "databricks-connect")
+	assert.FileExists(t, filepath.Join(dir, "uv.lock"))
+
+	// Validate observed the real installed environment.
+	require.NotNil(t, res.Resolved)
+	assert.Equal(t, "3.12", res.Resolved.PythonVersion)
+	assert.Truef(t, hasMajorPrefix(res.Resolved.DBConnectVersion, "17"),
+		"expected databricks-connect major 17, got %q", res.Resolved.DBConnectVersion)
+}
+
+// TestProvisionValidateIgnoresActiveVirtualEnv is the regression guard for the
+// validate fix: an active VIRTUAL_ENV pointing at a *real* interpreter of a
+// different version must not make validation read that interpreter instead of
+// the provisioned .venv. The bug only reproduces with a real, differently-
+// versioned active env — the pre-fix `uv run --no-project` reads it (verified:
+// reports 3.13), while invoking the .venv interpreter directly reads 3.12. A
+// bogus/non-existent VIRTUAL_ENV does NOT reproduce it (uv falls back), so this
+// test builds a real second venv on a different Python.
+func TestProvisionValidateIgnoresActiveVirtualEnv(t *testing.T) {
+	requireRealProvision(t)
+	baseCtx := realProvisionCtx(t)
+
+	// Build a real "active" venv on a different Python minor (3.13) than the
+	// target (3.12). Skip if that interpreter can't be provisioned here.
+	activeEnv := filepath.Join(t.TempDir(), "active-venv")
+	if _, err := process.Background(baseCtx,
+		[]string{mustUv(t, baseCtx), "venv", "--python", "3.13", activeEnv}); err != nil {
+		t.Skipf("could not create a 3.13 active venv for the negative control: %v", err)
+	}
+
+	dir := t.TempDir()
+	srv := serverlessConstraintServer(t)
+	// Activate the 3.13 env. Pre-fix, validation would report 3.13; post-fix it
+	// reads the provisioned 3.12 .venv directly and ignores this.
+	ctx := env.Set(baseCtx, "VIRTUAL_ENV", activeEnv)
+
+	p := &Pipeline{
+		Mode: ModeDefault, Check: false, ProjectDir: dir,
+		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
+		Flags:   TargetFlags{Serverless: "5"},
+		Compute: stubCompute{}, PM: NewUvManager(),
+	}
+	res, err := p.Run(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, res.Resolved)
+	assert.Equal(t, "3.12", res.Resolved.PythonVersion,
+		"validation must read the provisioned .venv (3.12), not the active VIRTUAL_ENV (3.13)")
+}
+
+// mustUv returns the discovered uv binary path, failing the test if uv is not
+// available (requireRealProvision has already gated on this).
+func mustUv(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	bin, err := discoverUv(ctx)
+	require.NoError(t, err)
+	return bin
+}
+
+// hasMajorPrefix reports whether version starts with major + ".".
+func hasMajorPrefix(version, major string) bool {
+	return len(version) > len(major) && version[:len(major)+1] == major+"."
+}

--- a/libs/localenv/uv.go
+++ b/libs/localenv/uv.go
@@ -93,9 +93,13 @@ func (m *uvManager) EnsurePython(ctx context.Context, minor string) error {
 	return nil
 }
 
-// Provision runs `uv sync` inside projectDir to install project dependencies.
-func (m *uvManager) Provision(ctx context.Context, projectDir string) error {
-	args := append([]string{m.bin}, m.syncArgs()...)
+// Provision runs `uv sync` inside projectDir to install project dependencies,
+// pinning the interpreter to pyMinor. Without --python, `uv sync` selects the
+// newest installed interpreter satisfying requires-python (e.g. 3.13 for a
+// ">=3.12" floor), which then fails validation against the 3.12 target; pinning
+// the minor we just installed keeps the venv on the intended version.
+func (m *uvManager) Provision(ctx context.Context, projectDir, pyMinor string) error {
+	args := append([]string{m.bin}, m.syncArgs(pyMinor)...)
 	if err := m.runUv(ctx, args, projectDir); err != nil {
 		return uvFailure(ErrProvision, err, "uv sync")
 	}
@@ -180,9 +184,10 @@ func lineWithPrefix(out, prefix string) (string, bool) {
 	return "", false
 }
 
-// syncArgs returns the argument slice for `uv sync` (without the binary).
-func (m *uvManager) syncArgs() []string {
-	return []string{"sync"}
+// syncArgs returns the argument slice for `uv sync` (without the binary),
+// pinning the interpreter to pyMinor via --python.
+func (m *uvManager) syncArgs(pyMinor string) []string {
+	return []string{"sync", "--python", pyMinor}
 }
 
 // pythonInstallArgs returns the argument slice for `uv python install <minor>`.

--- a/libs/localenv/uv.go
+++ b/libs/localenv/uv.go
@@ -147,14 +147,17 @@ try:
     print("` + validateDBCPrefix + `" + importlib.metadata.version("databricks-connect"))
 except importlib.metadata.PackageNotFoundError:
     print("` + validateDBCPrefix + `")`
-	// --no-project runs the interpreter from the created .venv without re-resolving/syncing
-	// the project's declared dependencies, so validation observes exactly what was installed.
+	// Invoke the venv interpreter directly rather than `uv run`: `uv run` resolves
+	// the interpreter from an active VIRTUAL_ENV / CONDA_PREFIX when one is set
+	// (even with --no-project), which would validate whatever env the caller has
+	// active instead of the .venv we just provisioned. The direct path is exactly
+	// what was installed, so validation observes the real target.
 	out, err := process.Background(ctx,
-		[]string{m.bin, "run", "--no-project", "python", "-c", pyCode},
+		[]string{venvPython(projectDir), "-c", pyCode},
 		process.WithDir(projectDir),
 	)
 	if err != nil {
-		return "", "", uvFailure(ErrValidate, err, "uv run python validation")
+		return "", "", uvFailure(ErrValidate, err, "venv python validation")
 	}
 	pyVer, ok := lineWithPrefix(out, validatePyPrefix)
 	if !ok || pyVer == "" {

--- a/libs/localenv/uv_test.go
+++ b/libs/localenv/uv_test.go
@@ -42,6 +42,19 @@ func TestUvArgs(t *testing.T) {
 	assert.Equal(t, []string{"pip", "install", "pip", "--python", "/p/.venv/bin/python"}, m.pipSeedArgs("/p/.venv/bin/python"))
 }
 
+func TestVenvPythonPath(t *testing.T) {
+	// Validate invokes this interpreter directly (not via `uv run`) so it observes
+	// exactly the .venv that was provisioned, ignoring any active VIRTUAL_ENV.
+	got := venvPython(filepath.Join("p", "proj"))
+	var want string
+	if runtime.GOOS == "windows" {
+		want = filepath.Join("p", "proj", ".venv", "Scripts", "python.exe")
+	} else {
+		want = filepath.Join("p", "proj", ".venv", "bin", "python")
+	}
+	assert.Equal(t, want, got)
+}
+
 func TestDiscoverUvFindsBinOnPath(t *testing.T) {
 	dir := t.TempDir()
 	// exec.LookPath only resolves a bare "uv" to a file with a PATHEXT extension

--- a/libs/localenv/uv_test.go
+++ b/libs/localenv/uv_test.go
@@ -37,7 +37,7 @@ func writePipConf(t *testing.T, conf string) context.Context {
 
 func TestUvArgs(t *testing.T) {
 	m := &uvManager{bin: "uv"}
-	assert.Equal(t, []string{"sync"}, m.syncArgs())
+	assert.Equal(t, []string{"sync", "--python", "3.12"}, m.syncArgs("3.12"))
 	assert.Equal(t, []string{"python", "install", "3.12"}, m.pythonInstallArgs("3.12"))
 	assert.Equal(t, []string{"pip", "install", "pip", "--python", "/p/.venv/bin/python"}, m.pipSeedArgs("/p/.venv/bin/python"))
 }


### PR DESCRIPTION
> Stacked on #6007 (`dbconnect/fix-provision-python-pin`) and includes the validate fix (`dbconnect/fix-validate-venv-python`), both of which its tests depend on. Review/merge those first.

## What

Every existing `localenv` unit and acceptance test uses `--dry-run` or a fake `PackageManager`, so the real **merge → provision → validate** path — a live `uv sync` that creates a `.venv` and installs databricks-connect — had **no regression coverage**. That gap is why the interpreter-selection bug (fixed in the stacked PR) shipped unnoticed.

## Changes

Add an integration test that drives the full non-dry-run pipeline against a stubbed constraint server and asserts a real venv is created and validated with the target's Python and databricks-connect versions.

- **Skipped by default** — guarded on `DATABRICKS_LOCALENV_TEST_PROVISION` and uv availability, so it never runs in unit-test CI (which lacks uv and a package index). Run it locally / in a suitable job with `DATABRICKS_LOCALENV_TEST_PROVISION=1 go test ./libs/localenv/ -run TestProvision`.
- One case is a **regression guard** for the validate + pin fixes: it sets `VIRTUAL_ENV` to a real, differently-versioned interpreter and asserts validation still reports the provisioned `.venv` version. Verified to fail on the pre-fix code and pass on the fixed base.

Part of the pre-unhide hardening of `environments setup-local` (still `Hidden`).

This pull request and its description were written by Isaac.
