### PR TITLE
bundle/dms: use service-assigned deployment IDs

### DIFF
--- a/acceptance/bundle/dms/add-resources/output.txt
+++ b/acceptance/bundle/dms/add-resources/output.txt
@@ -18,11 +18,11 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
 >>> print_requests.py --get --sort //bundle ^//workspace-files ^//import-file
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]"
+  "path": "/api/2.0/bundle/deployments/[NUMID]"
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -30,7 +30,7 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -39,17 +39,15 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
 {
   "method": "POST",
   "path": "/api/2.0/bundle/deployments",
-  "q": {
-    "deployment_id": "[UUID]"
-  },
   "body": {
     "display_name": "add-resources-test",
-    "target_name": "default"
+    "target_name": "default",
+    "initial_parent_path": "/Workspace/Users/[USERNAME]/.bundle/add-resources-test/default"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "1"
   },
@@ -67,7 +65,7 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "2"
   },
@@ -85,15 +83,15 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/1",
+    "name": "deployments/[NUMID]/versions/1",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/operations",
   "q": {
     "resource_key": "jobs.job_a"
   },
@@ -102,7 +100,7 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/add-resources-test/default/state/metadata.json",
         "version_id": "1"
@@ -121,15 +119,15 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/2/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/2/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/2",
+    "name": "deployments/[NUMID]/versions/2",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/2/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/2/operations",
   "q": {
     "resource_key": "jobs.job_b"
   },
@@ -138,7 +136,7 @@ Plan: 0 to add, 2 to change, 0 to delete, 0 unchanged
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/add-resources-test/default/state/metadata.json",
         "version_id": "2"

--- a/acceptance/bundle/dms/deploy-error/output.txt
+++ b/acceptance/bundle/dms/deploy-error/output.txt
@@ -14,17 +14,15 @@ API message: Invalid job configuration.
 {
   "method": "POST",
   "path": "/api/2.0/bundle/deployments",
-  "q": {
-    "deployment_id": "[UUID]"
-  },
   "body": {
     "display_name": "metadata-service-error-test",
-    "target_name": "default"
+    "target_name": "default",
+    "initial_parent_path": "/Workspace/Users/[USERNAME]/.bundle/metadata-service-error-test/default"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "1"
   },
@@ -42,7 +40,7 @@ API message: Invalid job configuration.
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/operations",
   "q": {
     "resource_key": "jobs.test_job"
   },
@@ -51,7 +49,7 @@ API message: Invalid job configuration.
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/metadata-service-error-test/default/state/metadata.json",
         "version_id": "1"
@@ -70,9 +68,9 @@ API message: Invalid job configuration.
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/1",
+    "name": "deployments/[NUMID]/versions/1",
     "completion_reason": "VERSION_COMPLETE_FAILURE"
   }
 }

--- a/acceptance/bundle/dms/plan-and-summary/output.txt
+++ b/acceptance/bundle/dms/plan-and-summary/output.txt
@@ -16,7 +16,7 @@ Workspace:
   User: [USERNAME]
   Path: /Workspace/Users/[USERNAME]/.bundle/plan-summary-test/default
 Deployment:
-  ID:      [UUID]
+  ID:      [NUMID]
   Version: 1
 Resources:
   Jobs:
@@ -26,7 +26,7 @@ Resources:
 
 >>> [CLI] bundle summary -o json
 {
-  "deployment_id": "[UUID]",
+  "deployment_id": "[NUMID]",
   "version_id": "1"
 }
 
@@ -34,17 +34,15 @@ Resources:
 {
   "method": "POST",
   "path": "/api/2.0/bundle/deployments",
-  "q": {
-    "deployment_id": "[UUID]"
-  },
   "body": {
     "display_name": "plan-summary-test",
-    "target_name": "default"
+    "target_name": "default",
+    "initial_parent_path": "/Workspace/Users/[USERNAME]/.bundle/plan-summary-test/default"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "1"
   },
@@ -62,7 +60,7 @@ Resources:
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/operations",
   "q": {
     "resource_key": "jobs.test_job"
   },
@@ -71,7 +69,7 @@ Resources:
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/plan-summary-test/default/state/metadata.json",
         "version_id": "1"
@@ -90,15 +88,15 @@ Resources:
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/1",
+    "name": "deployments/[NUMID]/versions/1",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -106,7 +104,7 @@ Resources:
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -114,11 +112,11 @@ Resources:
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]"
+  "path": "/api/2.0/bundle/deployments/[NUMID]"
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -126,5 +124,5 @@ Resources:
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]"
+  "path": "/api/2.0/bundle/deployments/[NUMID]"
 }

--- a/acceptance/bundle/dms/release-lock-error/output.txt
+++ b/acceptance/bundle/dms/release-lock-error/output.txt
@@ -9,17 +9,15 @@ Warn: Failed to release deployment lock: simulated complete version failure
 {
   "method": "POST",
   "path": "/api/2.0/bundle/deployments",
-  "q": {
-    "deployment_id": "[UUID]"
-  },
   "body": {
     "display_name": "dms-release-lock-error",
-    "target_name": "fail-complete"
+    "target_name": "fail-complete",
+    "initial_parent_path": "/Workspace/Users/[USERNAME]/.bundle/dms-release-lock-error/fail-complete"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "1"
   },
@@ -37,7 +35,7 @@ Warn: Failed to release deployment lock: simulated complete version failure
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/operations",
   "q": {
     "resource_key": "jobs.test_job"
   },
@@ -46,7 +44,7 @@ Warn: Failed to release deployment lock: simulated complete version failure
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/dms-release-lock-error/fail-complete/state/metadata.json",
         "version_id": "1"
@@ -65,9 +63,9 @@ Warn: Failed to release deployment lock: simulated complete version failure
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/1",
+    "name": "deployments/[NUMID]/versions/1",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }

--- a/acceptance/bundle/dms/sequential-deploys/output.txt
+++ b/acceptance/bundle/dms/sequential-deploys/output.txt
@@ -8,17 +8,15 @@ Deployment complete!
 {
   "method": "POST",
   "path": "/api/2.0/bundle/deployments",
-  "q": {
-    "deployment_id": "[UUID]"
-  },
   "body": {
     "display_name": "sequential-deploys-test",
-    "target_name": "default"
+    "target_name": "default",
+    "initial_parent_path": "/Workspace/Users/[USERNAME]/.bundle/sequential-deploys-test/default"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "1"
   },
@@ -36,15 +34,15 @@ Deployment complete!
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/1",
+    "name": "deployments/[NUMID]/versions/1",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/1/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/1/operations",
   "q": {
     "resource_key": "jobs.test_job"
   },
@@ -53,7 +51,7 @@ Deployment complete!
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/sequential-deploys-test/default/state/metadata.json",
         "version_id": "1"
@@ -79,11 +77,11 @@ Deployment complete!
 >>> print_requests.py --get --sort //bundle ^//workspace-files ^//import-file
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]"
+  "path": "/api/2.0/bundle/deployments/[NUMID]"
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -91,7 +89,7 @@ Deployment complete!
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "2"
   },
@@ -109,15 +107,15 @@ Deployment complete!
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/2/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/2/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/2",
+    "name": "deployments/[NUMID]/versions/2",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/2/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/2/operations",
   "q": {
     "resource_key": "jobs.new_job"
   },
@@ -126,7 +124,7 @@ Deployment complete!
     "action_type": "OPERATION_ACTION_TYPE_CREATE",
     "state": {
       "deployment": {
-        "deployment_id": "[UUID]",
+        "deployment_id": "[NUMID]",
         "kind": "BUNDLE",
         "metadata_file_path": "/Workspace/Users/[USERNAME]/.bundle/sequential-deploys-test/default/state/metadata.json",
         "version_id": "2"
@@ -152,11 +150,11 @@ Deployment complete!
 >>> print_requests.py --get --sort //bundle ^//workspace-files ^//import-file
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]"
+  "path": "/api/2.0/bundle/deployments/[NUMID]"
 }
 {
   "method": "GET",
-  "path": "/api/2.0/bundle/deployments/[UUID]/resources",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/resources",
   "q": {
     "page_size": "1000"
   },
@@ -164,7 +162,7 @@ Deployment complete!
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions",
   "q": {
     "version_id": "3"
   },
@@ -182,15 +180,15 @@ Deployment complete!
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/3/complete",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/3/complete",
   "body": {
-    "name": "deployments/[UUID]/versions/3",
+    "name": "deployments/[NUMID]/versions/3",
     "completion_reason": "VERSION_COMPLETE_SUCCESS"
   }
 }
 {
   "method": "POST",
-  "path": "/api/2.0/bundle/deployments/[UUID]/versions/3/operations",
+  "path": "/api/2.0/bundle/deployments/[NUMID]/versions/3/operations",
   "q": {
     "resource_key": "jobs.test_job"
   },

--- a/bundle/deploy/lock/deployment_metadata_service.go
+++ b/bundle/deploy/lock/deployment_metadata_service.go
@@ -23,7 +23,6 @@ import (
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/tmpdms"
 	"github.com/databricks/databricks-sdk-go/apierr"
-	"github.com/google/uuid"
 )
 
 const defaultHeartbeatInterval = 30 * time.Second
@@ -116,16 +115,20 @@ func acquireLock(ctx context.Context, b *bundle.Bundle, svc *tmpdms.DeploymentMe
 	}
 
 	if isNew {
-		// Fresh deployment: create the record and start at version 1.
-		_, createErr := svc.CreateDeployment(ctx, tmpdms.CreateDeploymentRequest{
-			DeploymentID: deploymentID,
+		// Fresh deployment: let the service assign the ID, then start at version 1.
+		deployment, createErr := svc.CreateDeployment(ctx, tmpdms.CreateDeploymentRequest{
 			Deployment: &tmpdms.Deployment{
-				DisplayName: b.Config.Bundle.Name,
-				TargetName:  b.Config.Bundle.Target,
+				DisplayName:       b.Config.Bundle.Name,
+				TargetName:        b.Config.Bundle.Target,
+				InitialParentPath: b.Config.Workspace.RootPath,
 			},
 		})
 		if createErr != nil {
 			return "", "", fmt.Errorf("failed to create deployment: %w", createErr)
+		}
+		deploymentID, err = deploymentIDFromName(deployment.Name)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to create deployment: %w", err)
 		}
 		// Write the deployment ID to workspace only after the server-side
 		// record is created. This avoids leaving a dangling ID if creation fails.
@@ -178,11 +181,10 @@ func acquireLock(ctx context.Context, b *bundle.Bundle, svc *tmpdms.DeploymentMe
 }
 
 // resolveDeploymentID reads the deployment ID from managed_service.json in the
-// workspace state directory. If the file doesn't exist or has no deployment ID,
-// a new UUID is generated. The boolean return indicates whether this is a fresh
-// deployment (true) or an existing one (false). For fresh deployments, the
-// caller is responsible for writing the deployment ID to workspace after the
-// server-side deployment record is created successfully.
+// workspace state directory. The boolean return indicates whether this is a
+// fresh deployment (true) or an existing one (false). For fresh deployments,
+// the service assigns the ID and the caller writes it to the workspace after
+// the server-side deployment record is created successfully.
 func resolveDeploymentID(ctx context.Context, b *bundle.Bundle) (string, bool, error) {
 	f, err := deploy.StateFiler(ctx, b)
 	if err != nil {
@@ -208,8 +210,15 @@ func resolveDeploymentID(ctx context.Context, b *bundle.Bundle) (string, bool, e
 		return "", false, fmt.Errorf("failed to read %s: %w", statemgmt.ManagedServiceFileName, readErr)
 	}
 
-	// Fresh deployment: generate a new ID but don't write yet.
-	return uuid.New().String(), true, nil
+	return "", true, nil
+}
+
+func deploymentIDFromName(name string) (string, error) {
+	deploymentID, ok := strings.CutPrefix(name, "deployments/")
+	if !ok || deploymentID == "" || strings.Contains(deploymentID, "/") {
+		return "", fmt.Errorf("create response has invalid deployment name %q", name)
+	}
+	return deploymentID, nil
 }
 
 // writeDeploymentID writes the deployment ID to managed_service.json in the

--- a/bundle/deploy/lock/deployment_metadata_service_test.go
+++ b/bundle/deploy/lock/deployment_metadata_service_test.go
@@ -75,6 +75,32 @@ func TestDeploymentMode(t *testing.T) {
 	}
 }
 
+func TestDeploymentIDFromName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		valid    bool
+	}{
+		{name: "deployments/123", expected: "123", valid: true},
+		{name: "", valid: false},
+		{name: "deployments/", valid: false},
+		{name: "123", valid: false},
+		{name: "deployments/123/versions/1", valid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deploymentID, err := deploymentIDFromName(tt.name)
+			if !tt.valid {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, deploymentID)
+		})
+	}
+}
+
 func TestWorkspaceInfo(t *testing.T) {
 	b := &bundle.Bundle{
 		Config: config.Root{

--- a/libs/testserver/deployment_metadata.go
+++ b/libs/testserver/deployment_metadata.go
@@ -47,12 +47,10 @@ const lockDuration = 2 * time.Minute
 func (s *FakeWorkspace) DeploymentMetadataCreateDeployment(req Request) Response {
 	defer s.LockUnlock()()
 
-	// deployment_id is a query parameter, not in the body.
-	deploymentID := req.URL.Query().Get("deployment_id")
-	if deploymentID == "" {
+	if req.URL.Query().Has("deployment_id") {
 		return Response{
 			StatusCode: http.StatusBadRequest,
-			Body:       map[string]string{"error_code": "INVALID_PARAMETER_VALUE", "message": "deployment_id is required"},
+			Body:       map[string]string{"error_code": "INVALID_PARAMETER_VALUE", "message": "deployment_id is assigned by the service"},
 		}
 	}
 
@@ -66,14 +64,15 @@ func (s *FakeWorkspace) DeploymentMetadataCreateDeployment(req Request) Response
 			}
 		}
 	}
-
-	state := s.deploymentMetadata
-	if _, exists := state.deployments[deploymentID]; exists {
+	if bodyDeployment.InitialParentPath == "" {
 		return Response{
-			StatusCode: http.StatusConflict,
-			Body:       map[string]string{"error_code": "ALREADY_EXISTS", "message": fmt.Sprintf("deployment %s already exists", deploymentID)},
+			StatusCode: http.StatusBadRequest,
+			Body:       map[string]string{"error_code": "INVALID_PARAMETER_VALUE", "message": "initial_parent_path is required"},
 		}
 	}
+
+	state := s.deploymentMetadata
+	deploymentID := strconv.FormatInt(nextID(), 10)
 
 	now := time.Now().UTC()
 	deployment := tmpdms.Deployment{

--- a/libs/tmpdms/api.go
+++ b/libs/tmpdms/api.go
@@ -32,8 +32,7 @@ func NewDeploymentMetadataAPI(w *databricks.WorkspaceClient) (*DeploymentMetadat
 func (a *DeploymentMetadataAPI) CreateDeployment(ctx context.Context, request CreateDeploymentRequest) (*Deployment, error) {
 	var resp Deployment
 	path := basePath + "/deployments"
-	query := map[string]any{"deployment_id": request.DeploymentID}
-	err := a.api.Do(ctx, http.MethodPost, path, nil, query, request.Deployment, &resp)
+	err := a.api.Do(ctx, http.MethodPost, path, nil, nil, request.Deployment, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/tmpdms/types.go
+++ b/libs/tmpdms/types.go
@@ -102,16 +102,17 @@ const (
 // Resource types (proto message equivalents).
 
 type Deployment struct {
-	Name          string           `json:"name,omitempty"`
-	DisplayName   string           `json:"display_name,omitempty"`
-	TargetName    string           `json:"target_name,omitempty"`
-	Status        DeploymentStatus `json:"status,omitempty"`
-	LastVersionID string           `json:"last_version_id,omitempty"`
-	CreatedBy     string           `json:"created_by,omitempty"`
-	CreateTime    *time.Time       `json:"create_time,omitempty"`
-	UpdateTime    *time.Time       `json:"update_time,omitempty"`
-	DestroyTime   *time.Time       `json:"destroy_time,omitempty"`
-	DestroyedBy   string           `json:"destroyed_by,omitempty"`
+	Name              string           `json:"name,omitempty"`
+	DisplayName       string           `json:"display_name,omitempty"`
+	TargetName        string           `json:"target_name,omitempty"`
+	Status            DeploymentStatus `json:"status,omitempty"`
+	LastVersionID     string           `json:"last_version_id,omitempty"`
+	CreatedBy         string           `json:"created_by,omitempty"`
+	CreateTime        *time.Time       `json:"create_time,omitempty"`
+	UpdateTime        *time.Time       `json:"update_time,omitempty"`
+	DestroyTime       *time.Time       `json:"destroy_time,omitempty"`
+	DestroyedBy       string           `json:"destroyed_by,omitempty"`
+	InitialParentPath string           `json:"initial_parent_path,omitempty"`
 }
 
 type Version struct {
@@ -176,8 +177,7 @@ type Resource struct {
 // Request types.
 
 type CreateDeploymentRequest struct {
-	DeploymentID string      `json:"deployment_id"`
-	Deployment   *Deployment `json:"deployment"`
+	Deployment *Deployment `json:"deployment"`
 }
 
 type GetDeploymentRequest struct {


### PR DESCRIPTION
## Changes

- Remove deployment_id from the temporary DMS create request and query.
- Send initial_parent_path and persist the ID returned in the created deployment name.
- Update the fake DMS and acceptance outputs for service-assigned numeric IDs.

## Why

The deployment metadata service now assigns deployment IDs from the workspace hierarchy tree node. The CLI must not generate or submit its own UUID.

This PR is stacked on #4856.

## Tests

- go test ./bundle/deploy/lock ./libs/tmpdms ./libs/testserver
- go test ./acceptance -run ^TestAccept$/bundle/dms -count=1 -timeout=5m