### PR TITLE
acc: fix permissions empty-list test that never exercised permissions: []

### DIFF
--- a/acceptance/bundle/resources/permissions/jobs/update/databricks.yml
+++ b/acceptance/bundle/resources/permissions/jobs/update/databricks.yml
@@ -15,4 +15,4 @@ resources:
           user_name: viewer@example.com # PERMISSIONS
         - level: CAN_MANAGE # DELETE_ONE
           group_name: data-team # DELETE_ONE
-          # permissions: [] # EXPLICIT_EMPTY
+      # permissions: [] # EXPLICIT_EMPTY

--- a/acceptance/bundle/resources/permissions/jobs/update/out.plan_set_empty.direct.json
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.plan_set_empty.direct.json
@@ -78,7 +78,7 @@
           "label": "${resources.jobs.job_with_permissions.id}"
         }
       ],
-      "action": "skip",
+      "action": "delete",
       "remote_state": {
         "object_id": "/jobs/[JOB_WITH_PERMISSIONS_ID]",
         "__embed__": [

--- a/acceptance/bundle/resources/permissions/jobs/update/out.plan_set_empty.terraform.json
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.plan_set_empty.terraform.json
@@ -5,7 +5,7 @@
       "action": "skip"
     },
     "resources.jobs.job_with_permissions.permissions": {
-      "action": "skip"
+      "action": "delete"
     }
   }
 }

--- a/acceptance/bundle/resources/permissions/jobs/update/out.requests_destroy.terraform.json
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.requests_destroy.terraform.json
@@ -1,16 +1,4 @@
 {
-  "method": "PUT",
-  "path": "/api/2.0/permissions/jobs/[JOB_WITH_PERMISSIONS_ID]",
-  "body": {
-    "access_control_list": [
-      {
-        "permission_level": "IS_OWNER",
-        "user_name": "[USERNAME]"
-      }
-    ]
-  }
-}
-{
   "method": "POST",
   "path": "/api/2.2/jobs/delete",
   "body": {

--- a/acceptance/bundle/resources/permissions/jobs/update/out.requests_set_empty.terraform.json
+++ b/acceptance/bundle/resources/permissions/jobs/update/out.requests_set_empty.terraform.json
@@ -1,0 +1,12 @@
+{
+  "method": "PUT",
+  "path": "/api/2.0/permissions/jobs/[JOB_WITH_PERMISSIONS_ID]",
+  "body": {
+    "access_control_list": [
+      {
+        "permission_level": "IS_OWNER",
+        "user_name": "[USERNAME]"
+      }
+    ]
+  }
+}

--- a/acceptance/bundle/resources/permissions/jobs/update/output.txt
+++ b/acceptance/bundle/resources/permissions/jobs/update/output.txt
@@ -127,7 +127,7 @@ Plan: 0 to add, 0 to change, 0 to delete, 1 unchanged
 -          user_name: viewer@example.com # PERMISSIONS
 -        - level: CAN_MANAGE # DELETE_ONE
 -          group_name: data-team # DELETE_ONE
-           # permissions: [] # EXPLICIT_EMPTY
+       # permissions: [] # EXPLICIT_EMPTY
 
 >>> [CLI] bundle plan -o json
 
@@ -145,16 +145,8 @@ Plan: 0 to add, 0 to change, 0 to delete, 2 unchanged
 === Set permissions: []
 
 >>> [CLI] bundle plan -o json
-Warning: unknown field: permissions
-  at resources.jobs.job_with_permissions.permissions[1]
-  in databricks.yml:18:11
-
 
 >>> [CLI] bundle deploy
-Warning: unknown field: permissions
-  at resources.jobs.job_with_permissions.permissions[1]
-  in databricks.yml:18:11
-
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/jobs-permissions-test/default/files...
 Deploying resources...
 Updating deployment state...
@@ -163,10 +155,6 @@ Deployment complete!
 >>> print_requests.py //jobs/
 
 >>> [CLI] bundle destroy --auto-approve
-Warning: unknown field: permissions
-  at resources.jobs.job_with_permissions.permissions[1]
-  in databricks.yml:18:11
-
 The following resources will be deleted:
   delete resources.jobs.job_with_permissions
 

--- a/acceptance/bundle/resources/permissions/jobs/update/script
+++ b/acceptance/bundle/resources/permissions/jobs/update/script
@@ -42,7 +42,7 @@ trace print_requests.py //jobs/ > out.requests_restore_original.json
 trace $CLI bundle plan
 
 title "Set permissions: []\n"
-grep -v '(PERMISSIONS|DELETE_ONE)' databricks.yml > tmp.yml && mv tmp.yml databricks.yml
+grep -vE '(PERMISSIONS|DELETE_ONE)' databricks.yml > tmp.yml && mv tmp.yml databricks.yml
 update_file.py databricks.yml '# permissions: [] # EXPLICIT_EMPTY' 'permissions: [] # EXPLICIT_EMPTY'
 trace $CLI bundle plan -o json > out.plan_set_empty.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy

--- a/acceptance/bundle/resources/permissions/output.txt
+++ b/acceptance/bundle/resources/permissions/output.txt
@@ -257,11 +257,12 @@ DIFF  jobs/update/out.requests_delete_all.direct.json
 +    "path": "/api/2.0/permissions/jobs/[JOB_WITH_PERMISSIONS_ID]"
 +  }
 +]
-DIFF  jobs/update/out.requests_destroy.direct.json
---- jobs/update/out.requests_destroy.direct.json
-+++ jobs/update/out.requests_destroy.terraform.json
-@@ -1,4 +1,16 @@
- [
+EXACT jobs/update/out.requests_destroy.direct.json
+DIFF  jobs/update/out.requests_set_empty.direct.json
+--- jobs/update/out.requests_set_empty.direct.json
++++ jobs/update/out.requests_set_empty.terraform.json
+@@ -1 +1,14 @@
+-[]+[
 +  {
 +    "body": {
 +      "access_control_list": [
@@ -273,11 +274,8 @@ DIFF  jobs/update/out.requests_destroy.direct.json
 +    },
 +    "method": "PUT",
 +    "path": "/api/2.0/permissions/jobs/[JOB_WITH_PERMISSIONS_ID]"
-+  },
-   {
-     "body": {
-       "job_id": "[JOB_WITH_PERMISSIONS_ID]"
-EXACT jobs/update/out.requests_set_empty.direct.json
++  }
++]
 MATCH jobs/viewers/out.requests.deploy.direct.json
 DIFF  jobs/viewers/out.requests.destroy.direct.json
 --- jobs/viewers/out.requests.destroy.direct.json

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -3,6 +3,7 @@ exclude:
   - acceptance/selftest/bundleconfig # https://github.com/google/yamlfmt/issues/254
   - acceptance/bundle/artifacts/nil_artifacts/databricks.yml # https://github.com/google/yamlfmt/issues/253
   - bundle/direct/dresources/apitypes.yml # remove comments
+  - acceptance/bundle/resources/permissions/jobs/update/databricks.yml # comment indentation is significant: it is uncommented into a top-level permissions: [] key
 formatter:
   type: basic
   retain_line_breaks_single: true


### PR DESCRIPTION
The "Set permissions: []" step never tested an empty list, due to two independent bugs. The `# permissions: []` line was indented one level too deep, so uncommenting it attached `permissions: []` as a field inside an ACL entry rather than as a top-level key (`unknown field: permissions`). And `grep -v '(PERMISSIONS|DELETE_ONE)'` used a basic regex that matched the alternation literally and stripped nothing, so the original permissions were never removed.

## Why
Confirms that `permissions: []` produces the same plan and requests as removing the permissions block entirely, for both engines.