### PR TITLE
acc: report an empty plan in verify_no_drift.py

### DIFF
--- a/acceptance/bin/verify_no_drift.py
+++ b/acceptance/bin/verify_no_drift.py
@@ -11,6 +11,10 @@ def check_plan(path):
     with open(path) as fobj:
         raw = fobj.read()
 
+    # A failed `bundle plan` leaves nothing to check; say so instead of raising below.
+    if not raw.strip():
+        sys.exit(f"{path}: empty plan output (bundle plan failed)")
+
     changes_detected = 0
 
     try:

--- a/acceptance/selftest/verify_no_drift/out.test.toml
+++ b/acceptance/selftest/verify_no_drift/out.test.toml
@@ -1,0 +1,3 @@
+Local = true
+Cloud = false
+EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/verify_no_drift/output.txt
+++ b/acceptance/selftest/verify_no_drift/output.txt
@@ -1,0 +1,17 @@
+
+=== A plan where every action is skip passes
+>>> verify_no_drift.py skip.json
+
+=== A plan with any other action fails
+>>> errcode verify_no_drift.py update.json
+Unexpected action='update' for resources.jobs.foo
+{"plan": {"resources.jobs.foo": {"action": "update"}}}
+
+
+Exit code: 10
+
+=== An empty plan says the plan failed, rather than raising a decode error
+>>> errcode verify_no_drift.py empty.json
+empty.json: empty plan output (bundle plan failed)
+
+Exit code: 1

--- a/acceptance/selftest/verify_no_drift/script
+++ b/acceptance/selftest/verify_no_drift/script
@@ -1,0 +1,11 @@
+title "A plan where every action is skip passes"
+echo '{"plan": {"resources.jobs.foo": {"action": "skip"}}}' > skip.json
+trace verify_no_drift.py skip.json
+
+title "A plan with any other action fails"
+echo '{"plan": {"resources.jobs.foo": {"action": "update"}}}' > update.json
+trace errcode verify_no_drift.py update.json
+
+title "An empty plan says the plan failed, rather than raising a decode error"
+touch empty.json
+trace errcode verify_no_drift.py empty.json

--- a/acceptance/selftest/verify_no_drift/test.toml
+++ b/acceptance/selftest/verify_no_drift/test.toml
@@ -1,0 +1,2 @@
+# The plan fixtures the script writes are inputs, not recorded output.
+Ignore = ["*.json"]


### PR DESCRIPTION
## Summary

When `bundle plan` fails it writes nothing. `verify_no_drift.py` then tried to JSON-decode an empty file and raised a traceback that said nothing about the actual failure. Report the empty plan instead.

Split out of the bundle schema fuzzer, where a failing plan is a routine outcome and the traceback was pure noise.

## Tests

New `acceptance/selftest/verify_no_drift` covers all three cases: all-skip passes, another action exits 10 and dumps the plan, empty plan reports the failure.