### PR TITLE
Fix deadlock in testcli Runner.Eventually on timeout

### DIFF
--- a/internal/testcli/runner.go
+++ b/internal/testcli/runner.go
@@ -236,9 +236,19 @@ func (r *Runner) Eventually(condition func() bool, waitFor, tick time.Duration, 
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
+	// Closed when this function returns to release any condition goroutine still
+	// blocked sending into the size-1 [ch]. Without it, a timeout leaves in-flight
+	// senders stuck forever and the deferred [wg.Wait] deadlocks. The defer order
+	// matters: [close] runs before [wg.Wait] (defers run last-in-first-out).
+	done := make(chan struct{})
+	defer close(done)
+
 	// Kick off condition check immediately.
 	wg.Go(func() {
-		ch <- condition()
+		select {
+		case ch <- condition():
+		case <-done:
+		}
 	})
 
 	for tick := ticker.C; ; {
@@ -252,7 +262,10 @@ func (r *Runner) Eventually(condition func() bool, waitFor, tick time.Duration, 
 		case <-tick:
 			tick = nil
 			wg.Go(func() {
-				ch <- condition()
+				select {
+				case ch <- condition():
+				case <-done:
+				}
 			})
 		case v := <-ch:
 			if v {


### PR DESCRIPTION
On the timeout path, `Eventually` returned while tick-spawned condition goroutines were still blocked sending into a size-1 channel, so the deferred `wg.Wait()` hung forever — turning a 30s assertion timeout into a 2h binary panic that also skipped ~10 other tests. Latent ~a year; surfaced once under GCP workspace-files slowness that stalled a continuous-sync watcher.

Fix: close a `done` channel on return and make the sends non-blocking (`select` on `ch <- condition()` vs `<-done`), so in-flight senders unblock and `wg.Wait()` drains.

This pull request and its description were written by Isaac.