### PR TITLE
Reject grants missing a principal at validation

### DIFF
--- a/.nextchanges/bundles/grant-principal-required.md
+++ b/.nextchanges/bundles/grant-principal-required.md
@@ -1,0 +1,1 @@
+`bundle validate` and `bundle deploy` now reject a grant that is missing a `principal` with an error instead of a warning. Previously the deploy would start and, on the direct engine, create the securable before the grants PATCH failed (`400 INVALID_PARAMETER_VALUE`), leaving a partially-applied deployment.

--- a/acceptance/bundle/validate/grants_required_principal/databricks.yml
+++ b/acceptance/bundle/validate/grants_required_principal/databricks.yml
@@ -6,7 +6,7 @@ resources:
     my_catalog:
       name: my_catalog
       grants:
-        # Missing principal (warns).
+        # Missing principal: rejected (the backend requires one).
         - privileges:
             - ALL_PRIVILEGES
   schemas:

--- a/acceptance/bundle/validate/grants_required_principal/databricks.yml
+++ b/acceptance/bundle/validate/grants_required_principal/databricks.yml
@@ -6,7 +6,7 @@ resources:
     my_catalog:
       name: my_catalog
       grants:
-        # Missing principal: rejected (the backend requires one).
+        # Missing principal: rejected.
         - privileges:
             - ALL_PRIVILEGES
   schemas:

--- a/acceptance/bundle/validate/grants_required_principal/output.txt
+++ b/acceptance/bundle/validate/grants_required_principal/output.txt
@@ -12,14 +12,10 @@ Workspace:
 
 Found 1 error
 
-Exit code: 1
-
 >>> [CLI] bundle deploy
 Error: grant principal is required
   at resources.catalogs.my_catalog.grants[0]
   in databricks.yml:10:11
 
-
-Exit code: 1
 
 >>> print_requests.py //unity-catalog

--- a/acceptance/bundle/validate/grants_required_principal/output.txt
+++ b/acceptance/bundle/validate/grants_required_principal/output.txt
@@ -1,6 +1,6 @@
 
 >>> [CLI] bundle validate
-Warning: grant principal is required
+Error: grant principal is required
   at resources.catalogs.my_catalog.grants[0]
   in databricks.yml:10:11
 
@@ -10,4 +10,16 @@ Workspace:
   User: [USERNAME]
   Path: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
 
-Found 1 warning
+Found 1 error
+
+Exit code: 1
+
+>>> [CLI] bundle deploy
+Error: grant principal is required
+  at resources.catalogs.my_catalog.grants[0]
+  in databricks.yml:10:11
+
+
+Exit code: 1
+
+>>> print_requests.py //unity-catalog

--- a/acceptance/bundle/validate/grants_required_principal/script
+++ b/acceptance/bundle/validate/grants_required_principal/script
@@ -1,1 +1,9 @@
-trace $CLI bundle validate
+errcode trace $CLI bundle validate
+
+# Deploy must abort at validation, so no securable is created and no grant is
+# applied: without this, the direct engine creates the securable and only then
+# fails the grants PATCH, leaving a partially-applied deployment.
+errcode trace $CLI bundle deploy
+trace print_requests.py //unity-catalog
+
+rm -f out.requests.txt

--- a/acceptance/bundle/validate/grants_required_principal/script
+++ b/acceptance/bundle/validate/grants_required_principal/script
@@ -1,7 +1,7 @@
-errcode trace $CLI bundle validate
+musterr trace $CLI bundle validate
 
 # Deploy must abort at validation: no securable is created, so no partial deploy.
-errcode trace $CLI bundle deploy
+musterr trace $CLI bundle deploy
 trace print_requests.py //unity-catalog
 
 rm -f out.requests.txt

--- a/acceptance/bundle/validate/grants_required_principal/script
+++ b/acceptance/bundle/validate/grants_required_principal/script
@@ -1,8 +1,6 @@
 errcode trace $CLI bundle validate
 
-# Deploy must abort at validation, so no securable is created and no grant is
-# applied: without this, the direct engine creates the securable and only then
-# fails the grants PATCH, leaving a partially-applied deployment.
+# Deploy must abort at validation: no securable is created, so no partial deploy.
 errcode trace $CLI bundle deploy
 trace print_requests.py //unity-catalog
 

--- a/acceptance/bundle/validate/grants_required_principal/test.toml
+++ b/acceptance/bundle/validate/grants_required_principal/test.toml
@@ -1,3 +1,5 @@
+RecordRequests = true
+
 # Catalogs and schemas are only supported by the direct engine.
 [EnvMatrix]
   DATABRICKS_BUNDLE_ENGINE = ["direct"]

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -144,10 +144,13 @@ func errorForMissingFields(ctx context.Context, b *bundle.Bundle) diag.Diagnosti
 	return diags
 }
 
-// warnForMissingGrantPrincipals warns for any grant that is missing a principal.
+// errorForMissingGrantPrincipals errors for any grant that is missing a principal.
 // grants[*].principal is optional in the SDK (json:"principal,omitempty") but the
-// backend requires it. Grants exist on every securable, so match any resource type.
-func warnForMissingGrantPrincipals(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
+// backend rejects a grant without one (400 INVALID_PARAMETER_VALUE). On the direct
+// engine the securable is created before grants are applied, so letting the deploy
+// start leaves a partially-applied deployment; fail validation instead. Grants exist
+// on every securable, so match any resource type.
+func errorForMissingGrantPrincipals(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
 	_, err := dyn.MapByPattern(
@@ -156,7 +159,7 @@ func warnForMissingGrantPrincipals(ctx context.Context, b *bundle.Bundle) diag.D
 		func(p dyn.Path, v dyn.Value) (dyn.Value, error) {
 			if isMissingOrEmptyString(v.Get("principal")) {
 				diags = diags.Append(diag.Diagnostic{
-					Severity:  diag.Warning,
+					Severity:  diag.Error,
 					Summary:   "grant principal is required",
 					Locations: v.Locations(),
 					Paths:     []dyn.Path{slices.Clone(p)},
@@ -188,10 +191,10 @@ func isMissingOrEmptyString(v dyn.Value) bool {
 
 func (f *required) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := errorForMissingFields(ctx, b)
+	diags = diags.Extend(errorForMissingGrantPrincipals(ctx, b))
 	if diags.HasError() {
 		return diags
 	}
 	diags = diags.Extend(warnForMissingFields(ctx, b))
-	diags = diags.Extend(warnForMissingGrantPrincipals(ctx, b))
 	return diags
 }

--- a/bundle/config/validate/required.go
+++ b/bundle/config/validate/required.go
@@ -144,12 +144,10 @@ func errorForMissingFields(ctx context.Context, b *bundle.Bundle) diag.Diagnosti
 	return diags
 }
 
-// errorForMissingGrantPrincipals errors for any grant that is missing a principal.
-// grants[*].principal is optional in the SDK (json:"principal,omitempty") but the
-// backend rejects a grant without one (400 INVALID_PARAMETER_VALUE). On the direct
-// engine the securable is created before grants are applied, so letting the deploy
-// start leaves a partially-applied deployment; fail validation instead. Grants exist
-// on every securable, so match any resource type.
+// errorForMissingGrantPrincipals errors for any grant missing a principal.
+// principal is optional in the SDK but rejected by the backend; erroring here
+// avoids a partial deploy where the securable is created before grants fail.
+// Grants exist on every securable, so match any resource type.
 func errorForMissingGrantPrincipals(ctx context.Context, b *bundle.Bundle) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 


### PR DESCRIPTION
## Changes

Promote the `grant principal is required` diagnostic from a warning to a hard validation error, so `bundle validate`/`plan`/`deploy` fail up front when a `grants[*]` entry has no `principal`.

## Why

#5818 added this as a warning only because the backend contract was unconfirmed. It's now confirmed: on the direct engine the securable is created and *then* the grants PATCH fails with `400 INVALID_PARAMETER_VALUE — at least one of 'principal' or 'principal_id' must be set`, leaving a partially-applied deployment. `principal` is the only way to name a grantee in a bundle (the config struct has no `principal_id`), so a missing one is always invalid. Erroring at validation stops the deploy before anything is created.

## Tests

Updated `acceptance/bundle/validate/grants_required_principal` to assert the error and that `bundle deploy` aborts with zero Unity Catalog requests (no partial deploy).