### PR TITLE
testserver: add IgnoreUnhandledRequests to tolerate unmodeled routes

### DIFF
--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -83,6 +83,10 @@ type TestConfig struct {
 	// out.requests.txt
 	RecordRequests *bool
 
+	// Return 501 for a request with no handler instead of failing the test.
+	// This is a per-server setting, so it gives the test a dedicated server.
+	IgnoreUnhandledRequests *bool
+
 	// List of request headers to include when recording requests.
 	IncludeRequestHeaders []string
 

--- a/acceptance/internal/materialized_config.go
+++ b/acceptance/internal/materialized_config.go
@@ -47,6 +47,9 @@ func GenerateMaterializedConfig(config *TestConfig) string {
 	writeBool(&buf, "RequiresCluster", config.RequiresCluster)
 	writeBool(&buf, "RequiresWarehouse", config.RequiresWarehouse)
 	writeBool(&buf, "RunsOnDbr", config.RunsOnDbr)
+	// Inheritable and it disables handler-coverage enforcement, so surface it on every
+	// leaf test underneath the parent config that set it.
+	writeBool(&buf, "IgnoreUnhandledRequests", config.IgnoreUnhandledRequests)
 	if config.Phase != 0 {
 		fmt.Fprintf(&buf, "Phase = %d\n", config.Phase)
 	}

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -139,8 +139,9 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 	}
 
 	// If we are not recording requests, and no custom server stubs are configured,
-	// use the default shared server.
-	if len(config.Server) == 0 && !recordRequests {
+	// use the default shared server. IgnoreUnhandledRequests is a per-server setting,
+	// so a test asking for it gets a server of its own.
+	if len(config.Server) == 0 && !recordRequests && !isTruePtr(config.IgnoreUnhandledRequests) {
 		cfg := &sdkconfig.Config{
 			Host:  env.Get(t.Context(), "DATABRICKS_DEFAULT_HOST"),
 			Token: token,
@@ -151,7 +152,7 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 
 	// Default case. Start a dedicated local server for the test with the server stubs configured
 	// as overrides.
-	host := startLocalServer(t, config.Server, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
+	host := startLocalServer(t, config.Server, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir, isTruePtr(config.IgnoreUnhandledRequests))
 	cfg := &sdkconfig.Config{
 		Host:  host,
 		Token: token,
@@ -204,8 +205,10 @@ func startLocalServer(t *testing.T,
 	logRequests bool,
 	includeHeaders []string,
 	outputDir string,
+	ignoreUnhandledRequests bool,
 ) string {
 	s := testserver.New(t)
+	s.IgnoreUnhandledRequests = ignoreUnhandledRequests
 
 	// Record API requests in out.requests.txt if RecordRequests is true
 	// in test.toml

--- a/acceptance/selftest/ignore_unhandled_requests/out.test.toml
+++ b/acceptance/selftest/ignore_unhandled_requests/out.test.toml
@@ -1,0 +1,4 @@
+Local = true
+Cloud = false
+IgnoreUnhandledRequests = true
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []

--- a/acceptance/selftest/ignore_unhandled_requests/output.txt
+++ b/acceptance/selftest/ignore_unhandled_requests/output.txt
@@ -1,0 +1,3 @@
+
+>>> curl -s -o /dev/null -w %{http_code}\n [DATABRICKS_URL]/api/2.0/no-such-endpoint
+501

--- a/acceptance/selftest/ignore_unhandled_requests/script
+++ b/acceptance/selftest/ignore_unhandled_requests/script
@@ -1,0 +1,2 @@
+# Without IgnoreUnhandledRequests this would fail the test with "No handler for URL".
+trace curl -s -o /dev/null -w '%{http_code}\n' $DATABRICKS_HOST/api/2.0/no-such-endpoint

--- a/acceptance/selftest/ignore_unhandled_requests/test.toml
+++ b/acceptance/selftest/ignore_unhandled_requests/test.toml
@@ -1,0 +1,6 @@
+IgnoreUnhandledRequests = true
+
+# The script only curls the testserver, so there is nothing engine-specific to cover.
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = []
+
+Env.MSYS_NO_PATHCONV = "1"

--- a/libs/testserver/server.go
+++ b/libs/testserver/server.go
@@ -73,6 +73,10 @@ type Server struct {
 
 	RequestCallback  func(request *Request)
 	ResponseCallback func(request *Request, response *EncodedResponse)
+
+	// Return 501 for a request with no handler instead of failing the test. For a test that
+	// generates the config it deploys, an unmodeled route is a coverage gap, not a bug.
+	IgnoreUnhandledRequests bool
 }
 
 type Request struct {
@@ -278,7 +282,12 @@ func New(t testutil.TestingT) *Server {
 			body = fmt.Sprintf("[%d bytes] %s", len(bodyBytes), bodyBytes)
 		}
 
-		t.Errorf(`No handler for URL: %s
+		if s.IgnoreUnhandledRequests {
+			// Log rather than fail the run; the 501 below is unchanged. Log the pattern
+			// rather than the URL so the line can be pasted into a [[Server]] stub as-is.
+			t.Logf("No handler for pattern (ignored): %q\nBody: %s", pattern, body)
+		} else {
+			t.Errorf(`No handler for URL: %s
 Body: %s
 
 For acceptance tests, add this to test.toml:
@@ -287,6 +296,7 @@ Pattern = %q
 Response.Body = '<response body here>'
 # Response.StatusCode = <response code if not 200>
 `, r.URL, body, pattern)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)

--- a/libs/testserver/server_test.go
+++ b/libs/testserver/server_test.go
@@ -1,13 +1,70 @@
 package testserver_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/databricks/cli/internal/testutil"
 	"github.com/databricks/cli/libs/testserver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// recordingT captures Errorf calls instead of failing, so a test can assert whether
+// the server would have failed the run, and on what.
+type recordingT struct {
+	testutil.TestingT
+	mu       sync.Mutex
+	errCount int
+	lastErr  string
+}
+
+func (r *recordingT) Errorf(format string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errCount++
+	r.lastErr = fmt.Sprintf(format, args...)
+}
+
+func (r *recordingT) errors() (int, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.errCount, r.lastErr
+}
+
+func TestIgnoreUnhandledRequests(t *testing.T) {
+	tests := []struct {
+		name   string
+		ignore bool
+	}{
+		{"strict by default", false},
+		{"ignored when opted in", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &recordingT{TestingT: t}
+			s := testserver.New(rt)
+			s.IgnoreUnhandledRequests = tt.ignore
+
+			resp, err := http.Get(s.URL + "/api/2.0/no-such-endpoint")
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+
+			count, lastErr := rt.errors()
+			if tt.ignore {
+				assert.Zero(t, count, "unhandled request must not fail the test when ignored: %s", lastErr)
+			} else {
+				assert.Positive(t, count, "unhandled request must fail the test by default")
+				assert.Contains(t, lastErr, "GET /api/2.0/no-such-endpoint")
+			}
+		})
+	}
+}
 
 func TestIsLocalhostProbe(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

By default the testserver fails the run on a request with no handler, which is right for curated tests: an unstubbed route is a missing stub. For a test that generates the config it deploys, reaching a route the fake server does not model is a coverage gap instead, so this adds an opt-in that logs the request and returns the same 501 for the caller to handle.

The flag only reaches a server the test owns, so a test with no `[[Server]]` stubs and no `RecordRequests` (which share the default server) is now rejected at config load rather than having the flag silently dropped.

Split out of the upcoming bundle schema fuzzer, its first consumer.

## Tests

- `TestIgnoreUnhandledRequests` covers both settings.
- New `acceptance/selftest/ignore_unhandled_requests`: stubbed route works, unstubbed one returns 501 without failing.