### PR TITLE
acc: set MSYS_NO_PATHCONV on the workspace commands in the idempotency invariants

### DIFF
--- a/acceptance/bundle/invariant/delete_idempotent/script
+++ b/acceptance/bundle/invariant/delete_idempotent/script
@@ -74,7 +74,10 @@ mv .databricks.backup .databricks
 # AlwaysPull=true would treat remote as newer and overwrite our restored local
 # state; nuking it leaves local as the sole state source, so the next plan
 # genuinely re-issues deletes for resources the server has already removed.
-$CLI workspace delete --recursive "$STATE_PATH" &> LOG.wipe_remote_state
+# MSYS_NO_PATHCONV=1 stops Git Bash on Windows from rewriting the leading-slash
+# workspace path into C:/Program Files/Git/...; it is scoped to this command so
+# the Python helpers (which need their own paths converted) are unaffected.
+MSYS_NO_PATHCONV=1 $CLI workspace delete --recursive "$STATE_PATH" &> LOG.wipe_remote_state
 cat LOG.wipe_remote_state | contains.py '!panic' '!internal error' > /dev/null
 
 if [[ -n "$READPLAN" ]]; then

--- a/acceptance/bundle/invariant/destroy_idempotent/script
+++ b/acceptance/bundle/invariant/destroy_idempotent/script
@@ -59,7 +59,10 @@ mv .databricks.backup .databricks
 
 # Recreate the workspace root path deleted by destroy1 so destroy2 proceeds
 # past the "no active deployment" check and actually re-runs resource deletions.
-$CLI workspace mkdirs "$ROOT_PATH" &> LOG.mkdirs
+# MSYS_NO_PATHCONV=1 stops Git Bash on Windows from rewriting the leading-slash
+# workspace path into C:/Program Files/Git/...; it is scoped to this command so
+# the Python helpers (which need their own paths converted) are unaffected.
+MSYS_NO_PATHCONV=1 $CLI workspace mkdirs "$ROOT_PATH" &> LOG.mkdirs
 cat LOG.mkdirs | contains.py '!panic' '!internal error' > /dev/null
 
 trace $CLI bundle destroy --auto-approve &> LOG.destroy2


### PR DESCRIPTION
The `delete_idempotent` and `destroy_idempotent` invariants (#6009) pass a workspace path to `workspace mkdirs` / `workspace delete`. On Windows, Git Bash rewrites the leading-slash argument into `C:/Program Files/Git/...`, so the CLI rejects it (`doesn't start with '/'`) and the Windows shards go red on the nightly, while Linux stays green.

Scope `MSYS_NO_PATHCONV=1` to just those two CLI invocations. Setting it for the whole invariant tree instead breaks the Python helpers (`contains.py` etc.), which rely on path conversion for their own arguments.

This pull request and its description were written by Isaac.