### PR TITLE
destroy: tolerate MAX_CHILD_NODE_SIZE_EXCEEDED with --force-lock

### DIFF
--- a/.nextchanges/bundles/destroy-force-lock-node-limit.md
+++ b/.nextchanges/bundles/destroy-force-lock-node-limit.md
@@ -1,0 +1,1 @@
+`bundle destroy --force-lock` now proceeds without a deployment lock when the workspace directory is at its child-node limit and cannot accept the lock file, so a deployment can still be torn down when the workspace is full.

--- a/acceptance/bin/fault.py
+++ b/acceptance/bin/fault.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """Set up a fault rule on the testserver for the current test token.
 
-Usage: fault.py PATTERN STATUS_CODE OFFSET TIMES
+Usage: fault.py PATTERN STATUS_CODE OFFSET TIMES [ERROR_CODE]
 
   PATTERN     HTTP method and path, supports trailing * wildcard,
               e.g. "PUT /api/2.0/permissions/pipelines/*"
   STATUS_CODE HTTP status code to return, e.g. 504
   OFFSET      number of requests to let through before fault starts
   TIMES       number of times to return the fault response
+  ERROR_CODE  optional error_code for the response body, e.g.
+              MAX_CHILD_NODE_SIZE_EXCEEDED (defaults to INJECTED)
 
 The rule is scoped to the current DATABRICKS_TOKEN so it only affects
 the test that registers it, even when tests share a server.
@@ -25,12 +27,13 @@ if not host:
     print("DATABRICKS_HOST not set", file=sys.stderr)
     sys.exit(1)
 
-if len(sys.argv) != 5:
-    print(f"usage: {sys.argv[0]} PATTERN STATUS_CODE OFFSET TIMES", file=sys.stderr)
+if len(sys.argv) not in (5, 6):
+    print(f"usage: {sys.argv[0]} PATTERN STATUS_CODE OFFSET TIMES [ERROR_CODE]", file=sys.stderr)
     sys.exit(1)
 
 pattern, status_code, offset, times = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
-body = '{"error_code":"INJECTED","message":"Fault injected by test."}'
+error_code = sys.argv[5] if len(sys.argv) == 6 else "INJECTED"
+body = json.dumps({"error_code": error_code, "message": "Fault injected by test."})
 
 data = json.dumps(
     {

--- a/acceptance/bundle/destroy/force-lock-node-limit/databricks.yml
+++ b/acceptance/bundle/destroy/force-lock-node-limit/databricks.yml
@@ -1,0 +1,7 @@
+bundle:
+  name: test-bundle
+
+resources:
+  jobs:
+    foo:
+      name: test-job

--- a/acceptance/bundle/destroy/force-lock-node-limit/out.test.toml
+++ b/acceptance/bundle/destroy/force-lock-node-limit/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/bundle/destroy/force-lock-node-limit/output.txt
+++ b/acceptance/bundle/destroy/force-lock-node-limit/output.txt
@@ -1,0 +1,31 @@
+
+=== Deploy (creates the job and the deployment)
+>>> [CLI] bundle deploy
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== destroy without --force-lock (lock write hits the node limit: aborts)
+>>> errcode [CLI] bundle destroy --auto-approve
+Error: Failed to acquire deployment lock: access denied: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deploy.lock
+Error: Failed to update, encountered possible permission error: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state
+Error: unable to deploy to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state as [USERNAME].
+Please make sure the current user or one of their groups is listed under the permissions of this bundle.
+For assistance, contact the owners of this project.
+They may need to redeploy the bundle to apply the new permissions.
+Please refer to https://docs.databricks.com/dev-tools/bundles/permissions.html for more on managing permissions.
+
+
+Exit code: 1
+
+=== destroy with --force-lock (tolerates the node limit: proceeds and completes)
+>>> [CLI] bundle destroy --force-lock --auto-approve
+Warn: Proceeding with destroy without a deployment lock: access denied: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/state/deploy.lock
+The following resources will be deleted:
+  delete resources.jobs.foo
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle/default
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/destroy/force-lock-node-limit/script
+++ b/acceptance/bundle/destroy/force-lock-node-limit/script
@@ -1,0 +1,15 @@
+# When the workspace .bundle directory is at its child-node limit, writing the
+# deploy.lock file fails with a 403 MAX_CHILD_NODE_SIZE_EXCEEDED. A plain destroy
+# aborts on this, but `destroy --force-lock` tolerates it and proceeds lock-less
+# so the deployment can still be torn down (which is what frees up capacity).
+
+title "Deploy (creates the job and the deployment)"
+trace $CLI bundle deploy
+
+title "destroy without --force-lock (lock write hits the node limit: aborts)"
+fault.py "POST /api/2.0/workspace-files/import-file/*" 403 0 1 MAX_CHILD_NODE_SIZE_EXCEEDED
+trace errcode $CLI bundle destroy --auto-approve
+
+title "destroy with --force-lock (tolerates the node limit: proceeds and completes)"
+fault.py "POST /api/2.0/workspace-files/import-file/*" 403 0 1 MAX_CHILD_NODE_SIZE_EXCEEDED
+trace $CLI bundle destroy --force-lock --auto-approve

--- a/acceptance/bundle/destroy/force-lock-node-limit/test.toml
+++ b/acceptance/bundle/destroy/force-lock-node-limit/test.toml
@@ -1,0 +1,1 @@
+Ignore = ["databricks.yml"]

--- a/bundle/deploy/lock/acquire.go
+++ b/bundle/deploy/lock/acquire.go
@@ -10,12 +10,20 @@ import (
 	"github.com/databricks/cli/libs/diag"
 	"github.com/databricks/cli/libs/locker"
 	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/databricks-sdk-go/apierr"
 )
 
-type acquire struct{}
+// maxChildNodeSizeExceeded is the error_code the Workspace API returns (as a 403)
+// when a directory is at its child-node limit and cannot accept a new child.
+// The SDK has no sentinel for it, so we match on the code directly.
+const maxChildNodeSizeExceeded = "MAX_CHILD_NODE_SIZE_EXCEEDED"
 
-func Acquire() bundle.Mutator {
-	return &acquire{}
+type acquire struct {
+	goal Goal
+}
+
+func Acquire(goal Goal) bundle.Mutator {
+	return &acquire{goal}
 }
 
 func (m *acquire) Name() string {
@@ -50,6 +58,19 @@ func (m *acquire) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 	log.Infof(ctx, "Acquiring deployment lock (force: %v)", force)
 	err = b.Locker.Lock(ctx, force)
 	if err != nil {
+		// When destroying with --force-lock, tolerate a full workspace directory
+		// that cannot accept the lock file: proceeding lock-less carries the same
+		// caveat --force-lock already documents (no guaranteed exclusive access),
+		// which is acceptable when the goal is to tear the deployment down.
+		// This check must precede the fs.ErrPermission branch below because the API
+		// reports the child-node limit as a 403, which the filer maps to that error.
+		if m.goal == GoalDestroy && force {
+			if aerr, ok := errors.AsType[*apierr.APIError](err); ok && aerr.ErrorCode == maxChildNodeSizeExceeded {
+				log.Warnf(ctx, "Proceeding with destroy without a deployment lock: %v", err)
+				return nil
+			}
+		}
+
 		log.Errorf(ctx, "Failed to acquire deployment lock: %v", err)
 
 		if errors.Is(err, fs.ErrPermission) {

--- a/bundle/deploy/lock/release.go
+++ b/bundle/deploy/lock/release.go
@@ -51,6 +51,12 @@ func (m *release) Apply(ctx context.Context, b *bundle.Bundle) diag.Diagnostics 
 	case GoalBind, GoalUnbind:
 		return diag.FromErr(b.Locker.Unlock(ctx))
 	case GoalDestroy:
+		// Destroy may have proceeded without acquiring a lock (see lock.Acquire:
+		// --force-lock tolerates a workspace directory at its child-node limit).
+		// There is nothing to release in that case.
+		if !b.Locker.Active {
+			return nil
+		}
 		return diag.FromErr(b.Locker.Unlock(ctx, locker.AllowLockFileNotExist))
 	default:
 		return diag.Errorf("unknown goal for lock release: %s", m.goal)

--- a/bundle/phases/bind.go
+++ b/bundle/phases/bind.go
@@ -23,7 +23,7 @@ import (
 func Bind(ctx context.Context, b *bundle.Bundle, opts *terraform.BindOptions, engine engine.EngineType) {
 	log.Info(ctx, "Phase: bind")
 
-	bundle.ApplyContext(ctx, b, lock.Acquire())
+	bundle.ApplyContext(ctx, b, lock.Acquire(lock.GoalBind))
 	if logdiag.HasError(ctx) {
 		return
 	}
@@ -119,7 +119,7 @@ func jsonDump(ctx context.Context, v any, field string) string {
 func Unbind(ctx context.Context, b *bundle.Bundle, bundleType, tfResourceType, resourceKey string, engine engine.EngineType) {
 	log.Info(ctx, "Phase: unbind")
 
-	bundle.ApplyContext(ctx, b, lock.Acquire())
+	bundle.ApplyContext(ctx, b, lock.Acquire(lock.GoalUnbind))
 	if logdiag.HasError(ctx) {
 		return
 	}

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -152,7 +152,7 @@ func Deploy(ctx context.Context, b *bundle.Bundle, outputHandler sync.OutputHand
 	// mutators need informed consent if they are potentially destructive.
 	bundle.ApplySeqContext(ctx, b,
 		scripts.Execute(config.ScriptPreDeploy),
-		lock.Acquire(),
+		lock.Acquire(lock.GoalDeploy),
 	)
 
 	if logdiag.HasError(ctx) {

--- a/bundle/phases/destroy.go
+++ b/bundle/phases/destroy.go
@@ -126,7 +126,7 @@ func Destroy(ctx context.Context, b *bundle.Bundle, engine engine.EngineType) {
 		return
 	}
 
-	bundle.ApplyContext(ctx, b, lock.Acquire())
+	bundle.ApplyContext(ctx, b, lock.Acquire(lock.GoalDestroy))
 	if logdiag.HasError(ctx) {
 		return
 	}

--- a/libs/filer/errors.go
+++ b/libs/filer/errors.go
@@ -106,6 +106,10 @@ func (err cannotDeleteRootError) Is(other error) bool {
 // when attempting to create a directory but lacking write permissions.
 type permissionError struct {
 	path string
+	// err is the underlying API error, preserved so callers can inspect its
+	// error_code (e.g. to distinguish a real permission denial from a workspace
+	// directory that is at its child-node limit, which the API also reports as 403).
+	err error
 }
 
 func (err permissionError) Error() string {
@@ -114,4 +118,8 @@ func (err permissionError) Error() string {
 
 func (err permissionError) Is(other error) bool {
 	return other == fs.ErrPermission
+}
+
+func (err permissionError) Unwrap() error {
+	return err.err
 }

--- a/libs/filer/errors_test.go
+++ b/libs/filer/errors_test.go
@@ -4,7 +4,9 @@ import (
 	"io/fs"
 	"testing"
 
+	"github.com/databricks/databricks-sdk-go/apierr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFileAlreadyExistsError_Is(t *testing.T) {
@@ -93,4 +95,17 @@ func TestPermissionError_Is(t *testing.T) {
 func TestPermissionError_Error(t *testing.T) {
 	err := permissionError{path: "/test/path"}
 	assert.Equal(t, "access denied: /test/path", err.Error())
+}
+
+func TestPermissionError_Unwrap(t *testing.T) {
+	// A wrapped API error must remain matchable as fs.ErrPermission while also
+	// being reachable via errors.As so callers can inspect its error_code.
+	apiErr := &apierr.APIError{StatusCode: 403, ErrorCode: "MAX_CHILD_NODE_SIZE_EXCEEDED"}
+	err := permissionError{path: "/test/path", err: apiErr}
+
+	assert.ErrorIs(t, err, fs.ErrPermission)
+
+	var got *apierr.APIError
+	require.ErrorAs(t, err, &got)
+	assert.Equal(t, "MAX_CHILD_NODE_SIZE_EXCEEDED", got.ErrorCode)
 }

--- a/libs/filer/workspace_files_client.go
+++ b/libs/filer/workspace_files_client.go
@@ -191,7 +191,7 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 		err = w.workspaceClient.Workspace.MkdirsByPath(ctx, path.Dir(absPath))
 		if err != nil {
 			if mkdirErr, ok := errors.AsType[*apierr.APIError](err); ok && mkdirErr.StatusCode == http.StatusForbidden {
-				return permissionError{absPath}
+				return permissionError{absPath, mkdirErr}
 			}
 			return fmt.Errorf("unable to mkdir to write file %s: %w", absPath, err)
 		}
@@ -217,7 +217,7 @@ func (w *WorkspaceFilesClient) Write(ctx context.Context, name string, reader io
 
 	// This API returns StatusForbidden when you have read access but don't have write access to a file
 	if aerr.StatusCode == http.StatusForbidden {
-		return permissionError{absPath}
+		return permissionError{absPath, aerr}
 	}
 
 	return err


### PR DESCRIPTION
When the workspace `.bundle` directory is at its child-node limit, writing `deploy.lock` fails with a 403 `MAX_CHILD_NODE_SIZE_EXCEEDED`. `bundle destroy --force-lock` now proceeds without a lock in that case so the deployment can still be torn down, which is what frees up capacity. Deploy and non-forced destroy still fail, and a real permission denial still aborts.

The filer previously collapsed any 403-on-mkdir to `permissionError`, discarding the `APIError`; it now wraps it so `lock.Acquire` can inspect the `error_code` while the error still matches `fs.ErrPermission`.