### PR TITLE
acc: fix change detection skipping new tests on windows/macOS PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -137,6 +137,21 @@ jobs:
         with:
           cache-key: test-${{ matrix.deployment }}
 
+      # Make origin/main available with enough history for `git diff --merge-base
+      # origin/main`, which the acceptance subset selector uses to always run the
+      # tests this PR adds/changes on the windows/macOS cells. actions/checkout does
+      # a shallow single-ref clone by default, so origin/main is otherwise absent and
+      # the diff fails, silently disabling change detection. This must run AFTER
+      # setup-build-environment, whose own checkout would re-shallow the repo. Only
+      # PRs subset tests, so the fetch is unnecessary elsewhere.
+      - name: Fetch origin/main for change detection
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --unshallow origin
+          fi
+
       - name: Run tests
         env:
           ENVFILTER: DATABRICKS_BUNDLE_ENGINE=${{ matrix.deployment }}

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -450,7 +450,7 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	// subset selector keep these tests, so detect them at most once here.
 	var changedTests map[string][]string
 	if skipLocalWithChanged || subset.enabled {
-		changedTests = selectChangedLocalTests(testDirsSet)
+		changedTests = selectChangedLocalTests(t, testDirsSet)
 	}
 	subset.changed = changedTests
 

--- a/acceptance/selftest/basic/script
+++ b/acceptance/selftest/basic/script
@@ -36,3 +36,6 @@ trace $CLI --version
 touch ignored_file.txt
 mkdir ignored_dir
 touch ignored_dir/hello.txt
+
+printf "\n=== TEMP: intentional divergence to verify change detection selects this test\n"
+echo "this line is not in output.txt and must fail the golden comparison"

--- a/acceptance/selftest/basic/script
+++ b/acceptance/selftest/basic/script
@@ -36,6 +36,3 @@ trace $CLI --version
 touch ignored_file.txt
 mkdir ignored_dir
 touch ignored_dir/hello.txt
-
-printf "\n=== TEMP: intentional divergence to verify change detection selects this test\n"
-echo "this line is not in output.txt and must fail the golden comparison"

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -67,15 +67,16 @@ func selectChangedLocalTests(t *testing.T, testDirs map[string]bool) map[string]
 	out, err := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
 	if err != nil {
 		// A failed diff (most commonly a missing origin/main in a shallow CI
-		// checkout) must not be silently treated as "nothing changed": that
-		// disables change detection and lets newly added tests skip on every
-		// windows/macOS PR run. Fail loudly instead. See push.yml, which fetches
-		// full history so origin/main resolves.
+		// checkout) disables change detection, so newly added tests fall back to
+		// the seeded subset and may not run. Log loudly but continue: failing the
+		// test here breaks integration runs whose checkout has no origin/main. The
+		// push.yml PR cells fetch full history so origin/main resolves there.
 		stderr := ""
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			stderr = strings.TrimSpace(string(exitErr.Stderr))
 		}
-		t.Fatalf("git diff --merge-base origin/main failed: %v\n%s", err, stderr)
+		t.Logf("WARNING: change detection disabled: git diff --merge-base origin/main failed: %v\n%s", err, stderr)
+		return nil
 	}
 	diff := strings.TrimSpace(string(out))
 

--- a/acceptance/skiplocal_test.go
+++ b/acceptance/skiplocal_test.go
@@ -1,10 +1,12 @@
 package acceptance_test
 
 import (
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"testing"
 )
 
 // DATABRICKS_TEST_SKIPLOCAL controls skipping of Local acceptance tests.
@@ -61,8 +63,20 @@ func testDirForFile(repoRelPath string, testDirs map[string]bool) string {
 // committed. The three-dot form origin/main...HEAD only covers committed
 // changes and misses unstaged edits, which breaks the "touch a config, run
 // the test" local dev workflow (same reason lintdiff.py uses --merge-base).
-func selectChangedLocalTests(testDirs map[string]bool) map[string][]string {
-	out, _ := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
+func selectChangedLocalTests(t *testing.T, testDirs map[string]bool) map[string][]string {
+	out, err := exec.Command("git", "diff", "--name-status", "--merge-base", "-M", "origin/main").Output()
+	if err != nil {
+		// A failed diff (most commonly a missing origin/main in a shallow CI
+		// checkout) must not be silently treated as "nothing changed": that
+		// disables change detection and lets newly added tests skip on every
+		// windows/macOS PR run. Fail loudly instead. See push.yml, which fetches
+		// full history so origin/main resolves.
+		stderr := ""
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			stderr = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		t.Fatalf("git diff --merge-base origin/main failed: %v\n%s", err, stderr)
+	}
 	diff := strings.TrimSpace(string(out))
 
 	// result accumulates dirs with their filters; added tracks brand-new dirs.


### PR DESCRIPTION
## Why
Subsetting is enabled only on the windows/macOS PR cells (`TESTS_SELECT_SUBSET_PCT`). There the subset selector runs `git diff --merge-base origin/main` to always run the tests a PR adds/changes, but the test job's shallow checkout has no origin/main, so the diff failed — and the error was swallowed, silently disabling change detection. New tests then fell through to the seeded hash and got skipped, which is how b82fa5c5fa's invariant tests passed on PR yet failed on the nightly Windows run.

## Changes
- push.yml: fetch origin/main (and unshallow the head) after setup-build-environment, which would otherwise re-shallow the repo, so the diff resolves on the PR cells.
- selectChangedLocalTests: log a warning and fail open on a failed diff instead of swallowing it. It can't fail hard: integration runs (`DATABRICKS_TEST_SKIPLOCAL=withchanged`) also call this from a checkout without origin/main.