### PR TITLE
Validate app log sources before opening output files

### DIFF
--- a/cmd/apps/logs.go
+++ b/cmd/apps/logs.go
@@ -95,6 +95,10 @@ Examples:
 			if tailLines < 0 {
 				return errors.New("--tail-lines cannot be negative")
 			}
+			sourceMap, err := buildSourceFilter(sourceFilters)
+			if err != nil {
+				return err
+			}
 
 			if follow && streamTimeout > 0 {
 				var cancel context.CancelFunc
@@ -171,11 +175,6 @@ Examples:
 
 			outputFormat := root.OutputType(cmd)
 			colorizeLogs := outputPath == "" && outputFormat == flags.OutputText && cmdio.SupportsColor(ctx, cmd.OutOrStdout())
-
-			sourceMap, err := buildSourceFilter(sourceFilters)
-			if err != nil {
-				return err
-			}
 
 			log.Infof(ctx, "Streaming logs for %s (%s)", name, wsURL)
 			return logstream.Run(ctx, logstream.Config{

--- a/cmd/apps/logs_test.go
+++ b/cmd/apps/logs_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/databricks/databricks-sdk-go/config"
@@ -93,4 +95,20 @@ func TestBuildSourceFilter(t *testing.T) {
 
 	_, err = buildSourceFilter([]string{"foo"})
 	require.Error(t, err)
+}
+
+func TestLogsInvalidSourcePreservesOutputFile(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "app.log")
+	require.NoError(t, os.WriteFile(outputPath, []byte("existing logs\n"), 0o600))
+
+	cmd := newLogsCommand()
+	require.NoError(t, cmd.Flags().Set("output-file", outputPath))
+	require.NoError(t, cmd.Flags().Set("source", "invalid"))
+
+	err := cmd.RunE(cmd, []string{"my-app"})
+	require.ErrorContains(t, err, `invalid --source value "invalid"`)
+
+	content, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing logs\n", string(content))
 }


### PR DESCRIPTION
## Changes

- validate `--source` before app lookup, token acquisition, and output-file creation
- preserve existing output files when source validation fails
- add command-level regression coverage

## Why

`apps logs` opened `--output-file` with truncation before validating `--source`. A typo in the source filter could therefore erase an existing file even though the command immediately returned an argument error.

## Tests

- `go test ./cmd/apps ./libs/apps/logstream`