### PR TITLE
acc: Destroy leaked bundles after cloud test runs

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -428,19 +428,22 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("NODE_TYPE_ID", nodeTypeID)
 	repls.Set(nodeTypeID, "[NODE_TYPE_ID]")
 
-	// The run id is embedded into every $UNIQUE_NAME (see ciUniqueName) so that
-	// resources can be attributed to a run and swept by prefix. On CI it is the
-	// GitHub run id; otherwise synthesize a random numeric id so a local cloud
-	// run (e.g. `deco env run`) is still sweepable. Empty off cloud, where names
-	// need no attribution.
+	// The run id and leg suffix are embedded into every $UNIQUE_NAME (see
+	// ciUniqueName) so that resources can be attributed to this run and swept by
+	// prefix. On CI the run id is the GitHub run id; otherwise synthesize a random
+	// numeric id so a local cloud run (e.g. `deco env run`) is still sweepable. The
+	// leg suffix is fresh per test process, so this leg's cleanup destroys only its
+	// own bundles even when a sibling matrix leg shares the workspace. Empty off
+	// cloud, where names need no attribution.
 	if cloudEnv != "" {
 		bundleRunID = os.Getenv("GITHUB_RUN_ID")
 		if bundleRunID == "" {
 			bundleRunID = strconv.Itoa(rand.IntN(1_000_000_000))
 		}
-		// Destroy every bundle this run deploys once all tests finish. Registered
+		bundleLegSuffix = randomBundleLegSuffix()
+		// Destroy every bundle this leg deploys once all tests finish. Registered
 		// before the tests are spawned so it runs after they complete.
-		setupBundleCleanup(t, execPath, bundleRunID)
+		setupBundleCleanup(t, execPath, bundleNamePrefix(bundleRunID, bundleLegSuffix))
 	}
 
 	testDirs := getTests(t)
@@ -739,25 +742,58 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 
 var ciRunID = regexp.MustCompile(`^[0-9]{1,16}$`)
 
-// bundleRunID identifies the current run for bundle attribution and cleanup. Set
-// once in testAccept on cloud (GitHub run id, or a random numeric id locally),
-// empty off cloud. Read by ciUniqueName to build the sweepable $UNIQUE_NAME prefix.
-var bundleRunID string
+// bundleRunID and bundleLegSuffix identify this run and this specific test
+// process for bundle attribution and cleanup. Set once in testAccept on cloud
+// (bundleRunID is the GitHub run id or a random numeric id locally;
+// bundleLegSuffix is a fresh random suffix), empty off cloud. Read by
+// ciUniqueName to build the sweepable $UNIQUE_NAME prefix.
+//
+// All matrix legs of a CI run share one GitHub run id, and legs of different OSes
+// share a workspace, so a run-id-only prefix would let one leg's cleanup destroy
+// another leg's live bundles. The per-process bundleLegSuffix makes each leg's
+// prefix distinct so its cleanup sweeps only its own deployments, while the
+// run id stays a matchable substring for the run-wide sweeper (sweep_test_resources.py).
+var (
+	bundleRunID     string
+	bundleLegSuffix string
+)
 
-// ciUniqueName embeds a CI run id into the random unique name as "ci<runID>x<random>".
-// The result stays purely lowercase-alphanumeric like the base32 name it replaces, so it
-// remains valid everywhere $UNIQUE_NAME is used: app names (no hyphens would be fine but
-// underscores/uppercase are not), Python and Unity Catalog identifiers (no hyphens). No
-// punctuation separator works for all of them, so the run id (all digits) is delimited by
-// the letter "x", which also keeps the sweep prefix "ci<runID>x" collision-free between
-// runs whose ids share a prefix. Length is preserved ("app-$UNIQUE_NAME" is exactly the
-// 30-char app name maximum). Returns random unchanged when runID is absent, malformed, or
-// too long to leave at least 8 random characters.
-func ciUniqueName(runID, random string) string {
+// bundleLegSuffixAlphabet is lowercase-alphanumeric to satisfy the same identifier
+// constraints as the unique name itself (see ciUniqueName).
+const bundleLegSuffixAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+// randomBundleLegSuffix returns a 3-character lowercase-alphanumeric suffix. 36^3
+// values make a collision between the few legs sharing a workspace within one run
+// vanishingly unlikely.
+func randomBundleLegSuffix() string {
+	b := make([]byte, 3)
+	for i := range b {
+		b[i] = bundleLegSuffixAlphabet[rand.IntN(len(bundleLegSuffixAlphabet))]
+	}
+	return string(b)
+}
+
+// bundleNamePrefix is the sweepable prefix embedded into $UNIQUE_NAME:
+// "ci<runID>x<legSuffix>". The run id (all digits) is delimited by "x" so the
+// run-wide sweep prefix "ci<runID>x" stays collision-free between runs whose ids
+// share a prefix; legSuffix then isolates one leg from another within the run.
+func bundleNamePrefix(runID, legSuffix string) string {
+	return "ci" + runID + "x" + legSuffix
+}
+
+// ciUniqueName embeds the run id and leg suffix into the random unique name as
+// "ci<runID>x<legSuffix><random>". The result stays purely lowercase-alphanumeric
+// like the base32 name it replaces, so it remains valid everywhere $UNIQUE_NAME is
+// used: app names (no hyphens would be fine but underscores/uppercase are not),
+// Python and Unity Catalog identifiers (no hyphens). Length is preserved
+// ("app-$UNIQUE_NAME" is exactly the 30-char app name maximum). Returns random
+// unchanged when runID is absent, malformed, or too long to leave at least 8
+// random characters.
+func ciUniqueName(runID, legSuffix, random string) string {
 	if !ciRunID.MatchString(runID) {
 		return random
 	}
-	prefix := "ci" + runID + "x"
+	prefix := bundleNamePrefix(runID, legSuffix)
 	randLen := len(random) - len(prefix)
 	if randLen < 8 {
 		return random
@@ -799,8 +835,8 @@ func runTest(t *testing.T,
 
 	id := uuid.New()
 	uniqueName := strings.ToLower(strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "="))
-	// Embed the run id, when present, so leaked resources can be attributed to a run and swept by prefix.
-	uniqueName = ciUniqueName(bundleRunID, uniqueName)
+	// Embed the run id and leg suffix, when present, so leaked resources can be attributed to a run and swept by prefix.
+	uniqueName = ciUniqueName(bundleRunID, bundleLegSuffix, uniqueName)
 	repls.Set(uniqueName, "[UNIQUE_NAME]")
 
 	var tmpDir string

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -427,6 +427,12 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("NODE_TYPE_ID", nodeTypeID)
 	repls.Set(nodeTypeID, "[NODE_TYPE_ID]")
 
+	// On cloud, destroy every bundle this run deploys once all tests finish.
+	// Registered before the tests are spawned so it runs after they complete.
+	if !inprocessMode {
+		setupBundleCleanup(t, execPath, cloudEnv)
+	}
+
 	testDirs := getTests(t)
 	require.NotEmpty(t, testDirs)
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -428,22 +428,13 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("NODE_TYPE_ID", nodeTypeID)
 	repls.Set(nodeTypeID, "[NODE_TYPE_ID]")
 
-	// The run id and leg suffix are embedded into every $UNIQUE_NAME (see
-	// ciUniqueName) so that resources can be attributed to this run and swept by
-	// prefix. On CI the run id is the GitHub run id; otherwise synthesize a random
-	// numeric id so a local cloud run (e.g. `deco env run`) is still sweepable. The
-	// leg suffix is fresh per test process, so this leg's cleanup destroys only its
-	// own bundles even when a sibling matrix leg shares the workspace. Empty off
-	// cloud, where names need no attribution.
+	// On cloud, tag every $UNIQUE_NAME with a per-process prefix (see
+	// newBundleNamePrefix) so this leg's bundles can be attributed and swept, and
+	// destroy them once all tests finish. Registered before the tests are spawned
+	// so it runs after they complete. Off cloud names need no attribution.
 	if cloudEnv != "" {
-		bundleRunID = os.Getenv("GITHUB_RUN_ID")
-		if bundleRunID == "" {
-			bundleRunID = strconv.Itoa(rand.IntN(1_000_000_000))
-		}
-		bundleLegSuffix = randomBundleLegSuffix()
-		// Destroy every bundle this leg deploys once all tests finish. Registered
-		// before the tests are spawned so it runs after they complete.
-		setupBundleCleanup(t, execPath, bundleNamePrefix(bundleRunID, bundleLegSuffix))
+		bundleNamePrefix = newBundleNamePrefix()
+		setupBundleCleanup(t, execPath, bundleNamePrefix)
 	}
 
 	testDirs := getTests(t)
@@ -742,60 +733,43 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 
 var ciRunID = regexp.MustCompile(`^[0-9]{1,16}$`)
 
-// bundleRunID and bundleLegSuffix identify this run and this specific test
-// process for bundle attribution and cleanup. Set once in testAccept on cloud
-// (bundleRunID is the GitHub run id or a random numeric id locally;
-// bundleLegSuffix is a fresh random suffix), empty off cloud. Read by
-// ciUniqueName to build the sweepable $UNIQUE_NAME prefix.
+// bundleNamePrefix is the sweepable prefix embedded into every $UNIQUE_NAME on
+// cloud runs (see newBundleNamePrefix / ciUniqueName). Set once in testAccept,
+// empty off cloud where names need no attribution.
+var bundleNamePrefix string
+
+// newBundleNamePrefix builds the "ci<runID>x<suffix>" prefix that attributes
+// deployed bundles to this test process so cleanup can sweep them.
 //
-// All matrix legs of a CI run share one GitHub run id, and legs of different OSes
-// share a workspace, so a run-id-only prefix would let one leg's cleanup destroy
-// another leg's live bundles. The per-process bundleLegSuffix makes each leg's
-// prefix distinct so its cleanup sweeps only its own deployments, while the
-// run id stays a matchable substring for the run-wide sweeper (sweep_test_resources.py).
-var (
-	bundleRunID     string
-	bundleLegSuffix string
-)
-
-// bundleLegSuffixAlphabet is lowercase-alphanumeric to satisfy the same identifier
-// constraints as the unique name itself (see ciUniqueName).
-const bundleLegSuffixAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
-
-// randomBundleLegSuffix returns a 3-character lowercase-alphanumeric suffix. 36^3
-// values make a collision between the few legs sharing a workspace within one run
-// vanishingly unlikely.
-func randomBundleLegSuffix() string {
-	b := make([]byte, 3)
-	for i := range b {
-		b[i] = bundleLegSuffixAlphabet[rand.IntN(len(bundleLegSuffixAlphabet))]
-	}
-	return string(b)
-}
-
-// bundleNamePrefix is the sweepable prefix embedded into $UNIQUE_NAME:
-// "ci<runID>x<legSuffix>". The run id (all digits) is delimited by "x" so the
-// run-wide sweep prefix "ci<runID>x" stays collision-free between runs whose ids
-// share a prefix; legSuffix then isolates one leg from another within the run.
-func bundleNamePrefix(runID, legSuffix string) string {
-	return "ci" + runID + "x" + legSuffix
-}
-
-// ciUniqueName embeds the run id and leg suffix into the random unique name as
-// "ci<runID>x<legSuffix><random>". The result stays purely lowercase-alphanumeric
-// like the base32 name it replaces, so it remains valid everywhere $UNIQUE_NAME is
-// used: app names (no hyphens would be fine but underscores/uppercase are not),
-// Python and Unity Catalog identifiers (no hyphens). Length is preserved
-// ("app-$UNIQUE_NAME" is exactly the 30-char app name maximum). Returns random
-// unchanged when runID is absent, malformed, or too long to leave at least 8
-// random characters.
-func ciUniqueName(runID, legSuffix, random string) string {
+// runID is the GitHub run id, or a random numeric id when it is unset/malformed
+// (e.g. a local `deco env run`). All matrix legs of a CI run share one GitHub run
+// id and legs of different OSes share a workspace, so a run-id-only prefix would
+// let one leg's cleanup destroy another leg's live bundles; the random 3-char
+// lowercase-alphanumeric suffix (36^3 values) makes each leg's prefix distinct
+// while keeping "ci<runID>x" a matchable substring for the run-wide sweeper
+// (sweep_test_resources.py). The run id (all digits) is delimited by "x" so that
+// prefix stays collision-free between runs whose ids share a prefix.
+func newBundleNamePrefix() string {
+	runID := os.Getenv("GITHUB_RUN_ID")
 	if !ciRunID.MatchString(runID) {
-		return random
+		runID = strconv.Itoa(rand.IntN(1_000_000_000))
 	}
-	prefix := bundleNamePrefix(runID, legSuffix)
+	const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+	suffix := make([]byte, 3)
+	for i := range suffix {
+		suffix[i] = alphabet[rand.IntN(len(alphabet))]
+	}
+	return "ci" + runID + "x" + string(suffix)
+}
+
+// ciUniqueName prepends prefix to the random unique name, preserving its length
+// (e.g. "app-$UNIQUE_NAME" is exactly the 30-char app name maximum) and its
+// lowercase-alphanumeric shape so it stays valid everywhere $UNIQUE_NAME is used
+// (app names, Python and Unity Catalog identifiers). Returns random unchanged
+// when prefix is empty or too long to leave at least 8 random characters.
+func ciUniqueName(prefix, random string) string {
 	randLen := len(random) - len(prefix)
-	if randLen < 8 {
+	if prefix == "" || randLen < 8 {
 		return random
 	}
 	return prefix + random[:randLen]
@@ -835,8 +809,8 @@ func runTest(t *testing.T,
 
 	id := uuid.New()
 	uniqueName := strings.ToLower(strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "="))
-	// Embed the run id and leg suffix, when present, so leaked resources can be attributed to a run and swept by prefix.
-	uniqueName = ciUniqueName(bundleRunID, bundleLegSuffix, uniqueName)
+	// Embed the run prefix, when present, so leaked resources can be attributed to this leg and swept.
+	uniqueName = ciUniqueName(bundleNamePrefix, uniqueName)
 	repls.Set(uniqueName, "[UNIQUE_NAME]")
 
 	var tmpDir string

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/fs"
 	"maps"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"os/exec"
@@ -427,10 +428,19 @@ func testAccept(t *testing.T, inprocessMode bool, singleTest string) int {
 	t.Setenv("NODE_TYPE_ID", nodeTypeID)
 	repls.Set(nodeTypeID, "[NODE_TYPE_ID]")
 
-	// On cloud, destroy every bundle this run deploys once all tests finish.
-	// Registered before the tests are spawned so it runs after they complete.
-	if !inprocessMode {
-		setupBundleCleanup(t, execPath, cloudEnv)
+	// The run id is embedded into every $UNIQUE_NAME (see ciUniqueName) so that
+	// resources can be attributed to a run and swept by prefix. On CI it is the
+	// GitHub run id; otherwise synthesize a random numeric id so a local cloud
+	// run (e.g. `deco env run`) is still sweepable. Empty off cloud, where names
+	// need no attribution.
+	if cloudEnv != "" {
+		bundleRunID = os.Getenv("GITHUB_RUN_ID")
+		if bundleRunID == "" {
+			bundleRunID = strconv.Itoa(rand.IntN(1_000_000_000))
+		}
+		// Destroy every bundle this run deploys once all tests finish. Registered
+		// before the tests are spawned so it runs after they complete.
+		setupBundleCleanup(t, execPath, bundleRunID)
 	}
 
 	testDirs := getTests(t)
@@ -729,6 +739,11 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 
 var ciRunID = regexp.MustCompile(`^[0-9]{1,16}$`)
 
+// bundleRunID identifies the current run for bundle attribution and cleanup. Set
+// once in testAccept on cloud (GitHub run id, or a random numeric id locally),
+// empty off cloud. Read by ciUniqueName to build the sweepable $UNIQUE_NAME prefix.
+var bundleRunID string
+
 // ciUniqueName embeds a CI run id into the random unique name as "ci<runID>x<random>".
 // The result stays purely lowercase-alphanumeric like the base32 name it replaces, so it
 // remains valid everywhere $UNIQUE_NAME is used: app names (no hyphens would be fine but
@@ -784,8 +799,8 @@ func runTest(t *testing.T,
 
 	id := uuid.New()
 	uniqueName := strings.ToLower(strings.Trim(base32.StdEncoding.EncodeToString(id[:]), "="))
-	// Embed the CI run id, when present, so leaked resources can be attributed to a run and swept by prefix.
-	uniqueName = ciUniqueName(os.Getenv("GITHUB_RUN_ID"), uniqueName)
+	// Embed the run id, when present, so leaked resources can be attributed to a run and swept by prefix.
+	uniqueName = ciUniqueName(bundleRunID, uniqueName)
 	repls.Set(uniqueName, "[UNIQUE_NAME]")
 
 	var tmpDir string

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -731,7 +731,11 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 	return ""
 }
 
-var ciRunID = regexp.MustCompile(`^[0-9]{1,16}$`)
+// Cap at 12 digits: the prefix "ci<runID>x<suffix>" plus the 8-char random
+// minimum must fit the 26-char unique name (26 - 8 - len("ci")-len("x") - 3 = 12),
+// so a longer GITHUB_RUN_ID falls through to a random id rather than building a
+// prefix ciUniqueName would silently drop.
+var ciRunID = regexp.MustCompile(`^[0-9]{1,12}$`)
 
 // bundleNamePrefix is the sweepable prefix embedded into every $UNIQUE_NAME on
 // cloud runs (see newBundleNamePrefix / ciUniqueName). Set once in testAccept,

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -778,11 +778,14 @@ func newBundleNamePrefix() string {
 // (app names, Python and Unity Catalog identifiers). Returns random unchanged
 // when prefix is empty or too long to leave at least 8 random characters.
 func ciUniqueName(prefix, random string) string {
-	randLen := len(random) - len(prefix)
-	if prefix == "" || randLen < 8 {
-		return random
+	// newBundleNamePrefix keeps the prefix short enough to leave at least this
+	// many random characters (empty prefix trivially fits); a longer one is a bug.
+	const minRandom = 8
+	cut := len(random) - len(prefix)
+	if cut < minRandom {
+		panic(fmt.Sprintf("bundle name prefix %q leaves only %d of %d random chars, need %d", prefix, cut, len(random), minRandom))
 	}
-	return prefix + random[:randLen]
+	return prefix + random[:cut]
 }
 
 func runTest(t *testing.T,

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -731,11 +731,17 @@ func getSkipReason(config *internal.TestConfig, configPath, dir, skipLocalMode s
 	return ""
 }
 
-// Cap at 12 digits: the prefix "ci<runID>x<suffix>" plus the 8-char random
-// minimum must fit the 26-char unique name (26 - 8 - len("ci")-len("x") - 3 = 12),
-// so a longer GITHUB_RUN_ID falls through to a random id rather than building a
-// prefix ciUniqueName would silently drop.
-var ciRunID = regexp.MustCompile(`^[0-9]{1,12}$`)
+// Cap at 11 digits: the prefix "ci<runID>x<suffix>" plus the 8-char random
+// minimum must fit the 26-char unique name (26 - 8 - len("ci")-len("x") -
+// bundleLegSuffixLen = 11), so a longer GITHUB_RUN_ID falls through to a random
+// id rather than building a prefix ciUniqueName would silently drop.
+var ciRunID = regexp.MustCompile(`^[0-9]{1,11}$`)
+
+// bundleLegSuffixLen is the length of the per-process random suffix. 36^4 values
+// keep an accidental collision between the few matrix legs that share a workspace
+// within one run (which would let one leg destroy another's live bundles)
+// negligible, while still leaving >=8 random characters after an 11-digit run id.
+const bundleLegSuffixLen = 4
 
 // bundleNamePrefix is the sweepable prefix embedded into every $UNIQUE_NAME on
 // cloud runs (see newBundleNamePrefix / ciUniqueName). Set once in testAccept,
@@ -748,18 +754,18 @@ var bundleNamePrefix string
 // runID is the GitHub run id, or a random numeric id when it is unset/malformed
 // (e.g. a local `deco env run`). All matrix legs of a CI run share one GitHub run
 // id and legs of different OSes share a workspace, so a run-id-only prefix would
-// let one leg's cleanup destroy another leg's live bundles; the random 3-char
-// lowercase-alphanumeric suffix (36^3 values) makes each leg's prefix distinct
-// while keeping "ci<runID>x" a matchable substring for the run-wide sweeper
-// (sweep_test_resources.py). The run id (all digits) is delimited by "x" so that
-// prefix stays collision-free between runs whose ids share a prefix.
+// let one leg's cleanup destroy another leg's live bundles; the random
+// lowercase-alphanumeric suffix (bundleLegSuffixLen chars) makes each leg's prefix
+// distinct while keeping "ci<runID>x" a matchable substring for the run-wide
+// sweeper (sweep_test_resources.py). The run id (all digits) is delimited by "x"
+// so that prefix stays collision-free between runs whose ids share a prefix.
 func newBundleNamePrefix() string {
 	runID := os.Getenv("GITHUB_RUN_ID")
 	if !ciRunID.MatchString(runID) {
 		runID = strconv.Itoa(rand.IntN(1_000_000_000))
 	}
 	const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
-	suffix := make([]byte, 3)
+	suffix := make([]byte, bundleLegSuffixLen)
 	for i := range suffix {
 		suffix[i] = alphabet[rand.IntN(len(alphabet))]
 	}

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -21,12 +21,12 @@ import (
 // cloud tests share one real workspace, whereas local tests each get a
 // throwaway in-memory fake workspace with nothing to clean up.
 //
-// runID is the sweepable id that ciUniqueName stamps into every $UNIQUE_NAME as
-// the "ci<runID>x" prefix, so the cleanup sweeps exactly the deployments
-// carrying this run's prefix and nothing else. That is what makes destroying
-// against the shared workspace safe even while other runs deploy concurrently.
-func setupBundleCleanup(t *testing.T, execPath, runID string) {
-	prefix := "ci" + runID + "x"
+// prefix is the leg-specific "ci<runID>x<legSuffix>" that ciUniqueName stamps
+// into every $UNIQUE_NAME, so the cleanup sweeps exactly the deployments this
+// leg created and nothing else. That is what makes destroying against the shared
+// workspace safe even while sibling matrix legs (which share the run id and may
+// share the workspace) deploy concurrently.
+func setupBundleCleanup(t *testing.T, execPath, prefix string) {
 	// t.Context() is canceled once the test finishes, before cleanups run, so
 	// derive a context that survives cancellation for the cleanup's API calls.
 	ctx := context.WithoutCancel(t.Context())

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -18,29 +17,15 @@ import (
 )
 
 // setupBundleCleanup arranges for every bundle deployed by this run to be
-// destroyed once the suite finishes. It is a cloud-only operation: all cloud
-// tests share one real workspace, whereas local tests each get a throwaway
-// in-memory fake workspace with nothing to clean up.
+// destroyed once the suite finishes. The caller invokes it only on cloud: all
+// cloud tests share one real workspace, whereas local tests each get a
+// throwaway in-memory fake workspace with nothing to clean up.
 //
-// It ensures a per-run id is present (synthesizing one for non-CI cloud runs)
-// so ciUniqueName stamps the "ci<runid>x" prefix onto every $UNIQUE_NAME. The
-// cleanup then sweeps exactly the deployments carrying this run's prefix and
-// nothing else, which is what makes destroying against the shared workspace
-// safe even while other runs deploy concurrently.
-func setupBundleCleanup(t *testing.T, execPath, cloudEnv string) {
-	if cloudEnv == "" {
-		return
-	}
-
-	runID := os.Getenv("GITHUB_RUN_ID")
-	if runID == "" {
-		// Non-CI cloud run (e.g. a developer using `deco env run`): mint a run id
-		// so deployed bundles are identifiable and sweepable. Milliseconds stay
-		// within ciUniqueName's 15-digit budget and are unique enough per run.
-		runID = strconv.FormatInt(time.Now().UnixMilli(), 10)
-		t.Setenv("GITHUB_RUN_ID", runID)
-	}
-
+// runID is the sweepable id that ciUniqueName stamps into every $UNIQUE_NAME as
+// the "ci<runID>x" prefix, so the cleanup sweeps exactly the deployments
+// carrying this run's prefix and nothing else. That is what makes destroying
+// against the shared workspace safe even while other runs deploy concurrently.
+func setupBundleCleanup(t *testing.T, execPath, runID string) {
 	prefix := "ci" + runID + "x"
 	// t.Context() is canceled once the test finishes, before cleanups run, so
 	// derive a context that survives cancellation for the cleanup's API calls.

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -53,10 +53,11 @@ func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 
 	// Tests deploy under the user's home .bundle by default, but some set
 	// workspace.root_path under /Shared (e.g. resources/jobs/shared-root-path),
-	// so sweep both.
+	// so sweep both. A "/Shared/..." root_path is normalized to "/Workspace/Shared/..."
+	// by prependWorkspacePrefix, so the swept path uses that form.
 	bundleRoots := []string{
 		"/Workspace/Users/" + me.UserName + "/.bundle",
-		"/Shared/" + me.UserName + "/.bundle",
+		"/Workspace/Shared/" + me.UserName + "/.bundle",
 	}
 
 	// The run's prefix always appears in the first path segment under .bundle

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"runtime"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -77,12 +77,14 @@ func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 	t.Logf("%s bundle cleanup: found %d deployment(s) with prefix %q", time.Now().Format(time.RFC3339), len(roots), prefix)
 
 	// Each destroy shells out to a separate `bundle destroy` (auth + state pull +
-	// deletes), so run them concurrently. Cap at 20 to stay well under the
-	// workspace API rate limit while still cutting wall-clock for large sweeps.
-	// This is best-effort, not fail-fast: a failed destroy is recorded and the
-	// rest still run, so a plain WaitGroup with a semaphore fits better than
-	// errgroup (whose error short-circuit we would not use).
-	sem := make(chan struct{}, min(runtime.GOMAXPROCS(0), 20))
+	// deletes), so run them concurrently. Each is network-bound (not CPU-bound),
+	// so cap at a fixed 20 rather than by GOMAXPROCS: it parallelizes the API
+	// waits while staying well under the workspace rate limit. This is
+	// best-effort, not fail-fast: a failed destroy is recorded and the rest still
+	// run, so a plain WaitGroup with a semaphore fits better than errgroup (whose
+	// error short-circuit we would not use).
+	const maxConcurrentDestroys = 20
+	sem := make(chan struct{}, maxConcurrentDestroys)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var failed []string
@@ -164,7 +166,7 @@ func destroyBundle(execPath, rootPath string) ([]byte, error) {
 	defer os.RemoveAll(dir)
 
 	databricksYML := "bundle:\n  name: cleanup\nworkspace:\n  root_path: " + rootPath + "\ntargets:\n  default: {}\n"
-	if err := os.WriteFile(path.Join(dir, "databricks.yml"), []byte(databricksYML), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "databricks.yml"), []byte(databricksYML), 0o644); err != nil {
 		return nil, err
 	}
 

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
-	"github.com/stretchr/testify/require"
 )
 
 // setupBundleCleanup arranges for every bundle deployed by this run to be
@@ -45,11 +44,19 @@ func setupBundleCleanup(t *testing.T, execPath, prefix string) {
 func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 	start := time.Now()
 
+	// Cleanup never fails the test (see the WARNING note below), so on any error
+	// that prevents sweeping, log loudly and return rather than require-failing.
 	w, err := databricks.NewWorkspaceClient()
-	require.NoError(t, err)
+	if err != nil {
+		t.Logf("WARNING: bundle cleanup skipped, cannot create client: %s", err)
+		return
+	}
 
 	me, err := w.CurrentUser.Me(ctx, iam.MeRequest{})
-	require.NoError(t, err)
+	if err != nil {
+		t.Logf("WARNING: bundle cleanup skipped, cannot resolve current user: %s", err)
+		return
+	}
 
 	// Tests deploy under the user's home .bundle by default, but some set
 	// workspace.root_path under /Shared (e.g. resources/jobs/shared-root-path),
@@ -105,7 +112,16 @@ func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 
 	slices.Sort(failed)
 	t.Logf("%s bundle cleanup: destroyed %d/%d deployment(s) in %s", time.Now().Format(time.RFC3339), len(roots)-len(failed), len(roots), time.Since(start))
-	require.Empty(t, failed, "failed to destroy %d deployment(s): %s", len(failed), strings.Join(failed, ", "))
+
+	// Do not fail the test on a cleanup failure: this runs in a t.Cleanup on the
+	// root TestAccept, so failing here marks the root test failed with no failed
+	// subtest, which makes gotestsum --rerun-fails (used by the integration task)
+	// rerun the entire cloud suite. Cleanup is best-effort housekeeping and the
+	// product tests already passed, so log loudly instead; leaked deployments are
+	// reclaimed by the periodic prefix sweep (sweep_test_resources.py).
+	if len(failed) > 0 {
+		t.Logf("WARNING: bundle cleanup failed to destroy %d deployment(s), leaked until swept: %s", len(failed), strings.Join(failed, ", "))
+	}
 }
 
 // findDeploymentRoots walks the workspace tree under dir and returns the paths
@@ -131,15 +147,16 @@ func findDeploymentRoots(ctx context.Context, t *testing.T, w *databricks.Worksp
 }
 
 // listChildDirs returns the immediate subdirectory paths of dir. A missing dir
-// (nothing was deployed under it) yields nil; any other listing error fails the
-// test, since silently treating it as empty would under-sweep and leak bundles.
+// (nothing was deployed under it) yields nil silently; any other listing error
+// is logged loudly (it means the sweep under dir is incomplete) but does not
+// fail the test, since cleanup runs in the root t.Cleanup.
 func listChildDirs(ctx context.Context, t *testing.T, w *databricks.WorkspaceClient, dir string) []string {
 	objects, err := w.Workspace.ListAll(ctx, workspace.ListWorkspaceRequest{Path: dir})
 	if err != nil {
-		if errors.Is(err, apierr.ErrNotFound) {
-			return nil
+		if !errors.Is(err, apierr.ErrNotFound) {
+			t.Logf("WARNING: bundle cleanup incomplete, cannot list %s: %s", dir, err)
 		}
-		require.NoError(t, err, "listing %s", dir)
+		return nil
 	}
 	var dirs []string
 	for _, o := range objects {

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -1,0 +1,159 @@
+package acceptance_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// setupBundleCleanup arranges for every bundle deployed by this run to be
+// destroyed once the suite finishes. It is a cloud-only operation: all cloud
+// tests share one real workspace, whereas local tests each get a throwaway
+// in-memory fake workspace with nothing to clean up.
+//
+// It ensures a per-run id is present (synthesizing one for non-CI cloud runs)
+// so ciUniqueName stamps the "ci<runid>x" prefix onto every $UNIQUE_NAME. The
+// cleanup then sweeps exactly the deployments carrying this run's prefix and
+// nothing else, which is what makes destroying against the shared workspace
+// safe even while other runs deploy concurrently.
+func setupBundleCleanup(t *testing.T, execPath, cloudEnv string) {
+	if cloudEnv == "" {
+		return
+	}
+
+	runID := os.Getenv("GITHUB_RUN_ID")
+	if runID == "" {
+		// Non-CI cloud run (e.g. a developer using `deco env run`): mint a run id
+		// so deployed bundles are identifiable and sweepable. Milliseconds stay
+		// within ciUniqueName's 15-digit budget and are unique enough per run.
+		runID = strconv.FormatInt(time.Now().UnixMilli(), 10)
+		t.Setenv("GITHUB_RUN_ID", runID)
+	}
+
+	prefix := "ci" + runID + "x"
+	// t.Context() is canceled once the test finishes, before cleanups run, so
+	// derive a context that survives cancellation for the cleanup's API calls.
+	ctx := context.WithoutCancel(t.Context())
+	t.Cleanup(func() {
+		cleanBundles(ctx, t, execPath, prefix)
+	})
+}
+
+// cleanBundles finds every bundle this run deployed under the current user's
+// ~/.bundle directory (identified by the run's prefix) and destroys each one,
+// logging each deployment and the total time taken.
+func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
+	start := time.Now()
+
+	w, err := databricks.NewWorkspaceClient()
+	require.NoError(t, err)
+
+	me, err := w.CurrentUser.Me(ctx, iam.MeRequest{})
+	require.NoError(t, err)
+
+	bundleRoot := "/Workspace/Users/" + me.UserName + "/.bundle"
+
+	// The run's prefix always appears in the first path segment under .bundle
+	// (the bundle name, or the leaf of a workspace.root_path override), so match
+	// there and only descend into this run's subtrees. This avoids walking the
+	// thousands of directories other runs may have leaked under .bundle.
+	var roots []string
+	for _, child := range listChildDirs(ctx, w, bundleRoot) {
+		if strings.Contains(path.Base(child), prefix) {
+			roots = append(roots, findDeploymentRoots(ctx, w, child)...)
+		}
+	}
+	slices.Sort(roots)
+
+	t.Logf("%s bundle cleanup: found %d deployment(s) with prefix %q", time.Now().Format(time.RFC3339), len(roots), prefix)
+
+	// Best-effort: attempt every deployment and report failures at the end, so
+	// one stuck bundle doesn't leave the rest leaked.
+	var failed []string
+	for _, root := range roots {
+		t.Logf("%s destroying %s", time.Now().Format(time.RFC3339), root)
+		if out, err := destroyBundle(execPath, root); err != nil {
+			t.Logf("%s destroy failed: %s\n%s", time.Now().Format(time.RFC3339), root, out)
+			failed = append(failed, root)
+		}
+	}
+
+	t.Logf("%s bundle cleanup: destroyed %d/%d deployment(s) in %s", time.Now().Format(time.RFC3339), len(roots)-len(failed), len(roots), time.Since(start))
+	require.Empty(t, failed, "failed to destroy %d deployment(s): %s", len(failed), strings.Join(failed, ", "))
+}
+
+// findDeploymentRoots walks the workspace tree under dir and returns the paths
+// of bundle deployment roots. A directory is a deployment root when it contains
+// a "state" or "files" child, which the bundle deploy writes beneath the
+// resolved workspace.root_path. This works regardless of whether the root is
+// the default ~/.bundle/<name>/<target> or a custom ~/.bundle/<...> override.
+func findDeploymentRoots(ctx context.Context, w *databricks.WorkspaceClient, dir string) []string {
+	var childDirs []string
+	for _, child := range listChildDirs(ctx, w, dir) {
+		if base := path.Base(child); base == "state" || base == "files" {
+			// dir is a deployment root; don't descend into its internals.
+			return []string{dir}
+		}
+		childDirs = append(childDirs, child)
+	}
+
+	var roots []string
+	for _, child := range childDirs {
+		roots = append(roots, findDeploymentRoots(ctx, w, child)...)
+	}
+	return roots
+}
+
+// listChildDirs returns the immediate subdirectory paths of dir, or nil if dir
+// does not exist (nothing was deployed under it).
+func listChildDirs(ctx context.Context, w *databricks.WorkspaceClient, dir string) []string {
+	objects, err := w.Workspace.ListAll(ctx, workspace.ListWorkspaceRequest{Path: dir})
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, o := range objects {
+		if o.ObjectType == workspace.ObjectTypeDirectory {
+			dirs = append(dirs, o.Path)
+		}
+	}
+	return dirs
+}
+
+// destroyBundle destroys the bundle deployed at rootPath using the CLI binary,
+// returning the combined output and any error. It writes a throwaway
+// databricks.yml pinning workspace.root_path to the deployment root; destroy
+// pulls the remote state from there (auto-detecting the engine) and deletes the
+// resources and files. The bundle name and target are placeholders because
+// root_path fully determines the deployment location. --force-lock overrides a
+// stale deployment lock left by a test that was killed mid-deploy; these are
+// known-leaked bundles, so there is no concurrent deployment to conflict with.
+func destroyBundle(execPath, rootPath string) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "bundle-clean") //nolint:usetesting // runs in a cleanup, where t.TempDir is already removed
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	databricksYML := "bundle:\n  name: cleanup\nworkspace:\n  root_path: " + rootPath + "\ntargets:\n  default: {}\n"
+	if err := os.WriteFile(path.Join(dir, "databricks.yml"), []byte(databricksYML), 0o644); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(execPath, "bundle", "destroy", "--target", "default", "--auto-approve", "--force-lock")
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+
+	return cmd.CombinedOutput()
+}

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,17 +65,32 @@ func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 
 	t.Logf("%s bundle cleanup: found %d deployment(s) with prefix %q", time.Now().Format(time.RFC3339), len(roots), prefix)
 
-	// Best-effort: attempt every deployment and report failures at the end, so
-	// one stuck bundle doesn't leave the rest leaked.
+	// Each destroy shells out to a separate `bundle destroy` (auth + state pull +
+	// deletes), so run them concurrently. Cap at 20 to stay well under the
+	// workspace API rate limit while still cutting wall-clock for large sweeps.
+	// This is best-effort, not fail-fast: a failed destroy is recorded and the
+	// rest still run, so a plain WaitGroup with a semaphore fits better than
+	// errgroup (whose error short-circuit we would not use).
+	sem := make(chan struct{}, min(runtime.GOMAXPROCS(0), 20))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
 	var failed []string
 	for _, root := range roots {
-		t.Logf("%s destroying %s", time.Now().Format(time.RFC3339), root)
-		if out, err := destroyBundle(execPath, root); err != nil {
-			t.Logf("%s destroy failed: %s\n%s", time.Now().Format(time.RFC3339), root, out)
-			failed = append(failed, root)
-		}
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			t.Logf("%s destroying %s", time.Now().Format(time.RFC3339), root)
+			if out, err := destroyBundle(execPath, root); err != nil {
+				t.Logf("%s destroy failed: %s\n%s", time.Now().Format(time.RFC3339), root, out)
+				mu.Lock()
+				failed = append(failed, root)
+				mu.Unlock()
+			}
+		})
 	}
+	wg.Wait()
 
+	slices.Sort(failed)
 	t.Logf("%s bundle cleanup: destroyed %d/%d deployment(s) in %s", time.Now().Format(time.RFC3339), len(roots)-len(failed), len(roots), time.Since(start))
 	require.Empty(t, failed, "failed to destroy %d deployment(s): %s", len(failed), strings.Join(failed, ", "))
 }

--- a/acceptance/bundle_clean_test.go
+++ b/acceptance/bundle_clean_test.go
@@ -2,6 +2,7 @@ package acceptance_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 	"github.com/stretchr/testify/require"
@@ -49,16 +51,24 @@ func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 	me, err := w.CurrentUser.Me(ctx, iam.MeRequest{})
 	require.NoError(t, err)
 
-	bundleRoot := "/Workspace/Users/" + me.UserName + "/.bundle"
+	// Tests deploy under the user's home .bundle by default, but some set
+	// workspace.root_path under /Shared (e.g. resources/jobs/shared-root-path),
+	// so sweep both.
+	bundleRoots := []string{
+		"/Workspace/Users/" + me.UserName + "/.bundle",
+		"/Shared/" + me.UserName + "/.bundle",
+	}
 
 	// The run's prefix always appears in the first path segment under .bundle
 	// (the bundle name, or the leaf of a workspace.root_path override), so match
 	// there and only descend into this run's subtrees. This avoids walking the
 	// thousands of directories other runs may have leaked under .bundle.
 	var roots []string
-	for _, child := range listChildDirs(ctx, w, bundleRoot) {
-		if strings.Contains(path.Base(child), prefix) {
-			roots = append(roots, findDeploymentRoots(ctx, w, child)...)
+	for _, bundleRoot := range bundleRoots {
+		for _, child := range listChildDirs(ctx, t, w, bundleRoot) {
+			if strings.Contains(path.Base(child), prefix) {
+				roots = append(roots, findDeploymentRoots(ctx, t, w, child)...)
+			}
 		}
 	}
 	slices.Sort(roots)
@@ -100,9 +110,9 @@ func cleanBundles(ctx context.Context, t *testing.T, execPath, prefix string) {
 // a "state" or "files" child, which the bundle deploy writes beneath the
 // resolved workspace.root_path. This works regardless of whether the root is
 // the default ~/.bundle/<name>/<target> or a custom ~/.bundle/<...> override.
-func findDeploymentRoots(ctx context.Context, w *databricks.WorkspaceClient, dir string) []string {
+func findDeploymentRoots(ctx context.Context, t *testing.T, w *databricks.WorkspaceClient, dir string) []string {
 	var childDirs []string
-	for _, child := range listChildDirs(ctx, w, dir) {
+	for _, child := range listChildDirs(ctx, t, w, dir) {
 		if base := path.Base(child); base == "state" || base == "files" {
 			// dir is a deployment root; don't descend into its internals.
 			return []string{dir}
@@ -112,17 +122,21 @@ func findDeploymentRoots(ctx context.Context, w *databricks.WorkspaceClient, dir
 
 	var roots []string
 	for _, child := range childDirs {
-		roots = append(roots, findDeploymentRoots(ctx, w, child)...)
+		roots = append(roots, findDeploymentRoots(ctx, t, w, child)...)
 	}
 	return roots
 }
 
-// listChildDirs returns the immediate subdirectory paths of dir, or nil if dir
-// does not exist (nothing was deployed under it).
-func listChildDirs(ctx context.Context, w *databricks.WorkspaceClient, dir string) []string {
+// listChildDirs returns the immediate subdirectory paths of dir. A missing dir
+// (nothing was deployed under it) yields nil; any other listing error fails the
+// test, since silently treating it as empty would under-sweep and leak bundles.
+func listChildDirs(ctx context.Context, t *testing.T, w *databricks.WorkspaceClient, dir string) []string {
 	objects, err := w.Workspace.ListAll(ctx, workspace.ListWorkspaceRequest{Path: dir})
 	if err != nil {
-		return nil
+		if errors.Is(err, apierr.ErrNotFound) {
+			return nil
+		}
+		require.NoError(t, err, "listing %s", dir)
 	}
 	var dirs []string
 	for _, o := range objects {

--- a/acceptance/unique_name_test.go
+++ b/acceptance/unique_name_test.go
@@ -10,21 +10,16 @@ func TestCIUniqueName(t *testing.T) {
 	// 26 lowercase base32 characters, like the generated unique name.
 	random := "osr5mzrrvzb73juixjoviti24y"
 
-	// Run id and leg suffix embedded, same length as input, lowercase-alphanumeric, sweepable prefix.
-	assert.Equal(t, "ci15799017600xabcosr5mzrrv", ciUniqueName("15799017600", "abc", random))
-	assert.Equal(t, "ci1xabcosr5mzrrvzb73juixjo", ciUniqueName("1", "abc", random))
+	// Prefix prepended, same length as input, lowercase-alphanumeric.
+	assert.Equal(t, "ci15799017600xabcosr5mzrrv", ciUniqueName("ci15799017600xabc", random))
+	assert.Equal(t, "ci1xabcosr5mzrrvzb73juixjo", ciUniqueName("ci1xabc", random))
 
-	// Empty leg suffix (backward-compatible prefix) still works.
-	assert.Equal(t, "ci15799017600xosr5mzrrvzb7", ciUniqueName("15799017600", "", random))
+	// Empty prefix: unchanged.
+	assert.Equal(t, random, ciUniqueName("", random))
 
-	// No or invalid run id: unchanged.
-	assert.Equal(t, random, ciUniqueName("", "abc", random))
-	assert.Equal(t, random, ciUniqueName("abc123", "abc", random))
-	assert.Equal(t, random, ciUniqueName("123 456", "abc", random))
+	// Prefix that leaves exactly the 8-char random minimum: prepended.
+	assert.Equal(t, "ci123456789012xabcosr5mzrr", ciUniqueName("ci123456789012xabc", random))
 
-	// 12-digit run id plus the 3-char suffix leaves exactly the 8-char random minimum: prefixed.
-	assert.Equal(t, "ci123456789012xabcosr5mzrr", ciUniqueName("123456789012", "abc", random))
-
-	// 13-digit run id plus the suffix is too long to leave enough randomness: unchanged.
-	assert.Equal(t, random, ciUniqueName("1234567890123", "abc", random))
+	// Prefix too long to leave enough randomness: unchanged.
+	assert.Equal(t, random, ciUniqueName("ci1234567890123xabc", random))
 }

--- a/acceptance/unique_name_test.go
+++ b/acceptance/unique_name_test.go
@@ -10,18 +10,21 @@ func TestCIUniqueName(t *testing.T) {
 	// 26 lowercase base32 characters, like the generated unique name.
 	random := "osr5mzrrvzb73juixjoviti24y"
 
-	// Run id embedded, same length as input, lowercase-alphanumeric, sweepable prefix.
-	assert.Equal(t, "ci15799017600xosr5mzrrvzb7", ciUniqueName("15799017600", random))
-	assert.Equal(t, "ci1xosr5mzrrvzb73juixjovit", ciUniqueName("1", random))
+	// Run id and leg suffix embedded, same length as input, lowercase-alphanumeric, sweepable prefix.
+	assert.Equal(t, "ci15799017600xabcosr5mzrrv", ciUniqueName("15799017600", "abc", random))
+	assert.Equal(t, "ci1xabcosr5mzrrvzb73juixjo", ciUniqueName("1", "abc", random))
+
+	// Empty leg suffix (backward-compatible prefix) still works.
+	assert.Equal(t, "ci15799017600xosr5mzrrvzb7", ciUniqueName("15799017600", "", random))
 
 	// No or invalid run id: unchanged.
-	assert.Equal(t, random, ciUniqueName("", random))
-	assert.Equal(t, random, ciUniqueName("abc123", random))
-	assert.Equal(t, random, ciUniqueName("123 456", random))
+	assert.Equal(t, random, ciUniqueName("", "abc", random))
+	assert.Equal(t, random, ciUniqueName("abc123", "abc", random))
+	assert.Equal(t, random, ciUniqueName("123 456", "abc", random))
 
-	// 15-digit run id still leaves exactly the 8-char random minimum: prefixed.
-	assert.Equal(t, "ci123456789012345xosr5mzrr", ciUniqueName("123456789012345", random))
+	// 12-digit run id plus the 3-char suffix leaves exactly the 8-char random minimum: prefixed.
+	assert.Equal(t, "ci123456789012xabcosr5mzrr", ciUniqueName("123456789012", "abc", random))
 
-	// 16-digit run id is too long to leave enough randomness: unchanged.
-	assert.Equal(t, random, ciUniqueName("1234567890123456", random))
+	// 13-digit run id plus the suffix is too long to leave enough randomness: unchanged.
+	assert.Equal(t, random, ciUniqueName("1234567890123", "abc", random))
 }

--- a/acceptance/unique_name_test.go
+++ b/acceptance/unique_name_test.go
@@ -14,12 +14,12 @@ func TestCIUniqueName(t *testing.T) {
 	assert.Equal(t, "ci15799017600xabcdosr5mzrr", ciUniqueName("ci15799017600xabcd", random))
 	assert.Equal(t, "ci1xabcdosr5mzrrvzb73juixj", ciUniqueName("ci1xabcd", random))
 
-	// Empty prefix: unchanged.
+	// Empty prefix (off cloud): unchanged.
 	assert.Equal(t, random, ciUniqueName("", random))
 
 	// An 11-digit run id plus the 4-char suffix leaves exactly the 8-char random minimum: prepended.
 	assert.Equal(t, "ci15799017600xabcdosr5mzrr", ciUniqueName("ci15799017600xabcd", random))
 
-	// One char longer leaves too little randomness: unchanged.
-	assert.Equal(t, random, ciUniqueName("ci159990176001xabcd", random))
+	// A prefix too long to leave 8 random chars is a bug in newBundleNamePrefix, so it panics.
+	assert.Panics(t, func() { ciUniqueName("ci159990176001xabcd", random) })
 }

--- a/acceptance/unique_name_test.go
+++ b/acceptance/unique_name_test.go
@@ -11,15 +11,15 @@ func TestCIUniqueName(t *testing.T) {
 	random := "osr5mzrrvzb73juixjoviti24y"
 
 	// Prefix prepended, same length as input, lowercase-alphanumeric.
-	assert.Equal(t, "ci15799017600xabcosr5mzrrv", ciUniqueName("ci15799017600xabc", random))
-	assert.Equal(t, "ci1xabcosr5mzrrvzb73juixjo", ciUniqueName("ci1xabc", random))
+	assert.Equal(t, "ci15799017600xabcdosr5mzrr", ciUniqueName("ci15799017600xabcd", random))
+	assert.Equal(t, "ci1xabcdosr5mzrrvzb73juixj", ciUniqueName("ci1xabcd", random))
 
 	// Empty prefix: unchanged.
 	assert.Equal(t, random, ciUniqueName("", random))
 
-	// Prefix that leaves exactly the 8-char random minimum: prepended.
-	assert.Equal(t, "ci123456789012xabcosr5mzrr", ciUniqueName("ci123456789012xabc", random))
+	// An 11-digit run id plus the 4-char suffix leaves exactly the 8-char random minimum: prepended.
+	assert.Equal(t, "ci15799017600xabcdosr5mzrr", ciUniqueName("ci15799017600xabcd", random))
 
-	// Prefix too long to leave enough randomness: unchanged.
-	assert.Equal(t, random, ciUniqueName("ci1234567890123xabc", random))
+	// One char longer leaves too little randomness: unchanged.
+	assert.Equal(t, random, ciUniqueName("ci159990176001xabcd", random))
 }


### PR DESCRIPTION
## Why
Cloud acceptance tests deploy bundles under the shared test workspace's ~/.bundle directory. Tests that crash before their cleanup trap fires leak their deployments, which accumulate and eventually exhaust the workspace child-node limit.

## Changes
A suite-level cleanup runs after all tests finish and destroys every bundle this run deployed, keyed off the "ci<runid>x" prefix that ciUniqueName embeds into $UNIQUE_NAME (synthesizing a run id for non-CI cloud runs). It sweeps only this run's deployments, so it is safe while other runs deploy concurrently. Local runs are unaffected — each gets its own in-memory fake workspace.

## Tests
Verified on gcp-cli: a bundle deployed without a destroy step is found and destroyed by the cleanup.