### PR TITLE
Deprecate terraform deployment engine

### DIFF
--- a/.nextchanges/bundles/deprecate-terraform-engine.md
+++ b/.nextchanges/bundles/deprecate-terraform-engine.md
@@ -1,1 +1,1 @@
-The terraform deployment engine is deprecated and will stop working in a future version of the CLI. Setting `bundle.engine: terraform` now emits a deprecation warning; remove the setting to use the direct deployment engine (https://docs.databricks.com/aws/en/dev-tools/bundles/direct).
+The terraform deployment engine is deprecated and will stop working in a future version of the CLI. Setting `bundle.engine: terraform` now emits a deprecation warning. See https://docs.databricks.com/aws/en/dev-tools/bundles/direct for how to migrate to the direct deployment engine.

--- a/.nextchanges/bundles/deprecate-terraform-engine.md
+++ b/.nextchanges/bundles/deprecate-terraform-engine.md
@@ -1,0 +1,1 @@
+The terraform deployment engine is deprecated and will stop working in a future version of the CLI. Setting `bundle.engine: terraform` now emits a deprecation warning; remove the setting to use the direct deployment engine (https://docs.databricks.com/aws/en/dev-tools/bundles/direct).

--- a/acceptance/bundle/migrate/engine-config-terraform/output.txt
+++ b/acceptance/bundle/migrate/engine-config-terraform/output.txt
@@ -3,6 +3,6 @@
 Warning: the terraform deployment engine is deprecated and will stop working in a future version of the CLI
   in databricks.yml:3:11
 
-Remove "engine: terraform" to use the direct deployment engine. Learn more at https://docs.databricks.com/aws/en/dev-tools/bundles/direct
+See https://docs.databricks.com/aws/en/dev-tools/bundles/direct for how to migrate to the direct deployment engine
 
 Error: bundle.engine is set to "terraform". Migration requires "engine: direct" or no engine setting. Change the setting to "engine: direct" and retry

--- a/acceptance/bundle/migrate/engine-config-terraform/output.txt
+++ b/acceptance/bundle/migrate/engine-config-terraform/output.txt
@@ -1,3 +1,8 @@
 
 >>> musterr [CLI] bundle deployment migrate
+Warning: the terraform deployment engine is deprecated and will stop working in a future version of the CLI
+  in databricks.yml:3:11
+
+Remove "engine: terraform" to use the direct deployment engine. Learn more at https://docs.databricks.com/aws/en/dev-tools/bundles/direct
+
 Error: bundle.engine is set to "terraform". Migration requires "engine: direct" or no engine setting. Change the setting to "engine: direct" and retry

--- a/acceptance/bundle/telemetry/deploy-app-lifecycle-started/output.txt
+++ b/acceptance/bundle/telemetry/deploy-app-lifecycle-started/output.txt
@@ -92,6 +92,14 @@ Deployment complete!
     {
       "key": "app_lifecycle_started",
       "value": true
+    },
+    {
+      "key": "engine_terraform_config",
+      "value": false
+    },
+    {
+      "key": "engine_terraform_env",
+      "value": false
     }
   ]
 }

--- a/acceptance/bundle/telemetry/deploy-app-lifecycle-started/output.txt
+++ b/acceptance/bundle/telemetry/deploy-app-lifecycle-started/output.txt
@@ -92,14 +92,6 @@ Deployment complete!
     {
       "key": "app_lifecycle_started",
       "value": true
-    },
-    {
-      "key": "engine_terraform_config",
-      "value": false
-    },
-    {
-      "key": "engine_terraform_env",
-      "value": false
     }
   ]
 }

--- a/acceptance/bundle/telemetry/deploy/out.engine.direct.txt
+++ b/acceptance/bundle/telemetry/deploy/out.engine.direct.txt
@@ -1,10 +1,1 @@
-[
-  {
-    "key": "engine_terraform_config",
-    "value": false
-  },
-  {
-    "key": "engine_terraform_env",
-    "value": false
-  }
-]
+[]

--- a/acceptance/bundle/telemetry/deploy/out.engine.direct.txt
+++ b/acceptance/bundle/telemetry/deploy/out.engine.direct.txt
@@ -1,0 +1,10 @@
+[
+  {
+    "key": "engine_terraform_config",
+    "value": false
+  },
+  {
+    "key": "engine_terraform_env",
+    "value": false
+  }
+]

--- a/acceptance/bundle/telemetry/deploy/out.engine.terraform.txt
+++ b/acceptance/bundle/telemetry/deploy/out.engine.terraform.txt
@@ -1,9 +1,5 @@
 [
   {
-    "key": "engine_terraform_config",
-    "value": false
-  },
-  {
     "key": "engine_terraform_env",
     "value": true
   }

--- a/acceptance/bundle/telemetry/deploy/out.engine.terraform.txt
+++ b/acceptance/bundle/telemetry/deploy/out.engine.terraform.txt
@@ -1,0 +1,10 @@
+[
+  {
+    "key": "engine_terraform_config",
+    "value": false
+  },
+  {
+    "key": "engine_terraform_env",
+    "value": true
+  }
+]

--- a/acceptance/bundle/telemetry/deploy/output.txt
+++ b/acceptance/bundle/telemetry/deploy/output.txt
@@ -12,3 +12,4 @@ Deployment complete!
 true
 
 === Assert the dry-run migration to the direct engine is reported
+=== Assert the terraform engine opt-in is reported

--- a/acceptance/bundle/telemetry/deploy/script
+++ b/acceptance/bundle/telemetry/deploy/script
@@ -25,12 +25,19 @@ cat telemetry.json | jq '.entry.databricks_cli_log.bundle_deploy_event.resources
 title "Assert the dry-run migration to the direct engine is reported"
 cat telemetry.json | jq '[.entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values[] | select(.key | startswith("direct_drymigrate_"))]' > out.migration.$DATABRICKS_BUNDLE_ENGINE.txt
 
+# engine_terraform_env reflects DATABRICKS_BUNDLE_ENGINE, which the acceptance
+# matrix sets per variant, so it diverges across the matrix. Capture the
+# engine_terraform_* keys per-engine and drop them from the engine-agnostic
+# out.telemetry.txt below.
+title "Assert the terraform engine opt-in is reported"
+cat telemetry.json | jq '[.entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values[] | select(.key | startswith("engine_terraform_"))]' > out.engine.$DATABRICKS_BUNDLE_ENGINE.txt
+
 # bundle_mutator_execution_time_ms can have variable number of entries depending upon the runtime of the mutators. Thus we omit it from
 # being asserted here.
 #
 # upload_file_count and upload_file_sizes are asserted here and kept deterministic by
 # the sync.paths restriction in databricks.yml (see the comment there).
-cat telemetry.json | jq 'del(.entry.databricks_cli_log.bundle_deploy_event.experimental.bundle_mutator_execution_time_ms, .entry.databricks_cli_log.bundle_deploy_event.resources_metadata) | .entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values |= map(select(.key | startswith("direct_drymigrate_") | not))' > out.telemetry.txt
+cat telemetry.json | jq 'del(.entry.databricks_cli_log.bundle_deploy_event.experimental.bundle_mutator_execution_time_ms, .entry.databricks_cli_log.bundle_deploy_event.resources_metadata) | .entry.databricks_cli_log.bundle_deploy_event.experimental.bool_values |= map(select(.key | (startswith("direct_drymigrate_") or startswith("engine_terraform_")) | not))' > out.telemetry.txt
 
 cmd_exec_id=$(extract_command_exec_id.py)
 deployment_id=$(cat .databricks/bundle/default/deployment.json | jq -r .id)

--- a/acceptance/bundle/validate/engine-config-valid/output.txt
+++ b/acceptance/bundle/validate/engine-config-valid/output.txt
@@ -9,10 +9,15 @@ Workspace:
 Validation OK!
 
 >>> [CLI] bundle validate -t terraform-target
+Warning: the terraform deployment engine is deprecated and will stop working in a future version of the CLI
+  in databricks.yml:10:15
+
+Remove "engine: terraform" to use the direct deployment engine. Learn more at https://docs.databricks.com/aws/en/dev-tools/bundles/direct
+
 Name: test-engine-config-valid
 Target: terraform-target
 Workspace:
   User: [USERNAME]
   Path: /Workspace/Users/[USERNAME]/.bundle/test-engine-config-valid/terraform-target
 
-Validation OK!
+Found 1 warning

--- a/acceptance/bundle/validate/engine-config-valid/output.txt
+++ b/acceptance/bundle/validate/engine-config-valid/output.txt
@@ -12,7 +12,7 @@ Validation OK!
 Warning: the terraform deployment engine is deprecated and will stop working in a future version of the CLI
   in databricks.yml:10:15
 
-Remove "engine: terraform" to use the direct deployment engine. Learn more at https://docs.databricks.com/aws/en/dev-tools/bundles/direct
+See https://docs.databricks.com/aws/en/dev-tools/bundles/direct for how to migrate to the direct deployment engine
 
 Name: test-engine-config-valid
 Target: terraform-target

--- a/acceptance/script.prepare
+++ b/acceptance/script.prepare
@@ -109,8 +109,12 @@ retry() {
     env -u MSYS_NO_PATHCONV retry.py "$@"
 }
 
+# The engine_terraform_* keys reflect the deployment engine opt-in; engine_terraform_env
+# in particular mirrors $DATABRICKS_BUNDLE_ENGINE, which the acceptance matrix sets per
+# variant, so it diverges across the matrix. Drop both here so this shared helper stays
+# engine-agnostic; they are asserted per-engine in bundle/telemetry/deploy.
 print_telemetry_bool_values() {
-    jq -r 'select(.path? == "/telemetry-ext") | (.body.protoLogs // [])[] | fromjson | ( (.entry // .) | (.databricks_cli_log.bundle_deploy_event.experimental.bool_values // []) ) | map("\(.key) \(.value)") | .[]' out.requests.txt | sort
+    jq -r 'select(.path? == "/telemetry-ext") | (.body.protoLogs // [])[] | fromjson | ( (.entry // .) | (.databricks_cli_log.bundle_deploy_event.experimental.bool_values // []) ) | map("\(.key) \(.value)") | .[]' out.requests.txt | grep -v '^engine_terraform_' | sort
 }
 
 sethome() {

--- a/bundle/config/validate/validate_engine.go
+++ b/bundle/config/validate/validate_engine.go
@@ -27,12 +27,22 @@ func (v *validateEngine) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnos
 		return nil
 	}
 
-	if _, ok := engine.Parse(string(configEngine)); !ok {
-		val := dyn.GetValue(b.Config.Value(), "bundle.engine")
-		loc := val.Location()
+	loc := dyn.GetValue(b.Config.Value(), "bundle.engine").Location()
+
+	parsed, ok := engine.Parse(string(configEngine))
+	if !ok {
 		return diag.Diagnostics{{
 			Severity:  diag.Error,
 			Summary:   fmt.Sprintf("invalid value %q for bundle.engine (expected %q or %q)", configEngine, engine.EngineTerraform, engine.EngineDirect),
+			Locations: []dyn.Location{loc},
+		}}
+	}
+
+	if parsed == engine.EngineTerraform {
+		return diag.Diagnostics{{
+			Severity:  diag.Warning,
+			Summary:   "the terraform deployment engine is deprecated and will stop working in a future version of the CLI",
+			Detail:    "Remove \"engine: terraform\" to use the direct deployment engine. Learn more at https://docs.databricks.com/aws/en/dev-tools/bundles/direct",
 			Locations: []dyn.Location{loc},
 		}}
 	}

--- a/bundle/config/validate/validate_engine.go
+++ b/bundle/config/validate/validate_engine.go
@@ -42,7 +42,7 @@ func (v *validateEngine) Apply(_ context.Context, b *bundle.Bundle) diag.Diagnos
 		return diag.Diagnostics{{
 			Severity:  diag.Warning,
 			Summary:   "the terraform deployment engine is deprecated and will stop working in a future version of the CLI",
-			Detail:    "Remove \"engine: terraform\" to use the direct deployment engine. Learn more at https://docs.databricks.com/aws/en/dev-tools/bundles/direct",
+			Detail:    "See https://docs.databricks.com/aws/en/dev-tools/bundles/direct for how to migrate to the direct deployment engine",
 			Locations: []dyn.Location{loc},
 		}}
 	}

--- a/bundle/config/validate/validate_engine_test.go
+++ b/bundle/config/validate/validate_engine_test.go
@@ -12,19 +12,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidateEngineValid(t *testing.T) {
-	for _, eng := range []engine.EngineType{engine.EngineTerraform, engine.EngineDirect} {
-		b := &bundle.Bundle{
-			Config: config.Root{
-				Bundle: config.Bundle{
-					Engine: eng,
-				},
+func TestValidateEngineDirect(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Bundle: config.Bundle{
+				Engine: engine.EngineDirect,
 			},
-		}
-		bundletest.SetLocation(b, "bundle.engine", []dyn.Location{{File: "databricks.yml", Line: 5, Column: 3}})
-		diags := ValidateEngine().Apply(t.Context(), b)
-		assert.Empty(t, diags)
+		},
 	}
+	bundletest.SetLocation(b, "bundle.engine", []dyn.Location{{File: "databricks.yml", Line: 5, Column: 3}})
+	diags := ValidateEngine().Apply(t.Context(), b)
+	assert.Empty(t, diags)
+}
+
+func TestValidateEngineTerraformDeprecated(t *testing.T) {
+	b := &bundle.Bundle{
+		Config: config.Root{
+			Bundle: config.Bundle{
+				Engine: engine.EngineTerraform,
+			},
+		},
+	}
+	loc := dyn.Location{File: "databricks.yml", Line: 5, Column: 3}
+	bundletest.SetLocation(b, "bundle.engine", []dyn.Location{loc})
+	diags := ValidateEngine().Apply(t.Context(), b)
+	assert.Len(t, diags, 1)
+	assert.Equal(t, diag.Warning, diags[0].Severity)
+	assert.Contains(t, diags[0].Summary, "deprecated")
+	assert.Equal(t, []dyn.Location{loc}, diags[0].Locations)
 }
 
 func TestValidateEngineNotSet(t *testing.T) {

--- a/bundle/metrics/metrics.go
+++ b/bundle/metrics/metrics.go
@@ -42,6 +42,15 @@ const (
 	DirectAutoMigrateViaConfig = "direct_migrated_via_config"
 	DirectAutoMigrateViaEnv    = "direct_migrated_via_env"
 
+	// Whether the (deprecated) terraform engine was explicitly opted into, and via
+	// which source. These are independent booleans: both can be true when config
+	// and env both request terraform. Recorded on every deploy so the population
+	// still on terraform can be sliced by opt-in source.
+	//   - engine_terraform_config: bundle.engine = "terraform" in the bundle config.
+	//   - engine_terraform_env:    DATABRICKS_BUNDLE_ENGINE=terraform in the environment.
+	EngineTerraformConfig = "engine_terraform_config"
+	EngineTerraformEnv    = "engine_terraform_env"
+
 	// Whether workspace.state_path is under /Workspace/Shared.
 	StatePathIsShared = "state_path_is_shared"
 

--- a/bundle/metrics/metrics.go
+++ b/bundle/metrics/metrics.go
@@ -43,9 +43,9 @@ const (
 	DirectAutoMigrateViaEnv    = "direct_migrated_via_env"
 
 	// Whether the (deprecated) terraform engine was explicitly opted into, and via
-	// which source. These are independent booleans: both can be true when config
-	// and env both request terraform. Recorded on every deploy so the population
-	// still on terraform can be sliced by opt-in source.
+	// which source. Independent: both can be present when config and env both
+	// request terraform. Emitted only when true; absence means "not opted in via
+	// this source", so the population still on terraform can be sliced by source.
 	//   - engine_terraform_config: bundle.engine = "terraform" in the bundle config.
 	//   - engine_terraform_env:    DATABRICKS_BUNDLE_ENGINE=terraform in the environment.
 	EngineTerraformConfig = "engine_terraform_config"

--- a/bundle/phases/telemetry.go
+++ b/bundle/phases/telemetry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/bundle/config/engine"
 	"github.com/databricks/cli/bundle/libraries"
 	"github.com/databricks/cli/bundle/metrics"
 	"github.com/databricks/cli/libs/dyn"
@@ -200,6 +201,14 @@ func LogDeployTelemetry(ctx context.Context, b *bundle.Bundle, errMsg string) {
 			break
 		}
 	}
+
+	// Record whether the deprecated terraform engine was explicitly opted into,
+	// separately per source. An invalid env value has already failed the command
+	// upstream via ResolveEngineSetting, so treating the FromEnv error as
+	// "not terraform" here cannot mask a real terraform opt-in.
+	envEngine, _ := engine.FromEnv(ctx)
+	b.Metrics.SetBoolValue(metrics.EngineTerraformConfig, b.Config.Bundle.Engine == engine.EngineTerraform)
+	b.Metrics.SetBoolValue(metrics.EngineTerraformEnv, envEngine == engine.EngineTerraform)
 
 	// If the bundle UUID is not set, we use a default 0 value.
 	bundleUuid := "00000000-0000-0000-0000-000000000000"

--- a/bundle/phases/telemetry.go
+++ b/bundle/phases/telemetry.go
@@ -203,12 +203,16 @@ func LogDeployTelemetry(ctx context.Context, b *bundle.Bundle, errMsg string) {
 	}
 
 	// Record whether the deprecated terraform engine was explicitly opted into,
-	// separately per source. An invalid env value has already failed the command
+	// separately per source. Only emitted when true; absence means "not opted in
+	// via this source". An invalid env value has already failed the command
 	// upstream via ResolveEngineSetting, so treating the FromEnv error as
 	// "not terraform" here cannot mask a real terraform opt-in.
-	envEngine, _ := engine.FromEnv(ctx)
-	b.Metrics.SetBoolValue(metrics.EngineTerraformConfig, b.Config.Bundle.Engine == engine.EngineTerraform)
-	b.Metrics.SetBoolValue(metrics.EngineTerraformEnv, envEngine == engine.EngineTerraform)
+	if b.Config.Bundle.Engine == engine.EngineTerraform {
+		b.Metrics.SetBoolValue(metrics.EngineTerraformConfig, true)
+	}
+	if envEngine, _ := engine.FromEnv(ctx); envEngine == engine.EngineTerraform {
+		b.Metrics.SetBoolValue(metrics.EngineTerraformEnv, true)
+	}
 
 	// If the bundle UUID is not set, we use a default 0 value.
 	bundleUuid := "00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Changes
Warn when `bundle.engine: terraform` is set, pointing to the direct engine docs (https://docs.databricks.com/aws/en/dev-tools/bundles/direct). Add `engine_terraform_config` and `engine_terraform_env` deploy telemetry.

## Why
The direct engine is now the default and terraform is on a path to removal, but users who explicitly pin it get no signal, and we have no data on how many still opt in. The warning only fires on the config setting (the durable opt-in that needs migrating); telemetry covers both config and the `DATABRICKS_BUNDLE_ENGINE` env var.