### PR TITLE
acc: cover config-remote-sync write-back for split lists

### DIFF
--- a/acceptance/bundle/config-remote-sync/split/isolation/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/isolation/databricks.yml.tmpl
@@ -1,0 +1,34 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# job_a's task list is split across both blocks and one task, "shared", is defined
+# in both. job_b is an ordinary single-block job.
+#
+# The point of the fixture: whatever happens to job_a, an unrelated resource's
+# unambiguous change must still be applied in the same run. The sync is
+# unattended, so one hard-to-place change must never stop the rest.
+resources:
+  jobs:
+    job_a:
+      tasks:
+        - task_key: shared
+          max_retries: 1
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/shared
+
+    job_b:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: simple
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/simple
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        job_a:
+          tasks:
+            - task_key: shared
+              timeout_seconds: 45

--- a/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/isolation/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/isolation/output.txt
@@ -1,0 +1,56 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Rename the two-block task on job_a, and edit job_b in the same run
+=== Sync
+Detected changes in 2 resource(s):
+
+Resource: resources.jobs.job_a
+  tasks[task_key='shared']: remove
+  tasks[task_key='shared_renamed']: add
+
+Resource: resources.jobs.job_b
+  max_concurrent_runs: replace
+
+
+
+=== job_b is updated, and job_a keeps exactly one copy of the task
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -12,11 +12,11 @@
+     job_a:
+       tasks:
+-        - task_key: shared
+-          max_retries: 1
++        - max_retries: 1
+           notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/shared
+-
++            notebook_path: '/Users/{{workspace_user_name}}/shared'
++          task_key: shared_renamed
++          timeout_seconds: 45
+     job_b:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 6
+       tasks:
+         - task_key: simple
+
+>>> grep -c max_concurrent_runs: 6 databricks.yml
+1
+
+>>> grep -c task_key: shared_renamed databricks.yml
+1
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.job_a
+  delete resources.jobs.job_b
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/isolation/script
+++ b/acceptance/bundle/config-remote-sync/split/isolation/script
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_a_id="$(read_id.py job_a)"
+job_b_id="$(read_id.py job_b)"
+
+
+# A rename of the two-block task on job_a, and a plain scalar edit on job_b, in the
+# SAME run. job_b's edit is independent of anything job_a does, so it must be
+# applied whether or not job_a's rename can be placed.
+title "Rename the two-block task on job_a, and edit job_b in the same run"
+edit_resource.py jobs $job_a_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "shared":
+        task["task_key"] = "shared_renamed"
+EOF
+
+edit_resource.py jobs $job_b_id <<EOF
+r["max_concurrent_runs"] = 6
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "job_b is updated, and job_a keeps exactly one copy of the task"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+trace grep -c "max_concurrent_runs: 6" databricks.yml
+trace grep -c "task_key: shared_renamed" databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/databricks.yml.tmpl
@@ -1,0 +1,30 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# The task list of split_job is defined in two physical blocks: the top-level
+# one below and the targets.dev override further down. After loading they merge
+# into one list sorted by task_key, so the merged order is
+#   [alpha (target), mu (top-level), zeta (top-level)]
+# while each physical block keeps its own order. Editing a task must therefore
+# resolve to (file, block, index-within-that-block), not to the merged index.
+resources:
+  jobs:
+    split_job:
+      tasks:
+        - task_key: zeta
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/zeta
+        - task_key: mu
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/mu
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        split_job:
+          tasks:
+            - task_key: alpha
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/alpha

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/output.txt
@@ -1,0 +1,57 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit alpha, defined only in the target block
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.split_job
+  tasks[task_key='alpha'].timeout_seconds: add
+
+
+
+=== Only alpha in the target block gains timeout_seconds: 111
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -18,4 +18,5 @@
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/mu
++        - timeout_seconds: 111
+
+ targets:
+
+=== Edit mu, a top-level task that is not first after the merge sort
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.split_job
+  tasks[task_key='']: remove
+  tasks[task_key='alpha'].timeout_seconds: add
+  tasks[task_key='mu'].timeout_seconds: add
+
+
+
+=== Only mu in the top-level block gains timeout_seconds: 222
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -18,4 +18,5 @@
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/mu
++          timeout_seconds: 222
+         - timeout_seconds: 111
+
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.split_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/script
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_id="$(read_id.py split_job)"
+
+
+# alpha is the only task in the target block, so it must be written at index 0 of
+# that block. Its merged index is also 0, but the top-level block's index 0 is
+# zeta -- a naive merged-index write lands on zeta instead.
+title "Edit alpha, defined only in the target block"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "alpha":
+        task["timeout_seconds"] = 111
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Only alpha in the target block gains timeout_seconds: 111"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# mu is at merged index 1 but physical index 1 of the top-level block, and zeta
+# (merged index 2) is physical index 0. The merged order and the block order
+# disagree, so writing by merged index edits the wrong task.
+title "Edit mu, a top-level task that is not first after the merge sort"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "mu":
+        task["timeout_seconds"] = 222
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Only mu in the top-level block gains timeout_seconds: 222"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/databricks.yml.tmpl
@@ -1,0 +1,45 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# remove_job: gamma/beta live top-level, alpha lives in the target block. The
+# merged order is [alpha, beta, gamma], so the merged indices collide with the
+# physical ones -- removing by merged index deletes the wrong tasks.
+#
+# twoblock_remove_job: "both" is defined in the two blocks at once. Removing it
+# cannot be expressed as "drop it from one scope but keep the merged result", so
+# the sync must leave the source untouched rather than half-deleting it.
+resources:
+  jobs:
+    remove_job:
+      tasks:
+        - task_key: gamma
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/gamma
+        - task_key: beta
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/beta
+
+    twoblock_remove_job:
+      tasks:
+        - task_key: both
+          max_retries: 2
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/both
+        - task_key: keep
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/keep
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        remove_job:
+          tasks:
+            - task_key: alpha
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/alpha
+        twoblock_remove_job:
+          tasks:
+            - task_key: both
+              timeout_seconds: 30

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/output.txt
@@ -1,0 +1,54 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Remove gamma from the top-level block and alpha from the target block
+=== Sync
+Error: failed to generate YAML files: failed to apply change to file [TEST_TMP_DIR]/databricks.yml for a field resources.jobs.remove_job.tasks[2]: failed to apply change: op remove /resources/jobs/remove_job/tasks/2: remove index key out of bounds (idx 2, len 2)
+
+Exit code: 1
+
+=== Exactly gamma and alpha are gone; beta survives
+
+>>> diff.py databricks.yml.backup databricks.yml
+
+=== Remove the task defined in BOTH blocks
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.twoblock_remove_job
+  tasks[task_key='both']: remove
+
+
+
+=== 'both' is gone from both blocks; 'keep' survives
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -22,8 +22,4 @@
+     twoblock_remove_job:
+       tasks:
+-        - task_key: both
+-          max_retries: 2
+-          notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/both
+         - task_key: keep
+           notebook_task:
+
+>>> grep -c task_key: both databricks.yml
+1
+
+>>> grep -c task_key: keep databricks.yml
+1
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.remove_job
+  delete resources.jobs.twoblock_remove_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/script
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+remove_job_id="$(read_id.py remove_job)"
+twoblock_job_id="$(read_id.py twoblock_remove_job)"
+
+
+# Remove one task from each block in a single run. Exactly gamma and alpha must
+# disappear; beta must survive even though the removals shift indices in both
+# blocks.
+title "Remove gamma from the top-level block and alpha from the target block"
+edit_resource.py jobs $remove_job_id <<EOF
+r["tasks"] = [t for t in r["tasks"] if t["task_key"] not in ("gamma", "alpha")]
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --select-ids "jobs:$remove_job_id" --save
+
+title "Exactly gamma and alpha are gone; beta survives"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# "both" is defined in two blocks, so it has a part in each. The merged element
+# only disappears once both parts are gone, so the removal has to be written to
+# both blocks. "keep" must survive in the top-level block.
+title "Remove the task defined in BOTH blocks"
+edit_resource.py jobs $twoblock_job_id <<EOF
+r["tasks"] = [t for t in r["tasks"] if t["task_key"] != "both"]
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --select-ids "jobs:$twoblock_job_id" --save
+
+title "'both' is gone from both blocks; 'keep' survives"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+# grep -c exits non-zero on a count of zero, which would abort the script under
+# bash -e before the second assertion runs.
+errcode trace grep -c "task_key: both" databricks.yml
+errcode trace grep -c "task_key: keep" databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/databricks.yml.tmpl
@@ -1,0 +1,39 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# "shared" is defined in BOTH blocks: the top-level one carries max_retries and
+# the targets.dev one carries timeout_seconds. Loading merges them into a single
+# element whose fields come from two different physical places, so each field
+# edit has to be routed to the block that actually defines that field.
+#
+# max_retries is set in BOTH blocks, so the target's value is the one that was
+# deployed and the one an edit has to overwrite.
+#
+# "omega" sits after "shared" in the target block. Because "shared" contributes
+# to both blocks its position is easy to miscount, which is what makes editing
+# the plain single-block sibling "omega" the subtle case.
+resources:
+  jobs:
+    twoblock_job:
+      tasks:
+        - task_key: shared
+          max_retries: 1
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/shared
+        - task_key: nu
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/nu
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        twoblock_job:
+          tasks:
+            - task_key: shared
+              max_retries: 2
+              timeout_seconds: 60
+            - task_key: omega
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/omega

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/output.txt
@@ -1,0 +1,70 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit omega, whose sibling is defined in two blocks
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.twoblock_job
+  tasks[task_key='omega'].timeout_seconds: add
+
+
+
+=== Only omega changes; shared is untouched in both blocks
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -24,4 +24,5 @@
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/nu
++        - timeout_seconds: 303
+
+ targets:
+
+=== Edit a field per block, a field defined in both, and add a new field
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.twoblock_job
+  tasks[task_key='']: remove
+  tasks[task_key='omega'].timeout_seconds: add
+  tasks[task_key='shared'].max_retries: replace
+  tasks[task_key='shared'].min_retry_interval_millis: add
+  tasks[task_key='shared'].timeout_seconds: replace
+
+
+
+=== Each edit lands on the definition that was deployed
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -18,7 +18,8 @@
+       tasks:
+         - task_key: shared
+-          max_retries: 1
++          max_retries: 9
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/shared
++          min_retry_interval_millis: 5000
+         - task_key: nu
+           notebook_task:
+@@ -35,5 +36,5 @@
+             - task_key: shared
+               max_retries: 2
+-              timeout_seconds: 60
++              timeout_seconds: 900
+             - task_key: omega
+               notebook_task:
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.twoblock_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/script
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_id="$(read_id.py twoblock_job)"
+
+
+# omega is defined only in the target block, but its sibling "shared" contributes
+# to both blocks. Editing omega must land on omega and must leave the two-block
+# element completely untouched.
+title "Edit omega, whose sibling is defined in two blocks"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "omega":
+        task["timeout_seconds"] = 303
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Only omega changes; shared is untouched in both blocks"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# timeout_seconds lives only in the target block, so its edit goes there.
+# max_retries is set in BOTH blocks: the target's value is the deployed one, so
+# that is the definition an edit has to overwrite -- writing the top-level copy
+# instead would leave the effective value unchanged. A brand-new field on the same
+# element must land in a single defined place, not be duplicated across both.
+title "Edit a field per block, a field defined in both, and add a new field"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "shared":
+        task["max_retries"] = 9
+        task["timeout_seconds"] = 900
+        task["min_retry_interval_millis"] = 5000
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Each edit lands on the definition that was deployed"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/multifile/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/multifile/databricks.yml.tmpl
@@ -1,0 +1,17 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# One target's override of a single job is spread across two included files.
+# Resource keys are unique across top-level files, but that is not enforced
+# inside the targets subtree, so a target override may legitimately span
+# several files. An edit must land in the exact file that defines the element.
+include:
+  - overrides/*.yml
+
+resources:
+  jobs:
+    multifile_job:
+      tasks:
+        - task_key: base
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/base

--- a/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/multifile/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/multifile/output.txt
@@ -1,0 +1,40 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit a task defined in the second included file
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.multifile_job
+  tasks[task_key='from_second_file'].timeout_seconds: add
+
+
+
+=== databricks.yml is untouched
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -16,2 +16,3 @@
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/base
++          timeout_seconds: 777
+
+=== overrides/10-first.yml is untouched
+
+>>> diff.py overrides/10-first.yml.backup overrides/10-first.yml
+
+=== overrides/20-second.yml gains timeout_seconds: 777
+
+>>> diff.py overrides/20-second.yml.backup overrides/20-second.yml
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.multifile_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/multifile/overrides/10-first.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/multifile/overrides/10-first.yml.tmpl
@@ -1,0 +1,10 @@
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        multifile_job:
+          tasks:
+            - task_key: from_first_file
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/first

--- a/acceptance/bundle/config-remote-sync/split/multifile/overrides/20-second.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/multifile/overrides/20-second.yml.tmpl
@@ -1,0 +1,9 @@
+targets:
+  dev:
+    resources:
+      jobs:
+        multifile_job:
+          tasks:
+            - task_key: from_second_file
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/second

--- a/acceptance/bundle/config-remote-sync/split/multifile/script
+++ b/acceptance/bundle/config-remote-sync/split/multifile/script
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+envsubst < overrides/10-first.yml.tmpl > overrides/10-first.yml
+envsubst < overrides/20-second.yml.tmpl > overrides/20-second.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_id="$(read_id.py multifile_job)"
+
+
+# from_second_file is defined in overrides/20-second.yml. The edit must be written
+# to that file only -- not to the top-level databricks.yml and not to the sibling
+# override file, and without creating a duplicate subtree anywhere.
+title "Edit a task defined in the second included file"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "from_second_file":
+        task["timeout_seconds"] = 777
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+cp overrides/10-first.yml overrides/10-first.yml.backup
+cp overrides/20-second.yml overrides/20-second.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "databricks.yml is untouched"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+
+title "overrides/10-first.yml is untouched"
+echo
+trace diff.py overrides/10-first.yml.backup overrides/10-first.yml
+
+title "overrides/20-second.yml gains timeout_seconds: 777"
+echo
+trace diff.py overrides/20-second.yml.backup overrides/20-second.yml
+
+rm databricks.yml.backup overrides/10-first.yml.backup overrides/20-second.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/positional/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/positional/databricks.yml.tmpl
@@ -1,0 +1,30 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# Pipeline clusters are NOT registered as a keyed slice, so they diff by
+# POSITION rather than by key: change paths arrive as clusters[N], and a
+# structural change can arrive as a replacement of the whole list. The list is
+# still split across the top-level block and the targets.dev override, so a
+# merged index has to be mapped to an index inside one physical block.
+resources:
+  pipelines:
+    split_pipeline:
+      name: test-pipeline-$UNIQUE_NAME
+      catalog: main
+      schema: default
+      clusters:
+        - label: default
+          num_workers: 2
+      libraries:
+        - notebook:
+            path: /Users/{{workspace_user_name}}/notebook
+
+targets:
+  dev:
+    mode: development
+    resources:
+      pipelines:
+        split_pipeline:
+          clusters:
+            - label: maintenance
+              num_workers: 1

--- a/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/positional/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/positional/output.txt
@@ -1,0 +1,52 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit num_workers on the top-level cluster and on the target cluster
+=== Sync
+Error: failed to generate YAML files: failed to apply change to file [TEST_TMP_DIR]/databricks.yml for a field resources.pipelines.split_pipeline.clusters[1].num_workers: field not found in YAML configuration: op replace /resources/pipelines/split_pipeline/clusters/1/num_workers: parent path /resources/pipelines/split_pipeline/clusters/1 does not exist
+
+Exit code: 1
+
+=== default updates top-level, maintenance updates the target block
+
+>>> diff.py databricks.yml.backup databricks.yml
+
+=== Remove the target-block cluster (length change)
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.pipelines.split_pipeline
+  clusters: replace
+
+
+
+=== Applied correctly or left unchanged; default cluster never corrupted
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -15,5 +15,5 @@
+       clusters:
+         - label: default
+-          num_workers: 2
++          num_workers: 5
+       libraries:
+         - notebook:
+
+>>> grep -c label: default databricks.yml
+1
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.pipelines.split_pipeline
+
+This action will result in the deletion of the following Lakeflow Spark Declarative Pipelines along with the
+Streaming Tables (STs) and Materialized Views (MVs) managed by them:
+  delete resources.pipelines.split_pipeline
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/positional/script
+++ b/acceptance/bundle/config-remote-sync/split/positional/script
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+pipeline_id="$(read_id.py split_pipeline)"
+
+
+# Length-preserving field edits on both elements of a positional list that is
+# split across two blocks. Each edit must land in its own block.
+title "Edit num_workers on the top-level cluster and on the target cluster"
+edit_resource.py pipelines $pipeline_id <<EOF
+for cluster in r["clusters"]:
+    if cluster["label"] == "default":
+        cluster["num_workers"] = 5
+    if cluster["label"] == "maintenance":
+        cluster["num_workers"] = 3
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "default updates top-level, maintenance updates the target block"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# A length change on a split positional list. Either it is applied correctly or
+# the source is left unchanged -- the surviving elements must never be corrupted,
+# and no cluster may be lost.
+title "Remove the target-block cluster (length change)"
+edit_resource.py pipelines $pipeline_id <<EOF
+r["clusters"] = [c for c in r["clusters"] if c["label"] != "maintenance"]
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Applied correctly or left unchanged; default cluster never corrupted"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+trace grep -c "label: default" databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/test.toml
+++ b/acceptance/bundle/config-remote-sync/split/test.toml
@@ -1,0 +1,10 @@
+# Unlike the other config-remote-sync tests these run against the in-process test
+# server instead of setting Cloud = true, so they execute in normal CI.
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup", "overrides/*.yml", "overrides/*.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]


### PR DESCRIPTION
## Stack

| | PR | What it does |
|---|---|---|
| 1 | **this PR** | Acceptance coverage for split-list write-back; goldens record the pre-fix corruption |
| 2 | [#6117](https://github.com/databricks/cli/pull/6117) | Route each change to the one block that defines it |
| 3 | [#6135](https://github.com/databricks/cli/pull/6135) | Removing an element defined in several blocks deletes it from each |
| 4 | [#6134](https://github.com/databricks/cli/pull/6134) | A key change is written as a key rewrite in every defining block |

Review in order — each PR is based on the one above it.

## Changes

Adds end-to-end coverage for `bundle config-remote-sync` write-back when a resource's list field is defined in more than one physical YAML region — a top-level `resources.<type>.<name>.<list>` block plus a `targets.<target>` override, possibly spread across included files.

Six directories under `acceptance/bundle/config-remote-sync/split/` sharing one `test.toml`: `keyed_edit`, `keyed_twoblock`, `keyed_remove`, `multifile`, `positional`, `isolation`. Unlike the existing directories here they omit `Cloud = true`, so they run against the in-process test server under both deployment engines and therefore execute in normal CI.

**The committed goldens record today's behaviour, which is wrong.** That is deliberate: the fixes land on top of this and each shows up as a golden diff — corruption on one side, correct output on the other. What the goldens currently show:

- `keyed_edit` — editing a task defined only in the target block appends a keyless `- timeout_seconds: 111` element to the top-level block; the next sync then reports `tasks[task_key='']: remove` for the element it just created.
- `keyed_twoblock` — a field set in *both* blocks is written to the top-level copy, but the target's value is the deployed one, so the edit silently has no effect.
- `keyed_remove` — removing one task per block fails with `remove index key out of bounds (idx 2, len 2)`, because a merged index is used against a block with fewer elements. Removing a task defined in *both* blocks deletes only the top-level half, orphaning the other.
- `multifile` — an edit to a task defined in an included override file is written to the top-level `databricks.yml` instead.
- `positional` — a field edit on a target-block pipeline cluster fails with `parent path ... does not exist`.
- `isolation` — a rename of a two-block task is applied by guessing, leaving the task duplicated.

Each `script` states the scenario it covers next to the step that exercises it.

## Why

Loading merges the separate YAML regions into one list (keyed lists are also sorted by key), but on disk they stay separate regions that have to be edited independently. A remote change is expressed against the merged view, so write-back has to map it back to the right `(file, block, position)`.

`config-remote-sync` runs unattended — nobody reads its output or exit code — so a silently wrong write is the worst outcome. None of this was covered before: the existing directories are all `Cloud = true`, so they don't run in normal CI, which makes "fails before the fix, passes after" impossible to demonstrate. `validation_errors` showed the hermetic path works, and these follow it.

The single-block path is already covered by `job_multiple_tasks`, which exercises edit, add, remove and rename on a resource defined in one block. It stays byte-for-byte unchanged through the whole stack, which is the regression evidence.

## Tests

This PR is only tests. Both engines pass locally, in seconds, with no cloud access.
