### PR TITLE
Support dots in target names when writing to an override block

### DIFF
--- a/acceptance/bundle/config-remote-sync/split/dotted_target/databricks.yml.tmpl
+++ b/acceptance/bundle/config-remote-sync/split/dotted_target/databricks.yml.tmpl
@@ -1,0 +1,24 @@
+bundle:
+  name: test-bundle-$UNIQUE_NAME
+
+# A target name may contain a dot. The write path to an override block is
+# targets.<target>.<field>, which is parsed back into segments, so a dotted name has to
+# be quoted or "dev.eu" becomes two keys and addresses a node that does not exist.
+resources:
+  jobs:
+    dotted_job:
+      tasks:
+        - task_key: main
+          max_retries: 1
+          notebook_task:
+            notebook_path: /Users/{{workspace_user_name}}/nb
+
+targets:
+  dev.eu:
+    mode: development
+    resources:
+      jobs:
+        dotted_job:
+          tasks:
+            - task_key: main
+              timeout_seconds: 45

--- a/acceptance/bundle/config-remote-sync/split/dotted_target/out.test.toml
+++ b/acceptance/bundle/config-remote-sync/split/dotted_target/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+GOOS.windows = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["direct", "terraform"]

--- a/acceptance/bundle/config-remote-sync/split/dotted_target/output.txt
+++ b/acceptance/bundle/config-remote-sync/split/dotted_target/output.txt
@@ -1,0 +1,33 @@
+Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev.eu/files...
+Deploying resources...
+Updating deployment state...
+Deployment complete!
+
+=== Edit a field in the override block of a target whose name contains a dot
+=== Sync
+Detected changes in 1 resource(s):
+
+Resource: resources.jobs.dotted_job
+  tasks[task_key='main'].timeout_seconds: replace
+
+
+
+=== The override block is updated
+
+>>> diff.py databricks.yml.backup databricks.yml
+--- databricks.yml.backup
++++ databricks.yml
+@@ -22,3 +22,3 @@
+           tasks:
+             - task_key: main
+-              timeout_seconds: 45
++              timeout_seconds: 900
+
+>>> [CLI] bundle destroy --auto-approve -t dev.eu
+The following resources will be deleted:
+  delete resources.jobs.dotted_job
+
+All files and directories at the following location will be deleted: /Workspace/Users/[USERNAME]/.bundle/test-bundle-[UNIQUE_NAME]/dev.eu
+
+Deleting files...
+Destroy complete!

--- a/acceptance/bundle/config-remote-sync/split/dotted_target/script
+++ b/acceptance/bundle/config-remote-sync/split/dotted_target/script
@@ -1,0 +1,22 @@
+#!/bin/bash
+envsubst < databricks.yml.tmpl > databricks.yml
+cleanup() { trace $CLI bundle destroy --auto-approve -t dev.eu; }
+trap cleanup EXIT
+$CLI bundle deploy -t dev.eu
+job_id="$(read_id.py -t dev.eu dotted_job)"
+
+title "Edit a field in the override block of a target whose name contains a dot"
+edit_resource.py jobs $job_id <<PYEDIT
+for task in r["tasks"]:
+    if task["task_key"] == "main":
+        task["timeout_seconds"] = 900
+PYEDIT
+
+title "Sync"
+echo
+cp databricks.yml databricks.yml.backup
+errcode $CLI bundle config-remote-sync -t dev.eu --save
+title "The override block is updated"
+echo
+trace diff.py databricks.yml.backup databricks.yml
+rm databricks.yml.backup

--- a/bundle/configsync/blockindex.go
+++ b/bundle/configsync/blockindex.go
@@ -157,11 +157,32 @@ func (r *blockResolver) regionPath(block sourceBlock, path dyn.Path) dyn.Path {
 
 // candidatePath renders a resolved path the way the patch layer addresses it,
 // which for an override block includes the targets.<target> prefix.
-func (r *blockResolver) candidatePath(block sourceBlock, path string) string {
+//
+// The prefix is built as path nodes rather than concatenated as text: a target name
+// may contain a dot ("dev.eu" is a legal name), and the result is parsed back into
+// segments, so text would split one name into two keys and address the wrong node.
+func (r *blockResolver) candidatePath(block sourceBlock, path *structpath.PatternNode) string {
 	if !block.override {
-		return path
+		return path.String()
 	}
-	return "targets." + r.target + "." + path
+	return targetPrefixedPath(r.target, path)
+}
+
+// targetPrefixedPath prefixes path with targets.<target>, quoting the target name
+// where necessary so the result parses back into the same segments.
+func targetPrefixedPath(target string, path *structpath.PatternNode) string {
+	prefixed := structpath.NewPatternStringKey(nil, "targets")
+	prefixed = structpath.NewPatternStringKey(prefixed, target)
+	for _, node := range path.AsSlice() {
+		if key, ok := node.StringKey(); ok {
+			prefixed = structpath.NewPatternStringKey(prefixed, key)
+		} else if index, ok := node.Index(); ok {
+			prefixed = structpath.NewPatternIndex(prefixed, index)
+		} else {
+			prefixed = structpath.NewPatternBracketStar(prefixed)
+		}
+	}
+	return prefixed.String()
 }
 
 // sortedBlocks lists the known blocks with the top-level ones first and a total

--- a/bundle/configsync/resolve.go
+++ b/bundle/configsync/resolve.go
@@ -342,7 +342,7 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 					result = append(result, FieldChange{
 						FilePath:        block.file,
 						Change:          destChange,
-						FieldCandidates: []string{blocks.candidatePath(block, mergedPath)},
+						FieldCandidates: []string{blocks.candidatePath(block, resolvedPath)},
 						mergedPath:      mergedPath,
 					})
 					continue
@@ -383,12 +383,11 @@ func ResolveChanges(ctx context.Context, b *bundle.Bundle, configChanges Changes
 				var candidates []string
 				if routed {
 					// The block is known, so there is exactly one path to write.
-					candidates = []string{blocks.candidatePath(block, resolvedPathStr)}
+					candidates = []string{blocks.candidatePath(block, resolvedPath)}
 				} else {
 					candidates = []string{resolvedPathStr}
 					if targetName != "" {
-						targetPrefixedPath := "targets." + targetName + "." + resolvedPathStr
-						candidates = append(candidates, targetPrefixedPath)
+						candidates = append(candidates, targetPrefixedPath(targetName, resolvedPath))
 					}
 				}
 


### PR DESCRIPTION
> Stacked on **#6138**. Based on its branch so this diff shows only the target-name fix; rebase onto `main` once #6138 merges.

## Problem

A target name may contain a dot — `targets: {dev.eu: ...}` passes `bundle validate` and deploys. But write-back addresses an override block by building `targets.<target>.<field>` as a **string**, which is then parsed back into path segments. A dotted name splits into two keys, so the write targets `/targets/dev/eu/...` and the command fails outright:

```
field not found in YAML configuration: op replace /targets/dev/eu/...: parent path /targets/dev does not exist
```

Pre-existing, not introduced by #6138: `main` fails the same way with a different message.

## Solution

Build the prefix as path nodes instead of concatenating text. `structpath.NewPatternStringKey` already switches to bracket notation for a name that is not a plain field, so `dev.eu` renders as `targets['dev.eu']` and round-trips as one key. Both the routed path and the unrouted fallback go through the same helper.

## Tests

`split/dotted_target` edits a field in the override block of a target named `dev.eu`. It fails on both engines without this change (non-zero exit, nothing written) and passes with it. No other golden changes.
