### PR TITLE
AIR CLI: always upload requirements.yaml on the run submit path

### DIFF
--- a/experimental/air/cmd/runupload.go
+++ b/experimental/air/cmd/runupload.go
@@ -72,6 +72,9 @@ func buildArtifacts(cfg *runConfig, configPath string) ([]uploadItem, error) {
 		{commandScriptName, []byte(*cfg.Command)},
 	}
 
+	// The AI Runtime launcher always reads <func_dir>/requirements.yaml, so always
+	// upload one: the declared file, a synthesized one from inline dependencies, or
+	// an empty doc. Without it the task fails at launch.
 	switch reqPath, ok := cfg.requirementsFile(); {
 	case ok:
 		// Resolve a relative requirements path against the config's directory.
@@ -84,14 +87,15 @@ func buildArtifacts(cfg *runConfig, configPath string) ([]uploadItem, error) {
 		}
 		items = append(items, uploadItem{requirementsName, data})
 	default:
-		if deps, ok := cfg.inlineDependencies(); ok {
-			version, _ := cfg.runtimeVersion()
-			data, err := yaml.Marshal(requirementsDoc{Version: version, Dependencies: deps})
-			if err != nil {
-				return nil, fmt.Errorf("failed to synthesize requirements.yaml: %w", err)
-			}
-			items = append(items, uploadItem{requirementsName, data})
+		// deps is nil when no inline dependencies are set, which marshals to an
+		// empty dependency list.
+		deps, _ := cfg.inlineDependencies()
+		version, _ := cfg.runtimeVersion()
+		data, err := yaml.Marshal(requirementsDoc{Version: version, Dependencies: deps})
+		if err != nil {
+			return nil, fmt.Errorf("failed to synthesize requirements.yaml: %w", err)
 		}
+		items = append(items, uploadItem{requirementsName, data})
 	}
 
 	if len(cfg.Parameters) > 0 {

--- a/experimental/air/cmd/runupload_test.go
+++ b/experimental/air/cmd/runupload_test.go
@@ -52,9 +52,11 @@ func TestBuildArtifacts_CommandAndConfig(t *testing.T) {
 
 	items, err := buildArtifacts(cfg, path)
 	require.NoError(t, err)
-	assert.Equal(t, []string{trainingConfigName, commandScriptName}, itemNames(items))
+	// requirements.yaml is always uploaded; with no dependencies it is an empty doc.
+	assert.Equal(t, []string{trainingConfigName, commandScriptName, requirementsName}, itemNames(items))
 	assert.Equal(t, minimalConfig, string(items[0].data))
 	assert.Equal(t, "python train.py", string(items[1].data))
+	assert.Equal(t, "dependencies: []\n", string(items[2].data))
 }
 
 func TestBuildArtifacts_InlineRequirementsAndParameters(t *testing.T) {


### PR DESCRIPTION
## Changes & Why

The AI Runtime launcher reads <func_dir>/requirements.yaml for every run. The Go CLI only uploaded it when a requirements file or inline dependencies were declared, so a run with no dependencies (e.g. a plain command) shipped no requirements.yaml and failed at launch with RUN_EXECUTION_ERROR. Jobs then retried, and the retries surfaced an unrelated PrincipalContext propagation error, masking the real cause.

Always upload requirements.yaml: the declared file, a synthesized doc from inline dependencies, or an empty doc when neither is set. This matches the Python CLI, which synthesizes an empty requirements.yaml for the AI Runtime path.

## Tests
- added 3 unit tests in `experimental/air/cmd/runupload_test.go` for each of the three branches as described above
- Manual verification: see screenshot below; was able to acquire gpu and run with same quickstart payload 
<img width="1452" height="496" alt="Screenshot 2026-07-22 at 11 29 13 AM" src="https://github.com/user-attachments/assets/84f15e89-0d72-4580-9d0b-2a538e986df1" />
