### PR TITLE
Move bundle/run.runPageURL to libs/workspaceurls

### DIFF
--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -5,9 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/databricks/cli/bundle"
@@ -99,7 +97,7 @@ func (m *jobRunMonitor) onProgress(info *jobs.Run) {
 
 	// First time we see this run.
 	if m.prevState == nil {
-		runURL := runPageURL(m.ctx, info.RunPageUrl)
+		runURL := workspaceurls.JobRunPageURL(m.ctx, info.RunPageUrl)
 		log.Infof(m.ctx, "Run available at %s", runURL)
 		cmdio.Log(m.ctx, progress.NewJobRunUrlEvent(runURL))
 	}
@@ -124,47 +122,6 @@ func (m *jobRunMonitor) onProgress(info *jobs.Run) {
 	}
 	cmdio.Log(m.ctx, event)
 	log.Info(m.ctx, event.String())
-}
-
-// runPageURL converts the legacy run URL returned by the Jobs API
-//
-//	https://<host>/?o=<id>#job/<jobID>/run/<runID>
-//
-// into the modern path form
-//
-//	https://<host>/jobs/<jobID>/runs/<runID>?o=<id>
-//
-// so that non-admin users permitted to view the run are not redirected to the
-// workspace homepage. See https://github.com/databricks/cli/issues/5142. The
-// workspace selector query param (o) is preserved as-is. The conversion is
-// cosmetic, so the original URL is returned on the rare chance the format is
-// unexpected.
-func runPageURL(ctx context.Context, raw string) string {
-	u, err := url.Parse(raw)
-	if err != nil {
-		log.Debugf(ctx, "could not parse run URL %q: %v", raw, err)
-		return raw
-	}
-
-	jobID, runID, ok := parseLegacyRunFragment(u.Fragment)
-	if !ok {
-		log.Debugf(ctx, "unexpected run URL fragment %q", u.Fragment)
-		return raw
-	}
-
-	u.Fragment = ""
-	u.Path = "/" + workspaceurls.JobRunPath(jobID, runID)
-	return u.String()
-}
-
-// parseLegacyRunFragment extracts the job and run IDs from a legacy run URL
-// fragment of the form "job/<jobID>/run/<runID>".
-func parseLegacyRunFragment(fragment string) (jobID, runID string, ok bool) {
-	parts := strings.Split(fragment, "/")
-	if len(parts) != 4 || parts[0] != "job" || parts[2] != "run" || parts[1] == "" || parts[3] == "" {
-		return "", "", false
-	}
-	return parts[1], parts[3], true
 }
 
 func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, error) {
@@ -205,7 +162,7 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 		if err != nil {
 			return nil, err
 		}
-		cmdio.Log(ctx, progress.NewJobRunUrlEvent(runPageURL(ctx, details.RunPageUrl)))
+		cmdio.Log(ctx, progress.NewJobRunUrlEvent(workspaceurls.JobRunPageURL(ctx, details.RunPageUrl)))
 		return nil, nil
 	}
 

--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -97,7 +97,7 @@ func (m *jobRunMonitor) onProgress(info *jobs.Run) {
 
 	// First time we see this run.
 	if m.prevState == nil {
-		runURL := workspaceurls.JobRunPageURL(m.ctx, info.RunPageUrl)
+		runURL := workspaceurls.JobRunPageURL(info.RunPageUrl)
 		log.Infof(m.ctx, "Run available at %s", runURL)
 		cmdio.Log(m.ctx, progress.NewJobRunUrlEvent(runURL))
 	}
@@ -162,7 +162,7 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 		if err != nil {
 			return nil, err
 		}
-		cmdio.Log(ctx, progress.NewJobRunUrlEvent(workspaceurls.JobRunPageURL(ctx, details.RunPageUrl)))
+		cmdio.Log(ctx, progress.NewJobRunUrlEvent(workspaceurls.JobRunPageURL(details.RunPageUrl)))
 		return nil, nil
 	}
 

--- a/bundle/run/job.go
+++ b/bundle/run/job.go
@@ -97,7 +97,7 @@ func (m *jobRunMonitor) onProgress(info *jobs.Run) {
 
 	// First time we see this run.
 	if m.prevState == nil {
-		runURL := workspaceurls.JobRunPageURL(info.RunPageUrl)
+		runURL := workspaceurls.ModernizeJobRunPageURL(info.RunPageUrl)
 		log.Infof(m.ctx, "Run available at %s", runURL)
 		cmdio.Log(m.ctx, progress.NewJobRunUrlEvent(runURL))
 	}
@@ -162,7 +162,7 @@ func (r *jobRunner) Run(ctx context.Context, opts *Options) (output.RunOutput, e
 		if err != nil {
 			return nil, err
 		}
-		cmdio.Log(ctx, progress.NewJobRunUrlEvent(workspaceurls.JobRunPageURL(details.RunPageUrl)))
+		cmdio.Log(ctx, progress.NewJobRunUrlEvent(workspaceurls.ModernizeJobRunPageURL(details.RunPageUrl)))
 		return nil, nil
 	}
 

--- a/bundle/run/job_test.go
+++ b/bundle/run/job_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/databricks/cli/libs/cmdio"
 	"github.com/databricks/databricks-sdk-go/experimental/mocks"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -291,51 +290,4 @@ func TestJobRunnerRestartForContinuousUnpausedJobs(t *testing.T) {
 
 	_, err := runner.Restart(ctx, &Options{})
 	require.NoError(t, err)
-}
-
-func TestRunPageURL(t *testing.T) {
-	ctx := t.Context()
-	tests := []struct {
-		name     string
-		raw      string
-		expected string
-	}{
-		{
-			"legacy fragment form preserves workspace selector",
-			"https://myworkspace.databricks.test/?o=900800700600#job/123/run/456",
-			"https://myworkspace.databricks.test/jobs/123/runs/456?o=900800700600",
-		},
-		{
-			"no workspace selector",
-			"https://myworkspace.databricks.test/#job/123/run/456",
-			"https://myworkspace.databricks.test/jobs/123/runs/456",
-		},
-		{
-			"http host with port",
-			"http://127.0.0.1:8080/?o=900800700600#job/1/run/2",
-			"http://127.0.0.1:8080/jobs/1/runs/2?o=900800700600",
-		},
-		// Unexpected formats are returned unchanged because the conversion is cosmetic.
-		{
-			"already modern path is left as-is",
-			"https://myworkspace.databricks.test/jobs/123/runs/456?o=900800700600",
-			"https://myworkspace.databricks.test/jobs/123/runs/456?o=900800700600",
-		},
-		{
-			"incomplete fragment is left as-is",
-			"https://myworkspace.databricks.test/?o=900800700600#job/123",
-			"https://myworkspace.databricks.test/?o=900800700600#job/123",
-		},
-		{
-			"empty job id is left as-is",
-			"https://myworkspace.databricks.test/?o=900800700600#job//run/456",
-			"https://myworkspace.databricks.test/?o=900800700600#job//run/456",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, runPageURL(ctx, tt.raw))
-		})
-	}
 }

--- a/libs/workspaceurls/urls.go
+++ b/libs/workspaceurls/urls.go
@@ -1,13 +1,10 @@
 package workspaceurls
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"slices"
 	"strings"
-
-	"github.com/databricks/cli/libs/log"
 )
 
 var resourceURLPatterns = map[string]string{
@@ -106,16 +103,14 @@ func JobRunURL(baseURL url.URL, jobID, runID string) string {
 // workspace selector query param (o) is preserved as-is. The conversion is
 // cosmetic, so the original URL is returned on the rare chance the format is
 // unexpected.
-func JobRunPageURL(ctx context.Context, raw string) string {
+func JobRunPageURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
-		log.Debugf(ctx, "could not parse run URL %q: %v", raw, err)
 		return raw
 	}
 
 	jobID, runID, ok := parseLegacyRunFragment(u.Fragment)
 	if !ok {
-		log.Debugf(ctx, "unexpected run URL fragment %q", u.Fragment)
 		return raw
 	}
 

--- a/libs/workspaceurls/urls.go
+++ b/libs/workspaceurls/urls.go
@@ -1,10 +1,13 @@
 package workspaceurls
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"slices"
 	"strings"
+
+	"github.com/databricks/cli/libs/log"
 )
 
 var resourceURLPatterns = map[string]string{
@@ -88,6 +91,47 @@ func JobRunPath(jobID, runID string) string {
 func JobRunURL(baseURL url.URL, jobID, runID string) string {
 	baseURL.Path = JobRunPath(jobID, runID)
 	return baseURL.String()
+}
+
+// JobRunPageURL converts the legacy run URL returned by the Jobs API
+//
+//	https://<host>/?o=<id>#job/<jobID>/run/<runID>
+//
+// into the modern path form
+//
+//	https://<host>/jobs/<jobID>/runs/<runID>?o=<id>
+//
+// so that non-admin users permitted to view the run are not redirected to the
+// workspace homepage. See https://github.com/databricks/cli/issues/5142. The
+// workspace selector query param (o) is preserved as-is. The conversion is
+// cosmetic, so the original URL is returned on the rare chance the format is
+// unexpected.
+func JobRunPageURL(ctx context.Context, raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		log.Debugf(ctx, "could not parse run URL %q: %v", raw, err)
+		return raw
+	}
+
+	jobID, runID, ok := parseLegacyRunFragment(u.Fragment)
+	if !ok {
+		log.Debugf(ctx, "unexpected run URL fragment %q", u.Fragment)
+		return raw
+	}
+
+	u.Fragment = ""
+	u.Path = "/" + JobRunPath(jobID, runID)
+	return u.String()
+}
+
+// parseLegacyRunFragment extracts the job and run IDs from a legacy run URL
+// fragment of the form "job/<jobID>/run/<runID>".
+func parseLegacyRunFragment(fragment string) (jobID, runID string, ok bool) {
+	parts := strings.Split(fragment, "/")
+	if len(parts) != 4 || parts[0] != "job" || parts[2] != "run" || parts[1] == "" || parts[3] == "" {
+		return "", "", false
+	}
+	return parts[1], parts[3], true
 }
 
 // ResourceURL constructs a workspace URL for a named resource type and ID.

--- a/libs/workspaceurls/urls.go
+++ b/libs/workspaceurls/urls.go
@@ -90,7 +90,7 @@ func JobRunURL(baseURL url.URL, jobID, runID string) string {
 	return baseURL.String()
 }
 
-// JobRunPageURL converts the legacy run URL returned by the Jobs API
+// ModernizeJobRunPageURL converts the legacy run URL returned by the Jobs API
 //
 //	https://<host>/?o=<id>#job/<jobID>/run/<runID>
 //
@@ -103,7 +103,7 @@ func JobRunURL(baseURL url.URL, jobID, runID string) string {
 // workspace selector query param (o) is preserved as-is. The conversion is
 // cosmetic, so the original URL is returned on the rare chance the format is
 // unexpected.
-func JobRunPageURL(raw string) string {
+func ModernizeJobRunPageURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return raw

--- a/libs/workspaceurls/urls_test.go
+++ b/libs/workspaceurls/urls_test.go
@@ -168,7 +168,6 @@ func TestHasWorkspaceIDInHostname(t *testing.T) {
 }
 
 func TestJobRunPageURL(t *testing.T) {
-	ctx := t.Context()
 	tests := []struct {
 		name     string
 		raw      string
@@ -209,7 +208,7 @@ func TestJobRunPageURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, JobRunPageURL(ctx, tt.raw))
+			assert.Equal(t, tt.expected, JobRunPageURL(tt.raw))
 		})
 	}
 }

--- a/libs/workspaceurls/urls_test.go
+++ b/libs/workspaceurls/urls_test.go
@@ -167,7 +167,7 @@ func TestHasWorkspaceIDInHostname(t *testing.T) {
 	}
 }
 
-func TestJobRunPageURL(t *testing.T) {
+func TestModernizeJobRunPageURL(t *testing.T) {
 	tests := []struct {
 		name     string
 		raw      string
@@ -208,7 +208,7 @@ func TestJobRunPageURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, JobRunPageURL(tt.raw))
+			assert.Equal(t, tt.expected, ModernizeJobRunPageURL(tt.raw))
 		})
 	}
 }

--- a/libs/workspaceurls/urls_test.go
+++ b/libs/workspaceurls/urls_test.go
@@ -166,3 +166,50 @@ func TestHasWorkspaceIDInHostname(t *testing.T) {
 		})
 	}
 }
+
+func TestJobRunPageURL(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{
+			"legacy fragment form preserves workspace selector",
+			"https://myworkspace.databricks.test/?o=900800700600#job/123/run/456",
+			"https://myworkspace.databricks.test/jobs/123/runs/456?o=900800700600",
+		},
+		{
+			"no workspace selector",
+			"https://myworkspace.databricks.test/#job/123/run/456",
+			"https://myworkspace.databricks.test/jobs/123/runs/456",
+		},
+		{
+			"http host with port",
+			"http://127.0.0.1:8080/?o=900800700600#job/1/run/2",
+			"http://127.0.0.1:8080/jobs/1/runs/2?o=900800700600",
+		},
+		// The conversion is cosmetic, so any other format passes through unchanged.
+		{
+			"already modern path is left as-is",
+			"https://myworkspace.databricks.test/jobs/123/runs/456?o=900800700600",
+			"https://myworkspace.databricks.test/jobs/123/runs/456?o=900800700600",
+		},
+		{
+			"incomplete fragment is left as-is",
+			"https://myworkspace.databricks.test/?o=900800700600#job/123",
+			"https://myworkspace.databricks.test/?o=900800700600#job/123",
+		},
+		{
+			"empty job id is left as-is",
+			"https://myworkspace.databricks.test/?o=900800700600#job//run/456",
+			"https://myworkspace.databricks.test/?o=900800700600#job//run/456",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, JobRunPageURL(ctx, tt.raw))
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Move the legacy-to-path run URL conversion from `bundle/run/job.go` into `libs/workspaceurls` as `JobRunPageURL`, next to the `JobRunPath` helper it already used. Tests move with it. The `ctx` parameter is dropped since it only fed two debug lines.

## Why

A second caller outside `bundle run` needs it: the `job_runs` resource in #6091.

## Tests

Existing unit tests, moved unchanged apart from the dropped `ctx`.