### PR TITLE
Skip TestFetchRepositoryInfoAPI_FromRepo on GCP

### DIFF
--- a/integration/libs/git/git_fetch_test.go
+++ b/integration/libs/git/git_fetch_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/databricks/cli/integration/internal/acc"
+	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/dbr"
 	"github.com/databricks/cli/libs/git"
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,13 @@ func ensureWorkspacePrefix(root string) string {
 }
 
 func TestFetchRepositoryInfoAPI_FromRepo(t *testing.T) {
+	// On GCP the Repos API returns no branch, commit, or origin URL for a
+	// freshly-cloned repo, so FetchRepositoryInfo comes back empty and the
+	// assertions in assertFullGitInfo fail.
+	if testutil.GetCloud(t) == testutil.GCP {
+		t.Skip("Skipping on GCP: Repos API does not return git metadata")
+	}
+
 	ctx, wt := acc.WorkspaceTest(t)
 	targetPath := ensureWorkspacePrefix(acc.TemporaryRepo(wt, examplesRepoUrl))
 


### PR DESCRIPTION
On GCP the Repos API returns no branch, commit, or origin URL for a freshly-cloned repo, so `git.FetchRepositoryInfo` comes back empty and the `assertFullGitInfo` assertions (branch `main`, non-empty commit, origin URL) fail. The `/root` and `/subdir` subtests fail deterministically on both GCP linux and windows in every nightly run.

Skip the test on GCP via `testutil.GetCloud(t)`. It continues to run on AWS and Azure, where the API returns full git metadata.

This is a workaround for the GCP Repos-API gap, not a fix for it.

This pull request and its description were written by Isaac.