### PR TITLE
Validate empty invalid_keywords in model serving guardrails

### DIFF
--- a/.nextchanges/bundles/model-serving-invalid-keywords.md
+++ b/.nextchanges/bundles/model-serving-invalid-keywords.md
@@ -1,0 +1,1 @@
+* `bundle validate` now reports a clear error when a model serving endpoint's AI gateway `invalid_keywords` list contains an empty entry, instead of letting the Terraform provider panic during deploy.

--- a/acceptance/bundle/validate/model_serving_invalid_keywords/databricks.yml
+++ b/acceptance/bundle/validate/model_serving_invalid_keywords/databricks.yml
@@ -6,15 +6,14 @@ resources:
     endpoint1:
       name: test-endpoint
       ai_gateway:
+        # Empty invalid_keywords entries crash the Terraform provider on deploy.
         guardrails:
           input:
             invalid_keywords:
               - secret
-              # Empty entry crashes the Terraform provider during marshaling.
               - ""
           output:
             invalid_keywords:
-              # Empty entry crashes the Terraform provider during marshaling.
               - ""
       config:
         served_entities:

--- a/acceptance/bundle/validate/model_serving_invalid_keywords/databricks.yml
+++ b/acceptance/bundle/validate/model_serving_invalid_keywords/databricks.yml
@@ -1,0 +1,22 @@
+bundle:
+  name: test-bundle
+
+resources:
+  model_serving_endpoints:
+    endpoint1:
+      name: test-endpoint
+      ai_gateway:
+        guardrails:
+          input:
+            invalid_keywords:
+              - secret
+              # Empty entry crashes the Terraform provider during marshaling.
+              - ""
+          output:
+            invalid_keywords:
+              # Empty entry crashes the Terraform provider during marshaling.
+              - ""
+      config:
+        served_entities:
+          - entity_name: my-entity
+            entity_version: "2"

--- a/acceptance/bundle/validate/model_serving_invalid_keywords/out.test.toml
+++ b/acceptance/bundle/validate/model_serving_invalid_keywords/out.test.toml
@@ -1,0 +1,5 @@
+Local = true
+Cloud = false
+GOOSOnPR.darwin = false
+GOOSOnPR.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/validate/model_serving_invalid_keywords/output.txt
+++ b/acceptance/bundle/validate/model_serving_invalid_keywords/output.txt
@@ -6,7 +6,7 @@ Error: invalid_keywords entry must not be empty
 
 Error: invalid_keywords entry must not be empty
   at resources.model_serving_endpoints.endpoint1.ai_gateway.guardrails.output.invalid_keywords[0]
-  in databricks.yml:18:17
+  in databricks.yml:17:17
 
 Name: test-bundle
 Target: default

--- a/acceptance/bundle/validate/model_serving_invalid_keywords/output.txt
+++ b/acceptance/bundle/validate/model_serving_invalid_keywords/output.txt
@@ -1,0 +1,19 @@
+
+>>> [CLI] bundle validate
+Error: invalid_keywords entry must not be empty
+  at resources.model_serving_endpoints.endpoint1.ai_gateway.guardrails.input.invalid_keywords[1]
+  in databricks.yml:14:17
+
+Error: invalid_keywords entry must not be empty
+  at resources.model_serving_endpoints.endpoint1.ai_gateway.guardrails.output.invalid_keywords[0]
+  in databricks.yml:18:17
+
+Name: test-bundle
+Target: default
+Workspace:
+  User: [USERNAME]
+  Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Found 2 errors
+
+Exit code: 1

--- a/acceptance/bundle/validate/model_serving_invalid_keywords/script
+++ b/acceptance/bundle/validate/model_serving_invalid_keywords/script
@@ -1,0 +1,1 @@
+trace $CLI bundle validate

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -174,12 +174,9 @@ func warnForMissingGrantPrincipals(ctx context.Context, b *bundle.Bundle) diag.D
 	return diags
 }
 
-// errorForEmptyGuardrailKeywords errors for any empty entry in a model serving
-// endpoint's AI gateway guardrail invalid_keywords list. An empty (or null) element
-// makes the Terraform provider panic while marshaling the config
-// ("invalid_keywords[<nil>] is not a string") before the API call is made, so no
-// endpoint is created. An empty keyword is also meaningless for keyword matching, so
-// reject it early with a clear location instead of leaking the provider crash.
+// errorForEmptyGuardrailKeywords errors for empty entries in a model serving guardrail
+// invalid_keywords list. An empty (or null) entry makes the Terraform provider panic
+// ("invalid_keywords[<nil>] is not a string") while marshaling, before the API call.
 func errorForEmptyGuardrailKeywords(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -174,6 +174,48 @@ func warnForMissingGrantPrincipals(ctx context.Context, b *bundle.Bundle) diag.D
 	return diags
 }
 
+// errorForEmptyGuardrailKeywords errors for any empty entry in a model serving
+// endpoint's AI gateway guardrail invalid_keywords list. An empty (or null) element
+// makes the Terraform provider panic while marshaling the config
+// ("invalid_keywords[<nil>] is not a string") before the API call is made, so no
+// endpoint is created. An empty keyword is also meaningless for keyword matching, so
+// reject it early with a clear location instead of leaking the provider crash.
+func errorForEmptyGuardrailKeywords(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	_, err := dyn.MapByPattern(
+		b.Config.Value(),
+		dyn.NewPattern(
+			dyn.Key("resources"),
+			dyn.Key("model_serving_endpoints"),
+			dyn.AnyKey(),
+			dyn.Key("ai_gateway"),
+			dyn.Key("guardrails"),
+			dyn.AnyKey(),
+			dyn.Key("invalid_keywords"),
+			dyn.AnyIndex(),
+		),
+		func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
+			if isMissingOrEmptyString(v) {
+				diags = diags.Append(diag.Diagnostic{
+					Severity:  diag.Error,
+					Summary:   "invalid_keywords entry must not be empty",
+					Locations: v.Locations(),
+					Paths:     []dyn.Path{slices.Clone(p)},
+				})
+			}
+			return v, nil
+		},
+	)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	sortDiagnostics(diags)
+
+	return diags
+}
+
 // isMissingOrEmptyString reports whether v is unset, null, or an empty string.
 func isMissingOrEmptyString(v dyn.Value) bool {
 	switch v.Kind() {
@@ -188,6 +230,7 @@ func isMissingOrEmptyString(v dyn.Value) bool {
 
 func (f *required) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := errorForMissingFields(ctx, b)
+	diags = diags.Extend(errorForEmptyGuardrailKeywords(ctx, b))
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
## Changes

`bundle validate` now errors when a model serving endpoint's AI gateway `invalid_keywords` list (input or output guardrails) contains an empty entry, instead of passing validation and crashing later on deploy:

```
Error: invalid_keywords entry must not be empty
  at resources.model_serving_endpoints.endpoint1.ai_gateway.guardrails.input.invalid_keywords[1]
```

## Why

An empty (or null) `invalid_keywords` entry makes the Terraform provider panic during marshaling, *before* the API call, so `validate` passed but `deploy` crashed and no endpoint was created:

```
cannot create model serving: panic: ... invalid_keywords[<nil>] is not a string
```

The direct engine accepts the same config, so we now reject the meaningless empty keyword early on both engines with an actionable path, rather than leaking the provider crash. Same class of bug as the empty task-parameter panic in #5950; found via fuzz testing. The provider panic should be filed upstream in `terraform-provider-databricks`.

## Tests

- New acceptance test `acceptance/bundle/validate/model_serving_invalid_keywords/` (both engines), covering empty entries in `input` and `output` guardrails.