### PR TITLE
testserver: echo columns_to_sync/columns_to_index on VS index reads

### DIFF
--- a/libs/testserver/vector_search_indexes.go
+++ b/libs/testserver/vector_search_indexes.go
@@ -177,6 +177,8 @@ func remapDeltaSyncSpec(req *vectorsearch.DeltaSyncVectorIndexSpecRequest) *vect
 		return nil
 	}
 	return &vectorsearch.DeltaSyncVectorIndexSpecResponse{
+		ColumnsToIndex:          req.ColumnsToIndex,
+		ColumnsToSync:           req.ColumnsToSync,
 		EmbeddingSourceColumns:  req.EmbeddingSourceColumns,
 		EmbeddingVectorColumns:  req.EmbeddingVectorColumns,
 		EmbeddingWritebackTable: req.EmbeddingWritebackTable,


### PR DESCRIPTION
Production RemapState already round-trips both fields from the GET response, but the testserver was dropping them. Bring the fake in line with the real backend.