### PR TITLE
schema: resolve SDK annotations for specs embedded at any depth

### DIFF
--- a/bundle/internal/schema/annotations.yml
+++ b/bundle/internal/schema/annotations.yml
@@ -1400,18 +1400,9 @@ resources:
         "branch_id":
           "description": |-
             PLACEHOLDER
-        "expire_time":
-          "description": |-
-            PLACEHOLDER
-        "is_protected":
-          "description": |-
-            PLACEHOLDER
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
-        "no_expiry":
-          "description": |-
-            PLACEHOLDER
         "parent":
           "description": |-
             PLACEHOLDER
@@ -1421,37 +1412,16 @@ resources:
         "replace_existing":
           "description": |-
             PLACEHOLDER
-        "source_branch":
-          "description": |-
-            PLACEHOLDER
-        "source_branch_lsn":
-          "description": |-
-            PLACEHOLDER
-        "source_branch_time":
-          "description": |-
-            PLACEHOLDER
-        "ttl":
-          "description": |-
-            PLACEHOLDER
     "postgres_catalogs":
       "description": |-
         The Postgres catalog definitions for the bundle, where each key is the name of the catalog. Each entry binds a Unity Catalog catalog to a Postgres database on a Lakebase Autoscaling branch.
       "$fields":
-        "branch":
-          "description": |-
-            PLACEHOLDER
         "catalog_id":
-          "description": |-
-            PLACEHOLDER
-        "create_database_if_missing":
           "description": |-
             PLACEHOLDER
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
-        "postgres_database":
-          "description": |-
-            PLACEHOLDER
     "postgres_databases":
       "description": |-
         PLACEHOLDER
@@ -1465,80 +1435,29 @@ resources:
         "parent":
           "description": |-
             PLACEHOLDER
-        "postgres_database":
-          "description": |-
-            PLACEHOLDER
         "replace_existing":
           "description": |-
             When true, take over an existing database with the same ID instead of failing with an ALREADY_EXISTS error. Use it to bring a database that already exists on the branch under bundle management. Only takes effect when the database is created.
-        "role":
-          "description": |-
-            PLACEHOLDER
     "postgres_endpoints":
       "description": |-
         PLACEHOLDER
       "$fields":
-        "autoscaling_limit_max_cu":
-          "description": |-
-            PLACEHOLDER
-        "autoscaling_limit_min_cu":
-          "description": |-
-            PLACEHOLDER
-        "disabled":
-          "description": |-
-            PLACEHOLDER
         "endpoint_id":
-          "description": |-
-            PLACEHOLDER
-        "endpoint_type":
-          "description": |-
-            PLACEHOLDER
-        "group":
           "description": |-
             PLACEHOLDER
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
-        "no_suspension":
-          "description": |-
-            PLACEHOLDER
         "parent":
           "description": |-
             PLACEHOLDER
         "replace_existing":
           "description": |-
             PLACEHOLDER
-        "settings":
-          "description": |-
-            PLACEHOLDER
-        "suspend_timeout_duration":
-          "description": |-
-            PLACEHOLDER
     "postgres_projects":
       "description": |-
         PLACEHOLDER
       "$fields":
-        "budget_policy_id":
-          "description": |-
-            PLACEHOLDER
-        "custom_tags":
-          "description": |-
-            PLACEHOLDER
-        "default_branch":
-          "description": |-
-            PLACEHOLDER
-        "default_endpoint_settings":
-          "description": |-
-            PLACEHOLDER
-        "display_name":
-          "description": |-
-            PLACEHOLDER
-        "enable_pg_native_login":
-          "description": |-
-            PLACEHOLDER
-        "history_retention_duration":
-          "description": |-
-            PLACEHOLDER
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
@@ -1559,9 +1478,6 @@ resources:
               - level: CAN_RUN
                 service_principal_name: 123456-abcdef
             ```
-        "pg_version":
-          "description": |-
-            PLACEHOLDER
         "project_id":
           "description": |-
             PLACEHOLDER
@@ -1613,46 +1529,10 @@ resources:
       "description": |-
         The Postgres synced table definitions for the bundle, where each key is the name of the synced table. Each entry continuously replicates a Unity Catalog Delta source table into a Postgres table on a Lakebase Autoscaling instance.
       "$fields":
-        "accelerated_sync":
-          "description": |-
-            PLACEHOLDER
-        "branch":
-          "description": |-
-            PLACEHOLDER
-        "create_database_objects_if_missing":
-          "description": |-
-            PLACEHOLDER
-        "existing_pipeline_id":
-          "description": |-
-            PLACEHOLDER
-        "extra_columns":
-          "description": |-
-            PLACEHOLDER
         "lifecycle":
           "description": |-
             Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.
-        "new_pipeline_spec":
-          "description": |-
-            PLACEHOLDER
-        "postgres_database":
-          "description": |-
-            PLACEHOLDER
-        "primary_key_columns":
-          "description": |-
-            PLACEHOLDER
-        "scheduling_policy":
-          "description": |-
-            PLACEHOLDER
-        "source_table_full_name":
-          "description": |-
-            PLACEHOLDER
         "synced_table_id":
-          "description": |-
-            PLACEHOLDER
-        "timeseries_key":
-          "description": |-
-            PLACEHOLDER
-        "type_overrides":
           "description": |-
             PLACEHOLDER
     "quality_monitors":

--- a/bundle/internal/schema/parser.go
+++ b/bundle/internal/schema/parser.go
@@ -37,49 +37,59 @@ func newParser(schemas map[string]*clijson.SchemaJSON) *annotationParser {
 
 // This function checks if the input type:
 // 1. Is a Databricks Go SDK type.
-// 2. Has a Databricks Go SDK type embedded in it.
+// 2. Has a Databricks Go SDK type embedded in it, at any depth.
 //
 // If the above conditions are met, the function returns the schema
 // corresponding to the Databricks Go SDK type from the spec.
+//
+// Embedded structs are traversed breadth first, mirroring how
+// [jsonschema.FromType] flattens them, so the shallowest SDK type present in
+// the spec wins. Traversing past the first level matters because some resources
+// wrap the SDK spec in an intermediate struct rather than embedding it directly
+// (e.g. PostgresProject -> PostgresProjectConfig -> postgres.ProjectSpec).
 func (p *annotationParser) findRef(typ reflect.Type) (*clijson.SchemaJSON, bool) {
-	typs := []reflect.Type{typ}
+	bfsQueue := []reflect.Type{typ}
 
-	// Check for embedded Databricks Go SDK types.
-	if typ.Kind() == reflect.Struct {
-		for field := range typ.Fields() {
+	for len(bfsQueue) > 0 {
+		ctyp := bfsQueue[0]
+		bfsQueue = bfsQueue[1:]
+
+		if ref, ok := p.lookupSDKType(ctyp); ok {
+			return ref, true
+		}
+
+		if ctyp.Kind() != reflect.Struct {
+			continue
+		}
+
+		for field := range ctyp.Fields() {
 			if !field.Anonymous {
 				continue
 			}
 
 			// Deference current type if it's a pointer.
-			ctyp := field.Type
-			for ctyp.Kind() == reflect.Pointer {
-				ctyp = ctyp.Elem()
+			ftyp := field.Type
+			for ftyp.Kind() == reflect.Pointer {
+				ftyp = ftyp.Elem()
 			}
 
-			typs = append(typs, ctyp)
+			bfsQueue = append(bfsQueue, ftyp)
 		}
-	}
-
-	for _, ctyp := range typs {
-		// Skip if it's not a Go SDK type.
-		if !strings.HasPrefix(ctyp.PkgPath(), "github.com/databricks/databricks-sdk-go") {
-			continue
-		}
-
-		pkgName := path.Base(ctyp.PkgPath())
-		k := fmt.Sprintf("%s.%s", pkgName, ctyp.Name())
-
-		// Skip if the type is not in the spec.
-		if _, ok := p.ref[k]; !ok {
-			continue
-		}
-
-		// Return the first Go SDK type found in the spec.
-		return p.ref[k], true
 	}
 
 	return nil, false
+}
+
+// lookupSDKType returns the spec schema for a Databricks Go SDK type, if the
+// spec defines one for it.
+func (p *annotationParser) lookupSDKType(typ reflect.Type) (*clijson.SchemaJSON, bool) {
+	if !strings.HasPrefix(typ.PkgPath(), "github.com/databricks/databricks-sdk-go") {
+		return nil, false
+	}
+
+	k := fmt.Sprintf("%s.%s", path.Base(typ.PkgPath()), typ.Name())
+	ref, ok := p.ref[k]
+	return ref, ok
 }
 
 // normalizeLaunchStage validates the contract's launch stage and drops GA so it

--- a/bundle/internal/schema/parser_test.go
+++ b/bundle/internal/schema/parser_test.go
@@ -1,12 +1,71 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/databricks/cli/internal/clijson"
+	"github.com/databricks/databricks-sdk-go/service/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testProjectConfig and testProject mirror the shape of resources.PostgresProject:
+// the SDK spec is embedded two levels down, behind an intermediate config struct.
+type testProjectConfig struct {
+	postgres.ProjectSpec
+
+	ProjectId string `json:"project_id"`
+}
+
+type testProject struct {
+	testProjectConfig
+}
+
+func TestFindRefNestedEmbeddedSDKType(t *testing.T) {
+	spec := &clijson.SchemaJSON{Description: "A Lakebase project."}
+	p := newParser(map[string]*clijson.SchemaJSON{"postgres.ProjectSpec": spec})
+
+	t.Run("resolves a spec embedded below the first level", func(t *testing.T) {
+		got, ok := p.findRef(reflect.TypeFor[testProject]())
+		require.True(t, ok)
+		assert.Same(t, spec, got)
+	})
+
+	t.Run("resolves the SDK type itself", func(t *testing.T) {
+		got, ok := p.findRef(reflect.TypeFor[postgres.ProjectSpec]())
+		require.True(t, ok)
+		assert.Same(t, spec, got)
+	})
+
+	t.Run("reports no match when the spec omits the type", func(t *testing.T) {
+		_, ok := newParser(nil).findRef(reflect.TypeFor[testProject]())
+		assert.False(t, ok)
+	})
+}
+
+// Descriptions and launch stages from a spec embedded below the first level must
+// land on the wrapping resource type, since that is where the schema generator
+// flattens the spec's fields to.
+func TestExtractAnnotationsNestedEmbeddedSDKType(t *testing.T) {
+	p := newParser(map[string]*clijson.SchemaJSON{
+		"postgres.ProjectSpec": {
+			Fields: map[string]*clijson.SchemaFieldJSON{
+				"display_name": {
+					Description: "Human-readable project name.",
+					LaunchStage: "PUBLIC_BETA",
+				},
+			},
+		},
+	})
+
+	annotations, err := p.extractAnnotations(reflect.TypeFor[testProject]())
+	require.NoError(t, err)
+
+	got := annotations[getPath(reflect.TypeFor[testProject]())].Fields["display_name"]
+	assert.Equal(t, "Human-readable project name.", got.Description)
+	assert.Equal(t, clijson.LaunchStagePublicBeta, got.LaunchStage)
+}
 
 func TestNormalizeLaunchStage(t *testing.T) {
 	tests := []struct {

--- a/bundle/schema/jsonschema.json
+++ b/bundle/schema/jsonschema.json
@@ -1796,9 +1796,11 @@
                         "$ref": "#/$defs/string"
                       },
                       "expire_time": {
+                        "description": "[Beta] Absolute expiration timestamp. When set, the branch will expire at this time.\nMutually exclusive with `ttl` and `no_expiry`. When updating, use `spec.expiration` in the update_mask.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/time.Time"
                       },
                       "is_protected": {
+                        "description": "[Beta] When set to true, protects the branch from deletion and reset. Associated compute endpoints and the project cannot be deleted while the branch is protected.",
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
@@ -1806,6 +1808,7 @@
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "no_expiry": {
+                        "description": "[Beta] Explicitly disable expiration. When set to true, the branch will not expire.\nIf set to false, the request is invalid; provide either ttl or expire_time instead.\nMutually exclusive with `expire_time` and `ttl`. When updating, use `spec.expiration` in the update_mask.",
                         "$ref": "#/$defs/bool"
                       },
                       "parent": {
@@ -1818,15 +1821,19 @@
                         "$ref": "#/$defs/bool"
                       },
                       "source_branch": {
+                        "description": "[Beta] The name of the source branch from which this branch was created (data lineage for point-in-time recovery).\nIf not specified, defaults to the project's default branch.\nFormat: projects/{project_id}/branches/{branch_id}",
                         "$ref": "#/$defs/string"
                       },
                       "source_branch_lsn": {
+                        "description": "[Beta] The Log Sequence Number (LSN) on the source branch from which this branch was created.",
                         "$ref": "#/$defs/string"
                       },
                       "source_branch_time": {
+                        "description": "[Beta] The point in time on the source branch from which this branch was created.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/time.Time"
                       },
                       "ttl": {
+                        "description": "[Beta] Relative time-to-live duration. When set, the branch will expire at creation_time + ttl.\nMutually exclusive with `expire_time` and `no_expiry`. When updating, use `spec.expiration` in the update_mask.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/duration.Duration"
                       }
                     },
@@ -1846,14 +1853,17 @@
                 "oneOf": [
                   {
                     "type": "object",
+                    "description": "The desired state of the Catalog.",
                     "properties": {
                       "branch": {
+                        "description": "[Beta] The resource path of the branch associated with the catalog.\n\nFormat: projects/{project_id}/branches/{branch_id}.",
                         "$ref": "#/$defs/string"
                       },
                       "catalog_id": {
                         "$ref": "#/$defs/string"
                       },
                       "create_database_if_missing": {
+                        "description": "[Beta] If set to true, the specified postgres_database is created on behalf of the calling user\nif it does not already exist. In this case, the calling user has a role created for\nthem in Postgres if they do not already have one.\n\nDefaults to false, meaning that the request fails if the specified postgres_database does not already exist.",
                         "$ref": "#/$defs/bool"
                       },
                       "lifecycle": {
@@ -1861,6 +1871,7 @@
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "postgres_database": {
+                        "description": "[Beta] The name of the Postgres database inside the specified Lakebase project and branch to be associated with the UC catalog.\nThis database must already exist, unless create_database_if_missing is set to true on creation.\n\nA database can only be registered with one UC catalog at a time.\nTo re-register a database with a different catalog, the existing catalog must be deleted first.\n\nA child branch inherits the fact of parent's registration. This means the same-named database\nin a child branch cannot be registered with a second catalog\nwhile the parent's registration exists. To allow registering the database of a child branch,\ndrop and recreate the database on the child branch.\nThis removes the fact of parent's registration from this branch only.\n\nDoing Point In Time Restore (PITR) prior to the moment before the Postgres DB was registered\nin the Catalog drops the fact of registration of the database. So the user should avoid doing so.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1892,6 +1903,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "postgres_database": {
+                        "description": "[Beta] The name of the Postgres database.\n\nThis expects a valid Postgres identifier as specified in the link below.\nhttps://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS\nRequired when creating the Database.\n\nTo rename, pass a valid postgres identifier when updating the Database.",
                         "$ref": "#/$defs/string"
                       },
                       "replace_existing": {
@@ -1899,6 +1911,7 @@
                         "$ref": "#/$defs/bool"
                       },
                       "role": {
+                        "description": "[Beta] The name of the role that owns the database.\nFormat: projects/{project_id}/branches/{branch_id}/roles/{role_id}\n\nTo change the owner, pass valid existing Role name when updating the Database\n\nA database always has an owner.",
                         "$ref": "#/$defs/string"
                       }
                     },
@@ -1921,21 +1934,26 @@
                     "type": "object",
                     "properties": {
                       "autoscaling_limit_max_cu": {
+                        "description": "[Beta] The maximum number of Compute Units. The maximum value is 64.\nThe difference between the minimum and maximum Compute Units (max - min) must not exceed 16.",
                         "$ref": "#/$defs/float64"
                       },
                       "autoscaling_limit_min_cu": {
+                        "description": "[Beta] The minimum number of Compute Units. Minimum value is 0.5.",
                         "$ref": "#/$defs/float64"
                       },
                       "disabled": {
+                        "description": "[Beta] Whether to restrict connections to the compute endpoint.\nEnabling this option schedules a suspend compute operation.\nA disabled compute endpoint cannot be enabled by a connection or\nconsole action.",
                         "$ref": "#/$defs/bool"
                       },
                       "endpoint_id": {
                         "$ref": "#/$defs/string"
                       },
                       "endpoint_type": {
+                        "description": "[Beta] The endpoint type. A branch can only have one READ_WRITE endpoint.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.EndpointType"
                       },
                       "group": {
+                        "description": "[Beta] Settings for optional HA configuration of the endpoint. If unspecified, the endpoint defaults\nto non HA settings, with a single compute backing the endpoint (and no readable secondaries\nfor Read/Write endpoints).",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.EndpointGroupSpec"
                       },
                       "lifecycle": {
@@ -1943,6 +1961,7 @@
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "no_suspension": {
+                        "description": "[Beta] When set to true, explicitly disables automatic suspension (never suspend).\nShould be set to true when provided.\nMutually exclusive with `suspend_timeout_duration`. When updating, use `spec.suspension` in the update_mask.",
                         "$ref": "#/$defs/bool"
                       },
                       "parent": {
@@ -1952,9 +1971,11 @@
                         "$ref": "#/$defs/bool"
                       },
                       "settings": {
+                        "description": "[Beta] A collection of settings for a compute endpoint.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.EndpointSettings"
                       },
                       "suspend_timeout_duration": {
+                        "description": "[Beta] Duration of inactivity after which the compute endpoint is automatically suspended.\nIf specified should be between 60s and 604800s (1 minute to 1 week).\nMutually exclusive with `no_suspension`. When updating, use `spec.suspension` in the update_mask.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/duration.Duration"
                       }
                     },
@@ -1977,24 +1998,31 @@
                     "type": "object",
                     "properties": {
                       "budget_policy_id": {
+                        "description": "[Beta] The desired budget policy to associate with the project.\nSee status.budget_policy_id for the policy that is actually applied to the project.",
                         "$ref": "#/$defs/string"
                       },
                       "custom_tags": {
+                        "description": "[Beta] Custom tags to associate with the project. Forwarded to LBM for billing and cost tracking.\nTo update tags, provide the new tag list and include \"spec.custom_tags\" in the update_mask.\nTo clear all tags, provide an empty list and include \"spec.custom_tags\" in the update_mask.\nTo preserve existing tags, omit this field from the update_mask (or use wildcard \"*\" which auto-excludes empty tags).",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/postgres.ProjectCustomTag"
                       },
                       "default_branch": {
+                        "description": "[Beta] The full resource path for the default branch of the project\nFormat: projects/{project_id}/branches/{branch_id}",
                         "$ref": "#/$defs/string"
                       },
                       "default_endpoint_settings": {
+                        "description": "[Beta] A collection of settings for a compute endpoint.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.ProjectDefaultEndpointSettings"
                       },
                       "display_name": {
+                        "description": "[Beta] Human-readable project name. Length should be between 1 and 256 characters.",
                         "$ref": "#/$defs/string"
                       },
                       "enable_pg_native_login": {
+                        "description": "[Beta] Whether to enable PG native password login on all endpoints in this project. Defaults to false.",
                         "$ref": "#/$defs/bool"
                       },
                       "history_retention_duration": {
+                        "description": "[Beta] The number of seconds to retain the shared history for point in time recovery for all branches in this project. Value should be between 172800s (2 days) and 3024000s (35 days).",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/common/types/duration.Duration"
                       },
                       "lifecycle": {
@@ -2007,6 +2035,7 @@
                         "markdownDescription": "A Sequence of permissions to apply to this resource, where each item grants a permission `level` to a single `user_name`, `group_name`, or `service_principal_name`. A principal cannot be set in both a resource's `permissions` and the top-level `permissions` mapping.\n\nSee [permissions](https://docs.databricks.com/dev-tools/bundles/settings.html#permissions) and [link](https://docs.databricks.com/dev-tools/bundles/permissions.html)."
                       },
                       "pg_version": {
+                        "description": "[Beta] The major Postgres version number. The set of supported versions may vary; consult the API documentation for currently accepted values.",
                         "$ref": "#/$defs/int"
                       },
                       "project_id": {
@@ -2033,15 +2062,15 @@
                     "type": "object",
                     "properties": {
                       "attributes": {
-                        "description": "The desired API-exposed Postgres role attributes to associate with the role.",
+                        "description": "[Beta] The desired API-exposed Postgres role attributes to associate with the role.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.RoleAttributes"
                       },
                       "auth_method": {
-                        "description": "How the role is authenticated when connecting to Postgres. If left unspecified, a meaningful authentication method is derived from the identity_type.",
+                        "description": "[Beta] How the role is authenticated when connecting to Postgres. If left unspecified, a meaningful authentication method is derived from the identity_type.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.RoleAuthMethod"
                       },
                       "identity_type": {
-                        "description": "The type of the Databricks managed identity that this Role represents. Leave empty to create a regular Postgres role not associated with a Databricks identity.",
+                        "description": "[Beta] The type of the Databricks managed identity that this Role represents. Leave empty to create a regular Postgres role not associated with a Databricks identity.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.RoleIdentityType"
                       },
                       "lifecycle": {
@@ -2049,7 +2078,7 @@
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "membership_roles": {
-                        "description": "Standard roles that this role is a member of.",
+                        "description": "[Beta] Standard roles that this role is a member of.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/postgres.RoleMembershipRole"
                       },
                       "parent": {
@@ -2057,7 +2086,7 @@
                         "$ref": "#/$defs/string"
                       },
                       "postgres_role": {
-                        "description": "The name of the Postgres role. Required when creating the role.",
+                        "description": "[Beta] The name of the Postgres role. Required when creating the role.",
                         "$ref": "#/$defs/string"
                       },
                       "replace_existing": {
@@ -2087,46 +2116,62 @@
                     "type": "object",
                     "properties": {
                       "accelerated_sync": {
-                        "$ref": "#/$defs/bool"
+                        "description": "[Private Preview] When true, enables accelerated sync mode for the initial data load.\nThis significantly improves performance for large tables.\nRequires workspace-level enablement through Lakebase Accelerated Sync preview.",
+                        "$ref": "#/$defs/bool",
+                        "x-databricks-launch-stage": "PRIVATE_PREVIEW",
+                        "doNotSuggest": true
                       },
                       "branch": {
+                        "description": "[Beta] The full resource name the branch associated with the table.\n\nFormat: \"projects/{project_id}/branches/{branch_id}\".",
                         "$ref": "#/$defs/string"
                       },
                       "create_database_objects_if_missing": {
+                        "description": "[Beta] If true, the synced table's logical database and schema resources in PG\nwill be created if they do not already exist.\nThe request will fail if this is false and the database/schema do not exist.\n\nDefaults to true if omitted.",
                         "$ref": "#/$defs/bool"
                       },
                       "existing_pipeline_id": {
+                        "description": "[Beta] ID of an existing pipeline to bin-pack this synced table into.\nAt most one of existing_pipeline_id and new_pipeline_spec should be defined.\n\nThe pipeline used for the synced table is returned via the top level pipeline_id attribute.",
                         "$ref": "#/$defs/string"
                       },
                       "extra_columns": {
-                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/postgres.SyncedTableSyncedTableSpecExtraColumn"
+                        "description": "[Private Preview] Extra PostgreSQL-only columns to add to the synced table.",
+                        "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/postgres.SyncedTableSyncedTableSpecExtraColumn",
+                        "x-databricks-launch-stage": "PRIVATE_PREVIEW",
+                        "doNotSuggest": true
                       },
                       "lifecycle": {
                         "description": "Settings that control the deployment lifecycle of the resource, such as preventing it from being destroyed.",
                         "$ref": "#/$defs/github.com/databricks/cli/bundle/config/resources.Lifecycle"
                       },
                       "new_pipeline_spec": {
+                        "description": "[Beta] Specification for creating a new pipeline.\nAt most one of existing_pipeline_id and new_pipeline_spec should be defined.\n\nThe pipeline used for the synced table is returned via the top level pipeline_id attribute.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.NewPipelineSpec"
                       },
                       "postgres_database": {
+                        "description": "[Beta] The Postgres database name where the synced table will be created in.\n\nIf this synced table is created inside a Lakebase Catalog, this attribute can be omitted on creation and is inferred\nfrom the postgres_database associated with the Lakebase Catalog. If specified when inside a Lakebase Catalog, the value must match.\n\nA value must be specified when creating a synced table inside a Standard Catalog.",
                         "$ref": "#/$defs/string"
                       },
                       "primary_key_columns": {
+                        "description": "[Beta] Primary Key columns to be used for data insert/update in the destination.",
                         "$ref": "#/$defs/slice/string"
                       },
                       "scheduling_policy": {
+                        "description": "[Beta] Scheduling policy of the underlying pipeline.",
                         "$ref": "#/$defs/github.com/databricks/databricks-sdk-go/service/postgres.SyncedTableSyncedTableSpecSyncedTableSchedulingPolicy"
                       },
                       "source_table_full_name": {
+                        "description": "[Beta] Three-part (catalog, schema, table) name of the source Delta table.\n\nFor the corresponding destination table, use any of the two:\n\n* synced_table_id used at the creation of the SyncedTable\n* \"name\" consisting of \"synced_tables/\" prefix and the full name of the destination table.",
                         "$ref": "#/$defs/string"
                       },
                       "synced_table_id": {
                         "$ref": "#/$defs/string"
                       },
                       "timeseries_key": {
+                        "description": "[Beta] Time series key to deduplicate (tie-break) rows with the same primary key.",
                         "$ref": "#/$defs/string"
                       },
                       "type_overrides": {
+                        "description": "[Beta] Override the default Delta-\u003ePG type mapping for specific columns.\nA TypeOverride with PG_SPECIFIC_TYPE_UNSPECIFIED is rejected; a valid pg_type must be set.",
                         "$ref": "#/$defs/slice/github.com/databricks/databricks-sdk-go/service/postgres.SyncedTableSyncedTableSpecTypeOverride"
                       }
                     },


### PR DESCRIPTION
## Problem

`postgres_*` resources appear in the bundle JSON schema with their fields but with no descriptions and no launch-stage prefixes, even though `.codegen/cli.json` documents every one of them and marks them `PUBLIC_BETA`.

`findRef` binds a config type to a spec schema by checking the type itself and its *direct* anonymous embeds only. That works for resources that embed the SDK type directly (`Job` -> `jobs.JobSettings`), but the postgres resources interpose a config struct so `ForceSendFields` is recorded on the struct that declares each field:

    PostgresProject -> PostgresProjectConfig -> postgres.ProjectSpec

`jsonschema.FromType` flattens embedded structs at any depth, so the Spec's fields land in the schema, but `findRef` stopped one level short and never found the schema documenting them.

## Solution

Traverse embedded structs breadth first, mirroring `getStructFields` in `libs/jsonschema/from_type.go`, so the shallowest SDK type present in the spec still wins. The lookup itself moves to `lookupSDKType`.

## Effect

Regenerating drops 40 now-stale `PLACEHOLDER` markers from `annotations.yml` (`dropShadowingPlaceholders` prunes a marker once upstream documents the field) and adds the inherited descriptions to `jsonschema.json`. Exactly the 7 postgres resource definitions change; no other definition in the schema is touched and none are added or removed.

Two fields that were silently exposed are now labelled: `accelerated_sync` and `extra_columns` on `postgres_synced_tables` pick up `[Private Preview]`, `x-databricks-launch-stage`, and `doNotSuggest`.

The bundle-only fields (`parent`, the `*_id`s, `replace_existing`, `purge_on_delete`) stay `PLACEHOLDER`: the spec documents them on sibling schemas (`postgres.Create*Request`, and the `postgres.Branch` / `Endpoint` / `Database` / `Role` envelopes) that no bundle type embeds. They need hand-authored text, which is a separate change.

## Tests

`TestFindRefNestedEmbeddedSDKType` and
`TestExtractAnnotationsNestedEmbeddedSDKType` cover a spec embedded below the first level, using the same shape as the postgres resources.

<img width="210" height="139" alt="Screenshot 2026-08-05 at 00 24 39" src="https://github.com/user-attachments/assets/096cfe16-ca0f-481e-a6d0-41ecc692e91c" />
