### PR TITLE
Record skipped changes in config-remote-sync telemetry

### DIFF
--- a/bundle/configsync/patch_test.go
+++ b/bundle/configsync/patch_test.go
@@ -50,8 +50,9 @@ resources:
 		},
 	}
 
-	fieldChanges, err := ResolveChanges(ctx, b, changes)
+	fieldChanges, skipped, err := ResolveChanges(ctx, b, changes)
 	require.NoError(t, err)
+	require.Empty(t, skipped)
 
 	fileChanges, err := ApplyChangesToYAML(ctx, b, fieldChanges)
 	require.NoError(t, err)

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -192,8 +192,14 @@ func adjustArrayIndex(path *structpath.PatternNode, scope string, operations map
 }
 
 // ResolveChanges resolves selectors and computes field path candidates for each change.
-func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes) ([]FieldChange, error) {
+//
+// A change that cannot be attributed to a single source location is left unapplied
+// rather than written to a guessed one. The count of those is returned so the caller can
+// record it: the command runs unattended, so a change that silently disappears looks
+// identical to one that was written.
+func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes) ([]FieldChange, int, error) {
 	var result []FieldChange
+	skipped := 0
 	targetName := b.Config.Bundle.Target
 	blocks := newBlockResolver(ctx, b)
 
@@ -250,13 +256,14 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			}
 			if reason, ok := renames.unpairedPaths[fieldPath]; ok {
 				log.Debugf(ctx, "config-remote-sync: skipping %s: %s", fullPath, reason)
+				skipped++
 				continue
 			}
 			rename, isRename := renames.byRemovePath[fieldPath]
 
 			resolved, err := resolveSelectors(fullPath, b, configChange.Operation)
 			if err != nil {
-				return nil, fmt.Errorf("failed to resolve selectors in path %s: %w", fullPath, err)
+				return nil, 0, fmt.Errorf("failed to resolve selectors in path %s: %w", fullPath, err)
 			}
 			resolvedPath := resolved.path
 
@@ -266,14 +273,19 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 			destinations, err := routeChange(blocks, resolved, isRename)
 			if err != nil {
 				if !errors.Is(err, errAmbiguousBlock) {
-					return nil, err
+					return nil, 0, err
 				}
 				// Applying this change would mean guessing a location. Leave it
 				// unapplied; a later run can pick it up.
 				log.Debugf(ctx, "config-remote-sync: skipping %s: %v", fullPath, err)
+				skipped++
 				continue
 			}
 			if len(destinations) == 0 {
+				// A rename whose element could not be attributed to a block: the whole
+				// pair is left for a later run rather than half-applied.
+				log.Debugf(ctx, "config-remote-sync: skipping %s: the renamed element has no source location", fullPath)
+				skipped++
 				continue
 			}
 
@@ -337,7 +349,7 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 						filePath = resourceLocation.File
 					}
 					if filePath == "" {
-						return nil, fmt.Errorf("failed to find location for resource %s for a field %s", resourceKey, fieldPath)
+						return nil, 0, fmt.Errorf("failed to find location for resource %s for a field %s", resourceKey, fieldPath)
 					}
 
 					log.Debugf(ctx, "Field %s has no location, using %s", fullPath, filePath)
@@ -361,7 +373,7 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 		}
 	}
 
-	return result, nil
+	return result, skipped, nil
 }
 
 // translateWorkspacePaths recursively converts absolute workspace paths to relative

--- a/bundle/configsync/telemetry.go
+++ b/bundle/configsync/telemetry.go
@@ -50,6 +50,10 @@ type Stats struct {
 	FilesChangedCount int64
 	FilesWrittenCount int64
 
+	// Changes that were detected and reported but not written back, because they
+	// could not be attributed to a single source location.
+	SkippedChangesCount int64
+
 	Restore RestoreStats
 
 	// Identity of the resource state the run actually read. Without these, a
@@ -280,6 +284,7 @@ func (s *Stats) LogTelemetry(ctx context.Context) {
 			ResourceChanges:        resourceChanges,
 			FilesChangedCount:      s.FilesChangedCount,
 			FilesWrittenCount:      s.FilesWrittenCount,
+			SkippedChangesCount:    s.SkippedChangesCount,
 			RefsRetargeted:         s.Restore.Retargeted,
 			RefsFromSiblings:       s.Restore.FromSiblings,
 			StateSerial:            s.StateSerial,

--- a/cmd/bundle/config_remote_sync.go
+++ b/cmd/bundle/config_remote_sync.go
@@ -119,11 +119,12 @@ Examples:
 					changes = configsync.FilterChanges(changes, selected)
 				}
 
-				fieldChanges, err := configsync.ResolveChanges(ctx, b, changes)
+				fieldChanges, skipped, err := configsync.ResolveChanges(ctx, b, changes)
 				if err != nil {
 					stats.ErrorCategory = protos.BundleConfigRemoteSyncErrorCategoryResolveFailed
 					return fmt.Errorf("failed to resolve field changes: %w", err)
 				}
+				stats.SkippedChangesCount = int64(skipped)
 
 				if err := configsync.RestoreVariableReferences(ctx, b, fieldChanges, &stats.Restore); err != nil {
 					log.Warnf(ctx, "variable restoration skipped: %v", err)

--- a/libs/telemetry/protos/bundle_config_remote_sync.go
+++ b/libs/telemetry/protos/bundle_config_remote_sync.go
@@ -54,6 +54,14 @@ type BundleConfigRemoteSyncEvent struct {
 	FilesChangedCount int64 `json:"files_changed_count,omitempty"`
 	FilesWrittenCount int64 `json:"files_written_count,omitempty"`
 
+	// Number of detected changes that were not written back because they could
+	// not be attributed to a single source location (e.g. a sequence element
+	// defined in both a top-level block and a target override). These are
+	// counted in ChangesTotal: a nonzero value means the command reported
+	// changes it did not apply. Distinct from the "skip" operation filtered out
+	// during change detection, which never reaches ChangesTotal.
+	SkippedChangesCount int64 `json:"skipped_changes_count,omitempty"`
+
 	// Variable-reference restoration counts for the two mechanisms that can
 	// write a current-target-scoped reference into a shared file (the source of
 	// the cross-target "reference does not exist" failures).


### PR DESCRIPTION
## Problem

`config-remote-sync` leaves a change unapplied when it cannot be attributed to a single source location. That is the right call — the command runs unattended, and a guessed location is worse than nothing. But every drop path is a `log.Debugf`, so there is no aggregate signal that it is happening at all.

## Solution

`ResolveChanges` returns the number of changes it left unapplied, and the command records it as `skipped_changes_count` on the sync telemetry event.

Only paths where a real user edit is discarded are counted: an unpaired rename, a rename whose element cannot be attributed to a block, and an ambiguous block. The `OperationRemove`-on-an-undefined-field path is deliberately excluded — a field absent from config has nothing to remove, so that drop is correct rather than a lost edit, and counting it would fire on ordinary runs.

`skipped_changes_count` counts a subset of `changes_total`: a nonzero value means the command reported changes it did not apply. It is distinct from the `skip` operation filtered out during change detection, which never reaches `changes_total`.

## Tests

No behaviour change, so no golden moves — the acceptance output is byte-identical to `main`. Covered indirectly: `split/keyed_rename` and `split/rename_two_removes_one_add` both exercise the counted paths.
