### PR TITLE
[VPEX] localenv: pin the interpreter on uv sync to the resolved Python minor

### DIFF
--- a/libs/localenv/pipeline.go
+++ b/libs/localenv/pipeline.go
@@ -356,7 +356,7 @@ func (p *Pipeline) provision(ctx context.Context, pyMinor string) error {
 	if err := p.PM.EnsurePython(ctx, pyMinor); err != nil {
 		return p.fail(PhaseProvision, true, asPipelineError(err, ErrPythonInstall, "ensure python %s failed", pyMinor))
 	}
-	if err := p.PM.Provision(ctx, p.ProjectDir); err != nil {
+	if err := p.PM.Provision(ctx, p.ProjectDir, pyMinor); err != nil {
 		return p.fail(PhaseProvision, true, asPipelineError(err, ErrProvision, "provision failed"))
 	}
 	if err := p.PM.PostProvision(ctx, p.ProjectDir); err != nil {

--- a/libs/localenv/pipeline_test.go
+++ b/libs/localenv/pipeline_test.go
@@ -19,7 +19,7 @@ type fakePM struct{ py, dbc string }
 func (fakePM) Name() string                                    { return "fake" }
 func (fakePM) EnsureAvailable(context.Context) (string, error) { return "fake 1.0", nil }
 func (fakePM) EnsurePython(context.Context, string) error      { return nil }
-func (fakePM) Provision(context.Context, string) error         { return nil }
+func (fakePM) Provision(context.Context, string, string) error { return nil }
 func (fakePM) PostProvision(context.Context, string) error     { return nil }
 func (f fakePM) Validate(context.Context, string) (string, string, error) {
 	return f.py, f.dbc, nil
@@ -39,7 +39,7 @@ func (noProvisionPM) EnsurePython(context.Context, string) error {
 	return errors.New("EnsurePython must not be called under --dry-run")
 }
 
-func (noProvisionPM) Provision(context.Context, string) error {
+func (noProvisionPM) Provision(context.Context, string, string) error {
 	return errors.New("Provision must not be called under --dry-run")
 }
 

--- a/libs/localenv/pkgmanager.go
+++ b/libs/localenv/pkgmanager.go
@@ -15,8 +15,11 @@ type PackageManager interface {
 	// available via the package manager.
 	EnsurePython(ctx context.Context, minor string) error
 
-	// Provision installs the project dependencies inside projectDir.
-	Provision(ctx context.Context, projectDir string) error
+	// Provision installs the project dependencies inside projectDir, pinning the
+	// environment to the given Python minor version (e.g. "3.12") so the resolved
+	// interpreter is the one EnsurePython installed rather than a newer minor the
+	// dependency solver would otherwise pick.
+	Provision(ctx context.Context, projectDir, pythonMinor string) error
 
 	// PostProvision seeds pip into the virtual environment inside projectDir.
 	// This step is required because VS Code's ms-python.vscode-python-envs

--- a/libs/localenv/uv.go
+++ b/libs/localenv/uv.go
@@ -94,8 +94,8 @@ func (m *uvManager) EnsurePython(ctx context.Context, minor string) error {
 }
 
 // Provision runs `uv sync` inside projectDir to install project dependencies.
-func (m *uvManager) Provision(ctx context.Context, projectDir string) error {
-	args := append([]string{m.bin}, m.syncArgs()...)
+func (m *uvManager) Provision(ctx context.Context, projectDir, pythonMinor string) error {
+	args := append([]string{m.bin}, m.syncArgs(pythonMinor)...)
 	if err := m.runUv(ctx, args, projectDir); err != nil {
 		return uvFailure(ErrProvision, err, "uv sync")
 	}
@@ -180,9 +180,14 @@ func lineWithPrefix(out, prefix string) (string, bool) {
 	return "", false
 }
 
-// syncArgs returns the argument slice for `uv sync` (without the binary).
-func (m *uvManager) syncArgs() []string {
-	return []string{"sync"}
+// syncArgs returns the argument slice for `uv sync` (without the binary),
+// pinning the interpreter to the given Python minor. Without --python, uv
+// resolves the newest interpreter satisfying an open requires-python (e.g.
+// ">=3.12" picks 3.13 when installed), which then fails the validate phase's
+// exact-minor check against the version EnsurePython installed. Pinning makes
+// the provisioned venv deterministically use the target minor.
+func (m *uvManager) syncArgs(pythonMinor string) []string {
+	return []string{"sync", "--python", pythonMinor}
 }
 
 // pythonInstallArgs returns the argument slice for `uv python install <minor>`.

--- a/libs/localenv/uv_test.go
+++ b/libs/localenv/uv_test.go
@@ -37,7 +37,9 @@ func writePipConf(t *testing.T, conf string) context.Context {
 
 func TestUvArgs(t *testing.T) {
 	m := &uvManager{bin: "uv"}
-	assert.Equal(t, []string{"sync"}, m.syncArgs())
+	// sync pins the interpreter to the target minor so uv does not resolve a
+	// newer one that would fail the validate phase's exact-minor check.
+	assert.Equal(t, []string{"sync", "--python", "3.12"}, m.syncArgs("3.12"))
 	assert.Equal(t, []string{"python", "install", "3.12"}, m.pythonInstallArgs("3.12"))
 	assert.Equal(t, []string{"pip", "install", "pip", "--python", "/p/.venv/bin/python"}, m.pipSeedArgs("/p/.venv/bin/python"))
 }


### PR DESCRIPTION
## What

`Provision` ran `uv sync` with no `--python` pin. Now it passes `uv sync --python <resolved minor>`.

## Why

When the constraint artifact's `requires-python` is an **open** lower bound (e.g. `>=3.12`), `uv sync` resolves the *newest* installed interpreter that satisfies it — 3.13 when present — even though `EnsurePython` just installed the target minor (3.12). The `validate` phase then does an exact-minor check and fails:

```
validate   error  python version mismatch: want 3.12, got 3.13
```

…**after** `pyproject.toml` and `.venv` were already written, so the command exits non-zero with `diskMutated: true` — a broken half-state.

The published constraint artifacts currently use *capped* ranges (`>=3.12,<3.13`), which masked this; an open range surfaced it during blackbox testing.

## Fix

Pin the interpreter on sync so the provisioned venv deterministically uses the same minor `EnsurePython` installed. `Provision` now takes the target minor (the pipeline already has it and passes it straight through from the provision phase).

## Test

- Updated `TestUvArgs` to assert `sync --python <minor>`, and the `PackageManager` fake/test impls for the new signature.
- **Verified end-to-end with real `uv`**: a real (non-dry-run) provision against a `>=3.12` open-range constraint that failed on `main` now succeeds — `validate ok python=3.12`, venv is Python 3.12.x, exit 0.
- Build, unit (`libs/localenv`, `cmd/environments`), lint, deadcode all pass.

No changelog fragment: the `environments setup-local` command is still hidden/experimental.

This pull request and its description were written by Isaac.
