### PR TITLE
Detect ai-dev-kit and add it to the user-agent

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -241,10 +241,12 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	// signal because os.LookupEnv reports them as present.
 	// Keep this list in sync with listKnownAgents() in
 	// github.com/databricks/databricks-sdk-go/useragent/agent.go
-	// plus the AGENT and AI_AGENT generic fallbacks.
+	// plus the AGENT and AI_AGENT generic fallbacks and the CLI's own
+	// AIDEVKIT_HOME detection override.
 	for _, v := range []string{
 		"AGENT",
 		"AI_AGENT",
+		"AIDEVKIT_HOME",
 		"AMP_CURRENT_THREAD_ID",
 		"ANTIGRAVITY_AGENT",
 		"AUGMENT_AGENT",

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -82,6 +82,7 @@ func New(ctx context.Context) *cobra.Command {
 		ctx = withUpstreamInUserAgent(ctx)
 		ctx = withInteractiveModeInUserAgent(ctx)
 		ctx = installer.WithAiToolsInUserAgent(ctx)
+		ctx = installer.WithAiDevKitInUserAgent(ctx)
 		ctx = InjectTestPidToUserAgent(ctx)
 		cmd.SetContext(ctx)
 

--- a/libs/aitools/installer/aidevkit.go
+++ b/libs/aitools/installer/aidevkit.go
@@ -1,0 +1,73 @@
+package installer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/databricks/cli/libs/env"
+	"github.com/databricks/databricks-sdk-go/useragent"
+)
+
+// aiDevKitStateDir is the marker directory the ai-dev-kit installer
+// (github.com/databricks-solutions/ai-dev-kit) writes into both the project root
+// and the global home (or $AIDEVKIT_HOME).
+const aiDevKitStateDir = ".ai-dev-kit"
+
+// aiDevKitVersionFile is the version file the ai-dev-kit installer writes under aiDevKitStateDir.
+// See https://github.com/databricks-solutions/ai-dev-kit install.sh.
+const aiDevKitVersionFile = "version"
+
+// aiDevKitHomeEnv overrides the global ai-dev-kit install location.
+const aiDevKitHomeEnv = "AIDEVKIT_HOME"
+
+// AiDevKitVersion returns the installed ai-dev-kit version and whether it is
+// installed, sanitized for the user agent.
+func AiDevKitVersion(ctx context.Context) (string, bool) {
+	installed := false
+	for _, dir := range aiDevKitStateDirs(ctx) {
+		version, ok := readAiDevKitVersion(dir)
+		if !ok {
+			continue
+		}
+		installed = true
+		// A blank marker still means installed; keep scanning so a real version
+		// in a lower-precedence scope isn't masked by an empty higher one.
+		if version != "" {
+			return version, true
+		}
+	}
+	return "", installed
+}
+
+// aiDevKitStateDirs returns the candidate ai-dev-kit state directories to probe,
+// project scope first. A scope whose base path can't be resolved is skipped
+// rather than guessed.
+func aiDevKitStateDirs(ctx context.Context) []string {
+	var dirs []string
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, filepath.Join(cwd, aiDevKitStateDir))
+	}
+	// AIDEVKIT_HOME already points at the install root, so the marker lives
+	// directly under it; otherwise it defaults to ~/.ai-dev-kit.
+	if home := env.Get(ctx, aiDevKitHomeEnv); home != "" {
+		dirs = append(dirs, home)
+	} else if home, err := env.UserHomeDir(ctx); err == nil {
+		dirs = append(dirs, filepath.Join(home, aiDevKitStateDir))
+	}
+	return dirs
+}
+
+// readAiDevKitVersion reads the version marker under dir, reporting whether it
+// exists. A present-but-blank marker reports ("", true).
+func readAiDevKitVersion(dir string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(dir, aiDevKitVersionFile))
+	if err != nil {
+		return "", false
+	}
+	// Sanitize the first line: the value is set outside our control and
+	// useragent panics on anything but alphanumerics/semver.
+	firstLine, _, _ := strings.Cut(string(data), "\n")
+	return useragent.Sanitize(strings.TrimSpace(firstLine)), true
+}

--- a/libs/aitools/installer/aidevkit_test.go
+++ b/libs/aitools/installer/aidevkit_test.go
@@ -1,0 +1,86 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeAiDevKitMarker writes a .ai-dev-kit/version marker under baseDir (a temp
+// dir standing in for a project root or the global home).
+func writeAiDevKitMarker(t *testing.T, baseDir, contents string) {
+	t.Helper()
+	dir := filepath.Join(baseDir, aiDevKitStateDir)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, aiDevKitVersionFile), []byte(contents), 0o644))
+}
+
+func TestAiDevKitVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		// global/project contents; "" means no marker written for that scope.
+		global      string
+		project     string
+		wantVersion string
+		wantOK      bool
+	}{
+		{"not installed", "", "", "", false},
+		{"global marker", "1.2.3\n", "", "1.2.3", true},
+		{"project marker", "", "2.0.0\n", "2.0.0", true},
+		{"project overrides global", "1.2.3\n", "2.0.0\n", "2.0.0", true},
+		{"dev version", "dev\n", "", "dev", true},
+		{"empty marker still installed", "\n", "", "", true},
+		{"whitespace-only marker", "  \n", "", "", true},
+		// A blank project marker must not mask a real global version: still
+		// installed, but the global version wins over project's "unknown".
+		{"empty project does not mask global", "1.2.3\n", "\n", "1.2.3", true},
+		{"trailing newline trimmed", "1.2.3\n", "", "1.2.3", true},
+		{"multi-line keeps first line", "1.2.3\nextra\n", "", "1.2.3", true},
+		{"multi-line CRLF has no trailing hyphen", "1.2.3\r\nextra\r\n", "", "1.2.3", true},
+		{"sanitizes illegal chars", "1.2.3 (beta/rc)\n", "", "1.2.3--beta-rc-", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			project := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Chdir(project)
+
+			if tc.global != "" {
+				writeAiDevKitMarker(t, home, tc.global)
+			}
+			if tc.project != "" {
+				writeAiDevKitMarker(t, project, tc.project)
+			}
+
+			version, ok := AiDevKitVersion(t.Context())
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantVersion, version)
+		})
+	}
+}
+
+// TestAiDevKitVersionHomeOverride verifies AIDEVKIT_HOME points directly at the
+// install root, so the marker is read from $AIDEVKIT_HOME/version, not
+// $AIDEVKIT_HOME/.ai-dev-kit/version.
+func TestAiDevKitVersionHomeOverride(t *testing.T) {
+	home := t.TempDir()
+	installRoot := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv(aiDevKitHomeEnv, installRoot)
+	t.Chdir(t.TempDir())
+
+	require.NoError(t, os.WriteFile(filepath.Join(installRoot, aiDevKitVersionFile), []byte("3.1.4\n"), 0o644))
+	// A marker under ~/.ai-dev-kit must be ignored once AIDEVKIT_HOME is set.
+	writeAiDevKitMarker(t, home, "9.9.9\n")
+
+	version, ok := AiDevKitVersion(t.Context())
+	assert.True(t, ok)
+	assert.Equal(t, "3.1.4", version)
+}

--- a/libs/aitools/installer/useragent.go
+++ b/libs/aitools/installer/useragent.go
@@ -10,6 +10,11 @@ import (
 // dimension. Each installed tool contributes an "<key>/<tool>_<version>" pair.
 const aiToolsUserAgentKey = "aitools"
 
+// aiDevKitUserAgentKey is the user-agent key for the ai-dev-kit toolkit
+// (github.com/databricks-solutions/ai-dev-kit). Its skills have been subsumed
+// into databricks-agent-skills, but we track ai-dev-kit installs separately.
+const aiDevKitUserAgentKey = "aidevkit"
+
 // WithAiToolsInUserAgent adds one aitools/<tool>_<version> pair to the user
 // agent for each coding tool that has the Databricks plugin installed, e.g.
 // "aitools/claude-code_0.2.9 aitools/codex_0.2.9". Nothing is added when no tool
@@ -23,4 +28,20 @@ func WithAiToolsInUserAgent(ctx context.Context) context.Context {
 		ctx = useragent.InContext(ctx, aiToolsUserAgentKey, tool) //nolint:fatcontext
 	}
 	return ctx
+}
+
+// WithAiDevKitInUserAgent adds an "aidevkit/<version>" pair to the user agent
+// when the ai-dev-kit toolkit is installed (project scope preferred, else the
+// global $AIDEVKIT_HOME/~/.ai-dev-kit marker), e.g. "aidevkit/1.2.3". Nothing is
+// added when it is not installed. An installed marker with an unreadable version
+// emits "aidevkit/unknown" so adoption is still counted.
+func WithAiDevKitInUserAgent(ctx context.Context) context.Context {
+	version, ok := AiDevKitVersion(ctx)
+	if !ok {
+		return ctx
+	}
+	if version == "" {
+		version = "unknown"
+	}
+	return useragent.InContext(ctx, aiDevKitUserAgentKey, version)
 }

--- a/libs/aitools/installer/useragent_test.go
+++ b/libs/aitools/installer/useragent_test.go
@@ -67,3 +67,53 @@ func TestWithAiToolsInUserAgent(t *testing.T) {
 		})
 	}
 }
+
+// TestWithAiDevKitInUserAgent drives WithAiDevKitInUserAgent against a prepared
+// HOME containing (or lacking) an ai-dev-kit version marker and asserts the
+// resulting user-agent string.
+func TestWithAiDevKitInUserAgent(t *testing.T) {
+	tests := []struct {
+		name string
+		// marker, when set, is written to ~/.ai-dev-kit/version.
+		marker         string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "not installed adds no pair",
+			wantNotContain: []string{"aidevkit/"},
+		},
+		{
+			name:         "version from the marker",
+			marker:       "1.2.3\n",
+			wantContains: []string{"aidevkit/1.2.3"},
+		},
+		{
+			name:         "installed but unversioned reports unknown",
+			marker:       "\n",
+			wantContains: []string{"aidevkit/unknown"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			// Fresh cwd so a project-scope marker never leaks from the package dir.
+			t.Chdir(t.TempDir())
+
+			if tc.marker != "" {
+				writeAiDevKitMarker(t, home, tc.marker)
+			}
+
+			ua := useragent.FromContext(WithAiDevKitInUserAgent(t.Context()))
+			for _, want := range tc.wantContains {
+				assert.Contains(t, ua, want)
+			}
+			for _, notWant := range tc.wantNotContain {
+				assert.NotContains(t, ua, notWant)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Emit an `aidevkit/<version>` pair in the CLI user-agent when [ai-dev-kit](https://github.com/databricks-solutions/ai-dev-kit) is installed, mirroring the `aitools/` plugin detection from #5924 with a separate dimension.

## Why

So ai-dev-kit adoption is measurable from request telemetry. Its skills have been subsumed into databricks-agent-skills, but we track its installs separately.

## Tests

Unit tests, manually validated with AI.