### PR TITLE
[VPEX] localenv: rename compute-target vocabulary `target` → `compute`

### DIFF
--- a/acceptance/localenv/constraints-only/output.txt
+++ b/acceptance/localenv/constraints-only/output.txt
@@ -6,7 +6,7 @@
   "ok": true,
   "mode": "constraints-only",
   "dryRun": true,
-  "target": {
+  "compute": {
     "source": "serverless",
     "serverlessVersion": "v4",
     "envKey": "serverless/serverless-v4"

--- a/acceptance/localenv/serverless-json/output.txt
+++ b/acceptance/localenv/serverless-json/output.txt
@@ -6,7 +6,7 @@
   "ok": true,
   "mode": "default",
   "dryRun": true,
-  "target": {
+  "compute": {
     "source": "serverless",
     "serverlessVersion": "v4",
     "envKey": "serverless/serverless-v4"

--- a/cmd/environments/compute.go
+++ b/cmd/environments/compute.go
@@ -106,7 +106,7 @@ func (c sdkCompute) JobTaskEnvironment(ctx context.Context, jobID, taskKey strin
 	}
 
 	// No task key given: ask the caller to pick one, listing what is available.
-	// This is a usage error, not a resolve failure — see ResolveTarget.
+	// This is a usage error, not a resolve failure — see ResolveCompute.
 	if taskKey == "" {
 		return "", false, "", &localenv.ErrTaskKeyRequired{JobID: jobID, TaskKeys: taskKeys}
 	}

--- a/cmd/environments/sync.go
+++ b/cmd/environments/sync.go
@@ -74,7 +74,7 @@ func runPipeline(cmd *cobra.Command) error {
 	check, _ := cmd.Flags().GetBool("dry-run")
 	constraintSource, _ := cmd.Flags().GetString("constraint-source-url")
 
-	targetFlags := libslocalenv.TargetFlags{
+	computeFlags := libslocalenv.ComputeFlags{
 		Cluster:     cluster,
 		ClusterName: clusterName,
 		Serverless:  serverless,
@@ -102,7 +102,7 @@ func runPipeline(cmd *cobra.Command) error {
 	}
 	cacheDir = filepath.Join(cacheDir, "databricks", "localenv")
 
-	// The bundle is only a fallback: ResolveTarget consults it solely when no
+	// The bundle is only a fallback: ResolveCompute consults it solely when no
 	// explicit --cluster-id/--cluster-name/--serverless-version/--job-task flag is set. Skip the bundle load
 	// entirely when a flag is present — it would otherwise re-run TryConfigureBundle
 	// (a second full load) and re-print any bundle load-time diagnostics for nothing.
@@ -118,7 +118,7 @@ func runPipeline(cmd *cobra.Command) error {
 		ProjectDir:        projectDir,
 		ConstraintBaseURL: constraintBaseURL,
 		CacheDir:          cacheDir,
-		Flags:             targetFlags,
+		Flags:             computeFlags,
 		Compute:           sdkCompute{w: w},
 		Bundle:            bt,
 		PM:                libslocalenv.NewUvManager(),

--- a/cmd/environments/sync.go
+++ b/cmd/environments/sync.go
@@ -38,15 +38,15 @@ env-owned sections are refreshed, user-owned content is preserved).`,
 	// silently ignoring them.
 	cmd.Args = cobra.NoArgs
 	cmd.PreRunE = root.MustWorkspaceClient
-	addTargetFlags(cmd)
+	addComputeFlags(cmd)
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return runPipeline(cmd)
 	}
 	return cmd
 }
 
-// addTargetFlags adds the shared target and mode flags to a command.
-func addTargetFlags(cmd *cobra.Command) {
+// addComputeFlags adds the shared compute and mode flags to a command.
+func addComputeFlags(cmd *cobra.Command) {
 	cmd.Flags().String("cluster-id", "", "cluster ID to use as the compute target")
 	cmd.Flags().String("cluster-name", "", "cluster name to use as the compute target (resolved to an ID via the Clusters API)")
 	cmd.Flags().String("serverless-version", "", "serverless version to use as the compute target (e.g. 5)")

--- a/libs/localenv/compute.go
+++ b/libs/localenv/compute.go
@@ -31,7 +31,7 @@ type ComputeClient interface {
 }
 
 // ErrTaskKeyRequired is returned by JobTaskEnvironment when --job-task names a
-// job but no task, so ResolveTarget can classify it as E_USAGE (the user must
+// job but no task, so ResolveCompute can classify it as E_USAGE (the user must
 // pick a task) rather than E_RESOLVE. It carries the job's task keys so the
 // error message can list them.
 type ErrTaskKeyRequired struct {
@@ -44,8 +44,8 @@ func (e *ErrTaskKeyRequired) Error() string {
 		e.JobID, e.JobID, strings.Join(e.TaskKeys, ", "))
 }
 
-// TargetFlags holds the mutually-exclusive compute target flags from the CLI.
-type TargetFlags struct {
+// ComputeFlags holds the mutually-exclusive compute target flags from the CLI.
+type ComputeFlags struct {
 	Cluster     string
 	ClusterName string
 	Serverless  string
@@ -67,9 +67,9 @@ type BundleTarget struct {
 // matching spec §2.3.
 const noTargetMessage = "No compute target is selected. Select a cluster or serverless target, or pass --cluster-id / --cluster-name / --serverless-version / --job-task"
 
-// ValidateTargetFlags returns an error if more than one of the target flags is set.
+// ValidateComputeFlags returns an error if more than one of the target flags is set.
 // Cobra marks them mutually exclusive too; this guards the library path.
-func ValidateTargetFlags(f TargetFlags) error {
+func ValidateComputeFlags(f ComputeFlags) error {
 	var set []string
 	if f.Cluster != "" {
 		set = append(set, "--cluster-id")
@@ -89,7 +89,7 @@ func ValidateTargetFlags(f TargetFlags) error {
 	return nil
 }
 
-// ResolveTarget resolves the compute target using ordered precedence:
+// ResolveCompute resolves the compute target using ordered precedence:
 // --cluster-id → --cluster-name → --serverless-version → --job-task → bundle target.
 // PythonVersion is left empty; it is filled later from constraint data.
 //
@@ -97,8 +97,8 @@ func ValidateTargetFlags(f TargetFlags) error {
 // bypasses Cobra (which also marks the flags mutually exclusive) and passes more
 // than one target flag would have all but the first precedence branch silently
 // ignored, resolving a different target than requested.
-func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt BundleTarget) (*TargetInfo, error) {
-	if err := ValidateTargetFlags(f); err != nil {
+func ResolveCompute(ctx context.Context, f ComputeFlags, c ComputeClient, bt BundleTarget) (*ComputeInfo, error) {
+	if err := ValidateComputeFlags(f); err != nil {
 		return nil, NewError(ErrResolve, err, "invalid compute target flags")
 	}
 
@@ -107,7 +107,7 @@ func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt Bundl
 		if err != nil {
 			return nil, NewError(ErrResolve, err, "resolving cluster %s", f.Cluster)
 		}
-		return &TargetInfo{
+		return &ComputeInfo{
 			Source:       "cluster",
 			ClusterID:    f.Cluster,
 			SparkVersion: v,
@@ -123,7 +123,7 @@ func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt Bundl
 		if err != nil {
 			return nil, NewError(ErrResolve, err, "resolving cluster name %q", f.ClusterName)
 		}
-		return &TargetInfo{
+		return &ComputeInfo{
 			Source:       "cluster",
 			ClusterID:    id,
 			SparkVersion: v,
@@ -135,7 +135,7 @@ func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt Bundl
 		if !ValidServerlessVersion(f.Serverless) {
 			return nil, NewError(ErrResolve, nil, "invalid --serverless-version %q: expected a version number like 5", f.Serverless)
 		}
-		return &TargetInfo{
+		return &ComputeInfo{
 			Source:            "serverless",
 			ServerlessVersion: NormalizeServerless(f.Serverless),
 			EnvKey:            EnvKeyForServerless(f.Serverless),
@@ -161,14 +161,14 @@ func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt Bundl
 			// The task's serverless environment version is read directly from its
 			// bound environment, so there is no version to guess: unlike the bundle
 			// path, the job-task path never applies the serverless-vN fallback.
-			return &TargetInfo{
+			return &ComputeInfo{
 				Source:            "job",
 				ServerlessVersion: NormalizeServerless(version),
 				EnvKey:            EnvKeyForServerless(version),
 			}, nil
 		}
 		// Classic compute: sparkVersion is the task cluster's runtime.
-		return &TargetInfo{
+		return &ComputeInfo{
 			Source:       "job",
 			SparkVersion: sparkVersion,
 			EnvKey:       EnvKeyForSparkVersion(sparkVersion),
@@ -183,7 +183,7 @@ func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt Bundl
 	if bt.Serverless {
 		// The bundle records that the target is serverless but not which version,
 		// so use the default stand-in (spec §4.3).
-		return &TargetInfo{
+		return &ComputeInfo{
 			Source:            "bundle",
 			ServerlessVersion: NormalizeServerless(defaultServerlessVersion),
 			EnvKey:            EnvKeyForServerless(defaultServerlessVersion),
@@ -195,7 +195,7 @@ func ResolveTarget(ctx context.Context, f TargetFlags, c ComputeClient, bt Bundl
 		if err != nil {
 			return nil, NewError(ErrResolve, err, "resolving bundle cluster %s", bt.ClusterID)
 		}
-		return &TargetInfo{
+		return &ComputeInfo{
 			Source:       "bundle",
 			ClusterID:    bt.ClusterID,
 			SparkVersion: v,

--- a/libs/localenv/compute_test.go
+++ b/libs/localenv/compute_test.go
@@ -30,7 +30,7 @@ func (s stubCompute) JobTaskEnvironment(_ context.Context, _, _ string) (string,
 }
 
 func TestResolveServerlessFlag(t *testing.T) {
-	ti, err := ResolveTarget(t.Context(), TargetFlags{Serverless: "v4"}, stubCompute{}, BundleTarget{})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{Serverless: "v4"}, stubCompute{}, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "serverless", ti.Source)
 	assert.Equal(t, "v4", ti.ServerlessVersion)
@@ -39,7 +39,7 @@ func TestResolveServerlessFlag(t *testing.T) {
 
 func TestResolveServerlessFlagBareNumber(t *testing.T) {
 	// The documented input is a bare number; it normalizes to the vN env key.
-	ti, err := ResolveTarget(t.Context(), TargetFlags{Serverless: "5"}, stubCompute{}, BundleTarget{})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{Serverless: "5"}, stubCompute{}, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "serverless/serverless-v5", ti.EnvKey)
 }
@@ -48,7 +48,7 @@ func TestResolveServerlessFlagRejectsMalformed(t *testing.T) {
 	// Malformed values fail fast at resolve (E_RESOLVE) rather than resolving to
 	// a bogus env key that only 404s at fetch.
 	for _, bad := range []string{"vv5", "v", " 5", "5x", "latest"} {
-		_, err := ResolveTarget(t.Context(), TargetFlags{Serverless: bad}, stubCompute{}, BundleTarget{})
+		_, err := ResolveCompute(t.Context(), ComputeFlags{Serverless: bad}, stubCompute{}, BundleTarget{})
 		var pe *PipelineError
 		require.ErrorAs(t, err, &pe, "input %q should error", bad)
 		assert.Equal(t, ErrResolve, pe.Code, "input %q", bad)
@@ -57,7 +57,7 @@ func TestResolveServerlessFlagRejectsMalformed(t *testing.T) {
 
 func TestResolveClusterFlag(t *testing.T) {
 	c := stubCompute{clusterVersion: "15.4.x-scala2.12"}
-	ti, err := ResolveTarget(t.Context(), TargetFlags{Cluster: "abc"}, c, BundleTarget{})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{Cluster: "abc"}, c, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "cluster", ti.Source)
 	assert.Equal(t, "15.4.x-scala2.12", ti.SparkVersion)
@@ -67,7 +67,7 @@ func TestResolveClusterFlag(t *testing.T) {
 
 func TestResolveClusterFlagError(t *testing.T) {
 	c := stubCompute{clusterErr: errors.New("cluster not found")}
-	_, err := ResolveTarget(t.Context(), TargetFlags{Cluster: "abc"}, c, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{Cluster: "abc"}, c, BundleTarget{})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrResolve, pe.Code)
@@ -78,7 +78,7 @@ func TestResolveClusterNameFlag(t *testing.T) {
 	// --cluster-id: source=cluster, the resolved ID is reported, and the env key
 	// derives from the resolved cluster's Spark version.
 	c := stubCompute{byNameID: "cid-123", byNameVersion: "15.4.x-scala2.12"}
-	ti, err := ResolveTarget(t.Context(), TargetFlags{ClusterName: "my-cluster"}, c, BundleTarget{})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{ClusterName: "my-cluster"}, c, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "cluster", ti.Source)
 	assert.Equal(t, "cid-123", ti.ClusterID)
@@ -89,7 +89,7 @@ func TestResolveClusterNameFlag(t *testing.T) {
 func TestResolveClusterNameFlagError(t *testing.T) {
 	// An unknown or ambiguous name surfaces as E_RESOLVE.
 	c := stubCompute{byNameErr: errors.New("there are 2 instances of ClusterDetails named 'dup'")}
-	_, err := ResolveTarget(t.Context(), TargetFlags{ClusterName: "dup"}, c, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{ClusterName: "dup"}, c, BundleTarget{})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrResolve, pe.Code)
@@ -97,14 +97,14 @@ func TestResolveClusterNameFlagError(t *testing.T) {
 
 func TestResolveClusterIdAndNameMutuallyExclusive(t *testing.T) {
 	// The library path rejects setting both --cluster-id and --cluster-name.
-	_, err := ResolveTarget(t.Context(), TargetFlags{Cluster: "abc", ClusterName: "xyz"}, stubCompute{}, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{Cluster: "abc", ClusterName: "xyz"}, stubCompute{}, BundleTarget{})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrResolve, pe.Code)
 }
 
 func TestResolveBundleNothingSelected(t *testing.T) {
-	_, err := ResolveTarget(t.Context(), TargetFlags{}, stubCompute{}, BundleTarget{Selected: false})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{}, stubCompute{}, BundleTarget{Selected: false})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrNoTarget, pe.Code)
@@ -112,7 +112,7 @@ func TestResolveBundleNothingSelected(t *testing.T) {
 
 func TestResolveBundleServerless(t *testing.T) {
 	// The bundle records serverless but no version, so the default stand-in applies.
-	ti, err := ResolveTarget(t.Context(), TargetFlags{}, stubCompute{}, BundleTarget{Selected: true, Serverless: true})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{}, stubCompute{}, BundleTarget{Selected: true, Serverless: true})
 	require.NoError(t, err)
 	assert.Equal(t, "bundle", ti.Source)
 	// Concrete literal, not "serverless-"+defaultServerlessVersion: the default
@@ -155,7 +155,7 @@ func (s *jobStubCompute) JobTaskEnvironment(_ context.Context, jobID, taskKey st
 func TestResolveJobTaskClassicUsesSparkVersion(t *testing.T) {
 	// A classic task resolves to its cluster's Spark version → dbr/ env key.
 	c := &jobStubCompute{sparkVersion: "15.4.x-scala2.12"}
-	ti, err := ResolveTarget(t.Context(), TargetFlags{JobTask: "42.ingest"}, c, BundleTarget{})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{JobTask: "42.ingest"}, c, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "job", ti.Source)
 	assert.Equal(t, "15.4.x-scala2.12", ti.SparkVersion)
@@ -169,7 +169,7 @@ func TestResolveJobTaskSplitsOnFirstDot(t *testing.T) {
 	// Task keys may themselves contain dots, so only the first dot separates the
 	// job ID from the task key.
 	c := &jobStubCompute{sparkVersion: "15.4.x-scala2.12"}
-	_, err := ResolveTarget(t.Context(), TargetFlags{JobTask: "42.a.b.c"}, c, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{JobTask: "42.a.b.c"}, c, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "42", c.gotJobID)
 	assert.Equal(t, "a.b.c", c.gotTaskKey)
@@ -179,7 +179,7 @@ func TestResolveJobTaskServerlessUsesTaskVersion(t *testing.T) {
 	// A serverless task's environment version is read directly (no fallback):
 	// it maps to the matching serverless-vN, not the classic dbr path.
 	c := &jobStubCompute{isServerless: true, version: "3"}
-	ti, err := ResolveTarget(t.Context(), TargetFlags{JobTask: "42.transform"}, c, BundleTarget{})
+	ti, err := ResolveCompute(t.Context(), ComputeFlags{JobTask: "42.transform"}, c, BundleTarget{})
 	require.NoError(t, err)
 	assert.Equal(t, "job", ti.Source)
 	assert.Empty(t, ti.SparkVersion)
@@ -190,7 +190,7 @@ func TestResolveJobTaskMissingKeyIsUsageError(t *testing.T) {
 	// A bare "<job-id>" (no task key) is E_USAGE, not E_RESOLVE: the user must
 	// pick a task. The stub reports the enumerate request via ErrTaskKeyRequired.
 	c := &jobStubCompute{err: &ErrTaskKeyRequired{JobID: "42", TaskKeys: []string{"ingest", "transform"}}}
-	_, err := ResolveTarget(t.Context(), TargetFlags{JobTask: "42"}, c, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{JobTask: "42"}, c, BundleTarget{})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrUsage, pe.Code)
@@ -201,22 +201,22 @@ func TestResolveJobTaskUnknownKeyIsResolveError(t *testing.T) {
 	// An unknown task key is a genuine resolve failure (E_RESOLVE), distinct from
 	// the missing-key usage error above.
 	c := &jobStubCompute{err: errors.New(`job 42 has no task "nope" (available: ingest)`)}
-	_, err := ResolveTarget(t.Context(), TargetFlags{JobTask: "42.nope"}, c, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{JobTask: "42.nope"}, c, BundleTarget{})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrResolve, pe.Code)
 }
 
 func TestValidateTargetFlagsMutuallyExclusive(t *testing.T) {
-	assert.Error(t, ValidateTargetFlags(TargetFlags{Cluster: "a", Serverless: "v4"}))
-	assert.NoError(t, ValidateTargetFlags(TargetFlags{Cluster: "a"}))
+	assert.Error(t, ValidateComputeFlags(ComputeFlags{Cluster: "a", Serverless: "v4"}))
+	assert.NoError(t, ValidateComputeFlags(ComputeFlags{Cluster: "a"}))
 }
 
 func TestResolveTargetRejectsConflictingFlags(t *testing.T) {
-	// ResolveTarget must reject incompatible flags rather than silently taking
+	// ResolveCompute must reject incompatible flags rather than silently taking
 	// the first precedence branch, so a library caller bypassing Cobra can't
 	// resolve a different target than it asked for.
-	_, err := ResolveTarget(t.Context(), TargetFlags{Cluster: "c", Serverless: "v4"}, stubCompute{}, BundleTarget{})
+	_, err := ResolveCompute(t.Context(), ComputeFlags{Cluster: "c", Serverless: "v4"}, stubCompute{}, BundleTarget{})
 	var pe *PipelineError
 	require.ErrorAs(t, err, &pe)
 	assert.Equal(t, ErrResolve, pe.Code)

--- a/libs/localenv/compute_test.go
+++ b/libs/localenv/compute_test.go
@@ -207,12 +207,12 @@ func TestResolveJobTaskUnknownKeyIsResolveError(t *testing.T) {
 	assert.Equal(t, ErrResolve, pe.Code)
 }
 
-func TestValidateTargetFlagsMutuallyExclusive(t *testing.T) {
+func TestValidateComputeFlagsMutuallyExclusive(t *testing.T) {
 	assert.Error(t, ValidateComputeFlags(ComputeFlags{Cluster: "a", Serverless: "v4"}))
 	assert.NoError(t, ValidateComputeFlags(ComputeFlags{Cluster: "a"}))
 }
 
-func TestResolveTargetRejectsConflictingFlags(t *testing.T) {
+func TestResolveComputeRejectsConflictingFlags(t *testing.T) {
 	// ResolveCompute must reject incompatible flags rather than silently taking
 	// the first precedence branch, so a library caller bypassing Cobra can't
 	// resolve a different target than it asked for.

--- a/libs/localenv/pipeline.go
+++ b/libs/localenv/pipeline.go
@@ -48,7 +48,7 @@ type Pipeline struct {
 	ProjectDir        string
 	ConstraintBaseURL string
 	CacheDir          string
-	Flags             TargetFlags
+	Flags             ComputeFlags
 	Bundle            BundleTarget
 	Compute           ComputeClient
 	PM                PackageManager
@@ -98,7 +98,7 @@ func (p *Pipeline) run(ctx context.Context) error {
 	// before any other work so the failure flows through the phase/JSON reporting
 	// (a plain Cobra mutual-exclusion error would print no command JSON object,
 	// which the --output json consumer needs).
-	if err := ValidateTargetFlags(p.Flags); err != nil {
+	if err := ValidateComputeFlags(p.Flags); err != nil {
 		return p.fail(PhasePreflight, false, NewError(ErrUsage, err, "invalid compute target flags"))
 	}
 	// P0 supports only uv; any other detected manager is a clean, non-blaming exit.
@@ -126,13 +126,13 @@ func (p *Pipeline) run(ctx context.Context) error {
 	}
 
 	// Phase: resolve — compute target → environment key.
-	target, err := p.resolve(ctx)
+	compute, err := p.resolve(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Phase: fetch — constraint artifact for the resolved env key.
-	c, err := p.fetch(ctx, target)
+	c, err := p.fetch(ctx, compute)
 	if err != nil {
 		return err
 	}
@@ -189,22 +189,22 @@ func (p *Pipeline) run(ctx context.Context) error {
 	return p.validate(ctx, pyMinor, dbcPin)
 }
 
-// resolve runs ResolveTarget and records the resolve phase.
-func (p *Pipeline) resolve(ctx context.Context) (*TargetInfo, error) {
-	target, err := ResolveTarget(ctx, p.Flags, p.Compute, p.Bundle)
+// resolve runs ResolveCompute and records the resolve phase.
+func (p *Pipeline) resolve(ctx context.Context) (*ComputeInfo, error) {
+	compute, err := ResolveCompute(ctx, p.Flags, p.Compute, p.Bundle)
 	if err != nil {
-		return nil, p.fail(PhaseResolve, false, asPipelineError(err, ErrResolve, "target resolution failed"))
+		return nil, p.fail(PhaseResolve, false, asPipelineError(err, ErrResolve, "compute resolution failed"))
 	}
-	p.res.Target = target
-	p.markOK(PhaseResolve, fmt.Sprintf("source=%s envKey=%s", target.Source, target.EnvKey))
-	return target, nil
+	p.res.Compute = compute
+	p.markOK(PhaseResolve, fmt.Sprintf("source=%s envKey=%s", compute.Source, compute.EnvKey))
+	return compute, nil
 }
 
 // fetch fetches constraints for the resolved target and records the fetch phase.
 // Under --dry-run the cache is not populated, so a dry run performs no disk writes
 // (an existing cache is still read for offline fallback).
-func (p *Pipeline) fetch(ctx context.Context, target *TargetInfo) (*Constraints, error) {
-	c, err := FetchConstraints(ctx, p.ConstraintBaseURL, target.EnvKey, p.CacheDir, !p.Check)
+func (p *Pipeline) fetch(ctx context.Context, compute *ComputeInfo) (*Constraints, error) {
+	c, err := FetchConstraints(ctx, p.ConstraintBaseURL, compute.EnvKey, p.CacheDir, !p.Check)
 	if err != nil {
 		// FetchConstraints classifies the cause: E_ENV_UNSUPPORTED for a missing
 		// key (404) versus E_FETCH for transport failure with no cache. Both are

--- a/libs/localenv/pipeline_test.go
+++ b/libs/localenv/pipeline_test.go
@@ -78,7 +78,7 @@ func newTestServer(t *testing.T) *httptest.Server {
 	}))
 }
 
-func TestPipelineRejectsConflictingTargetFlagsAtPreflight(t *testing.T) {
+func TestPipelineRejectsConflictingComputeFlagsAtPreflight(t *testing.T) {
 	// Incompatible target flags are a usage error surfaced as E_USAGE at
 	// preflight, before any manager/writability/fetch work.
 	dir := writeProject(t)

--- a/libs/localenv/pipeline_test.go
+++ b/libs/localenv/pipeline_test.go
@@ -84,7 +84,7 @@ func TestPipelineRejectsConflictingTargetFlagsAtPreflight(t *testing.T) {
 	dir := writeProject(t)
 	p := &Pipeline{
 		Mode: ModeDefault, Check: true, ProjectDir: dir, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Cluster: "abc", Serverless: "v4"},
+		Flags:   ComputeFlags{Cluster: "abc", Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -107,7 +107,7 @@ func TestPipelineCheckMutatesNothing(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, Check: true, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: cacheDir,
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -137,7 +137,7 @@ func TestPipelineCheckReRunPlanMatchesRealRun(t *testing.T) {
 		return &Pipeline{
 			Mode: ModeDefault, Check: check, ProjectDir: dir,
 			ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-			Flags:   TargetFlags{Serverless: "v4"},
+			Flags:   ComputeFlags{Serverless: "v4"},
 			Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 		}
 	}
@@ -166,7 +166,7 @@ func TestPipelineCheckDoesNotProvision(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, Check: true, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: noProvisionPM{},
 	}
 	res, err := p.Run(t.Context())
@@ -191,7 +191,7 @@ func TestPipelineCheckWorksOnReadOnlyDir(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, Check: true, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -214,7 +214,7 @@ func TestPipelineProvisionsAndValidatesExisting(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -241,7 +241,7 @@ func TestPipelineGreenfieldCreatesNewPyproject(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -277,7 +277,7 @@ func TestPipelineGreenfieldFromDotDirRendersValidName(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -296,7 +296,7 @@ func TestPipelineExistingBacksUp(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -318,7 +318,7 @@ func TestPipelineReRunDoesNotRewriteUnchangedPyproject(t *testing.T) {
 		return &Pipeline{
 			Mode: ModeDefault, ProjectDir: dir,
 			ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-			Flags:   TargetFlags{Serverless: "v4"},
+			Flags:   ComputeFlags{Serverless: "v4"},
 			Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 		}
 	}
@@ -390,7 +390,7 @@ func TestPipelineManagerUnsupportedFailsAtPreflight(t *testing.T) {
 
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -406,7 +406,7 @@ func TestPipelineUvMissingFailsAtPreflight(t *testing.T) {
 
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: uvMissingPM{},
 	}
 	res, err := p.Run(t.Context())
@@ -456,7 +456,7 @@ func TestPipelineConstraintsOnlyOmitsDBConnect(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeConstraintsOnly, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -481,7 +481,7 @@ func TestPipelineNoTarget(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{},
+		Flags:   ComputeFlags{},
 		Compute: stubCompute{}, PM: fakePM{},
 	}
 	res, err := p.Run(t.Context())
@@ -528,7 +528,7 @@ dev = ["databricks-connect~=17.2.0"]
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -572,7 +572,7 @@ dev = ["databricks-connect~=16.0.0"]
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -599,7 +599,7 @@ func TestPipelineResultPopulatesResolved(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, Check: true, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -638,7 +638,7 @@ func TestPipelineValidateRejectsUnparseablePin(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: "17.2.0"},
 	}
 	res, err := p.Run(t.Context())
@@ -658,7 +658,7 @@ func TestPipelineValidateRejectsUnparseableInstalledVersion(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "v4"},
+		Flags:   ComputeFlags{Serverless: "v4"},
 		Compute: stubCompute{}, PM: fakePM{py: "3.12", dbc: ""},
 	}
 	res, err := p.Run(t.Context())

--- a/libs/localenv/provision_integration_test.go
+++ b/libs/localenv/provision_integration_test.go
@@ -75,7 +75,7 @@ func TestProvisionCreatesAndValidatesVenv(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, Check: false, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "5"},
+		Flags:   ComputeFlags{Serverless: "5"},
 		Compute: stubCompute{}, PM: NewUvManager(),
 	}
 	res, err := p.Run(realProvisionCtx(t))
@@ -134,7 +134,7 @@ func TestProvisionValidateIgnoresActiveVirtualEnv(t *testing.T) {
 	p := &Pipeline{
 		Mode: ModeDefault, Check: false, ProjectDir: dir,
 		ConstraintBaseURL: srv.URL, CacheDir: t.TempDir(),
-		Flags:   TargetFlags{Serverless: "5"},
+		Flags:   ComputeFlags{Serverless: "5"},
 		Compute: stubCompute{}, PM: NewUvManager(),
 	}
 	res, err := p.Run(ctx)

--- a/libs/localenv/result.go
+++ b/libs/localenv/result.go
@@ -20,7 +20,10 @@ const (
 	CommandName  = CommandGroup + " " + CommandVerb
 
 	// SchemaVersion is the version of the --json output contract (spec §6).
-	// Bump it on any breaking change to the JSON shape.
+	// Bump it on any breaking change to the JSON shape once the command is
+	// unveiled and the payload has real consumers. The command is still hidden
+	// with no shipped JSON consumer, so the "target" → "compute" key rename does
+	// not bump this: there is no old payload in the wild to distinguish.
 	SchemaVersion = 1
 )
 
@@ -139,12 +142,13 @@ func NewError(code ErrorCode, err error, format string, args ...any) *PipelineEr
 	}
 }
 
-// TargetInfo is the resolved compute target (spec §6 "target"). Source records
-// which precedence source was used ("cluster", "serverless", "job", or
-// "bundle"). SparkVersion is the raw cluster runtime string the resolver read;
+// ComputeInfo is the resolved compute target, serialized as the result's
+// "compute" key (spec §6). Source records which precedence source was used
+// ("cluster", "serverless", "job", or "bundle"). SparkVersion is the raw cluster
+// runtime string the resolver read;
 // it is folded into EnvKey (dbr/<SparkVersion>) and is not part of the JSON
 // contract, kept only as intermediate resolver state.
-type TargetInfo struct {
+type ComputeInfo struct {
 	Source            string `json:"source"`
 	ClusterID         string `json:"clusterId,omitempty"`
 	ServerlessVersion string `json:"serverlessVersion,omitempty"`
@@ -200,7 +204,7 @@ type Result struct {
 	OK            bool           `json:"ok"`
 	Mode          string         `json:"mode"`
 	DryRun        bool           `json:"dryRun"`
-	Target        *TargetInfo    `json:"target,omitempty"`
+	Compute       *ComputeInfo   `json:"compute,omitempty"`
 	Resolved      *ResolvedInfo  `json:"resolved,omitempty"`
 	Greenfield    bool           `json:"greenfield"`
 	Plan          *Plan          `json:"plan,omitempty"`

--- a/libs/localenv/result.go
+++ b/libs/localenv/result.go
@@ -20,10 +20,7 @@ const (
 	CommandName  = CommandGroup + " " + CommandVerb
 
 	// SchemaVersion is the version of the --json output contract (spec §6).
-	// Bump it on any breaking change to the JSON shape once the command is
-	// unveiled and the payload has real consumers. The command is still hidden
-	// with no shipped JSON consumer, so the "target" → "compute" key rename does
-	// not bump this: there is no old payload in the wild to distinguish.
+	// Bump it on any breaking change to the JSON shape.
 	SchemaVersion = 1
 )
 


### PR DESCRIPTION
## What

Rename the compute-selection vocabulary from `target` to `compute` across the
`setup-local` layer, so the `--output json` result key, the Go model, and the
resolver names all match the invocation-side field the VS Code extension already
adopted (`SetupLocalInvocation.target` → `compute`, databricks-vscode#2039).

```diff
- "target": { "source": "serverless", "envKey": "serverless/serverless-v5", ... }
+ "compute": { "source": "serverless", "envKey": "serverless/serverless-v5", ... }
```

## Why carry it beyond the wire key

The extension parses the CLI result with a bare structural cast, so the JSON key
must match the model field. Renaming only the tag would leave `Result.Compute
*TargetInfo` `json:"compute"` — three-way naming drift for one concept. The
extension makes the same full move (`PythonSetupTargetInfo` →
`PythonSetupComputeInfo`), so this aligns the whole vocabulary.

## Renamed
- `Result.Target` field + json tag → `Compute` / `"compute"`
- `TargetInfo` type → `ComputeInfo`
- `ResolveTarget` → `ResolveCompute`
- `TargetFlags` / `ValidateTargetFlags` → `ComputeFlags` / `ValidateComputeFlags`
- `libs/localenv/target.go` (+ `_test`) → `compute.go` (+ `_test`)

## Deliberately NOT renamed
- **`BundleTarget`** — "target" is first-class bundle vocabulary (`databricks.yml`
  `targets:`, `--target`), correctly named at that boundary.
- **`ErrNoTarget` / `E_NO_TARGET`** — the Go const mirrors the stable wire
  error-code string; renaming would desync it from the error-code contract.
- **`ComputeClient`** — already "compute".

## schemaVersion stays 1

Not bumped: the command is still `Hidden` with **no shipped JSON consumer**, so
there's no old payload in the wild to distinguish and no compatibility window to
maintain. It will bump once the command is unveiled and the contract has real
consumers. (Confirmed with the ticket owner; drops the ticket's step-3
"tolerate both keys" work for the CLI side.)

## Test

Build, unit (`libs/localenv`, `cmd/environments`), acceptance
(`serverless-json`/`constraints-only`/`json-error` regenerated), lint (0),
deadcode — all pass.

Part of DECO-27794 (CLI side). The extension-side model rename
(`PythonSetupResult.target` → `compute`, `PythonSetupTargetInfo` →
`PythonSetupComputeInfo`, errorMessages/fixtures/tests) is tracked separately in
databricks-vscode.

This pull request and its description were written by Isaac.
