### PR TITLE
acc: add empty-grants invariant config, disable failing migrate variant

### DIFF
--- a/acceptance/bundle/invariant/configs/schema_empty_grants.yml.tmpl
+++ b/acceptance/bundle/invariant/configs/schema_empty_grants.yml.tmpl
@@ -1,0 +1,11 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+resources:
+  schemas:
+    foo:
+      catalog_name: main
+      name: test-schema-$UNIQUE_NAME
+      # Empty grants: Terraform records no grants resource for an empty list, so
+      # migrate leaves no state entry and plan must not show a spurious create.
+      grants: []

--- a/acceptance/bundle/invariant/continue_293/out.test.toml
+++ b/acceptance/bundle/invariant/continue_293/out.test.toml
@@ -34,6 +34,7 @@ EnvMatrix.INPUT_CONFIG = [
   "postgres_synced_table.yml.tmpl",
   "registered_model.yml.tmpl",
   "schema.yml.tmpl",
+  "schema_empty_grants.yml.tmpl",
   "schema_uppercase_name.yml.tmpl",
   "secret_scope.yml.tmpl",
   "secret_scope_default_backend_type.yml.tmpl",

--- a/acceptance/bundle/invariant/delete_idempotent/out.test.toml
+++ b/acceptance/bundle/invariant/delete_idempotent/out.test.toml
@@ -41,6 +41,7 @@ EnvMatrix.INPUT_CONFIG = [
   "postgres_synced_table.yml.tmpl",
   "registered_model.yml.tmpl",
   "schema.yml.tmpl",
+  "schema_empty_grants.yml.tmpl",
   "schema_grant_ref.yml.tmpl",
   "schema_uppercase_name.yml.tmpl",
   "secret_scope.yml.tmpl",

--- a/acceptance/bundle/invariant/destroy_idempotent/out.test.toml
+++ b/acceptance/bundle/invariant/destroy_idempotent/out.test.toml
@@ -41,6 +41,7 @@ EnvMatrix.INPUT_CONFIG = [
   "postgres_synced_table.yml.tmpl",
   "registered_model.yml.tmpl",
   "schema.yml.tmpl",
+  "schema_empty_grants.yml.tmpl",
   "schema_grant_ref.yml.tmpl",
   "schema_uppercase_name.yml.tmpl",
   "secret_scope.yml.tmpl",

--- a/acceptance/bundle/invariant/migrate/test.toml
+++ b/acceptance/bundle/invariant/migrate/test.toml
@@ -26,6 +26,17 @@ EnvMatrixExclude.no_cross_resource_ref = ["INPUT_CONFIG=job_cross_resource_ref.y
 # Grant cross-references require the EmbeddedSlice pattern not present in terraform mode.
 EnvMatrixExclude.no_grant_ref = ["INPUT_CONFIG=schema_grant_ref.yml.tmpl"]
 
+# An empty grants list plans a spurious create after migrate: Terraform records no
+# databricks_grants resource for grants: [], so migrate leaves no state entry for the
+# grants node, but the direct plan emits a "create" for it anyway. Found by fuzz testing.
+# The plan check fails with:
+#   Unexpected action='create' for resources.schemas.foo.grants
+#   ...
+#   "resources.schemas.foo.grants": { "action": "create", ... }
+#   Exit code: 10
+# Fixed by https://github.com/databricks/cli/pull/6039; re-enable once that lands.
+EnvMatrixExclude.no_empty_grants = ["INPUT_CONFIG=schema_empty_grants.yml.tmpl"]
+
 # SQL warehouses currently failing with migration with permanent drift. TODO: fix this.
 EnvMatrixExclude.no_sql_warehouse = ["INPUT_CONFIG=sql_warehouse.yml.tmpl"]
 

--- a/acceptance/bundle/invariant/no_drift/out.test.toml
+++ b/acceptance/bundle/invariant/no_drift/out.test.toml
@@ -42,6 +42,7 @@ EnvMatrix.INPUT_CONFIG = [
   "postgres_synced_table.yml.tmpl",
   "registered_model.yml.tmpl",
   "schema.yml.tmpl",
+  "schema_empty_grants.yml.tmpl",
   "schema_grant_ref.yml.tmpl",
   "schema_uppercase_name.yml.tmpl",
   "secret_scope.yml.tmpl",

--- a/acceptance/bundle/invariant/test.toml
+++ b/acceptance/bundle/invariant/test.toml
@@ -60,6 +60,7 @@ EnvMatrix.INPUT_CONFIG = [
     "postgres_synced_table.yml.tmpl",
     "registered_model.yml.tmpl",
     "schema.yml.tmpl",
+    "schema_empty_grants.yml.tmpl",
     "schema_grant_ref.yml.tmpl",
     "schema_uppercase_name.yml.tmpl",
     "secret_scope.yml.tmpl",


### PR DESCRIPTION
Adds a `schema_empty_grants` acceptance invariant (a schema with `grants: []`), found by fuzz testing. Because Terraform records no grants resource for an empty list, the direct engine's post-migrate plan shows a spurious `grants -> create`, so that one migrate variant is disabled in `migrate/test.toml` (with the full error in a comment) while the other invariants keep running.