### PR TITLE
bundle: route config sync edits to the block that defines them

### DIFF
--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/databricks.yml.tmpl
@@ -1,0 +1,30 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# The task list of split_job is defined in two physical blocks: the top-level
+# one below and the targets.dev override further down. After loading they merge
+# into one list sorted by task_key, so the merged order is
+#   [alpha (target), mu (top-level), zeta (top-level)]
+# while each physical block keeps its own order. Editing a task must therefore
+# resolve to (file, block, index-within-that-block), not to the merged index.
+resources:
+  jobs:
+    split_job:
+      tasks:
+        - task_key: zeta
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/zeta
+        - task_key: mu
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/mu
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        split_job:
+          tasks:
+            - task_key: alpha
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/alpha

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/output.txt
@@ -1,0 +1,53 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit alpha, defined only in the target block
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.split_job
+  tasks[task_key='alpha'].timeout_seconds: add
+
+
+
+=== Only alpha in the target block gains timeout_seconds: 111
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -29,2 +29,3 @@
+               notebook_task:
+                 notebook_path: /Users/{{workspace_user_name}}/alpha
++              timeout_seconds: 111
+
+=== Edit mu, a top-level task that is not first after the merge sort
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.split_job
+  tasks[task_key='mu'].timeout_seconds: add
+
+
+
+=== Only mu in the top-level block gains timeout_seconds: 222
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -18,4 +18,5 @@
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/mu
++          timeout_seconds: 222
+
+ targets:
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.split_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/keyed_edit/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_edit/script
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_id="$(read_id.py split_job)"
+
+
+# alpha is the only task in the target block, so it must be written at index 0 of
+# that block. Its merged index is also 0, but the top-level block's index 0 is
+# zeta -- a naive merged-index write lands on zeta instead.
+title "Edit alpha, defined only in the target block"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "alpha":
+        task["timeout_seconds"] = 111
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Only alpha in the target block gains timeout_seconds: 111"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# mu is at merged index 1 but physical index 1 of the top-level block, and zeta
+# (merged index 2) is physical index 0. The merged order and the block order
+# disagree, so writing by merged index edits the wrong task.
+title "Edit mu, a top-level task that is not first after the merge sort"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "mu":
+        task["timeout_seconds"] = 222
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Only mu in the top-level block gains timeout_seconds: 222"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/databricks.yml.tmpl
@@ -1,0 +1,39 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# "shared" is defined in BOTH blocks: the top-level one carries max_retries and
+# the targets.dev one carries timeout_seconds. Loading merges them into a single
+# element whose fields come from two different physical places, so each field
+# edit has to be routed to the block that actually defines that field.
+#
+# max_retries is set in BOTH blocks, so the target's value is the one that was
+# deployed and the one an edit has to overwrite.
+#
+# "omega" sits after "shared" in the target block. Because "shared" contributes
+# to both blocks its position is easy to miscount, which is what makes editing
+# the plain single-block sibling "omega" the subtle case.
+resources:
+  jobs:
+    twoblock_job:
+      tasks:
+        - task_key: shared
+          max_retries: 1
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/shared
+        - task_key: nu
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/nu
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        twoblock_job:
+          tasks:
+            - task_key: shared
+              max_retries: 2
+              timeout_seconds: 60
+            - task_key: omega
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/omega

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/output.txt
@@ -1,0 +1,64 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit omega, whose sibling is defined in two blocks
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.twoblock_job
+  tasks[task_key='omega'].timeout_seconds: add
+
+
+
+=== Only omega changes; shared is untouched in both blocks
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -38,2 +38,3 @@
+               notebook_task:
+                 notebook_path: /Users/{{workspace_user_name}}/omega
++              timeout_seconds: 303
+
+=== Edit a field per block, a field defined in both, and add a new field
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.twoblock_job
+  tasks[task_key='shared'].max_retries: replace
+  tasks[task_key='shared'].min_retry_interval_millis: add
+  tasks[task_key='shared'].timeout_seconds: replace
+
+
+
+=== Each edit lands on the definition that was deployed
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -21,4 +21,5 @@
+           notebook_task:
+             notebook_path: /Users/{{workspace_user_name}}/shared
++          min_retry_interval_millis: 5000
+         - task_key: nu
+           notebook_task:
+@@ -33,6 +34,6 @@
+           tasks:
+             - task_key: shared
+-              max_retries: 2
+-              timeout_seconds: 60
++              max_retries: 9
++              timeout_seconds: 900
+             - task_key: omega
+               notebook_task:
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.twoblock_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/keyed_twoblock/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_twoblock/script
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_id="$(read_id.py twoblock_job)"
+
+
+# omega is defined only in the target block, but its sibling "shared" contributes
+# to both blocks. Editing omega must land on omega and must leave the two-block
+# element completely untouched.
+title "Edit omega, whose sibling is defined in two blocks"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "omega":
+        task["timeout_seconds"] = 303
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Only omega changes; shared is untouched in both blocks"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# timeout_seconds lives only in the target block, so its edit goes there.
+# max_retries is set in BOTH blocks: the target's value is the deployed one, so
+# that is the definition an edit has to overwrite -- writing the top-level copy
+# instead would leave the effective value unchanged. A brand-new field on the same
+# element must land in a single defined place, not be duplicated across both.
+title "Edit a field per block, a field defined in both, and add a new field"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "shared":
+        task["max_retries"] = 9
+        task["timeout_seconds"] = 900
+        task["min_retry_interval_millis"] = 5000
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Each edit lands on the definition that was deployed"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/multifile/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/multifile/databricks.yml.tmpl
@@ -1,0 +1,17 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# One target's override of a single job is spread across two included files.
+# Resource keys are unique across top-level files, but that is not enforced
+# inside the targets subtree, so a target override may legitimately span
+# several files. An edit must land in the exact file that defines the element.
+include:
+  - overrides/*.yml
+
+resources:
+  jobs:
+    multifile_job:
+      tasks:
+        - task_key: base
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/base

--- a/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/multifile/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/multifile/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/multifile/output.txt
@@ -1,0 +1,40 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit a task defined in the second included file
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.multifile_job
+  tasks[task_key='from_second_file'].timeout_seconds: add
+
+
+
+=== databricks.yml is untouched
+
+>>> diff.py databricks.yml.backup databricks.yml
+
+=== overrides/10-first.yml is untouched
+
+>>> diff.py overrides/10-first.yml.backup overrides/10-first.yml
+
+=== overrides/20-second.yml gains timeout_seconds: 777
+
+>>> diff.py overrides/20-second.yml.backup overrides/20-second.yml
+--- overrides/20-second.yml.backup
++++ overrides/20-second.yml
+@@ -8,2 +8,3 @@
+               notebook_task:
+                 notebook_path: /Users/{{workspace_user_name}}/second
++              timeout_seconds: 777
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.multifile_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/multifile/overrides/10-first.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/multifile/overrides/10-first.yml.tmpl
@@ -1,0 +1,10 @@
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        multifile_job:
+          tasks:
+            - task_key: from_first_file
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/first

--- a/acceptance/bundle/config-remote-sync/split/multifile/overrides/20-second.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/multifile/overrides/20-second.yml.tmpl
@@ -1,0 +1,9 @@
+targets:
+  dev:
+    resources:
+      jobs:
+        multifile_job:
+          tasks:
+            - task_key: from_second_file
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/second

--- a/acceptance/bundle/config-remote-sync/split/multifile/script
+++ b/acceptance/bundle/config-remote-sync/split/multifile/script
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+envsubst < overrides/10-first.yml.tmpl > overrides/10-first.yml
+envsubst < overrides/20-second.yml.tmpl > overrides/20-second.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_id="$(read_id.py multifile_job)"
+
+
+# from_second_file is defined in overrides/20-second.yml. The edit must be written
+# to that file only -- not to the top-level databricks.yml and not to the sibling
+# override file, and without creating a duplicate subtree anywhere.
+title "Edit a task defined in the second included file"
+edit_resource.py jobs $job_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "from_second_file":
+        task["timeout_seconds"] = 777
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+cp overrides/10-first.yml overrides/10-first.yml.backup
+cp overrides/20-second.yml overrides/20-second.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "databricks.yml is untouched"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+
+title "overrides/10-first.yml is untouched"
+echo
+trace diff.py overrides/10-first.yml.backup overrides/10-first.yml
+
+title "overrides/20-second.yml gains timeout_seconds: 777"
+echo
+trace diff.py overrides/20-second.yml.backup overrides/20-second.yml
+
+rm databricks.yml.backup overrides/10-first.yml.backup overrides/20-second.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/positional/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/positional/databricks.yml.tmpl
@@ -1,0 +1,30 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# Pipeline clusters are NOT registered as a keyed slice, so they diff by
+# POSITION rather than by key: change paths arrive as clusters[N], and a
+# structural change can arrive as a replacement of the whole list. The list is
+# still split across the top-level block and the targets.dev override, so a
+# merged index has to be mapped to an index inside one physical block.
+resources:
+  pipelines:
+    split_pipeline:
+      name: test-pipeline-$UNIQUE_NAME
+      catalog: main
+      schema: default
+      clusters:
+        - label: default
+          num_workers: 2
+      libraries:
+        - notebook:
+            path: /Users/{{workspace_user_name}}/notebook
+
+targets:
+  dev:
+    mode: development
+    resources:
+      pipelines:
+        split_pipeline:
+          clusters:
+            - label: maintenance
+              num_workers: 1

--- a/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/positional/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/positional/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/positional/output.txt
@@ -1,0 +1,68 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit num_workers on the top-level cluster and on the target cluster
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.pipelines.split_pipeline
+  clusters[0].num_workers: replace
+  clusters[1].num_workers: replace
+
+
+
+=== default updates top-level, maintenance updates the target block
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -15,5 +15,5 @@
+       clusters:
+         - label: default
+-          num_workers: 2
++          num_workers: 5
+       libraries:
+         - notebook:
+@@ -28,3 +28,3 @@
+           clusters:
+             - label: maintenance
+-              num_workers: 1
++              num_workers: 3
+
+=== Remove the target-block cluster (length change)
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.pipelines.split_pipeline
+  clusters: replace
+  clusters[1].num_workers: remove
+
+
+
+=== Applied correctly or left unchanged; default cluster never corrupted
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -28,3 +28,2 @@
+           clusters:
+             - label: maintenance
+-              num_workers: 3
+
+>>> grep -c label: default databricks.yml
+1
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.pipelines.split_pipeline
+
+This action will result in the deletion of the following Lakeflow Spark Declarative Pipelines along with the
+Streaming Tables (STs) and Materialized Views (MVs) managed by them:
+  delete resources.pipelines.split_pipeline
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/positional/script
+++ b/acceptance/bundle/config-remote-sync/split/positional/script
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+pipeline_id="$(read_id.py split_pipeline)"
+
+
+# Length-preserving field edits on both elements of a positional list that is
+# split across two blocks. Each edit must land in its own block.
+title "Edit num_workers on the top-level cluster and on the target cluster"
+edit_resource.py pipelines $pipeline_id <<EOF
+for cluster in r["clusters"]:
+    if cluster["label"] == "default":
+        cluster["num_workers"] = 5
+    if cluster["label"] == "maintenance":
+        cluster["num_workers"] = 3
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "default updates top-level, maintenance updates the target block"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# A length change on a split positional list. Either it is applied correctly or
+# the source is left unchanged -- the surviving elements must never be corrupted,
+# and no cluster may be lost.
+title "Remove the target-block cluster (length change)"
+edit_resource.py pipelines $pipeline_id <<EOF
+r["clusters"] = [c for c in r["clusters"] if c["label"] != "maintenance"]
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "Applied correctly or left unchanged; default cluster never corrupted"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+trace grep -c "label: default" databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/test.toml
+++ b/acceptance/bundle/config-remote-sync/split/test.toml
@@ -1,0 +1,10 @@
+# Unlike the other config-remote-sync tests these run against the in-process test
+# server instead of setting Cloud = true, so they execute in normal CI.
+RecordRequests = false
+Ignore = [".databricks", "databricks.yml", "databricks.yml.backup", "overrides/*.yml", "overrides/*.backup"]
+
+[Env]
+DATABRICKS_BUNDLE_ENABLE_EXPERIMENTAL_YAML_SYNC = "true"
+
+[EnvMatrix]
+DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/bundle/configsync/blockindex.go
+++ b/bundle/configsync/blockindex.go
@@ -1,0 +1,418 @@
+package configsync
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+
+	"github.com/databricks/cli/bundle"
+	"github.com/databricks/cli/bundle/config"
+	"github.com/databricks/cli/libs/dyn"
+	"github.com/databricks/cli/libs/log"
+	"github.com/databricks/cli/libs/structs/structpath"
+)
+
+// A sequence field of a resource may be defined in more than one physical YAML
+// region: the top-level resources.<type>.<name>.<field> block and the
+// targets.<target>.resources.<type>.<name>.<field> override block, either of
+// which may live in its own included file. Loading merges those regions into one
+// sequence, and keyed sequences are also sorted by key, so an index into the
+// merged sequence does not address any single region. Write-back has to map a
+// merged position back to a region and to the position inside that region.
+type sourceBlock struct {
+	// prefix is empty for a top-level block and "targets.<target>" for a target
+	// override block. Both may occur in the same file, so the file alone does not
+	// identify a block.
+	prefix string
+	file   string
+}
+
+// blockResolver answers which physical block a merged value came from.
+//
+// It works by location: a merged value keeps the locations of the entries it was
+// loaded from, and merging accumulates them (see libs/dyn/merge), so a value
+// assembled from two blocks reports a location in each. Selecting a target folds
+// its overrides into the resources tree and drops the targets subtree, so the
+// blocks are recovered by parsing the contributing files again, where the two
+// regions are still separate.
+type blockResolver struct {
+	// blocks holds one parsed file per contributing file, keyed by block, so a
+	// path relative to a block can be looked up inside it.
+	blocks     map[sourceBlock]dyn.Value
+	target     string
+	byLocation map[dyn.Location]sourceBlock
+}
+
+// newBlockResolver builds the location -> block mapping for the bundle's
+// resources. It returns nil when the source cannot be re-read, in which case
+// callers keep their existing single-block behaviour.
+//
+// Only the files the merged configuration actually references are read, and they
+// are parsed directly rather than reloaded through the mutator pipeline: the
+// pipeline resolves includes, reports through logdiag and executes the bundle's
+// preinit script, none of which belongs to reading back a source location.
+func newBlockResolver(ctx context.Context, b *bundle.Bundle) *blockResolver {
+	root := b.Config.Value()
+	if !root.IsValid() {
+		return nil
+	}
+
+	r := &blockResolver{
+		blocks:     make(map[sourceBlock]dyn.Value),
+		target:     b.Config.Bundle.Target,
+		byLocation: make(map[dyn.Location]sourceBlock),
+	}
+
+	for _, file := range slices.Sorted(maps.Keys(referencedFiles(root))) {
+		contents, err := os.ReadFile(file)
+		if err != nil {
+			log.Debugf(ctx, "config-remote-sync: cannot read %s, treating its sequences as unsplit: %v", file, err)
+			continue
+		}
+		parsed, diags := config.LoadFromBytes(file, contents)
+		if diags.HasError() {
+			log.Debugf(ctx, "config-remote-sync: cannot parse %s, treating its sequences as unsplit: %v", file, diags.Error())
+			continue
+		}
+		r.indexRegion(parsed.Value(), sourceBlock{file: file})
+		if r.target != "" {
+			r.indexRegion(parsed.Value(), sourceBlock{prefix: "targets." + r.target, file: file})
+		}
+	}
+
+	if len(r.byLocation) == 0 {
+		return nil
+	}
+	return r
+}
+
+// referencedFiles returns the files the merged configuration was loaded from.
+func referencedFiles(root dyn.Value) map[string]struct{} {
+	files := map[string]struct{}{}
+	_ = dyn.WalkReadOnly(root, func(_ dyn.Path, v dyn.Value) error {
+		for _, location := range v.Locations() {
+			if location.File != "" {
+				files[location.File] = struct{}{}
+			}
+		}
+		return nil
+	})
+	return files
+}
+
+// indexRegion records every location under one region's resources subtree of a
+// parsed file, and keeps the parsed file so paths can be resolved inside it.
+func (r *blockResolver) indexRegion(parsed dyn.Value, block sourceBlock) {
+	subtree, err := dyn.GetByPath(parsed, r.regionPath(block.prefix, dyn.NewPath(dyn.Key("resources"))))
+	if err != nil {
+		return
+	}
+	r.blocks[block] = parsed
+	_ = dyn.WalkReadOnly(subtree, func(_ dyn.Path, v dyn.Value) error {
+		for _, location := range v.Locations() {
+			// A file only carries locations of its own, so a location seen here
+			// belongs to this block. First writer wins: an outer node accumulates
+			// its children's locations, but the innermost node that owns a location
+			// is the one walked last.
+			if location.File != block.file {
+				continue
+			}
+			if _, ok := r.byLocation[location]; !ok {
+				r.byLocation[location] = block
+			}
+		}
+		return nil
+	})
+}
+
+// regionPath prefixes a resources-relative path with the region it belongs to.
+func (r *blockResolver) regionPath(prefix string, path dyn.Path) dyn.Path {
+	if prefix == "" {
+		return path
+	}
+	return append(dyn.NewPath(dyn.Key("targets"), dyn.Key(r.target)), path...)
+}
+
+// sortedBlocks lists the known blocks with the top-level ones first and a total
+// order within each scope, so a choice between blocks never depends on map or
+// location iteration order.
+func (r *blockResolver) sortedBlocks() []sourceBlock {
+	blocks := slices.Collect(maps.Keys(r.blocks))
+	slices.SortFunc(blocks, compareBlocks)
+	return blocks
+}
+
+// compareBlocks orders top-level blocks before target blocks, then by file.
+func compareBlocks(a, b sourceBlock) int {
+	if (a.prefix == "") != (b.prefix == "") {
+		if a.prefix == "" {
+			return -1
+		}
+		return 1
+	}
+	return cmp.Or(cmp.Compare(a.prefix, b.prefix), cmp.Compare(a.file, b.file))
+}
+
+// blocksOf returns the distinct blocks that contributed to value, sorted with the
+// top-level block first. More than one result means the value is assembled from
+// several regions and has no single source location.
+func (r *blockResolver) blocksOf(value dyn.Value) []sourceBlock {
+	var blocks []sourceBlock
+	for _, location := range value.Locations() {
+		block, ok := r.byLocation[location]
+		if !ok {
+			continue
+		}
+		if !slices.Contains(blocks, block) {
+			blocks = append(blocks, block)
+		}
+	}
+	// Order is total and independent of how locations happened to accumulate, so
+	// callers that prefer the top-level block get a deterministic answer.
+	slices.SortFunc(blocks, compareBlocks)
+	return blocks
+}
+
+// winningBlock returns the block whose definition of value is the one the merged
+// configuration ended up with.
+//
+// A scalar defined in several blocks is not ambiguous: merging keeps the incoming
+// value and records its location first (see mergePrimitive in libs/dyn/merge), so
+// the deployed value came from whichever block owns Locations()[0]. Writing the
+// remote change anywhere else would leave the effective value unchanged.
+func (r *blockResolver) winningBlock(value dyn.Value) (sourceBlock, bool) {
+	for _, location := range value.Locations() {
+		if block, ok := r.byLocation[location]; ok {
+			return block, true
+		}
+	}
+	return sourceBlock{}, false
+}
+
+// localIndex returns the position of element inside the sequence that block
+// defines at sequencePath, where sequencePath is relative to the block.
+func (r *blockResolver) localIndex(block sourceBlock, sequencePath dyn.Path, element dyn.Value) (int, bool) {
+	parsed, ok := r.blocks[block]
+	if !ok {
+		return 0, false
+	}
+	sequence, err := dyn.GetByPath(parsed, r.regionPath(block.prefix, sequencePath))
+	if err != nil {
+		return 0, false
+	}
+	entries, ok := sequence.AsSequence()
+	if !ok {
+		return 0, false
+	}
+
+	locations := make(map[dyn.Location]struct{}, len(element.Locations()))
+	for _, location := range element.Locations() {
+		locations[location] = struct{}{}
+	}
+
+	// A region's sequence is the concatenation of the entries contributed by each
+	// included file, but the write targets one file, so the index has to be
+	// counted among that file's entries only.
+	local := 0
+	for _, entry := range entries {
+		entryFile := entry.Location().File
+		if entryFile != block.file {
+			continue
+		}
+		for _, location := range entry.Locations() {
+			if _, ok := locations[location]; ok {
+				return local, true
+			}
+		}
+		local++
+	}
+	return 0, false
+}
+
+// errAmbiguousBlock reports a change that cannot be attributed to one physical
+// block. Leaving such a change unapplied is preferable to writing it to a guessed
+// location, since the sync runs unattended and a later run can retry.
+var errAmbiguousBlock = errors.New("change cannot be attributed to a single source block")
+
+// route maps a change resolved against the merged configuration onto the physical
+// block that owns it, rewriting merged sequence indices into block-local ones.
+//
+// The element that the change addresses decides the block: an element defined in
+// exactly one block is written there. When the addressed element is assembled from
+// several blocks, the leaf field decides instead, because merging records the
+// location of each field separately. If neither identifies a single block the
+// change is ambiguous and is reported as such.
+func (r *blockResolver) route(change resolvedChange) (sourceBlock, *structpath.PatternNode, error) {
+	block, err := r.blockFor(change)
+	if err != nil {
+		return sourceBlock{}, nil, err
+	}
+
+	path, err := r.localize(block, change)
+	if err != nil {
+		return sourceBlock{}, nil, err
+	}
+	return block, path, nil
+}
+
+// blockFor picks the block a change belongs to.
+func (r *blockResolver) blockFor(change resolvedChange) (sourceBlock, error) {
+	// A new element has no source of its own; it is placed relative to the
+	// sequence that receives it.
+	for _, step := range change.steps {
+		if step.newElement {
+			return r.blockForNewElement(change)
+		}
+	}
+
+	if len(change.steps) > 0 {
+		last := change.steps[len(change.steps)-1]
+		blocks := r.blocksOf(last.element)
+		switch len(blocks) {
+		case 1:
+			return blocks[0], nil
+		case 0:
+			return sourceBlock{}, fmt.Errorf("%w: no source location for the addressed element", errAmbiguousBlock)
+		}
+
+		// The element is assembled from several blocks, but a field of it is not:
+		// it is written in one block, or written in both and one of them wins. A
+		// field-level change therefore routes by the field's own location.
+		if change.leaf.IsValid() {
+			if block, ok := r.winningBlock(change.leaf); ok {
+				return block, nil
+			}
+			return sourceBlock{}, fmt.Errorf("%w: element is defined in %d blocks and the field has no source location", errAmbiguousBlock, len(blocks))
+		}
+
+		// A field that exists in no block is new. It has no location to route by,
+		// but it still needs a defined destination, so it goes to the block that
+		// declares the resource rather than a target-specific scope.
+		if len(change.path.AsSlice()) > last.component+1 {
+			for _, block := range blocks {
+				if block.prefix == "" {
+					return block, nil
+				}
+			}
+			return blocks[0], nil
+		}
+
+		// The change addresses the element itself, not one of its fields. Removing
+		// or recreating it cannot be expressed against a single block.
+		return sourceBlock{}, fmt.Errorf("%w: element is defined in %d blocks", errAmbiguousBlock, len(blocks))
+	}
+
+	// No sequence on the path: route by the leaf's own location.
+	if change.leaf.IsValid() {
+		if block, ok := r.winningBlock(change.leaf); ok {
+			return block, nil
+		}
+	}
+	return sourceBlock{}, fmt.Errorf("%w: no source location for the change", errAmbiguousBlock)
+}
+
+// blockForNewElement chooses where an element that exists in no source block
+// should be written: the block that defines the sequence, or when several do, the
+// block that declares the resource. Adding to the resource's own block keeps a new
+// element out of a target-specific scope the user did not ask for.
+func (r *blockResolver) blockForNewElement(change resolvedChange) (sourceBlock, error) {
+	step := change.steps[len(change.steps)-1]
+
+	// A nested sequence is reached through the enclosing elements, which are
+	// already placed: route by the innermost one that exists in the source, since
+	// a new element belongs in the same block as its parent.
+	for i := len(change.steps) - 2; i >= 0; i-- {
+		enclosing := change.steps[i]
+		if enclosing.newElement {
+			continue
+		}
+		if blocks := r.blocksOf(enclosing.element); len(blocks) == 1 {
+			return blocks[0], nil
+		}
+	}
+
+	var blocks []sourceBlock
+	for _, block := range r.sortedBlocks() {
+		sequence, err := dyn.GetByPath(r.blocks[block], r.regionPath(block.prefix, step.sequencePath))
+		if err != nil {
+			continue
+		}
+		for _, location := range sequence.Locations() {
+			if location.File == block.file && !slices.Contains(blocks, block) {
+				blocks = append(blocks, block)
+			}
+		}
+	}
+
+	switch len(blocks) {
+	case 0:
+		return sourceBlock{}, fmt.Errorf("%w: no block defines the sequence receiving the new element", errAmbiguousBlock)
+	case 1:
+		return blocks[0], nil
+	}
+
+	// blocksOf orders the top-level block first, and the resource is declared
+	// there whenever a top-level block exists at all.
+	for _, block := range blocks {
+		if block.prefix == "" {
+			return block, nil
+		}
+	}
+	return blocks[0], nil
+}
+
+// localize rewrites the merged sequence indices in a change's path into indices
+// inside block.
+func (r *blockResolver) localize(block sourceBlock, change resolvedChange) (*structpath.PatternNode, error) {
+	nodes := change.path.AsSlice()
+	local := make([]int, len(change.steps))
+	for i, step := range change.steps {
+		if step.newElement {
+			// Keeps the [*] placeholder; the patcher appends to the block's
+			// sequence.
+			local[i] = -1
+			continue
+		}
+		// A nested sequence is reached through the outer sequences on the path,
+		// whose indices refer to the merged view. Rewrite them to the block's own
+		// indices, otherwise the lookup addresses the wrong parent element.
+		sequencePath := slices.Clone(step.sequencePath)
+		for j := range i {
+			outer := change.steps[j]
+			if local[j] < 0 || len(outer.sequencePath) >= len(sequencePath) {
+				continue
+			}
+			sequencePath[len(outer.sequencePath)] = dyn.Index(local[j])
+		}
+
+		index, ok := r.localIndex(block, sequencePath, step.element)
+		if !ok {
+			return nil, fmt.Errorf("%w: element has no position in %s", errAmbiguousBlock, block.file)
+		}
+		local[i] = index
+	}
+
+	var result *structpath.PatternNode
+	next := 0
+	for component, node := range nodes {
+		if next < len(change.steps) && change.steps[next].component == component {
+			if local[next] < 0 {
+				result = structpath.NewPatternBracketStar(result)
+			} else {
+				result = structpath.NewPatternIndex(result, local[next])
+			}
+			next++
+			continue
+		}
+		key, ok := node.StringKey()
+		if !ok {
+			return nil, fmt.Errorf("%w: unsupported path component in %s", errAmbiguousBlock, change.path.String())
+		}
+		result = structpath.NewPatternStringKey(result, key)
+	}
+	return result, nil
+}

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -3,6 +3,7 @@ package configsync
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"maps"
@@ -23,23 +24,50 @@ type FieldChange struct {
 	FieldCandidates []string
 }
 
-// resolveSelectors converts key-value selectors to numeric indices that match
-// the YAML file positions. It also returns the location of the resolved leaf value.
+// sequenceStep records a sequence element that a change path navigated through.
+// The element's index inside a physical block is only known once the block has
+// been chosen, so the merged position is kept until then.
+type sequenceStep struct {
+	// position in the pattern built so far, i.e. how many components precede
+	// this sequence's index.
+	component int
+	// path of the sequence relative to a block, e.g. resources.jobs.j.tasks.
+	sequencePath dyn.Path
+	element      dyn.Value
+	// newElement marks an Add whose key is not in the merged sequence yet.
+	newElement bool
+}
+
+// resolvedChange locates a change in the source YAML.
+type resolvedChange struct {
+	// path is relative to the block, with merged indices still in place.
+	path  *structpath.PatternNode
+	steps []sequenceStep
+	// leaf is the merged value the change addresses, invalid for a new field.
+	leaf dyn.Value
+}
+
+// resolveSelectors converts key-value selectors to the indices of the merged
+// configuration and records the sequence elements traversed on the way, so the
+// caller can map those positions onto the physical block that owns them.
 // Example: "resources.jobs.foo.tasks[task_key='main'].name" -> "resources.jobs.foo.tasks[1].name"
 // Returns a PatternNode because for Add operations, [*] may be used as a placeholder for new elements.
-func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType) (*structpath.PatternNode, dyn.Location, error) {
+func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType) (resolvedChange, error) {
 	node, err := structpath.ParsePath(pathStr)
 	if err != nil {
-		return nil, dyn.Location{}, fmt.Errorf("failed to parse path %s: %w", pathStr, err)
+		return resolvedChange{}, fmt.Errorf("failed to parse path %s: %w", pathStr, err)
 	}
 
 	nodes := node.AsSlice()
 	var result *structpath.PatternNode
+	var steps []sequenceStep
+	var currentPath dyn.Path
 	currentValue := b.Config.Value()
 
-	for _, n := range nodes {
+	for component, n := range nodes {
 		if key, ok := n.StringKey(); ok {
 			result = structpath.NewPatternStringKey(result, key)
+			currentPath = append(currentPath, dyn.Key(key))
 			if currentValue.IsValid() {
 				currentValue, _ = dyn.GetByPath(currentValue, dyn.Path{dyn.Key(key)})
 			}
@@ -47,17 +75,26 @@ func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType)
 		}
 
 		if idx, ok := n.Index(); ok {
+			sequencePath := slices.Clone(currentPath)
 			result = structpath.NewPatternIndex(result, idx)
+			currentPath = append(currentPath, dyn.Index(idx))
+			var element dyn.Value
 			if currentValue.IsValid() {
-				currentValue, _ = dyn.GetByPath(currentValue, dyn.Path{dyn.Index(idx)})
+				element, _ = dyn.GetByPath(currentValue, dyn.Path{dyn.Index(idx)})
+				currentValue = element
 			}
+			steps = append(steps, sequenceStep{
+				component:    component,
+				sequencePath: sequencePath,
+				element:      element,
+			})
 			continue
 		}
 
 		// Check for key-value selector: [key='value']
 		if key, value, ok := n.KeyValue(); ok {
 			if !currentValue.IsValid() || currentValue.Kind() != dyn.KindSequence {
-				return nil, dyn.Location{}, fmt.Errorf("cannot apply [%s='%s'] selector to non-array value in path %s", key, value, pathStr)
+				return resolvedChange{}, fmt.Errorf("cannot apply [%s='%s'] selector to non-array value in path %s", key, value, pathStr)
 			}
 
 			seq, _ := currentValue.AsSequence()
@@ -75,50 +112,36 @@ func resolveSelectors(pathStr string, b *bundle.Bundle, operation OperationType)
 				}
 			}
 
+			sequencePath := slices.Clone(currentPath)
+
 			if foundIndex == -1 {
 				if operation == OperationAdd {
 					result = structpath.NewPatternBracketStar(result)
+					steps = append(steps, sequenceStep{
+						component:    component,
+						sequencePath: sequencePath,
+						newElement:   true,
+					})
 					// Can't navigate further into non-existent element
 					currentValue = dyn.Value{}
 					continue
 				}
-				return nil, dyn.Location{}, fmt.Errorf("no array element found with %s='%s' in path %s", key, value, pathStr)
+				return resolvedChange{}, fmt.Errorf("no array element found with %s='%s' in path %s", key, value, pathStr)
 			}
 
-			// Mutators may reorder sequence elements (e.g., tasks sorted by task_key).
-			// Use location information to determine the original YAML file position.
-			yamlIndex := yamlFileIndex(seq, foundIndex)
-			result = structpath.NewPatternIndex(result, yamlIndex)
+			result = structpath.NewPatternIndex(result, foundIndex)
+			currentPath = append(currentPath, dyn.Index(foundIndex))
+			steps = append(steps, sequenceStep{
+				component:    component,
+				sequencePath: sequencePath,
+				element:      seq[foundIndex],
+			})
 			currentValue = seq[foundIndex]
 			continue
 		}
 	}
 
-	return result, currentValue.Location(), nil
-}
-
-// yamlFileIndex determines the original YAML file position of a sequence element.
-// Mutators may reorder sequence elements (e.g., tasks sorted by task_key), so the
-// in-memory index may not match the position in the YAML file. This function uses
-// location information to count how many elements from the same file appear before
-// the target element, giving the correct index for YAML patching.
-func yamlFileIndex(seq []dyn.Value, sortedIndex int) int {
-	matchLocation := seq[sortedIndex].Location()
-	if matchLocation.File == "" {
-		return sortedIndex
-	}
-
-	yamlIndex := 0
-	for i, elem := range seq {
-		if i == sortedIndex {
-			continue
-		}
-		loc := elem.Location()
-		if loc.File == matchLocation.File && loc.Line < matchLocation.Line {
-			yamlIndex++
-		}
-	}
-	return yamlIndex
+	return resolvedChange{path: result, steps: steps, leaf: currentValue}, nil
 }
 
 func pathDepth(pathStr string) int {
@@ -132,7 +155,7 @@ func pathDepth(pathStr string) int {
 // adjustArrayIndex adjusts the index in a PatternNode based on previous operations.
 // When operations are applied sequentially, removals and additions shift array indices.
 // This function adjusts the index to account for those shifts.
-func adjustArrayIndex(path *structpath.PatternNode, operations map[string][]struct {
+func adjustArrayIndex(path *structpath.PatternNode, scope string, operations map[string][]struct {
 	index     int
 	operation OperationType
 },
@@ -143,7 +166,7 @@ func adjustArrayIndex(path *structpath.PatternNode, operations map[string][]stru
 	}
 
 	parentPath := path.Parent()
-	parentPathStr := parentPath.String()
+	parentPathStr := scope + parentPath.String()
 	ops := operations[parentPathStr]
 
 	adjustment := 0
@@ -168,6 +191,7 @@ func adjustArrayIndex(path *structpath.PatternNode, operations map[string][]stru
 func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes) ([]FieldChange, error) {
 	var result []FieldChange
 	targetName := b.Config.Bundle.Target
+	blocks := newBlockResolver(ctx, b)
 
 	resourceKeys := slices.Sorted(maps.Keys(configChanges))
 
@@ -215,9 +239,37 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			configChange := resourceChanges[fieldPath]
 			fullPath := resourceKey + "." + fieldPath
 
-			resolvedPath, resolvedLocation, err := resolveSelectors(fullPath, b, configChange.Operation)
+			resolved, err := resolveSelectors(fullPath, b, configChange.Operation)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve selectors in path %s: %w", fullPath, err)
+			}
+			resolvedPath := resolved.path
+
+			// A sequence element addressed by the merged view has to be mapped onto
+			// the physical block that defines it, because the merged order and the
+			// per-block order differ once a sequence is split across blocks.
+			var block sourceBlock
+			routed := false
+			if blocks != nil && len(resolved.steps) > 0 {
+				var routeErr error
+				block, resolvedPath, routeErr = blocks.route(resolved)
+				if routeErr != nil {
+					if errors.Is(routeErr, errAmbiguousBlock) {
+						// Applying this change would mean guessing a location.
+						// Leave it unapplied; a later run can pick it up.
+						log.Debugf(ctx, "config-remote-sync: skipping %s: %v", fullPath, routeErr)
+						continue
+					}
+					return nil, fmt.Errorf("failed to route change %s: %w", fullPath, routeErr)
+				}
+				routed = true
+			}
+
+			// Index bookkeeping is scoped to a block so that shifts caused by
+			// operations on one block cannot move indices in another.
+			scope := ""
+			if routed {
+				scope = block.prefix + "\x00" + block.file + "\x00"
 			}
 
 			// If the element is removed, we can use the index to replace it with added element
@@ -225,13 +277,13 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			if configChange.Operation == OperationRemove {
 				freeIndex, ok := resolvedPath.Index()
 				if ok {
-					parentPath := resolvedPath.Parent().String()
+					parentPath := scope + resolvedPath.Parent().String()
 					indicesToReplaceMap[parentPath] = append(indicesToReplaceMap[parentPath], freeIndex)
 				}
 			}
 
 			if configChange.Operation == OperationAdd && resolvedPath.BracketStar() {
-				parentPath := resolvedPath.Parent().String()
+				parentPath := scope + resolvedPath.Parent().String()
 				indices, ok := indicesToReplaceMap[parentPath]
 				if ok && len(indices) > 0 {
 					index := indices[0]
@@ -240,11 +292,11 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 				}
 			}
 
-			resolvedPath = adjustArrayIndex(resolvedPath, indexOperations)
+			resolvedPath = adjustArrayIndex(resolvedPath, scope, indexOperations)
 
 			// Track this operation for future index adjustments (only for array element operations)
 			if originalIndex, ok := resolvedPath.Index(); ok {
-				parentPath := resolvedPath.Parent().String()
+				parentPath := scope + resolvedPath.Parent().String()
 				indexOperations[parentPath] = append(indexOperations[parentPath], struct {
 					index     int
 					operation OperationType
@@ -252,15 +304,31 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			}
 
 			resolvedPathStr := resolvedPath.String()
-			candidates := []string{resolvedPathStr}
-			if targetName != "" {
-				targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
-				candidates = append(candidates, targetPrefixedPath)
+			var candidates []string
+			if routed {
+				// The block is known, so there is exactly one path to write.
+				if block.prefix == "" {
+					candidates = []string{resolvedPathStr}
+				} else {
+					candidates = []string{block.prefix + "." + resolvedPathStr}
+				}
+			} else {
+				candidates = []string{resolvedPathStr}
+				if targetName != "" {
+					targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
+					candidates = append(candidates, targetPrefixedPath)
+				}
 			}
 
-			filePath := resolvedLocation.File
-
+			// A routed change has a known destination file even when the leaf
+			// itself is new, but "defined in the config" must still be decided by
+			// the leaf: a field with no source location is added, not replaced.
+			filePath := resolved.leaf.Location().File
 			isDefinedInConfig := filePath != ""
+			if routed && isDefinedInConfig {
+				filePath = block.file
+			}
+
 			if !isDefinedInConfig {
 				if configChange.Operation == OperationRemove {
 					// If the field is not defined in the config and the operation is remove, it is more likely a CLI default
@@ -274,13 +342,19 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 					configChange.Operation = OperationAdd
 				}
 
-				resourceLocation := b.Config.GetLocation(resourceKey)
-				filePath = resourceLocation.File
+				if routed {
+					// The enclosing element was resolved to a block, so a new field
+					// on it belongs in that same block.
+					filePath = block.file
+				} else {
+					resourceLocation := b.Config.GetLocation(resourceKey)
+					filePath = resourceLocation.File
+				}
 				if filePath == "" {
 					return nil, fmt.Errorf("failed to find location for resource %s for a field %s", resourceKey, fieldPath)
 				}
 
-				log.Debugf(ctx, "Field %s has no location, using resource location: %s", fullPath, filePath)
+				log.Debugf(ctx, "Field %s has no location, using %s", fullPath, filePath)
 			}
 
 			if (configChange.Operation == OperationAdd || configChange.Operation == OperationReplace) && b.SyncRootPath != "" {

--- a/bundle/configsync/resolve_test.go
+++ b/bundle/configsync/resolve_test.go
@@ -8,11 +8,21 @@ import (
 	"github.com/databricks/cli/bundle"
 	"github.com/databricks/cli/bundle/config/mutator"
 	"github.com/databricks/cli/libs/cmdio"
-	"github.com/databricks/cli/libs/dyn"
 	"github.com/databricks/cli/libs/logdiag"
+	"github.com/databricks/cli/libs/structs/structpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// resolveSelectorsPath resolves a change path and returns only the pattern, for
+// tests that do not exercise block routing.
+func resolveSelectorsPath(pathStr string, b *bundle.Bundle, operation OperationType) (*structpath.PatternNode, error) {
+	resolved, err := resolveSelectors(pathStr, b, operation)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.path, nil
+}
 
 func TestResolveSelectors_NoSelectors(t *testing.T) {
 	ctx := logdiag.InitContext(t.Context())
@@ -32,7 +42,7 @@ func TestResolveSelectors_NoSelectors(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.name", b, OperationReplace)
+	result, err := resolveSelectorsPath("resources.jobs.test_job.name", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.name", result.String())
 }
@@ -57,11 +67,11 @@ func TestResolveSelectors_NumericIndices(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.tasks[0].task_key", b, OperationReplace)
+	result, err := resolveSelectorsPath("resources.jobs.test_job.tasks[0].task_key", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[0].task_key", result.String())
 
-	result, _, err = resolveSelectors("resources.jobs.test_job.tasks[1].task_key", b, OperationReplace)
+	result, err = resolveSelectorsPath("resources.jobs.test_job.tasks[1].task_key", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[1].task_key", result.String())
 }
@@ -90,11 +100,11 @@ func TestResolveSelectors_KeyValueSelector(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.tasks[task_key='main'].notebook_task.notebook_path", b, OperationReplace)
+	result, err := resolveSelectorsPath("resources.jobs.test_job.tasks[task_key='main'].notebook_task.notebook_path", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[1].notebook_task.notebook_path", result.String())
 
-	result, _, err = resolveSelectors("resources.jobs.test_job.tasks[task_key='setup'].notebook_task.notebook_path", b, OperationReplace)
+	result, err = resolveSelectorsPath("resources.jobs.test_job.tasks[task_key='setup'].notebook_task.notebook_path", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[0].notebook_task.notebook_path", result.String())
 }
@@ -120,7 +130,7 @@ func TestResolveSelectors_SelectorNotFound(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	_, _, err = resolveSelectors("resources.jobs.test_job.tasks[task_key='nonexistent'].notebook_task.notebook_path", b, OperationReplace)
+	_, err = resolveSelectorsPath("resources.jobs.test_job.tasks[task_key='nonexistent'].notebook_task.notebook_path", b, OperationReplace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no array element found with task_key='nonexistent'")
 }
@@ -143,7 +153,7 @@ func TestResolveSelectors_SelectorOnNonArray(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	_, _, err = resolveSelectors("resources.jobs.test_job[task_key='main'].name", b, OperationReplace)
+	_, err = resolveSelectorsPath("resources.jobs.test_job[task_key='main'].name", b, OperationReplace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot apply [task_key='main'] selector to non-array value")
 }
@@ -174,7 +184,7 @@ func TestResolveSelectors_NestedSelectors(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	result, _, err := resolveSelectors("resources.jobs.test_job.tasks[task_key='main'].libraries[0].pypi.package", b, OperationReplace)
+	result, err := resolveSelectorsPath("resources.jobs.test_job.tasks[task_key='main'].libraries[0].pypi.package", b, OperationReplace)
 	require.NoError(t, err)
 	assert.Equal(t, "resources.jobs.test_job.tasks[1].libraries[0].pypi.package", result.String())
 }
@@ -200,52 +210,7 @@ func TestResolveSelectors_WildcardNotSupported(t *testing.T) {
 
 	mutator.DefaultMutators(ctx, b)
 
-	_, _, err = resolveSelectors("resources.jobs.test_job.tasks.*.task_key", b, OperationReplace)
+	_, err = resolveSelectorsPath("resources.jobs.test_job.tasks.*.task_key", b, OperationReplace)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "wildcards not allowed in path")
-}
-
-func TestYamlFileIndex(t *testing.T) {
-	// Simulate a sequence that was sorted alphabetically by a mutator.
-	// Original YAML order: notebook_task (line 10), python_wheel_task (line 20), pipeline_task (line 30), extra (line 40)
-	// Sorted order:        extra (line 40), notebook_task (line 10), pipeline_task (line 30), python_wheel_task (line 20)
-	seq := []dyn.Value{
-		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 40}}), // extra
-		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 10}}), // notebook_task
-		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 30}}), // pipeline_task
-		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 20}}), // python_wheel_task
-	}
-
-	assert.Equal(t, 3, yamlFileIndex(seq, 0)) // extra: 3 elements before it in YAML
-	assert.Equal(t, 0, yamlFileIndex(seq, 1)) // notebook_task: first in YAML
-	assert.Equal(t, 2, yamlFileIndex(seq, 2)) // pipeline_task: 2 elements before it
-	assert.Equal(t, 1, yamlFileIndex(seq, 3)) // python_wheel_task: 1 element before it
-}
-
-func TestYamlFileIndex_MultipleFiles(t *testing.T) {
-	// Tasks from two different files, sorted alphabetically by mutator.
-	// File A (lines 10, 20): task_a, task_b
-	// File B (lines 5, 15): task_c, task_d
-	// Sorted order: task_a (A:10), task_b (A:20), task_c (B:5), task_d (B:15)
-	seq := []dyn.Value{
-		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 10}}), // task_a
-		dyn.NewValue(nil, []dyn.Location{{File: "a.yml", Line: 20}}), // task_b
-		dyn.NewValue(nil, []dyn.Location{{File: "b.yml", Line: 5}}),  // task_c
-		dyn.NewValue(nil, []dyn.Location{{File: "b.yml", Line: 15}}), // task_d
-	}
-
-	// Indices are relative to each file
-	assert.Equal(t, 0, yamlFileIndex(seq, 0)) // task_a: first in file A
-	assert.Equal(t, 1, yamlFileIndex(seq, 1)) // task_b: second in file A
-	assert.Equal(t, 0, yamlFileIndex(seq, 2)) // task_c: first in file B
-	assert.Equal(t, 1, yamlFileIndex(seq, 3)) // task_d: second in file B
-}
-
-func TestYamlFileIndex_NoLocation(t *testing.T) {
-	seq := []dyn.Value{
-		dyn.NewValue(nil, nil),
-		dyn.NewValue(nil, nil),
-	}
-	assert.Equal(t, 0, yamlFileIndex(seq, 0))
-	assert.Equal(t, 1, yamlFileIndex(seq, 1))
 }


### PR DESCRIPTION
## Stack

| | PR | What it does |
|---|---|---|
| 1 | **this PR** | Route each change to the one block that defines it |
| 2 | [#6135](https://github.com/databricks/cli/pull/6135) | Removing an element defined in several blocks deletes it from each |
| 3 | [#6134](https://github.com/databricks/cli/pull/6134) | A key change is written as a key rewrite in every defining block |

Each PR is based on the one above it and carries the acceptance tests for its own behaviour.

## Problem

A resource's list field — a job's `tasks` or `job_clusters`, a pipeline's `clusters` — can be defined in more than one physical YAML region: a top-level `resources.<type>.<name>.<list>` block and a `targets.<target>.resources…<list>` override, either of which may live in its own included file. Loading merges those regions into one list, and keyed lists are also sorted by key, but on disk they stay separate regions that have to be edited independently.

A remote change is expressed against the merged view, so `resolveSelectors` found the element in the merged list and `yamlFileIndex` converted the merged index to a physical one by counting elements that share `Location().File` and have a smaller `Line`. That has no notion of *block*: a top-level block and a target override in the same file are indistinguishable. `FieldCandidates` compounded it by guessing — it emitted `[path, "targets.<t>."+path]`, and `patch.go` tried the top-level pointer first and fell back only on error, so a top-level block that happened to have an element at that index silently accepted the patch.

`config-remote-sync` runs unattended: nobody reads its output or exit code, and it re-runs periodically. So a silently wrong write is the worst outcome — worse than leaving a change for the next run.

## Changes

New `bundle/configsync/blockindex.go` recovers the physical blocks and builds a `dyn.Location -> block` mapping. `resolveSelectors` now records the sequence elements a change path traverses, and each merged index is rewritten into the index inside the chosen block. **`yamlFileIndex` is deleted.**

Selecting a target folds its overrides into the resources tree and drops the `targets` subtree, so the two regions are no longer distinguishable in the loaded configuration. They are recovered by parsing the contributing files again — the file list comes from the locations already on the merged tree, and each file is parsed directly with `config.LoadFromBytes`. Parsing the files rather than reloading through the mutator pipeline matters: the pipeline resolves includes, reports through `logdiag`, and **executes the bundle's `preinit` script**, none of which belongs to reading back a source location. `preinit` runs once per sync, as it did before this PR.

How a destination gets picked:

- element defined in exactly one block → that block;
- element assembled from several blocks → the **leaf field** decides, since merging records each field's location separately, so `max_retries` and `timeout_seconds` on the same task can go to different blocks;
- leaf field itself defined in several blocks → the block owning `Locations()[0]`, which is the definition that won the merge and therefore the value that was deployed. Writing any other copy would leave the effective value unchanged;
- brand-new element or field → the block declaring the resource, keeping it out of a target-specific scope the user did not ask for;
- nothing identifies a single block → left unapplied rather than written to a guess.

Index bookkeeping (`indicesToReplaceMap`, `indexOperations`) is now scoped per block, so a removal in one block no longer shifts indices in another.

## Scope

This PR routes every change to **one** destination, which is the whole story for a field edit. Two cases need more than one destination and are the follow-ups in the stack above. Until #6135 lands, removing an element defined in several blocks is left unapplied: safe, but it never converges.

## Tests

Four new directories under `acceptance/bundle/config-remote-sync/split/`, sharing one `test.toml`. Unlike the existing directories here they omit `Cloud = true`, so they run against the in-process test server under both deployment engines and therefore execute in normal CI.

Each fails on the parent commit and passes here:

- `keyed_edit` — a task defined only in the target block, and a top-level task whose merged position differs from its position in the block. Before: the first appends a keyless `- timeout_seconds: 111` to the top-level block, and the next sync reports `tasks[task_key='']: remove` for the element it just created.
- `keyed_twoblock` — a task defined in both blocks: one field per block, one field set in *both*, plus a brand-new field. Before: the both-blocks field was written to the top-level copy while the target's value stayed in effect, so the edit silently did nothing.
- `multifile` — one target's override spread across two included files. Before: the edit went to the top-level `databricks.yml`.
- `positional` — pipeline clusters, which diff by position rather than by key. Before: a field edit on the target-block cluster failed with `parent path ... does not exist`.

All 21 pre-existing directories are **byte-for-byte unchanged**, including `job_multiple_tasks` (edit/add/remove/rename on a single-block job — the evidence that the common path is unaffected) and `multiple_files` (renames with `depends_on` references across included files).
