### PR TITLE
configsync: skip ambiguous split sequence changes

### DIFF
--- a/acceptance/bundle/config-remote-sync/clusters_split/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/clusters_split/databricks.yml.tmpl
@@ -3,8 +3,8 @@ bundle:
 
 # job_clusters are keyed (merge.ElementsByKey by job_cluster_key, non-sorted);
 # pipeline clusters are positional (no KeyedSlices, so changes diff by numeric
-# index). Both sequences are split across the top-level block and the
-# targets.default override, exercising both resolveSelectors branches.
+# index). Changes to either kind of split sequence must be left stale because
+# the merged value cannot always be mapped safely back to its YAML block.
 resources:
   jobs:
     my_job:

--- a/acceptance/bundle/config-remote-sync/clusters_split/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/clusters_split/databricks.yml.tmpl
@@ -1,0 +1,73 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# job_clusters are keyed (merge.ElementsByKey by job_cluster_key, non-sorted);
+# pipeline clusters are positional (no KeyedSlices, so changes diff by numeric
+# index). Both sequences are split across the top-level block and the
+# targets.default override, exercising both resolveSelectors branches.
+resources:
+  jobs:
+    my_job:
+      job_clusters:
+        - job_cluster_key: aaa_cluster
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+        - job_cluster_key: bbb_cluster
+          new_cluster:
+            spark_version: $DEFAULT_SPARK_VERSION
+            node_type_id: $NODE_TYPE_ID
+            num_workers: 1
+      tasks:
+        - task_key: main
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/notebook
+          job_cluster_key: aaa_cluster
+
+  pipelines:
+    # positional target edit: maintenance cluster lives in the target block.
+    pipeline_target:
+      name: test-pipeline-target-$UNIQUE_NAME
+      development: false
+      libraries:
+        - notebook:
+            path: /Users/{{workspace_user_name}}/notebook
+      clusters:
+        - label: default
+          num_workers: 1
+
+    # positional top-level index 1: maintenance is the second top-level cluster.
+    pipeline_index:
+      name: test-pipeline-index-$UNIQUE_NAME
+      development: false
+      libraries:
+        - notebook:
+            path: /Users/{{workspace_user_name}}/notebook
+      clusters:
+        - label: default
+          num_workers: 1
+        - label: maintenance
+          num_workers: 1
+
+targets:
+  default:
+    mode: development
+    resources:
+      jobs:
+        my_job:
+          job_clusters:
+            - job_cluster_key: ccc_cluster
+              new_cluster:
+                spark_version: $DEFAULT_SPARK_VERSION
+                node_type_id: $NODE_TYPE_ID
+                num_workers: 1
+      pipelines:
+        pipeline_target:
+          clusters:
+            - label: maintenance
+              num_workers: 1
+        pipeline_index:
+          clusters:
+            - label: default
+              num_workers: 2

--- a/acceptance/bundle/config-remote-sync/clusters_split/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/clusters_split/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/clusters_split/output.txt
+++ b/acceptance/bundle/config-remote-sync/clusters_split/output.txt
@@ -20,28 +20,6 @@ Resource: resources.pipelines.pipeline_target
 === Configuration changes
 
 >>> diff.py databricks.yml.backup databricks.yml
---- databricks.yml.backup
-+++ databricks.yml
-@@ -49,5 +49,5 @@
-           num_workers: 1
-         - label: maintenance
--          num_workers: 1
-+          num_workers: 7
-
- targets:
-@@ -62,10 +62,10 @@
-                 spark_version: 13.3.x-snapshot-scala2.12
-                 node_type_id: [NODE_TYPE_ID]
--                num_workers: 1
-+                num_workers: 5
-       pipelines:
-         pipeline_target:
-           clusters:
-             - label: maintenance
--              num_workers: 1
-+              num_workers: 3
-         pipeline_index:
-           clusters:
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:

--- a/acceptance/bundle/config-remote-sync/clusters_split/output.txt
+++ b/acceptance/bundle/config-remote-sync/clusters_split/output.txt
@@ -1,0 +1,60 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Detect and save changes
+Detected changes in 3 resource(s):
+
+Resource: resources.jobs.my_job
+  job_clusters[job_cluster_key='ccc_cluster'].new_cluster.num_workers: replace
+
+Resource: resources.pipelines.pipeline_index
+  clusters[1].num_workers: replace
+
+Resource: resources.pipelines.pipeline_target
+  clusters[1].num_workers: replace
+
+
+
+=== Configuration changes
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -49,5 +49,5 @@
+           num_workers: 1
+         - label: maintenance
+-          num_workers: 1
++          num_workers: 7
+
+ targets:
+@@ -62,10 +62,10 @@
+                 spark_version: 13.3.x-snapshot-scala2.12
+                 node_type_id: [NODE_TYPE_ID]
+-                num_workers: 1
++                num_workers: 5
+       pipelines:
+         pipeline_target:
+           clusters:
+             - label: maintenance
+-              num_workers: 1
++              num_workers: 3
+         pipeline_index:
+           clusters:
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.my_job
+  delete resources.pipelines.pipeline_index
+  delete resources.pipelines.pipeline_target
+
+This action will result in the deletion of the following Lakeflow Spark Declarative Pipelines along with the
+Streaming Tables (STs) and Materialized Views (MVs) managed by them:
+  delete resources.pipelines.pipeline_index
+  delete resources.pipelines.pipeline_target
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/clusters_split/script
+++ b/acceptance/bundle/config-remote-sync/clusters_split/script
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+
+# job_clusters (keyed): top-level [aaa,bbb]+target [ccc]. Edit ccc (target block).
+job_id="$(read_id.py my_job)"
+edit_resource.py jobs "$job_id" <<PY
+for c in r.get("job_clusters", []):
+    if c.get("job_cluster_key") == "ccc_cluster":
+        c["new_cluster"]["num_workers"] = 5
+PY
+
+# pipeline_target (positional): top-level [default]+target [maintenance]. Edit
+# maintenance (merged index 1, target-local index 0) -> must patch target block.
+pt_id="$(read_id.py pipeline_target)"
+edit_resource.py pipelines "$pt_id" <<PY
+for c in r.get("clusters", []):
+    if c.get("label") == "maintenance":
+        c["num_workers"] = 3
+PY
+
+# pipeline_index (positional): top-level [default,maintenance]+target [default].
+# Edit maintenance (top-level block index 1) -> must patch top-level block.
+pi_id="$(read_id.py pipeline_index)"
+edit_resource.py pipelines "$pi_id" <<PY
+for c in r.get("clusters", []):
+    if c.get("label") == "maintenance":
+        c["num_workers"] = 7
+PY
+
+title "Detect and save changes"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --save
+
+title "Configuration changes"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/clusters_split/test.toml
+++ b/acceptance/bundle/config-remote-sync/clusters_split/test.toml
@@ -1,0 +1,11 @@
+# Local-only. Cluster sequences split across top-level and target blocks:
+# job_clusters (keyed, non-sorted ElementsByKey) and pipeline clusters
+# (positional, no KeyedSlices -> numeric change paths).
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/databricks.yml.tmpl
@@ -1,0 +1,32 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# Two targets. dev_only_task exists ONLY in the targets.dev override block.
+# Renaming it (remove+add) must keep the recreated task in targets.dev, reusing
+# the removed task's slot. If it were relocated to the top-level block it would
+# start applying to prod too — a silent multi-target semantics change.
+resources:
+  jobs:
+    my_job:
+      tasks:
+        - task_key: top_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/top
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        my_job:
+          tasks:
+            - task_key: dev_only_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/dev
+  prod:
+    resources:
+      jobs:
+        my_job:
+          max_concurrent_runs: 5

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/databricks.yml.tmpl
@@ -2,9 +2,9 @@ bundle:
   name: test-bundle-$UNIQUE_NAME
 
 # Two targets. dev_only_task exists ONLY in the targets.dev override block.
-# Renaming it (remove+add) must keep the recreated task in targets.dev, reusing
-# the removed task's slot. If it were relocated to the top-level block it would
-# start applying to prod too — a silent multi-target semantics change.
+# A rename is an unpaired remove+add, so config sync cannot prove that the add
+# belongs in targets.dev. It must leave both operations stale rather than risk
+# relocating the task to the top-level block where it would also affect prod.
 resources:
   jobs:
     my_job:

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/output.txt
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/output.txt
@@ -1,0 +1,42 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Rename dev_only_task -> renamed_task (target dev block)
+
+=== Sync (target dev)
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.my_job
+  tasks[task_key='dev_only_task']: remove
+  tasks[task_key='renamed_task']: add
+
+
+
+=== Result: where did renamed_task land?
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -22,8 +22,7 @@
+         my_job:
+           tasks:
+-            - task_key: dev_only_task
+-              run_if: ALL_SUCCESS
+-              notebook_task:
+-                notebook_path: /Users/{{workspace_user_name}}/dev
++            - notebook_task:
++                notebook_path: '/Users/{{workspace_user_name}}/dev'
++              task_key: renamed_task
+   prod:
+     resources:
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.my_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/output.txt
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/output.txt
@@ -14,23 +14,9 @@ Resource: resources.jobs.my_job
 
 
 
-=== Result: where did renamed_task land?
+=== Result: ambiguous rename stays stale
 
 >>> diff.py databricks.yml.backup databricks.yml
---- databricks.yml.backup
-+++ databricks.yml
-@@ -22,8 +22,7 @@
-         my_job:
-           tasks:
--            - task_key: dev_only_task
--              run_if: ALL_SUCCESS
--              notebook_task:
--                notebook_path: /Users/{{workspace_user_name}}/dev
-+            - notebook_task:
-+                notebook_path: '/Users/{{workspace_user_name}}/dev'
-+              task_key: renamed_task
-   prod:
-     resources:
 
 >>> [CLI] bundle destroy --auto-approve -t dev
 The following resources will be deleted:

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/script
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/script
@@ -18,7 +18,7 @@ title "Sync (target dev)"
 echo
 cp databricks.yml databricks.yml.backup
 $CLI bundle config-remote-sync --save -t dev
-title "Result: where did renamed_task land?"
+title "Result: ambiguous rename stays stale"
 echo
 trace diff.py databricks.yml.backup databricks.yml
 rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/script
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/script
@@ -1,0 +1,24 @@
+#!/bin/bash
+export DATABRICKS_BUNDLE_TARGET=dev
+envsubst < databricks.yml.tmpl > databricks.yml
+cleanup() { trace $CLI bundle destroy --auto-approve -t dev; }
+trap cleanup EXIT
+$CLI bundle deploy -t dev
+job_id="$(read_id.py -t dev my_job)"
+
+title "Rename dev_only_task -> renamed_task (target dev block)"
+echo
+edit_resource.py jobs $job_id <<PY
+for task in r["tasks"]:
+    if task["task_key"] == "dev_only_task":
+        task["task_key"] = "renamed_task"
+PY
+
+title "Sync (target dev)"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --save -t dev
+title "Result: where did renamed_task land?"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/task_split_target_only_rename/test.toml
+++ b/acceptance/bundle/config-remote-sync/task_split_target_only_rename/test.toml
@@ -1,0 +1,10 @@
+# Local-only: renaming a task defined only in a target override block must keep
+# it in that block (multi-target semantics), not relocate it to the top level.
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/tasks_split/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/tasks_split/databricks.yml.tmpl
@@ -1,0 +1,126 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# Each job below defines tasks partly in the top-level block and partly in the
+# targets.default override block. MergeJobTasks merges and sorts them by
+# task_key into one in-memory sequence, but each block is patched separately in
+# the YAML, so block-aware indexing must resolve edits to the right block.
+# Multiple split jobs in one bundle also prove block anchors are grouped per
+# resource, not globally across the file.
+resources:
+  jobs:
+    # target_index: edit a top-level task (bbb) that is not first after the sort.
+    job_index:
+      tasks:
+        - task_key: bbb_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/bbb
+        - task_key: ccc_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/ccc
+
+    # target_local: edit a target-block task (aaa) while a top-level task (zzz)
+    # sits at the same block-local index 0 and also has run_if.
+    job_local:
+      tasks:
+        - task_key: zzz_top
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/zzz
+
+    # nonzero_index: edit the second task of the top-level block (nnn).
+    job_nonzero:
+      tasks:
+        - task_key: mmm_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/mmm
+        - task_key: nnn_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/nnn
+
+    # mixed_ops: remove a top-level task (ppp) and edit another (rrr) whose index
+    # shifts after the removal.
+    job_mixed:
+      tasks:
+        - task_key: ppp_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/ppp
+        - task_key: rrr_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/rrr
+
+    # crossblock_removes: remove one task from each block in a single sync.
+    job_xremove:
+      tasks:
+        - task_key: bbb_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/bbb
+        - task_key: ccc_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/ccc
+
+    # crossblock_rename: rename one task in each block (remove+add) in one sync.
+    job_xrename:
+      tasks:
+        - task_key: mmm_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/mmm
+        - task_key: nnn_task
+          run_if: ALL_SUCCESS
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/nnn
+
+targets:
+  default:
+    mode: development
+    resources:
+      jobs:
+        job_index:
+          tasks:
+            - task_key: aaa_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/aaa
+        job_local:
+          tasks:
+            - task_key: aaa_tgt
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/aaa
+        job_nonzero:
+          tasks:
+            - task_key: aaa_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/aaa
+        job_mixed:
+          tasks:
+            - task_key: aaa_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/aaa
+        job_xremove:
+          tasks:
+            - task_key: aaa_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/aaa
+            - task_key: eee_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/eee
+        job_xrename:
+          tasks:
+            - task_key: aaa_task
+              run_if: ALL_SUCCESS
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/aaa

--- a/acceptance/bundle/config-remote-sync/tasks_split/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/tasks_split/databricks.yml.tmpl
@@ -3,10 +3,9 @@ bundle:
 
 # Each job below defines tasks partly in the top-level block and partly in the
 # targets.default override block. MergeJobTasks merges and sorts them by
-# task_key into one in-memory sequence, but each block is patched separately in
-# the YAML, so block-aware indexing must resolve edits to the right block.
-# Multiple split jobs in one bundle also prove block anchors are grouped per
-# resource, not globally across the file.
+# task_key into one in-memory sequence, but each block is a separate region of
+# YAML. Config sync must leave changes to these sequences stale instead of
+# risking a write to the wrong block.
 resources:
   jobs:
     # target_index: edit a top-level task (bbb) that is not first after the sort.
@@ -79,6 +78,14 @@ resources:
           notebook_task:
             notebook_path: /Users/{{workspace_user_name}}/nnn
 
+    # A scalar edit remains safe even when another field is a split sequence.
+    job_scalar:
+      timeout_seconds: 100
+      tasks:
+        - task_key: top_task
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/top
+
 targets:
   default:
     mode: development
@@ -124,3 +131,8 @@ targets:
               run_if: ALL_SUCCESS
               notebook_task:
                 notebook_path: /Users/{{workspace_user_name}}/aaa
+        job_scalar:
+          tasks:
+            - task_key: target_task
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/target

--- a/acceptance/bundle/config-remote-sync/tasks_split/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/tasks_split/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/tasks_split/output.txt
+++ b/acceptance/bundle/config-remote-sync/tasks_split/output.txt
@@ -1,0 +1,121 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Detect and save changes
+Detected changes in 6 resource(s):
+
+Resource: resources.jobs.job_index
+  tasks[task_key='bbb_task'].run_if: replace
+
+Resource: resources.jobs.job_local
+  tasks[task_key='aaa_tgt'].run_if: replace
+
+Resource: resources.jobs.job_mixed
+  tasks[task_key='ppp_task']: remove
+  tasks[task_key='rrr_task'].run_if: replace
+
+Resource: resources.jobs.job_nonzero
+  tasks[task_key='nnn_task'].run_if: replace
+
+Resource: resources.jobs.job_xremove
+  tasks[task_key='bbb_task']: remove
+  tasks[task_key='eee_task']: remove
+
+Resource: resources.jobs.job_xrename
+  tasks[task_key='aaa_task']: remove
+  tasks[task_key='mmm_task']: remove
+  tasks[task_key='ppp_task']: add
+  tasks[task_key='qqq_task']: add
+
+
+
+=== Configuration changes
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -14,5 +14,5 @@
+       tasks:
+         - task_key: bbb_task
+-          run_if: ALL_SUCCESS
++          run_if: ALL_DONE
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/bbb
+@@ -39,5 +39,5 @@
+             notebook_path: /Users/{{workspace_user_name}}/mmm
+         - task_key: nnn_task
+-          run_if: ALL_SUCCESS
++          run_if: ALL_DONE
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/nnn
+@@ -47,10 +47,6 @@
+     job_mixed:
+       tasks:
+-        - task_key: ppp_task
+-          run_if: ALL_SUCCESS
+-          notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/ppp
+         - task_key: rrr_task
+-          run_if: ALL_SUCCESS
++          run_if: ALL_DONE
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/rrr
+@@ -59,8 +55,4 @@
+     job_xremove:
+       tasks:
+-        - task_key: bbb_task
+-          run_if: ALL_SUCCESS
+-          notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/bbb
+         - task_key: ccc_task
+           run_if: ALL_SUCCESS
+@@ -71,8 +63,7 @@
+     job_xrename:
+       tasks:
+-        - task_key: mmm_task
+-          run_if: ALL_SUCCESS
+-          notebook_task:
++        - notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/mmm
++          task_key: ppp_task
+         - task_key: nnn_task
+           run_if: ALL_SUCCESS
+@@ -94,5 +85,5 @@
+           tasks:
+             - task_key: aaa_tgt
+-              run_if: ALL_SUCCESS
++              run_if: ALL_DONE
+               notebook_task:
+                 notebook_path: /Users/{{workspace_user_name}}/aaa
+@@ -115,12 +106,7 @@
+               notebook_task:
+                 notebook_path: /Users/{{workspace_user_name}}/aaa
+-            - task_key: eee_task
+-              run_if: ALL_SUCCESS
+-              notebook_task:
+-                notebook_path: /Users/{{workspace_user_name}}/eee
+         job_xrename:
+           tasks:
+-            - task_key: aaa_task
+-              run_if: ALL_SUCCESS
+-              notebook_task:
+-                notebook_path: /Users/{{workspace_user_name}}/aaa
++            - notebook_task:
++                notebook_path: '/Users/{{workspace_user_name}}/aaa'
++              task_key: qqq_task
+
+>>> [CLI] bundle destroy --auto-approve
+The following resources will be deleted:
+  delete resources.jobs.job_index
+  delete resources.jobs.job_local
+  delete resources.jobs.job_mixed
+  delete resources.jobs.job_nonzero
+  delete resources.jobs.job_xremove
+  delete resources.jobs.job_xrename
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/tasks_split/output.txt
+++ b/acceptance/bundle/config-remote-sync/tasks_split/output.txt
@@ -4,7 +4,7 @@ Updating deployment state...
 Deployment complete!
 
 === Detect and save changes
-Detected changes in 6 resource(s):
+Detected changes in 7 resource(s):
 
 Resource: resources.jobs.job_index
   tasks[task_key='bbb_task'].run_if: replace
@@ -18,6 +18,9 @@ Resource: resources.jobs.job_mixed
 
 Resource: resources.jobs.job_nonzero
   tasks[task_key='nnn_task'].run_if: replace
+
+Resource: resources.jobs.job_scalar
+  timeout_seconds: replace
 
 Resource: resources.jobs.job_xremove
   tasks[task_key='bbb_task']: remove
@@ -36,75 +39,15 @@ Resource: resources.jobs.job_xrename
 >>> diff.py databricks.yml.backup databricks.yml
 --- databricks.yml.backup
 +++ databricks.yml
-@@ -14,5 +14,5 @@
+@@ -80,7 +80,7 @@
+
+     # A scalar edit remains safe even when another field is a split sequence.
+     job_scalar:
+-      timeout_seconds: 100
++      timeout_seconds: 200
        tasks:
-         - task_key: bbb_task
--          run_if: ALL_SUCCESS
-+          run_if: ALL_DONE
+         - task_key: top_task
            notebook_task:
-             notebook_path: /Users/{{workspace_user_name}}/bbb
-@@ -39,5 +39,5 @@
-             notebook_path: /Users/{{workspace_user_name}}/mmm
-         - task_key: nnn_task
--          run_if: ALL_SUCCESS
-+          run_if: ALL_DONE
-           notebook_task:
-             notebook_path: /Users/{{workspace_user_name}}/nnn
-@@ -47,10 +47,6 @@
-     job_mixed:
-       tasks:
--        - task_key: ppp_task
--          run_if: ALL_SUCCESS
--          notebook_task:
--            notebook_path: /Users/{{workspace_user_name}}/ppp
-         - task_key: rrr_task
--          run_if: ALL_SUCCESS
-+          run_if: ALL_DONE
-           notebook_task:
-             notebook_path: /Users/{{workspace_user_name}}/rrr
-@@ -59,8 +55,4 @@
-     job_xremove:
-       tasks:
--        - task_key: bbb_task
--          run_if: ALL_SUCCESS
--          notebook_task:
--            notebook_path: /Users/{{workspace_user_name}}/bbb
-         - task_key: ccc_task
-           run_if: ALL_SUCCESS
-@@ -71,8 +63,7 @@
-     job_xrename:
-       tasks:
--        - task_key: mmm_task
--          run_if: ALL_SUCCESS
--          notebook_task:
-+        - notebook_task:
-             notebook_path: /Users/{{workspace_user_name}}/mmm
-+          task_key: ppp_task
-         - task_key: nnn_task
-           run_if: ALL_SUCCESS
-@@ -94,5 +85,5 @@
-           tasks:
-             - task_key: aaa_tgt
--              run_if: ALL_SUCCESS
-+              run_if: ALL_DONE
-               notebook_task:
-                 notebook_path: /Users/{{workspace_user_name}}/aaa
-@@ -115,12 +106,7 @@
-               notebook_task:
-                 notebook_path: /Users/{{workspace_user_name}}/aaa
--            - task_key: eee_task
--              run_if: ALL_SUCCESS
--              notebook_task:
--                notebook_path: /Users/{{workspace_user_name}}/eee
-         job_xrename:
-           tasks:
--            - task_key: aaa_task
--              run_if: ALL_SUCCESS
--              notebook_task:
--                notebook_path: /Users/{{workspace_user_name}}/aaa
-+            - notebook_task:
-+                notebook_path: '/Users/{{workspace_user_name}}/aaa'
-+              task_key: qqq_task
 
 >>> [CLI] bundle destroy --auto-approve
 The following resources will be deleted:
@@ -112,6 +55,7 @@ The following resources will be deleted:
   delete resources.jobs.job_local
   delete resources.jobs.job_mixed
   delete resources.jobs.job_nonzero
+  delete resources.jobs.job_scalar
   delete resources.jobs.job_xremove
   delete resources.jobs.job_xrename
 

--- a/acceptance/bundle/config-remote-sync/tasks_split/script
+++ b/acceptance/bundle/config-remote-sync/tasks_split/script
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve
+}
+trap cleanup EXIT
+
+$CLI bundle deploy
+
+apply_edit() {
+  # $1 = job name, rest = python operating on the job settings (task list in r)
+  local name="$1"; shift
+  local id
+  id="$(read_id.py "$name")"
+  edit_resource.py jobs "$id" <<PY
+$*
+PY
+}
+
+# Merged+sorted order per job is shown in comments; edits target specific tasks.
+# job_index: top-level [bbb,ccc]+target [aaa] -> aaa,bbb,ccc. Edit bbb (top idx 0).
+apply_edit job_index '
+for t in r["tasks"]:
+    if t["task_key"] == "bbb_task": t["run_if"] = "ALL_DONE"
+'
+# job_local: top-level [zzz]+target [aaa_tgt] -> aaa_tgt,zzz. Edit aaa_tgt (target).
+apply_edit job_local '
+for t in r["tasks"]:
+    if t["task_key"] == "aaa_tgt": t["run_if"] = "ALL_DONE"
+'
+# job_nonzero: top-level [mmm,nnn]+target [aaa] -> aaa,mmm,nnn. Edit nnn (top idx 1).
+apply_edit job_nonzero '
+for t in r["tasks"]:
+    if t["task_key"] == "nnn_task": t["run_if"] = "ALL_DONE"
+'
+# job_mixed: top-level [ppp,rrr]+target [aaa]. Remove ppp (top idx 0), edit rrr.
+apply_edit job_mixed '
+r["tasks"] = [t for t in r["tasks"] if t["task_key"] != "ppp_task"]
+for t in r["tasks"]:
+    if t["task_key"] == "rrr_task": t["run_if"] = "ALL_DONE"
+'
+# job_xremove: top-level [bbb,ccc]+target [aaa,eee]. Remove bbb (top) and eee (target).
+apply_edit job_xremove '
+r["tasks"] = [t for t in r["tasks"] if t["task_key"] not in ("bbb_task", "eee_task")]
+'
+# job_xrename: top-level [mmm,nnn]+target [aaa]. Rename mmm->ppp (top) and aaa->qqq (target).
+apply_edit job_xrename '
+for t in r["tasks"]:
+    if t["task_key"] == "mmm_task": t["task_key"] = "ppp_task"
+    if t["task_key"] == "aaa_task": t["task_key"] = "qqq_task"
+'
+
+title "Detect and save changes"
+echo
+cp databricks.yml databricks.yml.backup
+$CLI bundle config-remote-sync --save
+
+title "Configuration changes"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/tasks_split/script
+++ b/acceptance/bundle/config-remote-sync/tasks_split/script
@@ -51,6 +51,10 @@ for t in r["tasks"]:
     if t["task_key"] == "mmm_task": t["task_key"] = "ppp_task"
     if t["task_key"] == "aaa_task": t["task_key"] = "qqq_task"
 '
+# A change that does not enter the split sequence is still safe to apply.
+apply_edit job_scalar '
+r["timeout_seconds"] = 200
+'
 
 title "Detect and save changes"
 echo

--- a/acceptance/bundle/config-remote-sync/tasks_split/test.toml
+++ b/acceptance/bundle/config-remote-sync/tasks_split/test.toml
@@ -1,0 +1,11 @@
+# Local-only. One bundle with several jobs, each a distinct block-split scenario,
+# synced in one pass. Having multiple split jobs also verifies block anchors are
+# grouped per resource, not globally.
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -27,14 +27,19 @@ type FieldChange struct {
 // the YAML file positions. It also returns the location of the resolved leaf value.
 // Example: "resources.jobs.foo.tasks[task_key='main'].name" -> "resources.jobs.foo.tasks[1].name"
 // Returns a PatternNode because for Add operations, [*] may be used as a placeholder for new elements.
-func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType) (*structpath.PatternNode, dyn.Location, error) {
+//
+// The returned bool reports whether the resolved element was contributed by a
+// target override block. Its numeric index is then local to that block, so only
+// the targets.<t>.-prefixed candidate is valid (see ResolveChanges).
+func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType) (*structpath.PatternNode, dyn.Location, bool, error) {
 	node, err := structpath.ParsePath(pathStr)
 	if err != nil {
-		return nil, dyn.Location{}, fmt.Errorf("failed to parse path %s: %w", pathStr, err)
+		return nil, dyn.Location{}, false, fmt.Errorf("failed to parse path %s: %w", pathStr, err)
 	}
 
 	nodes := node.AsSlice()
 	var result *structpath.PatternNode
+	inOverrideBlock := false
 	currentValue := b.Config.Value()
 
 	for _, n := range nodes {
@@ -47,6 +52,23 @@ func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType)
 		}
 
 		if idx, ok := n.Index(); ok {
+			// A numeric index reaches here when the change path is positional
+			// rather than keyed — i.e. the resource registered no KeyedSlices
+			// entry for this sequence (e.g. pipeline `clusters`, which structdiff
+			// compares by position). When such a sequence is split across a
+			// top-level and a target override block, idx is the merged-sequence
+			// position; convert it to the block-local index and flag target-block
+			// elements, exactly as the keyed selector below does.
+			if currentValue.IsValid() && currentValue.Kind() == dyn.KindSequence {
+				seq, _ := currentValue.AsSequence()
+				seqLocations := currentValue.Locations()
+				if len(seqLocations) >= 2 && idx >= 0 && idx < len(seq) {
+					result = structpath.NewPatternIndex(result, yamlFileIndex(seq, idx, seqLocations))
+					inOverrideBlock = inOverrideBlock || elementInOverrideBlock(seq[idx].Location(), seqLocations)
+					currentValue = seq[idx]
+					continue
+				}
+			}
 			result = structpath.NewPatternIndex(result, idx)
 			if currentValue.IsValid() {
 				currentValue, _ = dyn.GetByPath(currentValue, dyn.Path{dyn.Index(idx)})
@@ -57,10 +79,11 @@ func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType)
 		// Check for key-value selector: [key='value']
 		if key, value, ok := n.KeyValue(); ok {
 			if !currentValue.IsValid() || currentValue.Kind() != dyn.KindSequence {
-				return nil, dyn.Location{}, fmt.Errorf("cannot apply [%s='%s'] selector to non-array value in path %s", key, value, pathStr)
+				return nil, dyn.Location{}, false, fmt.Errorf("cannot apply [%s='%s'] selector to non-array value in path %s", key, value, pathStr)
 			}
 
 			seq, _ := currentValue.AsSequence()
+			seqLocations := currentValue.Locations()
 			foundIndex := -1
 
 			for i, elem := range seq {
@@ -82,31 +105,52 @@ func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType)
 					currentValue = dyn.Value{}
 					continue
 				}
-				return nil, dyn.Location{}, fmt.Errorf("no array element found with %s='%s' in path %s", key, value, pathStr)
+				return nil, dyn.Location{}, false, fmt.Errorf("no array element found with %s='%s' in path %s", key, value, pathStr)
 			}
 
 			// Mutators may reorder sequence elements (e.g., tasks sorted by task_key).
 			// Use location information to determine the original YAML file position.
-			yamlIndex := yamlFileIndex(seq, foundIndex)
+			yamlIndex := yamlFileIndex(seq, foundIndex, seqLocations)
 			result = structpath.NewPatternIndex(result, yamlIndex)
+			// yamlIndex is local to the element's own block; latch so a nested
+			// single-block selector further down doesn't clear a target match.
+			inOverrideBlock = inOverrideBlock || elementInOverrideBlock(seq[foundIndex].Location(), seqLocations)
 			currentValue = seq[foundIndex]
 			continue
 		}
 	}
 
-	return result, currentValue.Location(), nil
+	return result, currentValue.Location(), inOverrideBlock, nil
 }
 
-// yamlFileIndex determines the original YAML file position of a sequence element.
-// Mutators may reorder sequence elements (e.g., tasks sorted by task_key), so the
-// in-memory index may not match the position in the YAML file. This function uses
-// location information to count how many elements from the same file appear before
-// the target element, giving the correct index for YAML patching.
-func yamlFileIndex(seq []dyn.Value, sortedIndex int) int {
+// elementInOverrideBlock reports whether a merged sequence element came from a
+// target override block rather than the top-level block. merge keeps the
+// reference (top-level) locations first, so seqLocations[0] is the top-level
+// anchor; an element anchored elsewhere came from a target block and its
+// block-local index is only valid under the targets.<t>. prefix. A resource is
+// declared once across top-level files (duplicate keys are rejected at load), so
+// a second anchor can only be a target override, never a second top-level file.
+func elementInOverrideBlock(elemLoc dyn.Location, seqLocations []dyn.Location) bool {
+	if len(seqLocations) < 2 || elemLoc.File == "" {
+		return false
+	}
+	topAnchor := seqLocations[0]
+	return elemLoc.File != topAnchor.File || blockAnchor(elemLoc, seqLocations) != topAnchor.Line
+}
+
+// yamlFileIndex returns a sequence element's index within its own config block.
+// Tasks/clusters merged from a top-level block and a target override are one
+// sorted in-memory sequence but patched per block in the YAML, so the merged
+// index is wrong. seqLocations holds one anchor per block; counting only
+// same-block, earlier-line elements yields the block-local index. A single-block
+// sequence reduces to a plain same-file count.
+func yamlFileIndex(seq []dyn.Value, sortedIndex int, seqLocations []dyn.Location) int {
 	matchLocation := seq[sortedIndex].Location()
 	if matchLocation.File == "" {
 		return sortedIndex
 	}
+
+	matchAnchor := blockAnchor(matchLocation, seqLocations)
 
 	yamlIndex := 0
 	for i, elem := range seq {
@@ -114,11 +158,26 @@ func yamlFileIndex(seq []dyn.Value, sortedIndex int) int {
 			continue
 		}
 		loc := elem.Location()
-		if loc.File == matchLocation.File && loc.Line < matchLocation.Line {
+		if loc.File == matchLocation.File && loc.Line < matchLocation.Line && blockAnchor(loc, seqLocations) == matchAnchor {
 			yamlIndex++
 		}
 	}
 	return yamlIndex
+}
+
+// blockAnchor returns the config block a sequence element belongs to, identified by the
+// line of that block's sequence node. Blocks never interleave within a file, so the
+// element's block is the anchor with the greatest line at or before the element in the
+// same file. Returns 0 when no anchor matches (single unlocated block), which keeps all
+// elements in one group.
+func blockAnchor(loc dyn.Location, seqLocations []dyn.Location) int {
+	anchor := 0
+	for _, l := range seqLocations {
+		if l.File == loc.File && l.Line <= loc.Line && l.Line > anchor {
+			anchor = l.Line
+		}
+	}
+	return anchor
 }
 
 func pathDepth(pathStr string) int {
@@ -129,10 +188,30 @@ func pathDepth(pathStr string) int {
 	return len(node.AsSlice())
 }
 
+// blockScopedParent namespaces per-sequence index bookkeeping by block. A target
+// override block and the top-level block share the same unprefixed parent path
+// but keep block-local indices, so add/remove operations in one block must not
+// shift indices resolved in the other. Prefixing the override block's key with
+// targets.<t>. keeps the two buckets separate.
+func blockScopedParent(parentPathStr, targetName string, inOverrideBlock bool) string {
+	if inOverrideBlock {
+		return "targets." + targetName + "." + parentPathStr
+	}
+	return parentPathStr
+}
+
+// reuseFreedIndex pops the first index freed by a prior removal and rewrites path
+// to point at that slot, so a recreated (renamed) element reuses the removed
+// element's position instead of appending. Returns the remaining indices.
+func reuseFreedIndex(indices []int, path *structpath.PatternNode) ([]int, *structpath.PatternNode) {
+	return indices[1:], structpath.NewPatternIndex(path.Parent(), indices[0])
+}
+
 // adjustArrayIndex adjusts the index in a PatternNode based on previous operations.
 // When operations are applied sequentially, removals and additions shift array indices.
-// This function adjusts the index to account for those shifts.
-func adjustArrayIndex(path *structpath.PatternNode, operations map[string][]struct {
+// This function adjusts the index to account for those shifts. parentKey selects the
+// block-scoped bucket of operations that apply to this element's sequence block.
+func adjustArrayIndex(path *structpath.PatternNode, parentKey string, operations map[string][]struct {
 	index     int
 	operation OperationType
 },
@@ -143,8 +222,7 @@ func adjustArrayIndex(path *structpath.PatternNode, operations map[string][]stru
 	}
 
 	parentPath := path.Parent()
-	parentPathStr := parentPath.String()
-	ops := operations[parentPathStr]
+	ops := operations[parentKey]
 
 	adjustment := 0
 	for _, op := range ops {
@@ -215,7 +293,7 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			configChange := resourceChanges[fieldPath]
 			fullPath := resourceKey + "." + fieldPath
 
-			resolvedPath, resolvedLocation, err := resolveSelectors(fullPath, b, configChange.Operation)
+			resolvedPath, resolvedLocation, inOverrideBlock, err := resolveSelectors(fullPath, b, configChange.Operation)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve selectors in path %s: %w", fullPath, err)
 			}
@@ -225,37 +303,57 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			if configChange.Operation == OperationRemove {
 				freeIndex, ok := resolvedPath.Index()
 				if ok {
-					parentPath := resolvedPath.Parent().String()
-					indicesToReplaceMap[parentPath] = append(indicesToReplaceMap[parentPath], freeIndex)
+					parentKey := blockScopedParent(resolvedPath.Parent().String(), targetName, inOverrideBlock)
+					indicesToReplaceMap[parentKey] = append(indicesToReplaceMap[parentKey], freeIndex)
 				}
 			}
 
 			if configChange.Operation == OperationAdd && resolvedPath.BracketStar() {
-				parentPath := resolvedPath.Parent().String()
-				indices, ok := indicesToReplaceMap[parentPath]
-				if ok && len(indices) > 0 {
-					index := indices[0]
-					indicesToReplaceMap[parentPath] = indices[1:]
-					resolvedPath = structpath.NewPatternIndex(resolvedPath.Parent(), index)
+				// A newly added keyed element has no location, so inOverrideBlock is
+				// false here. Reuse an index freed by a removal in the same sync (a
+				// rename diffs as remove+add): try the top-level block first, then the
+				// target override block. Reusing a target-block slot means this add
+				// renames a target-only element, so it must stay in that block — latch
+				// inOverrideBlock so it is not relocated to the top-level block.
+				topKey := resolvedPath.Parent().String()
+				targetKey := blockScopedParent(topKey, targetName, true)
+				switch {
+				case len(indicesToReplaceMap[topKey]) > 0:
+					indicesToReplaceMap[topKey], resolvedPath = reuseFreedIndex(indicesToReplaceMap[topKey], resolvedPath)
+				case targetName != "" && len(indicesToReplaceMap[targetKey]) > 0:
+					indicesToReplaceMap[targetKey], resolvedPath = reuseFreedIndex(indicesToReplaceMap[targetKey], resolvedPath)
+					inOverrideBlock = true
 				}
 			}
 
-			resolvedPath = adjustArrayIndex(resolvedPath, indexOperations)
+			parentKey := blockScopedParent(resolvedPath.Parent().String(), targetName, inOverrideBlock)
+			resolvedPath = adjustArrayIndex(resolvedPath, parentKey, indexOperations)
 
 			// Track this operation for future index adjustments (only for array element operations)
 			if originalIndex, ok := resolvedPath.Index(); ok {
-				parentPath := resolvedPath.Parent().String()
-				indexOperations[parentPath] = append(indexOperations[parentPath], struct {
+				indexOperations[parentKey] = append(indexOperations[parentKey], struct {
 					index     int
 					operation OperationType
 				}{originalIndex, configChange.Operation})
 			}
 
 			resolvedPathStr := resolvedPath.String()
-			candidates := []string{resolvedPathStr}
-			if targetName != "" {
-				targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
-				candidates = append(candidates, targetPrefixedPath)
+			var candidates []string
+			targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
+			switch {
+			case inOverrideBlock:
+				// inOverrideBlock is only ever set when a target override block
+				// contributed to the sequence, which requires a selected target, so
+				// targetName is non-empty here and targetPrefixedPath is well-formed.
+				// The index is local to that override block, so only the target-prefixed
+				// candidate points at the right element. Emitting the unprefixed
+				// candidate too would let applyChange write the same index into the
+				// top-level block and silently patch the wrong element.
+				candidates = []string{targetPrefixedPath}
+			case targetName != "":
+				candidates = []string{resolvedPathStr, targetPrefixedPath}
+			default:
+				candidates = []string{resolvedPathStr}
 			}
 
 			filePath := resolvedLocation.File

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -188,6 +188,49 @@ func pathDepth(pathStr string) int {
 	return len(node.AsSlice())
 }
 
+// pathTouchesSplitSequence reports whether resolving path crosses a sequence
+// assembled from multiple YAML blocks. The merged value does not retain enough
+// per-element provenance to map every remote edit back to the correct block, so
+// callers must not emit patches for resources containing such changes.
+func pathTouchesSplitSequence(pathStr string, b *bundle.Bundle) (bool, error) {
+	node, err := structpath.ParsePath(pathStr)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse path %s: %w", pathStr, err)
+	}
+
+	currentValue := b.Config.Value()
+	for _, n := range node.AsSlice() {
+		if currentValue.IsValid() && currentValue.Kind() == dyn.KindSequence && len(currentValue.Locations()) > 1 {
+			return true, nil
+		}
+
+		if key, ok := n.StringKey(); ok {
+			currentValue, _ = dyn.GetByPath(currentValue, dyn.Path{dyn.Key(key)})
+			continue
+		}
+		if idx, ok := n.Index(); ok {
+			currentValue, _ = dyn.GetByPath(currentValue, dyn.Path{dyn.Index(idx)})
+			continue
+		}
+		if key, value, ok := n.KeyValue(); ok {
+			seq, ok := currentValue.AsSequence()
+			if !ok {
+				return false, nil
+			}
+			currentValue = dyn.Value{}
+			for _, elem := range seq {
+				keyValue, err := dyn.GetByPath(elem, dyn.Path{dyn.Key(key)})
+				if err == nil && keyValue.Kind() == dyn.KindString && keyValue.MustString() == value {
+					currentValue = elem
+					break
+				}
+			}
+		}
+	}
+
+	return currentValue.IsValid() && currentValue.Kind() == dyn.KindSequence && len(currentValue.Locations()) > 1, nil
+}
+
 // blockScopedParent namespaces per-sequence index bookkeeping by block. A target
 // override block and the top-level block share the same unprefixed parent path
 // but keep block-local indices, so add/remove operations in one block must not
@@ -251,6 +294,26 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 
 	for _, resourceKey := range resourceKeys {
 		resourceChanges := configChanges[resourceKey]
+
+		// A split sequence can contain an unpaired remove/add rename and elements
+		// whose target-block location was collapsed by the merge. Skip the whole
+		// resource before resolving any fields so a compound edit cannot be applied
+		// partially and corrupt the source YAML.
+		skipResource := false
+		for fieldPath := range resourceChanges {
+			split, err := pathTouchesSplitSequence(resourceKey+"."+fieldPath, b)
+			if err != nil {
+				return nil, err
+			}
+			if split {
+				skipResource = true
+				break
+			}
+		}
+		if skipResource {
+			log.Debugf(ctx, "Skipping config sync for resource %s because a changed sequence is defined in multiple YAML blocks", resourceKey)
+			continue
+		}
 
 		fieldPaths := make([]string, 0, len(resourceChanges))
 		fieldPathsDepths := map[string]int{}

--- a/bundle/configsync/resolve_test.go
+++ b/bundle/configsync/resolve_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/mutator"
+	"github.com/databricks/cli/bundle/config/mutator/resourcemutator"
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/logdiag"
@@ -296,4 +297,56 @@ func TestElementInOverrideBlock(t *testing.T) {
 	multiFile := []dyn.Location{{File: "a.yml", Line: 6}, {File: "b.yml", Line: 4}}
 	assert.True(t, elementInOverrideBlock(dyn.Location{File: "b.yml", Line: 6}, multiFile))  // target block, other file
 	assert.False(t, elementInOverrideBlock(dyn.Location{File: "a.yml", Line: 8}, multiFile)) // top-level block
+}
+
+func TestResolveChangesSkipsResourceWithChangedSplitSequence(t *testing.T) {
+	ctx := logdiag.InitContext(t.Context())
+	tmpDir := t.TempDir()
+	yamlContent := `bundle:
+  name: test
+resources:
+  jobs:
+    split_job:
+      name: split
+      tasks:
+        - task_key: top
+          description: top
+    regular_job:
+      name: regular
+targets:
+  default:
+    default: true
+    resources:
+      jobs:
+        split_job:
+          tasks:
+            - task_key: target
+              description: target
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "databricks.yml"), []byte(yamlContent), 0o644))
+
+	b, err := bundle.Load(ctx, tmpDir)
+	require.NoError(t, err)
+	mutator.DefaultMutators(ctx, b)
+	diags := bundle.Apply(ctx, b, mutator.SelectTarget("default"))
+	require.NoError(t, diags.Error())
+	diags = bundle.Apply(ctx, b, resourcemutator.MergeJobTasks())
+	require.NoError(t, diags.Error())
+
+	changes := Changes{
+		"resources.jobs.split_job": {
+			"name":                                 {Operation: OperationReplace, Value: "changed"},
+			"tasks[task_key='top']":                {Operation: OperationRemove},
+			"tasks[task_key='target'].description": {Operation: OperationReplace, Value: "changed"},
+			"tasks[task_key='new_task']":           {Operation: OperationAdd, Value: map[string]any{"task_key": "new_task"}},
+		},
+		"resources.jobs.regular_job": {
+			"name": {Operation: OperationReplace, Value: "changed"},
+		},
+	}
+
+	fieldChanges, err := ResolveChanges(ctx, b, changes)
+	require.NoError(t, err)
+	require.Len(t, fieldChanges, 1)
+	assert.Equal(t, []string{"resources.jobs.regular_job.name", "targets.default.resources.jobs.regular_job.name"}, fieldChanges[0].FieldCandidates)
 }

--- a/bundle/configsync/resolve_test.go
+++ b/bundle/configsync/resolve_test.go
@@ -32,7 +32,7 @@ func TestResolveSelectors_NoSelectors(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.name", b, OperationReplace)
+	result, _, _, err := resolveSelectors("resources.jobs.test_job.name", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.name", result.String())
 }
@@ -57,11 +57,11 @@ func TestResolveSelectors_NumericIndices(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.tasks[0].task_key", b, OperationReplace)
+	result, _, _, err := resolveSelectors("resources.jobs.test_job.tasks[0].task_key", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[0].task_key", result.String())
 
-	result, _, err = resolveSelectors("resources.jobs.test_job.tasks[1].task_key", b, OperationReplace)
+	result, _, _, err = resolveSelectors("resources.jobs.test_job.tasks[1].task_key", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[1].task_key", result.String())
 }
@@ -90,11 +90,11 @@ func TestResolveSelectors_KeyValueSelector(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.tasks[task_key='main'].notebook_task.notebook_path", b, OperationReplace)
+	result, _, _, err := resolveSelectors("resources.jobs.test_job.tasks[task_key='main'].notebook_task.notebook_path", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[1].notebook_task.notebook_path", result.String())
 
-	result, _, err = resolveSelectors("resources.jobs.test_job.tasks[task_key='setup'].notebook_task.notebook_path", b, OperationReplace)
+	result, _, _, err = resolveSelectors("resources.jobs.test_job.tasks[task_key='setup'].notebook_task.notebook_path", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[0].notebook_task.notebook_path", result.String())
 }
@@ -120,7 +120,7 @@ func TestResolveSelectors_SelectorNotFound(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	_, _, err = resolveSelectors("resources.jobs.test_job.tasks[task_key='nonexistent'].notebook_task.notebook_path", b, OperationReplace)
+	_, _, _, err = resolveSelectors("resources.jobs.test_job.tasks[task_key='nonexistent'].notebook_task.notebook_path", b, OperationReplace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no array element found with task_key='nonexistent'")
 }
@@ -143,7 +143,7 @@ func TestResolveSelectors_SelectorOnNonArray(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	_, _, err = resolveSelectors("resources.jobs.test_job[task_key='main'].name", b, OperationReplace)
+	_, _, _, err = resolveSelectors("resources.jobs.test_job[task_key='main'].name", b, OperationReplace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot apply [task_key='main'] selector to non-array value")
 }
@@ -174,7 +174,7 @@ func TestResolveSelectors_NestedSelectors(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.tasks[task_key='main'].libraries[0].pypi.package", b, OperationReplace)
+	result, _, _, err := resolveSelectors("resources.jobs.test_job.tasks[task_key='main'].libraries[0].pypi.package", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[1].libraries[0].pypi.package", result.String())
 }
@@ -200,7 +200,7 @@ func TestResolveSelectors_WildcardNotSupported(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	_, _, err = resolveSelectors("resources.jobs.test_job.tasks.*.task_key", b, OperationReplace)
+	_, _, _, err = resolveSelectors("resources.jobs.test_job.tasks.*.task_key", b, OperationReplace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wildcards not allowed in path")
 }
@@ -215,11 +215,13 @@ func TestYamlFileIndex(t *testing.T) {
 		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 30}}), // pipeline_task
 		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 20}}), // python_wheel_task
 	}
+	// Single block: the sequence node is anchored at the block's line in the file.
+	seqLocations := []dyn.Location{{File: "a.yml", Line: 5}}
 
-	assert.Equal(t, 3, yamlFileIndex(seq, 0)) // extra: 3 elements before it in YAML
-	assert.Equal(t, 0, yamlFileIndex(seq, 1)) // notebook_task: first in YAML
-	assert.Equal(t, 2, yamlFileIndex(seq, 2)) // pipeline_task: 2 elements before it
-	assert.Equal(t, 1, yamlFileIndex(seq, 3)) // python_wheel_task: 1 element before it
+	assert.Equal(t, 3, yamlFileIndex(seq, 0, seqLocations)) // extra: 3 elements before it in YAML
+	assert.Equal(t, 0, yamlFileIndex(seq, 1, seqLocations)) // notebook_task: first in YAML
+	assert.Equal(t, 2, yamlFileIndex(seq, 2, seqLocations)) // pipeline_task: 2 elements before it
+	assert.Equal(t, 1, yamlFileIndex(seq, 3, seqLocations)) // python_wheel_task: 1 element before it
 }
 
 func TestYamlFileIndex_MultipleFiles(t *testing.T) {
@@ -233,12 +235,14 @@ func TestYamlFileIndex_MultipleFiles(t *testing.T) {
 		dyn.NewValue(nil, []dyn.Location{{File: "b.yml", Line: 5}}),  // task_c
 		dyn.NewValue(nil, []dyn.Location{{File: "b.yml", Line: 15}}), // task_d
 	}
+	// One anchor per file, each above its file's first element.
+	seqLocations := []dyn.Location{{File: "a.yml", Line: 3}, {File: "b.yml", Line: 2}}
 
 	// Indices are relative to each file
-	assert.Equal(t, 0, yamlFileIndex(seq, 0)) // task_a: first in file A
-	assert.Equal(t, 1, yamlFileIndex(seq, 1)) // task_b: second in file A
-	assert.Equal(t, 0, yamlFileIndex(seq, 2)) // task_c: first in file B
-	assert.Equal(t, 1, yamlFileIndex(seq, 3)) // task_d: second in file B
+	assert.Equal(t, 0, yamlFileIndex(seq, 0, seqLocations)) // task_a: first in file A
+	assert.Equal(t, 1, yamlFileIndex(seq, 1, seqLocations)) // task_b: second in file A
+	assert.Equal(t, 0, yamlFileIndex(seq, 2, seqLocations)) // task_c: first in file B
+	assert.Equal(t, 1, yamlFileIndex(seq, 3, seqLocations)) // task_d: second in file B
 }
 
 func TestYamlFileIndex_NoLocation(t *testing.T) {
@@ -246,6 +250,50 @@ func TestYamlFileIndex_NoLocation(t *testing.T) {
 		dyn.NewValue(nil, nil),
 		dyn.NewValue(nil, nil),
 	}
-	assert.Equal(t, 0, yamlFileIndex(seq, 0))
-	assert.Equal(t, 1, yamlFileIndex(seq, 1))
+	assert.Equal(t, 0, yamlFileIndex(seq, 0, nil))
+	assert.Equal(t, 1, yamlFileIndex(seq, 1, nil))
+}
+
+func TestYamlFileIndex_SplitBlocksSameFile(t *testing.T) {
+	// A job's tasks split across two blocks in the SAME file: a targets override
+	// block (aaa, near the top) and the top-level resources block (bbb, ccc, lower
+	// down). MergeJobTasks concatenates and sorts by task_key -> [aaa, bbb, ccc].
+	// The tasks sequence node carries one anchor per block: top-level tasks at line
+	// 20, target tasks at line 11 (order matches the real merge, which keeps the
+	// top-level location first). Each element's index must be relative to its own
+	// block, not the whole file.
+	seq := []dyn.Value{
+		dyn.NewValue(nil, []dyn.Location{{File: "databricks.yml", Line: 11}}), // aaa (target block)
+		dyn.NewValue(nil, []dyn.Location{{File: "databricks.yml", Line: 20}}), // bbb (top-level block)
+		dyn.NewValue(nil, []dyn.Location{{File: "databricks.yml", Line: 28}}), // ccc (top-level block)
+	}
+	seqLocations := []dyn.Location{{File: "databricks.yml", Line: 20}, {File: "databricks.yml", Line: 11}}
+
+	assert.Equal(t, 0, yamlFileIndex(seq, 0, seqLocations)) // aaa: first in target block
+	assert.Equal(t, 0, yamlFileIndex(seq, 1, seqLocations)) // bbb: first in top-level block (NOT 1)
+	assert.Equal(t, 1, yamlFileIndex(seq, 2, seqLocations)) // ccc: second in top-level block
+}
+
+func TestElementInOverrideBlock(t *testing.T) {
+	// seqLocations[0] is always the top-level anchor (merge keeps the reference
+	// block first); seqLocations[1] is the target override anchor. This holds
+	// regardless of which block appears first in the file.
+	topFirst := []dyn.Location{{File: "databricks.yml", Line: 6}, {File: "databricks.yml", Line: 20}}
+	assert.True(t, elementInOverrideBlock(dyn.Location{File: "databricks.yml", Line: 22}, topFirst)) // target block
+	assert.False(t, elementInOverrideBlock(dyn.Location{File: "databricks.yml", Line: 8}, topFirst)) // top-level block
+
+	// Target block precedes resources in the file: top-level anchor still first.
+	targetFirst := []dyn.Location{{File: "databricks.yml", Line: 20}, {File: "databricks.yml", Line: 6}}
+	assert.True(t, elementInOverrideBlock(dyn.Location{File: "databricks.yml", Line: 8}, targetFirst))   // target block
+	assert.False(t, elementInOverrideBlock(dyn.Location{File: "databricks.yml", Line: 22}, targetFirst)) // top-level block
+
+	// Single block (no override contribution) is never in an override block.
+	single := []dyn.Location{{File: "databricks.yml", Line: 6}}
+	assert.False(t, elementInOverrideBlock(dyn.Location{File: "databricks.yml", Line: 8}, single))
+	assert.False(t, elementInOverrideBlock(dyn.Location{}, topFirst))
+
+	// Multi-file split: a top-level block in a.yml and a target block in b.yml.
+	multiFile := []dyn.Location{{File: "a.yml", Line: 6}, {File: "b.yml", Line: 4}}
+	assert.True(t, elementInOverrideBlock(dyn.Location{File: "b.yml", Line: 6}, multiFile))  // target block, other file
+	assert.False(t, elementInOverrideBlock(dyn.Location{File: "a.yml", Line: 8}, multiFile)) // top-level block
 }


### PR DESCRIPTION
## Changes

- detect changed sequence paths assembled from multiple YAML blocks
- skip all changes for the affected resource atomically to avoid partial remove/add updates
- continue syncing safe changes that do not traverse a split sequence
- update keyed and positional split-sequence acceptance coverage

## Tests

- `go test ./bundle/configsync`
- `go vet ./bundle/configsync`
- `./task ws`
- shell syntax checks for updated acceptance scripts
- `git diff --check`