### PR TITLE
acc: subset acceptance tests on windows/macOS PR runs

### DIFF
--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -97,8 +97,6 @@ If the only reason for divergence is a server-side default that one engine sets 
 
 **RULE: If a test's `out.test.toml` is still in the older `[EnvMatrix]` block format, a regen rewrites it to the inline form and the post-test `git diff --exit-code` check fails** ("out.test.toml files that are out of date"). Regenerate just those files with `go test ./acceptance -run "^TestAccept$" -only-out-test-toml`, then commit.
 
-**RULE: Be aware of `GOOSOnPR` when adding or editing an acceptance test — an inherited opt-out may be skipping it on windows/macOS PR runs.** By default every test runs everywhere. For speed, some directories set `GOOSOnPR.windows = false` / `GOOSOnPR.darwin = false` in `test.toml`, which recursively opts their tests out of windows/macOS PR runs (they still run on Linux for PRs and on every OS on push to main). Check the resolved value in `out.test.toml`. This is right for the platform-independent majority, but if your test genuinely depends on the OS — path separators, `.exe`, CRLF, symlinks, file locking, process/signal semantics, venv layout (`Scripts` vs `bin`), wheel build — and it sits under such a directory, override the inherited skip with `GOOSOnPR.windows = true` / `GOOSOnPR.darwin = true`, or a Windows/macOS-only regression can merge unseen. `MSYS_NO_PATHCONV`, a leading `//`, or a CRLF-normalizing `sed` are portability scaffolding (they make output OS-identical), not evidence of OS-specific behavior. See `GOOSOnPR` in `acceptance/internal/config.go`.
-
 ### Reference
 
 - Tests live in `acceptance/` with a nested directory structure.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -137,6 +137,22 @@ jobs:
         with:
           cache-key: test-${{ matrix.deployment }}
 
+      # On pull requests, run only a subset of acceptance subtests on the slower
+      # windows/macOS cells so neither lands on the critical path to merge. Linux
+      # runs the full suite, and so does push-to-main (full coverage on every OS).
+      # The percentages are fixed (not per-commit) and tuned to keep windows/macOS
+      # under the Linux wall-clock time. The seed is the head commit, so a re-run of
+      # the same commit repeats the subset while a new commit reshuffles it.
+      - name: Configure test subset
+        if: ${{ github.event_name == 'pull_request' && matrix.os.name != 'linux' }}
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Windows is the slowest cell, so it runs the smallest subset.
+          SUBSET_PCT: ${{ matrix.os.name == 'windows' && '40' || '75' }}
+        run: |
+          echo "TESTS_SELECT_SUBSET_SEED=$HEAD_SHA" >> "$GITHUB_ENV"
+          echo "TESTS_SELECT_SUBSET_PCT=$SUBSET_PCT" >> "$GITHUB_ENV"
+
       - name: Run tests
         env:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -148,7 +148,7 @@ jobs:
           # the head commit, so a re-run of the same commit repeats the subset while a
           # new commit reshuffles it.
           TESTS_SELECT_SUBSET_SEED: ${{ github.event.pull_request.head.sha }}
-          TESTS_SELECT_SUBSET_PCT: ${{ github.event_name == 'pull_request' && (matrix.os.name == 'windows' && '20' || matrix.os.name == 'macos' && '60') || '' }}
+          TESTS_SELECT_SUBSET_PCT: ${{ github.event_name == 'pull_request' && (matrix.os.name == 'windows' && '10' || matrix.os.name == 'macos' && '60') || '' }}
         run: go tool -modfile=tools/task/go.mod task test
 
       - name: Upload gotestsum JSON output

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -148,7 +148,7 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           # Windows is the slowest cell, so it runs the smallest subset.
-          SUBSET_PCT: ${{ matrix.os.name == 'windows' && '40' || '75' }}
+          SUBSET_PCT: ${{ matrix.os.name == 'windows' && '20' || '60' }}
         run: |
           echo "TESTS_SELECT_SUBSET_SEED=$HEAD_SHA" >> "$GITHUB_ENV"
           echo "TESTS_SELECT_SUBSET_PCT=$SUBSET_PCT" >> "$GITHUB_ENV"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -137,25 +137,18 @@ jobs:
         with:
           cache-key: test-${{ matrix.deployment }}
 
-      # On pull requests, run only a subset of acceptance subtests on the slower
-      # windows/macOS cells so neither lands on the critical path to merge. Linux
-      # runs the full suite, and so does push-to-main (full coverage on every OS).
-      # The percentages are fixed (not per-commit) and tuned to keep windows/macOS
-      # under the Linux wall-clock time. The seed is the head commit, so a re-run of
-      # the same commit repeats the subset while a new commit reshuffles it.
-      - name: Configure test subset
-        if: ${{ github.event_name == 'pull_request' && matrix.os.name != 'linux' }}
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          # Windows is the slowest cell, so it runs the smallest subset.
-          SUBSET_PCT: ${{ matrix.os.name == 'windows' && '20' || '60' }}
-        run: |
-          echo "TESTS_SELECT_SUBSET_SEED=$HEAD_SHA" >> "$GITHUB_ENV"
-          echo "TESTS_SELECT_SUBSET_PCT=$SUBSET_PCT" >> "$GITHUB_ENV"
-
       - name: Run tests
         env:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}
+          # On pull requests, run only a subset of acceptance subtests on the slower
+          # windows/macOS cells so neither lands on the critical path to merge. An
+          # empty percentage disables subsetting, so Linux PRs and push-to-main run
+          # the full suite (full coverage on every OS). The percentages are fixed and
+          # tuned to keep windows/macOS under the Linux wall-clock time. The seed is
+          # the head commit, so a re-run of the same commit repeats the subset while a
+          # new commit reshuffles it.
+          TESTS_SELECT_SUBSET_SEED: ${{ github.event.pull_request.head.sha }}
+          TESTS_SELECT_SUBSET_PCT: ${{ github.event_name == 'pull_request' && (matrix.os.name == 'windows' && '20' || matrix.os.name == 'macos' && '60') || '' }}
         run: go tool -modfile=tools/task/go.mod task test
 
       - name: Upload gotestsum JSON output

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -436,18 +436,30 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	}
 
 	skipLocalMode := os.Getenv(SkipLocalEnvVar)
-	// changedTests maps test dir to extra env filters to apply for that dir.
-	// nil value means all variants run; a non-nil slice restricts to matching variants.
-	var changedTests map[string][]string
+	subset := newSubsetSelector(t, testdiff.OverwriteMode, Forcerun)
+
 	switch skipLocalMode {
-	case "", SkipLocalAll:
-	case SkipLocalWithChanged:
-		changedTests = selectChangedLocalTests(testDirsSet)
+	case "", SkipLocalAll, SkipLocalWithChanged:
 	default:
 		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, skipLocalMode, SkipLocalAll, SkipLocalWithChanged)
 	}
 
-	subset := newSubsetSelector(t, testdiff.OverwriteMode, Forcerun, testDirsSet)
+	// Both SkipLocalWithChanged and the subset selector keep added/modified tests, so
+	// detect them at most once. The subset selector keeps them regardless of the
+	// percentage; SkipLocalWithChanged additionally uses changedTests below to restrict
+	// re-enabled invariant dirs to their changed variants.
+	var changed map[string][]string
+	if skipLocalMode == SkipLocalWithChanged || subset.enabled {
+		changed = selectChangedLocalTests(testDirsSet)
+	}
+	subset.changed = changed
+
+	// changedTests maps test dir to extra env filters to apply for that dir.
+	// nil value means all variants run; a non-nil slice restricts to matching variants.
+	var changedTests map[string][]string
+	if skipLocalMode == SkipLocalWithChanged {
+		changedTests = changed
+	}
 
 	if singleTest != "" {
 		testDirs = slices.DeleteFunc(testDirs, func(n string) bool {

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -111,12 +111,6 @@ const (
 
 var ApplyCITimeoutMultipler = os.Getenv("GITHUB_WORKFLOW") != ""
 
-// IsPullRequest is true when the test run was triggered by a GitHub pull_request
-// event. GitHub Actions sets GITHUB_EVENT_NAME automatically. On pull requests we
-// additionally apply each test's GOOSOnPR filter, so OS-independent tests can be
-// skipped on windows/macOS for PRs while still running on every OS on push to main.
-var IsPullRequest = os.Getenv("GITHUB_EVENT_NAME") == "pull_request"
-
 var exeSuffix = func() string {
 	if runtime.GOOS == "windows" {
 		return ".exe"
@@ -436,6 +430,11 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	testDirs := getTests(t)
 	require.NotEmpty(t, testDirs)
 
+	testDirsSet := make(map[string]bool, len(testDirs))
+	for _, d := range testDirs {
+		testDirsSet[d] = true
+	}
+
 	skipLocalMode := os.Getenv(SkipLocalEnvVar)
 	// changedTests maps test dir to extra env filters to apply for that dir.
 	// nil value means all variants run; a non-nil slice restricts to matching variants.
@@ -443,14 +442,12 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	switch skipLocalMode {
 	case "", SkipLocalAll:
 	case SkipLocalWithChanged:
-		testDirsSet := make(map[string]bool, len(testDirs))
-		for _, d := range testDirs {
-			testDirsSet[d] = true
-		}
 		changedTests = selectChangedLocalTests(testDirsSet)
 	default:
 		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, skipLocalMode, SkipLocalAll, SkipLocalWithChanged)
 	}
+
+	subset := newSubsetSelector(t, testdiff.OverwriteMode, Forcerun, testDirsSet)
 
 	if singleTest != "" {
 		testDirs = slices.DeleteFunc(testDirs, func(n string) bool {
@@ -549,6 +546,9 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 			// If the matrix expands to a single empty envset, run the test directly
 			// without creating a subtest (avoids the "#00" dummy subtest name).
 			if len(expanded) == 1 && len(expanded[0]) == 0 {
+				if reason := subset.skipReason(dir, nil); reason != "" {
+					t.Skip(reason)
+				}
 				runTest(t, dir, 0, coverDir, repls.Clone(), config, nil, envFilters, sandboxProxyURL)
 			} else {
 				for ind, envset := range expanded {
@@ -561,6 +561,9 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 						// skip variants not matching that config.
 						if variantFilters := changedTests[dir]; variantFilters != nil {
 							checkEnvFilters(t, envset, variantFilters)
+						}
+						if reason := subset.skipReason(dir, envset); reason != "" {
+							t.Skip(reason)
 						}
 						runTest(t, dir, ind, coverDir, repls.Clone(), config, envset, envFilters, sandboxProxyURL)
 					})
@@ -661,13 +664,6 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 	isEnabled, isPresent := config.GOOS[runtime.GOOS]
 	if isPresent && !isEnabled {
 		return fmt.Sprintf("Disabled via GOOS.%s setting in %s", runtime.GOOS, configPath)
-	}
-
-	if IsPullRequest {
-		isEnabled, isPresent := config.GOOSOnPR[runtime.GOOS]
-		if isPresent && !isEnabled {
-			return fmt.Sprintf("Disabled via GOOSOnPR.%s setting in %s", runtime.GOOS, configPath)
-		}
 	}
 
 	cloudEnv := os.Getenv("CLOUD_ENV")

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -443,23 +443,16 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	default:
 		t.Fatalf("Unsupported %s=%q, expected %q or %q", SkipLocalEnvVar, skipLocalMode, SkipLocalAll, SkipLocalWithChanged)
 	}
+	skipLocalWithChanged := skipLocalMode == SkipLocalWithChanged
 
-	// Both SkipLocalWithChanged and the subset selector keep added/modified tests, so
-	// detect them at most once. The subset selector keeps them regardless of the
-	// percentage; SkipLocalWithChanged additionally uses changedTests below to restrict
-	// re-enabled invariant dirs to their changed variants.
-	var changed map[string][]string
-	if skipLocalMode == SkipLocalWithChanged || subset.enabled {
-		changed = selectChangedLocalTests(testDirsSet)
-	}
-	subset.changed = changed
-
-	// changedTests maps test dir to extra env filters to apply for that dir.
-	// nil value means all variants run; a non-nil slice restricts to matching variants.
+	// changedTests maps test dir to extra env filters for added/modified tests; nil
+	// filters means all variants of that dir changed. Both SkipLocalWithChanged and the
+	// subset selector keep these tests, so detect them at most once here.
 	var changedTests map[string][]string
-	if skipLocalMode == SkipLocalWithChanged {
-		changedTests = changed
+	if skipLocalWithChanged || subset.enabled {
+		changedTests = selectChangedLocalTests(testDirsSet)
 	}
+	subset.changed = changedTests
 
 	if singleTest != "" {
 		testDirs = slices.DeleteFunc(testDirs, func(n string) bool {
@@ -569,10 +562,12 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 						if runParallel {
 							t.Parallel()
 						}
-						// For invariant dirs re-enabled by a specific config change,
-						// skip variants not matching that config.
-						if variantFilters := changedTests[dir]; variantFilters != nil {
-							checkEnvFilters(t, envset, variantFilters)
+						// Under SkipLocalWithChanged, an invariant dir re-enabled by a
+						// specific config change runs only its matching variants.
+						if skipLocalWithChanged {
+							if variantFilters := changedTests[dir]; variantFilters != nil {
+								checkEnvFilters(t, envset, variantFilters)
+							}
 						}
 						if reason := subset.skipReason(dir, envset); reason != "" {
 							t.Skip(reason)

--- a/acceptance/bundle/bundle_tag/id/out.test.toml
+++ b/acceptance/bundle/bundle_tag/id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/test.toml
+++ b/acceptance/bundle/bundle_tag/test.toml
@@ -1,7 +1,1 @@
 Badness = "configs with id and url should be rejected"
-
-# These tests exercise platform-independent bundle logic (tag validation) and behave
-# identically on every OS, so on pull requests they run on Linux only to keep the
-# windows/macOS CI jobs fast. They still run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/bundle_tag/url/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/bundle_tag/url_ref/out.test.toml
+++ b/acceptance/bundle/bundle_tag/url_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/alert/out.test.toml
+++ b/acceptance/bundle/deployment/bind/alert/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/catalog/out.test.toml
+++ b/acceptance/bundle/deployment/bind/catalog/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/cluster/out.test.toml
+++ b/acceptance/bundle/deployment/bind/cluster/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresCluster = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
+++ b/acceptance/bundle/deployment/bind/dashboard/recreation/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/database_instance/out.test.toml
+++ b/acceptance/bundle/deployment/bind/database_instance/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/experiment/out.test.toml
+++ b/acceptance/bundle/deployment/bind/experiment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/external_location/out.test.toml
+++ b/acceptance/bundle/deployment/bind/external_location/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/genie_space/out.test.toml
+++ b/acceptance/bundle/deployment/bind/genie_space/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-different/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/already-managed-same/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/engine-from-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/generate-and-bind/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-abort-bind/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/job-spark-python-task/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/noop-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/python-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
+++ b/acceptance/bundle/deployment/bind/job/stale-state/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/model-serving-endpoint/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/recreate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
+++ b/acceptance/bundle/deployment/bind/pipelines/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/postgres_database/out.test.toml
+++ b/acceptance/bundle/deployment/bind/postgres_database/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/postgres_role/out.test.toml
+++ b/acceptance/bundle/deployment/bind/postgres_role/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
+++ b/acceptance/bundle/deployment/bind/quality-monitor/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/registered-model/out.test.toml
+++ b/acceptance/bundle/deployment/bind/registered-model/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/schema/out.test.toml
+++ b/acceptance/bundle/deployment/bind/schema/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
+++ b/acceptance/bundle/deployment/bind/secret-scope/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
+++ b/acceptance/bundle/deployment/bind/sql_warehouse/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_endpoint/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/vector_search_index/out.test.toml
+++ b/acceptance/bundle/deployment/bind/vector_search_index/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/bind/volume/out.test.toml
+++ b/acceptance/bundle/deployment/bind/volume/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/test.toml
+++ b/acceptance/bundle/deployment/test.toml
@@ -1,10 +1,1 @@
 Cloud = true
-
-# These tests exercise platform-independent bundle logic (bind/unbind, deploy/destroy
-# sequencing). Some pass Unix-style paths and use MSYS_NO_PATHCONV or a leading "//"
-# to stop Git Bash from mangling them on Windows, but that is test scaffolding to make
-# the tests portable, not OS-specific product behavior under test (output is identical
-# on every OS). So on pull requests they run on Linux only to keep the windows/macOS
-# CI jobs fast; they still run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/engine-from-config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/deployment/unbind/grants/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/grants/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/permissions/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/deployment/unbind/python-job/out.test.toml
+++ b/acceptance/bundle/deployment/unbind/python-job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/base/out.test.toml
+++ b/acceptance/bundle/integration_whl/base/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/custom_params/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = true
-GOOSOnPR.windows = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/interactive_cluster/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster/test.toml
@@ -1,5 +1,0 @@
-# Re-enable on pull requests (the parent integration_whl/ dir opts out): kept for
-# symmetry with the serverless variants so both cluster modes exercise the wheel
-# deploy path (uv venv activation) on windows/macOS for PRs.
-GOOSOnPR.windows = true
-GOOSOnPR.darwin = true

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = true
-GOOSOnPR.windows = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DATA_SECURITY_MODE = ["USER_ISOLATION", "SINGLE_USER"]

--- a/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/test.toml
+++ b/acceptance/bundle/integration_whl/interactive_cluster_dynamic_version/test.toml
@@ -1,9 +1,3 @@
-# Re-enable on pull requests (the parent integration_whl/ dir opts out): this variant
-# builds a wheel (bdist_wheel) on the interactive/classic-cluster path, exercising the
-# OS-specific venv build, so it must keep running on windows/macOS for PRs.
-GOOSOnPR.windows = true
-GOOSOnPR.darwin = true
-
 [EnvMatrix]
 DATA_SECURITY_MODE = [
     "USER_ISOLATION",

--- a/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
+++ b/acceptance/bundle/integration_whl/interactive_single_user/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = true
-GOOSOnPR.windows = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless/test.toml
+++ b/acceptance/bundle/integration_whl/serverless/test.toml
@@ -4,12 +4,6 @@ Local = true
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true
 
-# Re-enable on pull requests (the parent integration_whl/ dir opts out): this variant
-# builds a wheel (bdist_wheel) on the serverless path, exercising the OS-specific venv
-# build, so it must keep running on windows/macOS for PRs.
-GOOSOnPR.windows = true
-GOOSOnPR.darwin = true
-
 [[Repls]]
 Old = '\\'
 New = '/'

--- a/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_custom_params/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = true
-GOOSOnPR.windows = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/serverless_dynamic_version/test.toml
+++ b/acceptance/bundle/integration_whl/serverless_dynamic_version/test.toml
@@ -1,12 +1,6 @@
 # serverless is only enabled if UC is enabled
 RequiresUnityCatalog = true
 
-# Re-enable on pull requests (the parent integration_whl/ dir opts out): this variant
-# builds a wheel (bdist_wheel) on the serverless path, exercising the OS-specific venv
-# build, so it must keep running on windows/macOS for PRs.
-GOOSOnPR.windows = true
-GOOSOnPR.darwin = true
-
 [[Repls]]
 Old = '\\'
 New = '/'

--- a/acceptance/bundle/integration_whl/test.toml
+++ b/acceptance/bundle/integration_whl/test.toml
@@ -1,16 +1,6 @@
 Local = true
 CloudSlow = true
 
-# The OS-specific surface here is the wheel build path (uv venv layout: .venv/Scripts
-# vs .venv/bin, and the python3->python alias; see venv_activate in
-# acceptance/script.prepare). That path is identical across every variant, so on pull
-# requests we run only a couple of representative building variants on windows/macOS
-# (serverless and interactive_cluster_dynamic_version re-enable themselves) and skip
-# the rest, which vary only OS-independent bundle logic. All still run on every OS on
-# push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false
-
 # Workspace file system does not allow initializing python envs on it.
 # I suspect something about the default python env on DBR interferes with it.
 # We'll likely need a first class venv abstraction in acceptance tests to fix this.

--- a/acceptance/bundle/integration_whl/wrapper/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.aws = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
+++ b/acceptance/bundle/integration_whl/wrapper_custom_params/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.aws = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/migrate/out.test.toml
+++ b/acceptance/bundle/invariant/migrate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/no_drift/out.test.toml
+++ b/acceptance/bundle/invariant/no_drift/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.INPUT_CONFIG = [
   "alert.yml.tmpl",

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -3,13 +3,6 @@ Cloud = true
 RequiresUnityCatalog = true
 Timeout = '10m'
 
-# These tests drive platform-independent bundle logic (config normalization,
-# no-drift checks, state migration) and behave identically on every OS, so on pull
-# requests they run on Linux only to keep the windows/macOS CI jobs fast. They still
-# run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false
-
 Ignore = [
     ".databricks",
     ".venv",

--- a/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
+++ b/acceptance/bundle/lifecycle/prevent-destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/lifecycle/started-validation/out.test.toml
+++ b/acceptance/bundle/lifecycle/started-validation/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/lifecycle/started/out.test.toml
+++ b/acceptance/bundle/lifecycle/started/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/lifecycle/test.toml
+++ b/acceptance/bundle/lifecycle/test.toml
@@ -1,8 +1,2 @@
 Local = true
 Cloud = false
-
-# These tests exercise platform-independent bundle logic (deploy/destroy lifecycle)
-# and behave identically on every OS, so on pull requests they run on Linux only to
-# keep the windows/macOS CI jobs fast. They still run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/migrate/added/out.test.toml
+++ b/acceptance/bundle/migrate/added/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-clean/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-clean/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/migrate/auto-migrate-empty-tfstate/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-empty-tfstate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-envvar/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-envvar/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-push-failure/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-push-failure/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/auto-migrate-tfbackup-failure/out.test.toml
+++ b/acceptance/bundle/migrate/auto-migrate-tfbackup-failure/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/basic/out.test.toml
+++ b/acceptance/bundle/migrate/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/dashboards/out.test.toml
+++ b/acceptance/bundle/migrate/dashboards/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/default-python/out.test.toml
+++ b/acceptance/bundle/migrate/default-python/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/engine-config-direct/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-direct/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
+++ b/acceptance/bundle/migrate/engine-config-terraform/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/grants/out.test.toml
+++ b/acceptance/bundle/migrate/grants/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/permissions/out.test.toml
+++ b/acceptance/bundle/migrate/permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/profile_arg/out.test.toml
+++ b/acceptance/bundle/migrate/profile_arg/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/removed/out.test.toml
+++ b/acceptance/bundle/migrate/removed/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/runas/out.test.toml
+++ b/acceptance/bundle/migrate/runas/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/migrate/test.toml
+++ b/acceptance/bundle/migrate/test.toml
@@ -7,10 +7,3 @@ Ignore = [".databricks"]
 # matrix to ["direct"] so CI's engine filter includes these tests without
 # also running the same script twice per engine.
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
-
-# These tests exercise platform-independent bundle logic (state and config
-# migration) and behave identically on every OS, so on pull requests they run on
-# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
-# push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/migrate/var_arg/out.test.toml
+++ b/acceptance/bundle/migrate/var_arg/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_ref_string_to_int/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
+++ b/acceptance/bundle/resource_deps/bad_syntax/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/computed_volume_path/out.test.toml
+++ b/acceptance/bundle/resource_deps/computed_volume_path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/create_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/create_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/duplicate_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/duplicate_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/grant_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/grant_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/id_chain/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_chain/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/id_star/out.test.toml
+++ b/acceptance/bundle/resource_deps/id_star/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/immutable_field_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_model_serving_endpoint/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_quality_monitor/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_registered_model/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
+++ b/acceptance/bundle/resource_deps/implicit_deps_volume/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/delete_all/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_big_graph/destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_bar/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_id_delete_foo/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/job_tasks/out.test.toml
+++ b/acceptance/bundle/resource_deps/job_tasks/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
+++ b/acceptance/bundle/resource_deps/jobs_update_remote/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_jobs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/loop_self/out.test.toml
+++ b/acceptance/bundle/resource_deps/loop_self/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_ingestion_definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_map_key/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/missing_string_field/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/model_id_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/model_id_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
+++ b/acceptance/bundle/resource_deps/non_existent_field/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/permission_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/permission_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
+++ b/acceptance/bundle/resource_deps/pipelines_recreate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
+++ b/acceptance/bundle/resource_deps/present_ingestion_definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_app_url/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_field_storage_location/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
+++ b/acceptance/bundle/resource_deps/remote_pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
+++ b/acceptance/bundle/resource_deps/resources_var_presets_implicit_deps/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/test.toml
+++ b/acceptance/bundle/resource_deps/test.toml
@@ -4,10 +4,3 @@ Ignore = [
     ".databricks",
     ".gitignore",
 ]
-
-# These tests exercise platform-independent bundle logic (resource dependency
-# ordering and reference resolution) and behave identically on every OS, so on pull
-# requests they run on Linux only to keep the windows/macOS CI jobs fast. They still
-# run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/resource_deps/tf_path_only_error/out.test.toml
+++ b/acceptance/bundle/resource_deps/tf_path_only_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/tf_path_renames/out.test.toml
+++ b/acceptance/bundle/resource_deps/tf_path_renames/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/unicode_reference/out.test.toml
+++ b/acceptance/bundle/resource_deps/unicode_reference/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/volume_path_contains_id/out.test.toml
+++ b/acceptance/bundle/resource_deps/volume_path_contains_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resource_deps/volume_path_job_ref/out.test.toml
+++ b/acceptance/bundle/resource_deps/volume_path_job_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/alerts/basic/out.test.toml
+++ b/acceptance/bundle/resources/alerts/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_not_allowed_field_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_run_from_subdir/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_run_from_subdir/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
+++ b/acceptance/bundle/resources/alerts/with_file_variable_interpolation_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/config-drift-stopped/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift-stopped/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-drift/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-drift/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/config-no-deployment/out.test.toml
+++ b/acceptance/bundle/resources/apps/config-no-deployment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
+++ b/acceptance/bundle/resources/apps/create_already_exists/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/default_description/out.test.toml
+++ b/acceptance/bundle/resources/apps/default_description/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/git-source-no-deployment/out.test.toml
+++ b/acceptance/bundle/resources/apps/git-source-no-deployment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/immutable/out.test.toml
+++ b/acceptance/bundle/resources/apps/immutable/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/inline_config/out.test.toml
+++ b/acceptance/bundle/resources/apps/inline_config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-omitted/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-terraform-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started-toggle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/apps/lifecycle-started/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/apps/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/apps/readplan-lifecycle/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/apps/resource-refs/out.test.toml
+++ b/acceptance/bundle/resources/apps/resource-refs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/apps/update/out.test.toml
+++ b/acceptance/bundle/resources/apps/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/auto-approve/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/drift/managed_properties/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/drift/managed_properties/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
+++ b/acceptance/bundle/resources/catalogs/with-schemas/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/data_security_mode/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/local_ssd_count/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.aws = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = true

--- a/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/num_workers_absent/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/simple/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-after-create/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize-autoscale/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/update-and-resize/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
+++ b/acceptance/bundle/resources/clusters/deploy/workload_type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-terraform-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started-toggle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/clusters/lifecycle-started/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
+++ b/acceptance/bundle/resources/clusters/readplan-lifecycle/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
+++ b/acceptance/bundle/resources/clusters/resize-terminated-fallback/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
+++ b/acceptance/bundle/resources/clusters/run/spark_python_task/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-embed-credentials/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-name/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-parent-path/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/change-serialized-dashboard/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/dataset-catalog-schema/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/delete-trashed-out-of-band/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/destroy/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/destroy/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/detect-change/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/generate_inplace/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/nested-folders/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-cleans-up-dashboard/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/publish-failure-stale-content/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/publish-failure-stale-content/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/dashboards/simple/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_outside_bundle_root/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/simple_syncroot/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
+++ b/acceptance/bundle/resources/dashboards/unpublish-out-of-band/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresWarehouse = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/basic/out.test.toml
@@ -3,7 +3,5 @@ Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/database_catalogs/recreate/out.test.toml
+++ b/acceptance/bundle/resources/database_catalogs/recreate/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/database_instances/recreate/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/recreate/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
+++ b/acceptance/bundle/resources/database_instances/single-instance/out.test.toml
@@ -2,7 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/experiments/basic/out.test.toml
+++ b/acceptance/bundle/resources/experiments/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/external_locations/out.test.toml
+++ b/acceptance/bundle/resources/external_locations/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/delete_warning/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/delete_warning/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/inline/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/inline/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/parent_path_update/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/parent_path_update/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/recreate_when_gone/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/recreate_when_gone/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/serialized_space/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/serialized_space/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/simple/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/simple/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/genie_spaces/version_migration/out.test.toml
+++ b/acceptance/bundle/resources/genie_spaces/version_migration/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/catalogs/out.test.toml
+++ b/acceptance/bundle/resources/grants/catalogs/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/grants/registered_models/out.test.toml
+++ b/acceptance/bundle/resources/grants/registered_models/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/all_privileges/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_privileges/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/empty_array/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
+++ b/acceptance/bundle/resources/grants/schemas/remove_principal/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/grants/volumes/out.test.toml
+++ b/acceptance/bundle/resources/grants/volumes/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/independent/out.test.toml
+++ b/acceptance/bundle/resources/independent/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/instance_pools/out.test.toml
+++ b/acceptance/bundle/resources/instance_pools/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/basic/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/job_parameters/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/job_parameters/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/job_runs/redeploy/out.test.toml
+++ b/acceptance/bundle/resources/job_runs/redeploy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/alert-task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/alert-task/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/big_id/out.test.toml
+++ b/acceptance/bundle/resources/jobs/big_id/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
+++ b/acceptance/bundle/resources/jobs/check-metadata/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/create-error/out.test.toml
+++ b/acceptance/bundle/resources/jobs/create-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/jobs/delete_job/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_job/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/delete_task/out.test.toml
+++ b/acceptance/bundle/resources/jobs/delete_task/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
+++ b/acceptance/bundle/resources/jobs/double-underscore-keys/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
+++ b/acceptance/bundle/resources/jobs/fail-on-active-runs/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
+++ b/acceptance/bundle/resources/jobs/instance_pool_and_node_type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
+++ b/acceptance/bundle/resources/jobs/no-git-provider/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/num_workers/out.test.toml
+++ b/acceptance/bundle/resources/jobs/num_workers/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
+++ b/acceptance/bundle/resources/jobs/on_failure_empty_slice/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_add_tag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/deploy/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/destroy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_delete/removed_from_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_delete/removed_from_config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
+++ b/acceptance/bundle/resources/jobs/remote_matches_config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
+++ b/acceptance/bundle/resources/jobs/shared-root-path/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tags_empty_map/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/task-source/out.test.toml
+++ b/acceptance/bundle/resources/jobs/task-source/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
+++ b/acceptance/bundle/resources/jobs/tasks-reorder-locally/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/jobs/unknown-terraform-field/out.test.toml
+++ b/acceptance/bundle/resources/jobs/unknown-terraform-field/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
+++ b/acceptance/bundle/resources/jobs/update_single_node/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/drift/write_only/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/catalog-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/name-change/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/route-optimized/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/schema-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/recreate/table-prefix/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/running-endpoint/out.test.toml
@@ -2,7 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/ai-gateway/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/both_gateway_and_tags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/config/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/email-notifications/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
+++ b/acceptance/bundle/resources/model_serving_endpoints/update/tags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/basic/out.test.toml
+++ b/acceptance/bundle/resources/models/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/models/readplan-permissions/out.test.toml
+++ b/acceptance/bundle/resources/models/readplan-permissions/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/apps/other_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
+++ b/acceptance/bundle/resources/permissions/clusters/target/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/dashboards/create/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
 RequiresWarehouse = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/database_instances/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/experiments/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/factcheck/out.test.toml
+++ b/acceptance/bundle/resources/permissions/factcheck/out.test.toml
@@ -2,7 +2,5 @@ Local = true
 Cloud = true
 CloudSlow = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/genie_spaces/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/out.test.toml
+++ b/acceptance/bundle/resources/permissions/genie_spaces/out_of_band_deletion/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/added_remotely/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_can_manage_run/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/current_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/delete_one/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/deleted_remotely/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/with_permissions/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/destroy_without_mgmtperms/without_permissions/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RunsOnDbr = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/empty_list/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_can_manage_run/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/other_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_locally/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/reorder_remotely/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
+++ b/acceptance/bundle/resources/permissions/jobs/viewers/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/models/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 Phase = 1
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/504/create/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/create/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/504/plan/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/plan/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/504/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/504/update/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]
 EnvMatrix.READPLAN = []

--- a/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/current_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/empty_list/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/other_is_owner/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/permissions/pipelines/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/postgres_projects/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/sql_warehouses/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
+++ b/acceptance/bundle/resources/permissions/target_permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
+++ b/acceptance/bundle/resources/permissions/vector_search_endpoints/current_can_manage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/allow-duplicate-names/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/auto-approve/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/drift/parameters/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/drift/parameters/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/lakeflow-pipeline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/num-workers-zero/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/photon-true/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-ingestion-definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate-keys/change-storage/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/recreate/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/recreate/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/update/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
+++ b/acceptance/bundle/resources/pipelines/zero-value-fields/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/purge_on_delete_transitions/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/purge_on_delete_transitions/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/replace_existing/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/update_protected/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_branches/without_branch_id/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_catalogs/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_catalogs/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_catalogs/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_database_id/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/live_errors/bad_role_ref/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_databases/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/replace_existing/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_databases/update/out.test.toml
+++ b/acceptance/bundle/resources/postgres_databases/update/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_endpoints/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/replace_existing/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/update_autoscaling/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_endpoints/without_endpoint_id/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/purge_on_delete_transitions/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/purge_on_delete_transitions/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/update_display_name/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
+++ b/acceptance/bundle/resources/postgres_projects/without_project_id/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-bind/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-bind/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/inherited-role-conflict/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/recreate-postgres-role/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/postgres_roles/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/replace_existing/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/replace_existing/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_roles/update/out.test.toml
+++ b/acceptance/bundle/resources/postgres_roles/update/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_synced_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/basic/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/postgres_synced_tables/recreate/out.test.toml
+++ b/acceptance/bundle/resources/postgres_synced_tables/recreate/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_assets_dir/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_output_schema_name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/change_table_name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/quality_monitors/create/out.test.toml
+++ b/acceptance/bundle/resources/quality_monitors/create/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/aliases_converge/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/aliases_converge/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/registered_models/basic/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/basic/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/registered_models/drift/browse_only/out.test.toml
+++ b/acceptance/bundle/resources/registered_models/drift/browse_only/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
+++ b/acceptance/bundle/resources/schemas/auto-approve/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/drift/managed_properties/out.test.toml
+++ b/acceptance/bundle/resources/schemas/drift/managed_properties/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/schemas/recreate/out.test.toml
+++ b/acceptance/bundle/resources/schemas/recreate/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/schemas/update/out.test.toml
+++ b/acceptance/bundle/resources/schemas/update/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/backend-type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/delete_scope/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions-collapse/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
+++ b/acceptance/bundle/resources/secret_scopes/permissions/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-edit/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 CloudSlow = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-terraform-error/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 CloudSlow = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started-toggle/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 CloudSlow = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/lifecycle-started/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 CloudSlow = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/sql_warehouses/out.test.toml
+++ b/acceptance/bundle/resources/sql_warehouses/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 CloudSlow = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/basic/out.test.toml
@@ -2,7 +2,5 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/synced_database_tables/recreate/out.test.toml
+++ b/acceptance/bundle/resources/synced_database_tables/recreate/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/test.toml
+++ b/acceptance/bundle/resources/test.toml
@@ -1,8 +1,1 @@
 RecordRequests = true
-
-# These tests exercise platform-independent bundle logic (resource CRUD, diffing,
-# permissions) and behave identically on every OS, so on pull requests they run on
-# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
-# push to main. Individual OS-sensitive tests below re-enable themselves.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/basic/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/budget_policy/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/recreated_same_name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/drift/target_qps/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/create-fails/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/create-fails/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/recreate/endpoint_type/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/budget_policy/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_endpoints/update/target_qps/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/basic/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/basic/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/deleted_remotely/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/drift/orphaned_endpoint/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/grants/select/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/grants/select/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/embedding_dimension/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/recreate/with_endpoint/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = false
 CloudSlow = false
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
+++ b/acceptance/bundle/resources/vector_search_indexes/schema_normalization/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 CloudSlow = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
+++ b/acceptance/bundle/resources/volumes/catalog-var-ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/resources/volumes/change-comment/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-comment/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/change-schema-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/recreate/out.test.toml
+++ b/acceptance/bundle/resources/volumes/recreate/out.test.toml
@@ -2,6 +2,4 @@ Local = true
 Cloud = true
 RequiresUnityCatalog = true
 RunsOnDbr = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-change-name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
+++ b/acceptance/bundle/resources/volumes/remote-delete/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-storage-location/out.test.toml
@@ -1,8 +1,6 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 CloudEnvs.azure = false
 CloudEnvs.gcp = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/set-volume-path/out.test.toml
+++ b/acceptance/bundle/resources/volumes/set-volume-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/resources/volumes/uppercase-name/out.test.toml
+++ b/acceptance/bundle/resources/volumes/uppercase-name/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = true
 RequiresUnityCatalog = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/regular_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/allowed/service_principal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/dashboard_embed/out.test.toml
+++ b/acceptance/bundle/run_as/dashboard_embed/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_override/out.test.toml
+++ b/acceptance/bundle/run_as/empty_override/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
+++ b/acceptance/bundle/run_as/empty_run_as_dict/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_sp/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
+++ b/acceptance/bundle/run_as/empty_user_and_sp/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
+++ b/acceptance/bundle/run_as/invalid_both_sp_and_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/job_default/out.test.toml
+++ b/acceptance/bundle/run_as/job_default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/run_as/model_serving_different/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_different/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/model_serving_matching/out.test.toml
+++ b/acceptance/bundle/run_as/model_serving_matching/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/out.test.toml
+++ b/acceptance/bundle/run_as/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/regular_user/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines/service_principal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
+++ b/acceptance/bundle/run_as/pipelines_legacy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/run_as/test.toml
+++ b/acceptance/bundle/run_as/test.toml
@@ -1,6 +1,0 @@
-# These tests exercise platform-independent bundle logic (run_as identity
-# resolution) and behave identically on every OS, so on pull requests they run on
-# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
-# push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/state/bad_env/out.test.toml
+++ b/acceptance/bundle/state/bad_env/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/bad_json_local/out.test.toml
+++ b/acceptance/bundle/state/bad_json_local/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/basic/out.test.toml
+++ b/acceptance/bundle/state/basic/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/engine_default/out.test.toml
+++ b/acceptance/bundle/state/engine_default/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/engine_mismatch/out.test.toml
+++ b/acceptance/bundle/state/engine_mismatch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/feature_flags/out.test.toml
+++ b/acceptance/bundle/state/feature_flags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/force_pull_commands/out.test.toml
+++ b/acceptance/bundle/state/force_pull_commands/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/future_version/out.test.toml
+++ b/acceptance/bundle/state/future_version/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/lineage_different/out.test.toml
+++ b/acceptance/bundle/state/lineage_different/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/permission_level_migration/out.test.toml
+++ b/acceptance/bundle/state/permission_level_migration/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/state/same_serial/out.test.toml
+++ b/acceptance/bundle/state/same_serial/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/state_present/out.test.toml
+++ b/acceptance/bundle/state/state_present/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/state/test.toml
+++ b/acceptance/bundle/state/test.toml
@@ -1,6 +1,0 @@
-# These tests exercise platform-independent bundle logic (deployment state
-# tracking and lineage) and behave identically on every OS, so on pull requests they
-# run on Linux only to keep the windows/macOS CI jobs fast. They still run on every
-# OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
+++ b/acceptance/bundle/summary/missing-libraries-file-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/summary/modified_status/out.test.toml
+++ b/acceptance/bundle/summary/modified_status/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.VARIANT = ["empty_resources.yml", "no_resources.yml"]

--- a/acceptance/bundle/summary/test.toml
+++ b/acceptance/bundle/summary/test.toml
@@ -1,5 +1,0 @@
-# These tests exercise platform-independent bundle logic (summary rendering) and
-# behave identically on every OS, so on pull requests they run on Linux only to keep
-# the windows/macOS CI jobs fast. They still run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/telemetry/config-remote-sync-error/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync-error/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 GOOS.windows = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/telemetry/config-remote-sync-recreate/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync-recreate/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 GOOS.windows = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/config-remote-sync-save/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync-save/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 GOOS.windows = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/config-remote-sync/out.test.toml
+++ b/acceptance/bundle/telemetry/config-remote-sync/out.test.toml
@@ -1,6 +1,4 @@
 Local = true
 Cloud = false
 GOOS.windows = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/deploy-app-lifecycle-started/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-app-lifecycle-started/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifact-path-type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-artifacts-variables/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-compute-type/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-config-file-count/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error-message/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error-message/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-error/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-experimental/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-mode/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-mode/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/custom/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-name-prefix/mode-development/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-no-uuid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-run-as/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-target-count/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-variable-count/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-whl-artifacts/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy-workspace-folder-permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/deploy/out.test.toml
+++ b/acceptance/bundle/telemetry/deploy/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/telemetry/test.toml
+++ b/acceptance/bundle/telemetry/test.toml
@@ -1,13 +1,6 @@
 RecordRequests = true
 IncludeRequestHeaders = ["User-Agent"]
 
-# These tests assert the telemetry payload emitted on deploy; the output is
-# OS-normalized (see the (linux|darwin|windows) -> [OS] replacement below), so it
-# behaves identically on every OS. On pull requests they run on Linux only to keep
-# the windows/macOS CI jobs fast; they still run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false
-
 [Env]
 DATABRICKS_CACHE_ENABLED = 'false'
 

--- a/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/classic/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DLT = ["yes", "no"]
 EnvMatrix.NBOOK = ["yes", "no"]

--- a/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/serverless/out.test.toml
@@ -1,7 +1,5 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]
 EnvMatrix.DLT = ["yes", "no"]
 EnvMatrix.NBOOK = ["yes", "no"]

--- a/acceptance/bundle/templates/default-python/combinations/test.toml
+++ b/acceptance/bundle/templates/default-python/combinations/test.toml
@@ -1,13 +1,5 @@
 Cloud = true
 
-# This matrix (notebook/DLT/python inclusion) tests OS-independent bundle logic; the
-# only OS-specific surface is the wheel build (uv venv layout, bdist_wheel), which is
-# covered on every OS by templates/default-python/integration_classic. So on pull
-# requests these run on Linux only to keep the windows/macOS CI jobs fast; they still
-# run on every OS on push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false
-
 Ignore = ["input.json"]
 
 EnvMatrix.READPLAN = ["", "1"]

--- a/acceptance/bundle/validate/anchor_containers/out.test.toml
+++ b/acceptance/bundle/validate/anchor_containers/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/catalog_requires_direct_mode/out.test.toml
+++ b/acceptance/bundle/validate/catalog_requires_direct_mode/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform"]

--- a/acceptance/bundle/validate/dashboard_defaults/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dashboard_required_name/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_required_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/dashboard_required_warehouse_id/out.test.toml
+++ b/acceptance/bundle/validate/dashboard_required_warehouse_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/definitions_yaml_anchors/out.test.toml
+++ b/acceptance/bundle/validate/definitions_yaml_anchors/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/duplicate_yaml_merge_key/out.test.toml
+++ b/acceptance/bundle/validate/duplicate_yaml_merge_key/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/empty_def/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/empty_def/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/empty_dict/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/empty_dict/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/null/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/null/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/with_grants/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/with_grants/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_resources/with_permissions/out.test.toml
+++ b/acceptance/bundle/validate/empty_resources/with_permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/empty_tasks/out.test.toml
+++ b/acceptance/bundle/validate/empty_tasks/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/engine-config-valid/out.test.toml
+++ b/acceptance/bundle/validate/engine-config-valid/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/enum/out.test.toml
+++ b/acceptance/bundle/validate/enum/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/enum_resource_refs/out.test.toml
+++ b/acceptance/bundle/validate/enum_resource_refs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_complex/out.test.toml
+++ b/acceptance/bundle/validate/genie_space_complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_defaults/out.test.toml
+++ b/acceptance/bundle/validate/genie_space_defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/genie_space_file_path_and_inline/out.test.toml
+++ b/acceptance/bundle/validate/genie_space_file_path_and_inline/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/grants_required_principal/out.test.toml
+++ b/acceptance/bundle/validate/grants_required_principal/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/immutable_workspace_paths/out.test.toml
+++ b/acceptance/bundle/validate/immutable_workspace_paths/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/include_locations/out.test.toml
+++ b/acceptance/bundle/validate/include_locations/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/invalid-engine-bundle/out.test.toml
+++ b/acceptance/bundle/validate/invalid-engine-bundle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/invalid-engine-target/out.test.toml
+++ b/acceptance/bundle/validate/invalid-engine-target/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/job-references/out.test.toml
+++ b/acceptance/bundle/validate/job-references/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_both_fields_error/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_both_fields_error/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_conversion/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_conversion/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/models/missing_name/out.test.toml
+++ b/acceptance/bundle/validate/models/missing_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/models/user_id/out.test.toml
+++ b/acceptance/bundle/validate/models/user_id/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/no_dashboard_etag/out.test.toml
+++ b/acceptance/bundle/validate/no_dashboard_etag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/no_genie_space_etag/out.test.toml
+++ b/acceptance/bundle/validate/no_genie_space_etag/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/permissions/out.test.toml
+++ b/acceptance/bundle/validate/permissions/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/permissions_overlap/out.test.toml
+++ b/acceptance/bundle/validate/permissions_overlap/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_max_concurrent_runs/out.test.toml
+++ b/acceptance/bundle/validate/presets_max_concurrent_runs/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_name_prefix/out.test.toml
+++ b/acceptance/bundle/validate/presets_name_prefix/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/presets_name_prefix_dev/out.test.toml
+++ b/acceptance/bundle/validate/presets_name_prefix_dev/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/acceptance/bundle/validate/presets_tags/out.test.toml
+++ b/acceptance/bundle/validate/presets_tags/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/required/out.test.toml
+++ b/acceptance/bundle/validate/required/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/reserved_deployment_fields/out.test.toml
+++ b/acceptance/bundle/validate/reserved_deployment_fields/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/sql_warehouse_required_name/out.test.toml
+++ b/acceptance/bundle/validate/sql_warehouse_required_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/strict/out.test.toml
+++ b/acceptance/bundle/validate/strict/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/sync_patterns/out.test.toml
+++ b/acceptance/bundle/validate/sync_patterns/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/test.toml
+++ b/acceptance/bundle/validate/test.toml
@@ -1,6 +1,0 @@
-# These tests exercise platform-independent bundle logic (config validation and
-# diagnostics) and behave identically on every OS, so on pull requests they run on
-# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
-# push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/validate/var_in_bundle_name/out.test.toml
+++ b/acceptance/bundle/validate/var_in_bundle_name/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/volume_defaults/out.test.toml
+++ b/acceptance/bundle/validate/volume_defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/arg-repeat/out.test.toml
+++ b/acceptance/bundle/variables/arg-repeat/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cross-ref/out.test.toml
+++ b/acceptance/bundle/variables/complex-cross-ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cycle-self/out.test.toml
+++ b/acceptance/bundle/variables/complex-cycle-self/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-cycle/out.test.toml
+++ b/acceptance/bundle/variables/complex-cycle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-simple/out.test.toml
+++ b/acceptance/bundle/variables/complex-simple/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive-deep/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive-deep/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive-deeper/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive-deeper/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-transitive/out.test.toml
+++ b/acceptance/bundle/variables/complex-transitive/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-with-var-reference/out.test.toml
+++ b/acceptance/bundle/variables/complex-with-var-reference/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex-within-complex/out.test.toml
+++ b/acceptance/bundle/variables/complex-within-complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex/out.test.toml
+++ b/acceptance/bundle/variables/complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/complex_multiple_files/out.test.toml
+++ b/acceptance/bundle/variables/complex_multiple_files/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/cycle/out.test.toml
+++ b/acceptance/bundle/variables/cycle/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/double_underscore/out.test.toml
+++ b/acceptance/bundle/variables/double_underscore/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/empty/out.test.toml
+++ b/acceptance/bundle/variables/empty/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/env_overrides/out.test.toml
+++ b/acceptance/bundle/variables/env_overrides/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/file-defaults/out.test.toml
+++ b/acceptance/bundle/variables/file-defaults/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/git-branch/out.test.toml
+++ b/acceptance/bundle/variables/git-branch/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/host/out.test.toml
+++ b/acceptance/bundle/variables/host/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/int/out.test.toml
+++ b/acceptance/bundle/variables/int/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/issue_2436/out.test.toml
+++ b/acceptance/bundle/variables/issue_2436/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/issue_3039_lookup_with_ref/out.test.toml
+++ b/acceptance/bundle/variables/issue_3039_lookup_with_ref/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/lookup/out.test.toml
+++ b/acceptance/bundle/variables/lookup/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = true
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/prepend-workspace-var/out.test.toml
+++ b/acceptance/bundle/variables/prepend-workspace-var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-builtin/out.test.toml
+++ b/acceptance/bundle/variables/resolve-builtin/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-empty/out.test.toml
+++ b/acceptance/bundle/variables/resolve-empty/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-field-within-complex/out.test.toml
+++ b/acceptance/bundle/variables/resolve-field-within-complex/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-nonstrings/out.test.toml
+++ b/acceptance/bundle/variables/resolve-nonstrings/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-resources-fields/out.test.toml
+++ b/acceptance/bundle/variables/resolve-resources-fields/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/resolve-vars-in-root-path/out.test.toml
+++ b/acceptance/bundle/variables/resolve-vars-in-root-path/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/test.toml
+++ b/acceptance/bundle/variables/test.toml
@@ -1,6 +1,0 @@
-# These tests exercise platform-independent bundle logic (variable resolution and
-# interpolation) and behave identically on every OS, so on pull requests they run on
-# Linux only to keep the windows/macOS CI jobs fast. They still run on every OS on
-# push to main.
-GOOSOnPR.windows = false
-GOOSOnPR.darwin = false

--- a/acceptance/bundle/variables/unicode_reference/out.test.toml
+++ b/acceptance/bundle/variables/unicode_reference/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/vanilla/out.test.toml
+++ b/acceptance/bundle/variables/vanilla/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/var_in_var/out.test.toml
+++ b/acceptance/bundle/variables/var_in_var/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/variable_in_resource_key/out.test.toml
+++ b/acceptance/bundle/variables/variable_in_resource_key/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/variable_overrides_in_target/out.test.toml
+++ b/acceptance/bundle/variables/variable_overrides_in_target/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/variables/without_definition/out.test.toml
+++ b/acceptance/bundle/variables/without_definition/out.test.toml
@@ -1,5 +1,3 @@
 Local = true
 Cloud = false
-GOOSOnPR.darwin = false
-GOOSOnPR.windows = false
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -37,12 +37,6 @@ type TestConfig struct {
 	// If absent, default to true.
 	GOOS map[string]bool
 
-	// Like GOOS, but only consulted when the test run is triggered by a GitHub
-	// pull_request event. Each string is compared against runtime.GOOS; if absent,
-	// default to true. This lets an OS-independent test run on Linux only for pull
-	// requests while still running on every OS on push to main.
-	GOOSOnPR map[string]bool
-
 	// Which Clouds the test is enabled on. Allowed values: "aws", "azure", "gcp".
 	// If absent, default to true.
 	// Only checked if CLOUD_ENV is not empty.

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -54,9 +54,6 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	for _, k := range slices.Sorted(maps.Keys(config.GOOS)) {
 		fmt.Fprintf(&buf, "GOOS.%s = %v\n", k, config.GOOS[k])
 	}
-	for _, k := range slices.Sorted(maps.Keys(config.GOOSOnPR)) {
-		fmt.Fprintf(&buf, "GOOSOnPR.%s = %v\n", k, config.GOOSOnPR[k])
-	}
 	for _, k := range slices.Sorted(maps.Keys(config.CloudEnvs)) {
 		fmt.Fprintf(&buf, "CloudEnvs.%s = %v\n", k, config.CloudEnvs[k])
 	}

--- a/acceptance/subset_test.go
+++ b/acceptance/subset_test.go
@@ -25,8 +25,8 @@ const (
 // subsetSelector decides, per subtest, whether it runs under TESTS_SELECT_SUBSET_PCT.
 // A subtest runs if it is an added/modified test on this branch (always kept, reusing
 // the same change detection as SkipLocalWithChanged), or if its seeded hash falls
-// under the percentage. Added/modified tests thus count against the percentage only in
-// the sense that they occupy the run; they are never dropped by it.
+// under the percentage. The decision is independent per subtest, so added/modified
+// tests run on top of the hash-selected subset rather than displacing anything.
 type subsetSelector struct {
 	enabled bool
 	pct     int
@@ -39,9 +39,9 @@ type subsetSelector struct {
 
 // newSubsetSelector reads the subset env vars. Subsetting is disabled in update mode
 // and under -forcerun so that every output is regenerated and forced runs are honored.
-// When enabled, added/modified tests are detected once (reusing the change detection
-// behind SkipLocalWithChanged) so they are always kept.
-func newSubsetSelector(t *testing.T, overwrite, forcerun bool, testDirs map[string]bool) subsetSelector {
+// The caller assigns .changed (the added/modified tests to always keep) so that the
+// change detection is shared with SkipLocalWithChanged and runs at most once.
+func newSubsetSelector(t *testing.T, overwrite, forcerun bool) subsetSelector {
 	raw := os.Getenv(SubsetPctEnvVar)
 	if raw == "" || overwrite || forcerun {
 		return subsetSelector{}
@@ -56,7 +56,6 @@ func newSubsetSelector(t *testing.T, overwrite, forcerun bool, testDirs map[stri
 		enabled: true,
 		pct:     pct,
 		seed:    os.Getenv(SubsetSeedEnvVar),
-		changed: selectChangedLocalTests(testDirs),
 	}
 }
 

--- a/acceptance/subset_test.go
+++ b/acceptance/subset_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 // TESTS_SELECT_SUBSET_PCT/SEED select a random subset of subtests to run, so a CI
@@ -19,6 +21,7 @@ const (
 
 	// SubsetSeedEnvVar seeds the selection. CI sets it to the HEAD commit hash, so
 	// a new commit reshuffles the subset while a retry of the same commit repeats it.
+	// If unset, a random seed is generated and logged so the run can be reproduced.
 	SubsetSeedEnvVar = "TESTS_SELECT_SUBSET_SEED"
 )
 
@@ -52,10 +55,17 @@ func newSubsetSelector(t *testing.T, overwrite, forcerun bool) subsetSelector {
 		t.Fatalf("Invalid %s=%q, expected an integer 0..100", SubsetPctEnvVar, raw)
 	}
 
+	seed := os.Getenv(SubsetSeedEnvVar)
+	if seed == "" {
+		// Reproduce this run's subset by re-running with the logged seed.
+		seed = uuid.NewString()
+		t.Logf("%s not set, using random seed %q", SubsetSeedEnvVar, seed)
+	}
+
 	return subsetSelector{
 		enabled: true,
 		pct:     pct,
-		seed:    os.Getenv(SubsetSeedEnvVar),
+		seed:    seed,
 	}
 }
 

--- a/acceptance/subset_test.go
+++ b/acceptance/subset_test.go
@@ -1,0 +1,122 @@
+package acceptance_test
+
+import (
+	"hash/fnv"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TESTS_SELECT_SUBSET_PCT/SEED select a random subset of subtests to run, so a CI
+// cell can cover a fraction of the suite in less time. CI sets these only on the
+// windows/macOS pull_request cells (see .github/workflows/push.yml); on Linux they
+// are unset and the full suite runs.
+const (
+	// SubsetPctEnvVar is an integer 0..100: the percentage of subtests to run.
+	// Unset (or empty) disables subsetting entirely.
+	SubsetPctEnvVar = "TESTS_SELECT_SUBSET_PCT"
+
+	// SubsetSeedEnvVar seeds the selection. CI sets it to the HEAD commit hash, so
+	// a new commit reshuffles the subset while a retry of the same commit repeats it.
+	SubsetSeedEnvVar = "TESTS_SELECT_SUBSET_SEED"
+)
+
+// subsetSelector decides, per subtest, whether it runs under TESTS_SELECT_SUBSET_PCT.
+// A subtest runs if it is an added/modified test on this branch (always kept, reusing
+// the same change detection as SkipLocalWithChanged), or if its seeded hash falls
+// under the percentage. Added/modified tests thus count against the percentage only in
+// the sense that they occupy the run; they are never dropped by it.
+type subsetSelector struct {
+	enabled bool
+	pct     int
+	seed    string
+
+	// changed maps test dir -> variant filters for added/modified tests (nil filters
+	// means all variants of that dir are changed). Same shape as changedTests.
+	changed map[string][]string
+}
+
+// newSubsetSelector reads the subset env vars. Subsetting is disabled in update mode
+// and under -forcerun so that every output is regenerated and forced runs are honored.
+// When enabled, added/modified tests are detected once (reusing the change detection
+// behind SkipLocalWithChanged) so they are always kept.
+func newSubsetSelector(t *testing.T, overwrite, forcerun bool, testDirs map[string]bool) subsetSelector {
+	raw := os.Getenv(SubsetPctEnvVar)
+	if raw == "" || overwrite || forcerun {
+		return subsetSelector{}
+	}
+
+	pct, err := strconv.Atoi(raw)
+	if err != nil || pct < 0 || pct > 100 {
+		t.Fatalf("Invalid %s=%q, expected an integer 0..100", SubsetPctEnvVar, raw)
+	}
+
+	return subsetSelector{
+		enabled: true,
+		pct:     pct,
+		seed:    os.Getenv(SubsetSeedEnvVar),
+		changed: selectChangedLocalTests(testDirs),
+	}
+}
+
+// skipReason returns a non-empty skip message if the subtest identified by dir and
+// envset should be skipped by subsetting, or "" if it should run.
+func (s subsetSelector) skipReason(dir string, envset []string) string {
+	if !s.enabled {
+		return ""
+	}
+	if s.isChanged(dir, envset) {
+		return ""
+	}
+	id := dir
+	if len(envset) > 0 {
+		id += "/" + strings.Join(envset, "/")
+	}
+	if hashPercent(s.seed, id) < s.pct {
+		return ""
+	}
+	return "Skipped by " + SubsetPctEnvVar
+}
+
+// isChanged reports whether the subtest belongs to an added/modified test dir. For an
+// invariant dir re-enabled by a specific config change, only the matching variants
+// count as changed.
+func (s subsetSelector) isChanged(dir string, envset []string) bool {
+	filters, ok := s.changed[dir]
+	if !ok {
+		return false
+	}
+	if filters == nil {
+		return true
+	}
+	return envMatchesFilters(envset, filters)
+}
+
+// envMatchesFilters reports whether envset satisfies every KEY=value filter, mirroring
+// the skip semantics of checkEnvFilters: a filter matches unless its key is present in
+// envset with a different value.
+func envMatchesFilters(envset, filters []string) bool {
+	envMap := make(map[string]string, len(envset))
+	for _, kv := range envset {
+		key, value, _ := strings.Cut(kv, "=")
+		envMap[key] = value
+	}
+	for _, filter := range filters {
+		key, expected, _ := strings.Cut(filter, "=")
+		if actual, ok := envMap[key]; ok && actual != expected {
+			return false
+		}
+	}
+	return true
+}
+
+// hashPercent maps (seed, id) deterministically to 0..99. A subtest runs when this is
+// below the percentage, so pct=100 runs everything and pct=0 runs nothing.
+func hashPercent(seed, id string) int {
+	h := fnv.New64a()
+	h.Write([]byte(seed))
+	h.Write([]byte{0})
+	h.Write([]byte(id))
+	return int(h.Sum64() % 100)
+}

--- a/acceptance/subset_unit_test.go
+++ b/acceptance/subset_unit_test.go
@@ -1,0 +1,106 @@
+package acceptance_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubsetDisabled(t *testing.T) {
+	var s subsetSelector
+	assert.Empty(t, s.skipReason("bundle/foo", nil))
+	assert.Empty(t, s.skipReason("bundle/foo", []string{"DATABRICKS_BUNDLE_ENGINE=direct"}))
+}
+
+func TestSubsetPctBoundaries(t *testing.T) {
+	all := subsetSelector{enabled: true, pct: 100, seed: "seed"}
+	none := subsetSelector{enabled: true, pct: 0, seed: "seed"}
+
+	for _, dir := range []string{"bundle/a", "bundle/b", "cmd/c"} {
+		assert.Empty(t, all.skipReason(dir, nil), "pct=100 must run everything")
+		assert.NotEmpty(t, none.skipReason(dir, nil), "pct=0 must skip everything")
+	}
+}
+
+func TestSubsetChangedAlwaysRuns(t *testing.T) {
+	// pct=0 would skip everything, but a changed dir is always kept.
+	s := subsetSelector{
+		enabled: true,
+		pct:     0,
+		seed:    "seed",
+		changed: map[string][]string{"bundle/changed": nil},
+	}
+	assert.Empty(t, s.skipReason("bundle/changed", []string{"DATABRICKS_BUNDLE_ENGINE=direct"}))
+	assert.NotEmpty(t, s.skipReason("bundle/other", nil))
+}
+
+func TestSubsetChangedVariantFilter(t *testing.T) {
+	// A changed dir restricted to a specific config only keeps matching variants.
+	s := subsetSelector{
+		enabled: true,
+		pct:     0,
+		seed:    "seed",
+		changed: map[string][]string{"bundle/invariant/x": {"INPUT_CONFIG=job.yml.tmpl"}},
+	}
+	assert.Empty(t, s.skipReason("bundle/invariant/x", []string{"INPUT_CONFIG=job.yml.tmpl"}))
+	assert.NotEmpty(t, s.skipReason("bundle/invariant/x", []string{"INPUT_CONFIG=pipeline.yml.tmpl"}))
+}
+
+func TestSubsetSeedDeterministic(t *testing.T) {
+	// Same seed selects the same subset; the decision does not depend on ordering.
+	a := subsetSelector{enabled: true, pct: 50, seed: "abc"}
+	b := subsetSelector{enabled: true, pct: 50, seed: "abc"}
+	for _, dir := range []string{"bundle/a", "bundle/b", "bundle/c", "bundle/d"} {
+		assert.Equal(t, a.skipReason(dir, nil), b.skipReason(dir, nil))
+	}
+}
+
+func TestSubsetSeedChangesSelection(t *testing.T) {
+	// Different seeds should produce different selections across a set of dirs.
+	var dirs []string
+	for i := range 100 {
+		dirs = append(dirs, "bundle/dir"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+	}
+	s1 := subsetSelector{enabled: true, pct: 50, seed: "seed-1"}
+	s2 := subsetSelector{enabled: true, pct: 50, seed: "seed-2"}
+	diff := 0
+	for _, dir := range dirs {
+		if (s1.skipReason(dir, nil) == "") != (s2.skipReason(dir, nil) == "") {
+			diff++
+		}
+	}
+	assert.NotZero(t, diff, "different seeds should select different subsets")
+}
+
+func TestSubsetVariantsIndependent(t *testing.T) {
+	// Two variants of one dir are decided independently: at least one differs from the
+	// other across a spread of dirs (they are not forced to the same outcome).
+	s := subsetSelector{enabled: true, pct: 50, seed: "seed"}
+	sawDifferent := false
+	for i := range 50 {
+		dir := "bundle/d" + string(rune('a'+i%26))
+		a := s.skipReason(dir, []string{"DATABRICKS_BUNDLE_ENGINE=direct"}) == ""
+		b := s.skipReason(dir, []string{"DATABRICKS_BUNDLE_ENGINE=terraform"}) == ""
+		if a != b {
+			sawDifferent = true
+			break
+		}
+	}
+	assert.True(t, sawDifferent, "variants of the same dir should be decided independently")
+}
+
+func TestSubsetApproximatesPct(t *testing.T) {
+	// Over many subtests the selected fraction should be close to pct.
+	s := subsetSelector{enabled: true, pct: 30, seed: "seed"}
+	run := 0
+	total := 1000
+	for i := range total {
+		id := "bundle/pkg" + string(rune('a'+i%26)) + "/case" + string(rune('0'+i/26%10))
+		if s.skipReason(id, []string{"V=" + string(rune('a'+i%7))}) == "" {
+			run++
+		}
+	}
+	// Allow a generous margin; this guards against gross bias, not exact proportion.
+	assert.Greater(t, run, 200)
+	assert.Less(t, run, 400)
+}


### PR DESCRIPTION
## Changes

Replace the `GOOSOnPR` test.toml filter (https://github.com/databricks/cli/pull/5876) with a general per-subtest subset selector for acceptance tests. Linux runs all tests while darwin and windows run a subset. The subset is random but seeded with HEAD commit hash, so retries run the same set.

- `TESTS_SELECT_SUBSET_PCT` (0-100) selects a fraction of subtests to run; the rest are skipped . The decision is per-subtest, e.g. `no_drift/config=jobs.yml` can run while `config=pipelines.yml` is skipped.
- Added/modified tests on the branch always run on top of the selected subset (reusing the `SkipLocalWithChanged` change detection).
- `TESTS_SELECT_SUBSET_SEED`  controls the set selected.

## Why

test.toml is wrong place to decide whether this test runs on PR or not:
 - it’s too much mental overhead (we have 1000 tests)
 - it depends on global situation, which other tests are running on PRs, how fast is runner, etc. It’s not a property of a particular test.
 - it’s hard to get right which tests are OS independent. Innocent-looking things like os.Rename or temp dirs could trigger OS-specific issues.

In addition this produces a lot of churn in out.test.toml files.

Selecting subset randomly exposes all tests (with some probability), so you get a better exposure and you’re don’t have to think hard about extra setting.

There is just one number to tweak - percentage of tests to run on PR. The configuration is done in github action, that's the right place for this, as depending on runner, cloud vs local, we might want a different setting.

Note, added/modifies tests are included always.