### PR TITLE
Report per-type resource counts for every resource type and both engines

### DIFF
--- a/.agent/rules/telemetry.md
+++ b/.agent/rules/telemetry.md
@@ -10,13 +10,13 @@ paths:
 
 # Extending bundle deploy telemetry
 
-The deploy payload is declared twice: the proto in the universe repo (`proto/logs/frontend/databricks_cli/bundle_deploy.proto`, source of truth for the backend table) and the Go struct in `libs/telemetry/protos/` that the CLI serializes to JSON. Ingestion ignores unknown fields, so the two PRs are independent and can land in either order — a field the CLI sends before the proto lands is dropped, not rejected.
+The deploy payload is declared twice: the proto in the universe repo (`proto/logs/frontend/databricks_cli/bundle_deploy.proto`, source of truth for the backend table) and the Go struct in `libs/telemetry/protos/` that the CLI serializes to JSON. Ingestion ignores unknown fields, so the two PRs can land in either order — a field the CLI sends before the proto lands is dropped, not rejected.
 
 ## Adding a new resource type
 
-**RULE: A new bundle resource type needs no telemetry change at all.** Per-type counts come from `resources_metadata.resources[*]`, which `resourceMetadata` in `bundle/phases/resources_metadata.go` derives from `Resources.AllResources()`. That list is exhaustive by construction and guarded by `TestResourcesAllResourcesCompleteness`, so a new type is reported from the moment it ships.
+**RULE: A new bundle resource type needs no telemetry change.** Per-type counts come from `resources_metadata.resources[*]`, which `resourceMetadata` in `bundle/phases/resources_metadata.go` derives from `Resources.AllResources()` — exhaustive by construction and guarded by `TestResourcesAllResourcesCompleteness`.
 
-**RULE: Do not add new `resource_<type>_count` fields to `BundleDeployEvent`.** The 13 that exist are marked `deprecated = true` in the universe proto and are kept only for continuity of existing dashboards. Adding more re-creates the problem `resources_metadata` was introduced to solve: a hand-maintained field list that silently lags the resource types, making a new type indistinguishable from zero adoption. New dashboard panels should read `resources_metadata`.
+**RULE: Do not add new `resource_<type>_count` fields to `BundleDeployEvent`.** The 13 that exist are `deprecated = true` in the universe proto, kept only for continuity of existing dashboards. Adding more re-creates what `resources_metadata` fixed: a hand-maintained field list that silently lags the resource types, making a new type indistinguishable from zero adoption. New dashboard panels should read `resources_metadata`.
 
 ## Adding a new metric
 
@@ -24,7 +24,7 @@ The deploy payload is declared twice: the proto in the universe repo (`proto/log
 2. Refresh the acceptance golden: `go test ./acceptance -run '^TestAccept/bundle/telemetry' -update`. Anything engine-dependent belongs in a per-engine `out.*.$DATABRICKS_BUNDLE_ENGINE.txt` file rather than the engine-agnostic `out.telemetry.txt`; see the comments in that test's `script`.
 3. Send the universe PR adding the same field to the proto, with a `compliance.data_label` annotation matching the neighbouring fields.
 
-**RULE: Never send a resource name, path, or any other user-authored string.** Names are PII. Resource identity is reported through the numeric/UUID ID lists (`resource_job_ids` and friends), and only for types that have such an ID.
+**RULE: Never send a resource name, path, or any other user-authored string.** Names are PII. Resource identity goes through the numeric/UUID ID lists (`resource_job_ids` and friends), and only for types that have such an ID.
 
 **RULE: Do not add `omitempty` to a count or measurement that can legitimately be zero.** An explicit `0` distinguishes "nothing of this kind in this deploy" from "CLI too old to report the field"; with `omitempty` both arrive as null and the population can't be sized.
 
@@ -37,4 +37,4 @@ Other things worth knowing:
 
 ## Where the data lands
 
-Deploy events land in `main.team_eng_deco.bundle_deploy_telemetry`; the dashboard is `app/dabs_telemetry` in `databricks-eng/ds-projects`. A new field is picked up by the daily pipeline because it reads `entry.bundle_deploy_event.*` wholesale, but it has to be added to a dashboard panel by hand to become visible.
+Deploy events land in `main.team_eng_deco.bundle_deploy_telemetry`; the dashboard is `app/dabs_telemetry` in `databricks-eng/ds-projects`. The daily pipeline reads `entry.bundle_deploy_event.*` wholesale, so a new field arrives on its own, but it has to be added to a dashboard panel by hand to become visible.

--- a/.agent/rules/telemetry.md
+++ b/.agent/rules/telemetry.md
@@ -16,7 +16,7 @@ The deploy payload is declared twice: the proto in the universe repo (`proto/log
 
 **RULE: A new bundle resource type needs no telemetry change.** Per-type counts come from `resources_metadata.resources[*]`, which `resourceMetadata` in `bundle/phases/resources_metadata.go` derives from `Resources.AllResources()` — exhaustive by construction and guarded by `TestResourcesAllResourcesCompleteness`.
 
-**RULE: Do not add new `resource_<type>_count` fields to `BundleDeployEvent`.** The 13 that exist are `deprecated = true` in the universe proto, kept only for continuity of existing dashboards. Adding more re-creates what `resources_metadata` fixed: a hand-maintained field list that silently lags the resource types, making a new type indistinguishable from zero adoption. New dashboard panels should read `resources_metadata`.
+**RULE: Do not add new `resource_<type>_count` fields to `BundleDeployEvent`.** The 12 that exist, and the aggregate `resource_count`, are `deprecated = true` in the universe proto, kept only for continuity of existing dashboards. Adding more re-creates what `resources_metadata` fixed: a hand-maintained field list that silently lags the resource types, making a new type indistinguishable from zero adoption. New dashboard panels should read `resources_metadata`.
 
 ## Adding a new metric
 

--- a/.agent/rules/telemetry.md
+++ b/.agent/rules/telemetry.md
@@ -1,6 +1,10 @@
 ---
 description: How to add or extend bundle deploy telemetry metrics
-globs: libs/telemetry/**/*.go
+globs:
+  - "libs/telemetry/**/*.go"
+  - "bundle/phases/telemetry.go"
+  - "bundle/phases/resources_metadata.go"
+  - "bundle/metrics/**/*.go"
 paths:
   - "libs/telemetry/**/*.go"
   - "bundle/phases/telemetry.go"

--- a/.agent/rules/telemetry.md
+++ b/.agent/rules/telemetry.md
@@ -1,0 +1,40 @@
+---
+description: How to add or extend bundle deploy telemetry metrics
+globs: libs/telemetry/**/*.go
+paths:
+  - "libs/telemetry/**/*.go"
+  - "bundle/phases/telemetry.go"
+  - "bundle/phases/resources_metadata.go"
+  - "bundle/metrics/**/*.go"
+---
+
+# Extending bundle deploy telemetry
+
+The deploy payload is declared twice: the proto in the universe repo (`proto/logs/frontend/databricks_cli/bundle_deploy.proto`, source of truth for the backend table) and the Go struct in `libs/telemetry/protos/` that the CLI serializes to JSON. Ingestion ignores unknown fields, so the two PRs are independent and can land in either order — a field the CLI sends before the proto lands is dropped, not rejected.
+
+## Adding a new resource type
+
+**RULE: A new bundle resource type needs no telemetry change at all.** Per-type counts come from `resources_metadata.resources[*]`, which `resourceMetadata` in `bundle/phases/resources_metadata.go` derives from `Resources.AllResources()`. That list is exhaustive by construction and guarded by `TestResourcesAllResourcesCompleteness`, so a new type is reported from the moment it ships.
+
+**RULE: Do not add new `resource_<type>_count` fields to `BundleDeployEvent`.** The 13 that exist are marked `deprecated = true` in the universe proto and are kept only for continuity of existing dashboards. Adding more re-creates the problem `resources_metadata` was introduced to solve: a hand-maintained field list that silently lags the resource types, making a new type indistinguishable from zero adoption. New dashboard panels should read `resources_metadata`.
+
+## Adding a new metric
+
+1. Add the field to the relevant message in `libs/telemetry/protos/`, and populate it in `bundle/phases/telemetry.go`.
+2. Refresh the acceptance golden: `go test ./acceptance -run '^TestAccept/bundle/telemetry' -update`. Anything engine-dependent belongs in a per-engine `out.*.$DATABRICKS_BUNDLE_ENGINE.txt` file rather than the engine-agnostic `out.telemetry.txt`; see the comments in that test's `script`.
+3. Send the universe PR adding the same field to the proto, with a `compliance.data_label` annotation matching the neighbouring fields.
+
+**RULE: Never send a resource name, path, or any other user-authored string.** Names are PII. Resource identity is reported through the numeric/UUID ID lists (`resource_job_ids` and friends), and only for types that have such an ID.
+
+**RULE: Do not add `omitempty` to a count or measurement that can legitimately be zero.** An explicit `0` distinguishes "nothing of this kind in this deploy" from "CLI too old to report the field"; with `omitempty` both arrive as null and the population can't be sized.
+
+Other things worth knowing:
+
+- A one-off boolean needs no proto change: add a key constant to `bundle/metrics/metrics.go` (snake_case, matching the constant name) and call `b.Metrics.SetBoolValue(...)`. It lands in `experimental.bool_values`.
+- Metrics that may be removed later belong in `BundleDeployExperimental`, which carries no compatibility guarantees.
+- Positional encodings such as the `upload_file_sizes` histogram are frozen once the metric has adoption: changing a bucket bound silently changes the meaning of every previously reported entry.
+- Anything measured from the deployment state is engine-dependent. The direct engine keeps per-resource state in `resources.json` and reports sizes; the terraform path leaves `StateSizeBytes` zero and reports only counts.
+
+## Where the data lands
+
+Deploy events land in `main.team_eng_deco.bundle_deploy_telemetry`; the dashboard is `app/dabs_telemetry` in `databricks-eng/ds-projects`. A new field is picked up by the daily pipeline because it reads `entry.bundle_deploy_event.*` wholesale, but it has to be added to a dashboard panel by hand to become visible.

--- a/.cursor/rules/telemetry.mdc
+++ b/.cursor/rules/telemetry.mdc
@@ -1,0 +1,1 @@
+../../.agent/rules/telemetry.md

--- a/acceptance/bundle/telemetry/deploy/out.resources_metadata.terraform.txt
+++ b/acceptance/bundle/telemetry/deploy/out.resources_metadata.terraform.txt
@@ -1,1 +1,13 @@
-null
+{
+  "state_engine": "terraform",
+  "resources": [
+    {
+      "resource_type": "jobs",
+      "count": 3
+    },
+    {
+      "resource_type": "pipelines",
+      "count": 2
+    }
+  ]
+}

--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -8,14 +8,12 @@ trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext
 title "Assert that mutator execution times are being recorded"
 trace cat telemetry.json | jq ' .entry.databricks_cli_log.bundle_deploy_event.experimental.bundle_mutator_execution_time_ms | length > 0'
 
-# resources_metadata reports per-type counts for both engines, but only the
-# direct engine reports state sizes, so it diverges across the
-# DATABRICKS_BUNDLE_ENGINE matrix. Capture it in a per-engine file and omit it
-# from the engine-agnostic out.telemetry.txt below. Per-resource sizes are
-# deterministic for a fixed config and asserted exactly. state_file_size_bytes
-# is dropped from the golden because it is os.Stat of resources.json, whose
-# header embeds the CLI version string (0.0.0-dev+<sha> on linux/macos vs
-# 0.0.0-dev on windows) — it is still emitted in real telemetry.
+# resources_metadata carries counts for both engines but sizes only for direct, so
+# it diverges across the DATABRICKS_BUNDLE_ENGINE matrix: capture it per-engine and
+# omit it from the engine-agnostic out.telemetry.txt below. Sizes are deterministic
+# for a fixed config and asserted exactly. state_file_size_bytes is dropped because
+# it is os.Stat of resources.json, whose header embeds the CLI version string
+# (0.0.0-dev+<sha> on linux/macos vs 0.0.0-dev on windows).
 cat telemetry.json | jq '.entry.databricks_cli_log.bundle_deploy_event.resources_metadata | if . then del(.state_file_size_bytes) else . end' > out.resources_metadata.$DATABRICKS_BUNDLE_ENGINE.txt
 
 # The dry-run migration to the direct engine runs only after a terraform deploy,

--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -8,10 +8,10 @@ trace cat out.requests.txt | jq 'select(has("path") and .path == "/telemetry-ext
 title "Assert that mutator execution times are being recorded"
 trace cat telemetry.json | jq ' .entry.databricks_cli_log.bundle_deploy_event.experimental.bundle_mutator_execution_time_ms | length > 0'
 
-# resources_metadata is only emitted for direct deploys (it is derived from the
-# direct engine's state), so it diverges across the DATABRICKS_BUNDLE_ENGINE
-# matrix. Capture it in a per-engine file (terraform produces "null") and omit
-# it from the engine-agnostic out.telemetry.txt below. Per-resource sizes are
+# resources_metadata reports per-type counts for both engines, but only the
+# direct engine reports state sizes, so it diverges across the
+# DATABRICKS_BUNDLE_ENGINE matrix. Capture it in a per-engine file and omit it
+# from the engine-agnostic out.telemetry.txt below. Per-resource sizes are
 # deterministic for a fixed config and asserted exactly. state_file_size_bytes
 # is dropped from the golden because it is os.Stat of resources.json, whose
 # header embeds the CLI version string (0.0.0-dev+<sha> on linux/macos vs

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -58,8 +58,8 @@ type Metrics struct {
 	ExecutionTimes              []protos.IntMapEntry
 	LocalCacheMeasurementsMs    []protos.IntMapEntry // Local cache measurements stored as milliseconds
 
-	// StateEngine is the engine that ran the deploy, captured in deployCore.
-	// Empty when telemetry is emitted without a deploy having run.
+	// StateEngine is the engine that ran the deploy, set in deployCore. Empty when
+	// telemetry is emitted without a deploy having run.
 	StateEngine engine.EngineType
 
 	// ResourceState is the direct engine's per-resource deployment state

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/direct"
 	"github.com/databricks/cli/bundle/env"
 	"github.com/databricks/cli/bundle/metadata"
@@ -56,6 +57,10 @@ type Metrics struct {
 	PythonUpdatedResourcesCount int64
 	ExecutionTimes              []protos.IntMapEntry
 	LocalCacheMeasurementsMs    []protos.IntMapEntry // Local cache measurements stored as milliseconds
+
+	// StateEngine is the engine that ran the deploy, captured in deployCore.
+	// Empty when telemetry is emitted without a deploy having run.
+	StateEngine engine.EngineType
 
 	// ResourceState is the direct engine's per-resource deployment state
 	// captured right after the deploy. It carries each resource's state-size in

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -88,6 +88,9 @@ func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, st
 		state statemgmt.ExportedResourcesMap
 		err   error
 	)
+	// Resolve before recording so telemetry reports the engine that actually ran
+	// rather than an empty value when the engine was left unset.
+	b.Metrics.StateEngine = stateEngine.ThisOrDefault()
 	if stateEngine.IsDirect() {
 		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan)
 		state, err = b.DeploymentBundle.StateDB.Finalize(ctx)

--- a/bundle/phases/deploy.go
+++ b/bundle/phases/deploy.go
@@ -88,8 +88,8 @@ func deployCore(ctx context.Context, b *bundle.Bundle, plan *deployplan.Plan, st
 		state statemgmt.ExportedResourcesMap
 		err   error
 	)
-	// Resolve before recording so telemetry reports the engine that actually ran
-	// rather than an empty value when the engine was left unset.
+	// ThisOrDefault: an unset setting still runs the default engine, and telemetry
+	// should report the engine that ran.
 	b.Metrics.StateEngine = stateEngine.ThisOrDefault()
 	if stateEngine.IsDirect() {
 		b.DeploymentBundle.Apply(ctx, b.WorkspaceClient(ctx), plan)

--- a/bundle/phases/resources_metadata.go
+++ b/bundle/phases/resources_metadata.go
@@ -7,46 +7,63 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/statemgmt/resourcestate"
 	"github.com/databricks/cli/libs/log"
 	"github.com/databricks/cli/libs/telemetry/protos"
 )
 
-// directEngine is the only engine for which resources_metadata is populated.
-const directEngine = "direct"
-
-// collectResourcesMetadata builds a BundleResourcesMetadata from the per-resource
-// state sizes captured during the deploy.
+// collectResourcesMetadata builds a BundleResourcesMetadata for the deployment:
+// how many resources of each type the bundle declares, plus per-type state-size
+// statistics where the engine reports them.
 //
-// Only direct deploys are measured. b.Metrics.ResourceState is the direct
-// engine's finalized state, populated in deployCore from the WAL replay the
-// deploy already performs; each entry carries StateSizeBytes (len of the JSON
-// blob stored in resources.json). So no marshalling, file read, or JSON parsing
-// happens here — sizes are read straight off the in-memory map. The whole-file
-// size comes from a single os.Stat (no parse). Returns nil for terraform
-// deploys (ResourceState is nil) and when no resources are in state.
+// Counts are taken from the configuration rather than from the deployment state
+// so that every resource type is reported on every deploy, whatever the engine.
+// That is what makes this message a superset of the per-type
+// resource_*_count fields it replaces (those are deprecated in the proto), and it
+// means a newly added resource type is covered without any telemetry change:
+// AllResources is exhaustive by construction and guarded by
+// TestResourcesAllResourcesCompleteness.
+//
+// Sizes come from b.Metrics.ResourceState, the direct engine's finalized state
+// populated in deployCore from the WAL replay the deploy already performs; each
+// entry carries StateSizeBytes (len of the JSON blob stored in resources.json).
+// So no marshalling, file read, or JSON parsing happens here — sizes are read
+// straight off the in-memory map. The terraform path leaves StateSizeBytes zero,
+// so terraform deploys report counts with zero sizes.
+//
+// Returns nil when the bundle declares no resources and none are in state.
 func collectResourcesMetadata(ctx context.Context, b *bundle.Bundle) *protos.BundleResourcesMetadata {
-	state := b.Metrics.ResourceState
-	if len(state) == 0 {
-		return nil
-	}
-
-	resources := resourceMetadataFromState(state)
+	resources := resourceMetadata(&b.Config.Resources, b.Metrics.ResourceState)
 	if len(resources) == 0 {
 		return nil
 	}
 
-	return &protos.BundleResourcesMetadata{
-		StateEngine:        directEngine,
-		StateFileSizeBytes: directStateFileSize(ctx, b),
-		Resources:          resources,
+	md := &protos.BundleResourcesMetadata{
+		StateEngine: string(b.Metrics.StateEngine),
+		Resources:   resources,
 	}
+
+	// Only the direct engine keeps the whole deployment state in one local file.
+	// The terraform state file size is reported as terraform_state_size_bytes.
+	if b.Metrics.StateEngine == engine.EngineDirect {
+		md.StateFileSizeBytes = directStateFileSize(ctx, b)
+	}
+
+	return md
 }
 
-// resourceMetadataFromState groups the deployment state by resource type and
-// computes per-type count and max/mean/median state size. Sizes are sorted per
-// type (needed for the median).
-func resourceMetadataFromState(state resourcestate.ExportedResourcesMap) []protos.ResourceMetadata {
+// resourceMetadata reports one entry per resource type, ordered by type name.
+// Counts come from the configuration; max/mean/median state sizes are filled in
+// for the types present in the deployment state.
+func resourceMetadata(r *config.Resources, state resourcestate.ExportedResourcesMap) []protos.ResourceMetadata {
+	counts := make(map[string]int64)
+	for _, group := range r.AllResources() {
+		if len(group.Resources) > 0 {
+			counts[group.Description.PluralName] = int64(len(group.Resources))
+		}
+	}
+
 	sizesByType := make(map[string][]int64)
 	for key, rs := range state {
 		t := config.GetResourceTypeFromKey(key)
@@ -56,23 +73,35 @@ func resourceMetadataFromState(state resourcestate.ExportedResourcesMap) []proto
 		sizesByType[t] = append(sizesByType[t], int64(rs.StateSizeBytes))
 	}
 
-	types := make([]string, 0, len(sizesByType))
-	for t := range sizesByType {
+	types := make([]string, 0, len(counts))
+	for t := range counts {
 		types = append(types, t)
+	}
+	for t, sizes := range sizesByType {
+		if _, ok := counts[t]; !ok {
+			// Types that exist only in state: sub-resources such as
+			// "jobs.permissions", which the configuration does not model as a
+			// resource type, and resources being removed from the bundle. Their
+			// count comes from the state since the configuration has none.
+			counts[t] = int64(len(sizes))
+			types = append(types, t)
+		}
 	}
 	slices.Sort(types)
 
 	resources := make([]protos.ResourceMetadata, 0, len(types))
 	for _, t := range types {
-		sizes := sizesByType[t]
-		slices.Sort(sizes)
-		resources = append(resources, protos.ResourceMetadata{
-			ResourceType:         t,
-			Count:                int64(len(sizes)),
-			StateSizeMaxBytes:    statMax(sizes),
-			StateSizeMeanBytes:   statMean(sizes),
-			StateSizeMedianBytes: statMedian(sizes),
-		})
+		m := protos.ResourceMetadata{
+			ResourceType: t,
+			Count:        counts[t],
+		}
+		if sizes := sizesByType[t]; len(sizes) > 0 {
+			slices.Sort(sizes)
+			m.StateSizeMaxBytes = statMax(sizes)
+			m.StateSizeMeanBytes = statMean(sizes)
+			m.StateSizeMedianBytes = statMedian(sizes)
+		}
+		resources = append(resources, m)
 	}
 	return resources
 }

--- a/bundle/phases/resources_metadata.go
+++ b/bundle/phases/resources_metadata.go
@@ -14,23 +14,17 @@ import (
 )
 
 // collectResourcesMetadata builds a BundleResourcesMetadata for the deployment:
-// how many resources of each type the bundle declares, plus per-type state-size
-// statistics where the engine reports them.
+// per-resource-type counts, plus state sizes for the types the engine measures.
 //
-// Counts are taken from the configuration rather than from the deployment state
-// so that every resource type is reported on every deploy, whatever the engine.
-// That is what makes this message a superset of the per-type
-// resource_*_count fields it replaces (those are deprecated in the proto), and it
-// means a newly added resource type is covered without any telemetry change:
-// AllResources is exhaustive by construction and guarded by
-// TestResourcesAllResourcesCompleteness.
+// Counts come from the configuration rather than from state, so every type is
+// reported on every deploy whatever the engine, and a newly added resource type
+// needs no telemetry change (AllResources is exhaustive by construction, guarded
+// by TestResourcesAllResourcesCompleteness). That is what makes this message a
+// superset of the deprecated per-type resource_*_count fields.
 //
-// Sizes come from b.Metrics.ResourceState, the direct engine's finalized state
-// populated in deployCore from the WAL replay the deploy already performs; each
-// entry carries StateSizeBytes (len of the JSON blob stored in resources.json).
-// So no marshalling, file read, or JSON parsing happens here — sizes are read
-// straight off the in-memory map. The terraform path leaves StateSizeBytes zero,
-// so terraform deploys report counts with zero sizes.
+// Sizes come from b.Metrics.ResourceState, whose entries already carry
+// StateSizeBytes from the WAL replay the direct deploy performed, so nothing is
+// marshalled, read, or parsed here. Terraform leaves those zero.
 //
 // Returns nil when the bundle declares no resources and none are in state.
 func collectResourcesMetadata(ctx context.Context, b *bundle.Bundle) *protos.BundleResourcesMetadata {
@@ -79,10 +73,9 @@ func resourceMetadata(r *config.Resources, state resourcestate.ExportedResources
 	}
 	for t, sizes := range sizesByType {
 		if _, ok := counts[t]; !ok {
-			// Types that exist only in state: sub-resources such as
-			// "jobs.permissions", which the configuration does not model as a
-			// resource type, and resources being removed from the bundle. Their
-			// count comes from the state since the configuration has none.
+			// Sub-resources such as "jobs.permissions", and resources being removed
+			// from the bundle: the configuration declares none, so the state is the
+			// only available count.
 			counts[t] = int64(len(sizes))
 			types = append(types, t)
 		}

--- a/bundle/phases/resources_metadata_test.go
+++ b/bundle/phases/resources_metadata_test.go
@@ -32,9 +32,8 @@ func TestResourceMetadata_CountsFromConfigSizesFromState(t *testing.T) {
 
 	got := resourceMetadata(r, state)
 
-	// Sorted by resource type. jobs median is the lower-middle of sorted [10,20]
-	// -> index (2-1)/2 = 0 -> 10. jobs.permissions is not a configuration
-	// resource type, so its count comes from the state.
+	// Sorted by resource type. jobs median is the lower-middle of [10,20], so 10.
+	// jobs.permissions is not a configuration type, so its count comes from state.
 	assert.Equal(t, []protos.ResourceMetadata{
 		{ResourceType: "jobs", Count: 2, StateSizeMaxBytes: 20, StateSizeMeanBytes: 15, StateSizeMedianBytes: 10},
 		{ResourceType: "jobs.permissions", Count: 1, StateSizeMaxBytes: 2, StateSizeMeanBytes: 2, StateSizeMedianBytes: 2},
@@ -43,8 +42,7 @@ func TestResourceMetadata_CountsFromConfigSizesFromState(t *testing.T) {
 	}, got)
 }
 
-// A terraform deploy reports counts with no sizes: the terraform path leaves
-// StateSizeBytes zero, so there is nothing to measure per type.
+// A terraform deploy has no per-resource state, so it reports counts only.
 func TestResourceMetadata_CountsWithoutState(t *testing.T) {
 	r := &config.Resources{
 		Jobs: map[string]*resources.Job{"foo": {}},
@@ -81,11 +79,9 @@ func TestCollectResourcesMetadata_NilWhenNoResources(t *testing.T) {
 	assert.Nil(t, collectResourcesMetadata(t.Context(), b))
 }
 
-// Every resource type must be reported, otherwise a type looks like it has zero
-// adoption and the omission only surfaces when someone reads the dashboard and
-// concludes nobody uses it. resourceMetadata derives the types from
-// AllResources, so filling one resource of every type is enough to catch a type
-// that falls out of that list.
+// A type missing from the report is indistinguishable from zero adoption on the
+// dashboard, so fill one resource of every type to catch a type that falls out of
+// AllResources.
 func TestResourceMetadataCoversAllResourceTypes(t *testing.T) {
 	var r config.Resources
 	rv := reflect.ValueOf(&r).Elem()

--- a/bundle/phases/resources_metadata_test.go
+++ b/bundle/phases/resources_metadata_test.go
@@ -1,15 +1,28 @@
 package phases
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/resources"
 	"github.com/databricks/cli/bundle/statemgmt/resourcestate"
 	"github.com/databricks/cli/libs/telemetry/protos"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestResourceMetadataFromState_GroupsByType(t *testing.T) {
+func TestResourceMetadata_CountsFromConfigSizesFromState(t *testing.T) {
+	r := &config.Resources{
+		Jobs: map[string]*resources.Job{
+			"foo": {},
+			"bar": {},
+		},
+		Pipelines: map[string]*resources.Pipeline{"qux": {}},
+		// Declared but never deployed, so it has no state and no sizes.
+		Volumes: map[string]*resources.Volume{"vol": {}},
+	}
 	state := resourcestate.ExportedResourcesMap{
 		"resources.jobs.foo":             {StateSizeBytes: 20},
 		"resources.jobs.bar":             {StateSizeBytes: 10},
@@ -17,15 +30,30 @@ func TestResourceMetadataFromState_GroupsByType(t *testing.T) {
 		"resources.pipelines.qux":        {StateSizeBytes: 14},
 	}
 
-	got := resourceMetadataFromState(state)
+	got := resourceMetadata(r, state)
 
-	// Sorted by resource type. Sub-resources (permissions) group under
-	// "<parent>.permissions" per config.GetResourceTypeFromKey. jobs median is
-	// the lower-middle of sorted [10,20] -> index (2-1)/2 = 0 -> 10.
+	// Sorted by resource type. jobs median is the lower-middle of sorted [10,20]
+	// -> index (2-1)/2 = 0 -> 10. jobs.permissions is not a configuration
+	// resource type, so its count comes from the state.
 	assert.Equal(t, []protos.ResourceMetadata{
 		{ResourceType: "jobs", Count: 2, StateSizeMaxBytes: 20, StateSizeMeanBytes: 15, StateSizeMedianBytes: 10},
 		{ResourceType: "jobs.permissions", Count: 1, StateSizeMaxBytes: 2, StateSizeMeanBytes: 2, StateSizeMedianBytes: 2},
 		{ResourceType: "pipelines", Count: 1, StateSizeMaxBytes: 14, StateSizeMeanBytes: 14, StateSizeMedianBytes: 14},
+		{ResourceType: "volumes", Count: 1},
+	}, got)
+}
+
+// A terraform deploy reports counts with no sizes: the terraform path leaves
+// StateSizeBytes zero, so there is nothing to measure per type.
+func TestResourceMetadata_CountsWithoutState(t *testing.T) {
+	r := &config.Resources{
+		Jobs: map[string]*resources.Job{"foo": {}},
+	}
+
+	got := resourceMetadata(r, nil)
+
+	assert.Equal(t, []protos.ResourceMetadata{
+		{ResourceType: "jobs", Count: 1},
 	}, got)
 }
 
@@ -37,19 +65,45 @@ func TestStatHelpers(t *testing.T) {
 	assert.Equal(t, int64(2), statMedian([]int64{1, 2, 3, 4}))
 }
 
-func TestResourceMetadataFromState_SkipsNonResourceKeys(t *testing.T) {
+func TestResourceMetadata_SkipsNonResourceStateKeys(t *testing.T) {
 	state := resourcestate.ExportedResourcesMap{
 		"resources.jobs.foo": {StateSizeBytes: 5},
 		"bogus":              {StateSizeBytes: 99},
 	}
-	got := resourceMetadataFromState(state)
+	got := resourceMetadata(&config.Resources{}, state)
 	assert.Equal(t, []protos.ResourceMetadata{
 		{ResourceType: "jobs", Count: 1, StateSizeMaxBytes: 5, StateSizeMeanBytes: 5, StateSizeMedianBytes: 5},
 	}, got)
 }
 
-func TestCollectResourcesMetadata_NilWhenNoState(t *testing.T) {
-	// Terraform deploys leave Metrics.ResourceState nil.
+func TestCollectResourcesMetadata_NilWhenNoResources(t *testing.T) {
 	b := &bundle.Bundle{}
 	assert.Nil(t, collectResourcesMetadata(t.Context(), b))
+}
+
+// Every resource type must be reported, otherwise a type looks like it has zero
+// adoption and the omission only surfaces when someone reads the dashboard and
+// concludes nobody uses it. resourceMetadata derives the types from
+// AllResources, so filling one resource of every type is enough to catch a type
+// that falls out of that list.
+func TestResourceMetadataCoversAllResourceTypes(t *testing.T) {
+	var r config.Resources
+	rv := reflect.ValueOf(&r).Elem()
+	rt := rv.Type()
+
+	// Resource fields are all map[string]*T; TestCustomMarshallerIsImplemented in
+	// bundle/config enforces that shape.
+	for i := range rt.NumField() {
+		mapType := rt.Field(i).Type
+		m := reflect.MakeMap(mapType)
+		m.SetMapIndex(reflect.ValueOf("my_resource"), reflect.New(mapType.Elem().Elem()))
+		rv.Field(i).Set(m)
+	}
+
+	got := resourceMetadata(&r, nil)
+	require.Len(t, got, rt.NumField())
+
+	for _, m := range got {
+		assert.Equal(t, int64(1), m.Count, "resource type %q", m.ResourceType)
+	}
 }

--- a/libs/telemetry/protos/bundle_deploy.go
+++ b/libs/telemetry/protos/bundle_deploy.go
@@ -10,6 +10,12 @@ type BundleDeployEvent struct {
 	// Error message encountered during the bundle deploy command, if any.
 	ErrorMessage string `json:"error_message,omitempty"`
 
+	// Deprecated: per-resource-type counts, superseded by
+	// ResourcesMetadata.Resources[*].Count, which covers every resource type
+	// instead of the subset that happens to have a field here. Both are populated
+	// during the transition. Do not add fields here for new resource types; the
+	// counts in ResourcesMetadata are derived from the bundle configuration and
+	// pick new types up automatically.
 	ResourceCount                     int64 `json:"resource_count"`
 	ResourceJobCount                  int64 `json:"resource_job_count"`
 	ResourcePipelineCount             int64 `json:"resource_pipeline_count"`
@@ -112,21 +118,26 @@ type BundleDeployExperimental struct {
 	LocalCacheMeasurementsMs []IntMapEntry `json:"local_cache_measurements_ms,omitempty"`
 }
 
-// BundleResourcesMetadata mirrors the universe proto. Per-resource-type
-// state-size metadata for one bundle deployment.
+// BundleResourcesMetadata mirrors the universe proto. Per-resource-type counts
+// and state-size metadata for one bundle deployment.
 //
-// Only direct deploys are measured: the direct engine persists each resource's
-// state as a JSON blob in resources.json, so sizes are read off directly as
-// len(state) — no serialization happens at telemetry time. Terraform stores
-// state in a different shape and is not collected (the field is absent there).
+// Counts are reported for both engines. State sizes are only measured for direct
+// deploys: the direct engine persists each resource's state as a JSON blob in
+// resources.json, so sizes are read off directly as len(state) — no
+// serialization happens at telemetry time. Terraform stores state in a different
+// shape and is not sized per resource, so its entries carry counts only.
 type BundleResourcesMetadata struct {
-	// Always "direct"; terraform deploys do not populate this message.
+	// Engine that ran the deploy: "direct" or "terraform".
 	StateEngine string `json:"state_engine,omitempty"`
 
 	// Size in bytes of the direct engine's resources.json state file on disk.
+	// Absent for terraform deploys, which report the whole-file size as
+	// BundleDeployExperimental.TerraformStateSizeBytes instead.
 	StateFileSizeBytes int64 `json:"state_file_size_bytes,omitempty"`
 
-	// One entry per resource type present in the deployment state.
+	// One entry per resource type declared in the bundle configuration, plus any
+	// type present only in the deployment state (sub-resources such as
+	// "jobs.permissions", or a type being removed from the bundle).
 	Resources []ResourceMetadata `json:"resources,omitempty"`
 }
 
@@ -136,11 +147,15 @@ type ResourceMetadata struct {
 	// Resource type name: "jobs", "pipelines", "schemas", ...
 	ResourceType string `json:"resource_type,omitempty"`
 
-	// Number of resources of this type tracked in the deployment state.
+	// Number of resources of this type declared in the bundle configuration.
+	// Replaces the deprecated BundleDeployEvent.Resource*Count fields. For a type
+	// that appears only in the deployment state, this is the number of state
+	// entries instead, since the configuration declares none.
 	Count int64 `json:"count,omitempty"`
 
 	// State-size statistics across resources of this type, each measured as
-	// len(state) of the JSON blob stored in resources.json.
+	// len(state) of the JSON blob stored in resources.json. Zero when the type has
+	// no state: a terraform deploy, or a resource declared but not yet deployed.
 	StateSizeMaxBytes    int64 `json:"state_size_max_bytes,omitempty"`
 	StateSizeMeanBytes   int64 `json:"state_size_mean_bytes,omitempty"`
 	StateSizeMedianBytes int64 `json:"state_size_median_bytes,omitempty"`

--- a/libs/telemetry/protos/bundle_deploy.go
+++ b/libs/telemetry/protos/bundle_deploy.go
@@ -10,12 +10,9 @@ type BundleDeployEvent struct {
 	// Error message encountered during the bundle deploy command, if any.
 	ErrorMessage string `json:"error_message,omitempty"`
 
-	// Deprecated: per-resource-type counts, superseded by
-	// ResourcesMetadata.Resources[*].Count, which covers every resource type
-	// instead of the subset that happens to have a field here. Both are populated
-	// during the transition. Do not add fields here for new resource types; the
-	// counts in ResourcesMetadata are derived from the bundle configuration and
-	// pick new types up automatically.
+	// Deprecated: superseded by ResourcesMetadata.Resources[*].Count, which covers
+	// every resource type rather than this hand-maintained subset. Both are
+	// populated during the transition; do not add fields here for new types.
 	ResourceCount                     int64 `json:"resource_count"`
 	ResourceJobCount                  int64 `json:"resource_job_count"`
 	ResourcePipelineCount             int64 `json:"resource_pipeline_count"`
@@ -121,23 +118,20 @@ type BundleDeployExperimental struct {
 // BundleResourcesMetadata mirrors the universe proto. Per-resource-type counts
 // and state-size metadata for one bundle deployment.
 //
-// Counts are reported for both engines. State sizes are only measured for direct
-// deploys: the direct engine persists each resource's state as a JSON blob in
-// resources.json, so sizes are read off directly as len(state) — no
-// serialization happens at telemetry time. Terraform stores state in a different
-// shape and is not sized per resource, so its entries carry counts only.
+// Counts cover both engines. Sizes are direct-only: the direct engine stores each
+// resource's state as a JSON blob in resources.json, so a size is len(state) and
+// nothing is serialized at telemetry time. Terraform entries carry counts only.
 type BundleResourcesMetadata struct {
 	// Engine that ran the deploy: "direct" or "terraform".
 	StateEngine string `json:"state_engine,omitempty"`
 
-	// Size in bytes of the direct engine's resources.json state file on disk.
-	// Absent for terraform deploys, which report the whole-file size as
-	// BundleDeployExperimental.TerraformStateSizeBytes instead.
+	// Size in bytes of the direct engine's resources.json on disk. Terraform
+	// reports its state file size as Experimental.TerraformStateSizeBytes.
 	StateFileSizeBytes int64 `json:"state_file_size_bytes,omitempty"`
 
-	// One entry per resource type declared in the bundle configuration, plus any
-	// type present only in the deployment state (sub-resources such as
-	// "jobs.permissions", or a type being removed from the bundle).
+	// One entry per resource type declared in the configuration, plus types that
+	// exist only in state: sub-resources such as "jobs.permissions", and types
+	// being removed from the bundle.
 	Resources []ResourceMetadata `json:"resources,omitempty"`
 }
 
@@ -147,10 +141,9 @@ type ResourceMetadata struct {
 	// Resource type name: "jobs", "pipelines", "schemas", ...
 	ResourceType string `json:"resource_type,omitempty"`
 
-	// Number of resources of this type declared in the bundle configuration.
-	// Replaces the deprecated BundleDeployEvent.Resource*Count fields. For a type
-	// that appears only in the deployment state, this is the number of state
-	// entries instead, since the configuration declares none.
+	// Number of resources of this type declared in the bundle configuration, or the
+	// number of state entries for a type that exists only in state. Replaces the
+	// deprecated BundleDeployEvent.Resource*Count fields.
 	Count int64 `json:"count,omitempty"`
 
 	// State-size statistics across resources of this type, each measured as


### PR DESCRIPTION
## Changes

`resources_metadata` was emitted only for direct deploys, with counts derived from the direct engine's state. Counts now come from `Resources.AllResources()` and the message is emitted for both engines; `state_engine` records the engine that ran. For direct deploys this changes what `count` means — resources declared in the configuration rather than resources present in state — so a declared-but-not-yet-deployed resource is now counted.

State sizes remain direct-only, since the terraform path leaves `StateSizeBytes` zero and has no per-resource state here.

## Why

Dashboards fall back to the deprecated `resource_*_count` fields, which cover 12 of the 32 resource types, so newer types (`job_runs`, `genie_spaces`, `alerts`, `sql_warehouses`, `postgres_*`, ...) look like zero adoption. Deriving counts from `AllResources()` reports a new resource type the moment it ships, with no telemetry or proto change — and matches what the proto already specifies for `count` ("declared in the bundle configuration").

## Tests

- `TestResourceMetadataCoversAllResourceTypes` puts one resource of every type in `config.Resources` and asserts each is reported, so a type dropping out of `AllResources()` fails loudly.
- Unit tests for counts-from-config with and without state.
- Regenerated `out.resources_metadata.terraform.txt`: per-type counts instead of `null`.