### PR TITLE
Generate: fix notebook download in foldesr

### DIFF
--- a/.nextchanges/bundles/generate-notebook-download-in-folder.md
+++ b/.nextchanges/bundles/generate-notebook-download-in-folder.md
@@ -1,0 +1,1 @@
+Fixed `bundle generate` downloading notebooks found inside a folder without their file extension. They are now exported like top-level notebooks, so a Python notebook lands as `notebook.py` instead of an extensionless file ([#6144](https://github.com/databricks/cli/pull/6144)).

--- a/bundle/generate/downloader.go
+++ b/bundle/generate/downloader.go
@@ -126,13 +126,17 @@ func (n *Downloader) MarkDirectoryForDownload(ctx context.Context, dirPath *stri
 	}
 
 	for _, obj := range objects {
-		if obj.ObjectType == workspace.ObjectTypeDirectory {
+		switch obj.ObjectType {
+		case workspace.ObjectTypeDirectory:
 			continue
-		}
-
-		err := n.markFileForDownload(ctx, &obj.Path)
-		if err != nil {
-			return err
+		case workspace.ObjectTypeNotebook:
+			if err := n.markNotebookForDownload(ctx, &obj.Path); err != nil {
+				return err
+			}
+		default:
+			if err := n.markFileForDownload(ctx, &obj.Path); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/bundle/generate/downloader_test.go
+++ b/bundle/generate/downloader_test.go
@@ -521,23 +521,23 @@ func TestDownloader_MarkDirectoryForDownload_NotebookGetsExtension(t *testing.T)
 					{Path: filePath, ObjectType: workspace.ObjectTypeFile},
 				},
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		case "/api/2.0/workspace/get-status":
 			path := r.URL.Query().Get("path")
 			switch path {
 			case rootPath:
 				err := json.NewEncoder(rw).Encode(workspace.ObjectInfo{Path: rootPath})
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			case notebookPath:
 				err := json.NewEncoder(rw).Encode(workspaceStatus{
 					Language:     workspace.LanguagePython,
 					ObjectType:   workspace.ObjectTypeNotebook,
 					ExportFormat: workspace.ExportFormatSource,
 				})
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			case filePath:
 				err := json.NewEncoder(rw).Encode(workspace.ObjectInfo{Path: filePath})
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			default:
 				t.Fatalf("unexpected get-status path: %s", path)
 			}

--- a/bundle/generate/downloader_test.go
+++ b/bundle/generate/downloader_test.go
@@ -500,6 +500,66 @@ func TestWriteAndClose(t *testing.T) {
 	}
 }
 
+func TestDownloader_MarkDirectoryForDownload_NotebookGetsExtension(t *testing.T) {
+	ctx := t.Context()
+
+	rootPath := "/pipeline/root"
+	notebookPath := "/pipeline/root/ExploratoryNotebook"
+	filePath := "/pipeline/root/utils.py"
+
+	type listResponse struct {
+		Objects []workspace.ObjectInfo `json:"objects"`
+	}
+
+	w := newTestWorkspaceClient(t, func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/2.0/workspace/list":
+			err := json.NewEncoder(rw).Encode(listResponse{
+				Objects: []workspace.ObjectInfo{
+					{Path: notebookPath, ObjectType: workspace.ObjectTypeNotebook},
+					{Path: filePath, ObjectType: workspace.ObjectTypeFile},
+				},
+			})
+			require.NoError(t, err)
+		case "/api/2.0/workspace/get-status":
+			path := r.URL.Query().Get("path")
+			switch path {
+			case rootPath:
+				err := json.NewEncoder(rw).Encode(workspace.ObjectInfo{Path: rootPath})
+				require.NoError(t, err)
+			case notebookPath:
+				err := json.NewEncoder(rw).Encode(workspaceStatus{
+					Language:     workspace.LanguagePython,
+					ObjectType:   workspace.ObjectTypeNotebook,
+					ExportFormat: workspace.ExportFormatSource,
+				})
+				require.NoError(t, err)
+			case filePath:
+				err := json.NewEncoder(rw).Encode(workspace.ObjectInfo{Path: filePath})
+				require.NoError(t, err)
+			default:
+				t.Fatalf("unexpected get-status path: %s", path)
+			}
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	dir := "base/dir"
+	sourceDir := filepath.Join(dir, "source")
+	configDir := filepath.Join(dir, "config")
+	downloader := NewDownloader(w, sourceDir, configDir)
+
+	err := downloader.MarkDirectoryForDownload(ctx, &rootPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, downloader.files, filepath.Join(sourceDir, "ExploratoryNotebook.py"))
+	assert.NotContains(t, downloader.files, filepath.Join(sourceDir, "ExploratoryNotebook"))
+	assert.Contains(t, downloader.files, filepath.Join(sourceDir, "utils.py"))
+	assert.Len(t, downloader.files, 2)
+}
+
 func TestDownloader_CleanupOldFiles(t *testing.T) {
 	ctx := t.Context()
 	sourceDir := t.TempDir()


### PR DESCRIPTION
## Changes
Call `markNotebookForDownload` for notebooks

## Why
Fixes issue where notebooks are downloaded as files on WSFS.

## Tests
Unit test & manual

<!-- If your PR needs to be included in the release notes for next release,
add a changelog fragment: create .nextchanges/<section>/<name>.md with a
one-line description (e.g. .nextchanges/cli/quickstart.md). See .nextchanges/README.md. -->
