### PR TITLE
AIR CLI Migration: resolve usage_policy_name to a policy id

### DIFF
--- a/experimental/air/cmd/runconfig.go
+++ b/experimental/air/cmd/runconfig.go
@@ -31,6 +31,11 @@ var taskKeyRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 // exec args). Only safe ref characters are allowed.
 var gitRefRe = regexp.MustCompile(`^[\w./-]+$`)
 
+// Canonical UUID (8-4-4-4-12 hex). Usage policy ids are server-generated UUIDs,
+// so an obviously-wrong value (e.g. a policy name pasted into usage_policy_id)
+// is rejected up front with a hint pointing at usage_policy_name.
+var uuidRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
 // runConfig is the top-level run YAML schema: experiment_name + compute /
 // environment / code_source plus the command and run options.
 type runConfig struct {
@@ -164,8 +169,14 @@ func (c *runConfig) validate() error {
 			return fmt.Errorf("usage_policy_name must be at most 127 characters, got %d", len(v))
 		}
 	}
-	if c.UsagePolicyID != nil && strings.TrimSpace(*c.UsagePolicyID) == "" {
-		return errors.New("usage_policy_id must not be empty")
+	if c.UsagePolicyID != nil {
+		v := strings.TrimSpace(*c.UsagePolicyID)
+		if v == "" {
+			return errors.New("usage_policy_id must not be empty")
+		}
+		if !uuidRe.MatchString(v) {
+			return fmt.Errorf("usage_policy_id must be a UUID (for example, '12345678-90ab-cdef-1234-567890abcdef'), got: %s. To assign a policy by name instead, use usage_policy_name", v)
+		}
 	}
 
 	return nil

--- a/experimental/air/cmd/runconfig_test.go
+++ b/experimental/air/cmd/runconfig_test.go
@@ -243,7 +243,10 @@ func TestRunConfigValidate_FieldRules(t *testing.T) {
 			c.UsagePolicyID = str("id")
 		}, "mutually exclusive"},
 		{"empty usage_policy_id", func(c *runConfig) { c.UsagePolicyID = str("  ") }, "usage_policy_id must not be empty"},
-		{"usage_policy_id alone is ok", func(c *runConfig) { c.UsagePolicyID = str("policy-uuid") }, ""},
+		{"non-uuid usage_policy_id", func(c *runConfig) { c.UsagePolicyID = str("policy-uuid") }, "usage_policy_id must be a UUID"},
+		// A name pasted into the id field gets pointed at the right field.
+		{"policy name in usage_policy_id", func(c *runConfig) { c.UsagePolicyID = str("team-a") }, "use usage_policy_name"},
+		{"uuid usage_policy_id alone is ok", func(c *runConfig) { c.UsagePolicyID = str("12345678-90ab-cdef-1234-567890abcdef") }, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -112,9 +112,8 @@ func buildSubmitPayload(cfg *runConfig, commandPath, dlImage, usagePolicyID stri
 
 	return jobs.SubmitRun{
 		RunName: cfg.ExperimentName,
-		// budget_policy_id is the field the AI Runtime backend reads; the newer
-		// usage_policy_id alias on SubmitRun is not honored there yet, so send the
-		// same field the Python CLI does.
+		// budget_policy_id matches what the Python CLI and `ssh connect` send;
+		// usage_policy_id is the newer alias for the same thing on SubmitRun.
 		BudgetPolicyId: usagePolicyID,
 		TimeoutSeconds: cfg.timeoutSeconds(),
 		Tasks:          []jobs.SubmitTask{st},
@@ -146,7 +145,14 @@ func submitToken(flag string, cfg *runConfig) (string, error) {
 // upload the launch artifacts, assemble the Jobs payload, and submit it. It
 // returns the new run_id and its dashboard URL.
 func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig, configPath, idempotencyKey string) (int64, string, error) {
-	// Resolve the usage policy to its id up front, so a bad name fails fast with a
+	// Resolve the idempotency token first so a bad key fails before any upload,
+	// and before the policy lookup below spends a round trip on it.
+	token, err := submitToken(idempotencyKey, cfg)
+	if err != nil {
+		return 0, "", err
+	}
+
+	// Resolve the usage policy to its id next, so a bad name fails fast with a
 	// clear (caller-fixable) message before we upload any artifacts. Validation
 	// guarantees name and id are mutually exclusive: a literal id is used as-is, a
 	// name is resolved against the workspace.
@@ -155,17 +161,10 @@ func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *run
 		usagePolicyID = strings.TrimSpace(*cfg.UsagePolicyID)
 	}
 	if cfg.UsagePolicyName != nil {
-		id, err := resolveUsagePolicyIDByName(ctx, w, *cfg.UsagePolicyName)
+		usagePolicyID, err = resolveUsagePolicyIDByName(ctx, w, *cfg.UsagePolicyName)
 		if err != nil {
 			return 0, "", err
 		}
-		usagePolicyID = id
-	}
-
-	// Resolve the idempotency token first so a bad key fails before any upload.
-	token, err := submitToken(idempotencyKey, cfg)
-	if err != nil {
-		return 0, "", err
 	}
 
 	// Resolve dependencies before any upload too, so a bad requirements file fails

--- a/experimental/air/cmd/runsubmit.go
+++ b/experimental/air/cmd/runsubmit.go
@@ -2,7 +2,6 @@ package aircmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -61,6 +60,7 @@ func environmentDependencies(cfg *runConfig, configPath string) (deps []string, 
 
 // buildSubmitPayload assembles the runs/submit payload. commandPath is the
 // workspace path of the uploaded command.sh; dlImage is the runtime channel;
+// usagePolicyID is the already-resolved policy id ("" when the run has none);
 // deps is the user's declared dependencies (nil when none are declared).
 //
 // max_retries is always sent (including 0) so the user's YAML value is honored:
@@ -69,7 +69,7 @@ func environmentDependencies(cfg *runConfig, configPath string) (deps []string, 
 // omitempty so the wire form matches the Python CLI (which never emits a bare
 // "false"). Jobs performs the retries — each attempt is a fresh AI Runtime
 // workload.
-func buildSubmitPayload(cfg *runConfig, commandPath, dlImage string, snap snapshotResult, deps []string) jobs.SubmitRun {
+func buildSubmitPayload(cfg *runConfig, commandPath, dlImage, usagePolicyID string, snap snapshotResult, deps []string) jobs.SubmitRun {
 	task := jobs.AiRuntimeTask{
 		Experiment: cfg.ExperimentName,
 		Deployments: []jobs.DeploymentSpec{{
@@ -111,7 +111,11 @@ func buildSubmitPayload(cfg *runConfig, commandPath, dlImage string, snap snapsh
 	}
 
 	return jobs.SubmitRun{
-		RunName:        cfg.ExperimentName,
+		RunName: cfg.ExperimentName,
+		// budget_policy_id is the field the AI Runtime backend reads; the newer
+		// usage_policy_id alias on SubmitRun is not honored there yet, so send the
+		// same field the Python CLI does.
+		BudgetPolicyId: usagePolicyID,
 		TimeoutSeconds: cfg.timeoutSeconds(),
 		Tasks:          []jobs.SubmitTask{st},
 		Environments: []jobs.JobEnvironment{{
@@ -142,10 +146,20 @@ func submitToken(flag string, cfg *runConfig) (string, error) {
 // upload the launch artifacts, assemble the Jobs payload, and submit it. It
 // returns the new run_id and its dashboard URL.
 func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *runConfig, configPath, idempotencyKey string) (int64, string, error) {
-	// Resolving usage_policy_name to a budget policy id is not ported yet; reject
-	// rather than silently drop.
+	// Resolve the usage policy to its id up front, so a bad name fails fast with a
+	// clear (caller-fixable) message before we upload any artifacts. Validation
+	// guarantees name and id are mutually exclusive: a literal id is used as-is, a
+	// name is resolved against the workspace.
+	usagePolicyID := ""
+	if cfg.UsagePolicyID != nil {
+		usagePolicyID = strings.TrimSpace(*cfg.UsagePolicyID)
+	}
 	if cfg.UsagePolicyName != nil {
-		return 0, "", errors.New("usage_policy_name is not yet supported")
+		id, err := resolveUsagePolicyIDByName(ctx, w, *cfg.UsagePolicyName)
+		if err != nil {
+			return 0, "", err
+		}
+		usagePolicyID = id
 	}
 
 	// Resolve the idempotency token first so a bad key fails before any upload.
@@ -209,7 +223,7 @@ func submitWorkload(ctx context.Context, w *databricks.WorkspaceClient, cfg *run
 	if !ok {
 		runtimeVersion = fileVersion
 	}
-	payload := buildSubmitPayload(cfg, path.Join(funcDir, commandScriptName), dlRuntimeImage(ctx, runtimeVersion), snap, deps)
+	payload := buildSubmitPayload(cfg, path.Join(funcDir, commandScriptName), dlRuntimeImage(ctx, runtimeVersion), usagePolicyID, snap, deps)
 	payload.IdempotencyToken = token
 
 	// Submit returns as soon as the run is created; we don't wait for it to finish.

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -42,10 +42,12 @@ func TestBuildSubmitPayload(t *testing.T) {
 		MLflowExperimentDirectory: new("/Workspace/Users/me/exp"),
 	}
 
-	p := buildSubmitPayload(cfg, "/d/command.sh", "5", snapshotResult{}, nil)
+	p := buildSubmitPayload(cfg, "/d/command.sh", "5", "", snapshotResult{}, nil)
 
 	assert.Equal(t, "exp", p.RunName)
 	assert.Equal(t, 1800, p.TimeoutSeconds)
+	// No policy configured: the field stays empty and is omitted from the wire form.
+	assert.Empty(t, p.BudgetPolicyId)
 	require.Len(t, p.Environments, 1)
 	assert.Equal(t, aiRuntimeEnvironmentKey, p.Environments[0].EnvironmentKey)
 	require.NotNil(t, p.Environments[0].Spec)
@@ -77,7 +79,7 @@ func TestBuildSubmitPayloadDefaultRetries(t *testing.T) {
 		Command:        new("x"),
 		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
 	}
-	task := buildSubmitPayload(cfg, "/d/command.sh", "4", snapshotResult{}, nil).Tasks[0]
+	task := buildSubmitPayload(cfg, "/d/command.sh", "4", "", snapshotResult{}, nil).Tasks[0]
 	assert.Equal(t, defaultMaxRetries, task.MaxRetries)
 	assert.True(t, task.RetryOnTimeout)
 }
@@ -92,7 +94,7 @@ func TestBuildSubmitPayloadNoRetries(t *testing.T) {
 		Compute:        &computeConfig{AcceleratorType: "GPU_1xH100", NumAccelerators: 1},
 		MaxRetries:     new(0),
 	}
-	task := buildSubmitPayload(cfg, "/d/command.sh", "4", snapshotResult{}, nil).Tasks[0]
+	task := buildSubmitPayload(cfg, "/d/command.sh", "4", "", snapshotResult{}, nil).Tasks[0]
 	assert.Equal(t, 0, task.MaxRetries)
 	assert.False(t, task.RetryOnTimeout)
 
@@ -113,13 +115,13 @@ func TestBuildSubmitPayloadInlineDependencies(t *testing.T) {
 	}
 
 	deps := []string{"torch==2.3.0", "--extra-index-url https://internal/pypi", "numpy"}
-	spec := buildSubmitPayload(cfg, "/d/command.sh", "5", snapshotResult{}, deps).Environments[0].Spec
+	spec := buildSubmitPayload(cfg, "/d/command.sh", "5", "", snapshotResult{}, deps).Environments[0].Spec
 	assert.Equal(t, deps, spec.Dependencies)
 	assert.Equal(t, "5", spec.EnvironmentVersion)
 
 	// The SDK marshaler drops empty/nil slices, so no "dependencies" key is emitted.
 	for _, empty := range [][]string{{}, nil} {
-		spec = buildSubmitPayload(cfg, "/d/command.sh", "5", snapshotResult{}, empty).Environments[0].Spec
+		spec = buildSubmitPayload(cfg, "/d/command.sh", "5", "", snapshotResult{}, empty).Environments[0].Spec
 		b, err := json.Marshal(spec)
 		require.NoError(t, err)
 		assert.NotContains(t, string(b), "dependencies")
@@ -557,16 +559,63 @@ code_source:
 }
 
 func TestSubmitWorkloadGuards(t *testing.T) {
-	w := newFakeWorkspaceClient(t)
 	cfgPath := writeConfigFile(t, "run.yaml", minimalConfig)
 	base, err := loadRunConfig(cfgPath)
 	require.NoError(t, err)
 
-	t.Run("usage_policy_name rejected", func(t *testing.T) {
+	t.Run("unresolvable usage_policy_name fails before upload", func(t *testing.T) {
+		// An empty policy list makes the name unresolvable; the error must surface
+		// before any artifact upload.
+		pw, _ := policyServer(t, usagePoliciesResponse{})
 		cfg := *base
-		cfg.UsagePolicyName = new("p")
-		_, _, err := submitWorkload(t.Context(), w, &cfg, cfgPath, "")
-		require.ErrorContains(t, err, "usage_policy_name is not yet supported")
+		cfg.UsagePolicyName = new("nope")
+		_, _, err := submitWorkload(t.Context(), pw, &cfg, cfgPath, "")
+		require.ErrorContains(t, err, `no usage policy named "nope"`)
+	})
+}
+
+// The resolved policy id must reach the submit payload, by literal id and by name.
+func TestSubmitWorkloadSendsUsagePolicy(t *testing.T) {
+	const policyID = "12345678-90ab-cdef-1234-567890abcdef"
+
+	setup := func(t *testing.T) (*databricks.WorkspaceClient, *jobs.SubmitRun) {
+		server := testserver.New(t)
+		t.Cleanup(server.Close)
+
+		got := &jobs.SubmitRun{}
+		server.Handle("POST", "/api/2.2/jobs/runs/submit", func(req testserver.Request) any {
+			require.NoError(t, json.Unmarshal(req.Body, got))
+			return jobs.SubmitRunResponse{RunId: 1}
+		})
+		server.Handle("GET", "/api/2.0/serverless-policies", func(req testserver.Request) any {
+			return usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: policyID, PolicyName: "team-a"}}}
+		})
+		testserver.AddDefaultHandlers(server)
+		w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
+		require.NoError(t, err)
+		return w, got
+	}
+
+	t.Run("literal id", func(t *testing.T) {
+		w, got := setup(t)
+		cfgPath := writeConfigFile(t, "run.yaml", minimalConfig+"usage_policy_id: "+policyID+"\n")
+		cfg, err := loadRunConfig(cfgPath)
+		require.NoError(t, err)
+
+		_, _, err = submitWorkload(cmdio.MockDiscard(t.Context()), w, cfg, cfgPath, "idem")
+		require.NoError(t, err)
+		assert.Equal(t, policyID, got.BudgetPolicyId)
+	})
+
+	t.Run("resolved from name", func(t *testing.T) {
+		w, got := setup(t)
+		cfgPath := writeConfigFile(t, "run.yaml", minimalConfig+"usage_policy_name: team-a\n")
+		cfg, err := loadRunConfig(cfgPath)
+		require.NoError(t, err)
+
+		_, _, err = submitWorkload(cmdio.MockDiscard(t.Context()), w, cfg, cfgPath, "idem")
+		require.NoError(t, err)
+		assert.Equal(t, policyID, got.BudgetPolicyId)
 	})
 
 	t.Run("bad requirements file fails before any upload", func(t *testing.T) {

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -590,6 +590,25 @@ func TestSubmitWorkloadGuards(t *testing.T) {
 			assert.NotContains(t, p, "/workspace/", "no workspace write may precede policy resolution")
 		}
 	})
+
+	t.Run("bad requirements file fails before any upload", func(t *testing.T) {
+		server := testserver.New(t)
+		t.Cleanup(server.Close)
+		var uploaded bool
+		server.Handle("POST", "/api/2.0/workspace-files/import-file/{path...}", func(testserver.Request) any {
+			uploaded = true
+			return nil
+		})
+		testserver.AddDefaultHandlers(server)
+		tw, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
+		require.NoError(t, err)
+
+		cfg := *base
+		cfg.Environment = &environmentConfig{Dependencies: dependencies{set: true, isList: false, path: "missing.yaml"}}
+		_, _, err = submitWorkload(t.Context(), tw, &cfg, cfgPath, "")
+		require.ErrorContains(t, err, "failed to read requirements file")
+		assert.False(t, uploaded, "no artifacts should be uploaded when dependency resolution fails")
+	})
 }
 
 // The resolved policy id must reach the submit payload, by literal id and by name.
@@ -634,24 +653,5 @@ func TestSubmitWorkloadSendsUsagePolicy(t *testing.T) {
 		_, _, err = submitWorkload(cmdio.MockDiscard(t.Context()), w, cfg, cfgPath, "idem")
 		require.NoError(t, err)
 		assert.Equal(t, policyID, got.BudgetPolicyId)
-	})
-
-	t.Run("bad requirements file fails before any upload", func(t *testing.T) {
-		server := testserver.New(t)
-		t.Cleanup(server.Close)
-		var uploaded bool
-		server.Handle("POST", "/api/2.0/workspace-files/import-file/{path...}", func(testserver.Request) any {
-			uploaded = true
-			return nil
-		})
-		testserver.AddDefaultHandlers(server)
-		tw, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
-		require.NoError(t, err)
-
-		cfg := *base
-		cfg.Environment = &environmentConfig{Dependencies: dependencies{set: true, isList: false, path: "missing.yaml"}}
-		_, _, err = submitWorkload(t.Context(), tw, &cfg, cfgPath, "")
-		require.ErrorContains(t, err, "failed to read requirements file")
-		assert.False(t, uploaded, "no artifacts should be uploaded when dependency resolution fails")
 	})
 }

--- a/experimental/air/cmd/runsubmit_test.go
+++ b/experimental/air/cmd/runsubmit_test.go
@@ -564,13 +564,31 @@ func TestSubmitWorkloadGuards(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("unresolvable usage_policy_name fails before upload", func(t *testing.T) {
-		// An empty policy list makes the name unresolvable; the error must surface
-		// before any artifact upload.
-		pw, _ := policyServer(t, usagePoliciesResponse{})
+		// An empty policy list makes the name unresolvable. Record every path the
+		// server sees so the "fails before any upload" ordering is asserted, not just
+		// asserted-by-comment: no import/mkdirs request may be made.
+		server := testserver.New(t)
+		t.Cleanup(server.Close)
+		var paths []string
+		server.Handle("GET", "/api/2.0/serverless-policies", func(req testserver.Request) any {
+			paths = append(paths, req.URL.Path)
+			return usagePoliciesResponse{}
+		})
+		server.Handle("POST", "/api/2.0/workspace/{path...}", func(req testserver.Request) any {
+			paths = append(paths, req.URL.Path)
+			return testserver.Response{StatusCode: 200}
+		})
+		testserver.AddDefaultHandlers(server)
+		pw, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
+		require.NoError(t, err)
+
 		cfg := *base
 		cfg.UsagePolicyName = new("nope")
-		_, _, err := submitWorkload(t.Context(), pw, &cfg, cfgPath, "")
+		_, _, err = submitWorkload(t.Context(), pw, &cfg, cfgPath, "")
 		require.ErrorContains(t, err, `no usage policy named "nope"`)
+		for _, p := range paths {
+			assert.NotContains(t, p, "/workspace/", "no workspace write may precede policy resolution")
+		}
 	})
 }
 

--- a/experimental/air/cmd/usagepolicy.go
+++ b/experimental/air/cmd/usagepolicy.go
@@ -37,9 +37,9 @@ type usagePoliciesResponse struct {
 	NextPageToken string        `json:"next_page_token"`
 }
 
-// listUsagePolicies pages the serverless-policy index and returns every policy
-// the caller can see. When policyName is non-empty it is sent as
-// filter_by.policy_name, a partial case-insensitive server-side filter.
+// listUsagePolicies pages the serverless-policy index for policies matching
+// policyName, which is sent as filter_by.policy_name: a partial,
+// case-insensitive server-side filter. Callers must pass a non-empty name.
 //
 // The filter key is spelled with its dotted proto path rather than as a nested
 // map: the SDK only flattens nesting for struct-typed query values, and would
@@ -51,11 +51,16 @@ func listUsagePolicies(ctx context.Context, w *databricks.WorkspaceClient, polic
 	}
 
 	var out []usagePolicy
+	// The index can return the same policy on more than one page, and a stuck or
+	// cycling cursor can repeat a whole page; dedupe both so an unambiguous name
+	// never looks like an ambiguous match downstream.
+	seenIDs := map[string]bool{}
+	seenTokens := map[string]bool{}
 	var pageToken string
 	for {
-		query := map[string]any{"page_size": maxPolicyPageSize}
-		if policyName != "" {
-			query["filter_by.policy_name"] = policyName
+		query := map[string]any{
+			"page_size":             maxPolicyPageSize,
+			"filter_by.policy_name": policyName,
 		}
 		if pageToken != "" {
 			query["page_token"] = pageToken
@@ -67,10 +72,18 @@ func listUsagePolicies(ctx context.Context, w *databricks.WorkspaceClient, polic
 			return nil, fmt.Errorf("failed to list usage policies: %w", err)
 		}
 
-		out = append(out, resp.Policies...)
-		if resp.NextPageToken == "" || resp.NextPageToken == pageToken {
+		for _, p := range resp.Policies {
+			if seenIDs[p.PolicyID] {
+				continue
+			}
+			seenIDs[p.PolicyID] = true
+			out = append(out, p)
+		}
+
+		if resp.NextPageToken == "" || seenTokens[resp.NextPageToken] {
 			return out, nil
 		}
+		seenTokens[resp.NextPageToken] = true
 		pageToken = resp.NextPageToken
 	}
 }
@@ -81,9 +94,8 @@ func listUsagePolicies(ctx context.Context, w *databricks.WorkspaceClient, polic
 // match is re-applied locally; policy names are unique among active policies.
 func resolveUsagePolicyIDByName(ctx context.Context, w *databricks.WorkspaceClient, name string) (string, error) {
 	target := strings.TrimSpace(name)
-	// Guard the contract independently of the YAML validator: an empty name would
-	// otherwise drop the server-side filter and list (then reject against) every
-	// policy in the workspace.
+	// Guard the contract independently of the YAML validator: an empty filter would
+	// otherwise list (then reject against) every policy in the workspace.
 	if target == "" {
 		return "", errors.New("a usage policy name must be a non-empty string")
 	}

--- a/experimental/air/cmd/usagepolicy.go
+++ b/experimental/air/cmd/usagepolicy.go
@@ -27,6 +27,11 @@ const maxPolicyPageSize = 1000
 // error: enough to spot a typo or casing mistake without dumping a huge list.
 const maxPolicySuggestions = 10
 
+// usagePolicy models only the two fields resolution needs. The API also returns
+// display_name, which is deliberately not read: policy_name is the unique key
+// (unique among active policies) and the only field filter_by can match on. The
+// two are identical for user-created policies and diverge only for the system
+// defaults, whose display_name is fixed to "Default Policy".
 type usagePolicy struct {
 	PolicyID   string `json:"policy_id"`
 	PolicyName string `json:"policy_name"`
@@ -92,6 +97,11 @@ func listUsagePolicies(ctx context.Context, w *databricks.WorkspaceClient, polic
 //
 // The server-side filter is a partial match, so the exact (but case-insensitive)
 // match is re-applied locally; policy names are unique among active policies.
+//
+// name is matched against policy_name, not the policy's display_name. For a
+// user-created policy the two are the same, so the distinction only surfaces for
+// the system defaults; a user who supplies a display name that isn't a
+// policy_name gets the not-found error with the real names as candidates.
 func resolveUsagePolicyIDByName(ctx context.Context, w *databricks.WorkspaceClient, name string) (string, error) {
 	target := strings.TrimSpace(name)
 	// Guard the contract independently of the YAML validator: an empty filter would
@@ -121,7 +131,10 @@ func resolveUsagePolicyIDByName(ctx context.Context, w *databricks.WorkspaceClie
 
 	case 0:
 		// policies holds the partial-match candidates the server returned for this
-		// name; surface a few to help the user fix a typo or casing.
+		// name; surface a few to help the user fix a typo or casing. These are
+		// policy_name values, which is also what a user who typed a policy's UI
+		// display name needs to see: the two differ only for the system default
+		// policies, so listing the real names points them at the right one.
 		return "", fmt.Errorf("no usage policy named %q was found in this workspace%s", target, suggestionHint(policies))
 
 	default:

--- a/experimental/air/cmd/usagepolicy.go
+++ b/experimental/air/cmd/usagepolicy.go
@@ -1,0 +1,153 @@
+package aircmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/client"
+)
+
+// serverlessPoliciesPath is the workspace-scoped ListBudgetPolicies endpoint on
+// the serverless-policy service. This is called with a raw client.Do because the
+// SDK only models the account-scoped /api/2.1/accounts/{id}/budget-policies
+// service, which is a different (and unusable here) endpoint.
+const serverlessPoliciesPath = "/api/2.0/serverless-policies"
+
+// maxPolicyPageSize is the server's cap: anything larger is coerced down to it.
+// Request the max so the common case (a workspace with a handful of policies) is
+// a single round-trip.
+const maxPolicyPageSize = 1000
+
+// maxPolicySuggestions bounds the candidate names surfaced in a "no exact match"
+// error: enough to spot a typo or casing mistake without dumping a huge list.
+const maxPolicySuggestions = 10
+
+type usagePolicy struct {
+	PolicyID   string `json:"policy_id"`
+	PolicyName string `json:"policy_name"`
+}
+
+type usagePoliciesResponse struct {
+	Policies      []usagePolicy `json:"policies"`
+	NextPageToken string        `json:"next_page_token"`
+}
+
+// listUsagePolicies pages the serverless-policy index and returns every policy
+// the caller can see. When policyName is non-empty it is sent as
+// filter_by.policy_name, a partial case-insensitive server-side filter.
+//
+// The filter key is spelled with its dotted proto path rather than as a nested
+// map: the SDK only flattens nesting for struct-typed query values, and would
+// format a nested map with %v into a useless "map[...]" literal.
+func listUsagePolicies(ctx context.Context, w *databricks.WorkspaceClient, policyName string) ([]usagePolicy, error) {
+	apiClient, err := client.New(w.Config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create API client: %w", err)
+	}
+
+	var out []usagePolicy
+	var pageToken string
+	for {
+		query := map[string]any{"page_size": maxPolicyPageSize}
+		if policyName != "" {
+			query["filter_by.policy_name"] = policyName
+		}
+		if pageToken != "" {
+			query["page_token"] = pageToken
+		}
+
+		var resp usagePoliciesResponse
+		err = apiClient.Do(ctx, http.MethodGet, serverlessPoliciesPath, nil, nil, query, &resp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list usage policies: %w", err)
+		}
+
+		out = append(out, resp.Policies...)
+		if resp.NextPageToken == "" || resp.NextPageToken == pageToken {
+			return out, nil
+		}
+		pageToken = resp.NextPageToken
+	}
+}
+
+// resolveUsagePolicyIDByName resolves a usage policy name to its UUID policy id.
+//
+// The server-side filter is a partial match, so the exact (but case-insensitive)
+// match is re-applied locally; policy names are unique among active policies.
+func resolveUsagePolicyIDByName(ctx context.Context, w *databricks.WorkspaceClient, name string) (string, error) {
+	target := strings.TrimSpace(name)
+	// Guard the contract independently of the YAML validator: an empty name would
+	// otherwise drop the server-side filter and list (then reject against) every
+	// policy in the workspace.
+	if target == "" {
+		return "", errors.New("a usage policy name must be a non-empty string")
+	}
+
+	policies, err := listUsagePolicies(ctx, w, target)
+	if err != nil {
+		return "", err
+	}
+
+	var matches []usagePolicy
+	for _, p := range policies {
+		if strings.EqualFold(strings.TrimSpace(p.PolicyName), target) {
+			matches = append(matches, p)
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		if matches[0].PolicyID == "" {
+			return "", fmt.Errorf("policy %q has no policy_id in the API response", target)
+		}
+		return matches[0].PolicyID, nil
+
+	case 0:
+		// policies holds the partial-match candidates the server returned for this
+		// name; surface a few to help the user fix a typo or casing.
+		return "", fmt.Errorf("no usage policy named %q was found in this workspace%s", target, suggestionHint(policies))
+
+	default:
+		// Multiple exact (case-insensitive) matches should not happen given name
+		// uniqueness, but guard so we never silently pick the wrong policy.
+		ids := make([]string, 0, len(matches))
+		for _, p := range matches {
+			ids = append(ids, fmt.Sprintf("%q", p.PolicyID))
+		}
+		return "", fmt.Errorf("multiple usage policies match the name %q (ids: %s); please disambiguate with your workspace admin",
+			target, strings.Join(ids, ", "))
+	}
+}
+
+// suggestionHint renders a deduplicated, sorted "did you mean" clause for the
+// candidates the partial filter returned, or "" when there are none.
+func suggestionHint(candidates []usagePolicy) string {
+	names := make([]string, 0, len(candidates))
+	for _, p := range candidates {
+		if p.PolicyName != "" {
+			names = append(names, p.PolicyName)
+		}
+	}
+	slices.Sort(names)
+	names = slices.Compact(names)
+	if len(names) == 0 {
+		return ""
+	}
+
+	shown := names
+	suffix := ""
+	if len(names) > maxPolicySuggestions {
+		shown = names[:maxPolicySuggestions]
+		suffix = ", ..."
+	}
+	quoted := make([]string, 0, len(shown))
+	for _, n := range shown {
+		quoted = append(quoted, fmt.Sprintf("%q", n))
+	}
+	return fmt.Sprintf(". Did you mean one of: %s%s?", strings.Join(quoted, ", "), suffix)
+}

--- a/experimental/air/cmd/usagepolicy_test.go
+++ b/experimental/air/cmd/usagepolicy_test.go
@@ -193,4 +193,35 @@ func TestResolveUsagePolicyIDByName(t *testing.T) {
 		require.ErrorContains(t, err, "must be a non-empty string")
 		assert.Empty(t, *queries)
 	})
+
+	// A failed lookup must surface, never fall through to an empty (= no policy) id.
+	t.Run("api error surfaces", func(t *testing.T) {
+		server := testserver.New(t)
+		t.Cleanup(server.Close)
+		server.Handle("GET", "/api/2.0/serverless-policies", func(req testserver.Request) any {
+			return testserver.Response{StatusCode: 403, Body: `{"error_code":"PERMISSION_DENIED","message":"nope"}`}
+		})
+		testserver.AddDefaultHandlers(server)
+		w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
+		require.NoError(t, err)
+
+		_, err = resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.ErrorContains(t, err, "failed to list usage policies")
+	})
+}
+
+// The --override path re-decodes and re-validates the config, so the policy rules
+// must hold there too and not just for fields set in the YAML file.
+func TestOverrideUsagePolicyValidation(t *testing.T) {
+	t.Run("override trips mutual exclusion", func(t *testing.T) {
+		cfgPath := writeConfigFile(t, "run.yaml", minimalConfig+"usage_policy_id: 12345678-90ab-cdef-1234-567890abcdef\n")
+		_, err := loadRunConfigWithOverrides(t.Context(), cfgPath, []string{"usage_policy_name=team-a"})
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("override id is UUID-checked", func(t *testing.T) {
+		cfgPath := writeConfigFile(t, "run.yaml", minimalConfig)
+		_, err := loadRunConfigWithOverrides(t.Context(), cfgPath, []string{"usage_policy_id=team-a"})
+		require.ErrorContains(t, err, "must be a UUID")
+	})
 }

--- a/experimental/air/cmd/usagepolicy_test.go
+++ b/experimental/air/cmd/usagepolicy_test.go
@@ -47,23 +47,13 @@ func TestListUsagePoliciesSendsFilterAndPageSize(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(maxPolicyPageSize), q.Get("page_size"))
 }
 
-func TestListUsagePoliciesOmitsFilterWhenNoName(t *testing.T) {
-	w, queries := policyServer(t, usagePoliciesResponse{})
-
-	_, err := listUsagePolicies(t.Context(), w, "")
-	require.NoError(t, err)
-
-	require.Len(t, *queries, 1)
-	assert.Empty(t, (*queries)[0].Get("filter_by.policy_name"))
-}
-
 func TestListUsagePoliciesPaginates(t *testing.T) {
 	w, queries := policyServer(t,
 		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "a"}}, NextPageToken: "tok"},
 		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-2", PolicyName: "b"}}},
 	)
 
-	policies, err := listUsagePolicies(t.Context(), w, "")
+	policies, err := listUsagePolicies(t.Context(), w, "a")
 	require.NoError(t, err)
 	assert.Equal(t, []usagePolicy{
 		{PolicyID: "id-1", PolicyName: "a"},
@@ -74,17 +64,52 @@ func TestListUsagePoliciesPaginates(t *testing.T) {
 	assert.Equal(t, "tok", (*queries)[1].Get("page_token"))
 }
 
-// A page token that repeats itself must not spin forever.
+// A page token that repeats itself must not spin forever, and the repeated page
+// must not be counted twice: a duplicated policy would otherwise look like an
+// ambiguous name to resolveUsagePolicyIDByName.
 func TestListUsagePoliciesStopsOnRepeatedToken(t *testing.T) {
 	w, _ := policyServer(t, usagePoliciesResponse{
 		Policies:      []usagePolicy{{PolicyID: "id-1", PolicyName: "a"}},
 		NextPageToken: "same",
 	})
 
-	policies, err := listUsagePolicies(t.Context(), w, "")
+	policies, err := listUsagePolicies(t.Context(), w, "a")
 	require.NoError(t, err)
-	// Second response repeats "same", which ends the loop.
-	assert.Len(t, policies, 2)
+	assert.Equal(t, []usagePolicy{{PolicyID: "id-1", PolicyName: "a"}}, policies)
+}
+
+// An A->B->A token cycle also terminates, rather than only a self-repeat.
+func TestListUsagePoliciesStopsOnTokenCycle(t *testing.T) {
+	w, _ := policyServer(t,
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "a"}}, NextPageToken: "b"},
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-2", PolicyName: "b"}}, NextPageToken: "a"},
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-3", PolicyName: "c"}}, NextPageToken: "b"},
+	)
+
+	policies, err := listUsagePolicies(t.Context(), w, "a")
+	require.NoError(t, err)
+	assert.Len(t, policies, 3)
+}
+
+// The same policy arriving on two pages is returned once.
+func TestListUsagePoliciesDedupesAcrossPages(t *testing.T) {
+	w, _ := policyServer(t,
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "team-a"}}, NextPageToken: "tok"},
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "team-a"}}},
+	)
+
+	policies, err := listUsagePolicies(t.Context(), w, "team-a")
+	require.NoError(t, err)
+	assert.Equal(t, []usagePolicy{{PolicyID: "id-1", PolicyName: "team-a"}}, policies)
+
+	// A repeat must not read as an ambiguous match.
+	w2, _ := policyServer(t,
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "team-a"}}, NextPageToken: "tok"},
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "team-a"}}},
+	)
+	got, err := resolveUsagePolicyIDByName(t.Context(), w2, "team-a")
+	require.NoError(t, err)
+	assert.Equal(t, "id-1", got)
 }
 
 func TestResolveUsagePolicyIDByName(t *testing.T) {
@@ -160,8 +185,8 @@ func TestResolveUsagePolicyIDByName(t *testing.T) {
 		require.ErrorContains(t, err, "has no policy_id")
 	})
 
-	// An empty name would drop the server-side filter and list every policy in the
-	// workspace, so it is rejected without a round-trip.
+	// An empty filter would list every policy in the workspace, so a blank name is
+	// rejected without a round-trip.
 	t.Run("blank name is rejected", func(t *testing.T) {
 		w, queries := policyServer(t, usagePoliciesResponse{})
 		_, err := resolveUsagePolicyIDByName(t.Context(), w, "   ")

--- a/experimental/air/cmd/usagepolicy_test.go
+++ b/experimental/air/cmd/usagepolicy_test.go
@@ -1,0 +1,171 @@
+package aircmd
+
+import (
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/databricks/cli/libs/testserver"
+	"github.com/databricks/databricks-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// policyServer serves /api/2.0/serverless-policies from the given pages,
+// returning one page per request and recording each request's query.
+func policyServer(t *testing.T, pages ...usagePoliciesResponse) (*databricks.WorkspaceClient, *[]url.Values) {
+	server := testserver.New(t)
+	t.Cleanup(server.Close)
+
+	var queries []url.Values
+	var n int
+	server.Handle("GET", "/api/2.0/serverless-policies", func(req testserver.Request) any {
+		queries = append(queries, req.URL.Query())
+		page := pages[min(n, len(pages)-1)]
+		n++
+		return page
+	})
+	testserver.AddDefaultHandlers(server)
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{Host: server.URL, Token: "token"})
+	require.NoError(t, err)
+	return w, &queries
+}
+
+func TestListUsagePoliciesSendsFilterAndPageSize(t *testing.T) {
+	w, queries := policyServer(t, usagePoliciesResponse{
+		Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "alpha"}},
+	})
+
+	policies, err := listUsagePolicies(t.Context(), w, "alpha")
+	require.NoError(t, err)
+	assert.Equal(t, []usagePolicy{{PolicyID: "id-1", PolicyName: "alpha"}}, policies)
+
+	require.Len(t, *queries, 1)
+	q := (*queries)[0]
+	// The filter must arrive under its flattened proto path, not as a nested map.
+	assert.Equal(t, "alpha", q.Get("filter_by.policy_name"))
+	assert.Equal(t, strconv.Itoa(maxPolicyPageSize), q.Get("page_size"))
+}
+
+func TestListUsagePoliciesOmitsFilterWhenNoName(t *testing.T) {
+	w, queries := policyServer(t, usagePoliciesResponse{})
+
+	_, err := listUsagePolicies(t.Context(), w, "")
+	require.NoError(t, err)
+
+	require.Len(t, *queries, 1)
+	assert.Empty(t, (*queries)[0].Get("filter_by.policy_name"))
+}
+
+func TestListUsagePoliciesPaginates(t *testing.T) {
+	w, queries := policyServer(t,
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-1", PolicyName: "a"}}, NextPageToken: "tok"},
+		usagePoliciesResponse{Policies: []usagePolicy{{PolicyID: "id-2", PolicyName: "b"}}},
+	)
+
+	policies, err := listUsagePolicies(t.Context(), w, "")
+	require.NoError(t, err)
+	assert.Equal(t, []usagePolicy{
+		{PolicyID: "id-1", PolicyName: "a"},
+		{PolicyID: "id-2", PolicyName: "b"},
+	}, policies)
+
+	require.Len(t, *queries, 2)
+	assert.Equal(t, "tok", (*queries)[1].Get("page_token"))
+}
+
+// A page token that repeats itself must not spin forever.
+func TestListUsagePoliciesStopsOnRepeatedToken(t *testing.T) {
+	w, _ := policyServer(t, usagePoliciesResponse{
+		Policies:      []usagePolicy{{PolicyID: "id-1", PolicyName: "a"}},
+		NextPageToken: "same",
+	})
+
+	policies, err := listUsagePolicies(t.Context(), w, "")
+	require.NoError(t, err)
+	// Second response repeats "same", which ends the loop.
+	assert.Len(t, policies, 2)
+}
+
+func TestResolveUsagePolicyIDByName(t *testing.T) {
+	const id = "12345678-90ab-cdef-1234-567890abcdef"
+
+	t.Run("exact match", func(t *testing.T) {
+		w, _ := policyServer(t, usagePoliciesResponse{
+			Policies: []usagePolicy{{PolicyID: id, PolicyName: "team-a"}},
+		})
+		got, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.NoError(t, err)
+		assert.Equal(t, id, got)
+	})
+
+	// The server filter is partial; only the exact name (case-insensitively) wins.
+	t.Run("case-insensitive exact match wins over partial", func(t *testing.T) {
+		w, _ := policyServer(t, usagePoliciesResponse{
+			Policies: []usagePolicy{
+				{PolicyID: "other", PolicyName: "team-a-staging"},
+				{PolicyID: id, PolicyName: "Team-A"},
+			},
+		})
+		got, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.NoError(t, err)
+		assert.Equal(t, id, got)
+	})
+
+	t.Run("no match suggests candidates", func(t *testing.T) {
+		w, _ := policyServer(t, usagePoliciesResponse{
+			Policies: []usagePolicy{{PolicyID: "x", PolicyName: "team-a-staging"}},
+		})
+		_, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.ErrorContains(t, err, `no usage policy named "team-a"`)
+		require.ErrorContains(t, err, `Did you mean one of: "team-a-staging"?`)
+	})
+
+	t.Run("no match and no candidates omits the hint", func(t *testing.T) {
+		w, _ := policyServer(t, usagePoliciesResponse{})
+		_, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.ErrorContains(t, err, `no usage policy named "team-a"`)
+		assert.NotContains(t, err.Error(), "Did you mean")
+	})
+
+	t.Run("suggestions are capped", func(t *testing.T) {
+		var policies []usagePolicy
+		for i := range maxPolicySuggestions + 5 {
+			// Zero-padded so lexical order matches numeric order.
+			policies = append(policies, usagePolicy{PolicyID: strconv.Itoa(i), PolicyName: "team-a-" + strconv.Itoa(100+i)})
+		}
+		w, _ := policyServer(t, usagePoliciesResponse{Policies: policies})
+		_, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.ErrorContains(t, err, `"team-a-109", ...?`)
+		assert.NotContains(t, err.Error(), "team-a-110")
+	})
+
+	t.Run("ambiguous match refuses to guess", func(t *testing.T) {
+		w, _ := policyServer(t, usagePoliciesResponse{
+			Policies: []usagePolicy{
+				{PolicyID: "id-1", PolicyName: "team-a"},
+				{PolicyID: "id-2", PolicyName: "TEAM-A"},
+			},
+		})
+		_, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.ErrorContains(t, err, "multiple usage policies match")
+		require.ErrorContains(t, err, `"id-1", "id-2"`)
+	})
+
+	t.Run("match without an id is an error", func(t *testing.T) {
+		w, _ := policyServer(t, usagePoliciesResponse{
+			Policies: []usagePolicy{{PolicyName: "team-a"}},
+		})
+		_, err := resolveUsagePolicyIDByName(t.Context(), w, "team-a")
+		require.ErrorContains(t, err, "has no policy_id")
+	})
+
+	// An empty name would drop the server-side filter and list every policy in the
+	// workspace, so it is rejected without a round-trip.
+	t.Run("blank name is rejected", func(t *testing.T) {
+		w, queries := policyServer(t, usagePoliciesResponse{})
+		_, err := resolveUsagePolicyIDByName(t.Context(), w, "   ")
+		require.ErrorContains(t, err, "must be a non-empty string")
+		assert.Empty(t, *queries)
+	})
+}


### PR DESCRIPTION
## Changes & Why 
usage_policy_id was also validated and then silently dropped: nothing wired it into the runs/submit payload. Both paths now populate budget_policy_id, the field the AI Runtime backend reads (matching the Python CLI).

The resolver pages GET /api/2.0/serverless-policies with the partial, case-insensitive filter_by.policy_name filter, then re-applies an exact case-insensitive match locally. Not-found errors list candidate names; an ambiguous match refuses to guess rather than pick the wrong policy. Resolution happens before any artifact upload so a bad name fails fast.

Also ports the UUID-shape check on usage_policy_id, so a policy name pasted into the id field gets an error pointing at usage_policy_name.

## Tests
Unit tests: usagepolicy_test.go (new)
- Wire format: filter_by.policy_name arrives as a flattened dotted key (not a nested map), page_size=1000
- Pagination: follows next_page_token; terminates on self-repeat and on A→B→A cycles; dedupes the same policy_id across pages
- Resolution: exact match; case-insensitive exact wins over a partial sibling; not-found with candidate suggestions; not-found with no candidates omits the hint; suggestions capped at 10 with ...; ambiguous match refuses to guess; match missing policy_id; blank name rejected with zero API calls

Unit tests: runsubmit_test.go / runconfig_test.go (modified)
- TestSubmitWorkloadSendsUsagePolicy: id reaches BudgetPolicyId on the wire via both a literal id and a resolved name (asserted against the captured jobs.SubmitRun)
- Unresolvable name fails before any workspace write — asserted by recording served paths
- Empty payload case: no policy configured leaves BudgetPolicyId empty
- Validation: non-UUID id rejected, a name pasted into the id field gets pointed at usage_policy_name, valid UUID accepted
- Replaced the old usage_policy_name is not yet supported guard test

Acceptance tests
- go test ./acceptance -run 'TestAccept/experimental/air' passes with no golden-file changes needed
- No new acceptance test added: the feature needs a workspace API response, which the unit tests cover via testserver