### PR TITLE
acc: run selftest/record_cloud locally against the testserver

### DIFF
--- a/acceptance/bundle/resources/schemas/recreate/output.txt
+++ b/acceptance/bundle/resources/schemas/recreate/output.txt
@@ -63,7 +63,7 @@ Deployment complete!
 }
 
 >>> musterr [CLI] schemas get main.myschema
-Error: Resource catalog.SchemaInfo not found: main.myschema
+Error: Schema 'main.myschema' does not exist.
 
 >>> [CLI] schemas get newmain.myschema
 {

--- a/acceptance/bundle/resources/volumes/change-comment/output.txt
+++ b/acceptance/bundle/resources/volumes/change-comment/output.txt
@@ -13,7 +13,7 @@
 
 === Verify volume does not exist
 >>> musterr [CLI] volumes read main.myschema.myvolume
-Error: Resource catalog.VolumeInfo not found: main.myschema.myvolume
+Error: Volume 'main.myschema.myvolume' does not exist.
 
 >>> [CLI] bundle deploy
 Uploading bundle files to /Workspace/Users/[USERNAME]/.bundle/test-bundle/default/files...
@@ -111,7 +111,7 @@ Destroy complete!
 }
 
 >>> musterr [CLI] volumes read main.myschema.myvolume
-Error: Resource catalog.VolumeInfo not found: main.myschema.myvolume
+Error: Volume 'main.myschema.myvolume' does not exist.
 {
   "catalog_name": "main",
   "comment": "COMMENT2",

--- a/acceptance/bundle/resources/volumes/change-name/output.txt
+++ b/acceptance/bundle/resources/volumes/change-name/output.txt
@@ -76,4 +76,4 @@ Deployment complete!
 }
 
 >>> musterr [CLI] volumes read main.myschema.myvolume
-Error: Resource catalog.VolumeInfo not found: main.myschema.myvolume
+Error: Volume 'main.myschema.myvolume' does not exist.

--- a/acceptance/bundle/resources/volumes/change-schema-name/output.txt
+++ b/acceptance/bundle/resources/volumes/change-schema-name/output.txt
@@ -72,9 +72,9 @@ Deployment complete!
 }
 
 >>> musterr [CLI] volumes read main.myschema.myvolume
-Error: Resource catalog.VolumeInfo not found: main.myschema.myvolume
+Error: Volume 'main.myschema.myvolume' does not exist.
 
 >>> [CLI] volumes read main.myschema.mynewvolume
-Error: Resource catalog.VolumeInfo not found: main.myschema.mynewvolume
+Error: Volume 'main.myschema.mynewvolume' does not exist.
 
 Exit code: 1

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -83,9 +83,8 @@ type TestConfig struct {
 	// out.requests.txt
 	RecordRequests *bool
 
-	// If true, route the CLI through the recording proxy (libs/testproxy) rather
-	// than straight to the testserver. Cloud runs take this topology anyway when
-	// requests are recorded or logged.
+	// If true, local runs route the CLI through the recording proxy (libs/testproxy)
+	// instead of straight to the testserver, matching the cloud topology.
 	Proxy *bool
 
 	// List of request headers to include when recording requests.

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -83,6 +83,12 @@ type TestConfig struct {
 	// out.requests.txt
 	RecordRequests *bool
 
+	// If true, route the CLI through the recording proxy (libs/testproxy) instead
+	// of talking to the workspace directly. On cloud this happens automatically
+	// whenever requests are recorded; setting this makes local runs use the same
+	// topology, with the testserver as the upstream, so the proxy is covered too.
+	Proxy *bool
+
 	// List of request headers to include when recording requests.
 	IncludeRequestHeaders []string
 

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -84,8 +84,8 @@ type TestConfig struct {
 	RecordRequests *bool
 
 	// If true, route the CLI through the recording proxy (libs/testproxy) rather
-	// than straight to the workspace. Cloud runs do this whenever requests are
-	// recorded; this opts local runs into the same topology.
+	// than straight to the workspace or testserver. Cloud runs also take this
+	// topology whenever requests are recorded or logged.
 	Proxy *bool
 
 	// List of request headers to include when recording requests.

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -83,10 +83,9 @@ type TestConfig struct {
 	// out.requests.txt
 	RecordRequests *bool
 
-	// If true, route the CLI through the recording proxy (libs/testproxy) instead
-	// of talking to the workspace directly. On cloud this happens automatically
-	// whenever requests are recorded; setting this makes local runs use the same
-	// topology, with the testserver as the upstream, so the proxy is covered too.
+	// If true, route the CLI through the recording proxy (libs/testproxy) rather
+	// than straight to the workspace. Cloud runs do this whenever requests are
+	// recorded; this opts local runs into the same topology.
 	Proxy *bool
 
 	// List of request headers to include when recording requests.

--- a/acceptance/internal/config.go
+++ b/acceptance/internal/config.go
@@ -84,8 +84,8 @@ type TestConfig struct {
 	RecordRequests *bool
 
 	// If true, route the CLI through the recording proxy (libs/testproxy) rather
-	// than straight to the workspace or testserver. Cloud runs also take this
-	// topology whenever requests are recorded or logged.
+	// than straight to the testserver. Cloud runs take this topology anyway when
+	// requests are recorded or logged.
 	Proxy *bool
 
 	// List of request headers to include when recording requests.

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -139,9 +139,8 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		return cfg, *user
 	}
 
-	// Same topology as cloud, with the testserver as the upstream. Only the proxy
-	// records and logs: the upstream sees the same requests, so instrumenting both
-	// would duplicate every entry.
+	// Same topology as cloud, with the testserver as the upstream. Both servers see
+	// the same requests, so only the proxy records and logs.
 	if isTruePtr(config.Proxy) {
 		upstream := startLocalServer(t, config.Server, false, false, nil, outputDir)
 		host := startProxyServer(t, &sdkconfig.Config{

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -122,8 +122,7 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		// If we are running in a cloud environment AND we need to intercept requests
 		// (for recording or logging), start a proxy server.
 		if recordRequests || logRequests {
-			// An empty config makes the proxy resolve the real workspace and its
-			// auth from the environment.
+			// An empty config resolves the real workspace from the environment.
 			host := startProxyServer(t, &sdkconfig.Config{}, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
 			cfg = &sdkconfig.Config{
 				Host:  host,
@@ -140,11 +139,8 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		return cfg, *user
 	}
 
-	// Mirror the cloud topology locally: the proxy records requests and forwards
-	// them to the workspace, which here is a dedicated testserver. This keeps the
-	// forwarding code in libs/testproxy covered on local runs instead of only when
-	// a cloud environment is configured. Recording is attached to the proxy only,
-	// so each request is recorded once, as it is on cloud.
+	// Same topology as cloud, with the testserver as the upstream. Only the proxy
+	// records, otherwise every request would be recorded twice.
 	if isTruePtr(config.Proxy) {
 		upstream := startLocalServer(t, config.Server, false, false, nil, outputDir)
 		host := startProxyServer(t, &sdkconfig.Config{

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -120,8 +120,8 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		cfg := w.Config
 
 		// If we are running in a cloud environment AND we need to intercept requests
-		// (for recording, logging, or an explicit Proxy), start a proxy server.
-		if recordRequests || logRequests || isTruePtr(config.Proxy) {
+		// (for recording or logging), start a proxy server.
+		if recordRequests || logRequests {
 			// An empty config resolves the real workspace from the environment.
 			host := startProxyServer(t, &sdkconfig.Config{}, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
 			cfg = &sdkconfig.Config{
@@ -140,9 +140,10 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 	}
 
 	// Same topology as cloud, with the testserver as the upstream. Only the proxy
-	// records, otherwise every request would be recorded twice.
+	// records and logs: the upstream sees the same requests, so instrumenting both
+	// would duplicate every entry.
 	if isTruePtr(config.Proxy) {
-		upstream := startLocalServer(t, config.Server, false, logRequests, nil, outputDir)
+		upstream := startLocalServer(t, config.Server, false, false, nil, outputDir)
 		host := startProxyServer(t, &sdkconfig.Config{
 			Host:  upstream,
 			Token: token,

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -122,7 +122,9 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		// If we are running in a cloud environment AND we need to intercept requests
 		// (for recording or logging), start a proxy server.
 		if recordRequests || logRequests {
-			host := startProxyServer(t, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
+			// An empty config makes the proxy resolve the real workspace and its
+			// auth from the environment.
+			host := startProxyServer(t, &sdkconfig.Config{}, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
 			cfg = &sdkconfig.Config{
 				Host:  host,
 				Token: token,
@@ -136,6 +138,26 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		}
 
 		return cfg, *user
+	}
+
+	// Mirror the cloud topology locally: the proxy records requests and forwards
+	// them to the workspace, which here is a dedicated testserver. This keeps the
+	// forwarding code in libs/testproxy covered on local runs instead of only when
+	// a cloud environment is configured. Recording is attached to the proxy only,
+	// so each request is recorded once, as it is on cloud.
+	if isTruePtr(config.Proxy) {
+		upstream := startLocalServer(t, config.Server, false, false, nil, outputDir)
+		host := startProxyServer(t, &sdkconfig.Config{
+			Host:  upstream,
+			Token: token,
+		}, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
+
+		cfg := &sdkconfig.Config{
+			Host:  host,
+			Token: token,
+		}
+
+		return cfg, testUser
 	}
 
 	// If we are not recording requests, and no custom server stubs are configured,
@@ -255,12 +277,13 @@ func startLocalServer(t *testing.T,
 }
 
 func startProxyServer(t *testing.T,
+	upstream *sdkconfig.Config,
 	recordRequests bool,
 	logRequests bool,
 	includeHeaders []string,
 	outputDir string,
 ) string {
-	s := testproxy.New(t)
+	s := testproxy.New(t, upstream)
 
 	// Record API requests in out.requests.txt if RecordRequests is true in test.toml.
 	if recordRequests {

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -120,8 +120,7 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		cfg := w.Config
 
 		// If we are running in a cloud environment AND we need to intercept requests
-		// (for recording, logging, or because the test asked for the proxy topology),
-		// start a proxy server.
+		// (for recording, logging, or an explicit Proxy), start a proxy server.
 		if recordRequests || logRequests || isTruePtr(config.Proxy) {
 			// An empty config resolves the real workspace from the environment.
 			host := startProxyServer(t, &sdkconfig.Config{}, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
@@ -141,8 +140,7 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 	}
 
 	// Same topology as cloud, with the testserver as the upstream. Only the proxy
-	// records, otherwise every request would be recorded twice; both layers log,
-	// so -logrequests shows what the fake did with what the proxy forwarded.
+	// records, otherwise every request would be recorded twice.
 	if isTruePtr(config.Proxy) {
 		upstream := startLocalServer(t, config.Server, false, logRequests, nil, outputDir)
 		host := startProxyServer(t, &sdkconfig.Config{

--- a/acceptance/internal/prepare_server.go
+++ b/acceptance/internal/prepare_server.go
@@ -120,8 +120,9 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 		cfg := w.Config
 
 		// If we are running in a cloud environment AND we need to intercept requests
-		// (for recording or logging), start a proxy server.
-		if recordRequests || logRequests {
+		// (for recording, logging, or because the test asked for the proxy topology),
+		// start a proxy server.
+		if recordRequests || logRequests || isTruePtr(config.Proxy) {
 			// An empty config resolves the real workspace from the environment.
 			host := startProxyServer(t, &sdkconfig.Config{}, recordRequests, logRequests, config.IncludeRequestHeaders, outputDir)
 			cfg = &sdkconfig.Config{
@@ -140,9 +141,10 @@ func PrepareServerAndClient(t *testing.T, config TestConfig, logRequests bool, o
 	}
 
 	// Same topology as cloud, with the testserver as the upstream. Only the proxy
-	// records, otherwise every request would be recorded twice.
+	// records, otherwise every request would be recorded twice; both layers log,
+	// so -logrequests shows what the fake did with what the proxy forwarded.
 	if isTruePtr(config.Proxy) {
-		upstream := startLocalServer(t, config.Server, false, false, nil, outputDir)
+		upstream := startLocalServer(t, config.Server, false, logRequests, nil, outputDir)
 		host := startProxyServer(t, &sdkconfig.Config{
 			Host:  upstream,
 			Token: token,

--- a/acceptance/selftest/record_cloud/basic/out.test.toml
+++ b/acceptance/selftest/record_cloud/basic/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/basic/script
+++ b/acceptance/selftest/record_cloud/basic/script
@@ -1,2 +1,2 @@
 # Proxy server successfully records a requests and returns a response.
-trace $CLI current-user me | jq .name.givenName
+trace $CLI current-user me | jq .userName

--- a/acceptance/selftest/record_cloud/error/out.test.toml
+++ b/acceptance/selftest/record_cloud/error/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
+++ b/acceptance/selftest/record_cloud/pipeline-crud/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/test.toml
+++ b/acceptance/selftest/record_cloud/test.toml
@@ -1,3 +1,9 @@
 Cloud = true
-Local = false
+Local = true
 RecordRequests = true
+
+# These tests cover the recording proxy (libs/testproxy), which on cloud sits
+# between the CLI and the workspace. Proxy = true puts it in front of the
+# testserver too, so the same goldens assert the proxy behaves identically
+# whether the upstream is a real workspace or the fake.
+Proxy = true

--- a/acceptance/selftest/record_cloud/test.toml
+++ b/acceptance/selftest/record_cloud/test.toml
@@ -2,8 +2,7 @@ Cloud = true
 Local = true
 RecordRequests = true
 
-# These tests cover the recording proxy (libs/testproxy), which on cloud sits
-# between the CLI and the workspace. Proxy = true puts it in front of the
-# testserver too, so the same goldens assert the proxy behaves identically
+# These tests cover the recording proxy (libs/testproxy). Running it in front of
+# the testserver too means one set of goldens asserts the proxy behaves the same
 # whether the upstream is a real workspace or the fake.
 Proxy = true

--- a/acceptance/selftest/record_cloud/test.toml
+++ b/acceptance/selftest/record_cloud/test.toml
@@ -2,6 +2,6 @@ Cloud = true
 Local = true
 RecordRequests = true
 
-# Putting the recording proxy (libs/testproxy) in front of the testserver too lets
-# one set of goldens assert it behaves the same against a real workspace and a fake.
+# Local runs go through the proxy too, so one set of goldens covers it against both
+# a real workspace and the fake.
 Proxy = true

--- a/acceptance/selftest/record_cloud/test.toml
+++ b/acceptance/selftest/record_cloud/test.toml
@@ -2,7 +2,6 @@ Cloud = true
 Local = true
 RecordRequests = true
 
-# These tests cover the recording proxy (libs/testproxy). Running it in front of
-# the testserver too means one set of goldens asserts the proxy behaves the same
-# whether the upstream is a real workspace or the fake.
+# Putting the recording proxy (libs/testproxy) in front of the testserver too lets
+# one set of goldens assert it behaves the same against a real workspace and a fake.
 Proxy = true

--- a/acceptance/selftest/record_cloud/volume-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/volume-io/out.test.toml
@@ -1,4 +1,4 @@
-Local = false
+Local = true
 Cloud = true
 RequiresUnityCatalog = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
+++ b/acceptance/selftest/record_cloud/workspace-file-io/out.test.toml
@@ -1,3 +1,3 @@
-Local = false
+Local = true
 Cloud = true
 EnvMatrix.DATABRICKS_BUNDLE_ENGINE = ["terraform", "direct"]

--- a/libs/testproxy/server.go
+++ b/libs/testproxy/server.go
@@ -37,17 +37,14 @@ type ProxyServer struct {
 // For reference, see:
 // https://github.com/databricks/databricks-sdk-go/blob/79e4b3a6e9b0b7dcb1af9ad4025deb447b01d933/common/environment/environments.go#L57
 //
-// The upstream argument selects what the proxy forwards to. Pass an empty config
-// to resolve a real workspace and its auth from the environment, or an explicit
-// host and token to forward to a testserver.
+// upstream selects what the proxy forwards to: an empty config resolves a real
+// workspace and its auth from the environment, an explicit host and token a
+// testserver.
 func New(t testutil.TestingT, upstream *config.Config) *ProxyServer {
 	s := &ProxyServer{
 		t: t,
 	}
 
-	// Create an API client for the upstream workspace. An empty config resolves
-	// the authentication context from the environment, which is how CI test
-	// environments supply the workspace to record against.
 	clientCfg, err := config.HTTPClientConfigFromConfig(upstream)
 	require.NoError(t, err)
 	s.apiClient = httpclient.NewApiClient(clientCfg)

--- a/libs/testproxy/server.go
+++ b/libs/testproxy/server.go
@@ -25,7 +25,7 @@ type ProxyServer struct {
 	ResponseCallback func(request *testserver.Request, response *testserver.EncodedResponse)
 }
 
-// This creates a reverse proxy server that sits in front of a real Databricks
+// New creates a reverse proxy server that sits in front of the upstream
 // workspace. This is useful for recording API requests and responses in
 // integration tests.
 //
@@ -49,7 +49,7 @@ func New(t testutil.TestingT, upstream *config.Config) *ProxyServer {
 	s.apiClient = httpclient.NewApiClient(clientCfg)
 
 	// Set up the proxy handler as the default handler for all requests.
-	server := httptest.NewServer(http.HandlerFunc(s.proxyToCloud))
+	server := httptest.NewServer(http.HandlerFunc(s.proxyToUpstream))
 	t.Cleanup(server.Close)
 
 	s.Server = server
@@ -71,7 +71,7 @@ func (s *ProxyServer) reqBody(r testserver.Request) any {
 	return r.Body
 }
 
-func (s *ProxyServer) proxyToCloud(w http.ResponseWriter, r *http.Request) {
+func (s *ProxyServer) proxyToUpstream(w http.ResponseWriter, r *http.Request) {
 	request := testserver.NewRequest(s.t, r, nil)
 	if s.RequestCallback != nil {
 		s.RequestCallback(&request)

--- a/libs/testproxy/server.go
+++ b/libs/testproxy/server.go
@@ -37,9 +37,8 @@ type ProxyServer struct {
 // For reference, see:
 // https://github.com/databricks/databricks-sdk-go/blob/79e4b3a6e9b0b7dcb1af9ad4025deb447b01d933/common/environment/environments.go#L57
 //
-// upstream selects what the proxy forwards to: an empty config resolves a real
-// workspace and its auth from the environment, an explicit host and token a
-// testserver.
+// An upstream with no fields set resolves a real workspace and its auth from the
+// environment; an explicit host and token point at a testserver instead.
 func New(t testutil.TestingT, upstream *config.Config) *ProxyServer {
 	s := &ProxyServer{
 		t: t,

--- a/libs/testproxy/server.go
+++ b/libs/testproxy/server.go
@@ -36,17 +36,19 @@ type ProxyServer struct {
 // OAuth endpoints based on the nature of the URL.
 // For reference, see:
 // https://github.com/databricks/databricks-sdk-go/blob/79e4b3a6e9b0b7dcb1af9ad4025deb447b01d933/common/environment/environments.go#L57
-func New(t testutil.TestingT) *ProxyServer {
+//
+// The upstream argument selects what the proxy forwards to. Pass an empty config
+// to resolve a real workspace and its auth from the environment, or an explicit
+// host and token to forward to a testserver.
+func New(t testutil.TestingT, upstream *config.Config) *ProxyServer {
 	s := &ProxyServer{
 		t: t,
 	}
 
-	// Create an API client using the current authentication context.
-	// In CI test environments this would read the appropriate environment
-	// variables.
-	var err error
-	cfg := &config.Config{}
-	clientCfg, err := config.HTTPClientConfigFromConfig(cfg)
+	// Create an API client for the upstream workspace. An empty config resolves
+	// the authentication context from the environment, which is how CI test
+	// environments supply the workspace to record against.
+	clientCfg, err := config.HTTPClientConfigFromConfig(upstream)
 	require.NoError(t, err)
 	s.apiClient = httpclient.NewApiClient(clientCfg)
 

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -277,10 +277,7 @@ func MapGetUC[T any](w *FakeWorkspace, collection map[string]T, key, securable s
 	if !ok {
 		return Response{
 			StatusCode: 404,
-			Body: map[string]string{
-				"error_code": "NOT_FOUND",
-				"message":    fmt.Sprintf("%s '%s' does not exist.", securable, key),
-			},
+			Body:       map[string]string{"message": fmt.Sprintf("%s '%s' does not exist.", securable, key)},
 		}
 	}
 	return Response{
@@ -477,10 +474,15 @@ func (s *FakeWorkspace) WorkspaceGetStatus(requestPath string) Response {
 func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	defer s.LockUnlock()()
 
-	// The real API 404s on a missing path; without this it looks like an empty directory.
-	_, isDir := s.directories[listPath]
-	_, isFile := s.files[listPath]
-	if !isDir && !isFile {
+	// The real API collapses duplicate slashes, so look up the cleaned path.
+	cleaned := path.Clean(listPath)
+
+	// The real API 404s on a missing path; without this it looks like an empty
+	// directory. Repos are listable but tracked outside s.directories, so they
+	// have to be admitted here too.
+	_, isDir := s.directories[cleaned]
+	_, isRepo := s.repoIdByPath[cleaned]
+	if !isDir && !isRepo {
 		return Response{
 			StatusCode: 404,
 			Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", listPath)},
@@ -490,12 +492,12 @@ func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	var objects []workspace.ObjectInfo
 
 	for filePath, entry := range s.files {
-		if path.Dir(filePath) == listPath {
+		if path.Dir(filePath) == cleaned {
 			objects = append(objects, entry.Info)
 		}
 	}
 	for dirPath, dirInfo := range s.directories {
-		if dirPath != listPath && path.Dir(dirPath) == listPath {
+		if dirPath != cleaned && path.Dir(dirPath) == cleaned {
 			objects = append(objects, dirInfo)
 		}
 	}
@@ -509,8 +511,9 @@ func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	}
 }
 
-// FsListDirectory implements GET /api/2.0/fs/directories/{path}. A missing path,
-// or one pointing at a file, is a 404 as in the HEAD handler for the same route.
+// FsListDirectory implements GET /api/2.0/fs/directories/{path}. Anything that is
+// not a directory, including a path pointing at a file, is a 404, as in the HEAD
+// handler for the same route.
 func (s *FakeWorkspace) FsListDirectory(dirPath string) Response {
 	if !strings.HasPrefix(dirPath, "/") {
 		dirPath = "/" + dirPath
@@ -518,11 +521,11 @@ func (s *FakeWorkspace) FsListDirectory(dirPath string) Response {
 
 	defer s.LockUnlock()()
 
-	if _, isFile := s.files[dirPath]; isFile {
-		return Response{StatusCode: 404}
-	}
 	if _, isDir := s.directories[dirPath]; !isDir {
-		return Response{StatusCode: 404}
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": "directory does not exist"},
+		}
 	}
 
 	var contents []files.DirectoryEntry
@@ -564,7 +567,10 @@ func (s *FakeWorkspace) FsDeleteFile(filePath string) Response {
 	defer s.LockUnlock()()
 
 	if _, exists := s.files[filePath]; !exists {
-		return Response{StatusCode: 404}
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": "file does not exist"},
+		}
 	}
 
 	delete(s.files, filePath)

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -267,9 +267,8 @@ func MapGet[T any](w *FakeWorkspace, collection map[string]T, key string) Respon
 	}
 }
 
-// MapGetUC is MapGet for Unity Catalog securables, which report a missing
-// securable as "Volume 'main.s.v' does not exist." Callers surface that verbatim,
-// so the generic MapGet message is not a faithful substitute.
+// MapGetUC is MapGet for Unity Catalog securables. The CLI surfaces the API's
+// message verbatim, and UC words it as "Volume 'main.s.v' does not exist."
 func MapGetUC[T any](w *FakeWorkspace, collection map[string]T, key, securable string) Response {
 	defer w.LockUnlock()()
 
@@ -477,9 +476,8 @@ func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	// The real API collapses duplicate slashes, so look up the cleaned path.
 	cleaned := path.Clean(listPath)
 
-	// The real API 404s on a missing path; without this it looks like an empty
-	// directory. Repos are listable but tracked outside s.directories, so they
-	// have to be admitted here too.
+	// The real API 404s on a missing path rather than reporting an empty directory.
+	// Repos are listable but tracked outside s.directories, so admit them too.
 	_, isDir := s.directories[cleaned]
 	_, isRepo := s.repoIdByPath[cleaned]
 	if !isDir && !isRepo {
@@ -511,9 +509,8 @@ func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	}
 }
 
-// FsListDirectory implements GET /api/2.0/fs/directories/{path}. Anything that is
-// not a directory, including a path pointing at a file, is a 404, as in the HEAD
-// handler for the same route.
+// FsListDirectory implements GET /api/2.0/fs/directories/{path}. A path that is
+// not a directory, including one pointing at a file, is a 404, as it is for HEAD.
 func (s *FakeWorkspace) FsListDirectory(dirPath string) Response {
 	if !strings.HasPrefix(dirPath, "/") {
 		dirPath = "/" + dirPath

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -267,9 +267,9 @@ func MapGet[T any](w *FakeWorkspace, collection map[string]T, key string) Respon
 	}
 }
 
-// MapGetUC is MapGet for Unity Catalog securables. UC reports a missing securable
-// by name and type ("Volume 'main.s.v' does not exist."), which callers surface
-// verbatim, so the generic MapGet message is not a faithful substitute.
+// MapGetUC is MapGet for Unity Catalog securables, which report a missing
+// securable as "Volume 'main.s.v' does not exist." Callers surface that verbatim,
+// so the generic MapGet message is not a faithful substitute.
 func MapGetUC[T any](w *FakeWorkspace, collection map[string]T, key, securable string) Response {
 	defer w.LockUnlock()()
 
@@ -477,8 +477,7 @@ func (s *FakeWorkspace) WorkspaceGetStatus(requestPath string) Response {
 func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	defer s.LockUnlock()()
 
-	// The real API 404s on a path that does not exist. Without this check a
-	// deleted or misspelled path is indistinguishable from an empty directory.
+	// The real API 404s on a missing path; without this it looks like an empty directory.
 	_, isDir := s.directories[listPath]
 	_, isFile := s.files[listPath]
 	if !isDir && !isFile {
@@ -510,9 +509,8 @@ func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	}
 }
 
-// FsListDirectory lists the immediate children of a directory for the Files API
-// (GET /api/2.0/fs/directories/{path}). A path that is absent or points at a file
-// is a 404, matching the HEAD handler for the same route.
+// FsListDirectory implements GET /api/2.0/fs/directories/{path}. A missing path,
+// or one pointing at a file, is a 404 as in the HEAD handler for the same route.
 func (s *FakeWorkspace) FsListDirectory(dirPath string) Response {
 	if !strings.HasPrefix(dirPath, "/") {
 		dirPath = "/" + dirPath
@@ -557,8 +555,7 @@ func (s *FakeWorkspace) FsListDirectory(dirPath string) Response {
 	}
 }
 
-// FsDeleteFile deletes a single file for the Files API
-// (DELETE /api/2.0/fs/files/{path}).
+// FsDeleteFile implements DELETE /api/2.0/fs/files/{path}.
 func (s *FakeWorkspace) FsDeleteFile(filePath string) Response {
 	if !strings.HasPrefix(filePath, "/") {
 		filePath = "/" + filePath

--- a/libs/testserver/fake_workspace.go
+++ b/libs/testserver/fake_workspace.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/databricks/databricks-sdk-go/service/apps"
 	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/databricks-sdk-go/service/files"
 	"github.com/databricks/databricks-sdk-go/service/iam"
 	"github.com/databricks/databricks-sdk-go/service/jobs"
 	"github.com/databricks/databricks-sdk-go/service/ml"
@@ -266,6 +267,27 @@ func MapGet[T any](w *FakeWorkspace, collection map[string]T, key string) Respon
 	}
 }
 
+// MapGetUC is MapGet for Unity Catalog securables. UC reports a missing securable
+// by name and type ("Volume 'main.s.v' does not exist."), which callers surface
+// verbatim, so the generic MapGet message is not a faithful substitute.
+func MapGetUC[T any](w *FakeWorkspace, collection map[string]T, key, securable string) Response {
+	defer w.LockUnlock()()
+
+	value, ok := collection[key]
+	if !ok {
+		return Response{
+			StatusCode: 404,
+			Body: map[string]string{
+				"error_code": "NOT_FOUND",
+				"message":    fmt.Sprintf("%s '%s' does not exist.", securable, key),
+			},
+		}
+	}
+	return Response{
+		Body: value,
+	}
+}
+
 func MapList[K comparable, T any](w *FakeWorkspace, collection map[K]T, responseFieldName string) Response {
 	defer w.LockUnlock()()
 
@@ -455,6 +477,17 @@ func (s *FakeWorkspace) WorkspaceGetStatus(requestPath string) Response {
 func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	defer s.LockUnlock()()
 
+	// The real API 404s on a path that does not exist. Without this check a
+	// deleted or misspelled path is indistinguishable from an empty directory.
+	_, isDir := s.directories[listPath]
+	_, isFile := s.files[listPath]
+	if !isDir && !isFile {
+		return Response{
+			StatusCode: 404,
+			Body:       map[string]string{"message": fmt.Sprintf("Path (%s) doesn't exist.", listPath)},
+		}
+	}
+
 	var objects []workspace.ObjectInfo
 
 	for filePath, entry := range s.files {
@@ -475,6 +508,70 @@ func (s *FakeWorkspace) WorkspaceList(listPath string) Response {
 	return Response{
 		Body: workspace.ListResponse{Objects: objects},
 	}
+}
+
+// FsListDirectory lists the immediate children of a directory for the Files API
+// (GET /api/2.0/fs/directories/{path}). A path that is absent or points at a file
+// is a 404, matching the HEAD handler for the same route.
+func (s *FakeWorkspace) FsListDirectory(dirPath string) Response {
+	if !strings.HasPrefix(dirPath, "/") {
+		dirPath = "/" + dirPath
+	}
+
+	defer s.LockUnlock()()
+
+	if _, isFile := s.files[dirPath]; isFile {
+		return Response{StatusCode: 404}
+	}
+	if _, isDir := s.directories[dirPath]; !isDir {
+		return Response{StatusCode: 404}
+	}
+
+	var contents []files.DirectoryEntry
+
+	for filePath, entry := range s.files {
+		if path.Dir(filePath) == dirPath {
+			contents = append(contents, files.DirectoryEntry{
+				Name:     path.Base(filePath),
+				Path:     filePath,
+				FileSize: int64(len(entry.Data)),
+			})
+		}
+	}
+	for childPath := range s.directories {
+		if childPath != dirPath && path.Dir(childPath) == dirPath {
+			contents = append(contents, files.DirectoryEntry{
+				Name:        path.Base(childPath),
+				Path:        childPath,
+				IsDirectory: true,
+			})
+		}
+	}
+
+	slices.SortFunc(contents, func(a, b files.DirectoryEntry) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+
+	return Response{
+		Body: files.ListDirectoryResponse{Contents: contents},
+	}
+}
+
+// FsDeleteFile deletes a single file for the Files API
+// (DELETE /api/2.0/fs/files/{path}).
+func (s *FakeWorkspace) FsDeleteFile(filePath string) Response {
+	if !strings.HasPrefix(filePath, "/") {
+		filePath = "/" + filePath
+	}
+
+	defer s.LockUnlock()()
+
+	if _, exists := s.files[filePath]; !exists {
+		return Response{StatusCode: 404}
+	}
+
+	delete(s.files, filePath)
+	return Response{}
 }
 
 func (s *FakeWorkspace) WorkspaceMkdirs(request workspace.Mkdirs) {

--- a/libs/testserver/handlers.go
+++ b/libs/testserver/handlers.go
@@ -209,6 +209,10 @@ func AddDefaultHandlers(server *Server) {
 		return Response{StatusCode: 404}
 	})
 
+	server.Handle("GET", "/api/2.0/fs/directories/{path...}", func(req Request) any {
+		return req.Workspace.FsListDirectory(req.Vars["path"])
+	})
+
 	server.Handle("HEAD", "/api/2.0/fs/files/{path...}", func(req Request) any {
 		path := req.Vars["path"]
 		if req.Workspace.FileExists(path) {
@@ -251,6 +255,10 @@ func AddDefaultHandlers(server *Server) {
 		path := req.Vars["path"]
 		overwrite := req.URL.Query().Get("overwrite") == "true"
 		return req.Workspace.WorkspaceFilesImportFile(path, req.Body, overwrite)
+	})
+
+	server.Handle("DELETE", "/api/2.0/fs/files/{path...}", func(req Request) any {
+		return req.Workspace.FsDeleteFile(req.Vars["path"])
 	})
 
 	server.Handle("GET", "/api/2.0/fs/files/{path...}", func(req Request) any {
@@ -497,7 +505,7 @@ func AddDefaultHandlers(server *Server) {
 	// Schemas:
 
 	server.Handle("GET", "/api/2.1/unity-catalog/schemas/{full_name}", func(req Request) any {
-		return MapGet(req.Workspace, req.Workspace.Schemas, req.Vars["full_name"])
+		return MapGetUC(req.Workspace, req.Workspace.Schemas, req.Vars["full_name"], "Schema")
 	})
 
 	server.Handle("POST", "/api/2.1/unity-catalog/schemas", func(req Request) any {
@@ -579,7 +587,7 @@ func AddDefaultHandlers(server *Server) {
 	// Volumes:
 
 	server.Handle("GET", "/api/2.1/unity-catalog/volumes/{full_name}", func(req Request) any {
-		return MapGet(req.Workspace, req.Workspace.Volumes, req.Vars["full_name"])
+		return MapGetUC(req.Workspace, req.Workspace.Volumes, req.Vars["full_name"], "Volume")
 	})
 
 	server.Handle("POST", "/api/2.1/unity-catalog/volumes", func(req Request) any {

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -129,6 +129,10 @@ func (s *FakeWorkspace) PipelineUpdate(req Request, pipelineId string) Response 
 
 	item.Spec = &spec
 	item.Parameters = edit.Parameters
+	// The backend echoes the spec name top-level on GetPipelineResponse.Name, so an edit
+	// that renames the pipeline must update it here too; otherwise a re-read reports the
+	// name the pipeline was created with.
+	item.Name = spec.Name
 	// run_as is on EditPipeline, not PipelineSpec; keep it in sync like Parameters so an edit
 	// that changes run_as is reflected on the next read (matches cloud top-level echo).
 	if edit.RunAs != nil {

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -129,8 +129,8 @@ func (s *FakeWorkspace) PipelineUpdate(req Request, pipelineId string) Response 
 
 	item.Spec = &spec
 	item.Parameters = edit.Parameters
-	// The backend echoes the spec name on GetPipelineResponse.Name; without this a
-	// rename is not visible on the next read.
+	// The backend echoes the spec name on GetPipelineResponse.Name; mirror that so a
+	// rename is reflected on the next read.
 	item.Name = spec.Name
 	// run_as is on EditPipeline, not PipelineSpec; keep it in sync like Parameters so an edit
 	// that changes run_as is reflected on the next read (matches cloud top-level echo).

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -129,9 +129,8 @@ func (s *FakeWorkspace) PipelineUpdate(req Request, pipelineId string) Response 
 
 	item.Spec = &spec
 	item.Parameters = edit.Parameters
-	// The backend echoes the spec name top-level on GetPipelineResponse.Name, so an edit
-	// that renames the pipeline must update it here too; otherwise a re-read reports the
-	// name the pipeline was created with.
+	// The backend echoes the spec name on GetPipelineResponse.Name, so without this a
+	// renamed pipeline still reads back as the name it was created with.
 	item.Name = spec.Name
 	// run_as is on EditPipeline, not PipelineSpec; keep it in sync like Parameters so an edit
 	// that changes run_as is reflected on the next read (matches cloud top-level echo).

--- a/libs/testserver/pipelines.go
+++ b/libs/testserver/pipelines.go
@@ -129,8 +129,8 @@ func (s *FakeWorkspace) PipelineUpdate(req Request, pipelineId string) Response 
 
 	item.Spec = &spec
 	item.Parameters = edit.Parameters
-	// The backend echoes the spec name on GetPipelineResponse.Name, so without this a
-	// renamed pipeline still reads back as the name it was created with.
+	// The backend echoes the spec name on GetPipelineResponse.Name; without this a
+	// rename is not visible on the next read.
 	item.Name = spec.Name
 	// run_as is on EditPipeline, not PipelineSpec; keep it in sync like Parameters so an edit
 	// that changes run_as is reflected on the next read (matches cloud top-level echo).


### PR DESCRIPTION
## Changes

Run the five `selftest/record_cloud` tests locally by putting the recording proxy (`libs/testproxy`) in front of the testserver: `testproxy.New` takes an explicit upstream config, and a new `Proxy` option in `test.toml` opts a local test into that topology.

Needed five testserver fidelity fixes: `GET /api/2.0/fs/directories/{path}` and `DELETE /api/2.0/fs/files/{path}` were unhandled, a pipeline rename was not reflected on a subsequent read, Unity Catalog reported a missing securable with a generic message, and `workspace list` reported a missing path as an empty directory instead of a 404. The last one is a behavior change other tests could have depended on; `workspace list` also now collapses duplicate slashes before the lookup, matching `workspace get-status`.

## Why

The proxy only started when `CLOUD_ENV` was set, so nothing exercised it on PRs.

## Tests

The four regenerated goldens under `bundle/resources/{schemas,volumes}` swap in the real API's not-found message, taken from the cloud-recorded `selftest/record_cloud/volume-io/output.txt` that those local-only tests were contradicting.