### PR TITLE
Update bundle templates to environment version 5

### DIFF
--- a/.nextchanges/bundles/default-template-environment-version.md
+++ b/.nextchanges/bundles/default-template-environment-version.md
@@ -1,0 +1,1 @@
+Updated built-in bundle templates to use serverless environment version 5.

--- a/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
+++ b/acceptance/bundle/templates/dbt-sql/output/my_dbt_sql/resources/my_dbt_sql.job.yml
@@ -29,6 +29,6 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"
             dependencies:
               - dbt-databricks>=1.8.0,<2.0.0

--- a/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
+++ b/acceptance/bundle/templates/default-python/classic/out.compare-vs-serverless.diff
@@ -51,7 +51,7 @@
 -      environments:
 -        - environment_key: default
 -          spec:
--            environment_version: "4"
+-            environment_version: "5"
 -            dependencies:
 -              # By default we just include the .whl file generated for the my_default_python package.
 -              # See https://docs.databricks.com/dev-tools/bundles/library-dependencies.html

--- a/acceptance/bundle/templates/default-python/classic/output/my_default_python/src/sample_notebook.ipynb
+++ b/acceptance/bundle/templates/default-python/classic/output/my_default_python/src/sample_notebook.ipynb
@@ -72,7 +72,7 @@
     "dependencies": [
      "--editable .."
     ],
-    "environment_version": "4"
+    "environment_version": "5"
    },
    "language": "python",
    "notebookMetadata": {

--- a/acceptance/bundle/templates/default-python/serverless/out.plan_after_deploy_dev.direct.json
+++ b/acceptance/bundle/templates/default-python/serverless/out.plan_after_deploy_dev.direct.json
@@ -28,7 +28,7 @@
               "dependencies": [
                 "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
               ],
-              "environment_version": "4"
+              "environment_version": "5"
             }
           }
         ],

--- a/acceptance/bundle/templates/default-python/serverless/out.plan_after_deploy_prod.direct.json
+++ b/acceptance/bundle/templates/default-python/serverless/out.plan_after_deploy_prod.direct.json
@@ -28,7 +28,7 @@
               "dependencies": [
                 "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
               ],
-              "environment_version": "4"
+              "environment_version": "5"
             }
           }
         ],

--- a/acceptance/bundle/templates/default-python/serverless/out.plan_dev.direct.json
+++ b/acceptance/bundle/templates/default-python/serverless/out.plan_dev.direct.json
@@ -24,7 +24,7 @@
                 "dependencies": [
                   "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
                 ],
-                "environment_version": "4"
+                "environment_version": "5"
               }
             }
           ],

--- a/acceptance/bundle/templates/default-python/serverless/out.plan_prod.direct.json
+++ b/acceptance/bundle/templates/default-python/serverless/out.plan_prod.direct.json
@@ -24,7 +24,7 @@
                 "dependencies": [
                   "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
                 ],
-                "environment_version": "4"
+                "environment_version": "5"
               }
             }
           ],

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.dev.direct.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.dev.direct.txt
@@ -111,7 +111,7 @@
           "dependencies": [
             "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
           ],
-          "environment_version": "4"
+          "environment_version": "5"
         }
       }
     ],

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.dev.terraform.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.dev.terraform.txt
@@ -111,7 +111,7 @@
           "dependencies": [
             "/Workspace/Users/[USERNAME]/.bundle/my_default_python/dev/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
           ],
-          "environment_version": "4"
+          "environment_version": "5"
         }
       }
     ],

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.prod.direct.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.prod.direct.txt
@@ -114,7 +114,7 @@
           "dependencies": [
             "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
           ],
-          "environment_version": "4"
+          "environment_version": "5"
         }
       }
     ],

--- a/acceptance/bundle/templates/default-python/serverless/out.requests.prod.terraform.txt
+++ b/acceptance/bundle/templates/default-python/serverless/out.requests.prod.terraform.txt
@@ -114,7 +114,7 @@
           "dependencies": [
             "/Workspace/Users/[USERNAME]/.bundle/my_default_python/prod/artifacts/.internal/my_default_python-0.0.1-py3-none-any.whl"
           ],
-          "environment_version": "4"
+          "environment_version": "5"
         }
       }
     ],

--- a/acceptance/bundle/templates/default-python/serverless/output/my_default_python/resources/sample_job.job.yml
+++ b/acceptance/bundle/templates/default-python/serverless/output/my_default_python/resources/sample_job.job.yml
@@ -46,7 +46,7 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"
             dependencies:
               # By default we just include the .whl file generated for the my_default_python package.
               # See https://docs.databricks.com/dev-tools/bundles/library-dependencies.html

--- a/acceptance/bundle/templates/default-python/serverless/output/my_default_python/src/sample_notebook.ipynb
+++ b/acceptance/bundle/templates/default-python/serverless/output/my_default_python/src/sample_notebook.ipynb
@@ -72,7 +72,7 @@
     "dependencies": [
      "--editable .."
     ],
-    "environment_version": "4"
+    "environment_version": "5"
    },
    "language": "python",
    "notebookMetadata": {

--- a/acceptance/bundle/templates/default-scala/output/my_default_scala/resources/my_default_scala.job.yml
+++ b/acceptance/bundle/templates/default-scala/output/my_default_scala/resources/my_default_scala.job.yml
@@ -22,6 +22,6 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"
             java_dependencies:
               - ${workspace.artifact_path}/.internal/my_default_scala-assembly-0.1.jar

--- a/acceptance/bundle/templates/lakeflow-pipelines/python/output/my_lakeflow_pipelines/resources/sample_job.job.yml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/python/output/my_lakeflow_pipelines/resources/sample_job.job.yml
@@ -29,4 +29,4 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"

--- a/acceptance/bundle/templates/lakeflow-pipelines/sql/output/my_lakeflow_pipelines/resources/sample_job.job.yml
+++ b/acceptance/bundle/templates/lakeflow-pipelines/sql/output/my_lakeflow_pipelines/resources/sample_job.job.yml
@@ -29,4 +29,4 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"

--- a/acceptance/pipelines/e2e/output/lakeflow_project/resources/sample_job.job.yml
+++ b/acceptance/pipelines/e2e/output/lakeflow_project/resources/sample_job.job.yml
@@ -29,4 +29,4 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"

--- a/acceptance/pipelines/init/python/output/my_python_project/resources/sample_job.job.yml
+++ b/acceptance/pipelines/init/python/output/my_python_project/resources/sample_job.job.yml
@@ -29,4 +29,4 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"

--- a/acceptance/pipelines/init/sql/output/my_sql_project/resources/sample_job.job.yml
+++ b/acceptance/pipelines/init/sql/output/my_sql_project/resources/sample_job.job.yml
@@ -29,4 +29,4 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"

--- a/libs/template/templates/dbt-sql/library/versions.tmpl
+++ b/libs/template/templates/dbt-sql/library/versions.tmpl
@@ -10,5 +10,5 @@
    * See https://docs.databricks.com/aws/en/release-notes/serverless/environment-version/
    */}}
 {{define "serverless_environment_version" -}}
-  4
+  5
 {{- end}}

--- a/libs/template/templates/default-scala/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/libs/template/templates/default-scala/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -31,7 +31,7 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4"
+            environment_version: "5"
             java_dependencies:
               - ${workspace.artifact_path}/.internal/{{.project_name}}-assembly-{{template `version` .}}.jar
 {{- else}}

--- a/libs/template/templates/default/library/versions.tmpl
+++ b/libs/template/templates/default/library/versions.tmpl
@@ -24,13 +24,13 @@
    * See https://docs.databricks.com/release-notes/runtime/index.html for available versions.
    */}}
 {{define "serverless_environment_version" -}}
-  4
+  5
 {{- end}}
 
 {{/* Python version specification for the template.
    * This needs to be compatible with the version of DB Connect and the serverless_environment_version.
    *
-   * Serverless environment version 4 (and upcoming v5), DBR 16, and DBR 17 all use Python 3.12.
+   * Serverless environment version 5, DBR 16, and DBR 17 all use Python 3.12.
    * DB Connect 15 supports all of these and is compatible with Python 3.10-3.12.
    *
    * We use >=3.10,<3.13 rather than pinning to 3.12 specifically because overly narrow pinning


### PR DESCRIPTION
## Changes

Update built-in bundle templates to use serverless environment version 5 and refresh their acceptance snapshots.

## Why

Environment version 5 has been generally available since February 25, 2026, according to the [serverless environment version release notes](https://docs.databricks.com/aws/en/release-notes/serverless/environment-version/). Updating the built-in templates to v5 gives newly generated projects the latest serverless environment and the newest, best user experience by default.

## Tests

- `go test ./libs/template/...`
- Focused acceptance coverage for dbt-sql and pipeline init/e2e templates