### PR TITLE
acc: normalize UC managed-default properties out of goldens

### DIFF
--- a/acceptance/bin/normalize_uc_payload.py
+++ b/acceptance/bin/normalize_uc_payload.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Normalize a UC JSON payload read from stdin, writing the result to stdout. The payload
+is either a bundle plan or a `catalogs get` / `schemas get` response; the same pruning
+applies to both (the plan-only `changes` handling simply does not fire on a GET response).
+
+UC managed-default properties (unity.catalog.managed.<format>.defaults.*) are ALWAYS
+pruned. UC auto-populates these on every catalog/schema, but only on some clouds (AWS/GCP
+yes, Azure no), so a committed golden cannot show them. The CLI already classifies them as
+backend defaults, so they never affect the plan; dropping them here is output-only.
+
+Managed properties surface in three shapes, all handled by pruning matching keys:
+  - a `properties` map (remote_state.properties, new_state.value.properties, ...);
+    an emptied `properties` object is then dropped so {} vs absent doesn't diverge.
+  - a `changes` entry keyed `properties` or `properties['unity.catalog.managed...']`;
+    an emptied `changes` object is likewise dropped.
+
+Any field names passed as arguments are additionally deleted wherever they appear. These
+are the volatile server-set fields (created_at, metastore_id, schema_id, ...) each test
+previously stripped with an inline `jq 'walk(del(...))'`; the set is test-specific, so it
+stays at the call site rather than being centralized here.
+"""
+
+import json
+import re
+import sys
+
+# Matches a managed-default property key, whether bare (as a map key) or wrapped in a
+# plan change key like properties['unity.catalog.managed.delta.defaults.delta....'].
+managed_re = re.compile(r"unity\.catalog\.managed\..*\.defaults\..*")
+
+
+def is_managed_change(key, value):
+    """Report whether a plan `changes` entry is purely a managed-default change.
+
+    UC emits the managed-property drift either per key (change key
+    `properties['unity.catalog.managed...']`) or as the whole map at the parent path
+    (bare `properties` key, managed map under `remote`). Both are backend defaults the
+    CLI already skips, so they are output noise.
+
+    >>> is_managed_change("properties['unity.catalog.managed.a.defaults.b']", {"action": "skip"})
+    True
+    >>> is_managed_change("properties", {"action": "skip", "reason": "backend_default", "remote": {"unity.catalog.managed.a.defaults.b": "1"}})
+    True
+    >>> is_managed_change("properties", {"action": "update", "remote": {"custom": "v"}})
+    False
+    >>> is_managed_change("name", {"action": "update"})
+    False
+    """
+    if managed_re.search(key):
+        return True
+    if key != "properties" or not isinstance(value, dict):
+        return False
+    remote = value.get("remote")
+    return isinstance(remote, dict) and bool(remote) and all(managed_re.search(k) for k in remote)
+
+
+def prune(node, drop_fields):
+    """Recursively drop managed-default properties and the given volatile fields.
+
+    >>> prune({"created_at": 1, "name": "c"}, {"created_at"})
+    {'name': 'c'}
+    >>> prune({"properties": {"unity.catalog.managed.delta.defaults.x": "true"}}, set())
+    {}
+    >>> prune({"properties": {"unity.catalog.managed.delta.defaults.x": "1", "k": "v"}}, set())
+    {'properties': {'k': 'v'}}
+    >>> prune({"changes": {"properties": {"action": "skip", "remote": {"unity.catalog.managed.a.defaults.b": "1"}}, "name": {"action": "update"}}}, set())
+    {'changes': {'name': {'action': 'update'}}}
+    >>> prune([{"metastore_id": "m", "full_name": "c.s"}], {"metastore_id"})
+    [{'full_name': 'c.s'}]
+    """
+    if isinstance(node, list):
+        return [prune(v, drop_fields) for v in node]
+    if not isinstance(node, dict):
+        return node
+
+    result = {}
+    for key, value in node.items():
+        if key in drop_fields or managed_re.search(key):
+            continue
+        if key == "changes" and isinstance(value, dict):
+            value = {k: v for k, v in value.items() if not is_managed_change(k, v)}
+        pruned = prune(value, drop_fields)
+        # Drop a properties/changes object emptied by managed-key removal so goldens
+        # don't diverge on {} (cloud that injects) vs absent (cloud that doesn't).
+        if key in ("properties", "changes") and pruned == {}:
+            continue
+        result[key] = pruned
+    return result
+
+
+def main():
+    drop_fields = set(sys.argv[1:])
+    data = json.load(sys.stdin)
+    json.dump(prune(data, drop_fields), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/acceptance/bundle/resources/catalogs/basic/script
+++ b/acceptance/bundle/resources/catalogs/basic/script
@@ -15,7 +15,7 @@ title "Deploy bundle with catalog"
 trace $CLI bundle deploy
 
 title "Assert the catalog is created"
-trace $CLI catalogs get "${CATALOG_NAME}" | jq "{name, comment, properties}"
+trace $CLI catalogs get "${CATALOG_NAME}" | jq "{name, comment, properties}" | normalize_uc_payload.py
 
 title "Update catalog comment"
 update_file.py databricks.yml "This catalog was created from DABs" "Updated comment from DABs"

--- a/acceptance/bundle/resources/catalogs/with-schemas/script
+++ b/acceptance/bundle/resources/catalogs/with-schemas/script
@@ -19,7 +19,7 @@ title "Deploy bundle with catalog and schema"
 trace $CLI bundle deploy
 
 title "Assert the catalog is created"
-trace $CLI catalogs get "${CATALOG_NAME}" | jq "{name, comment, properties}"
+trace $CLI catalogs get "${CATALOG_NAME}" | jq "{name, comment, properties}" | normalize_uc_payload.py
 
 title "Assert schema is created in the custom catalog"
 trace $CLI schemas get "${SCHEMA_FULL_NAME}" | jq "{full_name, catalog_name, comment}"

--- a/acceptance/bundle/resources/grants/catalogs/script
+++ b/acceptance/bundle/resources/grants/catalogs/script
@@ -1,8 +1,7 @@
 envsubst < databricks.yml.tmpl > databricks.yml
 
 trace $CLI bundle plan
-trace $CLI bundle plan -o json > out.plan1.$DATABRICKS_BUNDLE_ENGINE.json
-jq 'walk(if type == "object" then del(.created_at, .created_by, .updated_at, .updated_by, .metastore_id, .browse_only, .effective_predictive_optimization_flag, .enable_predictive_optimization, .isolation_mode, .securable_type) else . end)' out.plan1.$DATABRICKS_BUNDLE_ENGINE.json > tmp.json && mv tmp.json out.plan1.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | normalize_uc_payload.py created_at created_by updated_at updated_by metastore_id browse_only effective_predictive_optimization_flag enable_predictive_optimization isolation_mode securable_type > out.plan1.$DATABRICKS_BUNDLE_ENGINE.json
 trace print_requests.py --get //permissions
 trace $CLI bundle deploy
 trace print_requests.py //permissions > out.deploy1.requests.$DATABRICKS_BUNDLE_ENGINE.json
@@ -14,8 +13,7 @@ trace $CLI grants get catalog catalog_grants_$UNIQUE_NAME | jq --sort-keys
 
 update_file.py databricks.yml CREATE_SCHEMA USE_SCHEMA
 
-trace $CLI bundle plan -o json > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
-jq 'walk(if type == "object" then del(.created_at, .created_by, .updated_at, .updated_by, .metastore_id, .browse_only, .effective_predictive_optimization_flag, .enable_predictive_optimization, .isolation_mode, .securable_type) else . end)' out.plan2.$DATABRICKS_BUNDLE_ENGINE.json > tmp.json && mv tmp.json out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | normalize_uc_payload.py created_at created_by updated_at updated_by metastore_id browse_only effective_predictive_optimization_flag enable_predictive_optimization isolation_mode securable_type > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
 trace print_requests.py --get //permissions
 trace $CLI bundle deploy
 trace print_requests.py //permissions > out.deploy2.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/schemas/change_privilege/script
+++ b/acceptance/bundle/resources/grants/schemas/change_privilege/script
@@ -13,8 +13,7 @@ trace $CLI grants get schema main.schema_grants_$UNIQUE_NAME | jq --sort-keys
 
 update_file.py databricks.yml USE_SCHEMA APPLY_TAG
 
-trace $CLI bundle plan -o json > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
-jq 'walk(if type == "object" then del(.effective_predictive_optimization_flag, .enable_predictive_optimization, .metastore_id, .schema_id, .updated_at, .updated_by) else . end)' out.plan2.$DATABRICKS_BUNDLE_ENGINE.json > tmp.json && mv tmp.json out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | normalize_uc_payload.py effective_predictive_optimization_flag enable_predictive_optimization metastore_id schema_id updated_at updated_by > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
 trace print_requests.py --get //permissions
 trace $CLI bundle deploy
 trace print_requests.py //permissions > out.deploy2.requests.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/out.plan.direct.json
@@ -10,16 +10,14 @@
         "browse_only": false,
         "catalog_name": "main",
         "catalog_type": "MANAGED_CATALOG",
-        "created_at": [UNIX_TIME_MILLIS][0],
+        "created_at": [UNIX_TIME_MILLIS],
         "created_by": "[USERNAME]",
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_dup_grants_[UNIQUE_NAME]",
         "metastore_id": "[UUID]",
         "name": "schema_dup_grants_[UNIQUE_NAME]",
         "owner": "[USERNAME]",
-        "schema_id": "[UUID]",
-        "updated_at": [UNIX_TIME_MILLIS][1],
-        "updated_by": "[USERNAME]"
+        "schema_id": "[UUID]"
       }
     },
     "resources.schemas.apps_schema.grants": {

--- a/acceptance/bundle/resources/grants/schemas/duplicate_principals/script
+++ b/acceptance/bundle/resources/grants/schemas/duplicate_principals/script
@@ -9,7 +9,6 @@ trap cleanup EXIT
 # Same principal listed twice with the same privilege.
 trace $CLI bundle deploy
 print_requests.py --get //permissions --keep > out.requests.$DATABRICKS_BUNDLE_ENGINE.txt
-trace $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
-tmp=$(mktemp)
 # effective_predictive_optimization_flag is inherited from the metastore and backend-controlled; drop it so the test does not depend on metastore settings.
-jq 'del(.plan["resources.schemas.apps_schema"].remote_state.effective_predictive_optimization_flag)' out.plan.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan.$DATABRICKS_BUNDLE_ENGINE.json
+# updated_at/updated_by reflect UC's post-create system write that populates managed defaults, so on managed-defaults clouds they show a system principal rather than the creator; drop them.
+trace $CLI bundle plan -o json | normalize_uc_payload.py effective_predictive_optimization_flag updated_at updated_by > out.plan.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan.direct.json
@@ -10,16 +10,14 @@
         "browse_only": false,
         "catalog_name": "main",
         "catalog_type": "MANAGED_CATALOG",
-        "created_at": [UNIX_TIME_MILLIS][0],
+        "created_at": [UNIX_TIME_MILLIS],
         "created_by": "[USERNAME]",
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_out_of_band_principal_[UNIQUE_NAME]",
         "metastore_id": "[UUID]",
         "name": "schema_out_of_band_principal_[UNIQUE_NAME]",
         "owner": "[USERNAME]",
-        "schema_id": "[UUID]",
-        "updated_at": [UNIX_TIME_MILLIS][1],
-        "updated_by": "[USERNAME]"
+        "schema_id": "[UUID]"
       }
     },
     "resources.schemas.grants_schema.grants": {

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan2.direct.json
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/out.plan2.direct.json
@@ -10,16 +10,14 @@
         "browse_only": false,
         "catalog_name": "main",
         "catalog_type": "MANAGED_CATALOG",
-        "created_at": [UNIX_TIME_MILLIS][0],
+        "created_at": [UNIX_TIME_MILLIS],
         "created_by": "[USERNAME]",
         "enable_predictive_optimization": "INHERIT",
         "full_name": "main.schema_out_of_band_principal_[UNIQUE_NAME]",
         "metastore_id": "[UUID]",
         "name": "schema_out_of_band_principal_[UNIQUE_NAME]",
         "owner": "[USERNAME]",
-        "schema_id": "[UUID]",
-        "updated_at": [UNIX_TIME_MILLIS][1],
-        "updated_by": "[USERNAME]"
+        "schema_id": "[UUID]"
       }
     },
     "resources.schemas.grants_schema.grants": {

--- a/acceptance/bundle/resources/grants/schemas/out_of_band_principal/script
+++ b/acceptance/bundle/resources/grants/schemas/out_of_band_principal/script
@@ -16,9 +16,9 @@ trace $CLI bundle plan -o json > out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 # remote_state.__embed__ order is non-deterministic; extract and sort separately into per-engine file
 jq '.plan["resources.schemas.grants_schema.grants"].remote_state.__embed__' out.plan.$DATABRICKS_BUNDLE_ENGINE.json | gron.py --noindex | sort_lines.py --repl > out.embed.$DATABRICKS_BUNDLE_ENGINE.txt
 tmp=$(mktemp)
+# __embed__ is extracted above; drop it so its non-deterministic order does not churn this golden.
 # effective_predictive_optimization_flag is inherited from the metastore and backend-controlled; drop it so the test does not depend on metastore settings.
-jq 'del(.plan["resources.schemas.grants_schema.grants"].remote_state.__embed__, .plan["resources.schemas.grants_schema"].remote_state.effective_predictive_optimization_flag)' out.plan.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan.$DATABRICKS_BUNDLE_ENGINE.json
+# updated_at/updated_by reflect UC's post-create system write that populates managed defaults, so on managed-defaults clouds they show a system principal rather than the creator; drop them.
+jq 'del(.plan["resources.schemas.grants_schema.grants"].remote_state.__embed__)' out.plan.$DATABRICKS_BUNDLE_ENGINE.json | normalize_uc_payload.py effective_predictive_optimization_flag updated_at updated_by > "$tmp" && mv "$tmp" out.plan.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
-trace $CLI bundle plan -o json > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
-tmp=$(mktemp)
-jq 'del(.plan["resources.schemas.grants_schema"].remote_state.effective_predictive_optimization_flag)' out.plan2.$DATABRICKS_BUNDLE_ENGINE.json > "$tmp" && mv "$tmp" out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | normalize_uc_payload.py effective_predictive_optimization_flag updated_at updated_by > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json

--- a/acceptance/bundle/resources/grants/volumes/script
+++ b/acceptance/bundle/resources/grants/volumes/script
@@ -10,8 +10,7 @@ trace $CLI grants get volume main.schema_grants_$UNIQUE_NAME.volume_name | jq --
 update_file.py databricks.yml WRITE_VOLUME MANAGE
 
 # different on cloud vs local due to remote state
-trace $CLI bundle plan -o json > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
-jq 'walk(if type == "object" then del(.effective_predictive_optimization_flag, .enable_predictive_optimization, .metastore_id, .schema_id, .updated_at, .updated_by, .volume_id) else . end)' out.plan2.$DATABRICKS_BUNDLE_ENGINE.json > tmp.json && mv tmp.json out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
+trace $CLI bundle plan -o json | normalize_uc_payload.py effective_predictive_optimization_flag enable_predictive_optimization metastore_id schema_id updated_at updated_by volume_id > out.plan2.$DATABRICKS_BUNDLE_ENGINE.json
 trace $CLI bundle deploy
 trace print_requests.py //permissions > out.deploy2.requests.$DATABRICKS_BUNDLE_ENGINE.json
 

--- a/acceptance/bundle/resources/schemas/recreate/output.txt
+++ b/acceptance/bundle/resources/schemas/recreate/output.txt
@@ -71,7 +71,7 @@ Error: Resource catalog.SchemaInfo not found: main.myschema
   "catalog_name": "newmain",
   "catalog_type": "MANAGED_CATALOG",
   "comment": "COMMENT1",
-  "created_at": [UNIX_TIME_MILLIS][0],
+  "created_at": [UNIX_TIME_MILLIS],
   "created_by": "[USERNAME]",
   "effective_predictive_optimization_flag": {
     "inherited_from_name": "[METASTORE_NAME]",
@@ -83,7 +83,5 @@ Error: Resource catalog.SchemaInfo not found: main.myschema
   "metastore_id": "[UUID]",
   "name": "myschema",
   "owner": "[USERNAME]",
-  "schema_id": "[UUID]",
-  "updated_at": [UNIX_TIME_MILLIS][0],
-  "updated_by": "[USERNAME]"
+  "schema_id": "[UUID]"
 }

--- a/acceptance/bundle/resources/schemas/recreate/script
+++ b/acceptance/bundle/resources/schemas/recreate/script
@@ -11,5 +11,6 @@ trace $CLI bundle deploy --auto-approve
 trace print_requests.py //unity
 
 trace musterr $CLI schemas get main.myschema
-trace $CLI schemas get newmain.myschema
+# updated_at/updated_by reflect UC's post-create system write that populates managed defaults, so on managed-defaults clouds they show a system principal rather than the creator; drop them (the managed properties map is pruned automatically).
+trace $CLI schemas get newmain.myschema | normalize_uc_payload.py updated_at updated_by
 rm out.requests.txt


### PR DESCRIPTION
UC auto-populates `unity.catalog.managed.*.defaults.*` properties on every catalog and schema after create. The CLI already treats these as backend defaults (no plan drift), but they leak into acceptance goldens, and since the rollout is partial (AWS/GCP inject, Azure doesn't), a shared golden can't be right for all clouds, and each new key re-churns them.

Adds `acceptance/bin/normalize_uc_payload.py`, a structural JSON filter that prunes managed-default keys wherever they appear (plan or `catalogs get`/`schemas get` output), drops the emptied containers, and drops any extra volatile fields passed as args. Replaces the copy-pasted inline `jq 'walk(del(...))'` across the UC grant/catalog tests.

**Secondary effect:** cloud runs also failed on `updated_by`. Probing the backend showed UC populates the managed defaults via a separate write by a *system principal* a few seconds after create, so `updated_by` becomes a system UUID (not the creator) and `updated_at` shifts. Same backend behavior, different fields. Fixed by dropping `updated_at`/`updated_by` in the two schema-grant tests that still kept them. (Volumes get no such write, so those tests are untouched.)

No CLI/engine change, test fidelity only. Verified against a real workspace.

This pull request and its description were written by Isaac.