### PR TITLE
acc: normalize UC managed-defaults in volumes/uppercase-name plan

### DIFF
--- a/acceptance/bundle/resources/volumes/uppercase-name/script
+++ b/acceptance/bundle/resources/volumes/uppercase-name/script
@@ -17,7 +17,12 @@ if [ "$DATABRICKS_BUNDLE_ENGINE" = "direct" ]; then
         >> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
 
     echo "=== Plan on no-op redeploy: mixed-case names are skipped, not recreated" >> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
+    # UC injects managed-default properties on the schema, but only on some clouds
+    # (AWS/GCP yes, Azure no) and via an async system write seconds after create, so
+    # the schema's `properties` change is present nondeterministically. Prune it with
+    # normalize_uc_payload.py before reshaping so the golden matches everywhere. See #6027.
     $CLI bundle plan -o json \
+        | normalize_uc_payload.py \
         | jq '.plan | to_entries | map({resource: .key, changes: (.value.changes // {} | map_values({action, reason}))})' \
         >> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
 

--- a/acceptance/bundle/resources/volumes/uppercase-name/script
+++ b/acceptance/bundle/resources/volumes/uppercase-name/script
@@ -17,10 +17,10 @@ if [ "$DATABRICKS_BUNDLE_ENGINE" = "direct" ]; then
         >> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
 
     echo "=== Plan on no-op redeploy: mixed-case names are skipped, not recreated" >> out.deploy.$DATABRICKS_BUNDLE_ENGINE.txt
-    # UC injects managed-default properties on the schema, but only on some clouds
-    # (AWS/GCP yes, Azure no) and via an async system write seconds after create, so
-    # the schema's `properties` change is present nondeterministically. Prune it with
-    # normalize_uc_payload.py before reshaping so the golden matches everywhere. See #6027.
+    # UC injects managed-default properties on the schema via an async system write
+    # seconds after create, so the schema's `properties` change is present
+    # nondeterministically. Prune it with normalize_uc_payload.py before reshaping so
+    # the golden is stable. See #6027 and #6040.
     $CLI bundle plan -o json \
         | normalize_uc_payload.py \
         | jq '.plan | to_entries | map({resource: .key, changes: (.value.changes // {} | map_values({action, reason}))})' \


### PR DESCRIPTION
Follow-up to #6027, which normalized UC managed-default properties out of the catalog and grant goldens but missed `resources/volumes/uppercase-name`. That test prints a schema's plan `changes`, so it surfaces the same managed-default `properties` entry and kept drifting on the cloud nightly.

The backend behavior is cloud-partial and racy: UC injects these on AWS/GCP but not Azure, via a system write seconds after create — so the field appears nondeterministically (hard-fail on GCP, flaky on AWS, absent on Azure). Pinning it into the golden would just flip which side of the race fails, so it must be pruned. Pipe the raw plan through `normalize_uc_payload.py` before the reshaping `jq`, as #6027 does elsewhere. No golden change; test-fidelity only.

This pull request and its description were written by Isaac.