### PR TITLE
Skip GCP-seeded max_capacity in instance pool drift detection

### DIFF
--- a/bundle/direct/dresources/resources.yml
+++ b/bundle/direct/dresources/resources.yml
@@ -618,6 +618,8 @@ resources:
       # Backend applies a default of 60 minutes when the field is omitted.
       - field: idle_instance_autotermination_minutes
         values: [60]
+      # GCP seeds max_capacity (1000) when omitted; unconstrained as the default is cloud-dependent.
+      - field: max_capacity
 
   sql_warehouses:
     ignore_remote_changes:


### PR DESCRIPTION
## Why
On GCP, `no_drift` fails for `instance_pool.yml.tmpl`: the config omits `max_capacity`, but GCP seeds it to `1000` at creation, so the direct engine flagged it as drift → `update`.

## Changes
Add `max_capacity` to `instance_pools.backend_defaults` (unconstrained, since the seeded default is cloud-dependent). Only skipped when absent from config and state.

## Tests
Tested on GCP: both `READPLAN=` and `READPLAN=1` variants of the `no_drift` acceptance test now pass, with `max_capacity` classified as `backend_default` (skip) instead of `update`.