### PR TITLE
Fix instance_pools no-drift and continue_293 invariant tests

### DIFF
--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -18,7 +18,6 @@ EnvMatrix.INPUT_CONFIG = [
   "database_instance.yml.tmpl",
   "experiment.yml.tmpl",
   "external_location.yml.tmpl",
-  "instance_pool.yml.tmpl",
   "job.yml.tmpl",
   "job_pydabs_10_tasks.yml.tmpl",
   "job_run_job_ref.yml.tmpl",

--- a/acceptance/bundle/invariant/continue_293/test.toml
+++ b/acceptance/bundle/invariant/continue_293/test.toml
@@ -13,6 +13,9 @@ EnvMatrixExclude.no_vector_search_index = ["INPUT_CONFIG=vector_search_index.yml
 # genie_spaces resource is not supported on v0.293.0
 EnvMatrixExclude.no_genie_space = ["INPUT_CONFIG=genie_space.yml.tmpl"]
 
+# instance_pools resource is not supported on v0.293.0
+EnvMatrixExclude.no_instance_pool = ["INPUT_CONFIG=instance_pool.yml.tmpl"]
+
 # job_runs resource is not supported on v0.293.0
 EnvMatrixExclude.no_job_run = ["INPUT_CONFIG=job_run.yml.tmpl"]
 

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -617,6 +617,7 @@ resources:
       - field: enable_elastic_disk
       # Backend applies a default of 60 minutes when the field is omitted.
       - field: idle_instance_autotermination_minutes
+        values: [60]
 
   sql_warehouses:
     ignore_remote_changes:

--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -615,6 +615,8 @@ resources:
     backend_defaults:
       # Defaults to true server-side.
       - field: enable_elastic_disk
+      # Backend applies a default of 60 minutes when the field is omitted.
+      - field: idle_instance_autotermination_minutes
 
   sql_warehouses:
     ignore_remote_changes:


### PR DESCRIPTION
## Why

The `instance_pools` invariant tests fail on every cloud in the push-to-main integration run. They're skipped on PRs, so the bug landed unnoticed via #5934.

## What

- **`no_drift`:** the backend defaults `idle_instance_autotermination_minutes` to `60` when omitted, so the re-plan saw `remote=60` vs `config=0` and reported an `Update`. Add it to `instance_pools.backend_defaults` (pinned to `60`), mirroring `enable_elastic_disk`.
- **`continue_293`:** v0.293.0 predates the resource type and drops it (`unknown field: instance_pools`), so the seed deploy yields no state. Exclude it, matching `vector_search`/`genie_space`/`job_run`.

## Verified

`no_drift` passes on a real AWS workspace via deco — plan JSON shows `idle_instance_autotermination_minutes` skipped with reason `backend_default`, no remaining drift.