### PR TITLE
Clarify cluster Delete comment: terminates, does not remove

### DIFF
--- a/bundle/direct/dresources/cluster.go
+++ b/bundle/direct/dresources/cluster.go
@@ -197,7 +197,7 @@ func (r *ResourceCluster) DoUpdate(ctx context.Context, id string, config *Clust
 		return nil, err
 	} else if !desiredStarted && alreadyRunning {
 		// lifecycle.started=false: fire Delete; WaitAfterUpdate polls for TERMINATED.
-		// Delete does not remove the cluster, it just sets the state to TERMINATED.
+		// Note: Delete terminates the cluster; permanent removal is a separate API (permanent-delete).
 		_, err := r.client.Clusters.Delete(ctx, compute.DeleteCluster{ClusterId: id})
 		return nil, err
 	}
@@ -231,6 +231,7 @@ func (r *ResourceCluster) WaitAfterCreate(ctx context.Context, id string, config
 
 	if config.Lifecycle != nil && config.Lifecycle.Started != nil && !*config.Lifecycle.Started {
 		// started=false: terminate the cluster after it reaches RUNNING.
+		// Note: Delete terminates the cluster; permanent removal is a separate API (permanent-delete).
 		deleteWaiter, err := r.client.Clusters.Delete(ctx, compute.DeleteCluster{ClusterId: id})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
While reading `bundle/direct/dresources/cluster.go`, the `Clusters.Delete` calls in the `lifecycle.started=false` paths looked like they might *remove* the cluster rather than just terminate it. The naming is easy to misread.

This is a comment-only change. Reworded both `Clusters.Delete` call sites to state that Delete terminates the cluster and that permanent removal is a separate API, so the next reader does not hit the same confusion.

This pull request and its description were written by Isaac.