### PR TITLE
bundle: remove split config sync elements from every block

### DIFF
--- a/acceptance/bundle/config-remote-sync/split/isolation/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/isolation/databricks.yml.tmpl
@@ -1,0 +1,34 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# job_a's task list is split across both blocks and one task, "shared", is defined
+# in both. job_b is an ordinary single-block job.
+#
+# The point of the fixture: an unrelated resource's change must still be applied
+# in the same run as a structural change to a split element. The sync is
+# unattended, so one harder change must never stop the rest.
+resources:
+  jobs:
+    job_a:
+      tasks:
+        - task_key: shared
+          max_retries: 1
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/shared
+
+    job_b:
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: simple
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/simple
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        job_a:
+          tasks:
+            - task_key: shared
+              timeout_seconds: 45

--- a/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/isolation/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/isolation/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/isolation/output.txt
@@ -1,0 +1,63 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Rename the two-block task on job_a, and edit job_b in the same run
+=== Sync
+Detected changes in 2 resource(s):
+
+Resource: resources.jobs.job_a
+  tasks[task_key='shared']: remove
+  tasks[task_key='shared_renamed']: add
+
+Resource: resources.jobs.job_b
+  max_concurrent_runs: replace
+
+
+
+=== job_b is updated, and job_a's rename is written in both blocks
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -12,11 +12,11 @@
+     job_a:
+       tasks:
+-        - task_key: shared
+-          max_retries: 1
++        - max_retries: 1
+           notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/shared
+-
++            notebook_path: '/Users/{{workspace_user_name}}/shared'
++          task_key: shared_renamed
++          timeout_seconds: 45
+     job_b:
+-      max_concurrent_runs: 1
++      max_concurrent_runs: 6
+       tasks:
+         - task_key: simple
+@@ -30,5 +30,3 @@
+       jobs:
+         job_a:
+-          tasks:
+-            - task_key: shared
+-              timeout_seconds: 45
++          tasks: []
+
+>>> grep -c max_concurrent_runs: 6 databricks.yml
+1
+
+>>> grep -c task_key: shared_renamed databricks.yml
+1
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.job_a
+  delete resources.jobs.job_b
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/isolation/script
+++ b/acceptance/bundle/config-remote-sync/split/isolation/script
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+job_a_id="$(read_id.py job_a)"
+job_b_id="$(read_id.py job_b)"
+
+
+# A rename of the two-block task on job_a, and a plain scalar edit on job_b, in the
+# SAME run. job_b's edit is independent of anything job_a does, so it must be
+# applied whether or not job_a's rename can be placed.
+title "Rename the two-block task on job_a, and edit job_b in the same run"
+edit_resource.py jobs $job_a_id <<EOF
+for task in r["tasks"]:
+    if task["task_key"] == "shared":
+        task["task_key"] = "shared_renamed"
+EOF
+
+edit_resource.py jobs $job_b_id <<EOF
+r["max_concurrent_runs"] = 6
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --save
+
+title "job_b is updated, and job_a's rename is written in both blocks"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+trace grep -c "max_concurrent_runs: 6" databricks.yml
+trace grep -c "task_key: shared_renamed" databricks.yml
+rm databricks.yml.backup

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/databricks.yml.tmpl
@@ -1,0 +1,45 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# remove_job: gamma/beta live top-level, alpha lives in the target block. The
+# merged order is [alpha, beta, gamma], so the merged indices collide with the
+# physical ones -- removing by merged index deletes the wrong tasks.
+#
+# twoblock_remove_job: "both" is defined in the two blocks at once. Removing it
+# cannot be expressed as "drop it from one scope but keep the merged result", so
+# the sync must leave the source untouched rather than half-deleting it.
+resources:
+  jobs:
+    remove_job:
+      tasks:
+        - task_key: gamma
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/gamma
+        - task_key: beta
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/beta
+
+    twoblock_remove_job:
+      tasks:
+        - task_key: both
+          max_retries: 2
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/both
+        - task_key: keep
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/keep
+
+targets:
+  dev:
+    mode: development
+    resources:
+      jobs:
+        remove_job:
+          tasks:
+            - task_key: alpha
+              notebook_task:
+                notebook_path: /Users/{{workspace_user_name}}/alpha
+        twoblock_remove_job:
+          tasks:
+            - task_key: both
+              timeout_seconds: 30

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/output.txt
@@ -1,0 +1,87 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Remove gamma from the top-level block and alpha from the target block
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.remove_job
+  tasks[task_key='alpha']: remove
+  tasks[task_key='gamma']: remove
+
+
+
+=== Exactly gamma and alpha are gone; beta survives
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -13,7 +13,4 @@
+     remove_job:
+       tasks:
+-        - task_key: gamma
+-          notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/gamma
+         - task_key: beta
+           notebook_task:
+@@ -36,8 +33,5 @@
+       jobs:
+         remove_job:
+-          tasks:
+-            - task_key: alpha
+-              notebook_task:
+-                notebook_path: /Users/{{workspace_user_name}}/alpha
++          tasks: []
+         twoblock_remove_job:
+           tasks:
+
+=== Remove the task defined in BOTH blocks
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.twoblock_remove_job
+  tasks[task_key='both']: remove
+
+
+
+=== 'both' is gone from both blocks; 'keep' survives
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -19,8 +19,4 @@
+     twoblock_remove_job:
+       tasks:
+-        - task_key: both
+-          max_retries: 2
+-          notebook_task:
+-            notebook_path: /Users/{{workspace_user_name}}/both
+         - task_key: keep
+           notebook_task:
+@@ -35,5 +31,3 @@
+           tasks: []
+         twoblock_remove_job:
+-          tasks:
+-            - task_key: both
+-              timeout_seconds: 30
++          tasks: []
+
+>>> grep -c task_key: both databricks.yml
+0
+
+Exit code: 1
+
+>>> grep -c task_key: keep databricks.yml
+1
+
+>>> [CLI] bundle destroy --auto-approve -t dev
+The following resources will be deleted:
+  delete resources.jobs.remove_job
+  delete resources.jobs.twoblock_remove_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/keyed_remove/script
+++ b/acceptance/bundle/config-remote-sync/split/keyed_remove/script
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+envsubst < databricks.yml.tmpl > databricks.yml
+
+cleanup() {
+  trace $CLI bundle destroy --auto-approve -t dev
+}
+trap cleanup EXIT
+
+$CLI bundle deploy -t dev
+remove_job_id="$(read_id.py remove_job)"
+twoblock_job_id="$(read_id.py twoblock_remove_job)"
+
+
+# Remove one task from each block in a single run. Exactly gamma and alpha must
+# disappear; beta must survive even though the removals shift indices in both
+# blocks.
+title "Remove gamma from the top-level block and alpha from the target block"
+edit_resource.py jobs $remove_job_id <<EOF
+r["tasks"] = [t for t in r["tasks"] if t["task_key"] not in ("gamma", "alpha")]
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --select-ids "jobs:$remove_job_id" --save
+
+title "Exactly gamma and alpha are gone; beta survives"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup
+
+
+# "both" is defined in two blocks, so it has a part in each. The merged element
+# only disappears once both parts are gone, so the removal has to be written to
+# both blocks. "keep" must survive in the top-level block.
+title "Remove the task defined in BOTH blocks"
+edit_resource.py jobs $twoblock_job_id <<EOF
+r["tasks"] = [t for t in r["tasks"] if t["task_key"] != "both"]
+EOF
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev --select-ids "jobs:$twoblock_job_id" --save
+
+title "'both' is gone from both blocks; 'keep' survives"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+# grep -c exits non-zero on a count of zero, which would abort the script under
+# bash -e before the second assertion runs.
+errcode trace grep -c "task_key: both" databricks.yml
+errcode trace grep -c "task_key: keep" databricks.yml
+rm databricks.yml.backup

--- a/bundle/configsync/blockindex.go
+++ b/bundle/configsync/blockindex.go
@@ -259,6 +259,48 @@ func (r *blockResolver) route(change resolvedChange) (sourceBlock, *structpath.P
 	return block, path, nil
 }
 
+// routeDestination is one physical place a change has to be written.
+type routeDestination struct {
+	block sourceBlock
+	path  *structpath.PatternNode
+}
+
+// routeElement maps a change that addresses a whole sequence element onto every
+// block that defines it. An element assembled from two blocks has a part in each,
+// so removing it means deleting both parts. Expressing the change per block keeps
+// the split intact instead of collapsing the element into one scope.
+func (r *blockResolver) routeElement(change resolvedChange) ([]routeDestination, error) {
+	if len(change.steps) == 0 {
+		return nil, fmt.Errorf("%w: change does not address a sequence element", errAmbiguousBlock)
+	}
+	last := change.steps[len(change.steps)-1]
+
+	// A change to one of the element's fields addresses a single location and
+	// routes like any other change.
+	if len(change.path.AsSlice()) > last.component+1 {
+		block, path, err := r.route(change)
+		if err != nil {
+			return nil, err
+		}
+		return []routeDestination{{block: block, path: path}}, nil
+	}
+
+	blocks := r.blocksOf(last.element)
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("%w: no source location for the addressed element", errAmbiguousBlock)
+	}
+
+	destinations := make([]routeDestination, 0, len(blocks))
+	for _, block := range blocks {
+		path, err := r.localize(block, change)
+		if err != nil {
+			return nil, err
+		}
+		destinations = append(destinations, routeDestination{block: block, path: path})
+	}
+	return destinations, nil
+}
+
 // blockFor picks the block a change belongs to.
 func (r *blockResolver) blockFor(change resolvedChange) (sourceBlock, error) {
 	// A new element has no source of its own; it is placed relative to the

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -247,12 +247,21 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 
 			// A sequence element addressed by the merged view has to be mapped onto
 			// the physical block that defines it, because the merged order and the
-			// per-block order differ once a sequence is split across blocks.
-			var block sourceBlock
+			// per-block order differ once a sequence is split across blocks. An
+			// element assembled from several blocks has a part in each, so removing
+			// it yields one destination per block.
+			destinations := []routeDestination{{path: resolvedPath}}
 			routed := false
 			if blocks != nil && len(resolved.steps) > 0 {
 				var routeErr error
-				block, resolvedPath, routeErr = blocks.route(resolved)
+				if configChange.Operation == OperationRemove {
+					destinations, routeErr = blocks.routeElement(resolved)
+				} else {
+					var block sourceBlock
+					var path *structpath.PatternNode
+					block, path, routeErr = blocks.route(resolved)
+					destinations = []routeDestination{{block: block, path: path}}
+				}
 				if routeErr != nil {
 					if errors.Is(routeErr, errAmbiguousBlock) {
 						// Applying this change would mean guessing a location.
@@ -265,110 +274,126 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 				routed = true
 			}
 
-			// Index bookkeeping is scoped to a block so that shifts caused by
-			// operations on one block cannot move indices in another.
-			scope := ""
-			if routed {
-				scope = block.prefix + "\x00" + block.file + "\x00"
-			}
-
-			// If the element is removed, we can use the index to replace it with added element
-			// That may improve the diff in cases when the task is recreated because of renaming
-			if configChange.Operation == OperationRemove {
-				freeIndex, ok := resolvedPath.Index()
-				if ok {
-					parentPath := scope + resolvedPath.Parent().String()
-					indicesToReplaceMap[parentPath] = append(indicesToReplaceMap[parentPath], freeIndex)
-				}
-			}
-
-			if configChange.Operation == OperationAdd && resolvedPath.BracketStar() {
-				parentPath := scope + resolvedPath.Parent().String()
-				indices, ok := indicesToReplaceMap[parentPath]
-				if ok && len(indices) > 0 {
-					index := indices[0]
-					indicesToReplaceMap[parentPath] = indices[1:]
-					resolvedPath = structpath.NewPatternIndex(resolvedPath.Parent(), index)
-				}
-			}
-
-			resolvedPath = adjustArrayIndex(resolvedPath, scope, indexOperations)
-
-			// Track this operation for future index adjustments (only for array element operations)
-			if originalIndex, ok := resolvedPath.Index(); ok {
-				parentPath := scope + resolvedPath.Parent().String()
-				indexOperations[parentPath] = append(indexOperations[parentPath], struct {
-					index     int
-					operation OperationType
-				}{originalIndex, configChange.Operation})
-			}
-
-			resolvedPathStr := resolvedPath.String()
-			var candidates []string
-			if routed {
-				// The block is known, so there is exactly one path to write.
-				if block.prefix == "" {
-					candidates = []string{resolvedPathStr}
-				} else {
-					candidates = []string{block.prefix + "." + resolvedPathStr}
-				}
-			} else {
-				candidates = []string{resolvedPathStr}
-				if targetName != "" {
-					targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
-					candidates = append(candidates, targetPrefixedPath)
-				}
-			}
-
-			// A routed change has a known destination file even when the leaf
-			// itself is new, but "defined in the config" must still be decided by
-			// the leaf: a field with no source location is added, not replaced.
-			filePath := resolved.leaf.Location().File
-			isDefinedInConfig := filePath != ""
-			if routed && isDefinedInConfig {
-				filePath = block.file
-			}
-
-			if !isDefinedInConfig {
-				if configChange.Operation == OperationRemove {
-					// If the field is not defined in the config and the operation is remove, it is more likely a CLI default
-					// in this case we skip the change
-					continue
-				}
-
-				if configChange.Operation == OperationReplace {
-					// If the field is not defined in the config and the operation is replace, it is more likely a CLI default
-					// in this case we add it explicitly to the resource location
-					configChange.Operation = OperationAdd
-				}
-
-				if routed {
-					// The enclosing element was resolved to a block, so a new field
-					// on it belongs in that same block.
-					filePath = block.file
-				} else {
-					resourceLocation := b.Config.GetLocation(resourceKey)
-					filePath = resourceLocation.File
-				}
-				if filePath == "" {
-					return nil, fmt.Errorf("failed to find location for resource %s for a field %s", resourceKey, fieldPath)
-				}
-
-				log.Debugf(ctx, "Field %s has no location, using %s", fullPath, filePath)
-			}
-
-			if (configChange.Operation == OperationAdd || configChange.Operation == OperationReplace) && b.SyncRootPath != "" {
-				configChange = &ConfigChangeDesc{
+			for _, destination := range destinations {
+				block := destination.block
+				resolvedPath := destination.path
+				// Each destination gets its own copy: the operation and the value
+				// are rewritten below per destination, and one block's rewrite must
+				// not leak into the next.
+				destChange := &ConfigChangeDesc{
 					Operation: configChange.Operation,
-					Value:     translateWorkspacePaths(configChange.Value, b.SyncRootPath, b.SyncRoot, filepath.Dir(filePath)),
+					Value:     configChange.Value,
+					LocalEdit: configChange.LocalEdit,
 				}
-			}
 
-			result = append(result, FieldChange{
-				FilePath:        filePath,
-				Change:          configChange,
-				FieldCandidates: candidates,
-			})
+				// Index bookkeeping is scoped to a block so that shifts caused by
+				// operations on one block cannot move indices in another.
+				scope := ""
+				if routed {
+					scope = block.prefix + "\x00" + block.file + "\x00"
+				}
+
+				// If the element is removed, we can use the index to replace it with added element
+				// That may improve the diff in cases when the task is recreated because of renaming
+				if destChange.Operation == OperationRemove {
+					freeIndex, ok := resolvedPath.Index()
+					if ok {
+						parentPath := scope + resolvedPath.Parent().String()
+						indicesToReplaceMap[parentPath] = append(indicesToReplaceMap[parentPath], freeIndex)
+					}
+				}
+
+				if destChange.Operation == OperationAdd && resolvedPath.BracketStar() {
+					parentPath := scope + resolvedPath.Parent().String()
+					indices, ok := indicesToReplaceMap[parentPath]
+					if ok && len(indices) > 0 {
+						index := indices[0]
+						indicesToReplaceMap[parentPath] = indices[1:]
+						resolvedPath = structpath.NewPatternIndex(resolvedPath.Parent(), index)
+					}
+				}
+
+				resolvedPath = adjustArrayIndex(resolvedPath, scope, indexOperations)
+
+				// Track this operation for future index adjustments (only for array element operations)
+				if originalIndex, ok := resolvedPath.Index(); ok {
+					parentPath := scope + resolvedPath.Parent().String()
+					indexOperations[parentPath] = append(indexOperations[parentPath], struct {
+						index     int
+						operation OperationType
+					}{originalIndex, destChange.Operation})
+				}
+
+				resolvedPathStr := resolvedPath.String()
+				var candidates []string
+				if routed {
+					// The block is known, so there is exactly one path to write.
+					if block.prefix == "" {
+						candidates = []string{resolvedPathStr}
+					} else {
+						candidates = []string{block.prefix + "." + resolvedPathStr}
+					}
+				} else {
+					candidates = []string{resolvedPathStr}
+					if targetName != "" {
+						targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
+						candidates = append(candidates, targetPrefixedPath)
+					}
+				}
+
+				// A routed change has a known destination file even when the leaf
+				// itself is new, but "defined in the config" must still be decided by
+				// the leaf: a field with no source location is added, not replaced.
+				filePath := resolved.leaf.Location().File
+				isDefinedInConfig := filePath != ""
+				if routed && isDefinedInConfig {
+					filePath = block.file
+				}
+
+				if !isDefinedInConfig {
+					if destChange.Operation == OperationRemove {
+						// If the field is not defined in the config and the operation is remove, it is more likely a CLI default
+						// in this case we skip the change
+						continue
+					}
+
+					if destChange.Operation == OperationReplace {
+						// If the field is not defined in the config and the operation is replace, it is more likely a CLI default
+						// in this case we add it explicitly to the resource location.
+						// The reclassification is also recorded on the shared change so
+						// the command's output reports what was actually written.
+						destChange.Operation = OperationAdd
+						configChange.Operation = OperationAdd
+					}
+
+					if routed {
+						// The enclosing element was resolved to a block, so a new field
+						// on it belongs in that same block.
+						filePath = block.file
+					} else {
+						resourceLocation := b.Config.GetLocation(resourceKey)
+						filePath = resourceLocation.File
+					}
+					if filePath == "" {
+						return nil, fmt.Errorf("failed to find location for resource %s for a field %s", resourceKey, fieldPath)
+					}
+
+					log.Debugf(ctx, "Field %s has no location, using %s", fullPath, filePath)
+				}
+
+				if (destChange.Operation == OperationAdd || destChange.Operation == OperationReplace) && b.SyncRootPath != "" {
+					destChange = &ConfigChangeDesc{
+						Operation: destChange.Operation,
+						Value:     translateWorkspacePaths(destChange.Value, b.SyncRootPath, b.SyncRoot, filepath.Dir(filePath)),
+					}
+				}
+
+				result = append(result, FieldChange{
+					FilePath:        filePath,
+					Change:          destChange,
+					FieldCandidates: candidates,
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Stack

| | PR | What it does |
|---|---|---|
| 1 | [#6117](https://github.com/databricks/cli/pull/6117) | Route each change to the one block that defines it |
| 2 | **this PR** | Removing an element defined in several blocks deletes it from each |
| 3 | [#6134](https://github.com/databricks/cli/pull/6134) | A key change is written as a key rewrite in every defining block |

Each PR is based on the one above it and carries the acceptance tests for its own behaviour.

## Changes

Removes a keyed list element that is defined in more than one YAML block from **every** block that defines it.

The parent PR routes each change to a single block, which is right for a field edit but cannot express this removal: a job task declared both at the top level and in a `targets.<target>` override has a part in each, and the merged element only disappears once both are gone. That case was therefore left unapplied. `routeElement` now returns one destination per defining block, and `ApplyChangesToYAML` already groups changes by file, so the patch layer is unchanged.

```yaml
# "both" is defined in each block; remote deletes the task
 resources: {jobs: {j: {tasks:
-  - task_key: both
-      max_retries: 2
   - task_key: keep}}}                 # survives
 targets: {dev: {resources: {jobs: {j:
-      tasks:
-        - task_key: both
-            timeout_seconds: 30
+      tasks: []
```

Each destination gets its own copy of the change, because the `Replace`→`Add` reclassification for a field absent from the source rewrites the operation, and one block's rewrite must not leak into the next.

## Why

Leaving the change unapplied was safe but never converged: the element stays in configuration after the user deleted it remotely, so every later sync re-reports the same removal. Deleting only the top-level half — the behaviour before the parent PR — was worse, since it orphaned the override half.

## Tests

Two new directories, both failing on the parent commit and passing here:

- `split/keyed_remove` — removes one task per block in one run (exactly those two go, `beta` survives), then removes the task defined in both blocks: `task_key: both` goes from 2 to 0 and the top-level `keep` task is untouched.
- `split/isolation` — a structural change to a split element alongside an unrelated scalar edit on another resource, in the same run. The unrelated edit is applied regardless, so one harder change never stops the rest.

**Review with `git diff -w`.** The real change is +39/−14 in `resolve.go`; the rest of the raw line count is re-indentation from wrapping the existing body in a per-destination loop.
